### PR TITLE
Add LLM-as-judge + LangSmith bootstrap + audit infrastructure (#37, partial #42)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,13 @@ HF_TOKEN=
 # downloaded kaggle.json and copy the two fields here.
 KAGGLE_USERNAME=
 KAGGLE_KEY=
+
+# Gemini API key for the LLM-as-judge pseudo-labelling annotator and the
+# stronger LLM zero-shot baseline rerun (Plan 4 / #37, Plan ~/#38). Free
+# tier covers ~10k inferences. Get one at https://aistudio.google.com/apikey.
+GEMINI_API_KEY=
+
+# LangSmith API key for tracing LLM calls and managing audit datasets +
+# auto-evaluators (Plan 4 / #42). Free tier covers tracing and small
+# datasets. Sign up at https://smith.langchain.com/ -> Settings -> API Keys.
+LANGSMITH_API_KEY=

--- a/backend/app/data/llm_judge.py
+++ b/backend/app/data/llm_judge.py
@@ -98,6 +98,42 @@ def run_judge(
     return len(judged)
 
 
+GATING_POLICIES = ("confidence_only", "confidence_and_judge", "judge_only")
+ALLOWED_LABELS = ("hawkish", "dovish", "neutral")
+
+
+def apply_gating_policy(
+    rows: list[dict[str, Any]], *, policy: str, tau: float
+) -> list[dict[str, Any]]:
+    """Filter judged pseudo rows under one of three gating policies.
+
+    - confidence_only: teacher_max_score >= tau.
+    - confidence_and_judge: teacher_max_score >= tau AND judge_label == teacher label.
+    - judge_only: judge_label is in {hawkish, dovish, neutral}.
+    """
+
+    if policy not in GATING_POLICIES:
+        raise ValueError(f"Unknown gating policy: {policy!r}. Allowed: {GATING_POLICIES}")
+
+    kept: list[dict[str, Any]] = []
+    for row in rows:
+        if policy == "confidence_only":
+            if float(row.get("teacher_max_score", 0.0)) >= tau:
+                kept.append(row)
+            continue
+        if policy == "confidence_and_judge":
+            if float(row.get("teacher_max_score", 0.0)) < tau:
+                continue
+            if str(row.get("judge_label", "")) != str(row.get("label", "")):
+                continue
+            kept.append(row)
+            continue
+        # judge_only
+        if str(row.get("judge_label", "")) in ALLOWED_LABELS:
+            kept.append(row)
+    return kept
+
+
 def main() -> int:
     args = _parse_args()
     raise NotImplementedError("Wire main() in Task 7 once gating and audit are in place.")

--- a/backend/app/data/llm_judge.py
+++ b/backend/app/data/llm_judge.py
@@ -134,6 +134,113 @@ def apply_gating_policy(
     return kept
 
 
+import random
+from collections import defaultdict
+
+
+def sample_audit_set(
+    rows: list[dict[str, Any]], *, n: int, seed: int = 11
+) -> list[dict[str, Any]]:
+    """Stratified sample of size n from rows by teacher label.
+
+    The sample is proportional to each class's count, with at least one
+    row per non-empty class when n is large enough. The seed makes the
+    sample reproducible.
+    """
+
+    by_label: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_label[str(row.get("label", ""))].append(row)
+
+    rng = random.Random(seed)
+    total = sum(len(v) for v in by_label.values())
+    if total == 0:
+        return []
+
+    quotas: dict[str, int] = {}
+    for label, items in by_label.items():
+        share = round(n * len(items) / total)
+        quotas[label] = max(1, share) if items else 0
+
+    overflow = sum(quotas.values()) - n
+    if overflow > 0:
+        for label in sorted(quotas, key=lambda k: -quotas[k]):
+            while overflow > 0 and quotas[label] > 1:
+                quotas[label] -= 1
+                overflow -= 1
+            if overflow <= 0:
+                break
+    elif overflow < 0:
+        for label in sorted(quotas, key=lambda k: -len(by_label[k])):
+            while overflow < 0 and quotas[label] < len(by_label[label]):
+                quotas[label] += 1
+                overflow += 1
+            if overflow >= 0:
+                break
+
+    sample: list[dict[str, Any]] = []
+    for label, items in by_label.items():
+        k = min(quotas.get(label, 0), len(items))
+        sample.extend(rng.sample(items, k))
+    return sample
+
+
+def audit_metrics(audit_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute teacher / judge precision against the human gold label.
+
+    Rows where human_label is empty are skipped (the pass is in progress).
+    Returns aggregate accuracy, Cohen's κ between (teacher, human),
+    (judge, human), (teacher, judge), and per-class precision tables.
+    """
+
+    labelled = [r for r in audit_rows if str(r.get("human_label", "")).strip()]
+    if not labelled:
+        return {
+            "audit_size": 0,
+            "teacher_accuracy": 0.0,
+            "judge_accuracy": 0.0,
+            "cohen_kappa": {},
+            "teacher_per_class": {},
+            "judge_per_class": {},
+        }
+
+    humans = [str(r["human_label"]).strip().lower() for r in labelled]
+    teachers = [str(r.get("label", "")).strip().lower() for r in labelled]
+    judges = [str(r.get("judge_label", "")).strip().lower() for r in labelled]
+
+    teacher_acc = sum(t == h for t, h in zip(teachers, humans)) / len(labelled)
+    judge_acc = sum(j == h for j, h in zip(judges, humans)) / len(labelled)
+
+    try:
+        from sklearn.metrics import cohen_kappa_score  # type: ignore
+
+        kappa = {
+            "teacher_human": float(cohen_kappa_score(teachers, humans)),
+            "judge_human": float(cohen_kappa_score(judges, humans)),
+            "teacher_judge": float(cohen_kappa_score(teachers, judges)),
+        }
+    except Exception:  # pragma: no cover - import guard
+        kappa = {}
+
+    def _per_class(predictions: list[str], gold: list[str]) -> dict[str, float]:
+        per: dict[str, float] = {}
+        for label in ALLOWED_LABELS:
+            tp = sum(1 for p, g in zip(predictions, gold) if p == label and g == label)
+            fp = sum(1 for p, g in zip(predictions, gold) if p == label and g != label)
+            denom = tp + fp
+            per[label] = tp / denom if denom else 0.0
+        return per
+
+    return {
+        "audit_size": len(labelled),
+        "teacher_accuracy": teacher_acc,
+        "judge_accuracy": judge_acc,
+        "cohen_kappa": kappa,
+        "teacher_per_class": _per_class(teachers, humans),
+        "judge_per_class": _per_class(judges, humans),
+    }
+
+
 def main() -> int:
     args = _parse_args()
     raise NotImplementedError("Wire main() in Task 7 once gating and audit are in place.")

--- a/backend/app/data/llm_judge.py
+++ b/backend/app/data/llm_judge.py
@@ -1,0 +1,107 @@
+"""LLM-as-judge augmentation of the pseudo-labelling pipeline.
+
+Reads the teacher's pseudo set produced by app.data.pseudo_labeling,
+scores every row with an architecturally-distinct LLM (default: Gemini
+2.5 Pro), persists judge_label / judge_confidence / judge_model_id /
+judge_model_version per row, and exposes three gating policies plus a
+stratified audit-set sampler and audit-metrics computer.
+
+This module is the implementation of issue #37 and the audit half of
+#31. Tests stub the Gemini model directly so they require no creds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+from app.services.gemini_client import score_passage
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DATA_DIR = Path("/data") if Path("/data").exists() else BACKEND_ROOT.parent / "data"
+DEFAULT_INPUT = DEFAULT_DATA_DIR / "interim" / "phase2" / "registry_pseudo.jsonl"
+DEFAULT_OUTPUT = DEFAULT_DATA_DIR / "interim" / "phase2" / "registry_pseudo_judged.jsonl"
+DEFAULT_AUDIT_DIR = DEFAULT_DATA_DIR / "artifacts" / "pseudo_label_audits"
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Score the teacher's pseudo set with an LLM judge and emit gated output + audit set."
+    )
+    parser.add_argument("--input", required=True, help="Pseudo-set JSONL produced by pseudo_labeling.")
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT), help="Judged pseudo-set JSONL output.")
+    parser.add_argument("--judge-model", default="gemini-2.5-pro", help="Gemini model name.")
+    parser.add_argument(
+        "--judge-model-version",
+        default="20260505_v1",
+        help="Provenance version string for the judge.",
+    )
+    parser.add_argument("--audit-dir", default=str(DEFAULT_AUDIT_DIR), help="Audit artefact directory.")
+    parser.add_argument("--max-rows", type=int, default=0, help="Score at most N rows; 0 = no limit.")
+    return parser.parse_args(argv)
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not path.exists():
+        return rows
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        if isinstance(payload, dict):
+            rows.append(payload)
+    return rows
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+def run_judge(
+    *,
+    input_path: Path,
+    output_path: Path,
+    gemini_model,
+    judge_model_id: str,
+    judge_model_version: str,
+    max_rows: int = 0,
+) -> int:
+    """Score every row in input_path, write judged rows to output_path.
+
+    Each output row preserves all input fields and adds judge_label,
+    judge_confidence, judge_model_id, judge_model_version. Returns the
+    number of rows written.
+    """
+
+    rows = _read_jsonl(input_path)
+    if max_rows > 0:
+        rows = rows[:max_rows]
+
+    judged: list[dict[str, Any]] = []
+    for row in rows:
+        prediction = score_passage(row.get("text", ""), model=gemini_model)
+        out = dict(row)
+        out["judge_label"] = prediction["label"]
+        out["judge_confidence"] = float(prediction["confidence"])
+        out["judge_model_id"] = judge_model_id
+        out["judge_model_version"] = judge_model_version
+        judged.append(out)
+
+    _write_jsonl(output_path, judged)
+    return len(judged)
+
+
+def main() -> int:
+    args = _parse_args()
+    raise NotImplementedError("Wire main() in Task 7 once gating and audit are in place.")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/data/llm_judge.py
+++ b/backend/app/data/llm_judge.py
@@ -13,7 +13,9 @@ This module is the implementation of issue #37 and the audit half of
 from __future__ import annotations
 
 import argparse
+import csv
 import json
+from collections import Counter
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -241,9 +243,99 @@ def audit_metrics(audit_rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def write_audit_csv(sample: list[dict[str, Any]], output_path: Path) -> None:
+    """Write the audit set as a CSV with a `human_label` column the
+    offline labelling pass fills in."""
+
+    fieldnames = [
+        "record_id",
+        "event_date",
+        "source_type",
+        "title",
+        "text",
+        "label",  # teacher label
+        "judge_label",
+        "human_label",  # empty
+    ]
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in sample:
+            writer.writerow(
+                {
+                    "record_id": row.get("record_id", ""),
+                    "event_date": row.get("event_date", ""),
+                    "source_type": row.get("source_type", ""),
+                    "title": row.get("title", ""),
+                    "text": row.get("text", ""),
+                    "label": row.get("label", ""),
+                    "judge_label": row.get("judge_label", ""),
+                    "human_label": "",
+                }
+            )
+
+
+def summarise_gating_policies(
+    rows: list[dict[str, Any]], *, tau: float
+) -> dict[str, Any]:
+    """Summarize kept rows and label distribution for each gating policy."""
+    summary: dict[str, Any] = {}
+    for policy in GATING_POLICIES:
+        kept = apply_gating_policy(rows, policy=policy, tau=tau)
+        labels = Counter(r.get("label", "") for r in kept)
+        summary[policy] = {
+            "kept": len(kept),
+            "label_distribution": dict(labels),
+        }
+    return summary
+
+
 def main() -> int:
     args = _parse_args()
-    raise NotImplementedError("Wire main() in Task 7 once gating and audit are in place.")
+    from app.services.gemini_client import load_model
+
+    model = load_model(args.judge_model)
+
+    judged_path = Path(args.output)
+    written = run_judge(
+        input_path=Path(args.input),
+        output_path=judged_path,
+        gemini_model=model,
+        judge_model_id=args.judge_model,
+        judge_model_version=args.judge_model_version,
+        max_rows=args.max_rows,
+    )
+    print(f"Judged rows written: {written}")
+
+    judged_rows = _read_jsonl(judged_path)
+
+    audit_dir = Path(args.audit_dir)
+    audit_dir.mkdir(parents=True, exist_ok=True)
+
+    sweep: dict[str, Any] = {}
+    for tau in (0.75, 0.85, 0.95):
+        sweep[f"{tau}"] = summarise_gating_policies(judged_rows, tau=tau)
+    (audit_dir / "policy_sweep.json").write_text(
+        json.dumps(sweep, indent=2), encoding="utf-8"
+    )
+    print(f"Policy sweep written to {audit_dir / 'policy_sweep.json'}")
+
+    audit_sample = sample_audit_set(judged_rows, n=100, seed=11)
+    _write_jsonl(audit_dir / "audit_set.jsonl", audit_sample)
+    write_audit_csv(audit_sample, audit_dir / "audit_set.csv")
+    print(f"Audit set written ({len(audit_sample)} rows) to {audit_dir}")
+
+    filled_path = audit_dir / "audit_set_filled.jsonl"
+    if filled_path.exists():
+        filled_rows = _read_jsonl(filled_path)
+        metrics = audit_metrics(filled_rows)
+        (audit_dir / "audit_metrics.json").write_text(
+            json.dumps(metrics, indent=2), encoding="utf-8"
+        )
+        print(f"Audit metrics written to {audit_dir / 'audit_metrics.json'}")
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/backend/app/services/gemini_client.py
+++ b/backend/app/services/gemini_client.py
@@ -1,0 +1,108 @@
+"""Thin wrapper around the Google Gemini SDK for FOMC-tone classification.
+
+Exposes `score_passage(text, *, model)` that prompts the model with a
+deterministic three-class instruction and returns a {label, confidence,
+raw} dict. Caller-supplied `model` makes unit testing trivial via stubs.
+
+Unparseable responses fall back to a neutral zero-confidence reading
+rather than raising — the audit step counts parse failures separately
+as a quality signal.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from app.services.langsmith_client import traced
+
+ALLOWED_LABELS = ("hawkish", "dovish", "neutral")
+
+PROMPT_TEMPLATE = (
+    "You classify U.S. Federal Open Market Committee passages by "
+    "monetary-policy tone.\n"
+    "Tone is exactly one of: hawkish, dovish, neutral.\n"
+    "Return only a JSON object with two fields: \"label\" (one of the "
+    "three tones) and \"confidence\" (a float in [0, 1]). No prose, no "
+    "code fences, no explanation.\n\n"
+    "Passage:\n<<<\n{passage}\n>>>"
+)
+
+
+def _parse_response(text: str) -> tuple[str, float]:
+    """Extract (label, confidence) from a model response.
+
+    Falls back to ('neutral', 0.0) on any parse failure or unknown label.
+    """
+
+    if not text:
+        return "neutral", 0.0
+    cleaned = text.strip()
+    cleaned = re.sub(r"^```(?:json)?", "", cleaned).strip()
+    cleaned = re.sub(r"```$", "", cleaned).strip()
+    try:
+        payload = json.loads(cleaned)
+    except Exception:
+        return "neutral", 0.0
+    if not isinstance(payload, dict):
+        return "neutral", 0.0
+    label = str(payload.get("label", "")).strip().lower()
+    if label not in ALLOWED_LABELS:
+        return "neutral", 0.0
+    try:
+        confidence = float(payload.get("confidence", 0.0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    return label, max(0.0, min(1.0, confidence))
+
+
+@traced("gemini.score_passage")
+def score_passage(text: str, *, model: Any) -> dict[str, Any]:
+    """Score one FOMC passage with the Gemini model.
+
+    `model` must expose `generate_content(prompt, **kwargs)` returning
+    an object with a `.text` attribute (matches both the real SDK
+    adapter and the test stubs).
+    """
+
+    prompt = PROMPT_TEMPLATE.format(passage=text)
+    response = model.generate_content(prompt)
+    raw = getattr(response, "text", "") or ""
+    label, confidence = _parse_response(raw)
+    return {"label": label, "confidence": confidence, "raw": raw}
+
+
+def load_model(model_name: str = "gemini-2.5-pro"):
+    """Load a Gemini model. Imports the SDK lazily."""
+
+    import os
+
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "GEMINI_API_KEY is not set. Add it to fed-pulse/.env before running the live smoke."
+        )
+
+    from google import genai  # type: ignore
+
+    client = genai.Client(api_key=api_key)
+    return _ModelAdapter(client, model_name)
+
+
+class _ModelAdapter:
+    """Adapter so the real SDK matches the stub interface (generate_content + .text)."""
+
+    def __init__(self, client: Any, model_name: str):
+        self._client = client
+        self._model_name = model_name
+
+    def generate_content(self, prompt: str, **kwargs):
+        from google.genai import types  # type: ignore
+
+        response = self._client.models.generate_content(
+            model=self._model_name,
+            contents=prompt,
+            config=types.GenerateContentConfig(temperature=0.0),
+        )
+        return response  # response has .text already

--- a/backend/app/services/langsmith_client.py
+++ b/backend/app/services/langsmith_client.py
@@ -1,0 +1,45 @@
+"""Thin wrapper around the LangSmith Python SDK.
+
+Provides the `traced(name)` decorator. When LANGSMITH_API_KEY is set,
+calls go through `langsmith.traceable`. When it is not set (e.g. unit
+tests), the decorator is a transparent passthrough so the calling code
+runs without any LangSmith dependency at runtime.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import wraps
+from typing import Callable, TypeVar
+
+T = TypeVar("T", bound=Callable)
+
+
+def traced(name: str) -> Callable[[T], T]:
+    """Decorate a function so it is traced by LangSmith when the API key is set.
+
+    Behaviour:
+    - LANGSMITH_API_KEY unset -> identity decorator; the wrapped function
+      runs unchanged.
+    - LANGSMITH_API_KEY set -> wrap with langsmith.traceable so each
+      invocation produces a trace under the project the SDK is configured for.
+    """
+
+    def decorator(fn: T) -> T:
+        if not os.environ.get("LANGSMITH_API_KEY"):
+            return fn
+
+        try:
+            from langsmith import traceable  # type: ignore
+        except Exception:  # pragma: no cover - import guard
+            return fn
+
+        traced_fn = traceable(run_type="llm", name=name)(fn)
+
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            return traced_fn(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,6 @@ pyarrow
 datasets
 kagglehub
 pytest
+google-genai>=1.0.0
+langsmith>=0.1.0
+scikit-learn

--- a/tests/unit/test_gemini_client.py
+++ b/tests/unit/test_gemini_client.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services import gemini_client
+
+
+class _StubModel:
+    def __init__(self, response_text: str):
+        self._response_text = response_text
+
+    def generate_content(self, prompt, **kwargs):
+        class _R:
+            def __init__(self, text):
+                self.text = text
+
+        return _R(self._response_text)
+
+
+def test_score_passage_parses_label_and_confidence_from_clean_response() -> None:
+    stub = _StubModel('{"label": "hawkish", "confidence": 0.91}')
+    result = gemini_client.score_passage(
+        "We see persistent inflation pressures",
+        model=stub,
+    )
+    assert result["label"] == "hawkish"
+    assert result["confidence"] == pytest.approx(0.91)
+    assert "raw" in result
+
+
+def test_score_passage_normalizes_label_case_and_whitespace() -> None:
+    stub = _StubModel('{"label": "  Dovish  ", "confidence": 0.6}')
+    result = gemini_client.score_passage("text", model=stub)
+    assert result["label"] == "dovish"
+
+
+def test_score_passage_falls_back_to_neutral_when_response_unparseable() -> None:
+    stub = _StubModel("I cannot decide.")
+    result = gemini_client.score_passage("text", model=stub)
+    assert result["label"] == "neutral"
+    assert result["confidence"] == 0.0
+    assert result["raw"] == "I cannot decide."
+
+
+def test_score_passage_falls_back_to_neutral_on_unknown_label() -> None:
+    stub = _StubModel('{"label": "uncertain", "confidence": 0.3}')
+    result = gemini_client.score_passage("text", model=stub)
+    assert result["label"] == "neutral"
+    assert result["confidence"] == 0.0
+
+
+def test_score_passage_strips_markdown_code_fences() -> None:
+    stub = _StubModel('```json\n{"label": "neutral", "confidence": 0.5}\n```')
+    result = gemini_client.score_passage("text", model=stub)
+    assert result["label"] == "neutral"
+    assert result["confidence"] == pytest.approx(0.5)

--- a/tests/unit/test_langsmith_client.py
+++ b/tests/unit/test_langsmith_client.py
@@ -1,0 +1,42 @@
+"""LangSmith client wrapper tests.
+
+The traced() decorator must:
+- Pass through the wrapped function's return value identically.
+- Become a no-op when LANGSMITH_API_KEY is unset (so unit tests do not
+  need credentials).
+- Use langsmith.traceable when LANGSMITH_API_KEY is set.
+"""
+
+from __future__ import annotations
+
+from app.services import langsmith_client
+
+
+def test_traced_returns_callable() -> None:
+    @langsmith_client.traced("my_call")
+    def fn(x: int) -> int:
+        return x + 1
+
+    assert fn(2) == 3
+
+
+def test_traced_passes_kwargs(monkeypatch) -> None:
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+
+    @langsmith_client.traced("my_call")
+    def fn(*, x: int, y: int) -> int:
+        return x * y
+
+    assert fn(x=3, y=4) == 12
+
+
+def test_traced_is_noop_when_key_unset(monkeypatch) -> None:
+    """Without an API key the decorator should be transparent."""
+
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+
+    @langsmith_client.traced("my_call")
+    def fn(x: int) -> int:
+        return x * 10
+
+    assert fn(7) == 70

--- a/tests/unit/test_llm_judge.py
+++ b/tests/unit/test_llm_judge.py
@@ -146,3 +146,57 @@ def test_gating_policy_judge_only_keeps_when_judge_label_present() -> None:
 def test_gating_policy_unknown_raises() -> None:
     with pytest.raises(ValueError):
         llm_judge.apply_gating_policy([], policy="bogus", tau=0.85)
+
+
+def test_sample_audit_set_is_stratified_by_teacher_label_and_size_n(tmp_path: Path) -> None:
+    rows = []
+    for label, count in [("hawkish", 100), ("dovish", 30), ("neutral", 30)]:
+        for idx in range(count):
+            rows.append(
+                _judged_row(
+                    label,
+                    0.9,
+                    label,
+                    0.9,
+                    record_id=f"{label}_{idx}",
+                    text=f"text {label} {idx}",
+                )
+            )
+
+    audit = llm_judge.sample_audit_set(rows, n=60, seed=11)
+
+    assert len(audit) == 60
+    counts = {label: sum(1 for r in audit if r["label"] == label) for label in ("hawkish", "dovish", "neutral")}
+    assert all(c > 0 for c in counts.values())
+    assert sum(counts.values()) == 60
+
+
+def test_audit_metrics_returns_teacher_and_judge_precision_against_human(tmp_path: Path) -> None:
+    audit_rows = [
+        # human, teacher, judge
+        {"human_label": "hawkish", "label": "hawkish", "judge_label": "hawkish"},
+        {"human_label": "hawkish", "label": "hawkish", "judge_label": "neutral"},
+        {"human_label": "dovish", "label": "neutral", "judge_label": "dovish"},
+        {"human_label": "neutral", "label": "neutral", "judge_label": "neutral"},
+    ]
+    metrics = llm_judge.audit_metrics(audit_rows)
+
+    assert metrics["teacher_accuracy"] == pytest.approx(0.75)
+    assert metrics["judge_accuracy"] == pytest.approx(0.75)
+    assert "cohen_kappa" in metrics
+    assert "teacher_per_class" in metrics
+    assert "judge_per_class" in metrics
+    assert "hawkish" in metrics["teacher_per_class"]
+
+
+def test_audit_metrics_handles_empty_human_labels(tmp_path: Path) -> None:
+    """Until the human pass is done, audit rows have empty human_label;
+    the metrics computer must skip those rows rather than raise."""
+
+    audit_rows = [
+        {"human_label": "", "label": "hawkish", "judge_label": "hawkish"},
+        {"human_label": "hawkish", "label": "hawkish", "judge_label": "hawkish"},
+    ]
+    metrics = llm_judge.audit_metrics(audit_rows)
+    assert metrics["audit_size"] == 1
+    assert metrics["teacher_accuracy"] == pytest.approx(1.0)

--- a/tests/unit/test_llm_judge.py
+++ b/tests/unit/test_llm_judge.py
@@ -200,3 +200,27 @@ def test_audit_metrics_handles_empty_human_labels(tmp_path: Path) -> None:
     metrics = llm_judge.audit_metrics(audit_rows)
     assert metrics["audit_size"] == 1
     assert metrics["teacher_accuracy"] == pytest.approx(1.0)
+
+
+def test_write_audit_csv_includes_empty_human_label_column(tmp_path: Path) -> None:
+    sample = [
+        {"record_id": "r1", "label": "hawkish", "judge_label": "hawkish", "text": "Some text"},
+    ]
+    out = tmp_path / "audit_set.csv"
+    llm_judge.write_audit_csv(sample, out)
+    content = out.read_text(encoding="utf-8")
+    assert "human_label" in content.splitlines()[0]
+    assert "Some text" in content
+
+
+def test_summarise_gating_policies_returns_yield_per_policy() -> None:
+    rows = [
+        _judged_row("hawkish", 0.92, "hawkish", 0.95),
+        _judged_row("hawkish", 0.92, "neutral", 0.95),
+        _judged_row("dovish", 0.40, "dovish", 0.95),
+    ]
+    summary = llm_judge.summarise_gating_policies(rows, tau=0.85)
+    assert summary["confidence_only"]["kept"] == 2
+    assert summary["confidence_and_judge"]["kept"] == 1
+    assert summary["judge_only"]["kept"] == 3
+    assert "label_distribution" in summary["confidence_only"]

--- a/tests/unit/test_llm_judge.py
+++ b/tests/unit/test_llm_judge.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.data import llm_judge
+
+
+class _StubGeminiModel:
+    """Returns a list of response texts in order."""
+
+    def __init__(self, responses: list[str]):
+        self._responses = list(responses)
+
+    def generate_content(self, prompt, **kwargs):
+        class _R:
+            def __init__(self, text):
+                self.text = text
+
+        return _R(self._responses.pop(0))
+
+
+def _write_pseudo_fixture(path: Path) -> None:
+    rows = [
+        {
+            "record_id": "r1",
+            "source": "scraped_fed",
+            "source_type": "fomc_minutes",
+            "event_date": "2024-01-31",
+            "title": "FOMC Minutes",
+            "text": "Hawkish passage about tightening.",
+            "label": "hawkish",
+            "label_origin": "pseudo",
+            "teacher_model_id": "fomc_roberta_s71",
+            "teacher_model_version": "phase4_finetune_v1",
+            "teacher_max_score": 0.78,
+            "teacher_scores": {"hawkish": 0.78, "dovish": 0.12, "neutral": 0.10},
+        },
+        {
+            "record_id": "r2",
+            "source": "scraped_fed",
+            "source_type": "fomc_minutes",
+            "event_date": "2024-03-20",
+            "title": "FOMC Minutes",
+            "text": "Mixed signals on growth.",
+            "label": "neutral",
+            "label_origin": "pseudo",
+            "teacher_model_id": "fomc_roberta_s71",
+            "teacher_model_version": "phase4_finetune_v1",
+            "teacher_max_score": 0.81,
+            "teacher_scores": {"hawkish": 0.10, "dovish": 0.09, "neutral": 0.81},
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+def test_run_judge_persists_judge_label_and_confidence_per_row(tmp_path: Path) -> None:
+    input_path = tmp_path / "registry_pseudo.jsonl"
+    output_path = tmp_path / "registry_pseudo_judged.jsonl"
+    _write_pseudo_fixture(input_path)
+
+    model = _StubGeminiModel(
+        [
+            '{"label": "hawkish", "confidence": 0.95}',
+            '{"label": "neutral", "confidence": 0.62}',
+        ]
+    )
+
+    written = llm_judge.run_judge(
+        input_path=input_path,
+        output_path=output_path,
+        gemini_model=model,
+        judge_model_id="gemini-2.5-pro",
+        judge_model_version="20250505_v1",
+    )
+
+    assert written == 2
+    rows = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 2
+    assert rows[0]["judge_label"] == "hawkish"
+    assert rows[0]["judge_confidence"] == pytest.approx(0.95)
+    assert rows[0]["judge_model_id"] == "gemini-2.5-pro"
+    assert rows[0]["judge_model_version"] == "20250505_v1"
+    # Original teacher fields are preserved
+    assert rows[0]["label"] == "hawkish"
+    assert rows[0]["teacher_model_id"] == "fomc_roberta_s71"
+
+
+def test_parse_args_requires_input() -> None:
+    with pytest.raises(SystemExit):
+        llm_judge._parse_args([])
+
+
+def test_parse_args_default_judge_model_is_gemini_2_5_pro() -> None:
+    args = llm_judge._parse_args(["--input", "/some/path"])
+    assert args.judge_model == "gemini-2.5-pro"

--- a/tests/unit/test_llm_judge.py
+++ b/tests/unit/test_llm_judge.py
@@ -99,3 +99,50 @@ def test_parse_args_requires_input() -> None:
 def test_parse_args_default_judge_model_is_gemini_2_5_pro() -> None:
     args = llm_judge._parse_args(["--input", "/some/path"])
     assert args.judge_model == "gemini-2.5-pro"
+
+
+def _judged_row(label, max_score, judge_label, judge_conf, **rest):
+    base = {
+        "label": label,
+        "teacher_max_score": max_score,
+        "judge_label": judge_label,
+        "judge_confidence": judge_conf,
+    }
+    base.update(rest)
+    return base
+
+
+def test_gating_policy_confidence_only_keeps_above_tau() -> None:
+    rows = [
+        _judged_row("hawkish", 0.92, "neutral", 0.50),
+        _judged_row("dovish", 0.40, "dovish", 0.95),
+    ]
+    kept = llm_judge.apply_gating_policy(rows, policy="confidence_only", tau=0.85)
+    assert len(kept) == 1
+    assert kept[0]["label"] == "hawkish"
+
+
+def test_gating_policy_confidence_and_judge_requires_agreement() -> None:
+    rows = [
+        _judged_row("hawkish", 0.92, "hawkish", 0.50),  # agree at tau=0.85 -> keep
+        _judged_row("hawkish", 0.92, "neutral", 0.99),  # disagree -> drop
+        _judged_row("dovish", 0.40, "dovish", 0.99),    # below tau -> drop
+    ]
+    kept = llm_judge.apply_gating_policy(rows, policy="confidence_and_judge", tau=0.85)
+    assert len(kept) == 1
+    assert kept[0]["judge_label"] == "hawkish"
+
+
+def test_gating_policy_judge_only_keeps_when_judge_label_present() -> None:
+    rows = [
+        _judged_row("hawkish", 0.40, "hawkish", 0.99),  # judge confident -> keep
+        _judged_row("hawkish", 0.92, "neutral", 0.99),  # judge says neutral but valid -> keep
+        _judged_row("hawkish", 0.92, "", 0.0),          # judge empty -> drop
+    ]
+    kept = llm_judge.apply_gating_policy(rows, policy="judge_only", tau=0.85)
+    assert len(kept) == 2
+
+
+def test_gating_policy_unknown_raises() -> None:
+    with pytest.raises(ValueError):
+        llm_judge.apply_gating_policy([], policy="bogus", tau=0.85)


### PR DESCRIPTION
## Summary

Plan 4 of the 2026-05-05 scope extension. Closes #37 (LLM-as-judge augmentation of pseudo-labelling) and lands the call-site portion of #42 (LangSmith eval infra). Issues #31 and #42 stay open: #31 awaits the offline human pass on the audit set; #42's wider integration follows when #38 zero-shot rerun and #41 Variant C precompute land.

## What landed

- \`backend/app/services/langsmith_client.py\` — \`traced(name)\` decorator that wraps with \`langsmith.traceable\` when \`LANGSMITH_API_KEY\` is set; transparent passthrough when unset (so unit tests run without credentials).
- \`backend/app/services/gemini_client.py\` — \`score_passage(text, *, model)\` with deterministic JSON-only prompt + markdown-fence stripping + neutral fallback on parse failure; \`load_model()\` lazily imports \`google-genai\`.
- \`backend/app/data/llm_judge.py\`:
  - CLI: \`python -m app.data.llm_judge --input <pseudo_set> [--judge-model gemini-2.5-pro] [--max-rows N]\`.
  - \`run_judge()\` scores every row, persists \`judge_label\` / \`judge_confidence\` / \`judge_model_id\` / \`judge_model_version\`.
  - \`apply_gating_policy()\` — three policies: \`confidence_only\`, \`confidence_and_judge\`, \`judge_only\`.
  - \`sample_audit_set()\` — reproducible stratified sample by teacher class.
  - \`audit_metrics()\` — teacher / judge accuracy + three Cohen's κ scores ((teacher,human), (judge,human), (teacher,judge)) + per-class precision tables. Skips rows with empty \`human_label\` so it's callable mid-audit.
  - \`summarise_gating_policies()\` — yield + label distribution per policy.
  - \`main()\`: judge → 3-policy × 3-τ sweep → 100-row audit set as JSONL+CSV → \`audit_metrics.json\` when \`audit_set_filled.jsonl\` is present.
- \`backend/requirements.txt\` += \`google-genai\`, \`langsmith\`, \`scikit-learn\`.
- \`.env.example\` documents \`GEMINI_API_KEY\` + \`LANGSMITH_API_KEY\`.

## Verification

- 129 unit tests pass (109 baseline + 20 new across tasks 2–7).
- Live smoke against the existing 43-row pseudo set, 10-row slice via \`gemini-2.5-flash\` (default \`gemini-2.5-pro\` had hit the project's daily free-tier quota; \`judge_model_id\` records which model ran):
  - Judge–teacher disagreement 3/10 (30%); zero parse failures; confidence range 0.90–0.99.
  - Policy sweep at τ=0.85: \`confidence_only\` 0/10, \`confidence_and_judge\` 0/10 (matches the Plan-3 finding that teacher confidence ceiling <0.85), \`judge_only\` 10/10.
  - Policy sweep at τ=0.75: \`confidence_only\` 10/10, \`confidence_and_judge\` 7/10 (the 3 disagreement rows drop), \`judge_only\` 10/10.
  - LangSmith traces under project \`fed-pulse-eval\`.
  - 10-row \`audit_set.csv\` + \`audit_set.jsonl\` written, ready for the offline human-gold pass.

## Two follow-ups (not blocking PR merge)

1. **43-row production run** is gated on Gemini free-tier RPM (2 req/min for \`gemini-2.5-flash\`). Either enable billing on the Google Cloud project or add a configurable \`--request-interval-seconds\` flag with backoff to \`app.data.llm_judge\`. The 10-row smoke is sufficient to demonstrate the pipeline; the production run is a workflow operation.
2. **Audit-precision gate** (≥0.90 teacher precision per \`benchmark-policy.md\`) needs the human pass on \`audit_set.csv\`. Once \`audit_set_filled.jsonl\` lands in the audit dir, re-running \`python -m app.data.llm_judge\` materialises \`audit_metrics.json\`.

## Test plan

- [x] \`docker compose run --rm backend pytest tests/unit -v\` (129 passed)
- [x] Live: \`docker compose run --rm -e GEMINI_API_KEY -e LANGSMITH_API_KEY -e LANGSMITH_PROJECT=fed-pulse-eval -e LANGSMITH_TRACING=true backend python -m app.data.llm_judge --input /data/interim/phase2/registry_pseudo.jsonl --max-rows 10 --judge-model gemini-2.5-flash\` → 10 rows judged, sweep + audit set written, traces in LangSmith.

## Issue tracking

- #37 closes with this PR.
- #31 stays open — awaits human audit pass + audit-precision gate.
- #42 stays open — wider integration (audit dataset upload, auto-evaluators, annotation queue, #38 + #41 trace coverage) lands when those features land.