### PR TITLE
Add chair speeches adapter (first Fed-adjacent source, #32)

### DIFF
--- a/backend/app/data/ingest_sources.py
+++ b/backend/app/data/ingest_sources.py
@@ -19,7 +19,7 @@ DEFAULT_OUTPUT_FILE = "source_registry.jsonl"
 
 HF_DATASET_ID = "gtfintechlab/fomc_communication"
 KAGGLE_DATASET_ID = "drlexus/fed-statements-and-minutes"
-SCRAPED_FILES = ("fomc_statements.json", "fomc_minutes.json")
+SCRAPED_FILES = ("fomc_statements.json", "fomc_minutes.json", "chair_speeches.json")
 
 
 def _parse_args() -> argparse.Namespace:
@@ -270,6 +270,8 @@ def _iter_scraped_records(data_dir: Path) -> list[dict[str, Any]]:
             file_source_type = "fomc_minutes"
         elif filename == "fomc_statements.json":
             file_source_type = "fomc_statement"
+        elif filename == "chair_speeches.json":
+            file_source_type = "chair_speech"
         else:
             file_source_type = None
         payload = _read_json_or_jsonl(path)

--- a/backend/app/services/scraper_speeches.py
+++ b/backend/app/services/scraper_speeches.py
@@ -11,9 +11,12 @@ ingest_sources.SCRAPED_FILES.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
@@ -210,3 +213,51 @@ def extract_speech_listing(html: str) -> list[SpeechListingEntry]:
             )
         )
     return entries
+
+
+_CHAIR_PATTERN = re.compile(r"\b(chair|chairman|chairwoman)\b", flags=re.IGNORECASE)
+_VICE_CHAIR_PATTERN = re.compile(r"\bvice\s+(chair|chairman|chairwoman)\b", flags=re.IGNORECASE)
+
+
+def is_chair_speech(speaker: str) -> bool:
+    """Classify a speaker as the Chair/Chairman/Chairwoman (excluding Vice Chair).
+
+    Returns True if the speaker string contains chair/chairman/chairwoman and
+    does NOT contain "vice chair/chairman/chairwoman".
+    """
+    if not speaker:
+        return False
+    if _VICE_CHAIR_PATTERN.search(speaker):
+        return False
+    return bool(_CHAIR_PATTERN.search(speaker))
+
+
+def write_chair_speeches_json(parsed: Iterable[ParsedSpeech], output_path: Path) -> int:
+    """Write only chair speeches to output_path as a JSON list.
+
+    Returns the number of rows written. Each row matches the schema
+    consumed by ingest_sources._iter_scraped_records: date, title, text,
+    document_type ('chair_speech'), url, scraped_at_utc.
+    """
+
+    rows: list[dict[str, str]] = []
+    scraped_at = datetime.now(timezone.utc).isoformat()
+    for entry in parsed:
+        if not is_chair_speech(entry.speaker):
+            continue
+        if not entry.text or not entry.date:
+            continue
+        rows.append(
+            {
+                "date": entry.date,
+                "title": entry.title,
+                "text": entry.text,
+                "document_type": "chair_speech",
+                "url": entry.url,
+                "scraped_at_utc": scraped_at,
+            }
+        )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(rows, indent=2), encoding="utf-8")
+    return len(rows)

--- a/backend/app/services/scraper_speeches.py
+++ b/backend/app/services/scraper_speeches.py
@@ -69,6 +69,94 @@ def _coerce_date(value: str) -> str:
     return datetime.strptime(matched.group(0), "%B %d, %Y").date().isoformat()
 
 
+@dataclass(frozen=True)
+class ParsedSpeech:
+    date: str  # ISO yyyy-mm-dd
+    speaker: str
+    title: str
+    text: str
+    url: str
+
+
+_TITLE_TAIL_PATTERN = re.compile(r"\s*-\s*Federal Reserve Board\s*$", flags=re.IGNORECASE)
+
+
+def _extract_title(soup: BeautifulSoup) -> str:
+    # Prefer the og:title meta when present (the rendered page title without
+    # the " - Federal Reserve Board" tail). Fall back to <title> with the
+    # tail stripped, then to any in-content h3/h2.
+    og = soup.find("meta", attrs={"property": "og:title"})
+    if og is not None and og.get("content"):
+        return _clean_text(og["content"])
+    title_tag = soup.find("title")
+    if title_tag is not None:
+        return _TITLE_TAIL_PATTERN.sub("", _clean_text(title_tag.get_text(" ", strip=True)))
+    h3 = soup.select_one("h3.title, h3, h2")
+    if h3 is not None:
+        return _clean_text(h3.get_text(" ", strip=True))
+    return ""
+
+
+_SPEAKER_TITLE_PATTERN = re.compile(
+    r"\b(Chair|Chairman|Chairwoman|Vice\s+Chair|Vice\s+Chairman|Governor)\s+([A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*)",
+)
+
+
+def _extract_speaker(soup: BeautifulSoup, title: str) -> str:
+    # Try the explicit speaker selectors first (newer pages use these).
+    for selector in ("p.speaker", ".speaker", ".news__speaker", "span.speaker"):
+        node = soup.select_one(selector)
+        if node is not None:
+            text = _clean_text(node.get_text(" ", strip=True))
+            if text:
+                return text
+    # Fall back to extracting "Chair Powell" / "Governor Waller" out of the title.
+    matched = _SPEAKER_TITLE_PATTERN.search(title)
+    if matched:
+        return _clean_text(matched.group(0))
+    return ""
+
+
+def _extract_body(soup: BeautifulSoup) -> str:
+    selectors = [
+        "div.col-xs-12.col-sm-8.col-md-8 p",
+        "div#article p",
+        "article p",
+        "main p",
+    ]
+    for selector in selectors:
+        nodes = soup.select(selector)
+        if nodes:
+            chunks = [_clean_text(node.get_text(" ", strip=True)) for node in nodes]
+            return "\n".join(chunk for chunk in chunks if chunk)
+    return ""
+
+
+def parse_speech_page(html: str, *, source_url: str) -> ParsedSpeech:
+    """Parse a single federalreserve.gov speech page into a ParsedSpeech.
+
+    Falls back gracefully when individual fields are missing on the page;
+    callers decide whether to keep or discard rows with empty fields.
+    """
+
+    soup = BeautifulSoup(html, "html.parser")
+    title = _extract_title(soup)
+    speaker = _extract_speaker(soup, title)
+    body = _extract_body(soup)
+
+    article_time = soup.select_one("p.article__time, .article__time, time")
+    date_text = _clean_text(article_time.get_text(" ", strip=True)) if article_time else ""
+    date_iso = _date_from_url(source_url) or _coerce_date(date_text)
+
+    return ParsedSpeech(
+        date=date_iso,
+        speaker=speaker,
+        title=title,
+        text=body,
+        url=source_url,
+    )
+
+
 def extract_speech_listing(html: str) -> list[SpeechListingEntry]:
     """Parse a federalreserve.gov annual speech archive page.
 

--- a/backend/app/services/scraper_speeches.py
+++ b/backend/app/services/scraper_speeches.py
@@ -1,0 +1,124 @@
+"""Fed speech archive scraper.
+
+Two responsibilities (Task 2 lands the first; Task 3 lands the second):
+1. List speeches from the annual archive page (extract_speech_listing).
+2. Parse a single speech page into a structured row (parse_speech_page).
+
+Output rows match the schema used by services/scraper.py so the existing
+ingestion pipeline picks them up without changes when wired through
+ingest_sources.SCRAPED_FILES.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup
+
+ARCHIVE_BASE_URL = "https://www.federalreserve.gov"
+SPEECH_URL_PATTERN = re.compile(r"^/newsevents/speech/[a-z]+(\d{8})[a-z]\.htm$")
+DATE_FROM_URL_PATTERN = re.compile(r"/speech/[a-z]+(\d{8})[a-z]\.htm$")
+
+_MONTH_PATTERN = re.compile(
+    r"(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),\s+(\d{4})",
+    flags=re.IGNORECASE,
+)
+# Numeric date as used in the archive time tags: m/d/yyyy or mm/dd/yyyy
+_NUMERIC_DATE_PATTERN = re.compile(r"^(\d{1,2})/(\d{1,2})/(\d{4})$")
+
+
+@dataclass(frozen=True)
+class SpeechListingEntry:
+    date: str  # ISO yyyy-mm-dd
+    speaker: str
+    title: str
+    url: str  # absolute
+
+
+def _clean_text(value: str) -> str:
+    return re.sub(r"\s+", " ", (value or "")).strip()
+
+
+def _date_from_url(url: str) -> str:
+    matched = DATE_FROM_URL_PATTERN.search(url)
+    if not matched:
+        return ""
+    return datetime.strptime(matched.group(1), "%Y%m%d").date().isoformat()
+
+
+def _coerce_date(value: str) -> str:
+    """Parse a date string that may be in month-name or numeric m/d/yyyy form."""
+    text = (value or "").strip()
+
+    # Try numeric m/d/yyyy first (used in archive <time> tags)
+    m = _NUMERIC_DATE_PATTERN.match(text)
+    if m:
+        month, day, year = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        try:
+            return datetime(year, month, day).date().isoformat()
+        except ValueError:
+            pass
+
+    # Fall back to written-out month name
+    matched = _MONTH_PATTERN.search(text)
+    if not matched:
+        return ""
+    return datetime.strptime(matched.group(0), "%B %d, %Y").date().isoformat()
+
+
+def extract_speech_listing(html: str) -> list[SpeechListingEntry]:
+    """Parse a federalreserve.gov annual speech archive page.
+
+    Returns one SpeechListingEntry per linked speech. Duplicate URLs
+    collapse to the first occurrence; non-speech anchors are skipped.
+    """
+
+    soup = BeautifulSoup(html, "html.parser")
+    entries: list[SpeechListingEntry] = []
+    seen_urls: set[str] = set()
+
+    for anchor in soup.select("a[href]"):
+        href = (anchor.get("href") or "").strip()
+        if not SPEECH_URL_PATTERN.match(href):
+            continue
+        absolute = urljoin(ARCHIVE_BASE_URL, href)
+        if absolute in seen_urls:
+            continue
+        seen_urls.add(absolute)
+
+        title = _clean_text(anchor.get_text(" ", strip=True))
+        if not title:
+            continue
+
+        speaker = ""
+        explicit_date = ""
+        # Walk up to a row-level container that holds both the speaker and date.
+        # The immediate parent of the <a> is a <p>; we want the enclosing .row
+        # or the closest div/tr/li that is not the direct <p> wrapper.
+        row = anchor.find_parent(class_=re.compile(r"row|eventlist__event"))
+        if row is None:
+            row = anchor.find_parent(["tr", "li"])
+        if row is not None:
+            speaker_node = row.select_one(".speaker, .news__speaker")
+            if speaker_node is not None:
+                speaker = _clean_text(speaker_node.get_text(" ", strip=True))
+            time_node = row.select_one("time, .news__date, .eventlist__time")
+            if time_node is not None:
+                explicit_date = _clean_text(time_node.get_text(" ", strip=True))
+
+        date_iso = _date_from_url(absolute) or _coerce_date(explicit_date)
+        if not date_iso:
+            continue
+
+        entries.append(
+            SpeechListingEntry(
+                date=date_iso,
+                speaker=speaker,
+                title=title,
+                url=absolute,
+            )
+        )
+    return entries

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -6,7 +6,7 @@ Define a single contract from ingestion to training package export.
 ## Approved Sources
 - `hf_fomc_communication` (research-only, citation required)
 - `kaggle_fed_statements_minutes` (license/terms apply)
-- `scraped_fed` (internal scraper output)
+- `scraped_fed` (internal scraper output; covers FOMC minutes/statements and Chair speeches as of Plan 2 of the 2026-05-05 scope extension)
 
 ## Ingestion Contract
 Each row must contain:

--- a/tests/fixtures/fed_speech_archive_2024.html
+++ b/tests/fixtures/fed_speech_archive_2024.html
@@ -1,0 +1,3071 @@
+﻿<!doctype html>
+<html lang="en" class="no-js">
+<head>
+    
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.6, user-scalable=1">
+    <meta name="description" content="The Federal Reserve Board of Governors in Washington DC." />
+    <meta property="og:type" content="article" /> 
+    <meta property="og:title" content="2024 Speeches"/>    
+    <meta property="og:image" content="https://www.federalreserve.gov/images/social-media/social-default-image-opengraph.jpg" />
+    <meta property="og:image:alt" content="Board of Governors of the Federal Reserve System" />
+    <meta property="og:description" content="The Federal Reserve Board of Governors in Washington DC."/>
+    <meta property="og:url" content="https://www.federalreserve.gov/newsevents/speech/2024-speeches.htm" />
+    <meta name="twitter:card" content="summary" />    
+    <meta name="twitter:title" content="2024 Speeches" />
+    <meta name="twitter:image" content="https://www.federalreserve.gov/images/social-media/social-default-image-twitter.jpg" />
+    <meta name="twitter:image:alt" content="Board of Governors of the Federal Reserve System" />
+    <meta name="twitter:description" content="The Federal Reserve Board of Governors in Washington DC." />
+    <title>Federal Reserve Board - 2024 Speeches</title>
+    
+        <link href="/css/bootstrap.css" rel="stylesheet" type="text/css">
+        <link href="/css/bluesteel-theme.css" rel="stylesheet" type="text/css">
+        <link rel="stylesheet" href="/assets/main.css">
+        <script src="/assets/main.js" defer type="module"></script>
+        <script src="/js/modernizr-latest.js" type="text/javascript"></script>
+        <link href="/css/icons.data.svg.css" rel="stylesheet">           
+        <script src="/js/angular.min.js" type="text/javascript"></script>
+        <script src="/js/app.js" type="text/javascript"></script>
+        
+        <!-- For Linear Gradients in IE9 or greater -->
+        <!--[if gte IE 9]>
+            <style type="text/css">
+              .gradient {
+                 filter: none;
+              }
+            </style>
+        <![endif]-->
+
+ 
+</head>
+<body>
+    <a href="#content" class="globalskip">Skip to main content</a>
+<nav class="nav-primary-mobile" id="nav-primary-mobile"></nav>
+<div id='top-banner' data-hydrate='true'><link rel="preload" as="image" href="/images/icon-us-flag.svg"/><link rel="preload" as="image" href="/images/expand_more.svg"/><link rel="preload" as="image" href="https://designsystem.digital.gov/assets/img/icon-dot-gov.svg"/><link rel="preload" as="image" href="https://designsystem.digital.gov/assets/img/icon-https.svg"/><div class="custom-banner"><div class="custom-banner__header"><div class="custom-banner__left"><img class="custom-banner__flag" src="/images/icon-us-flag.svg" width="20" height="20" alt="US Flag"/><p class="custom-banner__text">An official website of the United States Government</p></div><button type="button" class="custom-banner__button"><span class="custom-banner__button-text">Here&#x27;s how you know</span><img id="banner-caret-_R_0_" class="custom-banner__caret " src="/images/expand_more.svg" alt="Expand More"/></button></div><div class="custom-banner__content " id="banner-content-_R_0_"><div class="custom-banner__info"><div class="info-block"><img src="https://designsystem.digital.gov/assets/img/icon-dot-gov.svg" alt=".gov icon"/><p><strong>Official websites use .gov</strong><br/>A <strong>.gov</strong> website belongs to an official government organization in the United States.</p></div><div class="info-block"><img src="https://designsystem.digital.gov/assets/img/icon-https.svg" alt="HTTPS icon"/><p><strong>Secure .gov websites use HTTPS</strong><br/>A <strong>lock</strong> (<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" role="img" aria-labelledby="banner-lock-description-_R_0_" focusable="false"><title id="banner-lock-title-_R_0_">Lock</title><desc id="banner-lock-description-_R_0_">Locked padlock icon</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"></path></svg></span>) or <strong>https://</strong> means you&#x27;ve safely connected to the .gov website. Share sensitive information only on official, secure websites.</p></div></div></div></div></div><div class="t1_nav navbar navbar-default navbar-fixed-top" role="navigation">
+    <div class="t1_container clearfix">
+        <a id="logo" class="btn btn-default icon-FRB_logo-bw visible-xs-table-cell t1__btnlogo" href="/default.htm" role="button"><span class="sr-only">Back to Home</span></a>
+        <a href="/default.htm" id="banner" class="visible-xs-table-cell t1__banner" title="Link to Home Page" role="button">Board of Governors of the Federal Reserve System</a>
+        <ul class="nav navbar-nav visible-md visible-lg t1_toplinks">
+            <li class="navbar-text navbar-text__social">
+                <span class="navbar-link" tabindex="0">Stay Connected</span>
+            <ul class="nav navbar-nav t1_social social_ten">
+              <li class="social__item">
+                <a
+                  data-icon="facebook"
+                  href="https://www.facebook.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-facebook-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Facebook Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="instagram"
+                  href="https://www.instagram.com/federalreserveboard/"
+                  class="noIcon"
+                >
+                  <div class="icon-instagram icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Instagram Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="youtube"
+                  href="https://www.youtube.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-youtube-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve YouTube Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="flickr"
+                  href="https://www.flickr.com/photos/federalreserve/"
+                  class="noIcon"
+                >
+                  <div class="icon-flickr-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Flickr Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="linkedin"
+                  href="https://www.linkedin.com/company/federal-reserve-board"
+                  class="noIcon"
+                >
+                  <div class="icon-linkedin-color icon icon__sm"></div>
+                  <span class="sr-only">Federal Reserve LinkedIn Page</span></a
+                >
+              </li>
+              <li class="social__item">
+                <a data-icon="threads" href="https://www.threads.net/@federalreserveboard" class="noIcon">
+                  <div class="icon-threads icon icon__sm"></div>
+                  <span class="sr-only">Federal Reserve Threads Page</span></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="twitter"
+                  href="https://x.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-social-x icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve X Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="bluesky"
+                  href="https://bsky.app/profile/federalreserve.gov"
+                  class="noIcon"
+                >
+                  <div class="icon-bluesky icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Bluesky Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a data-icon="rss" href="/feeds/feeds.htm" class="noIcon">
+                  <div class="icon-rss-color icon icon__sm"></div>
+                  <span class="sr-only">Subscribe to RSS</span></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a data-icon="email" href="/subscribe.htm" class="noIcon">
+                  <div class="icon-email-color icon icon__sm"></div>
+                  <span class="sr-only">Subscribe to Email</span></a
+                >
+              </li>
+                </ul>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/recentpostings.htm">Recent Postings</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/newsevents/calendar.htm">Calendar</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/publications.htm">Publications</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/sitemap.htm">Site Map</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/azindex.htm">A-Z index</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/careers.htm">Careers</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/faqs.htm">FAQs</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/videos.htm">Videos</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/aboutthefed/contact-us-topics.htm">Contact</a>
+            </li>
+        </ul>
+        <form class="nav navbar-form hidden-xs nav__search" role="search" action="//www.fedsearch.org/board_public/search"  method="get">
+            <div class="form-group input-group input-group-sm">
+                <label for="t1search" class="sr-only">Search</label>
+                <input id="t1search" class="nav__input form-control" name="text" placeholder="Search" type="text" />
+                <span class="input-group-btn">
+                    <button type="submit" class="nav__button btn btn-default" id="headerTopLinksSearchFormSubmit" name="Search">
+                        <span class="sr-only">Submit Search Button</span>
+                        <span class="icon-magnifying-glass icon icon__xs icon--right"></span>
+                    </button>
+                </span>
+            </div>
+            <div class="nav__advanced">
+                <a class="noIcon" href="//www.fedsearch.org/board_public/">Advanced</a>
+            </div>
+        </form>
+        <div class="btn-group visible-xs-table-cell visible-sm-table-cell t1__dropdown">
+            <span class="icon icon__md icon--right dropdown-toggle icon-options-nav" data-toggle="dropdown">
+                <span class="sr-only">Toggle Dropdown Menu</span>
+            </span>
+        </div>
+    </div>
+</div>
+<header class="jumbotron hidden-xs">
+    <a class="jumbotron__link" href="/default.htm" title="Link to Home Page">
+        <div class="container-fluid">
+            <h1 class="jumbotron__heading">Board of Governors of the Federal Reserve System
+            </h1>
+            <p class="jumbotron__content">
+                <em>The Federal Reserve, the central bank of the United States, provides
+          the nation with a safe, flexible, and stable monetary and financial
+          system.</em>
+            </p>
+        </div>
+    </a>
+</header>
+<div class="t2__offcanvas visible-xs-block">
+    <div class="navbar-header">
+        <button type="button" class="offcanvas__toggle icon-offcanvas-nav" data-toggle="offcanvas" data-target="#offcanvasT2Menu" data-canvas="body">
+            <span class="sr-only">Main Menu Toggle Button</span>
+        </button>
+        <span class="navbar-brand offcanvas__title">Sections</span>
+        <button type="button" class="offcanvas__search icon-search-nav" data-toggle="collapse" data-target="#navbar-collapse">
+            <span class="sr-only">Search Toggle Button</span>
+        </button>
+    </div>
+    <div class="navbar-collapse collapse mobile-form" id="navbar-collapse">
+        <form method="get" class="navbar-form" role="search" action="//www.fedsearch.org/board_public/search">
+            <div class="form-group input-group mobileSearch">
+                <label class="sr-only" for="t2search">Search</label>
+                <input id="t2search" name="text" class="form-control" placeholder="Search" type="text" />
+                <span class="input-group-btn">
+                    <span class="sr-only">Search Submit Button</span>
+                    <button type="submit" class="btn btn-default">Submit</button>
+                </span>
+            </div>
+        </form>
+    </div>
+</div>
+<nav class="nav-primary navbar hidden-xs nav-nine" id="nav-primary" role="navigation">
+    <ul class="nav navbar-nav" role="menubar">
+        <li role="menuitem" class="dropdown nav-about dropdown--3Col">
+            <a href="/aboutthefed.htm" class="sr-only-focusable" aria-haspopup="true" id="aboutMenu">About<br />the Fed</a>
+            <ul aria-labelledby="aboutMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fedexplained/who-we-are.htm">Structure of the Federal Reserve System</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/the-fed-explained.htm">The Fed Explained</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/bios/board/default.htm">Board Members</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/advisorydefault.htm">Advisory Councils</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/federal-reserve-system.htm">Federal Reserve Banks</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/directors/about.htm">Federal Reserve Bank and Branch Directors</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fract.htm">Federal Reserve Act</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/currency.htm">Currency</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/boardmeetings/meetingdates.htm">Board Meetings</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/boardvotes.htm">Board Votes</a>
+                            </li>
+
+                            
+
+                            <li>
+                                <a class="sr-only-focusable" href="/careers.htm">Careers</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/procurement/tips.htm">Do Business with the Board</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/k8.htm">Holidays Observed - K.8</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/ethics-values.htm">Ethics & Values</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/contact-us-topics.htm">Contact</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/foia/about_foia.htm">Requesting Information (FOIA)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/faqs.htm">FAQs</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/educational-tools/default.htm">Economic Education</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fed-financial-statements.htm">Fed Financial Statements</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/financial-innovation.htm">Financial Innovation</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-news dropdown--1Col">
+            <a href="/newsevents.htm" class="sr-only-focusable" aria-haspopup="true" id="newsMenu">News<br />& Events</a>
+            <ul aria-labelledby="newsMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/pressreleases.htm">Press Releases</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/speeches-testimony.htm">Speeches & Testimony</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/calendar.htm">Calendar</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/videos.htm">Videos</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/photogallery.htm">Photo Gallery</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/conferences.htm">Conferences</a>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-monetary dropdown--2Col">
+            <a href="/monetarypolicy.htm" class="sr-only-focusable" aria-haspopup="true" id="monetaryMenu">Monetary<br />Policy</a>
+            <ul aria-labelledby="monetaryMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Federal Open Market Committee</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc.htm">About the FOMC</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomccalendars.htm">Meeting calendars and information</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc_historical.htm">Transcripts and other historical materials</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc_projectionsfaqs.htm">FAQs</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Monetary Policy Principles and Practice</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/monetary-policy-principles-and-practice.htm">Notes</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Policy Implementation</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/policy-normalization.htm">Policy Normalization</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/policytools.htm">Policy Tools</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Reports</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/mpr_default.htm">Monetary Policy Report</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/beige-book-default.htm">Beige Book</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/balance-sheet-developments-report.htm">Federal Reserve Balance Sheet Developments</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Review of Monetary Policy Strategy, Tools, and Communications</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/review-of-monetary-policy-strategy-tools-and-communications-2025.htm">Overview</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-supervision dropdown--fw">
+    <a href="/supervisionreg.htm" class="sr-only-focusable" id="supervisionMenu"
+        aria-haspopup="true">Supervision<br />& Regulation</a>
+    <ul aria-labelledby="supervisionMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+        <li>
+            <div class="row">
+                <ul class="col-sm-3 col-nav list-unstyled">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Supervision</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/community-banks.htm">
+                            Community Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/regional-and-small-foreign-banks.htm">
+                            Regional Banks and Foreign Banks with U.S. Assets < $100 Billion</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/large-banks-and-large-foreign-banks.htm">
+                            Large Banks and Large Foreign Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/global-systemically-important-banks.htm">
+                            Global Systemically Important Banks</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/financial-market-utility-supervision.htm">Financial Market
+                            Utilities</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/consumer-compliance.htm">Consumer
+                            Compliance</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/resources-for-supervised-institutions.htm">
+                            Resources for Supervised Institutions</a>
+                    </li>
+
+                    
+
+                    <li class="nav__header">
+                        <p>
+                            <strong>Reports</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/publications/supervision-and-regulation-report.htm">Federal Reserve
+                            Supervision and Regulation Report</a>
+                    </li>
+                </ul>
+                <ul class="col-sm-3 list-unstyled col-nav">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Reporting Forms</strong>
+                        </p>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportingforms/recentupdates">Recent Reporting Form Updates</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportingforms/home/review">Information Collections
+                            Under Review</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["1"]'>Financial
+                            Statements</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["7"]'>Securities Exchange Act of 1934</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable"
+                            href='/apps/ReportingForms/?reportTypesIdsJson=["2"]'>Applications/Structure Change</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["3"]'>FFIEC</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["8"]'>Municipal and
+                            Government Securities</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["9"]'>Activities Monitoring</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/mdrm/'>Micro Data Reference Manual</a>
+                    </li>
+
+                     
+
+                </ul>
+
+
+
+
+                <ul class="col-sm-3 list-unstyled col-nav">
+
+<li class="nav__header">
+                        <p>
+                            <strong>Legal Developments</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/legal-developments.htm">Enforcement Actions and
+                            Legal Developments</a>
+                    </li>
+
+
+                     <li class="nav__header">
+                        <p>
+                            <strong>Mergers, Acquisitions, and Other Applications</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/application-process.htm">Process</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/afi/afi.htm">Filing
+                            Information</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/board-and-reserve-bank-actions.htm">Board and Reserve
+                            Bank Actions</a>
+                    </li>
+
+                
+                    
+                    
+                    
+                </ul>
+
+                <ul class="col-sm-3 list-unstyled col-nav">
+
+<li class="nav__header">
+                        <p>
+                            <strong>Supervision and Regulation Letters</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/srletters/srletters.htm">By Year</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/topics/topics.htm">By Topic</a>
+                    </li>
+
+
+                    <li class="nav__header">
+                        <p>
+                            <strong>Regulatory and Policy Resources</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/aboutthefed/fract.htm">Federal Reserve Act</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/frrs/regulations/bank-holding-company-act-of-1956.htm">Bank Holding Company Act</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/reglisting.htm">Regulations</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/publications/supmanual.htm">Supervision Manuals</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/frrs/federal-reserve-regulatory-service.htm">Federal Reserve Regulatory Service</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/disaster-preparedness-and-recovery-resources.htm">Disaster Preparedness and Recovery Resources
+     </a>
+                    </li>
+
+
+                    
+                </ul>
+                <ul class="col-sm-3 list-unstyled col-nav">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Banking and Data Structure</strong>
+                        </p>
+                    </li>
+
+                    
+
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportforms/insider.aspx">Beneficial Ownership
+                            Reports</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/releases/lbr/">Large Commercial Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/minority-depository-institutions.htm">Minority Depository
+                            Institutions</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/releases/iba/">U.S. Offices of Foreign Entities</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/fhc.htm">Financial Holding
+                            Companies</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/isb-default.htm">Interstate
+                            Branching</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/suds.htm">Securities
+                            Underwriting and Dealing Subsidiaries</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/state-member-banks-supervised-federal-reserve.htm">State Member Banks Supervised by the Federal Reserve</a>
+                    </li>
+
+                    
+                </ul>
+            </div>
+        </li>
+    </ul>
+</li>
+
+
+
+
+
+
+        <li role="menuitem" class="dropdown nav-stability dropdown--2Col">
+            <a href="/financial-stability.htm" class="sr-only-focusable" aria-haspopup="true" id="stabilityMenu">Financial<br />Stability</a>
+            <ul aria-labelledby="stabilityMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <div class="row">
+                    <ul class="col-sm-6 list-unstyled">
+                        <li class="nav__header">
+                            <p>
+                                <strong>Financial Stability Assessments </strong>
+                            </p>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/what-is-financial-stability.htm">About Financial Stability</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/types-of-financial-system-vulnerabilities-and-risks.htm">Types of Financial System Vulnerabilities & Risks</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/monitoring-risk-across-the-financial-system.htm">Monitoring Risk Across the Financial System</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/proactive-monitoring-of-markets-and-institutions.htm">Proactive Monitoring of Markets & Institutions</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/financial-stability-and-stress-testing.htm">Financial Stability & Stress Testing</a>
+                        </li>
+                    </ul>
+                    <ul class="col-sm-6 list-unstyled">
+                        <li class="nav__header">
+                            <p>
+                                <strong>Financial Stability Coordination & Actions</strong>
+                            </p>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/responding-to-financial-system-emergencies.htm">Responding to Financial System Emergencies</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/cooperation-on-financial-stability.htm">Cooperation on Financial Stability</a>
+                        </li>
+                        <li class="nav__header">
+                            <p>
+                                <strong>Reports</strong>
+                            </p>
+                        </li>
+
+                        <li>
+                            <a class="sr-only-focusable" href="/publications/financial-stability-report.htm">Financial Stability Report</a>
+                        </li>
+                    </ul>
+                </div>
+            </ul>
+        </li>
+        <li role="menuitem" class="dropdown nav-payment dropdown--fw">
+            <a href="/paymentsystems.htm" class="sr-only-focusable" id="paymentMenu" aria-haspopup="true">Payment<br />Systems</a>
+            <ul aria-labelledby="paymentMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 col-nav list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Regulations & Statutes</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/regcc-about.htm">Regulation CC (Availability of Funds and Collection of Checks)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/regii-about.htm">Regulation II (Debit Card Interchange Fees and Routing)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/reghh-about.htm">Regulation HH (Financial Market Utilities)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/other-regulations.htm">Other Regulations and Statutes</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Payment Policies</strong>
+                                </p>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/pfs_about.htm">Federal Reserve's Key Policies for the Provision of Financial Services</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/joint_requests.htm">Guidelines for Evaluating Joint Account Requests</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/oo_about.htm">Overnight Overdrafts</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/psr_about.htm">Payment System Risk</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/telecomm.htm">Sponsorship for Priority Telecommunication Services</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Reserve Bank Payment Services & Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedach_about.htm">Automated Clearinghouse Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/check_about.htm">Check Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/coin_about.htm">Currency and Coin Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/psr_data.htm">Daylight Overdrafts and Fees</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fednow_about.htm">FedNow<sup>&reg;</sup> Service</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedfunds_about.htm">Fedwire Funds Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedsecs_about.htm">Fedwire Securities Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fisagy_about.htm">Fiscal Agency Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/master-account-and-services-database-about.htm">Master Account and Services Database</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/natl_about.htm">National Settlement Service</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Financial Market Utilities & Infrastructures</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/over_about.htm">Supervision & Oversight of Financial Market Infrastructures</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/designated_fmu_about.htm">Designated Financial Market Utilities</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/int_standards.htm">International Standards for Financial Market Infrastructures</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Research, Reports, & Committees</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fr-payments-study.htm">Federal Reserve Payments Study (FRPS)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/payres_about.htm">Payments Research</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/reports.htm">Reports</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/pspa_committee.htm">Payments System Policy Advisory Committee</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-econ dropdown--right dropdown--2Col">
+            <a href="/econres.htm" class="sr-only-focusable" aria-haspopup="true" id="econMenu">Economic<br />Research</a>
+            <ul aria-labelledby="econMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-6 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/researchers.htm">Meet the Researchers</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Working Papers and Notes</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/feds/index.htm">Finance and Economics Discussion Series (FEDS)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/notes/feds-notes/default.htm">FEDS Notes</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/ifdp/index.htm">International Finance Discussion Papers (IFDP)</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Data, Models and Tools</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/economic-research-data.htm">Economic Research Data</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/us-models-about.htm">FRB/US Model</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/edo-models-about.htm">Estimated Dynamic Optimization (EDO) Model</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/scfindex.htm">Survey of Consumer Finances (SCF)</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-data dropdown--right dropdown--fw">
+            <a href="/data.htm" class="sr-only-focusable" id="dataMenu" aria-haspopup="true">Data</a>
+            <ul aria-labelledby="dataMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 col-nav list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/datadownload"><span class="icon icon-ddp icon__sm"></span>Data Download Program</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Bank Assets and Liabilities</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h3/current/default.htm">Aggregate Reserves of Depository Institutions and the Monetary Base - H.3</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h8/current/default.htm">Assets and Liabilities of Commercial Banks in the U.S. - H.8</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/assetliab/current.htm">Assets and Liabilities of U.S. Branches and Agencies of Foreign Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/chargeoff/">Charge-Off and Delinquency Rates on Loans and Leases at Commercial Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/sfos/sfos.htm">Senior Financial Officer Survey</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/sloos.htm">Senior Loan Officer Opinion Survey on Bank Lending Practices</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Bank Structure Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/lbr/">Large Commercial Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/minority-depository-institutions.htm">Minority Depository Institutions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/iba/default.htm">Structure and Share Data for the U.S. Offices of Foreign Banks</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Business Finance</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/cp/">Commercial Paper</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g20/current/default.htm">Finance Companies - G.20</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/govsecure/current.htm">New Security Issues, State and Local Governments</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/corpsecure/current.htm">New Security Issues, U.S. Corporations</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Dealer Financing Terms</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/scoos.htm">Senior Credit Officer Opinion Survey on Dealer Financing Terms</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Exchange Rates and International Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h10/current/">Foreign Exchange Rates - H.10/G.5</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/intlsumm/current.htm">International Summary Statistics</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/secholdtrans/current.htm">Securities Holdings and Transactions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/statbanksus/current.htm">Statistics Reported by Banks and Other Financial Firms in the United States</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/iba/default.htm">Structure and Share Data for U.S. Offices of Foreign Banks</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Financial Accounts</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/z1/default.htm">Financial Accounts of the United States - Z.1</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Household Finance</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g19/current/default.htm">Consumer Credit - G.19</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/DSR">Household Debt Service Ratios</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/mortoutstand/current.htm">Mortgage Debt Outstanding</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/scfindex.htm">Survey of Consumer Finances (SCF)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/shed.htm">Survey of Household Economics and Decisionmaking</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Industrial Activity</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g17/current/default.htm">Industrial Production and Capacity Utilization - G.17</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Interest Rates</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h15/">Selected Interest Rates - H.15</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Micro Data Reference Manual (MDRM)</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/mdrm.htm">Micro and Macro Data Collections</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Money Stock and Reserve Balances</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h41/">Factors Affecting Reserve Balances - H.4.1</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h6/current/default.htm">Money Stock Measures - H.6</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Other</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/yield-curve-models.htm">Yield Curve Models and Data</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-consumer dropdown--right dropdown--4Col">
+            <a href="/consumerscommunities.htm" class="sr-only-focusable" aria-haspopup="true" id="consumerMenu">Consumers<br /> & Communities</a>
+            <ul aria-labelledby="consumerMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Regulations</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/cra_about.htm">Community Reinvestment Act (CRA)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/reglisting.htm">All Regulations</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Supervision & Enforcement</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/caletters/caletters.htm">CA Letters</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/apps/enforcementactions/default.aspx">Enforcement Actions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/independent-foreclosure-review.htm">Independent Foreclosure Review</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Community Development</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/neighborhood-revitalization.htm">Housing and Neighborhood Revitalization</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/small-business-and-entrepreneurship.htm">Small Business and Entrepreneurship</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/workforce.htm">Employment and Workforce Development</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/cdf.htm">Community Development Finance</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/rural-community-economic-development.htm">Rural Community and Economic Development</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/conferences.htm">Conferences</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Research & Analysis</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/shed.htm">Survey of Household Economics and Decisionmaking</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/community-development-publications.htm">Research Publications & Data Analysis</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/cac.htm">Community Advisory Council</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Resources for Consumers</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/fraud-scams.htm">Frauds and Scams</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/foreclosure.htm">Mortgage and Foreclosure Resources</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/comm-dev-system-map.htm">Federal Reserve Community Development Resources</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+    </ul>
+</nav>
+    <div id="content" class="container container__main" role="main">
+        <div class="row">          
+            <div class="page-header">
+                <ol class="breadcrumb">
+                    
+                            <li class='breadcrumb__item'><a class="breadcrumb__link" href="/default.htm">Home</a></li>
+                            
+                                                    <li class='breadcrumb__item'><a class="breadcrumb__link" href="/newsevents.htm">News & Events</a></li>
+                                                    
+                                                    <li class='breadcrumb__item'><a class="breadcrumb__link" href="/newsevents/speeches.htm">Speeches</a></li>
+                                                    
+                    
+                
+                                                
+                                                
+                        
+                </ol>            
+                <div class="header-group">
+                    <div class="page-title" id="page-title">
+                        <h2>
+                           2024 Speeches
+                        </h2>
+                    </div>
+                </div>
+            </div>
+            <noscript>
+<div class="js-disabled text-center">
+    <span class='icon icon-alert icon--jsAlert'></span>
+    <span><strong>Please enable JavaScript if it is disabled in your browser or access the information through the links provided below.</strong> </span>
+</div>
+
+</noscript>
+ 
+        </div>
+        <div class="row">
+              
+                           
+            <div class='row eventlist'>
+                <div class="col-xs-12 col-sm-8 col-md-8">         
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>12/3/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/kugler20241203a.htm"><em>A Year in Review: A Tale of Two Supply Shocks</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/live/wY-YR0NoZYs"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Adriana D. Kugler</p>
+                            <p>At the Detroit Economic Club, Detroit, Michigan</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>12/2/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20241202a.htm"><em>Cut or Skip?</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://watch.civl.com/programs/live-from-dc-christopher-waller-federal-reserve"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At "Building a Better Fed Framework," American Institute for Economic Research Monetary Conference, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>11/22/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20241122a.htm"><em>Artificial Intelligence in the Financial System</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the 27th Annual Symposium on Building the Financial System of the 21st Century: An Agenda for Japan and the United States, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>11/20/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20241120a.htm"><em>Approaching Policymaking Pragmatically</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Forum Club of the Palm Beaches, West Palm Beach, Florida</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>11/20/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20241120a.htm"><em>Economic Outlook</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At the University of Virginia, Charlottesville, Virginia</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>11/14/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/powell20241114a.htm"><em>Economic Outlook</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.dallasfed.org/research/events/2024/24gp-powell"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Chair Jerome H. Powell</p>
+                            <p>At Conversation with Federal Reserve Chair Jerome Powell, Dallas, Texas</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>11/14/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/kugler20241114a.htm"><em>Central Bank Independence and the Conduct of Monetary Policy</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://salavirtual-udelar.zoom.us/j/88245227494"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Adriana D. Kugler</p>
+                            <p>At the Albert Hirschman Lecture, 2024 Annual Meeting of the Latin American and Caribbean Economic Association and the Latin American and Caribbean Chapter of the Econometric Society, Montevideo, Uruguay</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>11/12/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20241112a.htm"><em>What Roles Should the Private Sector and the Federal Reserve Play in Payments?</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://tch.webex.com/tch/j.php?MTID=m8299374dc119b52a4535c2e5bdbc9ee8"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At The Clearing House Annual Conference 2024, New York, New York</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>10/23/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20241023a.htm"><em>Opening Remarks</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MzVhZGU5OWEtZDViYy00ZDZhLTliOWMtYjJhYjRiOWJmMzYz%40thread.v2/0?context=%7b%22Tid%22%3a%22b397c653-5b19-463f-b9fc-af658ded9128%22%2c%22Oid%22%3a%22f37e091c-4266-439e-b1fc-d2b71a14271f%22%7d"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Eighth Annual Fintech Conference, Philadelphia, Pennsylvania</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>10/18/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20241018a.htm"><em>Centralized and Decentralized Finance: Substitutes or Complements?</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://go.ihs.ac.at/centralizedfinanceanddecentralizedfinance "><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At the Vienna Macroeconomics Workshop, Institute of Advanced Studies, Vienna, Austria</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>10/14/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20241014a.htm"><em>Thoughts on the Economy and Policy Rules at the Federal Open Market Committee</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At “A 50 Year Retrospective on the Shadow Open Market Committee and  Its Role in Monetary Policy,” a conference sponsored by the Hoover Institution, Stanford University, Stanford, California</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>10/11/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20241011a.htm"><em>Challenges to the Community Banking Model</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.chicagofed.org/events/2024/annual-community-bankers-symposium-18th"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the 18th Annual Community Bankers Symposium, Community Banking: Navigating a Changing Landscape, Chicago, Illinois</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>10/10/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20241010a.htm"><em>Entrepreneurs, Innovation, and Participation</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At the 2024 Women for Women Summit, Charleston, South Carolina</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>10/9/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/jefferson20241009a.htm"><em>The Fed&#39;s Discount Window: 1990 to the Present</em></a></p>
+                                    
+                            <p class="news__speaker">Vice Chair Philip N. Jefferson</p>
+                            <p>At the Charlotte Economics Club, Charlotte, North Carolina</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>10/8/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/jefferson20241008a.htm"><em>A History of the Fed&#39;s Discount Window: 1913–2000</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/live/dHFbJaS5g2U?si=O557Fm207nYj7VPW"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Vice Chair Philip N. Jefferson</p>
+                            <p>At Davidson College, Davidson, North Carolina</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>10/8/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/kugler20241008a.htm"><em>The Global Fight Against Inflation</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.ecb.europa.eu/press/conferences/html/20241007_monetary_policy_conf.en.html"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Adriana D. Kugler</p>
+                            <p>At the Conference on Monetary Policy 2024: Bridging Science and Practice, European Central Bank, Frankfurt, Germany</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>10/2/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20241002a.htm"><em>Building a Community Banking Framework for the Future</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.communitybanking.org/"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the 2024 Community Banking Research Conference, sponsored by the Federal Reserve System, the Conference of State Bank Supervisors, and the Federal Deposit Insurance Corporation, St. Louis, Missouri</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>10/1/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20241001a.htm"><em>Artificial Intelligence, Big Data, and the Path Ahead for Productivity</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/live/7B_DBWrd1rk"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At “Technology-Enabled Disruption: Implications of AI, Big Data, and Remote Work,” a conference organized by the Federal Reserve Banks of Atlanta, Boston, and Richmond, Atlanta, Georgia</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>9/30/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/powell20240930a.htm"><em>Economic Outlook</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/live/fbp9cRgWrBk"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Chair Jerome H. Powell</p>
+                            <p>At the National Association for Business Economics Annual Meeting, Nashville, Tennessee</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>9/30/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240930a.htm"><em>Recent Views on Monetary Policy and the Economic Outlook</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Georgia Bankers Association President/CEO Conference, Charleston, South Carolina</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>9/26/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20240926a.htm"><em>What Will Artificial Intelligence Mean for America’s Workers?</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://osu.zoom.us/j/99149894714?pwd=wNZuNi7j6VBPnGvi5OeK5jkJSIbf0e.1"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At The Ohio State University, Columbus, Ohio</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>9/26/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/barr20240926a.htm"><em>Supporting Market Resilience and Financial Stability</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.newyorkfed.org/newsevents/events/markets/2024/0926-2024"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Vice Chair for Supervision Michael S. Barr</p>
+                            <p>At the 2024 U.S. Treasury Market Conference, Federal Reserve Bank of New York, New York, New York</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>9/26/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/powell20240926a.htm"><em>Opening Remarks</em></a></p>
+                                    
+                            <p><a class='watchLive' href="/newsevents/speech/powell20240926a.htm"><span class="icon-video icon icon__sm"></span><span class="icon-label">Video</span></a></p>
+                                    
+                            <p class="news__speaker">Chair Jerome H. Powell</p>
+                            <p>At the 10th Annual U.S. Treasury Market Conference, Federal Reserve Bank of New York, New York, New York (via prerecorded video)</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>9/26/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240926a.htm"><em>Recent Views on Monetary Policy and the Economic Outlook</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Mid-Size Bank Coalition of America Board of Directors Workshop, Dallas, Texas</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>9/25/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/kugler20240925a.htm"><em>How We Got Here:  A Perspective on Inflation and the Labor Market</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/watch?v=q_j-mlLLs_g&amp;t=4s"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Adriana D. Kugler</p>
+                            <p>At the Mossavar-Rahmani Center for Business and Government, Harvard Kennedy School, Cambridge, Massachusetts </p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>9/24/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240924a.htm"><em>Recent Views on Monetary Policy and the Economic Outlook</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the 2024 Kentucky Bankers Association Annual Convention, Hot Springs, Virginia</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>9/20/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240920a.htm"><em>Statement by Governor Michelle W. Bowman</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p></p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>9/10/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240910a.htm"><em>The Future of Stress Testing and the Stress Capital Buffer Framework</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Executive Council of the Banking Law Section of the Federal Bar Association, Washington, D.C</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>9/10/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/barr20240910a.htm"><em>The Next Steps on Capital</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/user/BrookingsInstitution"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Vice Chair for Supervision Michael S. Barr</p>
+                            <p>At the Brookings Institution, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>9/6/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240906a.htm"><em>The Time Has Come</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/live/4V9q8ePU8AY?feature=shared"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At the University of Notre Dame, Notre Dame, Indiana</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>8/28/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240828a.htm"><em>Interlinking Fast Payment Systems</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/@GlobalFintechFest"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At the Global Fintech Fest, Mumbai, India</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>8/23/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/powell20240823a.htm"><em>Review and Outlook</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/KansasCityFed"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Chair Jerome H. Powell</p>
+                            <p>At “Reassessing the Effectiveness and Transmission of Monetary Policy,” an economic symposium sponsored by the Federal Reserve Bank of Kansas City, Jackson Hole, Wyoming</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>8/20/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240820a.htm"><em>Remarks on the Economic Outlook and Financial Inclusion</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Alaska Bankers Association, Anchorage, Alaska</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>8/19/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240819a.htm"><em>Opening Remarks</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/federalreserve"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At the Summer Workshop on Money, Banking, Payments, and Finance, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>8/10/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240810a.htm"><em>Update on the Economic Outlook, and Perspective on Bank Culture, M&amp;A, and Liquidity</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the 2024 CEO and Senior Management Summit and Annual Meeting, sponsored by the Kansas Bankers Association, Colorado Springs, Colorado</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>7/24/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240724a.htm"><em>Opening Remarks</em></a></p>
+                                    
+                            <p><a class='watchLive' href="/newsevents/speech/bowman20240724a.htm"><span class="icon-video icon icon__sm"></span><span class="icon-label">Video</span></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At "Advance Together: Celebrating the Achievements of Texas Community Partnerships," a public event at the  Federal Reserve Bank of Dallas, Dallas, Texas (via pre-recorded video)</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>7/18/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240718a.htm"><em>Liquidity, Supervision, and Regulatory Reform</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.dallasfed.org/research/events/2024/24deposit"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At "Exploring Conventional Bank Funding Regimes in an Unconventional World" A Research Conference Co-Sponsored by the Federal Reserve Banks of Dallas and Atlanta, Dallas, Texas</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>7/17/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240717a.htm"><em>Getting Closer</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At the Federal Reserve Bank of Kansas City, Kansas City, Missouri</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>7/16/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/kugler20240716a.htm"><em>The Challenges Facing Economic Measurement and Creative Solutions</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Adriana D. Kugler</p>
+                            <p>At the 21st Annual Economic Measurement Seminar, National Association for Business Economics Foundation, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>7/10/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20240710a.htm"><em>Common Inflation and Monetary Policy Challenges across Countries</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/@ACE_2024_Adelaide"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At the Australian Conference of Economists 2024, Adelaide, Australia</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>7/10/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240710a.htm"><em>Opening Remarks</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.chicagofed.org/events/2024/fed-listens"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At Fed Listens: Exploring Challenges Facing the Childcare Industry, Working Parents, and Employers, Chicago, Illinois</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>7/9/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240709a.htm"><em>Promoting an Inclusive Financial System</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/federalreserve"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At Financial Inclusion Practices and Innovations, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>7/9/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/barr20240709a.htm"><em>Financial Inclusion: Past, Present, and Hopes for the Future</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/federalreserve"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Vice Chair for Supervision Michael S. Barr</p>
+                            <p>At Financial Inclusion Practices and Innovations Conference, Board of Governors of the Federal Reserve System, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>6/27/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240627a.htm"><em>Brief Remarks on the Economy, Monetary Policy, and Bank Regulation</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Idaho, Nevada, Oregon, and Washington Bankers Associations 2024 Annual Convention, Stevenson, Washington</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>6/26/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240626a.htm"><em>The Consequences of Bank Capital Reform</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the ISDA Board of Directors, London, England</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>6/25/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240625b.htm"><em>Opening Remarks</em></a></p>
+                                    
+                            <p><a class='watchLive' href="/newsevents/speech/bowman20240625b.htm"><span class="icon-video icon icon__sm"></span><span class="icon-label">Video</span></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Midwest Cyber Workshop hosted by the Federal Reserve Banks of St. Louis, Chicago, and Kansas City, St. Louis, Missouri</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>6/25/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20240625a.htm"><em>Moving Toward Better Balance and Implications for Monetary Policy</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At the Economic Club of New York, New York, New York</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>6/25/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240625a.htm"><em>Perspectives on U.S. Monetary Policy and Bank Capital Reform</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/@PolicyExchangeUK"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At Policy Exchange, London, England</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>6/24/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240624a.htm"><em>Welcoming Remarks</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At the 2024 International Journal of Central Banking Conference, Rome, Italy </p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>6/18/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/kugler20240618a.htm"><em>Some Reasons for Optimism about Inflation</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/watch?v=roj5dKOQkWA"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Adriana D. Kugler</p>
+                            <p>At the Peterson Institute for International Economics, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>6/17/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20240617a.htm"><em>A Transformative Experience</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://youtube.com/live/CCeM-1BhlD8?feature=share"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At the 2024 Marshall Forum: A U.S.-U.K. Strategic and Economic Dialogue, Chicago, Illinois</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>6/17/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240617a.htm"><em>Innovation in the Financial System</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At The Salzburg Global Seminar on Financial Technology Innovation, Social Impact, and Regulation: Do We Need New Paradigms?, Salzburg, Austria</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>6/14/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20240614a.htm"><em>Lessons from the American Economic Association Summer Program</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At Celebrating 50 Years of the American Economic Association Summer Program, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>6/7/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20240607a.htm"><em>A New Class of Trailblazers</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At the Girls Global Academy 2024 Commencement Ceremony, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/28/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240528a.htm"><em>The Federal Reserve&#39;s Balance Sheet as a Monetary Policy Tool:  Past Lessons and Future Considerations</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the 2024 BOJ-IMES Conference, hosted by the Institute for Monetary and Economic Studies, Bank of Japan, Tokyo, Japan</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/24/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240524a.htm"><em>Some Thoughts on r*:  Why Did It Fall and Will It Rise?</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://vimeo.com/event/4306800/d6dcb68fda"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At the Reykjavik Economic Conference, Reykjavik, Iceland</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/21/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240521a.htm"><em>Little by Little, Progress Seems to be Resuming.</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/user/PetersonInstitute"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At the Peterson Institute for International Economics, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/20/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/jefferson20240520a.htm"><em>U.S. Economic Outlook and Housing Price Dynamics</em></a></p>
+                                    
+                            <p class="news__speaker">Vice Chair Philip N. Jefferson</p>
+                            <p>At the Mortgage Bankers Association’s  Secondary and Capital Markets Conference and Expo 2024  New York, New York</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/20/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/barr20240520a.htm"><em>On Building a Resilient Regulatory Framework</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/watch?v=VteV5qCjmqo"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Vice Chair for Supervision Michael S. Barr</p>
+                            <p>At Central Banking in the Post-Pandemic Financial System 28th Annual Financial Markets Conference, the Federal Reserve Bank of Atlanta, Fernandina Beach, Florida</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/20/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240520a.htm"><em>Welcoming Remarks on the International Role of the U.S. Dollar</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/federalreserve"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At the Third Conference on the International Roles of the U.S. Dollar, hosted by the Federal Reserve Board, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/19/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/powell20240519a.htm"><em>Georgetown University Law Center Commencement Address</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.facebook.com/georgetownuniv/"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Chair Jerome H. Powell</p>
+                            <p>At Georgetown University, Washington, D.C. (via prerecorded video)</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/18/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/kugler20240518a.htm"><em>On the Road Ahead, Cherish the Detours</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Adriana D. Kugler</p>
+                            <p>At the 2024 Diploma Ceremony, Frank Batten School of Leadership and Public Policy, University of Virginia, Charlottesville, Virginia</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/17/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240517a.htm"><em>Brief Remarks on the Economy, Monetary Policy, and Bank Regulation</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Pennsylvania Bankers Association 2024 Convention, Nashville, Tennessee</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/17/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240517a.htm"><em>Payments Innovation, Technical Standards, and the Federal Reserve&#39;s Roles</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.minneapolisfed.org/live"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At the International Organization for Standardization Technical Committee 68 Financial Services 44th Plenary Meeting, hosted by the Federal Reserve Bank of Minneapolis, Minneapolis, Minnesota</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/15/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240515a.htm"><em>Innovation and the Evolving Financial Landscape</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At The Digital Chamber DC Blockchain Summit 2024, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/14/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20240514a.htm"><em>Growth and Change at Community Development Financial Institutions</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At the Expanding Access to Capital for CDFIs event, hosted by the Federal Reserve Bank of New York, New York, New York</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/13/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/jefferson20240513a.htm"><em>Communicating about Monetary Policy</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/user/clevelandfed"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Vice Chair Philip N. Jefferson</p>
+                            <p>At “Central Bank Communications: Theory and Practice,” a conference hosted by the Federal Reserve Bank of Cleveland, Cleveland, Ohio</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/10/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/barr20240510a.htm"><em>Commencement Remarks</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.american.edu/commencement/ "><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Vice Chair for Supervision Michael S. Barr</p>
+                            <p>At the American University School of Public Affairs Graduation Ceremony, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/10/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240510a.htm"><em>Financial Stability Risks: Resiliency and the Role of Regulators</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Texas Bankers Association 2024 Annual Meeting, Arlington, Texas</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/8/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20240508a.htm"><em>Current Assessment of Financial Stability</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.brookings.edu/events/a-conversation-on-financial-stability-with-federal-reserve-governor-lisa-cook/"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At the Brookings Institution, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/4/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20240504a.htm"><em>&quot;Oh, the Places You’ll Go and the Things You’ll Do&quot;</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.gcsu.edu/graduation"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At the 2024 Commencement, Georgia College and State University College of Business and Technology and College of Arts and Sciences, at separate ceremonies, Milledgeville, Georgia</p>
+                            <p><strong><em>Governor Cook delivered identical remarks at separate ceremonies for the College of Business and Technology and College of Arts and Sciences on the same date.</em></strong></p>
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>5/3/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240503a.htm"><em>Brief Remarks on the Economy and Monetary Policy</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Massachusetts Bankers Association Annual Convention, Key Biscayne, Florida</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>4/18/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240418a.htm"><em>Opening Remarks</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://newyorkfed-org.zoomgov.com/j/1601885334?pwd=R2JMVDMySkdqZkg3OW83ZGdpRGdXUT09"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the 2024 New York Fed Regional and Community Banking Conference, New York, New York (via prerecorded video)</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>4/16/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/jefferson20240416a.htm"><em>Economic Uncertainty and the Evolution of Monetary Policymaking</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/federalreserve"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Vice Chair Philip N. Jefferson</p>
+                            <p>At the International Research Forum on Monetary Policy, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>4/5/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240405a.htm"><em>Risks and Uncertainty in Monetary Policy: Current and Past Considerations</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/watch?v=rsrEImDo-6g"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At “Frameworks for Monetary Policy, Regulation, and Bank Capital” Spring 2024 Meeting of the Shadow Open Market Committee, hosted by the Manhattan Institute, New York, New York</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>4/4/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/kugler20240404a.htm"><em>Enriching Data and Analysis in Economics with Real Life Experiences</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Adriana D. Kugler</p>
+                            <p>At Women in Economics Symposium, Federal Reserve Bank of St. Louis, St. Louis, Missouri</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>4/3/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/kugler20240403a.htm"><em>The Outlook for the U.S. Economy and Monetary Policy</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://wustl.zoom.us/j/93119963702"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Adriana D. Kugler</p>
+                            <p>At the Weidenbaum Center on the Economy, Government, and Public Policy, Washington University in St. Louis,  St. Louis, Missouri</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>4/3/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/powell20240403a.htm"><em>Opening Remarks</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/watch?v=Y7Il8I9Hb7s"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Chair Jerome H. Powell</p>
+                            <p>At the Stanford Business, Government, and Society Forum, Stanford Graduate School of Business, Stanford, California</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>4/3/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240403a.htm"><em>Bank Liquidity, Regulation, and the Fed&#39;s Role as Lender of Last Resort</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At The Roundtable on the Lender of Last Resort: The 2023 Banking Crisis and COVID, sponsored by the Committee on Capital Markets Regulation, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>4/2/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240402a.htm"><em>Bank Mergers and Acquisitions, and De Novo Bank Formation: Implications for the Future of the Banking System</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At A Workshop on the Future of Banking, hosted by the Federal Reserve Bank of Kansas City, Kansas City, Missouri</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>4/1/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20240401a.htm"><em>Hope, Promise, and Mentors</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At the Samuel DuBois Cook Center Career Achievement Awards Ceremony, the University Club, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>3/27/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240327a.htm"><em>There’s Still No Rush</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At the Economic Club of New York, New York, New York</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>3/25/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20240325a.htm"><em>The Dual Mandate and the Balance of Risks</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At Ec10b Principles of Economics Lecture, Department of Economics, Faculty of Arts and Sciences, Harvard University, Cambridge, Massachusetts</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>3/7/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240307a.htm"><em>Reflections on the Economy and Bank Regulation</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the New Jersey Bankers Association Annual Economic Leadership Forum, Somerset, New Jersey</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>3/5/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240305a.htm"><em>Tailoring, Fidelity to the Rule of Law, and Unintended Consequences</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Harvard Law School Faculty Club, Cambridge, Massachusetts</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>3/1/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/kugler20240301a.htm"><em>Disinflation without a Rise in Unemployment?  What Is Different This Time Around</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://youtu.be/-ClUw7fQ7Vg"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Adriana D. Kugler</p>
+                            <p>At the 2024 Stanford Institute for Economic Policy Research Economic Summit, Stanford University, Stanford, California</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>3/1/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240301a.htm"><em>Thoughts on Quantitative Tightening, Including Remarks on the Paper &quot;Quantitative Tightening around the Globe:  What Have We Learned?&quot;</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At the 2024 U.S. Monetary Policy Forum, New York, New York</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/27/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240227a.htm"><em>Reflections on the Economy and Bank Regulation</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Florida Bankers Association Leadership Luncheon Events, Miami, Florida</p>
+                            <p><strong><em>Governor Bowman presented identical remarks to the Florida Bankers Association Leadership Luncheon Events, Tampa, Florida, on February 28, 2024.</em></strong></p>
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/27/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/barr20240227a.htm"><em>The Importance of Counterparty Credit Risk Management</em></a></p>
+                                    
+                            <p class="news__speaker">Vice Chair for Supervision Michael S. Barr</p>
+                            <p>At Basel Committee on Banking Supervision-Federal Reserve Counterparty Credit Risk Conference, New York, New York</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/22/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240222a.htm"><em>What’s the Rush?</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://uofstthomasmn.my.salesforce-sites.com/summit__SummitEventsRegister?instanceID=a0zHq00000B2DTK"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At the Finding Forward Speaker Series, University of St. Thomas, Opus College of Business, Minneapolis, MN</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/22/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/cook20240222a.htm"><em>Sources of Uncertainty in the Short Run and the Long Run</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://mediacentrallive.princeton.edu/events/2024/jrcppf-13th-annual-conference"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Lisa D. Cook</p>
+                            <p>At "Macrofinance in the Long Run: New Insights on the Global Economy" 2024 Annual Conference of the Julis-Rabinowitz Center for Public Policy & Finance at Princeton's School of Public and International Affairs, Princeton, New Jersey</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/22/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/jefferson20240222a.htm"><em>Is This Time Different? Recent Monetary Policy Cycles in Retrospect</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.piie.com/events/2024/remarks-vice-chair-board-governors-federal-reserve-system-philip-n-jefferson"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Vice Chair Philip N. Jefferson</p>
+                            <p>At the Peterson Institute for International Economics, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/16/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/barr20240216a.htm"><em>Supervision with Speed, Force, and Agility</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://columbiauniversity.zoom.us/s/94590597932"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Vice Chair for Supervision Michael S. Barr</p>
+                            <p>At the Annual Columbia Law School Banking Conference, New York, New York</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/15/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240215a.htm"><em>The Dollar&#39;s International Role</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.facebook.com/events/s/the-government-and-public-poli/290494470374196/?mibextid=9l3rBW"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At "Climate, Currency, and Central Banking," a conference sponsored by the Global Interdependence Center and the University of the Bahamas, Nassau, Bahamas</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/15/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240215a.htm"><em>Advancing Cross-Border Payments and Financial Inclusion</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the 19th BCBS-FSI High-Level Meeting for Africa, Cape Town, South Africa</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/14/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/barr20240214a.htm"><em>The Intersection of Monetary Policy, Market Functioning, and Liquidity Risk Management</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://youtube.com/live/HHHv12FvEpg?feature=sh"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Vice Chair for Supervision Michael S. Barr</p>
+                            <p>At the 40th Annual National Association for Business Economics (NABE)  Economic Policy Conference, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/13/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/bowman-starling-insights-20240213.htm"><em>Accountability for Banks, Accountability for Regulators</em></a> </p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>Essay</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/12/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240212a.htm"><em>Defining a Bank</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://twitter.com/i/broadcasts/1gqGvQDanlQKB"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the American Bankers Association 2024 Conference for Community Bankers, San Antonio, Texas</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/7/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240207a.htm"><em>Supporting Entrepreneurship &amp; Small Businesses</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://fedcommunities.org/event/whos-minding-store-firm-level-characteristics-worker-outcomes/"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the Uneven Outcomes in the Labor Market Conference, Washington, D.C. (via pre-recorded video)</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/7/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/kugler20240207a.htm"><em>The Outlook for the Economy and Monetary Policy</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.brookings.edu/events/a-conversation-with-federal-reserve-governor-adriana-d-kugler/"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Adriana D. Kugler</p>
+                            <p>At the Brookings Institution, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>2/2/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240202a.htm"><em>The Future of Banking</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the 157th Assembly for Bank Directors, Southwestern Graduate School of Banking, Maui, Hawaii</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>1/17/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/barr20240117a.htm"><em>Opening Remarks</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://web.mit.edu/webcast/internetpolicy/s24/"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Vice Chair for Supervision Michael S. Barr</p>
+                            <p>At the Conference on Measuring Cyber Risk in the Financial Services Sector, Boston, Massachusetts</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>1/17/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240117a.htm"><em>The Path Forward for Bank Capital Reform</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.youtube.com/watch?v=mjmcYNmGte0"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At Protect Main Street sponsored by the Center for Capital Markets at the U.S. Chamber of Commerce, Washington, D.C. (virtual)</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>1/16/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/waller20240116a.htm"><em>Almost as Good as It Gets…But Will It Last?</em></a></p>
+                                    
+                            <p><a class='watchLive' href="https://www.brookings.edu/events/a-conversation-with-federal-reserve-governor-christopher-waller/"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a></p>
+                                            
+                            <p class="news__speaker">Governor Christopher J. Waller</p>
+                            <p>At The Brookings Institution, Washington, D.C.</p>
+                            
+                        </div>
+                    </div>
+                                  
+                    <div class="row">
+                        <div class="col-xs-3 col-md-2 eventlist__time">
+                            <time>1/8/2024</time>
+                        </div>
+                        <div class="col-xs-9 col-md-10 eventlist__event">
+                            
+                            <p><a href="/newsevents/speech/bowman20240108a.htm"><em>New Year’s Resolutions for Bank Regulatory Policymakers</em></a></p>
+                                    
+                            <p class="news__speaker">Governor Michelle W. Bowman</p>
+                            <p>At the South Carolina Bankers Association 2024 Community Bankers Conference, Columbia, South Carolina</p>
+                            
+                        </div>
+                    </div>
+                    
+                </div> 
+                <div class="col-xs-12 col-sm-4 col-md-4">
+                    
+                </div>
+           </div>
+        </div>
+        <div class="row">
+            <div id="lastUpdate" class='lastUpdate'>Last Update: 
+                February 26, 2026
+            </div>
+        </div>
+    </div>
+    <a id="back-top" class="icon__backTop icon-backtop" href="#" title="Scroll To Top"><span class="sr-only">Back to Top</span></a>
+                <footer class="container footer">
+                <div class="row footer__content">
+                    <div class="col-xs-12 col-sm-4">
+                        <h6 class="footer__heading"><span class="text-uppercase">Board of Governors</span> <em>of the</em> <span class="text-uppercase">Federal Reserve System</span></h6>
+                        <ul class="list-unstyled">
+                            <li class='footer__listItem'><a class="footer__link" href="/aboutthefed.htm">About the Fed</a></li><li class='footer__listItem'><a class="footer__link" href="/newsevents.htm">News & Events</a></li><li class='footer__listItem'><a class="footer__link" href="/monetarypolicy.htm">Monetary Policy</a></li><li class='footer__listItem'><a class="footer__link" href="/supervisionreg.htm">Supervision & Regulation</a></li><li class='footer__listItem'><a class="footer__link" href="/financial-stability.htm">Financial Stability</a></li><li class='footer__listItem'><a class="footer__link" href="/paymentsystems.htm">Payment Systems</a></li><li class='footer__listItem'><a class="footer__link" href="/econres.htm">Economic Research</a></li><li class='footer__listItem'><a class="footer__link" href="/data.htm">Data</a></li><li class='footer__listItem'><a class="footer__link" href="/consumerscommunities.htm">Consumers & Communities</a></li><li class='footer__listItem'><a class="footer__link" href="/aboutthefed/aroundtheboard/stayconnected-qr-code-2.htm">Connect with the Board</a></li> 
+                        </ul>
+                    </div>
+                    <div class="col-xs-12 col-sm-4">
+                        <h6 class="text-uppercase footer__heading">Tools and Information</h6>
+                        <ul class="list-unstyled">
+                             <li class='footer__listItem'><a href="/aboutthefed/contact-us-topics.htm" class="footer__link">Contact</a></li>
+                            <li class='footer__listItem'><a href="/publications.htm" class="footer__link">Publications</a></li>
+                            <li class='footer__listItem'><a href="/foia/about_foia.htm" class="footer__link">Freedom of Information (FOIA)</a></li>
+                            <li class='footer__listItem'><a href="https://oig.federalreserve.gov/" class="footer__link">Office of Inspector General</a></li>
+                            <li class='footer__listItem'><a href="/publications/annual-report.htm" class="footer__link">Budget &amp; Performance</a> | <a href="/regreform/audit.htm" class="footer__link">Audit</a></li>
+                            <li class='footer__listItem'><a href="/eeo.htm" class="footer__link">No FEAR Act</a></li>
+                            <li class='footer__listItem'><a href="/espanol.htm" class="footer__link">Espa&ntilde;ol</a></li>
+                            <li class='footer__listItem'><a href="/website-linking-policies.htm" class="footer__link">Website Policies</a>  | <a href="/privacy.htm" class="footer__link">Privacy Program</a></li>
+                            <li class='footer__listItem'><a href="/accessibility.htm" class="footer__link">Accessibility</a></li>
+                        </ul>
+                    </div>
+                    <div class="col-xs-12 col-sm-4">
+                        <div class="footer__social">
+                            <h6 class="text-uppercase footer__heading footer__heading--social">Stay Connected</h6>
+                            
+            <a
+              class="icon__md icon footer__btn icon-facebook-color"
+              href="https://www.facebook.com/federalreserve"
+              ><span class="sr-only"
+                >Federal Reserve Facebook Page</span
+              ></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-instagram"
+              href="https://www.instagram.com/federalreserveboard/"
+              ><span class="sr-only"
+                >Federal Reserve Instagram Page</span
+              ></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-youtube-color"
+              href="https://www.youtube.com/federalreserve"
+              ><span class="sr-only"
+                >Federal Reserve YouTube Page</span
+              ></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-flickr-color"
+              href="https://www.flickr.com/photos/federalreserve/"
+              ><span class="sr-only"
+                >Federal Reserve Flickr Page</span
+              ></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-linkedin-color"
+              href="https://www.linkedin.com/company/federal-reserve-board"
+              ><span class="sr-only">Federal Reserve LinkedIn Page</span></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-threads"
+              href="https://www.threads.net/@federalreserveboard"
+              ><span class="sr-only">Federal Reserve Threads Page</span></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-social-x"
+              href="https://x.com/federalreserve"
+              ><span class="sr-only"
+                >Link to Federal Reserve X Page</span
+              ></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-bluesky"
+              href="https://bsky.app/profile/federalreserve.gov"
+              ><span class="sr-only"
+                >Link to Federal Reserve Bluesky Page</span
+              ></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-rss-color"
+              href="/feeds/feeds.htm"
+              ><span class="sr-only">Subscribe to RSS</span></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-email-color"
+              href="/subscribe.htm"
+              ><span class="sr-only">Subscribe to Email</span></a
+            >
+ 
+                        </div>
+                        <a href="https://www.usa.gov/" target="_blank" title="Link to USA.gov">
+                            <img class='footer__image' src="/images/USAGov%402x.png" alt="Link to USA.gov" />
+                        </a>
+                        <a href="/open/open.htm" target="_blank" title="Link to Open.gov">
+                            <img class='footer__image' src="/images/OpenGov%402x.png" alt="Link to Open.gov" />
+                        </a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-xs-12 footer__footer">
+                        <p class="text-uppercase footer__text footer__text--left">Board of Governors <em class="text-lowercase">of the</em> Federal Reserve System</p>
+                        <p class="footer__text footer__text--right">20th Street and Constitution Avenue N.W., Washington, DC 20551</p>
+                    </div>
+                </div>
+            </footer>
+            
+            <script src="/js/jquery.min.js" type="text/javascript"></script>
+            <script src="/js/bootstrap.min.js" type="text/javascript"></script>
+            <script src="/js/scripts.js" type="text/javascript"></script>
+            <script src="/js/modal.js" type="text/javascript"></script>
+            <script src="/js/sticky-tables.js" type="text/javascript"></script>
+            <script type="text/javascript" src="/js/slides/ekko-lightbox.min.js"></script>
+            <script src="/js/t4-nav-controller.js" type="text/javascript"></script>
+                     
+            <script type="text/javascript">
+                $(document).ready(function($) {
+                    // delegate calls to data-toggle="lightbox"
+                    $(document).delegate('*[data-toggle="lightbox"]:not([data-gallery="navigateTo"])', 'click', function(event) {
+                        event.preventDefault();
+                        $(this).ekkoLightbox();
+                    });
+                    $('a[data-click="false"]').click(function(e) {
+                        e.preventDefault();
+                        var target = $(this).data('target');
+                        $(target).click();
+                    });
+                });
+            </script>          
+
+            
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'9f6f64310dd0ba2b',t:'MTc3Nzk4MDM5OA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>
+ 

--- a/tests/fixtures/fed_speech_powell_2024_sample.html
+++ b/tests/fixtures/fed_speech_powell_2024_sample.html
@@ -1,0 +1,1588 @@
+﻿<!doctype html>
+<html lang="en" class="no-js">
+<head>
+    
+    
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.6, user-scalable=1">
+    <meta name="description" content=" Good afternoon. Thank you to the World Affairs Council, the Federal Reserve Bank of Dallas, and the Dallas Regional Chamber for the kind invitation to be with " />
+    <meta property="og:site_name" content="Board of Governors of the Federal Reserve System"/>
+    <meta property="og:type" content="article" /> 
+    <meta property="og:title" content="Speech by Chair Powell on the economic outlook"/>    
+    <meta property="og:image" content="https://www.federalreserve.gov/images/social-media/social-default-image-opengraph.jpg" />
+    <meta property="og:image:alt" content="Board of Governors of the Federal Reserve System" />
+    <meta property="og:description" content=" Good afternoon. Thank you to the World Affairs Council, the Federal Reserve Bank of Dallas, and the Dallas Regional Chamber for the kind invitation to be with "/>
+    <meta property="og:url" content="https://www.federalreserve.gov/newsevents/speech/powell20241114a.htm" />
+    <meta name="twitter:card" content="summary" />    
+    <meta name="twitter:title" content="Speech by Chair Powell on the economic outlook" />
+    <meta name="twitter:image" content="https://www.federalreserve.gov/images/social-media/social-default-image-twitter.jpg" />
+    <meta name="twitter:image:alt" content="Board of Governors of the Federal Reserve System" />
+    <meta name="twitter:description" content=" Good afternoon. Thank you to the World Affairs Council, the Federal Reserve Bank of Dallas, and the Dallas Regional Chamber for the kind invitation to be with " />   
+    <title>Speech by Chair Powell on the economic outlook - Federal Reserve Board</title>
+    
+        <link href="/css/bootstrap.css" rel="stylesheet" type="text/css">
+        <link href="/css/bluesteel-theme.css" rel="stylesheet" type="text/css">
+        <link rel="stylesheet" href="/assets/main.css">
+        <script src="/assets/main.js" defer type="module"></script>
+        <script src="/js/modernizr-latest.js" type="text/javascript"></script>
+        <link href="/css/icons.data.svg.css" rel="stylesheet">           
+        <script src="/js/angular.min.js" type="text/javascript"></script>
+        <script src="/js/app.js" type="text/javascript"></script>
+        
+        <!-- For Linear Gradients in IE9 or greater -->
+        <!--[if gte IE 9]>
+            <style type="text/css">
+              .gradient {
+                 filter: none;
+              }
+            </style>
+        <![endif]-->
+
+ 
+</head>
+<body>
+    <a href="#content" class="globalskip">Skip to main content</a>
+<nav class="nav-primary-mobile" id="nav-primary-mobile"></nav>
+<div id='top-banner' data-hydrate='true'><link rel="preload" as="image" href="/images/icon-us-flag.svg"/><link rel="preload" as="image" href="/images/expand_more.svg"/><link rel="preload" as="image" href="https://designsystem.digital.gov/assets/img/icon-dot-gov.svg"/><link rel="preload" as="image" href="https://designsystem.digital.gov/assets/img/icon-https.svg"/><div class="custom-banner"><div class="custom-banner__header"><div class="custom-banner__left"><img class="custom-banner__flag" src="/images/icon-us-flag.svg" width="20" height="20" alt="US Flag"/><p class="custom-banner__text">An official website of the United States Government</p></div><button type="button" class="custom-banner__button"><span class="custom-banner__button-text">Here&#x27;s how you know</span><img id="banner-caret-_R_0_" class="custom-banner__caret " src="/images/expand_more.svg" alt="Expand More"/></button></div><div class="custom-banner__content " id="banner-content-_R_0_"><div class="custom-banner__info"><div class="info-block"><img src="https://designsystem.digital.gov/assets/img/icon-dot-gov.svg" alt=".gov icon"/><p><strong>Official websites use .gov</strong><br/>A <strong>.gov</strong> website belongs to an official government organization in the United States.</p></div><div class="info-block"><img src="https://designsystem.digital.gov/assets/img/icon-https.svg" alt="HTTPS icon"/><p><strong>Secure .gov websites use HTTPS</strong><br/>A <strong>lock</strong> (<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" role="img" aria-labelledby="banner-lock-description-_R_0_" focusable="false"><title id="banner-lock-title-_R_0_">Lock</title><desc id="banner-lock-description-_R_0_">Locked padlock icon</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"></path></svg></span>) or <strong>https://</strong> means you&#x27;ve safely connected to the .gov website. Share sensitive information only on official, secure websites.</p></div></div></div></div></div><div class="t1_nav navbar navbar-default navbar-fixed-top" role="navigation">
+    <div class="t1_container clearfix">
+        <a id="logo" class="btn btn-default icon-FRB_logo-bw visible-xs-table-cell t1__btnlogo" href="/default.htm" role="button"><span class="sr-only">Back to Home</span></a>
+        <a href="/default.htm" id="banner" class="visible-xs-table-cell t1__banner" title="Link to Home Page" role="button">Board of Governors of the Federal Reserve System</a>
+        <ul class="nav navbar-nav visible-md visible-lg t1_toplinks">
+            <li class="navbar-text navbar-text__social">
+                <span class="navbar-link" tabindex="0">Stay Connected</span>
+            <ul class="nav navbar-nav t1_social social_ten">
+              <li class="social__item">
+                <a
+                  data-icon="facebook"
+                  href="https://www.facebook.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-facebook-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Facebook Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="instagram"
+                  href="https://www.instagram.com/federalreserveboard/"
+                  class="noIcon"
+                >
+                  <div class="icon-instagram icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Instagram Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="youtube"
+                  href="https://www.youtube.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-youtube-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve YouTube Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="flickr"
+                  href="https://www.flickr.com/photos/federalreserve/"
+                  class="noIcon"
+                >
+                  <div class="icon-flickr-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Flickr Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="linkedin"
+                  href="https://www.linkedin.com/company/federal-reserve-board"
+                  class="noIcon"
+                >
+                  <div class="icon-linkedin-color icon icon__sm"></div>
+                  <span class="sr-only">Federal Reserve LinkedIn Page</span></a
+                >
+              </li>
+              <li class="social__item">
+                <a data-icon="threads" href="https://www.threads.net/@federalreserveboard" class="noIcon">
+                  <div class="icon-threads icon icon__sm"></div>
+                  <span class="sr-only">Federal Reserve Threads Page</span></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="twitter"
+                  href="https://x.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-social-x icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve X Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="bluesky"
+                  href="https://bsky.app/profile/federalreserve.gov"
+                  class="noIcon"
+                >
+                  <div class="icon-bluesky icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Bluesky Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a data-icon="rss" href="/feeds/feeds.htm" class="noIcon">
+                  <div class="icon-rss-color icon icon__sm"></div>
+                  <span class="sr-only">Subscribe to RSS</span></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a data-icon="email" href="/subscribe.htm" class="noIcon">
+                  <div class="icon-email-color icon icon__sm"></div>
+                  <span class="sr-only">Subscribe to Email</span></a
+                >
+              </li>
+                </ul>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/recentpostings.htm">Recent Postings</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/newsevents/calendar.htm">Calendar</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/publications.htm">Publications</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/sitemap.htm">Site Map</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/azindex.htm">A-Z index</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/careers.htm">Careers</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/faqs.htm">FAQs</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/videos.htm">Videos</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/aboutthefed/contact-us-topics.htm">Contact</a>
+            </li>
+        </ul>
+        <form class="nav navbar-form hidden-xs nav__search" role="search" action="//www.fedsearch.org/board_public/search"  method="get">
+            <div class="form-group input-group input-group-sm">
+                <label for="t1search" class="sr-only">Search</label>
+                <input id="t1search" class="nav__input form-control" name="text" placeholder="Search" type="text" />
+                <span class="input-group-btn">
+                    <button type="submit" class="nav__button btn btn-default" id="headerTopLinksSearchFormSubmit" name="Search">
+                        <span class="sr-only">Submit Search Button</span>
+                        <span class="icon-magnifying-glass icon icon__xs icon--right"></span>
+                    </button>
+                </span>
+            </div>
+            <div class="nav__advanced">
+                <a class="noIcon" href="//www.fedsearch.org/board_public/">Advanced</a>
+            </div>
+        </form>
+        <div class="btn-group visible-xs-table-cell visible-sm-table-cell t1__dropdown">
+            <span class="icon icon__md icon--right dropdown-toggle icon-options-nav" data-toggle="dropdown">
+                <span class="sr-only">Toggle Dropdown Menu</span>
+            </span>
+        </div>
+    </div>
+</div>
+<header class="jumbotron hidden-xs">
+    <a class="jumbotron__link" href="/default.htm" title="Link to Home Page">
+        <div class="container-fluid">
+            <h1 class="jumbotron__heading">Board of Governors of the Federal Reserve System
+            </h1>
+            <p class="jumbotron__content">
+                <em>The Federal Reserve, the central bank of the United States, provides
+          the nation with a safe, flexible, and stable monetary and financial
+          system.</em>
+            </p>
+        </div>
+    </a>
+</header>
+<div class="t2__offcanvas visible-xs-block">
+    <div class="navbar-header">
+        <button type="button" class="offcanvas__toggle icon-offcanvas-nav" data-toggle="offcanvas" data-target="#offcanvasT2Menu" data-canvas="body">
+            <span class="sr-only">Main Menu Toggle Button</span>
+        </button>
+        <span class="navbar-brand offcanvas__title">Sections</span>
+        <button type="button" class="offcanvas__search icon-search-nav" data-toggle="collapse" data-target="#navbar-collapse">
+            <span class="sr-only">Search Toggle Button</span>
+        </button>
+    </div>
+    <div class="navbar-collapse collapse mobile-form" id="navbar-collapse">
+        <form method="get" class="navbar-form" role="search" action="//www.fedsearch.org/board_public/search">
+            <div class="form-group input-group mobileSearch">
+                <label class="sr-only" for="t2search">Search</label>
+                <input id="t2search" name="text" class="form-control" placeholder="Search" type="text" />
+                <span class="input-group-btn">
+                    <span class="sr-only">Search Submit Button</span>
+                    <button type="submit" class="btn btn-default">Submit</button>
+                </span>
+            </div>
+        </form>
+    </div>
+</div>
+<nav class="nav-primary navbar hidden-xs nav-nine" id="nav-primary" role="navigation">
+    <ul class="nav navbar-nav" role="menubar">
+        <li role="menuitem" class="dropdown nav-about dropdown--3Col">
+            <a href="/aboutthefed.htm" class="sr-only-focusable" aria-haspopup="true" id="aboutMenu">About<br />the Fed</a>
+            <ul aria-labelledby="aboutMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fedexplained/who-we-are.htm">Structure of the Federal Reserve System</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/the-fed-explained.htm">The Fed Explained</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/bios/board/default.htm">Board Members</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/advisorydefault.htm">Advisory Councils</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/federal-reserve-system.htm">Federal Reserve Banks</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/directors/about.htm">Federal Reserve Bank and Branch Directors</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fract.htm">Federal Reserve Act</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/currency.htm">Currency</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/boardmeetings/meetingdates.htm">Board Meetings</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/boardvotes.htm">Board Votes</a>
+                            </li>
+
+                            
+
+                            <li>
+                                <a class="sr-only-focusable" href="/careers.htm">Careers</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/procurement/tips.htm">Do Business with the Board</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/k8.htm">Holidays Observed - K.8</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/ethics-values.htm">Ethics & Values</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/contact-us-topics.htm">Contact</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/foia/about_foia.htm">Requesting Information (FOIA)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/faqs.htm">FAQs</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/educational-tools/default.htm">Economic Education</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fed-financial-statements.htm">Fed Financial Statements</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/financial-innovation.htm">Financial Innovation</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-news dropdown--1Col">
+            <a href="/newsevents.htm" class="sr-only-focusable" aria-haspopup="true" id="newsMenu">News<br />& Events</a>
+            <ul aria-labelledby="newsMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/pressreleases.htm">Press Releases</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/speeches-testimony.htm">Speeches & Testimony</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/calendar.htm">Calendar</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/videos.htm">Videos</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/photogallery.htm">Photo Gallery</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/conferences.htm">Conferences</a>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-monetary dropdown--2Col">
+            <a href="/monetarypolicy.htm" class="sr-only-focusable" aria-haspopup="true" id="monetaryMenu">Monetary<br />Policy</a>
+            <ul aria-labelledby="monetaryMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Federal Open Market Committee</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc.htm">About the FOMC</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomccalendars.htm">Meeting calendars and information</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc_historical.htm">Transcripts and other historical materials</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc_projectionsfaqs.htm">FAQs</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Monetary Policy Principles and Practice</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/monetary-policy-principles-and-practice.htm">Notes</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Policy Implementation</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/policy-normalization.htm">Policy Normalization</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/policytools.htm">Policy Tools</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Reports</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/mpr_default.htm">Monetary Policy Report</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/beige-book-default.htm">Beige Book</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/balance-sheet-developments-report.htm">Federal Reserve Balance Sheet Developments</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Review of Monetary Policy Strategy, Tools, and Communications</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/review-of-monetary-policy-strategy-tools-and-communications-2025.htm">Overview</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-supervision dropdown--fw">
+    <a href="/supervisionreg.htm" class="sr-only-focusable" id="supervisionMenu"
+        aria-haspopup="true">Supervision<br />& Regulation</a>
+    <ul aria-labelledby="supervisionMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+        <li>
+            <div class="row">
+                <ul class="col-sm-3 col-nav list-unstyled">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Supervision</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/community-banks.htm">
+                            Community Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/regional-and-small-foreign-banks.htm">
+                            Regional Banks and Foreign Banks with U.S. Assets < $100 Billion</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/large-banks-and-large-foreign-banks.htm">
+                            Large Banks and Large Foreign Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/global-systemically-important-banks.htm">
+                            Global Systemically Important Banks</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/financial-market-utility-supervision.htm">Financial Market
+                            Utilities</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/consumer-compliance.htm">Consumer
+                            Compliance</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/resources-for-supervised-institutions.htm">
+                            Resources for Supervised Institutions</a>
+                    </li>
+
+                    
+
+                    <li class="nav__header">
+                        <p>
+                            <strong>Reports</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/publications/supervision-and-regulation-report.htm">Federal Reserve
+                            Supervision and Regulation Report</a>
+                    </li>
+                </ul>
+                <ul class="col-sm-3 list-unstyled col-nav">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Reporting Forms</strong>
+                        </p>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportingforms/recentupdates">Recent Reporting Form Updates</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportingforms/home/review">Information Collections
+                            Under Review</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["1"]'>Financial
+                            Statements</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["7"]'>Securities Exchange Act of 1934</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable"
+                            href='/apps/ReportingForms/?reportTypesIdsJson=["2"]'>Applications/Structure Change</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["3"]'>FFIEC</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["8"]'>Municipal and
+                            Government Securities</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["9"]'>Activities Monitoring</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/mdrm/'>Micro Data Reference Manual</a>
+                    </li>
+
+                     
+
+                </ul>
+
+
+
+
+                <ul class="col-sm-3 list-unstyled col-nav">
+
+<li class="nav__header">
+                        <p>
+                            <strong>Legal Developments</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/legal-developments.htm">Enforcement Actions and
+                            Legal Developments</a>
+                    </li>
+
+
+                     <li class="nav__header">
+                        <p>
+                            <strong>Mergers, Acquisitions, and Other Applications</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/application-process.htm">Process</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/afi/afi.htm">Filing
+                            Information</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/board-and-reserve-bank-actions.htm">Board and Reserve
+                            Bank Actions</a>
+                    </li>
+
+                
+                    
+                    
+                    
+                </ul>
+
+                <ul class="col-sm-3 list-unstyled col-nav">
+
+<li class="nav__header">
+                        <p>
+                            <strong>Supervision and Regulation Letters</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/srletters/srletters.htm">By Year</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/topics/topics.htm">By Topic</a>
+                    </li>
+
+
+                    <li class="nav__header">
+                        <p>
+                            <strong>Regulatory and Policy Resources</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/aboutthefed/fract.htm">Federal Reserve Act</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/frrs/regulations/bank-holding-company-act-of-1956.htm">Bank Holding Company Act</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/reglisting.htm">Regulations</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/publications/supmanual.htm">Supervision Manuals</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/frrs/federal-reserve-regulatory-service.htm">Federal Reserve Regulatory Service</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/disaster-preparedness-and-recovery-resources.htm">Disaster Preparedness and Recovery Resources
+     </a>
+                    </li>
+
+
+                    
+                </ul>
+                <ul class="col-sm-3 list-unstyled col-nav">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Banking and Data Structure</strong>
+                        </p>
+                    </li>
+
+                    
+
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportforms/insider.aspx">Beneficial Ownership
+                            Reports</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/releases/lbr/">Large Commercial Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/minority-depository-institutions.htm">Minority Depository
+                            Institutions</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/releases/iba/">U.S. Offices of Foreign Entities</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/fhc.htm">Financial Holding
+                            Companies</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/isb-default.htm">Interstate
+                            Branching</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/suds.htm">Securities
+                            Underwriting and Dealing Subsidiaries</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/state-member-banks-supervised-federal-reserve.htm">State Member Banks Supervised by the Federal Reserve</a>
+                    </li>
+
+                    
+                </ul>
+            </div>
+        </li>
+    </ul>
+</li>
+
+
+
+
+
+
+        <li role="menuitem" class="dropdown nav-stability dropdown--2Col">
+            <a href="/financial-stability.htm" class="sr-only-focusable" aria-haspopup="true" id="stabilityMenu">Financial<br />Stability</a>
+            <ul aria-labelledby="stabilityMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <div class="row">
+                    <ul class="col-sm-6 list-unstyled">
+                        <li class="nav__header">
+                            <p>
+                                <strong>Financial Stability Assessments </strong>
+                            </p>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/what-is-financial-stability.htm">About Financial Stability</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/types-of-financial-system-vulnerabilities-and-risks.htm">Types of Financial System Vulnerabilities & Risks</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/monitoring-risk-across-the-financial-system.htm">Monitoring Risk Across the Financial System</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/proactive-monitoring-of-markets-and-institutions.htm">Proactive Monitoring of Markets & Institutions</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/financial-stability-and-stress-testing.htm">Financial Stability & Stress Testing</a>
+                        </li>
+                    </ul>
+                    <ul class="col-sm-6 list-unstyled">
+                        <li class="nav__header">
+                            <p>
+                                <strong>Financial Stability Coordination & Actions</strong>
+                            </p>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/responding-to-financial-system-emergencies.htm">Responding to Financial System Emergencies</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/cooperation-on-financial-stability.htm">Cooperation on Financial Stability</a>
+                        </li>
+                        <li class="nav__header">
+                            <p>
+                                <strong>Reports</strong>
+                            </p>
+                        </li>
+
+                        <li>
+                            <a class="sr-only-focusable" href="/publications/financial-stability-report.htm">Financial Stability Report</a>
+                        </li>
+                    </ul>
+                </div>
+            </ul>
+        </li>
+        <li role="menuitem" class="dropdown nav-payment dropdown--fw">
+            <a href="/paymentsystems.htm" class="sr-only-focusable" id="paymentMenu" aria-haspopup="true">Payment<br />Systems</a>
+            <ul aria-labelledby="paymentMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 col-nav list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Regulations & Statutes</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/regcc-about.htm">Regulation CC (Availability of Funds and Collection of Checks)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/regii-about.htm">Regulation II (Debit Card Interchange Fees and Routing)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/reghh-about.htm">Regulation HH (Financial Market Utilities)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/other-regulations.htm">Other Regulations and Statutes</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Payment Policies</strong>
+                                </p>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/pfs_about.htm">Federal Reserve's Key Policies for the Provision of Financial Services</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/joint_requests.htm">Guidelines for Evaluating Joint Account Requests</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/oo_about.htm">Overnight Overdrafts</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/psr_about.htm">Payment System Risk</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/telecomm.htm">Sponsorship for Priority Telecommunication Services</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Reserve Bank Payment Services & Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedach_about.htm">Automated Clearinghouse Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/check_about.htm">Check Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/coin_about.htm">Currency and Coin Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/psr_data.htm">Daylight Overdrafts and Fees</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fednow_about.htm">FedNow<sup>&reg;</sup> Service</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedfunds_about.htm">Fedwire Funds Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedsecs_about.htm">Fedwire Securities Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fisagy_about.htm">Fiscal Agency Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/master-account-and-services-database-about.htm">Master Account and Services Database</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/natl_about.htm">National Settlement Service</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Financial Market Utilities & Infrastructures</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/over_about.htm">Supervision & Oversight of Financial Market Infrastructures</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/designated_fmu_about.htm">Designated Financial Market Utilities</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/int_standards.htm">International Standards for Financial Market Infrastructures</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Research, Reports, & Committees</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fr-payments-study.htm">Federal Reserve Payments Study (FRPS)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/payres_about.htm">Payments Research</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/reports.htm">Reports</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/pspa_committee.htm">Payments System Policy Advisory Committee</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-econ dropdown--right dropdown--2Col">
+            <a href="/econres.htm" class="sr-only-focusable" aria-haspopup="true" id="econMenu">Economic<br />Research</a>
+            <ul aria-labelledby="econMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-6 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/researchers.htm">Meet the Researchers</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Working Papers and Notes</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/feds/index.htm">Finance and Economics Discussion Series (FEDS)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/notes/feds-notes/default.htm">FEDS Notes</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/ifdp/index.htm">International Finance Discussion Papers (IFDP)</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Data, Models and Tools</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/economic-research-data.htm">Economic Research Data</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/us-models-about.htm">FRB/US Model</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/edo-models-about.htm">Estimated Dynamic Optimization (EDO) Model</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/scfindex.htm">Survey of Consumer Finances (SCF)</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-data dropdown--right dropdown--fw">
+            <a href="/data.htm" class="sr-only-focusable" id="dataMenu" aria-haspopup="true">Data</a>
+            <ul aria-labelledby="dataMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 col-nav list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/datadownload"><span class="icon icon-ddp icon__sm"></span>Data Download Program</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Bank Assets and Liabilities</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h3/current/default.htm">Aggregate Reserves of Depository Institutions and the Monetary Base - H.3</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h8/current/default.htm">Assets and Liabilities of Commercial Banks in the U.S. - H.8</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/assetliab/current.htm">Assets and Liabilities of U.S. Branches and Agencies of Foreign Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/chargeoff/">Charge-Off and Delinquency Rates on Loans and Leases at Commercial Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/sfos/sfos.htm">Senior Financial Officer Survey</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/sloos.htm">Senior Loan Officer Opinion Survey on Bank Lending Practices</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Bank Structure Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/lbr/">Large Commercial Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/minority-depository-institutions.htm">Minority Depository Institutions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/iba/default.htm">Structure and Share Data for the U.S. Offices of Foreign Banks</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Business Finance</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/cp/">Commercial Paper</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g20/current/default.htm">Finance Companies - G.20</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/govsecure/current.htm">New Security Issues, State and Local Governments</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/corpsecure/current.htm">New Security Issues, U.S. Corporations</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Dealer Financing Terms</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/scoos.htm">Senior Credit Officer Opinion Survey on Dealer Financing Terms</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Exchange Rates and International Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h10/current/">Foreign Exchange Rates - H.10/G.5</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/intlsumm/current.htm">International Summary Statistics</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/secholdtrans/current.htm">Securities Holdings and Transactions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/statbanksus/current.htm">Statistics Reported by Banks and Other Financial Firms in the United States</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/iba/default.htm">Structure and Share Data for U.S. Offices of Foreign Banks</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Financial Accounts</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/z1/default.htm">Financial Accounts of the United States - Z.1</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Household Finance</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g19/current/default.htm">Consumer Credit - G.19</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/DSR">Household Debt Service Ratios</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/mortoutstand/current.htm">Mortgage Debt Outstanding</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/scfindex.htm">Survey of Consumer Finances (SCF)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/shed.htm">Survey of Household Economics and Decisionmaking</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Industrial Activity</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g17/current/default.htm">Industrial Production and Capacity Utilization - G.17</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Interest Rates</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h15/">Selected Interest Rates - H.15</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Micro Data Reference Manual (MDRM)</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/mdrm.htm">Micro and Macro Data Collections</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Money Stock and Reserve Balances</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h41/">Factors Affecting Reserve Balances - H.4.1</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h6/current/default.htm">Money Stock Measures - H.6</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Other</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/yield-curve-models.htm">Yield Curve Models and Data</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-consumer dropdown--right dropdown--4Col">
+            <a href="/consumerscommunities.htm" class="sr-only-focusable" aria-haspopup="true" id="consumerMenu">Consumers<br /> & Communities</a>
+            <ul aria-labelledby="consumerMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Regulations</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/cra_about.htm">Community Reinvestment Act (CRA)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/reglisting.htm">All Regulations</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Supervision & Enforcement</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/caletters/caletters.htm">CA Letters</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/apps/enforcementactions/default.aspx">Enforcement Actions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/independent-foreclosure-review.htm">Independent Foreclosure Review</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Community Development</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/neighborhood-revitalization.htm">Housing and Neighborhood Revitalization</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/small-business-and-entrepreneurship.htm">Small Business and Entrepreneurship</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/workforce.htm">Employment and Workforce Development</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/cdf.htm">Community Development Finance</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/rural-community-economic-development.htm">Rural Community and Economic Development</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/conferences.htm">Conferences</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Research & Analysis</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/shed.htm">Survey of Household Economics and Decisionmaking</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/community-development-publications.htm">Research Publications & Data Analysis</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/cac.htm">Community Advisory Council</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Resources for Consumers</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/fraud-scams.htm">Frauds and Scams</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/foreclosure.htm">Mortgage and Foreclosure Resources</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/comm-dev-system-map.htm">Federal Reserve Community Development Resources</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+    </ul>
+</nav>
+    <div id="content" class="container container__main" role="main">
+        <div class="row">
+            <div class="page-header">
+                <ol id="t3_nav" class="breadcrumb">
+                    
+                            <li class='breadcrumb__item'><a class="breadcrumb__link" href="/default.htm">Home</a></li>
+                            
+                                                    <li class='breadcrumb__item'><a class="breadcrumb__link" href="/newsevents.htm">News & Events</a></li>
+                                                    
+                                                    <li class='breadcrumb__item'><a class="breadcrumb__link" href="/newsevents/speeches.htm">Speeches</a></li>
+                                                    
+                    
+                
+                                                
+                                                
+                        
+                </ol>
+                <div class="header-group">
+                    <div id="page-title" class="page-title">
+                        <h2>
+                            Speech
+                        </h2>
+                    </div>
+                    <div class="shareDL">
+                        <a type="button" href="/newsevents/speech/files/powell20241114a.pdf" class="btn shareDL__button">
+                            <span class="icon icon__sm icon--centered icon-download-header"></span>
+                            <span class="shareDL__iconTitle">PDF</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <noscript>
+<div class="js-disabled text-center">
+    <span class='icon icon-alert icon--jsAlert'></span>
+    <span><strong>Please enable JavaScript if it is disabled in your browser or access the information through the links provided below.</strong> </span>
+</div>
+
+</noscript>
+ 
+        </div>
+        <div class="row">
+              
+            
+            <div id="article">
+                <div class="heading col-xs-12 col-sm-8 col-md-8">
+                    <p class='article__time'>November 14, 2024</p>
+                    <h3 class='title'><em>Economic Outlook</em></h3>
+                    <p class="speaker">
+                        
+                        <a href="/aboutthefed/bios/board/powell.htm">Chair Jerome H. Powell</a>
+                                    
+                                    
+                                    
+                                    
+                                    
+                                    
+                                    
+                        
+                    </p> 
+                    <p class='location'>At Conversation with Federal Reserve Chair Jerome Powell, Dallas, Texas</p>
+                    <ul class="list-unstyled">
+                        <li class="share btn-group">
+                            <a class='shareLink dropdown-toggle' aria-labelledby="shareMenu" role="button" data-toggle="dropdown" href="#">Share<span class="icon-share icon icon__sm icon--right"></span></a>
+                            <ul role="menu" class="dropdown-menu shareDL__dropdown shareDL__dropdown--inline shareDL__dropdown--right" id="shareMenu">
+                                
+
+
+    
+            <li class='shareDL__item'>
+             
+                <a class="shareDL__link icon__link sr-only-focusable" href="https://twitter.com/share?url=https://www.federalreserve.gov/newsevents/speech/powell20241114a.htm&text=Economic Outlook&via=FederalReserve">
+                        <span class="icon icon__sm icon--centered icon-twitter-color"></span>
+                </a>
+            </li>
+            
+            <li class='shareDL__item'>
+             
+                <a class="shareDL__link icon__link sr-only-focusable" href="https://www.facebook.com/sharer.php?u=https://www.federalreserve.gov/newsevents/speech/powell20241114a.htm&name=Economic Outlook">
+                        <span class="icon icon__sm icon--centered icon-facebook-color"></span>
+                </a>
+            </li>
+            
+            <li class='shareDL__item'>
+             
+                <a class="shareDL__link icon__link sr-only-focusable" href="https://www.linkedin.com/shareArticle?url=https://www.federalreserve.gov/newsevents/speech/powell20241114a.htm&title=Economic Outlook&mini=true">
+                        <span class="icon icon__sm icon--centered icon-linkedin-color"></span>
+                </a>
+            </li>
+            
+            <li class='shareDL__item'>
+            
+                <a class="shareDL__link icon__link sr-only-focusable" href="/cdn-cgi/l/email-protection#c1fea3aea5b8fca9b5b5b1b2fbeeeeb6b6b6efa7a4a5a4b3a0adb3a4b2a4b3b7a4efa6aeb7eeafa4b6b2a4b7a4afb5b2eeb2b1a4a4a2a9eeb1aeb6a4adadf3f1f3f5f0f0f0f5a0efa9b5ace7b2b4a3aba4a2b5fc84a2aeafaeaca8a2e18eb4b5adaeaeaa">
+                        <span class="icon icon__sm icon--centered icon-email-color"></span>
+                </a>
+            </li>
+                    
+    
+ 
+ 
+                            </ul>
+                        </li>
+                    </ul>
+                    
+                    <a class='watchLive' href="https://www.dallasfed.org/research/events/2024/24gp-powell"><span class="icon-video icon icon__sm"></span><span class="icon-label">Watch Live</span></a>
+                </div>
+                <div class="col-xs-12 col-sm-4 col-md-4 hidden-sm"></div>
+                <div class="col-xs-12 col-sm-8 col-md-8">
+                    
+                    
+                    <p>Good afternoon. Thank you to the World Affairs Council, the Federal Reserve Bank of Dallas, and the Dallas Regional Chamber for the kind invitation to be with you today. I will start with some brief comments on the economy and monetary policy.</p>
+
+<p>Looking back, the U.S. economy has weathered a global pandemic and its aftermath and is now back to a good place. The economy has made significant progress toward our dual-mandate goals of maximum employment and stable prices. The labor market remains in solid condition. Inflation has eased substantially from its peak, and we believe it is on a sustainable path to our 2 percent goal. We are committed to maintaining our economy's strength by returning inflation to our goal while supporting maximum employment.</p>
+
+<p><strong>Recent Economic Data</strong><br />
+<em>Economic growth</em><br />
+The recent performance of our economy has been remarkably good, by far the best of any major economy in the world. Economic output grew by more than 3 percent last year and is expanding at a stout 2.5 percent rate so far this year. Growth in consumer spending has remained strong, supported by increases in disposable income and solid household balance sheets. Business investment in equipment and intangibles has accelerated over the past year. In contrast, activity in the housing sector has been weak.</p>
+
+<p>Improving supply conditions have supported this strong performance of the economy. The labor force has expanded rapidly, and productivity has grown faster over the past five years than its pace in the two decades before the pandemic, increasing the productive capacity of the economy and allowing rapid economic growth without overheating.</p>
+
+<p><em>The labor market</em><br />
+The labor market remains in solid condition, having cooled off from the significantly overheated conditions of a couple of years ago, and is now by many metrics back to more normal levels that are consistent with our employment mandate. The number of job openings is now just slightly above the number of unemployed Americans seeking work. The rate at which workers quit their jobs is below the pre-pandemic pace, after touching historic highs two years ago. Wages are still increasing, but at a more sustainable pace. Hiring has slowed from earlier in the year. The most recent jobs report for October reflected significant effects from hurricanes and labor strikes, making it difficult to get a clear signal. Finally, at 4.1 percent, the unemployment rate is notably higher than a year ago but has flattened out in recent months and remains historically low.</p>
+
+<p><em>Inflation</em><br />
+The labor market has cooled to the point where it is no longer a source of significant inflationary pressures. This cooling and the substantial improvement in broader supply conditions have brought inflation down significantly over the past two years from its mid-2022 peak above 7 percent. Progress on inflation has been broad based. Estimates based on the consumer price index and other data released this week indicate that total PCE prices rose 2.3 percent over the 12 months ending in October and that, excluding the volatile food and energy categories, core PCE prices rose 2.8 percent. Core measures of goods and services inflation, excluding housing, fell rapidly over the past two years and have returned to rates closer to those consistent with our goals. We expect that these rates will continue to fluctuate in their recent ranges. We are watching carefully to be sure that they do, however, just as we are closely tracking the gradual decline in housing services inflation, which has yet to fully normalize. Inflation is running much closer to our 2 percent longer-run goal, but it is not there yet. We are committed to finishing the job. With labor market conditions in rough balance and inflation expectations well anchored, I expect inflation to continue to come down toward our 2 percent objective, albeit on a sometimes-bumpy path.</p>
+
+<p><strong>Monetary Policy</strong><br />
+Given progress toward our inflation goal and the cooling of labor market conditions, last week my Federal Open Market Committee colleagues and I took another step in reducing the degree of policy restraint by lowering our policy interest rate 1/4 percentage point.</p>
+
+<p>We are confident that with an appropriate recalibration of our policy stance, strength in the economy and the labor market can be maintained, with inflation moving sustainably down to 2 percent. We see the risks to achieving our employment and inflation goals as being roughly in balance, and we are attentive to the risks to both sides. We know that reducing policy restraint too quickly could hinder progress on inflation. At the same time, reducing policy restraint too slowly could unduly weaken economic activity and employment.</p>
+
+<p>We are moving policy over time to a more neutral setting. But the path for getting there is not preset. In considering additional adjustments to the target range for the federal funds rate, we will carefully assess incoming data, the evolving outlook, and the balance of risks. The economy is not sending any signals that we need to be in a hurry to lower rates. The strength we are currently seeing in the economy gives us the ability to approach our decisions carefully. Ultimately, the path of the policy rate will depend on how the incoming data and the economic outlook evolve.</p>
+
+<p>We remain resolute in our commitment to the dual mandate given to us by Congress: maximum employment and price stability. Our aim has been to return inflation to our objective without the kind of painful rise in unemployment that has often accompanied past efforts to bring down high inflation. That would be a highly desirable result for the communities, families, and businesses we serve. While the task is not complete, we have made a good deal of progress toward that outcome.</p>
+
+<p>Thank you, and I look forward to our discussion.</p>
+                     
+                </div>
+                <div class="col-xs-12 col-sm-4 col-md-4">
+                    
+                    
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class='lastUpdate' id="lastUpdate">Last Update:
+                
+                            November 14, 2024
+                        
+            </div>
+            
+            
+        </div>
+    </div>
+
+    <a id="back-top" class="icon__backTop icon-backtop" href="#" title="Scroll To Top"><span class="sr-only">Back to Top</span></a>
+
+                <footer class="container footer">
+                <div class="row footer__content">
+                    <div class="col-xs-12 col-sm-4">
+                        <h6 class="footer__heading"><span class="text-uppercase">Board of Governors</span> <em>of the</em> <span class="text-uppercase">Federal Reserve System</span></h6>
+                        <ul class="list-unstyled">
+                            <li class='footer__listItem'><a class="footer__link" href="/aboutthefed.htm">About the Fed</a></li><li class='footer__listItem'><a class="footer__link" href="/newsevents.htm">News & Events</a></li><li class='footer__listItem'><a class="footer__link" href="/monetarypolicy.htm">Monetary Policy</a></li><li class='footer__listItem'><a class="footer__link" href="/supervisionreg.htm">Supervision & Regulation</a></li><li class='footer__listItem'><a class="footer__link" href="/financial-stability.htm">Financial Stability</a></li><li class='footer__listItem'><a class="footer__link" href="/paymentsystems.htm">Payment Systems</a></li><li class='footer__listItem'><a class="footer__link" href="/econres.htm">Economic Research</a></li><li class='footer__listItem'><a class="footer__link" href="/data.htm">Data</a></li><li class='footer__listItem'><a class="footer__link" href="/consumerscommunities.htm">Consumers & Communities</a></li><li class='footer__listItem'><a class="footer__link" href="/aboutthefed/aroundtheboard/stayconnected-qr-code-2.htm">Connect with the Board</a></li> 
+                        </ul>
+                    </div>
+                    <div class="col-xs-12 col-sm-4">
+                        <h6 class="text-uppercase footer__heading">Tools and Information</h6>
+                        <ul class="list-unstyled">
+                             <li class='footer__listItem'><a href="/aboutthefed/contact-us-topics.htm" class="footer__link">Contact</a></li>
+                            <li class='footer__listItem'><a href="/publications.htm" class="footer__link">Publications</a></li>
+                            <li class='footer__listItem'><a href="/foia/about_foia.htm" class="footer__link">Freedom of Information (FOIA)</a></li>
+                            <li class='footer__listItem'><a href="https://oig.federalreserve.gov/" class="footer__link">Office of Inspector General</a></li>
+                            <li class='footer__listItem'><a href="/publications/annual-report.htm" class="footer__link">Budget &amp; Performance</a> | <a href="/regreform/audit.htm" class="footer__link">Audit</a></li>
+                            <li class='footer__listItem'><a href="/eeo.htm" class="footer__link">No FEAR Act</a></li>
+                            <li class='footer__listItem'><a href="/espanol.htm" class="footer__link">Espa&ntilde;ol</a></li>
+                            <li class='footer__listItem'><a href="/website-linking-policies.htm" class="footer__link">Website Policies</a>  | <a href="/privacy.htm" class="footer__link">Privacy Program</a></li>
+                            <li class='footer__listItem'><a href="/accessibility.htm" class="footer__link">Accessibility</a></li>
+                        </ul>
+                    </div>
+                    <div class="col-xs-12 col-sm-4">
+                        <div class="footer__social">
+                            <h6 class="text-uppercase footer__heading footer__heading--social">Stay Connected</h6>
+                            
+            <a
+              class="icon__md icon footer__btn icon-facebook-color"
+              href="https://www.facebook.com/federalreserve"
+              ><span class="sr-only"
+                >Federal Reserve Facebook Page</span
+              ></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-instagram"
+              href="https://www.instagram.com/federalreserveboard/"
+              ><span class="sr-only"
+                >Federal Reserve Instagram Page</span
+              ></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-youtube-color"
+              href="https://www.youtube.com/federalreserve"
+              ><span class="sr-only"
+                >Federal Reserve YouTube Page</span
+              ></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-flickr-color"
+              href="https://www.flickr.com/photos/federalreserve/"
+              ><span class="sr-only"
+                >Federal Reserve Flickr Page</span
+              ></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-linkedin-color"
+              href="https://www.linkedin.com/company/federal-reserve-board"
+              ><span class="sr-only">Federal Reserve LinkedIn Page</span></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-threads"
+              href="https://www.threads.net/@federalreserveboard"
+              ><span class="sr-only">Federal Reserve Threads Page</span></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-social-x"
+              href="https://x.com/federalreserve"
+              ><span class="sr-only"
+                >Link to Federal Reserve X Page</span
+              ></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-bluesky"
+              href="https://bsky.app/profile/federalreserve.gov"
+              ><span class="sr-only"
+                >Link to Federal Reserve Bluesky Page</span
+              ></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-rss-color"
+              href="/feeds/feeds.htm"
+              ><span class="sr-only">Subscribe to RSS</span></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-email-color"
+              href="/subscribe.htm"
+              ><span class="sr-only">Subscribe to Email</span></a
+            >
+ 
+                        </div>
+                        <a href="https://www.usa.gov/" target="_blank" title="Link to USA.gov">
+                            <img class='footer__image' src="/images/USAGov%402x.png" alt="Link to USA.gov" />
+                        </a>
+                        <a href="/open/open.htm" target="_blank" title="Link to Open.gov">
+                            <img class='footer__image' src="/images/OpenGov%402x.png" alt="Link to Open.gov" />
+                        </a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-xs-12 footer__footer">
+                        <p class="text-uppercase footer__text footer__text--left">Board of Governors <em class="text-lowercase">of the</em> Federal Reserve System</p>
+                        <p class="footer__text footer__text--right">20th Street and Constitution Avenue N.W., Washington, DC 20551</p>
+                    </div>
+                </div>
+            </footer>
+            
+            <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="/js/jquery.min.js" type="text/javascript"></script>
+            <script src="/js/bootstrap.min.js" type="text/javascript"></script>
+            <script src="/js/scripts.js" type="text/javascript"></script>
+            <script src="/js/modal.js" type="text/javascript"></script>
+            <script src="/js/sticky-tables.js" type="text/javascript"></script>
+            <script type="text/javascript" src="/js/slides/ekko-lightbox.min.js"></script>
+            <script src="/js/t4-nav-controller.js" type="text/javascript"></script>
+                     
+            <script type="text/javascript">
+                $(document).ready(function($) {
+                    // delegate calls to data-toggle="lightbox"
+                    $(document).delegate('*[data-toggle="lightbox"]:not([data-gallery="navigateTo"])', 'click', function(event) {
+                        event.preventDefault();
+                        $(this).ekkoLightbox();
+                    });
+                    $('a[data-click="false"]').click(function(e) {
+                        e.preventDefault();
+                        var target = $(this).data('target');
+                        $(target).click();
+                    });
+                });
+            </script>          
+
+            
+            
+
+    <!-- -->
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'9f6f646e58991c2b',t:'MTc3Nzk4MDQwOA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/tests/unit/test_ingest_sources.py
+++ b/tests/unit/test_ingest_sources.py
@@ -7,6 +7,7 @@ import pytest
 
 from app.data import ingest_sources
 from app.data.source_type import (
+    SOURCE_TYPE_CHAIR_SPEECH,
     SOURCE_TYPE_FOMC_MINUTES,
     SOURCE_TYPE_FOMC_STATEMENT,
     SOURCE_TYPE_VALUES,
@@ -75,3 +76,25 @@ def test_write_summary_includes_source_type_counts(tmp_path: Path) -> None:
         SOURCE_TYPE_FOMC_MINUTES: 2,
         SOURCE_TYPE_FOMC_STATEMENT: 1,
     }
+
+
+def test_iter_scraped_records_assigns_chair_speech_source_type(tmp_path: Path) -> None:
+    speeches = [
+        {
+            "date": "2024-01-31",
+            "title": "Chair Powell on inflation",
+            "text": "Full speech text",
+            "document_type": "chair_speech",
+            "url": "https://www.federalreserve.gov/newsevents/speech/powell20240131a.htm",
+            "scraped_at_utc": "2024-01-31T12:00:00+00:00",
+        }
+    ]
+    (tmp_path / "chair_speeches.json").write_text(json.dumps(speeches), encoding="utf-8")
+
+    records = ingest_sources._iter_scraped_records(tmp_path)
+
+    chair_records = [r for r in records if r["source_type"] == SOURCE_TYPE_CHAIR_SPEECH]
+    assert len(chair_records) == 1
+    assert chair_records[0]["source"] == "scraped_fed"
+    assert chair_records[0]["title"] == "Chair Powell on inflation"
+    assert chair_records[0]["event_date"] == "2024-01-31"

--- a/tests/unit/test_scraper_speeches.py
+++ b/tests/unit/test_scraper_speeches.py
@@ -60,3 +60,81 @@ def test_parse_speech_page_extracts_speaker_date_and_body() -> None:
     assert len(parsed.text) > 500
     assert parsed.title  # non-empty
     assert parsed.url == source_url
+
+
+import json
+
+from app.services.scraper_speeches import (
+    is_chair_speech,
+    write_chair_speeches_json,
+)
+
+
+@pytest.mark.parametrize(
+    "speaker,expected",
+    [
+        ("Chair Powell", True),
+        ("Chairman Bernanke", True),
+        ("Chair Jerome H. Powell", True),
+        ("Chair Yellen", True),
+        ("Chairwoman Yellen", True),
+        ("Vice Chair Brainard", False),
+        ("Vice Chairman Clarida", False),
+        ("Governor Waller", False),
+        ("Governor Bowman", False),
+        ("", False),
+    ],
+)
+def test_is_chair_speech_classifies_speaker_correctly(speaker: str, expected: bool) -> None:
+    assert is_chair_speech(speaker) == expected
+
+
+def test_write_chair_speeches_json_emits_one_row_per_chair_speech(tmp_path: Path) -> None:
+    parsed = [
+        ParsedSpeech(
+            date="2024-01-31",
+            speaker="Chair Powell",
+            title="Speech on inflation",
+            text="Full body of the speech " * 30,
+            url="https://www.federalreserve.gov/newsevents/speech/powell20240131a.htm",
+        ),
+        ParsedSpeech(
+            date="2024-02-15",
+            speaker="Governor Waller",
+            title="Speech on the labor market",
+            text="Full body " * 30,
+            url="https://www.federalreserve.gov/newsevents/speech/waller20240215a.htm",
+        ),
+    ]
+
+    output = tmp_path / "chair_speeches.json"
+    written = write_chair_speeches_json(parsed, output)
+
+    assert written == 1
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    row = payload[0]
+    assert row["title"] == "Speech on inflation"
+    assert row["date"] == "2024-01-31"
+    assert row["text"].startswith("Full body of the speech")
+    assert row["document_type"] == "chair_speech"
+    assert row["url"].endswith("powell20240131a.htm")
+    assert "scraped_at_utc" in row
+
+
+def test_write_chair_speeches_json_skips_rows_with_empty_body(tmp_path: Path) -> None:
+    parsed = [
+        ParsedSpeech(
+            date="2024-01-31",
+            speaker="Chair Powell",
+            title="Empty speech",
+            text="",
+            url="https://www.federalreserve.gov/newsevents/speech/powell20240131a.htm",
+        )
+    ]
+    output = tmp_path / "chair_speeches.json"
+    written = write_chair_speeches_json(parsed, output)
+    assert written == 0
+    assert output.read_text(encoding="utf-8") == "[]"

--- a/tests/unit/test_scraper_speeches.py
+++ b/tests/unit/test_scraper_speeches.py
@@ -43,3 +43,20 @@ def test_extract_speech_listing_deduplicates_repeated_urls() -> None:
     entries = extract_speech_listing(html)
     assert len(entries) == 1
     assert entries[0].url.endswith(repeated_url)
+
+
+from app.services.scraper_speeches import ParsedSpeech, parse_speech_page
+
+
+def test_parse_speech_page_extracts_speaker_date_and_body() -> None:
+    html = (FIXTURES / "fed_speech_powell_2024_sample.html").read_text(encoding="utf-8")
+    source_url = "https://www.federalreserve.gov/newsevents/speech/powell20241114a.htm"
+
+    parsed = parse_speech_page(html, source_url=source_url)
+
+    assert isinstance(parsed, ParsedSpeech)
+    assert "Powell" in parsed.speaker
+    assert parsed.date == "2024-11-14"  # date is derivable from the URL
+    assert len(parsed.text) > 500
+    assert parsed.title  # non-empty
+    assert parsed.url == source_url

--- a/tests/unit/test_scraper_speeches.py
+++ b/tests/unit/test_scraper_speeches.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.services.scraper_speeches import (
+    SpeechListingEntry,
+    extract_speech_listing,
+)
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+def test_extract_speech_listing_returns_entries_from_real_archive_page() -> None:
+    html = (FIXTURES / "fed_speech_archive_2024.html").read_text(encoding="utf-8")
+
+    entries = extract_speech_listing(html)
+
+    # The archive lists at least 10 speeches in 2024.
+    assert len(entries) >= 10
+    for entry in entries:
+        assert isinstance(entry, SpeechListingEntry)
+        assert entry.url.startswith("https://www.federalreserve.gov/newsevents/speech/")
+        assert entry.url.endswith(".htm")
+        assert entry.date  # ISO yyyy-mm-dd
+        assert entry.title  # non-empty
+
+
+def test_extract_speech_listing_returns_empty_on_unrelated_html() -> None:
+    assert extract_speech_listing("<html><body>nothing here</body></html>") == []
+
+
+def test_extract_speech_listing_deduplicates_repeated_urls() -> None:
+    """Same URL listed twice in the archive must collapse to one entry."""
+    repeated_url = "/newsevents/speech/powell20240131a.htm"
+    html = f"""
+    <html><body>
+      <a href="{repeated_url}">Speech on inflation</a>
+      <a href="{repeated_url}">Speech on inflation (duplicate)</a>
+    </body></html>
+    """
+    entries = extract_speech_listing(html)
+    assert len(entries) == 1
+    assert entries[0].url.endswith(repeated_url)


### PR DESCRIPTION
## Summary

First Fed-adjacent source for issue #32. Lands the adapter framework (`backend/app/services/scraper_speeches.py`) plus the Chair-speeches scraper end-to-end. Issue #32 stays open — five remaining sources (governor speeches, Congressional testimony, press conferences, regional research, Beige Book) follow in subsequent plans.

## What landed

- Captured HTML fixtures: 2024 speech archive page (3,070 lines) and one Powell 2024 speech page (1,588 lines) under `tests/fixtures/`.
- `extract_speech_listing(html) -> list[SpeechListingEntry]` — parses an annual archive page into deduplicated entries (104 from the 2024 fixture).
- `parse_speech_page(html, source_url) -> ParsedSpeech` — extracts speaker, ISO date, title, and body. Uses `og:title` meta when present, falls through to `<title>` and `<h3>`. Date derived from URL path.
- `is_chair_speech(speaker)` — distinguishes Chair / Chairman / Chairwoman from Vice Chair and Governor speakers.
- `write_chair_speeches_json(parsed, output_path) -> int` — filters to chair only and writes the `data/chair_speeches.json` shape consumed by `ingest_sources._iter_scraped_records`.
- `ingest_sources.SCRAPED_FILES` extended with `chair_speeches.json`; the filename → `source_type` override now routes it to `chair_speech` (using the schema landed in #36).
- `docs/data-and-training-contracts.md` notes Chair speeches in the approved-sources list.
- Wiki `01_Progress_Snapshot.md` notes the new adapter and the remaining-sources tracking under #32.

## Verification

- 101 unit tests pass (16 new in `test_scraper_speeches.py`, 1 new in `test_ingest_sources.py`).
- Live smoke against federalreserve.gov: 5 of 5 Powell 2024 speeches fetched, parsed, classified, written, and ingested. Final registry counts: 42 \`fomc_minutes\` + 6 \`fomc_statement\` + 5 \`chair_speech\`.

## Test plan

- [x] \`docker compose run --rm backend pytest tests/unit -v\` (101 passed)
- [x] Live: \`docker compose run --rm backend python -c\` over the 2024 archive → 5 chair speeches written
- [x] \`docker compose run --rm backend python -m app.data.pipeline_data_prep --include-scraped --dataset-version chair_speech_smoke_v0 --feature-version fv_smoke_v0 --owner schema-smoke\`
- [x] Verify \`source_type_counts.chair_speech > 0\` in \`data/raw/phase2/ingestion_summary.json\`

## Issue tracking

#32 stays OPEN. Remaining adapters: governor speeches, Congressional testimony, press conferences, regional research, Beige Book.