### PR TITLE
Wire HF_TOKEN and add accelerate dep for fine-tune pilot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to .env and fill in the values. .env is gitignored.
+
+# Hugging Face access token (required for gated checkpoints and higher rate limits).
+# Get one at https://huggingface.co/settings/tokens with 'read' scope.
+HF_TOKEN=
+
+# Optional: alias the same token under the older env name if some tooling reads it.
+# HUGGINGFACE_HUB_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ npm-debug.log*
 # Local environment files
 .env
 .env.*
+!.env.example
 
 # Docker/runtime artifacts
 *.log

--- a/backend/app/data/phase3_finetune_pilot.py
+++ b/backend/app/data/phase3_finetune_pilot.py
@@ -57,6 +57,10 @@ def _set_all_seeds(seed: int) -> None:
         torch.cuda.manual_seed_all(seed)
 
 
+def _hf_token() -> str | None:
+    return os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_HUB_TOKEN") or None
+
+
 def _load_registry_rows(package_dir: Path) -> list[EvalRow]:
     path = package_dir / "registry_normalized.jsonl"
     rows: list[EvalRow] = []
@@ -194,13 +198,17 @@ def main() -> int:
         )
     print(f"[pilot] fold={args.fold_id} train_rows={len(train_rows)} test_rows={len(test_rows)}")
 
-    tokenizer = AutoTokenizer.from_pretrained(args.checkpoint)
+    hf_token = _hf_token()
+    if hf_token:
+        print(f"[pilot] using HF token (len={len(hf_token)})")
+    tokenizer = AutoTokenizer.from_pretrained(args.checkpoint, token=hf_token)
     model = AutoModelForSequenceClassification.from_pretrained(
         args.checkpoint,
         num_labels=len(LABELS),
         id2label=ID2LABEL,
         label2id=LABEL2ID,
         ignore_mismatched_sizes=True,
+        token=hf_token,
     )
 
     train_ds = TextClassificationDataset(train_rows, tokenizer, max_length=args.max_length)

--- a/backend/app/data/phase3_training_execution.py
+++ b/backend/app/data/phase3_training_execution.py
@@ -69,6 +69,10 @@ def _set_all_seeds(seed: int) -> None:
         torch.cuda.manual_seed_all(seed)
 
 
+def _hf_token() -> str | None:
+    return os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_HUB_TOKEN") or None
+
+
 @dataclass
 class EvalRow:
     text: str
@@ -322,12 +326,14 @@ def _run_single(
         classifier = None
         checkpoint_used = ""
         checkpoint_errors: list[str] = []
+        hf_token = _hf_token()
         for checkpoint in model_spec["checkpoints"]:
             try:
                 classifier = pipeline(
                     "text-classification",
                     model=checkpoint,
                     return_all_scores=True,
+                    token=hf_token,
                 )
                 checkpoint_used = checkpoint
                 break

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn[standard]
 transformers
+accelerate>=1.1.0
 torch
 python-multipart
 requests


### PR DESCRIPTION
## Summary
- Add `accelerate>=1.1.0` to `backend/requirements.txt` — required by `transformers.Trainer` in the fine-tune pilot.
- Read `HF_TOKEN` (or `HUGGINGFACE_HUB_TOKEN`) from env and pass it to `AutoTokenizer`, `AutoModelForSequenceClassification`, and `pipeline()` in both `phase3_finetune_pilot.py` and `phase3_training_execution.py`. Unlocks gated checkpoints (e.g. `gtfintechlab/FOMC-RoBERTa`) and quiets the unauthenticated-request warning.
- Add `.env.example` as a template and allowlist it past the `.env.*` gitignore rule.

## Test plan
- [ ] `pip install 'accelerate>=1.1.0'`
- [ ] `export HF_TOKEN=hf_xxx`
- [ ] `python -m app.data.phase3_finetune_pilot --training-package-id <tp_id> --owner <name>` runs to completion and writes `data/artifacts/phase3/pilot_finetune_<ts>/metrics.json`
- [ ] Zero-shot harness (`python -m app.data.phase3_training_execution --mode full ...`) still passes with or without `HF_TOKEN` set