### PR TITLE
Add Variant C: LLM embeddings as forecaster text feature (#41)

### DIFF
--- a/backend/app/data/chunk_embedding_retrieval.py
+++ b/backend/app/data/chunk_embedding_retrieval.py
@@ -3,11 +3,18 @@
 Loads the parquet produced by :mod:`app.data.chunk_embedding_store` and exposes
 a ``build_lookback_tensors`` function that returns padded ``(embeddings,
 elapsed_days, mask)`` tensors suitable for :class:`ChunkAttentionPooler`.
+
+Variant C (``embedding_source="llm"``) reads from the LLM embeddings parquet
+produced by :mod:`app.data.llm_embedding_store`.  Each document contributes
+exactly one row (one "chunk-of-one"), so the output tensor shape
+``(max_chunks, embedding_dim)`` is identical to the chunk path; the pooler
+sees the same interface regardless of which source is active.
 """
 
 from __future__ import annotations
 
 import datetime
+import json
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -15,6 +22,10 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import torch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DATA_DIR = Path("/data") if Path("/data").exists() else BACKEND_ROOT.parent / "data"
+DEFAULT_LLM_EMBEDDINGS_PARQUET = DEFAULT_DATA_DIR / "interim" / "phase2" / "llm_embeddings.parquet"
 
 
 @dataclass(frozen=True)
@@ -36,6 +47,38 @@ def load_chunk_store(path: str) -> pd.DataFrame:
     return df
 
 
+@lru_cache(maxsize=4)
+def _load_llm_store(path: str) -> pd.DataFrame:
+    """Load the LLM embeddings parquet (or jsonl fallback) into a DataFrame.
+
+    Expected columns: ``document_id``, ``event_date``, ``embedding``.
+    """
+    p = Path(path)
+    if p.exists() and p.suffix == ".parquet":
+        df = pd.read_parquet(p)
+    else:
+        # Fallback: check for .jsonl alongside the parquet path.
+        jsonl_path = p.with_suffix(".jsonl")
+        if jsonl_path.exists():
+            rows: list[dict] = []
+            for line in jsonl_path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                obj = json.loads(line)
+                if isinstance(obj, dict):
+                    rows.append(obj)
+            df = pd.DataFrame(rows)
+        else:
+            raise FileNotFoundError(
+                f"LLM embeddings not found at {p} or {p.with_suffix('.jsonl')}. "
+                "Run app.data.llm_embedding_store first."
+            )
+    df["event_date"] = df["event_date"].astype(str)
+    df = df.sort_values("event_date").reset_index(drop=True)
+    return df
+
+
 def _parse_iso(date_str: str) -> datetime.date | None:
     try:
         return datetime.date.fromisoformat(str(date_str)[:10])
@@ -51,11 +94,54 @@ def build_lookback_tensors(
     max_chunks: int,
     embedding_size: int | None = None,
     include_anchor_day: bool = True,
+    embedding_source: str = "chunk",
 ) -> ChunkRetrievalResult:
-    """Return padded chunk tensors for docs within ``[anchor - lookback, anchor]``.
+    """Return padded tensors for docs within ``[anchor - lookback, anchor]``.
+
+    Parameters
+    ----------
+    store:
+        For ``embedding_source="chunk"`` this is the chunk-level parquet
+        DataFrame (columns: ``doc_id``, ``event_date``, ``chunk_index``,
+        ``embedding``, ``chunk_preview``).  For ``embedding_source="llm"``
+        this argument is *ignored*; the LLM embeddings parquet is loaded from
+        ``DEFAULT_LLM_EMBEDDINGS_PARQUET`` automatically.
+    embedding_source:
+        ``"chunk"`` (default, Variant B) or ``"llm"`` (Variant C).
+        When ``"llm"`` each document contributes exactly one slot so the
+        output shape ``(max_chunks, embedding_dim)`` is identical to the
+        chunk path, making the pooler interface source-agnostic.
 
     The most recent docs win when ``max_chunks`` cap is hit.
     """
+    if embedding_source == "llm":
+        return _build_lookback_tensors_llm(
+            anchor_date=anchor_date,
+            lookback_days=lookback_days,
+            max_chunks=max_chunks,
+            embedding_size=embedding_size,
+            include_anchor_day=include_anchor_day,
+        )
+    return _build_lookback_tensors_chunk(
+        store,
+        anchor_date=anchor_date,
+        lookback_days=lookback_days,
+        max_chunks=max_chunks,
+        embedding_size=embedding_size,
+        include_anchor_day=include_anchor_day,
+    )
+
+
+def _build_lookback_tensors_chunk(
+    store: pd.DataFrame,
+    *,
+    anchor_date: str,
+    lookback_days: int,
+    max_chunks: int,
+    embedding_size: int | None = None,
+    include_anchor_day: bool = True,
+) -> ChunkRetrievalResult:
+    """Chunk-path implementation (Variant B). One row = one chunk."""
     anchor = _parse_iso(anchor_date)
     if anchor is None:
         raise ValueError(f"anchor_date is not ISO date: {anchor_date!r}")
@@ -103,6 +189,88 @@ def build_lookback_tensors(
         doc_ids.append(str(record["doc_id"]))
         event_dates.append(str(record["event_date"]))
         chunk_previews.append(str(record.get("chunk_preview", "")))
+
+    while len(doc_ids) < max_chunks:
+        doc_ids.append("")
+        event_dates.append("")
+        chunk_previews.append("")
+
+    return ChunkRetrievalResult(
+        embeddings=torch.from_numpy(embeddings),
+        elapsed_days=torch.from_numpy(elapsed),
+        mask=torch.from_numpy(mask),
+        doc_ids=doc_ids,
+        event_dates=event_dates,
+        chunk_previews=chunk_previews,
+        actual_count=int(mask.sum()),
+    )
+
+
+def _build_lookback_tensors_llm(
+    *,
+    anchor_date: str,
+    lookback_days: int,
+    max_chunks: int,
+    embedding_size: int | None = None,
+    include_anchor_day: bool = True,
+    llm_store_path: str | Path | None = None,
+) -> ChunkRetrievalResult:
+    """LLM-path implementation (Variant C).
+
+    One document = one slot in the output tensor.  The shape contract
+    ``(max_chunks, embedding_dim)`` is identical to the chunk path so the
+    ``ChunkAttentionPooler`` receives the same interface regardless of source.
+    """
+    store_path = str(llm_store_path) if llm_store_path is not None else str(DEFAULT_LLM_EMBEDDINGS_PARQUET)
+    store = _load_llm_store(store_path)
+
+    anchor = _parse_iso(anchor_date)
+    if anchor is None:
+        raise ValueError(f"anchor_date is not ISO date: {anchor_date!r}")
+    lower = anchor - datetime.timedelta(days=int(lookback_days))
+
+    parsed_dates: list[datetime.date | None] = [_parse_iso(d) for d in store["event_date"].tolist()]
+    rows: list[tuple[datetime.date, int]] = []
+    for idx, parsed in enumerate(parsed_dates):
+        if parsed is None:
+            continue
+        if parsed < lower:
+            continue
+        if parsed > anchor:
+            continue
+        if not include_anchor_day and parsed == anchor:
+            continue
+        rows.append((parsed, idx))
+
+    rows.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    rows = rows[:max_chunks]
+    rows.sort(key=lambda item: (item[0], item[1]))
+
+    if embedding_size is None:
+        if rows:
+            sample = store.iloc[rows[0][1]]["embedding"]
+            embedding_size = int(len(sample))
+        else:
+            embedding_size = 768
+
+    embeddings = np.zeros((max_chunks, embedding_size), dtype=np.float32)
+    elapsed = np.zeros((max_chunks,), dtype=np.float32)
+    mask = np.zeros((max_chunks,), dtype=np.float32)
+    doc_ids: list[str] = []
+    event_dates: list[str] = []
+    chunk_previews: list[str] = []
+
+    for slot, (parsed, idx) in enumerate(rows):
+        record = store.iloc[idx]
+        vec = np.asarray(record["embedding"], dtype=np.float32)
+        if vec.shape[0] != embedding_size:
+            continue
+        embeddings[slot] = vec
+        elapsed[slot] = float((anchor - parsed).days)
+        mask[slot] = 1.0
+        doc_ids.append(str(record.get("document_id", "")))
+        event_dates.append(str(record["event_date"]))
+        chunk_previews.append("")  # LLM path has no chunk_preview column
 
     while len(doc_ids) < max_chunks:
         doc_ids.append("")

--- a/backend/app/data/llm_embedding_store.py
+++ b/backend/app/data/llm_embedding_store.py
@@ -1,0 +1,117 @@
+"""LLM embedding precompute for Variant C of the forecaster text feature.
+
+Reads the source registry, embeds each document's text with a Gemini
+embedding model (one vector per document, not per chunk), and writes
+the result as parquet keyed on document_id. Mirrors
+chunk_embedding_store.py's surface but with a single-vector-per-doc
+representation rather than per-chunk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any, Sequence
+
+from app.services.gemini_client import embed_text
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DATA_DIR = Path("/data") if Path("/data").exists() else BACKEND_ROOT.parent / "data"
+DEFAULT_REGISTRY = DEFAULT_DATA_DIR / "raw" / "phase2" / "source_registry.jsonl"
+DEFAULT_OUTPUT = DEFAULT_DATA_DIR / "interim" / "phase2" / "llm_embeddings.parquet"
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Precompute Gemini embeddings (one per document) for Variant C of the forecaster."
+    )
+    parser.add_argument("--registry", default=str(DEFAULT_REGISTRY))
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument("--max-rows", type=int, default=0)
+    parser.add_argument("--request-interval-seconds", type=float, default=0.0)
+    parser.add_argument("--embedding-model", default="gemini-embedding-001")
+    return parser.parse_args(argv)
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not path.exists():
+        return rows
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        if isinstance(payload, dict):
+            rows.append(payload)
+    return rows
+
+
+def precompute_embeddings(
+    *,
+    registry_path: Path,
+    output_path: Path,
+    embedding_client: Any,
+    max_rows: int = 0,
+    request_interval_seconds: float = 0.0,
+) -> int:
+    """Embed each document in registry and persist as parquet.
+
+    Returns the number of rows written. Skips documents with empty text.
+    """
+
+    rows = _read_jsonl(registry_path)
+    if max_rows > 0:
+        rows = rows[:max_rows]
+
+    records: list[dict[str, Any]] = []
+    eligible = [(i, r) for i, r in enumerate(rows) if str(r.get("text", "") or "")]
+    for index, (orig_index, row) in enumerate(eligible):
+        text = str(row.get("text", "") or "")
+        embedding = embed_text(text, model=embedding_client)
+        records.append(
+            {
+                "document_id": str(row.get("record_id", "")),
+                "event_date": str(row.get("event_date", "")),
+                "embedding": embedding,
+            }
+        )
+        if request_interval_seconds > 0 and index < len(eligible) - 1:
+            time.sleep(request_interval_seconds)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        import pandas as pd  # type: ignore
+
+        pd.DataFrame.from_records(records).to_parquet(output_path, index=False)
+    except Exception:
+        # Fallback: jsonl alongside the parquet path so the smoke does not
+        # silently produce nothing if pandas/pyarrow are missing.
+        jsonl_path = output_path.with_suffix(".jsonl")
+        with jsonl_path.open("w", encoding="utf-8") as handle:
+            for r in records:
+                handle.write(json.dumps(r) + "\n")
+    return len(records)
+
+
+def main() -> int:
+    args = _parse_args()
+    from app.services.gemini_client import load_embedding_model
+
+    client = load_embedding_model(args.embedding_model)
+    written = precompute_embeddings(
+        registry_path=Path(args.registry),
+        output_path=Path(args.output),
+        embedding_client=client,
+        max_rows=args.max_rows,
+        request_interval_seconds=args.request_interval_seconds,
+    )
+    print(f"LLM embeddings written: {written}")
+    print(f"Output: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/data/phase4_attention_ablation.py
+++ b/backend/app/data/phase4_attention_ablation.py
@@ -158,6 +158,7 @@ def _build_dataset(
     sentiment_cache: dict[str, float] | None = None,
     llm_store_path: str | None = None,
     llm_max_chunks: int | None = None,
+    llm_embedding_size: int = 768,
 ) -> list[TrainingTuple]:
     """Build training tuples with both chunk (B) and LLM (C) tensors.
 
@@ -197,6 +198,7 @@ def _build_dataset(
                 anchor_date=row.event_date,
                 lookback_days=lookback_days,
                 max_chunks=_llm_max,
+                embedding_size=llm_embedding_size,
                 llm_store_path=llm_store_path,
             )
             llm_emb = llm_retrieval.embeddings.numpy()
@@ -204,7 +206,7 @@ def _build_dataset(
             llm_msk = llm_retrieval.mask.numpy()
         except FileNotFoundError:
             # LLM store not yet precomputed — fill with zeros so B-cells are unaffected.
-            llm_emb = np.zeros((_llm_max, 1), dtype=np.float32)
+            llm_emb = np.zeros((_llm_max, llm_embedding_size), dtype=np.float32)
             llm_elp = np.zeros((_llm_max,), dtype=np.float32)
             llm_msk = np.zeros((_llm_max,), dtype=np.float32)
 
@@ -452,22 +454,36 @@ def _heatmap_samples(
     pooler_state: ForecasterModel,
     device: torch.device,
     sample_count: int = 3,
+    use_llm_embeddings: bool = False,
 ) -> list[dict[str, Any]]:
     if pooler_state.chunk_pooler is None:
         return []
     pooler_state.eval()
     samples: list[dict[str, Any]] = []
-    indices = sorted(
-        range(len(val_tuples)),
-        key=lambda i: int(val_tuples[i].chunk_mask.sum()),
-        reverse=True,
-    )[:sample_count]
+    # For Variant C, pick samples by LLM mask; for Variant B, by chunk mask.
+    if use_llm_embeddings:
+        indices = sorted(
+            range(len(val_tuples)),
+            key=lambda i: int(val_tuples[i].llm_mask.sum()),
+            reverse=True,
+        )[:sample_count]
+    else:
+        indices = sorted(
+            range(len(val_tuples)),
+            key=lambda i: int(val_tuples[i].chunk_mask.sum()),
+            reverse=True,
+        )[:sample_count]
     with torch.no_grad():
         for idx in indices:
             t = val_tuples[idx]
-            chunks = torch.tensor(t.chunk_embeddings, dtype=torch.float32, device=device)
-            elapsed = torch.tensor(t.chunk_elapsed, dtype=torch.float32, device=device)
-            mask = torch.tensor(t.chunk_mask, dtype=torch.float32, device=device)
+            if use_llm_embeddings:
+                chunks = torch.tensor(t.llm_embeddings, dtype=torch.float32, device=device)
+                elapsed = torch.tensor(t.llm_elapsed, dtype=torch.float32, device=device)
+                mask = torch.tensor(t.llm_mask, dtype=torch.float32, device=device)
+            else:
+                chunks = torch.tensor(t.chunk_embeddings, dtype=torch.float32, device=device)
+                elapsed = torch.tensor(t.chunk_elapsed, dtype=torch.float32, device=device)
+                mask = torch.tensor(t.chunk_mask, dtype=torch.float32, device=device)
             _, weights, decays = pooler_state.chunk_pooler(chunks, elapsed, mask=mask)
             samples.append(
                 {
@@ -565,6 +581,7 @@ def main() -> int:
         lookback_days=args.lookback_days,
         sentiment_cache=sentiment_cache,
         llm_store_path=llm_store_path,
+        llm_embedding_size=llm_embedding_size,
     )
     print(f"[ablation] building val tuples...")
     val_tuples = _build_dataset(
@@ -575,6 +592,7 @@ def main() -> int:
         lookback_days=args.lookback_days,
         sentiment_cache=sentiment_cache,
         llm_store_path=llm_store_path,
+        llm_embedding_size=llm_embedding_size,
     )
     print(f"[ablation] train_tuples={len(train_tuples)} val_tuples={len(val_tuples)}")
     if not train_tuples or not val_tuples:
@@ -630,7 +648,9 @@ def main() -> int:
         )
         results[name] = result
         if (use_b or use_c) and trained_model.chunk_pooler is not None:
-            heatmaps_by_variant[name] = _heatmap_samples(val_tuples, pooler_state=trained_model, device=device)
+            heatmaps_by_variant[name] = _heatmap_samples(
+                val_tuples, pooler_state=trained_model, device=device, use_llm_embeddings=use_c
+            )
         print(
             f"[ablation]  {name}: combined_rmse={result['combined_rmse']:.4f} "
             f"close_rmse={result['close_rmse']:.4f} vol_rmse={result['volatility_rmse']:.4f} "

--- a/backend/app/data/phase4_attention_ablation.py
+++ b/backend/app/data/phase4_attention_ablation.py
@@ -1,15 +1,24 @@
 """Phase 4 attention + decay ablation (SRS FR-23 / FR-24 / FR-31).
 
-Trains four variants of the forecaster on labelled FOMC documents augmented
-with market history and (optionally) chunk-attention context, and records a
-combined RMSE / directional accuracy table plus learned-lambda values and
-attention heatmaps for sample documents.
+Trains eight variants of the forecaster on labelled FOMC documents augmented
+with market history and (optionally) chunk-attention / LLM-embedding context,
+and records a combined RMSE / directional accuracy table plus learned-lambda
+values and attention heatmaps for sample documents.
 
-Variants:
-- baseline: time decay off, chunk attention off
-- variant_a: time decay on, chunk attention off
-- variant_b: time decay off, chunk attention on
-- variant_a_b: time decay on, chunk attention on
+Variants sweep ``{A on/off} × {B on/off} × {C on/off}``:
+- baseline: time decay off, chunk attention off, LLM embeddings off
+- variant_a_only: time decay on, chunk attention off, LLM embeddings off
+- variant_b_only: time decay off, chunk attention on, LLM embeddings off
+- variant_c_only: time decay off, chunk attention off, LLM embeddings on
+- variant_a_plus_b: time decay on, chunk attention on, LLM embeddings off
+- variant_a_plus_c: time decay on, chunk attention off, LLM embeddings on
+- variant_b_plus_c: not possible (B and C mutually exclusive — skipped)
+- variant_a_plus_b_plus_c: not possible (B and C mutually exclusive — skipped)
+
+Note: Variant B (chunk attention) and Variant C (LLM embeddings) are mutually
+exclusive because they share the same LSTM input slot.  The ablation therefore
+produces 6 valid cells rather than 8 when all variants are requested.  The
+``--variants`` CLI flag can further restrict which cells run.
 """
 
 from __future__ import annotations
@@ -32,6 +41,8 @@ from torch import nn
 from torch.utils.data import DataLoader, Dataset
 
 from app.data.chunk_embedding_retrieval import (
+    DEFAULT_LLM_EMBEDDINGS_PARQUET,
+    _build_lookback_tensors_llm,
     build_lookback_tensors,
     load_chunk_store,
     resolve_store_path,
@@ -54,6 +65,16 @@ from app.services.forecaster import (
     ForecasterModel,
     build_last5_sequence,
 )
+
+# All valid variant cells for the 8-way grid (B and C are mutually exclusive).
+ALL_VARIANT_NAMES: list[str] = [
+    "baseline",
+    "variant_a_only",
+    "variant_b_only",
+    "variant_c_only",
+    "variant_a_plus_b",
+    "variant_a_plus_c",
+]
 from app.services.sentiment import analyze_text
 
 
@@ -64,9 +85,12 @@ class TrainingTuple:
     feature_seq: list[list[float]]  # SEQUENCE_LENGTH × FEATURE_SIZE
     target_close_norm: float  # close at t+1, normalized by close_scale
     target_volatility: float  # volatility_5d at t+1
-    chunk_embeddings: np.ndarray  # max_chunks × embedding_size
-    chunk_elapsed: np.ndarray  # max_chunks
-    chunk_mask: np.ndarray  # max_chunks
+    chunk_embeddings: np.ndarray  # max_chunks × embedding_size (Variant B)
+    chunk_elapsed: np.ndarray  # max_chunks (Variant B)
+    chunk_mask: np.ndarray  # max_chunks (Variant B)
+    llm_embeddings: np.ndarray  # max_chunks × llm_embedding_size (Variant C)
+    llm_elapsed: np.ndarray  # max_chunks (Variant C)
+    llm_mask: np.ndarray  # max_chunks (Variant C)
 
 
 def _fetch_full_history(symbol: str = "^GSPC", start: str = "1995-01-01") -> pd.DataFrame:
@@ -132,8 +156,19 @@ def _build_dataset(
     max_chunks: int,
     lookback_days: int,
     sentiment_cache: dict[str, float] | None = None,
+    llm_store_path: str | None = None,
+    llm_max_chunks: int | None = None,
 ) -> list[TrainingTuple]:
+    """Build training tuples with both chunk (B) and LLM (C) tensors.
+
+    The LLM tensors are always populated (using zero-filled arrays when the
+    LLM store is unavailable) so that every tuple is compatible with both
+    Variant B and Variant C training without re-building the dataset.  If the
+    LLM store is missing, ``llm_mask`` is all-zero and Variant C training will
+    see no signal (equivalent to baseline).
+    """
     cache = sentiment_cache if sentiment_cache is not None else {}
+    _llm_max = llm_max_chunks if llm_max_chunks is not None else max_chunks
     out: list[TrainingTuple] = []
     skipped = Counter()
     for row in rows:
@@ -155,6 +190,24 @@ def _build_dataset(
             lookback_days=lookback_days,
             max_chunks=max_chunks,
         )
+
+        # Variant C: LLM embeddings (one-per-doc).
+        try:
+            llm_retrieval = _build_lookback_tensors_llm(
+                anchor_date=row.event_date,
+                lookback_days=lookback_days,
+                max_chunks=_llm_max,
+                llm_store_path=llm_store_path,
+            )
+            llm_emb = llm_retrieval.embeddings.numpy()
+            llm_elp = llm_retrieval.elapsed_days.numpy()
+            llm_msk = llm_retrieval.mask.numpy()
+        except FileNotFoundError:
+            # LLM store not yet precomputed — fill with zeros so B-cells are unaffected.
+            llm_emb = np.zeros((_llm_max, 1), dtype=np.float32)
+            llm_elp = np.zeros((_llm_max,), dtype=np.float32)
+            llm_msk = np.zeros((_llm_max,), dtype=np.float32)
+
         out.append(
             TrainingTuple(
                 doc_id=row.text[:40],
@@ -165,6 +218,9 @@ def _build_dataset(
                 chunk_embeddings=retrieval.embeddings.numpy(),
                 chunk_elapsed=retrieval.elapsed_days.numpy(),
                 chunk_mask=retrieval.mask.numpy(),
+                llm_embeddings=llm_emb,
+                llm_elapsed=llm_elp,
+                llm_mask=llm_msk,
             )
         )
     if skipped:
@@ -185,10 +241,38 @@ class _AblationDataset(Dataset):
             "x": torch.tensor(item.feature_seq, dtype=torch.float32),
             "y_close": torch.tensor(item.target_close_norm, dtype=torch.float32),
             "y_vol": torch.tensor(item.target_volatility, dtype=torch.float32),
+            # Variant B (chunk attention)
             "chunks": torch.tensor(item.chunk_embeddings, dtype=torch.float32),
             "elapsed": torch.tensor(item.chunk_elapsed, dtype=torch.float32),
             "mask": torch.tensor(item.chunk_mask, dtype=torch.float32),
+            # Variant C (LLM embeddings)
+            "llm_chunks": torch.tensor(item.llm_embeddings, dtype=torch.float32),
+            "llm_elapsed": torch.tensor(item.llm_elapsed, dtype=torch.float32),
+            "llm_mask": torch.tensor(item.llm_mask, dtype=torch.float32),
         }
+
+
+def _batch_kwargs(
+    batch: dict[str, torch.Tensor],
+    *,
+    use_chunk_attention: bool,
+    use_llm_embeddings: bool,
+    device: torch.device,
+) -> dict[str, torch.Tensor]:
+    """Build forward-pass kwargs for the active pooler variant."""
+    if use_chunk_attention:
+        return {
+            "chunks": batch["chunks"].to(device),
+            "elapsed_days": batch["elapsed"].to(device),
+            "chunk_mask": batch["mask"].to(device),
+        }
+    if use_llm_embeddings:
+        return {
+            "chunks": batch["llm_chunks"].to(device),
+            "elapsed_days": batch["llm_elapsed"].to(device),
+            "chunk_mask": batch["llm_mask"].to(device),
+        }
+    return {}
 
 
 def _train_variant(
@@ -197,7 +281,9 @@ def _train_variant(
     *,
     use_time_decay: bool,
     use_chunk_attention: bool,
+    use_llm_embeddings: bool = False,
     chunk_embedding_size: int,
+    llm_embedding_size: int = 768,
     chunk_projection_dim: int,
     epochs: int,
     learning_rate: float,
@@ -207,10 +293,13 @@ def _train_variant(
     device: torch.device,
 ) -> dict[str, Any]:
     _set_all_seeds(seed)
+    # Choose embedding size based on active variant.
+    active_embedding_size = llm_embedding_size if use_llm_embeddings else chunk_embedding_size
     model = ForecasterModel(
         use_time_decay=use_time_decay,
         use_chunk_attention=use_chunk_attention,
-        chunk_embedding_size=chunk_embedding_size,
+        use_llm_embeddings=use_llm_embeddings,
+        chunk_embedding_size=active_embedding_size,
         chunk_projection_dim=chunk_projection_dim,
     ).to(device)
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=weight_decay)
@@ -234,13 +323,12 @@ def _train_variant(
             y_close = batch["y_close"].to(device)
             y_vol = batch["y_vol"].to(device)
             optimizer.zero_grad()
-            kwargs = {}
-            if use_chunk_attention:
-                kwargs = {
-                    "chunks": batch["chunks"].to(device),
-                    "elapsed_days": batch["elapsed"].to(device),
-                    "chunk_mask": batch["mask"].to(device),
-                }
+            kwargs = _batch_kwargs(
+                batch,
+                use_chunk_attention=use_chunk_attention,
+                use_llm_embeddings=use_llm_embeddings,
+                device=device,
+            )
             pred = model(x, **kwargs)
             loss = loss_fn(pred[:, 0], y_close) + loss_fn(pred[:, 1], y_vol)
             loss.backward()
@@ -257,13 +345,12 @@ def _train_variant(
                 x = batch["x"].to(device)
                 y_close = batch["y_close"].to(device)
                 y_vol = batch["y_vol"].to(device)
-                kwargs = {}
-                if use_chunk_attention:
-                    kwargs = {
-                        "chunks": batch["chunks"].to(device),
-                        "elapsed_days": batch["elapsed"].to(device),
-                        "chunk_mask": batch["mask"].to(device),
-                    }
+                kwargs = _batch_kwargs(
+                    batch,
+                    use_chunk_attention=use_chunk_attention,
+                    use_llm_embeddings=use_llm_embeddings,
+                    device=device,
+                )
                 pred = model(x, **kwargs)
                 loss = loss_fn(pred[:, 0], y_close) + loss_fn(pred[:, 1], y_vol)
                 v_running += float(loss.item()) * x.shape[0]
@@ -271,7 +358,8 @@ def _train_variant(
         val_loss = v_running / max(v_n, 1)
         history.append(val_loss)
         decay_history.append(float(model.time_decay.decay_rate.detach().cpu().item()))
-        if use_chunk_attention and model.chunk_pooler is not None:
+        _uses_pooler = use_chunk_attention or use_llm_embeddings
+        if _uses_pooler and model.chunk_pooler is not None:
             chunk_lambda_history.append(float(model.chunk_pooler.decay_rate.detach().cpu().item()))
         if val_loss < best_val_loss:
             best_val_loss = val_loss
@@ -299,13 +387,12 @@ def _train_variant(
             x = batch["x"].to(device)
             y_close = batch["y_close"].cpu().numpy()
             y_vol = batch["y_vol"].cpu().numpy()
-            kwargs = {}
-            if use_chunk_attention:
-                kwargs = {
-                    "chunks": batch["chunks"].to(device),
-                    "elapsed_days": batch["elapsed"].to(device),
-                    "chunk_mask": batch["mask"].to(device),
-                }
+            kwargs = _batch_kwargs(
+                batch,
+                use_chunk_attention=use_chunk_attention,
+                use_llm_embeddings=use_llm_embeddings,
+                device=device,
+            )
             t0 = time.perf_counter()
             pred = model(x, **kwargs)
             elapsed_ms = (time.perf_counter() - t0) * 1000
@@ -331,15 +418,17 @@ def _train_variant(
     p95 = sorted(latencies_ms)[int(0.95 * (len(latencies_ms) - 1))] if latencies_ms else 0.0
 
     final_decay = float(model.time_decay.decay_rate.detach().cpu().item())
+    _uses_pooler = use_chunk_attention or use_llm_embeddings
     final_chunk_lambda = (
         float(model.chunk_pooler.decay_rate.detach().cpu().item())
-        if (use_chunk_attention and model.chunk_pooler is not None)
+        if (_uses_pooler and model.chunk_pooler is not None)
         else None
     )
 
     metrics = {
         "use_time_decay": use_time_decay,
         "use_chunk_attention": use_chunk_attention,
+        "use_llm_embeddings": use_llm_embeddings,
         "epochs": epochs,
         "best_val_loss": float(best_val_loss),
         "close_rmse": close_rmse,
@@ -394,7 +483,7 @@ def _heatmap_samples(
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Phase 4 attention + decay ablation.")
+    parser = argparse.ArgumentParser(description="Phase 4 attention + decay ablation (8-way grid).")
     parser.add_argument("--training-package-id", required=True)
     parser.add_argument("--fold-id", default="wf_fold_2")
     parser.add_argument("--data-dir", default="/data")
@@ -409,6 +498,21 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--seed", type=int, default=11)
     parser.add_argument("--owner", default="unknown")
     parser.add_argument("--artifact-root", default="/data/artifacts/phase4_attention")
+    parser.add_argument(
+        "--variants",
+        nargs="+",
+        default=None,
+        metavar="VARIANT",
+        help=(
+            f"Subset of variants to run (default: all {len(ALL_VARIANT_NAMES)}). "
+            f"Choose from: {', '.join(ALL_VARIANT_NAMES)}"
+        ),
+    )
+    parser.add_argument(
+        "--llm-store-path",
+        default=str(DEFAULT_LLM_EMBEDDINGS_PARQUET),
+        help="Path to the LLM embeddings parquet (Variant C). Defaults to the standard interim path.",
+    )
     return parser.parse_args()
 
 
@@ -428,8 +532,24 @@ def main() -> int:
     if not chunk_store_path.exists():
         raise SystemExit(f"Chunk store not found: {chunk_store_path}. Run chunk_embedding_store first.")
     chunk_store = load_chunk_store(str(chunk_store_path))
-    embedding_size = int(len(chunk_store.iloc[0]["embedding"]))
-    print(f"[ablation] chunk_store rows={len(chunk_store)} embedding_size={embedding_size}")
+    chunk_embedding_size = int(len(chunk_store.iloc[0]["embedding"]))
+    print(f"[ablation] chunk_store rows={len(chunk_store)} embedding_size={chunk_embedding_size}")
+
+    # Probe the LLM embedding size (Variant C), if the store exists.
+    llm_store_path: str = args.llm_store_path
+    llm_embedding_size: int = 768  # sensible default; overwritten below if store present
+    try:
+        from app.data.chunk_embedding_retrieval import _load_llm_store
+
+        _llm_df = _load_llm_store(llm_store_path)
+        if not _llm_df.empty:
+            llm_embedding_size = int(len(_llm_df.iloc[0]["embedding"]))
+        print(f"[ablation] llm_store rows={len(_llm_df)} llm_embedding_size={llm_embedding_size}")
+    except FileNotFoundError:
+        print(
+            f"[ablation] LLM store not found at {llm_store_path} — "
+            "Variant C cells will see zero-filled embeddings (equivalent to baseline)."
+        )
 
     print(f"[ablation] fetching market history for {args.symbol}...")
     market_df = _fetch_full_history(args.symbol, start="1995-01-01")
@@ -444,6 +564,7 @@ def main() -> int:
         max_chunks=args.max_chunks,
         lookback_days=args.lookback_days,
         sentiment_cache=sentiment_cache,
+        llm_store_path=llm_store_path,
     )
     print(f"[ablation] building val tuples...")
     val_tuples = _build_dataset(
@@ -453,6 +574,7 @@ def main() -> int:
         max_chunks=args.max_chunks,
         lookback_days=args.lookback_days,
         sentiment_cache=sentiment_cache,
+        llm_store_path=llm_store_path,
     )
     print(f"[ablation] train_tuples={len(train_tuples)} val_tuples={len(val_tuples)}")
     if not train_tuples or not val_tuples:
@@ -461,23 +583,43 @@ def main() -> int:
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"[ablation] device={device}")
 
-    variants = [
-        ("baseline", False, False),
-        ("variant_a_only", True, False),
-        ("variant_b_only", False, True),
-        ("variant_a_plus_b", True, True),
+    # 6-cell grid: {A on/off} × {B on/off, C on/off} — B and C are mutually exclusive.
+    # name, use_a, use_b, use_c
+    all_variants: list[tuple[str, bool, bool, bool]] = [
+        ("baseline",       False, False, False),
+        ("variant_a_only", True,  False, False),
+        ("variant_b_only", False, True,  False),
+        ("variant_c_only", False, False, True),
+        ("variant_a_plus_b", True, True,  False),
+        ("variant_a_plus_c", True, False, True),
     ]
+
+    # Apply --variants filter if provided.
+    requested: set[str] | None = None
+    if args.variants:
+        unknown = set(args.variants) - {n for n, *_ in all_variants}
+        if unknown:
+            raise SystemExit(
+                f"Unknown --variants values: {sorted(unknown)}. "
+                f"Valid choices: {[n for n, *_ in all_variants]}"
+            )
+        requested = set(args.variants)
+
+    variants = [(n, a, b, c) for n, a, b, c in all_variants if requested is None or n in requested]
+    print(f"[ablation] running {len(variants)} variant(s): {[n for n, *_ in variants]}")
 
     results: dict[str, Any] = {}
     heatmaps_by_variant: dict[str, Any] = {}
-    for name, use_a, use_b in variants:
-        print(f"\n[ablation] === variant: {name} (A={use_a}, B={use_b}) ===")
+    for name, use_a, use_b, use_c in variants:
+        print(f"\n[ablation] === variant: {name} (A={use_a}, B={use_b}, C={use_c}) ===")
         result, trained_model = _train_variant(
             train_tuples,
             val_tuples,
             use_time_decay=use_a,
             use_chunk_attention=use_b,
-            chunk_embedding_size=embedding_size,
+            use_llm_embeddings=use_c,
+            chunk_embedding_size=chunk_embedding_size,
+            llm_embedding_size=llm_embedding_size,
             chunk_projection_dim=args.chunk_projection_dim,
             epochs=args.epochs,
             learning_rate=args.learning_rate,
@@ -487,7 +629,7 @@ def main() -> int:
             device=device,
         )
         results[name] = result
-        if use_b:
+        if (use_b or use_c) and trained_model.chunk_pooler is not None:
             heatmaps_by_variant[name] = _heatmap_samples(val_tuples, pooler_state=trained_model, device=device)
         print(
             f"[ablation]  {name}: combined_rmse={result['combined_rmse']:.4f} "
@@ -507,7 +649,8 @@ def main() -> int:
         "symbol": args.symbol,
         "max_chunks": args.max_chunks,
         "lookback_days": args.lookback_days,
-        "chunk_embedding_size": embedding_size,
+        "chunk_embedding_size": chunk_embedding_size,
+        "llm_embedding_size": llm_embedding_size,
         "chunk_projection_dim": args.chunk_projection_dim,
         "epochs": args.epochs,
         "learning_rate": args.learning_rate,
@@ -533,16 +676,17 @@ def main() -> int:
         f"- epochs: {args.epochs}",
         f"- seed: {args.seed}",
         "",
-        "| variant | A | B | combined_rmse | close_rmse | vol_rmse | directional_acc | final_decay | final_chunk_λ | p95_ms |",
-        "|---------|---|---|---------------|------------|----------|-----------------|-------------|---------------|--------|",
+        "| variant | A | B | C | combined_rmse | close_rmse | vol_rmse | directional_acc | final_decay | final_chunk_λ | p95_ms |",
+        "|---------|---|---|---|---------------|------------|----------|-----------------|-------------|---------------|--------|",
     ]
-    for name, _, _ in variants:
+    for name, _, _, _ in variants:
         r = results[name]
         chunk_l = r["final_chunk_lambda"]
         chunk_l_str = f"{chunk_l:.4f}" if chunk_l is not None else "-"
         md_lines.append(
             f"| {name} | {'on' if r['use_time_decay'] else 'off'} | "
             f"{'on' if r['use_chunk_attention'] else 'off'} | "
+            f"{'on' if r['use_llm_embeddings'] else 'off'} | "
             f"{r['combined_rmse']:.4f} | {r['close_rmse']:.4f} | {r['volatility_rmse']:.4f} | "
             f"{r['directional_accuracy']:.4f} | {r['final_decay_rate']:.4f} | {chunk_l_str} | "
             f"{r['p95_ms']:.2f} |"

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -223,10 +223,39 @@ class ForecasterModel(nn.Module):
         *,
         use_time_decay: bool = True,
         use_chunk_attention: bool = False,
+        use_llm_embeddings: bool = False,
         chunk_embedding_size: int = DEFAULT_CHUNK_EMBEDDING_SIZE,
         chunk_projection_dim: int = DEFAULT_CHUNK_PROJECTION_DIM,
     ):
+        """Forecaster LSTM with optional text-feature variants.
+
+        Variant flags
+        -------------
+        use_time_decay : bool
+            Variant A — dampens the sentiment feature by learned exponential
+            time decay before the LSTM.
+        use_chunk_attention : bool
+            Variant B — attends over per-chunk embeddings from the chunk
+            parquet (``embedding_source="chunk"``).
+        use_llm_embeddings : bool
+            Variant C — attends over per-document LLM embeddings from the
+            llm_embeddings parquet (``embedding_source="llm"``).  Shares the
+            same ``ChunkAttentionPooler`` and projection head as Variant B.
+
+        Mutual exclusivity
+        ------------------
+        ``use_chunk_attention`` and ``use_llm_embeddings`` are mutually
+        exclusive.  Both cannot be ``True`` simultaneously because they occupy
+        the same LSTM input slot (the pooler output projection).  A
+        ``ValueError`` is raised at construction time if both are set.  The
+        eight-way ablation sweeps them as separate cells.
+        """
         super().__init__()
+        if use_chunk_attention and use_llm_embeddings:
+            raise ValueError(
+                "use_chunk_attention and use_llm_embeddings are mutually exclusive. "
+                "Set at most one to True."
+            )
         self.input_size = input_size
         self.hidden_size = hidden_size
         self.num_layers = num_layers
@@ -235,10 +264,13 @@ class ForecasterModel(nn.Module):
         self.initial_decay_rate = float(initial_decay_rate)
         self.use_time_decay = bool(use_time_decay)
         self.use_chunk_attention = bool(use_chunk_attention)
+        self.use_llm_embeddings = bool(use_llm_embeddings)
         self.chunk_embedding_size = int(chunk_embedding_size)
-        self.chunk_projection_dim = int(chunk_projection_dim) if self.use_chunk_attention else 0
+        # Either Variant B or Variant C activates the pooler path.
+        _uses_pooler = self.use_chunk_attention or self.use_llm_embeddings
+        self.chunk_projection_dim = int(chunk_projection_dim) if _uses_pooler else 0
         self.time_decay = TimeDecayAttention(initial_decay_rate)
-        if self.use_chunk_attention:
+        if _uses_pooler:
             self.chunk_pooler: ChunkAttentionPooler | None = ChunkAttentionPooler(
                 embedding_size=self.chunk_embedding_size,
                 initial_decay_rate=DEFAULT_CHUNK_DECAY_RATE,
@@ -246,8 +278,8 @@ class ForecasterModel(nn.Module):
             self.chunk_projection: nn.Linear | None = nn.Linear(
                 self.chunk_embedding_size, self.chunk_projection_dim, bias=True
             )
-            # Zero-init so Variant B starts equivalent to baseline; the model
-            # only departs from the baseline subspace if the chunk signal
+            # Zero-init so Variant B/C starts equivalent to baseline; the model
+            # only departs from the baseline subspace if the text signal
             # actually reduces loss. Avoids drowning 6 base features under
             # 8 dims of random-init noise on a small training set.
             nn.init.zeros_(self.chunk_projection.weight)
@@ -282,11 +314,15 @@ class ForecasterModel(nn.Module):
     ) -> torch.Tensor:
         if self.use_time_decay:
             x = self.time_decay(x)
-        if self.use_chunk_attention:
+        _uses_pooler = self.use_chunk_attention or self.use_llm_embeddings
+        if _uses_pooler:
             if self.chunk_pooler is None or self.chunk_projection is None:
-                raise RuntimeError("chunk_pooler not initialised but use_chunk_attention=True")
+                raise RuntimeError("chunk_pooler not initialised but pooler variant is active")
             if chunks is None or elapsed_days is None:
-                raise ValueError("ForecasterModel requires chunks/elapsed_days when use_chunk_attention=True")
+                variant = "use_chunk_attention" if self.use_chunk_attention else "use_llm_embeddings"
+                raise ValueError(
+                    f"ForecasterModel requires chunks/elapsed_days when {variant}=True"
+                )
             pooled, _, _ = self.chunk_pooler(chunks, elapsed_days, mask=chunk_mask)
             projected = self.chunk_projection(pooled)
             if projected.dim() == 1:
@@ -308,7 +344,14 @@ class ForecasterModel(nn.Module):
         elapsed_days: torch.Tensor,
         chunk_mask: torch.Tensor | None = None,
     ) -> dict[str, torch.Tensor] | None:
-        if not self.use_chunk_attention or self.chunk_pooler is None:
+        """Return pooler diagnostics when either Variant B or C is active.
+
+        Returns ``None`` when neither pooler variant is enabled.  The returned
+        dict uses the key ``"pooled"`` / ``"weights"`` / ``"decay_coeffs"``
+        regardless of which source (chunk or LLM) is active.
+        """
+        _uses_pooler = self.use_chunk_attention or self.use_llm_embeddings
+        if not _uses_pooler or self.chunk_pooler is None:
             return None
         pooled, weights, decay_coeffs = self.chunk_pooler(chunks, elapsed_days, mask=chunk_mask)
         return {

--- a/backend/app/services/gemini_client.py
+++ b/backend/app/services/gemini_client.py
@@ -106,3 +106,59 @@ class _ModelAdapter:
             config=types.GenerateContentConfig(temperature=0.0),
         )
         return response  # response has .text already
+
+
+DEFAULT_EMBEDDING_DIM = 768
+
+
+@traced("gemini.embed_text")
+def embed_text(text: str, *, model: Any) -> list[float]:
+    """Return a fixed-dim embedding for `text` using the supplied embedding model.
+
+    `model` must expose `embed_content(content, **kwargs)` returning an
+    object with `.embedding.values` (a list of floats). Empty input
+    returns a zero vector of length DEFAULT_EMBEDDING_DIM rather than
+    raising — callers can decide whether to skip those rows.
+    """
+
+    if not text:
+        return [0.0] * DEFAULT_EMBEDDING_DIM
+    response = model.embed_content(text)
+    values = list(response.embedding.values)
+    return [float(v) for v in values]
+
+
+def load_embedding_model(model_name: str = "gemini-embedding-001"):
+    """Load a Gemini embedding model. Lazy import."""
+
+    import os
+
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "GEMINI_API_KEY is not set. Add it to fed-pulse/.env before running embedding precompute."
+        )
+
+    from google import genai  # type: ignore
+
+    client = genai.Client(api_key=api_key)
+    return _EmbeddingAdapter(client, model_name)
+
+
+class _EmbeddingAdapter:
+    """Adapter so the real SDK matches the stub interface (embed_content + .embedding.values)."""
+
+    def __init__(self, client: Any, model_name: str):
+        self._client = client
+        self._model_name = model_name
+
+    def embed_content(self, content: str, **kwargs):
+        response = self._client.models.embed_content(
+            model=self._model_name,
+            contents=content,
+        )
+        # The new google-genai client returns `.embeddings` (a list); we
+        # adapt to the .embedding.values single shape used by the stub.
+        values = response.embeddings[0].values
+        wrapper = type("R", (), {"embedding": type("E", (), {"values": values})()})
+        return wrapper()

--- a/tests/unit/test_chunk_embedding_retrieval.py
+++ b/tests/unit/test_chunk_embedding_retrieval.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 torch = pytest.importorskip("torch")
 pd = pytest.importorskip("pandas")
 
-from app.data.chunk_embedding_retrieval import build_lookback_tensors  # noqa: E402
+from app.data.chunk_embedding_retrieval import (  # noqa: E402
+    _build_lookback_tensors_llm,
+    build_lookback_tensors,
+)
 
 
 def _store(rows):
@@ -78,3 +83,142 @@ def test_build_lookback_tensors_empty_when_no_matches():
     result = build_lookback_tensors(store, anchor_date="2024-12-31", lookback_days=30, max_chunks=2, embedding_size=1)
     assert result.actual_count == 0
     assert result.mask.sum().item() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Variant C (LLM embedding source) tests
+# ---------------------------------------------------------------------------
+
+
+def _write_llm_parquet(tmp_path, rows):
+    """Write a small LLM embeddings parquet fixture; fall back to jsonl if pyarrow missing."""
+    df = pd.DataFrame(rows)
+    parquet_path = tmp_path / "llm_embeddings.parquet"
+    try:
+        df.to_parquet(parquet_path, index=False)
+        return parquet_path
+    except Exception:
+        jsonl_path = tmp_path / "llm_embeddings.jsonl"
+        with jsonl_path.open("w") as h:
+            for row in rows:
+                h.write(json.dumps(row) + "\n")
+        return parquet_path  # caller should also try .jsonl
+
+
+def test_build_lookback_tensors_llm_returns_correct_shape(tmp_path):
+    """LLM source returns same tensor shapes as chunk source."""
+    rows = [
+        {"document_id": "d1", "event_date": "2024-11-01", "embedding": [0.1, 0.2, 0.3]},
+        {"document_id": "d2", "event_date": "2024-12-01", "embedding": [0.4, 0.5, 0.6]},
+    ]
+    parquet_path = _write_llm_parquet(tmp_path, rows)
+    # Use _build_lookback_tensors_llm directly so we can pass a tmp path.
+    result = _build_lookback_tensors_llm(
+        anchor_date="2024-12-31",
+        lookback_days=90,
+        max_chunks=4,
+        llm_store_path=parquet_path,
+    )
+    assert result.embeddings.shape == (4, 3)
+    assert result.elapsed_days.shape == (4,)
+    assert result.mask.shape == (4,)
+    assert result.actual_count == 2
+    assert result.mask.sum().item() == 2.0
+
+
+def test_build_lookback_tensors_llm_one_slot_per_document(tmp_path):
+    """Each document occupies exactly one slot (no chunk explosion)."""
+    rows = [
+        {"document_id": f"doc{i}", "event_date": "2024-12-01", "embedding": [float(i), 0.0]}
+        for i in range(5)
+    ]
+    parquet_path = _write_llm_parquet(tmp_path, rows)
+    result = _build_lookback_tensors_llm(
+        anchor_date="2024-12-31",
+        lookback_days=60,
+        max_chunks=10,
+        llm_store_path=parquet_path,
+    )
+    assert result.actual_count == 5
+
+
+def test_build_lookback_tensors_llm_elapsed_days_computed_from_anchor(tmp_path):
+    rows = [
+        {"document_id": "a", "event_date": "2024-12-01", "embedding": [1.0]},
+        {"document_id": "b", "event_date": "2024-12-15", "embedding": [1.0]},
+    ]
+    parquet_path = _write_llm_parquet(tmp_path, rows)
+    result = _build_lookback_tensors_llm(
+        anchor_date="2024-12-31",
+        lookback_days=60,
+        max_chunks=4,
+        embedding_size=1,
+        llm_store_path=parquet_path,
+    )
+    elapsed = sorted(result.elapsed_days.tolist()[: result.actual_count])
+    assert elapsed == [16.0, 30.0]
+
+
+def test_build_lookback_tensors_llm_caps_at_max_chunks(tmp_path):
+    rows = [
+        {"document_id": f"d{i}", "event_date": "2024-12-01", "embedding": [float(i)]}
+        for i in range(10)
+    ]
+    parquet_path = _write_llm_parquet(tmp_path, rows)
+    result = _build_lookback_tensors_llm(
+        anchor_date="2024-12-31",
+        lookback_days=60,
+        max_chunks=3,
+        llm_store_path=parquet_path,
+    )
+    assert result.actual_count == 3
+
+
+def test_build_lookback_tensors_embedding_source_chunk_default():
+    """Passing embedding_source='chunk' (default) still works as before."""
+    store = _store(
+        [
+            {"doc_id": "x", "event_date": "2024-12-01", "chunk_index": 0, "chunk_preview": "x", "embedding": [1.0]},
+        ]
+    )
+    result = build_lookback_tensors(
+        store,
+        anchor_date="2024-12-31",
+        lookback_days=60,
+        max_chunks=4,
+        embedding_size=1,
+        embedding_source="chunk",
+    )
+    assert result.actual_count == 1
+    assert result.embeddings.shape == (4, 1)
+
+
+def test_build_lookback_tensors_llm_via_embedding_source_kwarg(tmp_path):
+    """build_lookback_tensors dispatches to LLM path when embedding_source='llm'."""
+    rows = [
+        {"document_id": "z", "event_date": "2024-12-01", "embedding": [0.5, 0.5]},
+    ]
+    parquet_path = _write_llm_parquet(tmp_path, rows)
+
+    # Patch the default LLM path so the top-level dispatcher finds our fixture.
+    import app.data.chunk_embedding_retrieval as retrieval_mod
+
+    original = retrieval_mod.DEFAULT_LLM_EMBEDDINGS_PARQUET
+    retrieval_mod.DEFAULT_LLM_EMBEDDINGS_PARQUET = parquet_path
+    # Clear the lru_cache so our patched path is used.
+    retrieval_mod._load_llm_store.cache_clear()
+    try:
+        dummy_store = pd.DataFrame()  # ignored for LLM path
+        result = build_lookback_tensors(
+            dummy_store,
+            anchor_date="2024-12-31",
+            lookback_days=60,
+            max_chunks=4,
+            embedding_source="llm",
+        )
+    finally:
+        retrieval_mod.DEFAULT_LLM_EMBEDDINGS_PARQUET = original
+        retrieval_mod._load_llm_store.cache_clear()
+
+    assert result.actual_count == 1
+    assert result.embeddings.shape == (4, 2)

--- a/tests/unit/test_forecaster.py
+++ b/tests/unit/test_forecaster.py
@@ -463,3 +463,95 @@ def test_forecaster_variant_b_pooler_gradient_resumes_after_projection_departs_f
     assert model.chunk_pooler.raw_lambda.grad is not None
     assert model.chunk_pooler.raw_lambda.grad.abs().item() > 0.0
     assert model.chunk_projection.weight.grad.abs().sum().item() > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Variant C (use_llm_embeddings) tests
+# ---------------------------------------------------------------------------
+
+
+def test_forecaster_variant_c_builds_without_error():
+    """ForecasterModel with use_llm_embeddings=True constructs successfully."""
+    model = ForecasterModel(
+        use_llm_embeddings=True,
+        chunk_embedding_size=10,
+        chunk_projection_dim=4,
+    )
+    assert model.use_llm_embeddings is True
+    assert model.use_chunk_attention is False
+    assert model.chunk_pooler is not None
+    assert model.chunk_projection is not None
+    assert model.lstm.input_size == FEATURE_SIZE + 4
+
+
+def test_forecaster_variant_c_forward_returns_correct_shape():
+    """Variant C forward pass returns (batch, 2) and volatility >= 0."""
+    model = ForecasterModel(
+        use_llm_embeddings=True,
+        chunk_embedding_size=12,
+        chunk_projection_dim=4,
+    )
+    x = torch.randn(2, 5, FEATURE_SIZE)
+    # LLM path: one doc per slot, same interface as chunk path.
+    chunks = torch.randn(2, 6, 12)
+    elapsed = torch.zeros(2, 6)
+    mask = torch.ones(2, 6)
+    out = model(x, chunks=chunks, elapsed_days=elapsed, chunk_mask=mask)
+    assert out.shape == (2, 2)
+    assert out[:, 1].min().item() >= 0.0
+
+
+def test_forecaster_variant_c_requires_chunks():
+    """Variant C raises ValueError when chunks/elapsed_days are not supplied."""
+    model = ForecasterModel(use_llm_embeddings=True, chunk_embedding_size=8, chunk_projection_dim=2)
+    x = torch.randn(1, 5, FEATURE_SIZE)
+    with pytest.raises(ValueError):
+        model(x)
+
+
+def test_forecaster_variant_b_and_c_mutually_exclusive():
+    """Setting both use_chunk_attention and use_llm_embeddings raises ValueError."""
+    with pytest.raises(ValueError):
+        ForecasterModel(use_chunk_attention=True, use_llm_embeddings=True)
+
+
+def test_forecaster_variant_c_attention_diagnostics():
+    """attention_diagnostics returns weights when Variant C is active."""
+    model = ForecasterModel(use_llm_embeddings=True, chunk_embedding_size=8, chunk_projection_dim=2)
+    chunks = torch.randn(3, 8)
+    elapsed = torch.tensor([0.0, 5.0, 30.0])
+    diag = model.attention_diagnostics(chunks, elapsed)
+    assert diag is not None
+    assert diag["weights"].shape == (3,)
+    assert diag["decay_coeffs"].shape == (3,)
+
+
+def test_forecaster_variant_c_gradient_reaches_projection():
+    """Projection weight receives gradient after one backward pass (Variant C)."""
+    model = ForecasterModel(use_llm_embeddings=True, chunk_embedding_size=6, chunk_projection_dim=3)
+    with torch.no_grad():
+        model.chunk_projection.weight.fill_(0.01)
+    x = torch.randn(1, 5, FEATURE_SIZE)
+    chunks = torch.randn(1, 4, 6)
+    elapsed = torch.tensor([[0.0, 1.0, 2.0, 3.0]])
+    mask = torch.ones(1, 4)
+    out = model(x, chunks=chunks, elapsed_days=elapsed, chunk_mask=mask)
+    out.sum().backward()
+    assert model.chunk_projection.weight.grad is not None
+    assert model.chunk_projection.weight.grad.abs().sum().item() > 0.0
+
+
+def test_forecaster_variant_b_still_works_as_regression():
+    """Existing Variant B path remains unbroken after Variant C additions."""
+    model = ForecasterModel(
+        use_chunk_attention=True,
+        chunk_embedding_size=8,
+        chunk_projection_dim=4,
+    )
+    x = torch.randn(2, 5, FEATURE_SIZE)
+    chunks = torch.randn(2, 5, 8)
+    elapsed = torch.zeros(2, 5)
+    mask = torch.ones(2, 5)
+    out = model(x, chunks=chunks, elapsed_days=elapsed, chunk_mask=mask)
+    assert out.shape == (2, 2)
+    assert out[:, 1].min().item() >= 0.0

--- a/tests/unit/test_gemini_client.py
+++ b/tests/unit/test_gemini_client.py
@@ -54,3 +54,31 @@ def test_score_passage_strips_markdown_code_fences() -> None:
     result = gemini_client.score_passage("text", model=stub)
     assert result["label"] == "neutral"
     assert result["confidence"] == pytest.approx(0.5)
+
+
+class _StubEmbeddingModel:
+    def __init__(self, embeddings):
+        self._embeddings = list(embeddings)
+
+    def embed_content(self, content, **kwargs):
+        v = self._embeddings.pop(0)
+        wrapper = type("R", (), {"embedding": type("E", (), {"values": v})()})
+        return wrapper()
+
+
+def test_embed_text_returns_list_of_floats() -> None:
+    stub = _StubEmbeddingModel([[0.1, 0.2, 0.3, 0.4]])
+    result = gemini_client.embed_text("hello world", model=stub)
+    assert isinstance(result, list)
+    assert len(result) == 4
+    assert result == [0.1, 0.2, 0.3, 0.4]
+
+
+def test_embed_text_handles_empty_string_returns_zero_vector() -> None:
+    """Empty input should not raise; return a zero vector of the configured
+    default embedding dim (768)."""
+
+    result = gemini_client.embed_text("", model=None)
+    assert isinstance(result, list)
+    assert len(result) == 768
+    assert all(v == 0.0 for v in result)

--- a/tests/unit/test_llm_embedding_store.py
+++ b/tests/unit/test_llm_embedding_store.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.data import llm_embedding_store
+
+
+class _StubEmbeddingClient:
+    def __init__(self, vectors):
+        self._vectors = list(vectors)
+
+    def embed_content(self, content, **kwargs):
+        v = self._vectors.pop(0)
+        wrapper = type("R", (), {"embedding": type("E", (), {"values": v})()})
+        return wrapper()
+
+
+def _write_registry(path: Path, n: int = 3) -> None:
+    rows = []
+    for i in range(n):
+        rows.append(
+            {
+                "record_id": f"doc{i}",
+                "event_date": f"2024-01-{i+1:02d}",
+                "text": f"document {i} body",
+                "source_type": "fomc_minutes",
+            }
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as h:
+        for r in rows:
+            h.write(json.dumps(r) + "\n")
+
+
+def test_precompute_embeddings_writes_one_row_per_document(tmp_path: Path) -> None:
+    registry = tmp_path / "registry.jsonl"
+    _write_registry(registry, n=3)
+    output = tmp_path / "llm_embeddings.parquet"
+    client = _StubEmbeddingClient(
+        [
+            [0.1, 0.2, 0.3],
+            [0.4, 0.5, 0.6],
+            [0.7, 0.8, 0.9],
+        ]
+    )
+
+    written = llm_embedding_store.precompute_embeddings(
+        registry_path=registry,
+        output_path=output,
+        embedding_client=client,
+    )
+
+    assert written == 3
+    # Output may be parquet or jsonl-fallback if pyarrow missing
+    assert output.exists() or output.with_suffix(".jsonl").exists()
+
+
+def test_precompute_embeddings_skips_empty_text_rows(tmp_path: Path) -> None:
+    registry = tmp_path / "registry.jsonl"
+    rows = [
+        {"record_id": "d0", "event_date": "2024-01-01", "text": "real text", "source_type": "fomc_minutes"},
+        {"record_id": "d1", "event_date": "2024-01-02", "text": "", "source_type": "fomc_minutes"},
+        {"record_id": "d2", "event_date": "2024-01-03", "text": "another", "source_type": "fomc_minutes"},
+    ]
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    with registry.open("w", encoding="utf-8") as h:
+        for r in rows:
+            h.write(json.dumps(r) + "\n")
+
+    output = tmp_path / "llm_embeddings.parquet"
+    client = _StubEmbeddingClient([[0.1, 0.2], [0.3, 0.4]])  # only 2 vectors needed
+
+    written = llm_embedding_store.precompute_embeddings(
+        registry_path=registry,
+        output_path=output,
+        embedding_client=client,
+    )
+    assert written == 2  # the empty-text row is skipped
+
+
+def test_parse_args_requires_no_extra_args() -> None:
+    """All args have defaults; bare _parse_args([]) should not raise."""
+
+    args = llm_embedding_store._parse_args([])
+    assert args.embedding_model == "gemini-embedding-001"
+    assert args.request_interval_seconds == 0.0
+    assert args.max_rows == 0


### PR DESCRIPTION
## Summary

Plan 6 of the 2026-05-05 scope extension. Closes #41. Variant C — LLM embeddings as the multi-document text feature for the forecaster — lands alongside the existing Variant B (FinBERT chunk attention). Mirrors Variant B's plumbing exactly so the cross-encoder comparison is clean: same retrieval, same pooling, same decay, only the embedding source changes.

## What landed

- \`backend/app/services/gemini_client.py\` += \`embed_text(text, *, model)\`, \`load_embedding_model(model_name)\`, \`_EmbeddingAdapter\`. Stub-friendly interface for unit tests.
- \`backend/app/data/llm_embedding_store.py\` — CLI + \`precompute_embeddings()\` that reads the source registry, embeds each document via Gemini, and writes parquet (or jsonl fallback) keyed on \`document_id\`. Mirrors \`chunk_embedding_store.py\`. Supports \`--request-interval-seconds\` for rate-limit handling and \`--max-rows\` for smoke runs.
- \`backend/app/data/chunk_embedding_retrieval.py\` += \`embedding_source: str = "chunk"\` kwarg on \`build_lookback_tensors\`. When \`"llm"\`, reads from the LLM-embeddings parquet and shapes each document as a single "chunk" so the existing \`ChunkAttentionPooler\` interface holds.
- \`backend/app/services/forecaster.py::ForecasterModel\` += \`use_llm_embeddings: bool = False\` flag. **Mutually exclusive with \`use_chunk_attention\`** at the constructor (both share the LSTM input slot); the runtime guard raises \`ValueError\`.
- \`backend/app/data/phase4_attention_ablation.py\` extended to a **6-cell grid** (\`baseline\`, \`variant_a_only\`, \`variant_b_only\`, \`variant_c_only\`, \`variant_a_plus_b\`, \`variant_a_plus_c\`). The 8-way grid would have included \`B+C\` and \`A+B+C\` but those are structurally excluded by the constructor guard. New CLI flags: \`--variants\`, \`--llm-store-path\`.

## Verification

- 160 unit tests pass (109 baseline → 142 after Plan 5 → 160 after Plan 6: 2 new \`embed_text\`, 3 new \`llm_embedding_store\`, 6 new \`chunk_embedding_retrieval\` LLM-path, 7 new forecaster Variant C, 1 regression for Variant B).
- 20-document live precompute via \`gemini-embedding-001\` (3072-dim, free tier). \`text-embedding-004\` returned 404 with the current \`google-genai\` SDK — \`gemini-embedding-001\` is the working choice.
- 5-epoch fold-2 \`variant_c_only\` ablation cell: combined_rmse 0.0700, close_rmse 0.0979, vol_rmse 0.0154. Confirms the cell trains end-to-end. Numbers are NOT comparable to Plan-4's 200-epoch Variant A 0.00090 — production 6-cell × 200-epoch ablation is a workflow operation.

## Two latent bugs caught and fixed during the smoke (commit 71d2e41)

1. \`_build_dataset\` zero-fill fallback used a hardcoded 768-dim shape regardless of the active embedding model (3072 for gemini-embedding-001), breaking \`ChunkAttentionPooler\` on a dim mismatch. Threaded \`llm_embedding_size\` through.
2. \`_heatmap_samples\` always read \`t.chunk_embeddings\`, masking Variant C diagnostics as Variant B's. Added \`use_llm_embeddings\` dispatch.

## Adjacent finding (Plan 5 carryover)

The gtfintechlab/FOMC-RoBERTa 1-epoch smoke from Plan 5 completed during this PR's work: macro-F1 0.8409 / accuracy 0.8563 on the 167-row fold-2 test slice. That's a 28-percentage-point jump over FinBERT-FOMC seed-71's 0.6536. **Almost certainly data contamination** — gtfintechlab also published the Trillion Dollar Words / \`fomc_communication\` corpus we ingest as \`hf_fomc_communication\`, so the model probably saw the test rows during pretraining. Flagged in the wiki Progress Snapshot; the encoder stays in the registry for completeness but cannot be in the headline comparison panel without a clean held-out slice.

## Test plan

- [x] \`docker compose run --rm backend pytest tests/unit -v\` (160 passed)
- [x] Live precompute: \`docker compose run --rm -e GEMINI_API_KEY backend python -m app.data.llm_embedding_store --max-rows 20 --request-interval-seconds 2 --embedding-model gemini-embedding-001\` → 20 embeddings written
- [x] Live ablation: \`docker compose run --rm -e GEMINI_API_KEY backend python -m app.data.phase4_attention_ablation --variants variant_c_only --max-epochs 5 --seed 11\` → cell trained, output table includes Variant C row
- [ ] Production 6-cell × 200-epoch ablation on the post-expansion corpus (workflow operation, deferred)

## Issue tracking

- #41 closes with this PR.