### PR TITLE
Add --request-interval-seconds rate-limit knob to llm_judge

### DIFF
--- a/backend/app/data/llm_judge.py
+++ b/backend/app/data/llm_judge.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import time
 from collections import Counter
 from pathlib import Path
 from typing import Any, Sequence
@@ -43,6 +44,12 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--audit-dir", default=str(DEFAULT_AUDIT_DIR), help="Audit artefact directory.")
     parser.add_argument("--max-rows", type=int, default=0, help="Score at most N rows; 0 = no limit.")
+    parser.add_argument(
+        "--request-interval-seconds",
+        type=float,
+        default=0.0,
+        help="Sleep this many seconds between Gemini calls to respect rate limits. 0 = no sleep.",
+    )
     return parser.parse_args(argv)
 
 
@@ -74,12 +81,17 @@ def run_judge(
     judge_model_id: str,
     judge_model_version: str,
     max_rows: int = 0,
+    request_interval_seconds: float = 0.0,
 ) -> int:
     """Score every row in input_path, write judged rows to output_path.
 
     Each output row preserves all input fields and adds judge_label,
     judge_confidence, judge_model_id, judge_model_version. Returns the
     number of rows written.
+
+    request_interval_seconds: sleep between successive Gemini calls
+    (skipped after the final call). Use this to respect free-tier
+    rate limits — e.g. 35.0 keeps under the gemini-2.5-flash 2 req/min cap.
     """
 
     rows = _read_jsonl(input_path)
@@ -87,7 +99,7 @@ def run_judge(
         rows = rows[:max_rows]
 
     judged: list[dict[str, Any]] = []
-    for row in rows:
+    for index, row in enumerate(rows):
         prediction = score_passage(row.get("text", ""), model=gemini_model)
         out = dict(row)
         out["judge_label"] = prediction["label"]
@@ -95,6 +107,8 @@ def run_judge(
         out["judge_model_id"] = judge_model_id
         out["judge_model_version"] = judge_model_version
         judged.append(out)
+        if request_interval_seconds > 0 and index < len(rows) - 1:
+            time.sleep(request_interval_seconds)
 
     _write_jsonl(output_path, judged)
     return len(judged)
@@ -305,6 +319,7 @@ def main() -> int:
         judge_model_id=args.judge_model,
         judge_model_version=args.judge_model_version,
         max_rows=args.max_rows,
+        request_interval_seconds=args.request_interval_seconds,
     )
     print(f"Judged rows written: {written}")
 

--- a/tests/unit/test_llm_judge.py
+++ b/tests/unit/test_llm_judge.py
@@ -224,3 +224,98 @@ def test_summarise_gating_policies_returns_yield_per_policy() -> None:
     assert summary["confidence_and_judge"]["kept"] == 1
     assert summary["judge_only"]["kept"] == 3
     assert "label_distribution" in summary["confidence_only"]
+
+
+def test_parse_args_default_request_interval_is_zero() -> None:
+    args = llm_judge._parse_args(["--input", "/some/path"])
+    assert args.request_interval_seconds == 0.0
+
+
+def test_parse_args_accepts_request_interval_flag() -> None:
+    args = llm_judge._parse_args(
+        ["--input", "/some/path", "--request-interval-seconds", "35"]
+    )
+    assert args.request_interval_seconds == 35.0
+
+
+def test_run_judge_sleeps_between_calls_when_interval_set(tmp_path: Path, monkeypatch) -> None:
+    """request_interval_seconds calls time.sleep between scoring rows.
+
+    Three input rows -> two between-call sleeps (one after row 1, one
+    after row 2; no sleep after the last row).
+    """
+
+    input_path = tmp_path / "registry_pseudo.jsonl"
+    output_path = tmp_path / "registry_pseudo_judged.jsonl"
+    rows = [
+        {
+            "record_id": f"r{i}",
+            "source": "scraped_fed",
+            "text": f"text {i}",
+            "label": "hawkish",
+            "label_origin": "pseudo",
+            "teacher_max_score": 0.8,
+            "teacher_scores": {"hawkish": 0.8, "dovish": 0.1, "neutral": 0.1},
+        }
+        for i in range(3)
+    ]
+    input_path.parent.mkdir(parents=True, exist_ok=True)
+    with input_path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+    sleep_calls: list[float] = []
+
+    def fake_sleep(secs: float) -> None:
+        sleep_calls.append(secs)
+
+    monkeypatch.setattr("app.data.llm_judge.time.sleep", fake_sleep)
+
+    model = _StubGeminiModel(
+        ['{"label": "hawkish", "confidence": 0.9}'] * 3
+    )
+
+    written = llm_judge.run_judge(
+        input_path=input_path,
+        output_path=output_path,
+        gemini_model=model,
+        judge_model_id="gemini-2.5-flash",
+        judge_model_version="v0",
+        request_interval_seconds=2.5,
+    )
+
+    assert written == 3
+    assert sleep_calls == [2.5, 2.5]  # n_rows - 1 sleeps
+
+
+def test_run_judge_does_not_sleep_when_interval_zero(tmp_path: Path, monkeypatch) -> None:
+    input_path = tmp_path / "registry_pseudo.jsonl"
+    output_path = tmp_path / "registry_pseudo_judged.jsonl"
+    rows = [
+        {
+            "record_id": "r0",
+            "source": "scraped_fed",
+            "text": "text",
+            "label": "hawkish",
+            "label_origin": "pseudo",
+        }
+    ]
+    input_path.parent.mkdir(parents=True, exist_ok=True)
+    with input_path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+    sleep_calls: list[float] = []
+    monkeypatch.setattr("app.data.llm_judge.time.sleep", lambda s: sleep_calls.append(s))
+
+    model = _StubGeminiModel(['{"label": "hawkish", "confidence": 0.9}'])
+    llm_judge.run_judge(
+        input_path=input_path,
+        output_path=output_path,
+        gemini_model=model,
+        judge_model_id="gemini-2.5-flash",
+        judge_model_version="v0",
+        request_interval_seconds=0.0,
+    )
+
+    assert sleep_calls == []


### PR DESCRIPTION
Tiny follow-up to PR #47. Adds a configurable inter-call delay so the 43-row production pseudo-label run can complete under Gemini free-tier RPM (2 req/min for gemini-2.5-flash). Tests cover both the no-sleep and sleep-between-calls paths.

Use: `--request-interval-seconds 35` keeps a 43-row run under the cap (~25 min wall-clock).

133 unit tests pass.