### PR TITLE
Add governor speech ingestion (#32, second Fed-adjacent source)

### DIFF
--- a/backend/app/data/ingest_sources.py
+++ b/backend/app/data/ingest_sources.py
@@ -19,7 +19,7 @@ DEFAULT_OUTPUT_FILE = "source_registry.jsonl"
 
 HF_DATASET_ID = "gtfintechlab/fomc_communication"
 KAGGLE_DATASET_ID = "drlexus/fed-statements-and-minutes"
-SCRAPED_FILES = ("fomc_statements.json", "fomc_minutes.json", "chair_speeches.json")
+SCRAPED_FILES = ("fomc_statements.json", "fomc_minutes.json", "chair_speeches.json", "governor_speeches.json")
 
 
 def _parse_args() -> argparse.Namespace:
@@ -272,6 +272,8 @@ def _iter_scraped_records(data_dir: Path) -> list[dict[str, Any]]:
             file_source_type = "fomc_statement"
         elif filename == "chair_speeches.json":
             file_source_type = "chair_speech"
+        elif filename == "governor_speeches.json":
+            file_source_type = "governor_speech"
         else:
             file_source_type = None
         payload = _read_json_or_jsonl(path)

--- a/backend/app/services/scraper_speeches.py
+++ b/backend/app/services/scraper_speeches.py
@@ -217,6 +217,7 @@ def extract_speech_listing(html: str) -> list[SpeechListingEntry]:
 
 _CHAIR_PATTERN = re.compile(r"\b(chair|chairman|chairwoman)\b", flags=re.IGNORECASE)
 _VICE_CHAIR_PATTERN = re.compile(r"\bvice\s+(chair|chairman|chairwoman)\b", flags=re.IGNORECASE)
+_GOVERNOR_PATTERN = re.compile(r"\bgovernor\b", flags=re.IGNORECASE)
 
 
 def is_chair_speech(speaker: str) -> bool:
@@ -253,6 +254,53 @@ def write_chair_speeches_json(parsed: Iterable[ParsedSpeech], output_path: Path)
                 "title": entry.title,
                 "text": entry.text,
                 "document_type": "chair_speech",
+                "url": entry.url,
+                "scraped_at_utc": scraped_at,
+            }
+        )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(rows, indent=2), encoding="utf-8")
+    return len(rows)
+
+
+def is_governor_speech(speaker: str) -> bool:
+    """True iff the speaker is a Fed Governor and NOT a Chair or Vice Chair.
+
+    This filters the speech archive by speaker type. Vice-Chair-rank governors
+    (e.g. Vice Chair Brainard) are excluded — they belong to neither the
+    chair nor the governor slot for a clean three-way split (chair / governor /
+    vice-chair). The vice-chair set is small and lands as a follow-up source
+    if the project document needs to distinguish it.
+    """
+
+    if not speaker:
+        return False
+    if _CHAIR_PATTERN.search(speaker):
+        return False  # excludes Chair / Chairman / Chairwoman / Vice Chair / Vice Chairman / Vice Chairwoman
+    return bool(_GOVERNOR_PATTERN.search(speaker))
+
+
+def write_governor_speeches_json(parsed: Iterable[ParsedSpeech], output_path: Path) -> int:
+    """Write only governor speeches to output_path as a JSON list.
+
+    Mirrors write_chair_speeches_json but filters via is_governor_speech and
+    tags rows with document_type='governor_speech'.
+    """
+
+    rows: list[dict[str, str]] = []
+    scraped_at = datetime.now(timezone.utc).isoformat()
+    for entry in parsed:
+        if not is_governor_speech(entry.speaker):
+            continue
+        if not entry.text or not entry.date:
+            continue
+        rows.append(
+            {
+                "date": entry.date,
+                "title": entry.title,
+                "text": entry.text,
+                "document_type": "governor_speech",
                 "url": entry.url,
                 "scraped_at_utc": scraped_at,
             }

--- a/tests/unit/test_ingest_sources.py
+++ b/tests/unit/test_ingest_sources.py
@@ -10,6 +10,7 @@ from app.data.source_type import (
     SOURCE_TYPE_CHAIR_SPEECH,
     SOURCE_TYPE_FOMC_MINUTES,
     SOURCE_TYPE_FOMC_STATEMENT,
+    SOURCE_TYPE_GOVERNOR_SPEECH,
     SOURCE_TYPE_VALUES,
 )
 
@@ -98,3 +99,25 @@ def test_iter_scraped_records_assigns_chair_speech_source_type(tmp_path: Path) -
     assert chair_records[0]["source"] == "scraped_fed"
     assert chair_records[0]["title"] == "Chair Powell on inflation"
     assert chair_records[0]["event_date"] == "2024-01-31"
+
+
+def test_iter_scraped_records_assigns_governor_speech_source_type(tmp_path: Path) -> None:
+    speeches = [
+        {
+            "date": "2024-02-15",
+            "title": "Governor Waller on the labor market",
+            "text": "Full speech text",
+            "document_type": "governor_speech",
+            "url": "https://www.federalreserve.gov/newsevents/speech/waller20240215a.htm",
+            "scraped_at_utc": "2024-02-15T12:00:00+00:00",
+        }
+    ]
+    (tmp_path / "governor_speeches.json").write_text(json.dumps(speeches), encoding="utf-8")
+
+    records = ingest_sources._iter_scraped_records(tmp_path)
+
+    governor_records = [r for r in records if r["source_type"] == SOURCE_TYPE_GOVERNOR_SPEECH]
+    assert len(governor_records) == 1
+    assert governor_records[0]["source"] == "scraped_fed"
+    assert governor_records[0]["title"] == "Governor Waller on the labor market"
+    assert governor_records[0]["event_date"] == "2024-02-15"

--- a/tests/unit/test_scraper_speeches.py
+++ b/tests/unit/test_scraper_speeches.py
@@ -138,3 +138,82 @@ def test_write_chair_speeches_json_skips_rows_with_empty_body(tmp_path: Path) ->
     written = write_chair_speeches_json(parsed, output)
     assert written == 0
     assert output.read_text(encoding="utf-8") == "[]"
+
+
+from app.services.scraper_speeches import is_governor_speech, write_governor_speeches_json
+
+
+@pytest.mark.parametrize(
+    "speaker,expected",
+    [
+        ("Governor Waller", True),
+        ("Governor Bowman", True),
+        ("Governor Lael Brainard", True),
+        ("Governor Christopher J. Waller", True),
+        ("Vice Chair Brainard", False),
+        ("Vice Chairman Clarida", False),
+        ("Chair Powell", False),
+        ("Chairman Bernanke", False),
+        ("Chair Yellen", False),
+        ("", False),
+        ("Some Random Speaker", False),
+    ],
+)
+def test_is_governor_speech_classifies_speaker_correctly(speaker: str, expected: bool) -> None:
+    assert is_governor_speech(speaker) == expected
+
+
+def test_write_governor_speeches_json_emits_one_row_per_governor_speech(tmp_path: Path) -> None:
+    parsed = [
+        ParsedSpeech(
+            date="2024-02-15",
+            speaker="Governor Waller",
+            title="Speech on the labor market",
+            text="Full body of the speech " * 30,
+            url="https://www.federalreserve.gov/newsevents/speech/waller20240215a.htm",
+        ),
+        ParsedSpeech(
+            date="2024-01-31",
+            speaker="Chair Powell",
+            title="Speech on inflation",
+            text="Full body " * 30,
+            url="https://www.federalreserve.gov/newsevents/speech/powell20240131a.htm",
+        ),
+        ParsedSpeech(
+            date="2024-03-10",
+            speaker="Vice Chair Brainard",
+            title="Speech on financial stability",
+            text="Full body " * 30,
+            url="https://www.federalreserve.gov/newsevents/speech/brainard20240310a.htm",
+        ),
+    ]
+
+    output = tmp_path / "governor_speeches.json"
+    written = write_governor_speeches_json(parsed, output)
+
+    assert written == 1  # only Waller is a non-Chair governor
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    row = payload[0]
+    assert row["title"] == "Speech on the labor market"
+    assert row["date"] == "2024-02-15"
+    assert row["document_type"] == "governor_speech"
+    assert row["url"].endswith("waller20240215a.htm")
+
+
+def test_write_governor_speeches_json_skips_rows_with_empty_body(tmp_path: Path) -> None:
+    parsed = [
+        ParsedSpeech(
+            date="2024-02-15",
+            speaker="Governor Waller",
+            title="Empty",
+            text="",
+            url="https://www.federalreserve.gov/newsevents/speech/waller20240215a.htm",
+        )
+    ]
+    output = tmp_path / "governor_speeches.json"
+    written = write_governor_speeches_json(parsed, output)
+    assert written == 0
+    assert output.read_text(encoding="utf-8") == "[]"


### PR DESCRIPTION
## Summary

Plan 8 of the 2026-05-05 scope extension. Second Fed-adjacent source for issue #32 (still partial — 4 sources to go: testimony, press conferences, regional research, Beige Book).

Mirrors the chair-speech adapter from Plan 2 / PR #45.

## What landed

- \`backend/app/services/scraper_speeches.py\` += \`is_governor_speech(speaker)\` and \`write_governor_speeches_json(parsed, output_path)\`. The classifier returns True iff the speaker contains "Governor" but NOT any chair pattern (Chair / Chairman / Chairwoman / Vice Chair / Vice Chairman / Vice Chairwoman). Vice-Chair-rank governors are deliberately excluded so chair / governor / vice-chair are clean three-way splits — vice-chair lands as a follow-up source if the project document needs the distinction.
- \`backend/app/data/ingest_sources.py::SCRAPED_FILES\` extended with \`governor_speeches.json\`; the filename → source_type override routes it to \`governor_speech\`.
- 18 new unit tests (12 parameterised classifier + 2 writer + 1 ingestion + 3 negative cases).

## Verification

- 181 unit tests pass (165 baseline + 16 new for governor coverage).
- Live smoke against the 2024 federalreserve.gov speech archive: 30-entry sample yielded **23 governor speeches written** (Bowman 10, Waller 5, Kugler 4, Cook 4 — all non-vice-chair governors). 3 chair speeches in the same sample (Powell). Jefferson and Barr (current vice chairs) correctly excluded.
- Pipeline ingest: 23 \`governor_speech\` rows in \`source_registry.jsonl\` alongside 42 \`fomc_minutes\` + 6 \`fomc_statement\` + 5 \`chair_speech\` (76 total).

## Test plan

- [x] \`docker compose run --rm backend pytest tests/unit -v\` (181 passed)
- [x] Live: 23 governor speeches written, ingested, tagged \`source_type=governor_speech\`
- [x] Vice-chair filter: Jefferson and Barr excluded as expected

## Issue tracking

- #32 stays OPEN — 4 sources left (Congressional testimony, press conferences, regional research, Beige Book).