### PR TITLE
feature: exponential decay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ models/
 *.bin
 *.safetensors
 
-# Project notes to ignore
-PHASE_1_MVP.md
-PHASE_2_RESEARCH DATA.md
-PROJECT_CONTEXT.md
+# Ignore all root markdown files except README
+/*.md
+!README.md

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -113,7 +113,7 @@ def _build_analyze_response(
         steps=horizon_steps,
     )
 
-    history_vectors = build_feature_vectors(market_history, sentiment_score=float(sentiment["score"]))
+    history_vectors = build_feature_vectors(market_history, sentiment_score=float(sentiment["score"]), document_date=payload.date)
     forecast = forecast_quantitative_series(
         vectors=history_vectors,
         forecast_mode=mode,
@@ -150,7 +150,7 @@ def _run_real_train_job(job_id: str, payload: AnalyzeRequest) -> None:
             symbol=payload.symbol,
             history_length=REAL_TRAIN_HISTORY_LENGTH,
         )
-        history_vectors = build_feature_vectors(market_history, sentiment_score=float(sentiment["score"]))
+        history_vectors = build_feature_vectors(market_history, sentiment_score=float(sentiment["score"]), document_date=payload.date)
 
         # Real Train intentionally runs a stronger checkpoint update over 252-day context.
         bootstrap_checkpoint(
@@ -220,6 +220,7 @@ def analyze(payload: AnalyzeRequest):
             warmup_vectors = build_feature_vectors(
                 warmup_history,
                 sentiment_score=float(warmup_sentiment["score"]),
+                document_date=payload.date,
             )
             bootstrap_checkpoint(
                 vectors=warmup_vectors,

--- a/backend/app/prepare_training_data.py
+++ b/backend/app/prepare_training_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -25,6 +26,8 @@ class PreparedTrainingRecord:
     document_type: str
     title: str
     source_file: str
+    document_date: str = ""
+    elapsed_days: float = 0.0
 
 
 @dataclass
@@ -126,9 +129,13 @@ def build_training_groups(
             except Exception:
                 skipped_symbol_pairs += 1
                 continue
+            date_used = str(market["date_used"])
+            elapsed_days = float(
+                (datetime.date.fromisoformat(date_used) - datetime.date.fromisoformat(date_value)).days
+            )
             grouped_records[symbol].append(
                 PreparedTrainingRecord(
-                    date=str(market["date_used"]),
+                    date=date_used,
                     sentiment_score=sentiment_score,
                     close=float(market["close"]),
                     volatility_5d=float(market["volatility_5d"]),
@@ -136,6 +143,8 @@ def build_training_groups(
                     document_type=document_type,
                     title=title,
                     source_file=source_file,
+                    document_date=date_value,
+                    elapsed_days=elapsed_days,
                 )
             )
 

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import csv
+import datetime
 import json
 import math
 import threading
@@ -15,7 +16,7 @@ from torch.nn import functional as F
 from torch.utils.data import DataLoader, TensorDataset
 
 SEQUENCE_LENGTH = 5
-FEATURE_SIZE = 5  # [sentiment_score, market_close, market_volatility, close_change_pct, volatility_change]
+FEATURE_SIZE = 6  # [sentiment_score, market_close, market_volatility, close_change_pct, volatility_change, elapsed_time]
 FORECAST_CONFIDENCE_LEVEL = 0.8
 CONFIDENCE_Z_SCORE = 1.2816  # Approximate central 80% interval
 DEFAULT_CLOSE_SCALE = 10000.0
@@ -149,6 +150,7 @@ class FeatureVector:
     market_volatility: float
     close_change_pct: float = 0.0
     volatility_change: float = 0.0
+    elapsed_time: float = 0.0
 
     @classmethod
     def from_market_state(
@@ -160,6 +162,7 @@ class FeatureVector:
         market_volatility: float,
         previous_close: float | None = None,
         previous_volatility: float | None = None,
+        elapsed_time: float = 0.0,
     ) -> "FeatureVector":
         close_change_pct = 0.0
         if previous_close is not None and abs(previous_close) > 1e-12:
@@ -176,6 +179,7 @@ class FeatureVector:
             market_volatility=float(market_volatility),
             close_change_pct=float(close_change_pct),
             volatility_change=float(volatility_change),
+            elapsed_time=float(elapsed_time),
         )
 
     def as_list(self, close_scale: float = DEFAULT_CLOSE_SCALE) -> list[float]:
@@ -185,6 +189,7 @@ class FeatureVector:
             float(self.market_volatility),
             max(min(float(self.close_change_pct), 1.0), -1.0),
             max(min(float(self.volatility_change), 1.0), -1.0),
+            float(self.elapsed_time) / 30.0,
         ]
 
 
@@ -380,16 +385,26 @@ def _extract_required_float(record: dict[str, Any], keys: Sequence[str]) -> floa
 def build_feature_vectors(
     records: Sequence[dict[str, Any]],
     sentiment_score: float | None = None,
+    document_date: str | None = None,
 ) -> list[FeatureVector]:
     vectors: list[FeatureVector] = []
     previous_close: float | None = None
     previous_volatility: float | None = None
+
+    parsed_doc_date: datetime.date | None = None
+    if document_date:
+        parsed_doc_date = datetime.date.fromisoformat(document_date)
 
     sorted_records = sorted(records, key=lambda item: str(item.get("date", item.get("timestamp", ""))))
     for record in sorted_records:
         date_value = str(record.get("date", record.get("timestamp", "")))
         if not date_value:
             continue
+
+        elapsed_time = 0.0
+        if parsed_doc_date is not None:
+            record_date = datetime.date.fromisoformat(date_value[:10])
+            elapsed_time = float((record_date - parsed_doc_date).days)
 
         close_value = _extract_required_float(record, ("close", "market_close"))
         volatility_value = _extract_required_float(
@@ -405,6 +420,7 @@ def build_feature_vectors(
                 market_volatility=volatility_value,
                 previous_close=previous_close,
                 previous_volatility=previous_volatility,
+                elapsed_time=elapsed_time,
             )
         )
         previous_close = close_value


### PR DESCRIPTION
This pull request enhances the feature engineering and data preparation pipeline by introducing a new `elapsed_time` feature, representing the number of days between each market record and the associated document date. This change affects both the training data preparation and the inference flow, ensuring that elapsed time is consistently included as a feature for forecasting models.

**Feature engineering and data pipeline improvements:**

* Added a new `elapsed_time` field to the `FeatureVector` dataclass and the `PreparedTrainingRecord`, and updated the `FEATURE_SIZE` constant to account for this new feature. This allows models to consider the temporal distance between the document and market data. [[1]](diffhunk://#diff-c655cdd6e13dddf30b6f7d89ceb2df50d1e0e35b8e84bb5bbdf6f7fd6345751aL18-R19) [[2]](diffhunk://#diff-c655cdd6e13dddf30b6f7d89ceb2df50d1e0e35b8e84bb5bbdf6f7fd6345751aR153) [[3]](diffhunk://#diff-f8bd0f739cb5aa04a6180435379869ff8fad5a4c583d7d50cbd55c9ee48f0124R29-R30)
* Modified the `build_feature_vectors` function to compute `elapsed_time` for each record based on the difference between the market record date and the provided `document_date`. This is now used in both training and inference. [[1]](diffhunk://#diff-c655cdd6e13dddf30b6f7d89ceb2df50d1e0e35b8e84bb5bbdf6f7fd6345751aR388-R408) [[2]](diffhunk://#diff-c655cdd6e13dddf30b6f7d89ceb2df50d1e0e35b8e84bb5bbdf6f7fd6345751aR423)
* Updated all relevant call sites in `main.py` to pass `document_date` when building feature vectors, ensuring the new feature is included throughout the pipeline. [[1]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3L116-R116) [[2]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3L153-R153) [[3]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R223)

**Training data preparation enhancements:**

* In `prepare_training_data.py`, added logic to compute and store `elapsed_days` for each training record, reflecting the temporal gap between the document and each market sample.

**Supporting changes:**

* Updated import statements to include the `datetime` module where needed for date calculations. [[1]](diffhunk://#diff-f8bd0f739cb5aa04a6180435379869ff8fad5a4c583d7d50cbd55c9ee48f0124R4) [[2]](diffhunk://#diff-c655cdd6e13dddf30b6f7d89ceb2df50d1e0e35b8e84bb5bbdf6f7fd6345751aR5)
* Updated the `as_list` method of `FeatureVector` to normalize `elapsed_time` by dividing by 30, making this feature scale-consistent for model input.

Closes #1.