### PR TITLE
Add pseudo-labelling teacher arm (#31, partial — judge follows in #37)

### DIFF
--- a/backend/app/data/phase3_finetune_pilot.py
+++ b/backend/app/data/phase3_finetune_pilot.py
@@ -240,6 +240,13 @@ def run_one(args: argparse.Namespace, *, artifact_dir: Path | None = None) -> di
     train_loss = float(train_output.metrics.get("train_loss", 0.0))
     print(f"[pilot] train_runtime={train_runtime:.1f}s train_loss={train_loss:.4f}")
 
+    model.config.id2label = ID2LABEL
+    model.config.label2id = LABEL2ID
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    model.save_pretrained(str(checkpoint_dir))
+    tokenizer.save_pretrained(str(checkpoint_dir))
+    print(f"[pilot] model and tokenizer saved to {checkpoint_dir}")
+
     # Inference mode (disables dropout, batchnorm-updates, etc.)
     model.train(False)
     device = next(model.parameters()).device

--- a/backend/app/data/pseudo_labeling.py
+++ b/backend/app/data/pseudo_labeling.py
@@ -132,7 +132,7 @@ def load_teacher(checkpoint_path: str):
     return TextClassificationPipeline(
         model=model,
         tokenizer=tokenizer,
-        return_all_scores=True,
+        top_k=None,
         truncation=True,
         max_length=512,
     )

--- a/backend/app/data/pseudo_labeling.py
+++ b/backend/app/data/pseudo_labeling.py
@@ -1,0 +1,78 @@
+"""Pseudo-labelling pipeline for the unlabelled scraped FOMC corpus.
+
+The teacher (Phase-4 fine-tune winner FinBERT-FOMC seed 71) scores each
+unlabelled row in source_registry.jsonl; rows whose max class score
+exceeds the threshold land in registry_pseudo.jsonl with
+label_origin="pseudo" and full provenance metadata. Plan 4 layers an
+LLM-as-judge second annotator + audit on top.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DATA_DIR = Path("/data") if Path("/data").exists() else BACKEND_ROOT.parent / "data"
+DEFAULT_INPUT = DEFAULT_DATA_DIR / "raw" / "phase2" / "source_registry.jsonl"
+DEFAULT_OUTPUT = DEFAULT_DATA_DIR / "interim" / "phase2" / "registry_pseudo.jsonl"
+DEFAULT_AUDIT_DIR = DEFAULT_DATA_DIR / "artifacts" / "pseudo_label_audits"
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Score unlabelled scraped FOMC text with a fine-tuned teacher and write a pseudo-labelled registry."
+    )
+    parser.add_argument(
+        "--teacher-checkpoint",
+        required=True,
+        help="Path to the fine-tuned teacher checkpoint directory (HF model dir).",
+    )
+    parser.add_argument(
+        "--teacher-model-id",
+        default="fomc_roberta_s71",
+        help="Provenance label for the teacher (matches Phase-4 fine-tune batch encoder slot).",
+    )
+    parser.add_argument(
+        "--teacher-model-version",
+        default="phase4_finetune_v1",
+        help="Provenance version string for the teacher.",
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="Source registry JSONL input.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Pseudo-labelled registry JSONL output.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.85,
+        help="Confidence threshold; rows with max class score below this are dropped.",
+    )
+    parser.add_argument(
+        "--max-rows",
+        type=int,
+        default=0,
+        help="Score at most this many rows; 0 means no limit (used for smoke).",
+    )
+    parser.add_argument(
+        "--audit-dir",
+        default=str(DEFAULT_AUDIT_DIR),
+        help="Directory where threshold sweep and audit artefacts are written.",
+    )
+    return parser.parse_args(argv)
+
+
+def main() -> int:
+    args = _parse_args()
+    raise NotImplementedError("Wire orchestrator in Task 4.")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/data/pseudo_labeling.py
+++ b/backend/app/data/pseudo_labeling.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Iterable, Sequence
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_DATA_DIR = Path("/data") if Path("/data").exists() else BACKEND_ROOT.parent / "data"
@@ -72,6 +72,52 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 def main() -> int:
     args = _parse_args()
     raise NotImplementedError("Wire orchestrator in Task 4.")
+
+
+def load_teacher(checkpoint_path: str):
+    """Load a fine-tuned text-classification pipeline from disk.
+
+    Imports transformers lazily so the module can be imported in tests
+    that stub the pipeline directly.
+    """
+
+    from transformers import (  # type: ignore
+        AutoModelForSequenceClassification,
+        AutoTokenizer,
+        TextClassificationPipeline,
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(checkpoint_path)
+    model = AutoModelForSequenceClassification.from_pretrained(checkpoint_path)
+    return TextClassificationPipeline(
+        model=model,
+        tokenizer=tokenizer,
+        return_all_scores=True,
+        truncation=True,
+        max_length=512,
+    )
+
+
+def score_passages(passages: Iterable[str], *, pipeline) -> list[dict[str, Any]]:
+    """Score a batch of passages and return one prediction dict per passage.
+
+    Each prediction carries: predicted_label (argmax label string),
+    max_score (float), scores (dict of label -> float).
+    """
+
+    raw = pipeline(list(passages), batch_size=8)
+    predictions: list[dict[str, Any]] = []
+    for entry in raw:
+        scores = {item["label"]: float(item["score"]) for item in entry}
+        top_label = max(scores, key=scores.get)
+        predictions.append(
+            {
+                "predicted_label": top_label,
+                "max_score": scores[top_label],
+                "scores": scores,
+            }
+        )
+    return predictions
 
 
 if __name__ == "__main__":

--- a/backend/app/data/pseudo_labeling.py
+++ b/backend/app/data/pseudo_labeling.py
@@ -10,6 +10,7 @@ LLM-as-judge second annotator + audit on top.
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
@@ -71,7 +72,19 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main() -> int:
     args = _parse_args()
-    raise NotImplementedError("Wire orchestrator in Task 4.")
+    pipeline = load_teacher(args.teacher_checkpoint)
+    written = run_pseudo_labeling(
+        input_path=Path(args.input),
+        output_path=Path(args.output),
+        teacher_pipeline=pipeline,
+        threshold=args.threshold,
+        teacher_model_id=args.teacher_model_id,
+        teacher_model_version=args.teacher_model_version,
+        max_rows=args.max_rows,
+    )
+    print(f"Pseudo-labelled rows written: {written}")
+    print(f"Output: {args.output}")
+    return 0
 
 
 def load_teacher(checkpoint_path: str):
@@ -156,6 +169,71 @@ def build_pseudo_row(
     row["teacher_max_score"] = float(prediction["max_score"])
     row["teacher_scores"] = dict(prediction["scores"])
     return row
+
+
+def _read_registry_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not path.exists():
+        return rows
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        if isinstance(payload, dict):
+            rows.append(payload)
+    return rows
+
+
+def _is_unlabelled(row: dict[str, Any]) -> bool:
+    """A row is eligible for pseudo-labelling iff it has no human label."""
+
+    return not str(row.get("label", "")).strip()
+
+
+def run_pseudo_labeling(
+    *,
+    input_path: Path,
+    output_path: Path,
+    teacher_pipeline,
+    threshold: float,
+    teacher_model_id: str,
+    teacher_model_version: str,
+    max_rows: int = 0,
+) -> int:
+    """Score unlabelled rows and write the kept pseudo set as JSONL.
+
+    Returns the number of rows written.
+    """
+
+    rows = _read_registry_jsonl(input_path)
+    candidates = [row for row in rows if _is_unlabelled(row)]
+    if max_rows > 0:
+        candidates = candidates[:max_rows]
+
+    if not candidates:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("", encoding="utf-8")
+        return 0
+
+    predictions = score_passages(
+        (row["text"] for row in candidates), pipeline=teacher_pipeline
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    with output_path.open("w", encoding="utf-8") as handle:
+        for row, prediction in zip(candidates, predictions):
+            if prediction["max_score"] < threshold:
+                continue
+            pseudo_row = build_pseudo_row(
+                row,
+                prediction,
+                teacher_model_id=teacher_model_id,
+                teacher_model_version=teacher_model_version,
+            )
+            handle.write(json.dumps(pseudo_row) + "\n")
+            written += 1
+    return written
 
 
 if __name__ == "__main__":

--- a/backend/app/data/pseudo_labeling.py
+++ b/backend/app/data/pseudo_labeling.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from collections import Counter
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
@@ -19,6 +20,32 @@ DEFAULT_DATA_DIR = Path("/data") if Path("/data").exists() else BACKEND_ROOT.par
 DEFAULT_INPUT = DEFAULT_DATA_DIR / "raw" / "phase2" / "source_registry.jsonl"
 DEFAULT_OUTPUT = DEFAULT_DATA_DIR / "interim" / "phase2" / "registry_pseudo.jsonl"
 DEFAULT_AUDIT_DIR = DEFAULT_DATA_DIR / "artifacts" / "pseudo_label_audits"
+
+
+def threshold_sweep(
+    predictions: list[dict[str, Any]], *, thresholds: tuple[float, ...] = (0.75, 0.85, 0.95)
+) -> dict[str, Any]:
+    """Yield + per-class distribution for each threshold over the same predictions.
+
+    Returns a dict shaped for the project document precision/recall trade
+    paragraph: {thresholds, total, yield, label_distribution}.
+    """
+
+    yield_by_tau: dict[str, int] = {}
+    label_by_tau: dict[str, dict[str, int]] = {}
+    for tau in thresholds:
+        kept, _ = apply_threshold(predictions, threshold=tau)
+        key = f"{tau}"
+        yield_by_tau[key] = len(kept)
+        label_by_tau[key] = dict(
+            Counter(p["predicted_label"] for p in kept)
+        )
+    return {
+        "thresholds": list(thresholds),
+        "total": len(predictions),
+        "yield": yield_by_tau,
+        "label_distribution": label_by_tau,
+    }
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:

--- a/backend/app/data/pseudo_labeling.py
+++ b/backend/app/data/pseudo_labeling.py
@@ -120,5 +120,43 @@ def score_passages(passages: Iterable[str], *, pipeline) -> list[dict[str, Any]]
     return predictions
 
 
+def apply_threshold(
+    predictions: list[dict[str, Any]], *, threshold: float
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split predictions into kept (max_score >= threshold) and dropped."""
+
+    kept: list[dict[str, Any]] = []
+    dropped: list[dict[str, Any]] = []
+    for prediction in predictions:
+        if prediction["max_score"] >= threshold:
+            kept.append(prediction)
+        else:
+            dropped.append(prediction)
+    return kept, dropped
+
+
+def build_pseudo_row(
+    source_row: dict[str, Any],
+    prediction: dict[str, Any],
+    *,
+    teacher_model_id: str,
+    teacher_model_version: str,
+) -> dict[str, Any]:
+    """Assemble a registry-shaped pseudo-labelled row.
+
+    Preserves every field of source_row, sets label / label_origin from
+    the prediction, and tacks on teacher provenance.
+    """
+
+    row = dict(source_row)
+    row["label"] = prediction["predicted_label"]
+    row["label_origin"] = "pseudo"
+    row["teacher_model_id"] = teacher_model_id
+    row["teacher_model_version"] = teacher_model_version
+    row["teacher_max_score"] = float(prediction["max_score"])
+    row["teacher_scores"] = dict(prediction["scores"])
+    return row
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -37,7 +37,7 @@ Unmappable labels are excluded and logged.
 - Near-duplicate checks on normalized text
 - No train/test near-duplicate leakage inside the same fold
 - Chronological splits only
-- Pseudo-labeling excludes reporting holdout
+- Pseudo-labeling (`backend/app/data/pseudo_labeling.py`) excludes the reporting holdout. Pseudo rows carry `label_origin = "pseudo"`, `teacher_model_id`, `teacher_model_version`, `teacher_max_score`, and `teacher_scores`.
 - Scalers/statistics fit on train only
 
 ## Training Package Contract

--- a/tests/unit/test_pseudo_labeling.py
+++ b/tests/unit/test_pseudo_labeling.py
@@ -228,3 +228,21 @@ def test_run_pseudo_labeling_scores_only_unlabelled_rows_and_writes_jsonl(tmp_pa
     assert pseudo["teacher_model_id"] == "fomc_roberta_s71"
     assert pseudo["teacher_max_score"] == pytest.approx(0.92)
     assert all(p["record_id"] != "r3" for p in pseudo_rows)
+
+
+def test_threshold_sweep_reports_yield_and_label_distribution_per_threshold() -> None:
+    predictions = [
+        {"predicted_label": "hawkish", "max_score": 0.92, "scores": {}},
+        {"predicted_label": "hawkish", "max_score": 0.80, "scores": {}},
+        {"predicted_label": "dovish", "max_score": 0.78, "scores": {}},
+        {"predicted_label": "dovish", "max_score": 0.40, "scores": {}},
+        {"predicted_label": "neutral", "max_score": 0.97, "scores": {}},
+    ]
+
+    sweep = pseudo_labeling.threshold_sweep(predictions, thresholds=(0.75, 0.85, 0.95))
+
+    assert sweep["thresholds"] == [0.75, 0.85, 0.95]
+    assert sweep["total"] == 5
+    assert sweep["yield"] == {"0.75": 4, "0.85": 2, "0.95": 1}
+    assert sweep["label_distribution"]["0.85"] == {"hawkish": 1, "neutral": 1}
+    assert sweep["label_distribution"]["0.95"] == {"neutral": 1}

--- a/tests/unit/test_pseudo_labeling.py
+++ b/tests/unit/test_pseudo_labeling.py
@@ -30,3 +30,47 @@ def test_parse_args_default_threshold_is_0_85() -> None:
     assert args.threshold == 0.85
     assert args.teacher_model_id == "fomc_roberta_s71"
     assert args.teacher_model_version == "phase4_finetune_v1"
+
+
+class _StubPipeline:
+    """Stand-in for transformers.pipeline that the teacher loader returns."""
+
+    def __init__(self, label_to_score: list[list[dict[str, float]]]):
+        self._batches = label_to_score
+
+    def __call__(self, texts, **kwargs):
+        # Mirror the transformers `text-classification` shape with
+        # return_all_scores=True: list of [list of {label, score}].
+        out = []
+        for _ in texts:
+            out.append(self._batches.pop(0))
+        return out
+
+
+def test_score_passages_returns_one_prediction_per_passage_with_label_and_confidence() -> None:
+    pipeline = _StubPipeline(
+        [
+            [
+                {"label": "hawkish", "score": 0.92},
+                {"label": "dovish", "score": 0.05},
+                {"label": "neutral", "score": 0.03},
+            ],
+            [
+                {"label": "hawkish", "score": 0.30},
+                {"label": "dovish", "score": 0.40},
+                {"label": "neutral", "score": 0.30},
+            ],
+        ]
+    )
+
+    predictions = pseudo_labeling.score_passages(
+        ["Strong tightening signal.", "Mixed signals on the labor market."],
+        pipeline=pipeline,
+    )
+
+    assert len(predictions) == 2
+    assert predictions[0]["predicted_label"] == "hawkish"
+    assert predictions[0]["max_score"] == pytest.approx(0.92)
+    assert predictions[0]["scores"] == {"hawkish": 0.92, "dovish": 0.05, "neutral": 0.03}
+    assert predictions[1]["predicted_label"] == "dovish"
+    assert predictions[1]["max_score"] == pytest.approx(0.40)

--- a/tests/unit/test_pseudo_labeling.py
+++ b/tests/unit/test_pseudo_labeling.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from app.data import pseudo_labeling
@@ -126,3 +129,102 @@ def test_build_pseudo_row_carries_provenance_and_label() -> None:
     assert row["source"] == "scraped_fed"
     assert row["source_type"] == "fomc_minutes"
     assert row["text"] == "Some passage text"
+
+
+def _write_registry_fixture(path: Path) -> None:
+    rows = [
+        {
+            "record_id": "r1",
+            "source": "scraped_fed",
+            "source_record_id": "fomc_minutes.json:0",
+            "document_type": "minutes",
+            "source_type": "fomc_minutes",
+            "event_date": "2024-01-31",
+            "title": "FOMC Meeting Minutes",
+            "text": "Hawkish passage about tightening monetary policy.",
+            "text_hash": "hash1",
+            "license_scope": "public_source_scrape_terms_required",
+            "citation_ref": "federalreserve_primary_source",
+            "ingested_at_utc": "2024-01-31T00:00:00+00:00",
+            "label": "",
+            "label_origin": "pseudo",
+        },
+        {
+            "record_id": "r2",
+            "source": "scraped_fed",
+            "source_record_id": "fomc_minutes.json:1",
+            "document_type": "minutes",
+            "source_type": "fomc_minutes",
+            "event_date": "2024-03-20",
+            "title": "FOMC Meeting Minutes",
+            "text": "Mixed signals on growth.",
+            "text_hash": "hash2",
+            "license_scope": "public_source_scrape_terms_required",
+            "citation_ref": "federalreserve_primary_source",
+            "ingested_at_utc": "2024-03-20T00:00:00+00:00",
+            "label": "",
+            "label_origin": "pseudo",
+        },
+        {
+            "record_id": "r3",
+            "source": "kaggle_fed_statements_minutes",
+            "source_record_id": "kaggle:0",
+            "document_type": "statement",
+            "source_type": "fomc_statement",
+            "event_date": "2024-04-15",
+            "title": "Statement",
+            "text": "A statement that already has a label.",
+            "text_hash": "hash3",
+            "license_scope": "source_terms_required",
+            "citation_ref": "kaggle_drlexus_fed_statements_and_minutes",
+            "ingested_at_utc": "2024-04-15T00:00:00+00:00",
+            "label": "hawkish",
+            "label_origin": "human",
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+def test_run_pseudo_labeling_scores_only_unlabelled_rows_and_writes_jsonl(tmp_path: Path) -> None:
+    input_path = tmp_path / "registry.jsonl"
+    output_path = tmp_path / "registry_pseudo.jsonl"
+    _write_registry_fixture(input_path)
+
+    pipeline = _StubPipeline(
+        [
+            [
+                {"label": "hawkish", "score": 0.92},
+                {"label": "dovish", "score": 0.05},
+                {"label": "neutral", "score": 0.03},
+            ],
+            [
+                {"label": "neutral", "score": 0.40},
+                {"label": "hawkish", "score": 0.35},
+                {"label": "dovish", "score": 0.25},
+            ],
+        ]
+    )
+
+    written = pseudo_labeling.run_pseudo_labeling(
+        input_path=input_path,
+        output_path=output_path,
+        teacher_pipeline=pipeline,
+        threshold=0.85,
+        teacher_model_id="fomc_roberta_s71",
+        teacher_model_version="phase4_finetune_v1",
+    )
+
+    assert written == 1
+
+    pseudo_rows = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+    assert len(pseudo_rows) == 1
+    pseudo = pseudo_rows[0]
+    assert pseudo["record_id"] == "r1"
+    assert pseudo["label"] == "hawkish"
+    assert pseudo["label_origin"] == "pseudo"
+    assert pseudo["teacher_model_id"] == "fomc_roberta_s71"
+    assert pseudo["teacher_max_score"] == pytest.approx(0.92)
+    assert all(p["record_id"] != "r3" for p in pseudo_rows)

--- a/tests/unit/test_pseudo_labeling.py
+++ b/tests/unit/test_pseudo_labeling.py
@@ -74,3 +74,55 @@ def test_score_passages_returns_one_prediction_per_passage_with_label_and_confid
     assert predictions[0]["scores"] == {"hawkish": 0.92, "dovish": 0.05, "neutral": 0.03}
     assert predictions[1]["predicted_label"] == "dovish"
     assert predictions[1]["max_score"] == pytest.approx(0.40)
+
+
+def test_apply_threshold_partitions_predictions_into_kept_and_dropped() -> None:
+    predictions = [
+        {"predicted_label": "hawkish", "max_score": 0.92, "scores": {}},
+        {"predicted_label": "dovish", "max_score": 0.40, "scores": {}},
+        {"predicted_label": "neutral", "max_score": 0.85, "scores": {}},
+    ]
+    kept, dropped = pseudo_labeling.apply_threshold(predictions, threshold=0.85)
+    assert len(kept) == 2
+    assert len(dropped) == 1
+    assert kept[0]["predicted_label"] == "hawkish"
+    assert dropped[0]["predicted_label"] == "dovish"
+
+
+def test_build_pseudo_row_carries_provenance_and_label() -> None:
+    source_row = {
+        "record_id": "abc123",
+        "source": "scraped_fed",
+        "source_record_id": "fomc_minutes.json:12",
+        "document_type": "minutes",
+        "source_type": "fomc_minutes",
+        "event_date": "2024-01-31",
+        "title": "FOMC Meeting Minutes",
+        "text": "Some passage text",
+        "text_hash": "deadbeef",
+        "license_scope": "public_source_scrape_terms_required",
+        "citation_ref": "federalreserve_primary_source",
+        "ingested_at_utc": "2024-01-31T00:00:00+00:00",
+    }
+    prediction = {
+        "predicted_label": "hawkish",
+        "max_score": 0.92,
+        "scores": {"hawkish": 0.92, "dovish": 0.05, "neutral": 0.03},
+    }
+    row = pseudo_labeling.build_pseudo_row(
+        source_row,
+        prediction,
+        teacher_model_id="fomc_roberta_s71",
+        teacher_model_version="phase4_finetune_v1",
+    )
+
+    assert row["record_id"] == "abc123"
+    assert row["label"] == "hawkish"
+    assert row["label_origin"] == "pseudo"
+    assert row["teacher_model_id"] == "fomc_roberta_s71"
+    assert row["teacher_model_version"] == "phase4_finetune_v1"
+    assert row["teacher_max_score"] == pytest.approx(0.92)
+    assert row["teacher_scores"] == prediction["scores"]
+    assert row["source"] == "scraped_fed"
+    assert row["source_type"] == "fomc_minutes"
+    assert row["text"] == "Some passage text"

--- a/tests/unit/test_pseudo_labeling.py
+++ b/tests/unit/test_pseudo_labeling.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from app.data import pseudo_labeling
+
+
+def test_parse_args_requires_teacher_checkpoint() -> None:
+    with pytest.raises(SystemExit):
+        pseudo_labeling._parse_args([])
+
+
+def test_parse_args_accepts_threshold_flag() -> None:
+    args = pseudo_labeling._parse_args(
+        [
+            "--teacher-checkpoint",
+            "/some/path",
+            "--threshold",
+            "0.95",
+        ]
+    )
+    assert args.teacher_checkpoint == "/some/path"
+    assert args.threshold == 0.95
+
+
+def test_parse_args_default_threshold_is_0_85() -> None:
+    args = pseudo_labeling._parse_args(
+        ["--teacher-checkpoint", "/some/path"]
+    )
+    assert args.threshold == 0.85
+    assert args.teacher_model_id == "fomc_roberta_s71"
+    assert args.teacher_model_version == "phase4_finetune_v1"


### PR DESCRIPTION
## Summary

Plan 3 of the 2026-05-05 scope extension. Lands the pseudo-labelling teacher arm of issue #31. The LLM-as-judge augmentation (#37) and audit + Cohen's κ infrastructure follow in the next plan; #31 stays open until both land.

## What landed

- New module \`backend/app/data/pseudo_labeling.py\`:
  - CLI: \`python -m app.data.pseudo_labeling --teacher-checkpoint <path> [--threshold 0.85] [--max-rows N]\`
  - \`load_teacher(checkpoint_path)\` — lazy transformers import, returns a \`TextClassificationPipeline\` with \`top_k=None\` (transformers 5.5+ compatible)
  - \`score_passages(passages, *, pipeline)\` — returns \`{predicted_label, max_score, scores}\` per passage
  - \`apply_threshold(predictions, *, threshold)\` — partitions kept/dropped
  - \`build_pseudo_row(source_row, prediction, *, teacher_model_id, teacher_model_version)\` — registry-shaped row with \`label_origin="pseudo"\` + provenance
  - \`run_pseudo_labeling(...)\` — reads source registry, scores only unlabelled rows, applies threshold, writes JSONL
  - \`threshold_sweep(predictions, thresholds=(0.75, 0.85, 0.95))\` — yield + per-class label distribution per cut
- 8 new unit tests (\`tests/unit/test_pseudo_labeling.py\`) using a stub pipeline so they run without real weights.

## Adjacent fixes

- \`phase3_finetune_pilot.py\` now persists model weights and tokenizer after training (prior runs had \`save_strategy="no"\` which left \`hf_checkpoints/\` empty alongside a valid \`metrics.json\`). Also pins \`config.id2label\` to \`{0: dovish, 1: neutral, 2: hawkish}\` so saved configs do not use \`LABEL_X\` defaults.
- \`docs/data-and-training-contracts.md\` cross-references the new module and enumerates the provenance fields each pseudo row carries.

## Verification

- 109 unit tests pass (8 new in \`test_pseudo_labeling.py\`; rest unchanged).
- Live smoke against the FinBERT-FOMC seed-71 fine-tuned checkpoint: re-trained the seed-71 weights (the empty-checkpoints bug is what triggered the persistence fix), then ran \`python -m app.data.pseudo_labeling --teacher-checkpoint ... --threshold 0.75 --max-rows 50\` → **43/50 pseudo rows written** with \`label_origin="pseudo"\` and full teacher provenance.

## Findings worth flagging for Plan 4

- The Phase-4 fine-tuned teacher's confidence on the 50-row scraped slice tops out near 0.83. The originally-planned \`τ=0.85\` produced 0 pseudo rows on this slice; \`τ=0.75\` produced 43. The judge augmentation in Plan 4 will re-evaluate the right cut alongside the audit gate.

## Test plan

- [x] \`docker compose run --rm backend pytest tests/unit -v\` (109 passed)
- [x] Live smoke: weights re-persisted, \`pseudo_labeling\` runs end-to-end, pseudo row JSON well-formed (label / label_origin / teacher_model_id / teacher_model_version / teacher_max_score / teacher_scores)
- [x] \`config.json["id2label"]\` after re-train: \`{0: dovish, 1: neutral, 2: hawkish}\`

## Issue tracking

#31 stays OPEN. Plan 4 closes it after the LLM-as-judge augmentation, three gating policies, audit set, and Cohen's κ inter-annotator agreement land.