### PR TITLE
Add Beige Book ingestion (#32, fifth Fed-adjacent source)

### DIFF
--- a/backend/app/data/ingest_sources.py
+++ b/backend/app/data/ingest_sources.py
@@ -26,6 +26,7 @@ SCRAPED_FILES = (
     "governor_speeches.json",
     "congressional_testimonies.json",
     "press_conferences.json",
+    "beige_book.json",
 )
 
 
@@ -285,6 +286,8 @@ def _iter_scraped_records(data_dir: Path) -> list[dict[str, Any]]:
             file_source_type = "congressional_testimony"
         elif filename == "press_conferences.json":
             file_source_type = "press_conference"
+        elif filename == "beige_book.json":
+            file_source_type = "beige_book"
         else:
             file_source_type = None
         payload = _read_json_or_jsonl(path)

--- a/backend/app/services/scraper_beige_book.py
+++ b/backend/app/services/scraper_beige_book.py
@@ -1,0 +1,241 @@
+"""Federal Reserve Beige Book scraper.
+
+The Beige Book is a regional economic survey published 8 times a year
+(one per FOMC meeting). Each issue contains a national summary plus
+12 district reports. The federalreserve.gov URL scheme uses base landing
+pages at /monetarypolicy/beigebook{YYYYMM}.htm (or date variants like
+beigebook20230531.htm) which contain only boilerplate "About This
+Publication" text. The substantive content lives at:
+  - /monetarypolicy/beigebook{YYYYMM}-summary.htm  (national summary)
+  - /monetarypolicy/beigebook{YYYYMM}-{district}.htm  (district reports)
+
+This adapter reads the archive listing at
+/monetarypolicy/publications/beige-book-default.htm, discovers issue
+base URLs (from both direct <a href> links and the commented-out sitemap
+list embedded in the page), and derives the summary URL for each issue.
+The national summary is used as the canonical content page — it contains
+the cross-district synthesis document which is the most analytically
+relevant single page for sentiment analysis.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup
+
+
+ARCHIVE_BASE_URL = "https://www.federalreserve.gov"
+
+# Matches any beigebook URL that looks like an issue page:
+#   beigebook202401.htm           (6-digit YYYYMM)
+#   beigebook20230531.htm         (8-digit YYYYMMDD, older convention)
+#   beigebook202401-summary.htm   (national summary direct link from listing)
+# Deliberately excludes:
+#   beige-book-faqs.htm, beige-book-archive.htm  (informational pages)
+#   beigebook202401-boston.htm  (district sub-pages — derived, not listed)
+BEIGE_BOOK_ISSUE_PATTERN = re.compile(
+    r"^/monetarypolicy/beigebook(\d{6}|\d{8})(-summary)?\.htm$"
+)
+
+# For extracting date from any beigebook URL variant
+DATE_FROM_URL_PATTERN = re.compile(r"/beigebook(\d{6,8})(?:-[a-z-]+)?\.htm")
+
+
+@dataclass(frozen=True)
+class BeigeBookListingEntry:
+    date: str  # ISO yyyy-mm-dd
+    url: str   # URL of the national summary page for this issue
+
+
+@dataclass(frozen=True)
+class ParsedBeigeBook:
+    date: str
+    title: str
+    text: str
+    url: str
+
+
+def _clean_text(value: str) -> str:
+    return re.sub(r"\s+", " ", (value or "")).strip()
+
+
+def _date_from_url(url: str) -> str:
+    """Extract an ISO date string from any beigebook URL variant.
+
+    Handles:
+      beigebook202401.htm          → 2024-01-01
+      beigebook202401-summary.htm  → 2024-01-01
+      beigebook20230531.htm        → 2023-05-31
+    """
+    matched = DATE_FROM_URL_PATTERN.search(url)
+    if not matched:
+        return ""
+    digits = matched.group(1)
+    if len(digits) == 6:
+        return f"{digits[:4]}-{digits[4:6]}-01"
+    if len(digits) == 8:
+        return f"{digits[:4]}-{digits[4:6]}-{digits[6:8]}"
+    return ""
+
+
+def _base_to_summary_url(base_url: str) -> str:
+    """Convert a beigebook base URL to its national summary URL.
+
+    beigebook202401.htm          → beigebook202401-summary.htm
+    beigebook202401-summary.htm  → beigebook202401-summary.htm  (idempotent)
+    """
+    if base_url.endswith("-summary.htm"):
+        return base_url
+    # Strip .htm and append -summary.htm
+    return base_url[:-4] + "-summary.htm"
+
+
+def extract_beige_book_listing(html: str) -> list[BeigeBookListingEntry]:
+    """Parse the Beige Book archive page and return one entry per issue.
+
+    Discovers issue URLs from two sources in the listing HTML:
+      1. Direct <a href> anchor tags (recent issues)
+      2. Commented-out sitemap list embedded by the CMS (full archive)
+
+    Returns entries whose URL points to the national summary page for each
+    issue. Entries without a parseable date are silently skipped.
+    Duplicate issues (same date/URL) are deduplicated.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    seen_dates: set[str] = set()
+    entries: list[BeigeBookListingEntry] = []
+
+    def _add(href: str) -> None:
+        href = href.strip()
+        if not BEIGE_BOOK_ISSUE_PATTERN.match(href):
+            return
+        summary_path = _base_to_summary_url(href)
+        absolute = urljoin(ARCHIVE_BASE_URL, summary_path)
+        date_iso = _date_from_url(absolute)
+        if not date_iso or date_iso in seen_dates:
+            return
+        seen_dates.add(date_iso)
+        entries.append(BeigeBookListingEntry(date=date_iso, url=absolute))
+
+    # Source 1: explicit <a href> links
+    for anchor in soup.select("a[href]"):
+        _add(anchor.get("href") or "")
+
+    # Source 2: commented-out sitemap list embedded by the CMS
+    # The listing page contains HTML comments like:
+    #   <!--<ul><li>/monetarypolicy/beigebook202604.htm</li>...-->
+    raw_html = html
+    for comment_match in re.finditer(r"<!--(.*?)-->", raw_html, re.DOTALL):
+        comment_body = comment_match.group(1)
+        for path_match in re.finditer(r"/monetarypolicy/beigebook[^<\"'\s]+\.htm", comment_body):
+            _add(path_match.group(0))
+
+    return entries
+
+
+def parse_beige_book_page(html: str, *, source_url: str) -> ParsedBeigeBook:
+    """Parse a Beige Book national summary (or district) page.
+
+    Extracts the page title and substantive body text from the FRB content
+    area (div#article). The national summary page contains the cross-district
+    synthesis which is the most analytically relevant content for sentiment
+    analysis. District pages follow the same HTML structure.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    # --- Title ---
+    title = ""
+    og = soup.find("meta", attrs={"property": "og:title"})
+    if og and og.get("content"):
+        title = _clean_text(str(og["content"]))
+    if not title:
+        title_tag = soup.find("title")
+        if title_tag:
+            title = _clean_text(title_tag.get_text(" ", strip=True))
+            title = re.sub(
+                r"\s*-\s*Federal Reserve Board\s*$", "", title, flags=re.IGNORECASE
+            )
+            title = re.sub(
+                r"^The Fed\s*-\s*", "", title, flags=re.IGNORECASE
+            )
+    if not title:
+        h_tag = soup.select_one("h1, h2, h3")
+        if h_tag:
+            title = _clean_text(h_tag.get_text(" ", strip=True))
+    if not title:
+        title = "Beige Book"
+
+    # Prefix with "Beige Book" if not already present
+    if "beige book" not in title.lower() and "beigebook" not in title.lower():
+        title = f"Beige Book - {title}"
+
+    # --- Body text ---
+    # Try progressively broader selectors; stop when we have substantive content
+    body_chunks: list[str] = []
+
+    for selector in [
+        "div#article p",
+        "div.col-xs-12.col-md-9 p",
+        "article p",
+        "main p",
+    ]:
+        nodes = soup.select(selector)
+        chunks = [_clean_text(n.get_text(" ", strip=True)) for n in nodes]
+        chunks = [c for c in chunks if c and len(c) > 20]
+        if len(chunks) >= 3:
+            body_chunks = chunks
+            break
+
+    if not body_chunks:
+        # Last resort: every <p> in the document
+        all_p = soup.select("p")
+        body_chunks = [
+            _clean_text(n.get_text(" ", strip=True))
+            for n in all_p
+            if _clean_text(n.get_text(" ", strip=True)) and len(_clean_text(n.get_text(" ", strip=True))) > 20
+        ]
+
+    body = "\n".join(body_chunks)
+    date_iso = _date_from_url(source_url)
+
+    return ParsedBeigeBook(
+        date=date_iso,
+        title=title,
+        text=body,
+        url=source_url,
+    )
+
+
+def write_beige_book_json(parsed: Iterable[ParsedBeigeBook], output_path: Path) -> int:
+    """Write parsed Beige Book entries to a JSON file.
+
+    Rows with empty date or text are skipped. Returns the number of rows
+    written. The output format mirrors other scraped JSON files so that
+    ingest_sources._iter_scraped_records can ingest it unchanged.
+    """
+    rows: list[dict[str, str]] = []
+    scraped_at = datetime.now(timezone.utc).isoformat()
+    for entry in parsed:
+        if not entry.text or not entry.date:
+            continue
+        rows.append(
+            {
+                "date": entry.date,
+                "title": entry.title,
+                "text": entry.text,
+                "document_type": "beige_book",
+                "url": entry.url,
+                "scraped_at_utc": scraped_at,
+            }
+        )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(rows, indent=2), encoding="utf-8")
+    return len(rows)

--- a/tests/fixtures/fed_beige_book_listing.html
+++ b/tests/fixtures/fed_beige_book_listing.html
@@ -1,0 +1,1620 @@
+﻿<!doctype html>
+<html lang="en" class="no-js">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.6, user-scalable=1"/>
+        <meta name="keywords" content="Board of Governors of the Federal Reserve System, Federal Reserve Board of Governors, Federal Reserve Board, Federal Reserve" />
+        <meta name="description" content="The Federal Reserve Board of Governors in Washington DC." />
+        <meta property="og:type" content="article" /> 
+        <meta property="og:title" content="Beige Book"/>    
+        <meta property="og:image" content="https://www.federalreserve.gov/images/social-media/social-default-image-opengraph.jpg" />
+        <meta property="og:image:alt" content="Board of Governors of the Federal Reserve System" />
+        <meta property="og:description" content="The Federal Reserve Board of Governors in Washington DC."/>
+        <meta property="og:url" content="https://www.federalreserve.gov/monetarypolicy/publications/beige-book-default.htm" />
+        <meta name="twitter:card" content="summary" />    
+        <meta name="twitter:title" content="Beige Book" />
+        <meta name="twitter:image" content="https://www.federalreserve.gov/images/social-media/social-default-image-twitter.jpg" />
+        <meta name="twitter:image:alt" content="Board of Governors of the Federal Reserve System" />
+        <meta name="twitter:description" content="The Federal Reserve Board of Governors in Washington DC." />
+        
+        <title>Federal Reserve Board - Beige Book</title>
+        
+        <link href="/css/bootstrap.css" rel="stylesheet" type="text/css">
+        <link href="/css/bluesteel-theme.css" rel="stylesheet" type="text/css">
+        <link rel="stylesheet" href="/assets/main.css">
+        <script src="/assets/main.js" defer type="module"></script>
+        <script src="/js/modernizr-latest.js" type="text/javascript"></script>
+        <link href="/css/icons.data.svg.css" rel="stylesheet">           
+        <script src="/js/angular.min.js" type="text/javascript"></script>
+        <script src="/js/app.js" type="text/javascript"></script>
+        
+        <!-- For Linear Gradients in IE9 or greater -->
+        <!--[if gte IE 9]>
+            <style type="text/css">
+              .gradient {
+                 filter: none;
+              }
+            </style>
+        <![endif]-->
+
+ 
+    </head>
+    <body data-ng-app="pubwebApp">
+        <a href="#content" class="globalskip">Skip to main content</a>
+<nav class="nav-primary-mobile" id="nav-primary-mobile"></nav>
+<div id='top-banner' data-hydrate='true'><link rel="preload" as="image" href="/images/icon-us-flag.svg"/><link rel="preload" as="image" href="/images/expand_more.svg"/><link rel="preload" as="image" href="https://designsystem.digital.gov/assets/img/icon-dot-gov.svg"/><link rel="preload" as="image" href="https://designsystem.digital.gov/assets/img/icon-https.svg"/><div class="custom-banner"><div class="custom-banner__header"><div class="custom-banner__left"><img class="custom-banner__flag" src="/images/icon-us-flag.svg" width="20" height="20" alt="US Flag"/><p class="custom-banner__text">An official website of the United States Government</p></div><button type="button" class="custom-banner__button"><span class="custom-banner__button-text">Here&#x27;s how you know</span><img id="banner-caret-_R_0_" class="custom-banner__caret " src="/images/expand_more.svg" alt="Expand More"/></button></div><div class="custom-banner__content " id="banner-content-_R_0_"><div class="custom-banner__info"><div class="info-block"><img src="https://designsystem.digital.gov/assets/img/icon-dot-gov.svg" alt=".gov icon"/><p><strong>Official websites use .gov</strong><br/>A <strong>.gov</strong> website belongs to an official government organization in the United States.</p></div><div class="info-block"><img src="https://designsystem.digital.gov/assets/img/icon-https.svg" alt="HTTPS icon"/><p><strong>Secure .gov websites use HTTPS</strong><br/>A <strong>lock</strong> (<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" role="img" aria-labelledby="banner-lock-description-_R_0_" focusable="false"><title id="banner-lock-title-_R_0_">Lock</title><desc id="banner-lock-description-_R_0_">Locked padlock icon</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"></path></svg></span>) or <strong>https://</strong> means you&#x27;ve safely connected to the .gov website. Share sensitive information only on official, secure websites.</p></div></div></div></div></div><div class="t1_nav navbar navbar-default navbar-fixed-top" role="navigation">
+    <div class="t1_container clearfix">
+        <a id="logo" class="btn btn-default icon-FRB_logo-bw visible-xs-table-cell t1__btnlogo" href="/default.htm" role="button"><span class="sr-only">Back to Home</span></a>
+        <a href="/default.htm" id="banner" class="visible-xs-table-cell t1__banner" title="Link to Home Page" role="button">Board of Governors of the Federal Reserve System</a>
+        <ul class="nav navbar-nav visible-md visible-lg t1_toplinks">
+            <li class="navbar-text navbar-text__social">
+                <span class="navbar-link" tabindex="0">Stay Connected</span>
+            <ul class="nav navbar-nav t1_social social_ten">
+              <li class="social__item">
+                <a
+                  data-icon="facebook"
+                  href="https://www.facebook.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-facebook-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Facebook Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="instagram"
+                  href="https://www.instagram.com/federalreserveboard/"
+                  class="noIcon"
+                >
+                  <div class="icon-instagram icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Instagram Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="youtube"
+                  href="https://www.youtube.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-youtube-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve YouTube Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="flickr"
+                  href="https://www.flickr.com/photos/federalreserve/"
+                  class="noIcon"
+                >
+                  <div class="icon-flickr-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Flickr Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="linkedin"
+                  href="https://www.linkedin.com/company/federal-reserve-board"
+                  class="noIcon"
+                >
+                  <div class="icon-linkedin-color icon icon__sm"></div>
+                  <span class="sr-only">Federal Reserve LinkedIn Page</span></a
+                >
+              </li>
+              <li class="social__item">
+                <a data-icon="threads" href="https://www.threads.net/@federalreserveboard" class="noIcon">
+                  <div class="icon-threads icon icon__sm"></div>
+                  <span class="sr-only">Federal Reserve Threads Page</span></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="twitter"
+                  href="https://x.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-social-x icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve X Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="bluesky"
+                  href="https://bsky.app/profile/federalreserve.gov"
+                  class="noIcon"
+                >
+                  <div class="icon-bluesky icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Bluesky Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a data-icon="rss" href="/feeds/feeds.htm" class="noIcon">
+                  <div class="icon-rss-color icon icon__sm"></div>
+                  <span class="sr-only">Subscribe to RSS</span></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a data-icon="email" href="/subscribe.htm" class="noIcon">
+                  <div class="icon-email-color icon icon__sm"></div>
+                  <span class="sr-only">Subscribe to Email</span></a
+                >
+              </li>
+                </ul>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/recentpostings.htm">Recent Postings</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/newsevents/calendar.htm">Calendar</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/publications.htm">Publications</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/sitemap.htm">Site Map</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/azindex.htm">A-Z index</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/careers.htm">Careers</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/faqs.htm">FAQs</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/videos.htm">Videos</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/aboutthefed/contact-us-topics.htm">Contact</a>
+            </li>
+        </ul>
+        <form class="nav navbar-form hidden-xs nav__search" role="search" action="//www.fedsearch.org/board_public/search"  method="get">
+            <div class="form-group input-group input-group-sm">
+                <label for="t1search" class="sr-only">Search</label>
+                <input id="t1search" class="nav__input form-control" name="text" placeholder="Search" type="text" />
+                <span class="input-group-btn">
+                    <button type="submit" class="nav__button btn btn-default" id="headerTopLinksSearchFormSubmit" name="Search">
+                        <span class="sr-only">Submit Search Button</span>
+                        <span class="icon-magnifying-glass icon icon__xs icon--right"></span>
+                    </button>
+                </span>
+            </div>
+            <div class="nav__advanced">
+                <a class="noIcon" href="//www.fedsearch.org/board_public/">Advanced</a>
+            </div>
+        </form>
+        <div class="btn-group visible-xs-table-cell visible-sm-table-cell t1__dropdown">
+            <span class="icon icon__md icon--right dropdown-toggle icon-options-nav" data-toggle="dropdown">
+                <span class="sr-only">Toggle Dropdown Menu</span>
+            </span>
+        </div>
+    </div>
+</div>
+<header class="jumbotron hidden-xs">
+    <a class="jumbotron__link" href="/default.htm" title="Link to Home Page">
+        <div class="container-fluid">
+            <h1 class="jumbotron__heading">Board of Governors of the Federal Reserve System
+            </h1>
+            <p class="jumbotron__content">
+                <em>The Federal Reserve, the central bank of the United States, provides
+          the nation with a safe, flexible, and stable monetary and financial
+          system.</em>
+            </p>
+        </div>
+    </a>
+</header>
+<div class="t2__offcanvas visible-xs-block">
+    <div class="navbar-header">
+        <button type="button" class="offcanvas__toggle icon-offcanvas-nav" data-toggle="offcanvas" data-target="#offcanvasT2Menu" data-canvas="body">
+            <span class="sr-only">Main Menu Toggle Button</span>
+        </button>
+        <span class="navbar-brand offcanvas__title">Sections</span>
+        <button type="button" class="offcanvas__search icon-search-nav" data-toggle="collapse" data-target="#navbar-collapse">
+            <span class="sr-only">Search Toggle Button</span>
+        </button>
+    </div>
+    <div class="navbar-collapse collapse mobile-form" id="navbar-collapse">
+        <form method="get" class="navbar-form" role="search" action="//www.fedsearch.org/board_public/search">
+            <div class="form-group input-group mobileSearch">
+                <label class="sr-only" for="t2search">Search</label>
+                <input id="t2search" name="text" class="form-control" placeholder="Search" type="text" />
+                <span class="input-group-btn">
+                    <span class="sr-only">Search Submit Button</span>
+                    <button type="submit" class="btn btn-default">Submit</button>
+                </span>
+            </div>
+        </form>
+    </div>
+</div>
+<nav class="nav-primary navbar hidden-xs nav-nine" id="nav-primary" role="navigation">
+    <ul class="nav navbar-nav" role="menubar">
+        <li role="menuitem" class="dropdown nav-about dropdown--3Col">
+            <a href="/aboutthefed.htm" class="sr-only-focusable" aria-haspopup="true" id="aboutMenu">About<br />the Fed</a>
+            <ul aria-labelledby="aboutMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fedexplained/who-we-are.htm">Structure of the Federal Reserve System</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/the-fed-explained.htm">The Fed Explained</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/bios/board/default.htm">Board Members</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/advisorydefault.htm">Advisory Councils</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/federal-reserve-system.htm">Federal Reserve Banks</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/directors/about.htm">Federal Reserve Bank and Branch Directors</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fract.htm">Federal Reserve Act</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/currency.htm">Currency</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/boardmeetings/meetingdates.htm">Board Meetings</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/boardvotes.htm">Board Votes</a>
+                            </li>
+
+                            
+
+                            <li>
+                                <a class="sr-only-focusable" href="/careers.htm">Careers</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/procurement/tips.htm">Do Business with the Board</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/k8.htm">Holidays Observed - K.8</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/ethics-values.htm">Ethics & Values</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/contact-us-topics.htm">Contact</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/foia/about_foia.htm">Requesting Information (FOIA)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/faqs.htm">FAQs</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/educational-tools/default.htm">Economic Education</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fed-financial-statements.htm">Fed Financial Statements</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/financial-innovation.htm">Financial Innovation</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-news dropdown--1Col">
+            <a href="/newsevents.htm" class="sr-only-focusable" aria-haspopup="true" id="newsMenu">News<br />& Events</a>
+            <ul aria-labelledby="newsMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/pressreleases.htm">Press Releases</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/speeches-testimony.htm">Speeches & Testimony</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/calendar.htm">Calendar</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/videos.htm">Videos</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/photogallery.htm">Photo Gallery</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/conferences.htm">Conferences</a>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-monetary dropdown--2Col">
+            <a href="/monetarypolicy.htm" class="sr-only-focusable" aria-haspopup="true" id="monetaryMenu">Monetary<br />Policy</a>
+            <ul aria-labelledby="monetaryMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Federal Open Market Committee</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc.htm">About the FOMC</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomccalendars.htm">Meeting calendars and information</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc_historical.htm">Transcripts and other historical materials</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc_projectionsfaqs.htm">FAQs</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Monetary Policy Principles and Practice</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/monetary-policy-principles-and-practice.htm">Notes</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Policy Implementation</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/policy-normalization.htm">Policy Normalization</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/policytools.htm">Policy Tools</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Reports</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/mpr_default.htm">Monetary Policy Report</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/beige-book-default.htm">Beige Book</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/balance-sheet-developments-report.htm">Federal Reserve Balance Sheet Developments</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Review of Monetary Policy Strategy, Tools, and Communications</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/review-of-monetary-policy-strategy-tools-and-communications-2025.htm">Overview</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-supervision dropdown--fw">
+    <a href="/supervisionreg.htm" class="sr-only-focusable" id="supervisionMenu"
+        aria-haspopup="true">Supervision<br />& Regulation</a>
+    <ul aria-labelledby="supervisionMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+        <li>
+            <div class="row">
+                <ul class="col-sm-3 col-nav list-unstyled">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Supervision</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/community-banks.htm">
+                            Community Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/regional-and-small-foreign-banks.htm">
+                            Regional Banks and Foreign Banks with U.S. Assets < $100 Billion</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/large-banks-and-large-foreign-banks.htm">
+                            Large Banks and Large Foreign Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/global-systemically-important-banks.htm">
+                            Global Systemically Important Banks</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/financial-market-utility-supervision.htm">Financial Market
+                            Utilities</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/consumer-compliance.htm">Consumer
+                            Compliance</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/resources-for-supervised-institutions.htm">
+                            Resources for Supervised Institutions</a>
+                    </li>
+
+                    
+
+                    <li class="nav__header">
+                        <p>
+                            <strong>Reports</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/publications/supervision-and-regulation-report.htm">Federal Reserve
+                            Supervision and Regulation Report</a>
+                    </li>
+                </ul>
+                <ul class="col-sm-3 list-unstyled col-nav">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Reporting Forms</strong>
+                        </p>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportingforms/recentupdates">Recent Reporting Form Updates</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportingforms/home/review">Information Collections
+                            Under Review</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["1"]'>Financial
+                            Statements</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["7"]'>Securities Exchange Act of 1934</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable"
+                            href='/apps/ReportingForms/?reportTypesIdsJson=["2"]'>Applications/Structure Change</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["3"]'>FFIEC</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["8"]'>Municipal and
+                            Government Securities</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["9"]'>Activities Monitoring</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/mdrm/'>Micro Data Reference Manual</a>
+                    </li>
+
+                     
+
+                </ul>
+
+
+
+
+                <ul class="col-sm-3 list-unstyled col-nav">
+
+<li class="nav__header">
+                        <p>
+                            <strong>Legal Developments</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/legal-developments.htm">Enforcement Actions and
+                            Legal Developments</a>
+                    </li>
+
+
+                     <li class="nav__header">
+                        <p>
+                            <strong>Mergers, Acquisitions, and Other Applications</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/application-process.htm">Process</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/afi/afi.htm">Filing
+                            Information</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/board-and-reserve-bank-actions.htm">Board and Reserve
+                            Bank Actions</a>
+                    </li>
+
+                
+                    
+                    
+                    
+                </ul>
+
+                <ul class="col-sm-3 list-unstyled col-nav">
+
+<li class="nav__header">
+                        <p>
+                            <strong>Supervision and Regulation Letters</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/srletters/srletters.htm">By Year</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/topics/topics.htm">By Topic</a>
+                    </li>
+
+
+                    <li class="nav__header">
+                        <p>
+                            <strong>Regulatory and Policy Resources</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/aboutthefed/fract.htm">Federal Reserve Act</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/frrs/regulations/bank-holding-company-act-of-1956.htm">Bank Holding Company Act</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/reglisting.htm">Regulations</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/publications/supmanual.htm">Supervision Manuals</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/frrs/federal-reserve-regulatory-service.htm">Federal Reserve Regulatory Service</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/disaster-preparedness-and-recovery-resources.htm">Disaster Preparedness and Recovery Resources
+     </a>
+                    </li>
+
+
+                    
+                </ul>
+                <ul class="col-sm-3 list-unstyled col-nav">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Banking and Data Structure</strong>
+                        </p>
+                    </li>
+
+                    
+
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportforms/insider.aspx">Beneficial Ownership
+                            Reports</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/releases/lbr/">U.S. Domestically Chartered Commercial Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/minority-depository-institutions.htm">Minority Depository
+                            Institutions</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/releases/iba/">U.S. Offices of Foreign Entities</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/fhc.htm">Financial Holding
+                            Companies</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/isb-default.htm">Interstate
+                            Branching</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/suds.htm">Securities
+                            Underwriting and Dealing Subsidiaries</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/state-member-banks-supervised-federal-reserve.htm">State Member Banks Supervised by the Federal Reserve</a>
+                    </li>
+
+                    
+                </ul>
+            </div>
+        </li>
+    </ul>
+</li>
+
+
+
+
+
+
+        <li role="menuitem" class="dropdown nav-stability dropdown--2Col">
+            <a href="/financial-stability.htm" class="sr-only-focusable" aria-haspopup="true" id="stabilityMenu">Financial<br />Stability</a>
+            <ul aria-labelledby="stabilityMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <div class="row">
+                    <ul class="col-sm-6 list-unstyled">
+                        <li class="nav__header">
+                            <p>
+                                <strong>Financial Stability Assessments </strong>
+                            </p>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/what-is-financial-stability.htm">About Financial Stability</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/types-of-financial-system-vulnerabilities-and-risks.htm">Types of Financial System Vulnerabilities & Risks</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/monitoring-risk-across-the-financial-system.htm">Monitoring Risk Across the Financial System</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/proactive-monitoring-of-markets-and-institutions.htm">Proactive Monitoring of Markets & Institutions</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/financial-stability-and-stress-testing.htm">Financial Stability & Stress Testing</a>
+                        </li>
+                    </ul>
+                    <ul class="col-sm-6 list-unstyled">
+                        <li class="nav__header">
+                            <p>
+                                <strong>Financial Stability Coordination & Actions</strong>
+                            </p>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/responding-to-financial-system-emergencies.htm">Responding to Financial System Emergencies</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/cooperation-on-financial-stability.htm">Cooperation on Financial Stability</a>
+                        </li>
+                        <li class="nav__header">
+                            <p>
+                                <strong>Reports</strong>
+                            </p>
+                        </li>
+
+                        <li>
+                            <a class="sr-only-focusable" href="/publications/financial-stability-report.htm">Financial Stability Report</a>
+                        </li>
+                    </ul>
+                </div>
+            </ul>
+        </li>
+        <li role="menuitem" class="dropdown nav-payment dropdown--fw">
+            <a href="/paymentsystems.htm" class="sr-only-focusable" id="paymentMenu" aria-haspopup="true">Payment<br />Systems</a>
+            <ul aria-labelledby="paymentMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 col-nav list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Regulations & Statutes</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/regcc-about.htm">Regulation CC (Availability of Funds and Collection of Checks)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/regii-about.htm">Regulation II (Debit Card Interchange Fees and Routing)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/reghh-about.htm">Regulation HH (Financial Market Utilities)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/other-regulations.htm">Other Regulations and Statutes</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Payment Policies</strong>
+                                </p>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/pfs_about.htm">Federal Reserve's Key Policies for the Provision of Financial Services</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/joint_requests.htm">Guidelines for Evaluating Joint Account Requests</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/oo_about.htm">Overnight Overdrafts</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/psr_about.htm">Payment System Risk</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/telecomm.htm">Sponsorship for Priority Telecommunication Services</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Reserve Bank Payment Services & Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedach_about.htm">Automated Clearinghouse Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/check_about.htm">Check Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/coin_about.htm">Currency and Coin Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/psr_data.htm">Daylight Overdrafts and Fees</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fednow_about.htm">FedNow<sup>&reg;</sup> Service</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedfunds_about.htm">Fedwire Funds Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedsecs_about.htm">Fedwire Securities Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fisagy_about.htm">Fiscal Agency Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/master-account-and-services-database-about.htm">Master Account and Services Database</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/natl_about.htm">National Settlement Service</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Financial Market Utilities & Infrastructures</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/over_about.htm">Supervision & Oversight of Financial Market Infrastructures</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/designated_fmu_about.htm">Designated Financial Market Utilities</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/int_standards.htm">International Standards for Financial Market Infrastructures</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Research, Reports, & Committees</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fr-payments-study.htm">Federal Reserve Payments Study (FRPS)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/payres_about.htm">Payments Research</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/reports.htm">Reports</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/pspa_committee.htm">Payments System Policy Advisory Committee</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-econ dropdown--right dropdown--2Col">
+            <a href="/econres.htm" class="sr-only-focusable" aria-haspopup="true" id="econMenu">Economic<br />Research</a>
+            <ul aria-labelledby="econMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-6 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/researchers.htm">Meet the Researchers</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Working Papers and Notes</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/feds/index.htm">Finance and Economics Discussion Series (FEDS)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/notes/feds-notes/default.htm">FEDS Notes</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/ifdp/index.htm">International Finance Discussion Papers (IFDP)</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Data, Models and Tools</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/economic-research-data.htm">Economic Research Data</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/us-models-about.htm">FRB/US Model</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/edo-models-about.htm">Estimated Dynamic Optimization (EDO) Model</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/scfindex.htm">Survey of Consumer Finances (SCF)</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-data dropdown--right dropdown--fw">
+            <a href="/data.htm" class="sr-only-focusable" id="dataMenu" aria-haspopup="true">Data</a>
+            <ul aria-labelledby="dataMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 col-nav list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/datadownload"><span class="icon icon-ddp icon__sm"></span>Data Download Program</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Bank Assets and Liabilities</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h3/current/default.htm">Aggregate Reserves of Depository Institutions and the Monetary Base - H.3</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h8/current/default.htm">Assets and Liabilities of Commercial Banks in the U.S. - H.8</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/assetliab/current.htm">Assets and Liabilities of U.S. Branches and Agencies of Foreign Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/chargeoff/">Charge-Off and Delinquency Rates on Loans and Leases at Commercial Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/sfos/sfos.htm">Senior Financial Officer Survey</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/sloos.htm">Senior Loan Officer Opinion Survey on Bank Lending Practices</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Bank Structure Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/lbr/">U.S. Domestically Chartered Commercial Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/minority-depository-institutions.htm">Minority Depository Institutions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/iba/default.htm">Structure and Share Data for the U.S. Offices of Foreign Banks</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Business Finance</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/cp/">Commercial Paper</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g20/current/default.htm">Finance Companies - G.20</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/govsecure/current.htm">New Security Issues, State and Local Governments</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/corpsecure/current.htm">New Security Issues, U.S. Corporations</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Dealer Financing Terms</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/scoos.htm">Senior Credit Officer Opinion Survey on Dealer Financing Terms</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Exchange Rates and International Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h10/current/">Foreign Exchange Rates - H.10/G.5</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/intlsumm/current.htm">International Summary Statistics</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/secholdtrans/current.htm">Securities Holdings and Transactions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/statbanksus/current.htm">Statistics Reported by Banks and Other Financial Firms in the United States</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/iba/default.htm">Structure and Share Data for U.S. Offices of Foreign Banks</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Financial Accounts</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/z1/default.htm">Financial Accounts of the United States - Z.1</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Household Finance</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g19/current/default.htm">Consumer Credit - G.19</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/DSR">Household Debt Service Ratios</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/mortoutstand/current.htm">Mortgage Debt Outstanding</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/scfindex.htm">Survey of Consumer Finances (SCF)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/shed.htm">Survey of Household Economics and Decisionmaking</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Industrial Activity</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g17/current/default.htm">Industrial Production and Capacity Utilization - G.17</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Interest Rates</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h15/">Selected Interest Rates - H.15</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Micro Data Reference Manual (MDRM)</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/mdrm.htm">Micro and Macro Data Collections</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Money Stock and Reserve Balances</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h41/">Factors Affecting Reserve Balances - H.4.1</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h6/current/default.htm">Money Stock Measures - H.6</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Other</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/yield-curve-models.htm">Yield Curve Models and Data</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-consumer dropdown--right dropdown--4Col">
+            <a href="/consumerscommunities.htm" class="sr-only-focusable" aria-haspopup="true" id="consumerMenu">Consumers<br /> & Communities</a>
+            <ul aria-labelledby="consumerMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Regulations</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/cra_about.htm">Community Reinvestment Act (CRA)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/reglisting.htm">All Regulations</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Supervision & Enforcement</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/caletters/caletters.htm">CA Letters</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/apps/enforcementactions/default.aspx">Enforcement Actions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/independent-foreclosure-review.htm">Independent Foreclosure Review</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Community Development</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/neighborhood-revitalization.htm">Housing and Neighborhood Revitalization</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/small-business-and-entrepreneurship.htm">Small Business and Entrepreneurship</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/workforce.htm">Employment and Workforce Development</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/cdf.htm">Community Development Finance</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/rural-community-economic-development.htm">Rural Community and Economic Development</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/conferences.htm">Conferences</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Research & Analysis</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/shed.htm">Survey of Household Economics and Decisionmaking</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/community-development-publications.htm">Research Publications & Data Analysis</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/cac.htm">Community Advisory Council</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Resources for Consumers</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/fraud-scams.htm">Frauds and Scams</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/foreclosure.htm">Mortgage and Foreclosure Resources</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/comm-dev-system-map.htm">Federal Reserve Community Development Resources</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+    </ul>
+</nav>
+        <!-- BODY CONTENT -->
+        <div id="content" class="container container__main" role="main">
+            <div class="row">
+                <div class="page-header">
+                    <ol class="breadcrumb">
+                        
+                            <li class='breadcrumb__item'><a class="breadcrumb__link" href="/default.htm">Home</a></li>
+                            
+                                                    <li class='breadcrumb__item'><a class="breadcrumb__link" href="/monetarypolicy.htm">Monetary Policy</a></li>
+                                                    
+                    
+                
+                                                
+                        
+                    </ol>
+                    <div class="header-group">
+                        <div id="page-title" class="page-title"> 
+                            
+                                        <h2>
+                                            Beige Book
+                                        </h2>
+                                    
+                        </div> 
+                        
+                    </div>
+                </div><!-- / .page-header -->
+                <noscript>
+<div class="js-disabled text-center">
+    <span class='icon icon-alert icon--jsAlert'></span>
+    <span><strong>Please enable JavaScript if it is disabled in your browser or access the information through the links provided below.</strong> </span>
+</div>
+
+</noscript>
+ 
+            </div><!-- / .row -->
+              
+            
+            
+            <div class='row'>
+            
+                <div class="col-xs-12 col-sm-8 col-md-8">
+                                
+                    <h3>Summary of Commentary on Current Economic Conditions by Federal Reserve District</h3>
+                                                
+                    
+                    <p>Commonly known as the Beige Book, this report is published eight times per year. Each Federal Reserve Bank gathers anecdotal information on current economic conditions in its District through reports from Bank and Branch directors and interviews with key business contacts, economists, market experts, and other sources. The Beige Book summarizes this information by District and sector. An overall summary of the twelve district reports is prepared by a designated Federal Reserve Bank on a rotating basis.</p>
+                    
+                    
+
+<table cellpadding="0" cellspacing="0" class="table table-layout" summary="This table is for formatting purposes only.">
+	<thead>
+		<tr>
+			<th class="alternate" colspan="3" id="year">2026</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>January 14: <a href="/monetarypolicy/beigebook202601-summary.htm">HTML</a> | <a href="https://www.federalreserve.gov/monetarypolicy/files/BeigeBook_20260114.pdf">PDF</a></td>
+		</tr>
+		<tr>
+			<td>March 4: <a href="/monetarypolicy/beigebook202602-summary.htm">HTML</a> | <a href="/monetarypolicy/files/BeigeBook_20260304.pdf">PDF</a></td>
+		</tr>
+		<tr>
+			<td>April 15: <a href="/monetarypolicy/beigebook202604.htm">HTML</a> | <a href="/monetarypolicy/files/BeigeBook_20260415.pdf">PDF</a></td>
+		</tr>
+		<tr>
+			<td>June 3</td>
+		</tr>
+		<tr>
+			<td>July 15</td>
+		</tr>
+		<tr>
+			<td>September 2</td>
+		</tr>
+		<tr>
+			<td>October 14</td>
+		</tr>
+		<tr>
+			<td>November 25</td>
+		</tr>
+	</tbody>
+</table>
+
+
+<h3>The Beige Book: Summary of Commentary on Current Economic Conditions by Federal Reserve District</h3>
+
+
+
+<!-- -->
+    <div class="embed-responsive embed-responsive-16by9">
+        <div style="display: block; position: relative; max-width: 100%;">
+            <div style="display: block; padding-top: 56.25%;">
+                <video id="frb-video44446" style="width: 100%; height: 100%; position: absolute; top: 0px; bottom: 0px; right: 0px; left: 0px;" 
+                data-video-id="6369634683112" data-account="66043936001" data-player="default" data-embed="default" class="video-js" controls></video>                
+                   <script src="//players.brightcove.net/66043936001/default_default/index.min.js" defer></script> 
+            </div>
+           
+        </div> 
+        <div class="sr-only">
+            <p><strong>Accessible Keys for Video</strong></p>
+            <p><strong>[Space Bar]</strong> toggles play/pause;</p>
+            <p><strong>[Right/Left Arrows]</strong> seeks the video forwards and back (5 sec );</p>
+            <p><strong>[Up/Down Arrows]</strong> increase/decrease volume;</p>
+            <p><strong>[M]</strong> toggles mute on/off;</p>
+            <p><strong>[F]</strong> toggles fullscreen on/off (Except IE 11);</p>
+            <p>The <strong>[Tab]</strong> key may be used in combination with the <strong>[Enter/Return]</strong> key to navigate and activate control buttons, such as caption on/off.</p>
+        </div>
+</div>
+        <div id="videoDetails44446" class="row">
+        </div>        
+        <script>
+            var seek;
+            window.addEventListener('DOMContentLoaded', function() {
+
+            var myPlayer;
+            videojs('frb-video44446').ready(function() {
+                myPlayer = this;
+                myPlayer.on('loadstart',function(){
+                  var videoInfo = "";
+                  var transcriptLinkLabel;
+                  if (myPlayer.mediainfo.custom_fields["actualdatetext"]) {
+                    videoInfo += "<span class='col-xs-6'>" + myPlayer.mediainfo.custom_fields["actualdatetext"] + "</span>";
+                  }
+            
+                  if (myPlayer.mediainfo.custom_fields["transcriptlinkurl"]) {
+                    if (myPlayer.mediainfo.custom_fields["transcripttext"]) {
+                      transcriptLinkLabel = myPlayer.mediainfo.custom_fields["transcripttext"];
+                    } else {
+                      transcriptLinkLabel = "Transcript (PDF)";
+                    }
+                    videoInfo += "<span class='col-xs-6 text-right'><a href='" + myPlayer.mediainfo.custom_fields["transcriptlinkurl"] + "'>" + transcriptLinkLabel + "</a></span>";
+                  }
+                  $("#videoDetails44446").html(videoInfo);
+                })
+
+
+              });
+              seek = function (time) {
+                    // Advance to cue point, start playing if not playing.
+                    myPlayer.currentTime(time);
+                    if (myPlayer.paused()) {
+                        myPlayer.play();
+                    }
+                }});
+        </script>
+    
+                </div>
+                
+                <div class="col-xs-12 col-sm-4 col-md-4">
+                    
+                    
+
+<div class="archive">
+    <h5><a href="/monetarypolicy/beige-book-archive.htm"><span class="icon icon__md icon-archive"></span><span class="icon-label">Archive</span><span class="icon icon--right icon__xs icon-more"></span></a></h5>
+</div>
+
+<!-- Text Box Begins -->
+
+<div class="panel panel-related">
+    <div class="panel-heading">
+                   
+                <h5 class="panel-title text-capitalize">
+                    Related Information  
+                </h5>
+                
+    </div>
+    <div class="panel-body">
+        <p><a href="/monetarypolicy/beige-book-faqs.htm">Frequently Asked Questions</a></p>
+    </div>
+</div>
+
+
+
+
+            
+                </div>     
+                
+                                
+            </div>            
+            <a id="back-top" class="icon__backTop icon-backtop" href="#" title="Scroll To Top"><span class="sr-only">Back to Top</span></a>
+    
+            
+            <div class="row">
+                <div class='lastUpdate' id="lastUpdate">Last Update:
+                    April 15, 2026
+                </div>
+            </div>
+        </div><!-- / #content .container -->
+                    <footer class="container footer">
+                <div class="row footer__content">
+                    <div class="col-xs-12 col-sm-4">
+                        <h6 class="footer__heading"><span class="text-uppercase">Board of Governors</span> <em>of the</em> <span class="text-uppercase">Federal Reserve System</span></h6>
+                        <ul class="list-unstyled">
+                            <li class='footer__listItem'><a class="footer__link" href="/aboutthefed.htm">About the Fed</a></li><li class='footer__listItem'><a class="footer__link" href="/newsevents.htm">News & Events</a></li><li class='footer__listItem'><a class="footer__link" href="/monetarypolicy.htm">Monetary Policy</a></li><li class='footer__listItem'><a class="footer__link" href="/supervisionreg.htm">Supervision & Regulation</a></li><li class='footer__listItem'><a class="footer__link" href="/financial-stability.htm">Financial Stability</a></li><li class='footer__listItem'><a class="footer__link" href="/paymentsystems.htm">Payment Systems</a></li><li class='footer__listItem'><a class="footer__link" href="/econres.htm">Economic Research</a></li><li class='footer__listItem'><a class="footer__link" href="/data.htm">Data</a></li><li class='footer__listItem'><a class="footer__link" href="/consumerscommunities.htm">Consumers & Communities</a></li><li class='footer__listItem'><a class="footer__link" href="/aboutthefed/aroundtheboard/stayconnected-qr-code-2.htm">Connect with the Board</a></li> 
+                        </ul>
+                    </div>
+                    <div class="col-xs-12 col-sm-4">
+                        <h6 class="text-uppercase footer__heading">Tools and Information</h6>
+                        <ul class="list-unstyled">
+                             <li class='footer__listItem'><a href="/aboutthefed/contact-us-topics.htm" class="footer__link">Contact</a></li>
+                            <li class='footer__listItem'><a href="/publications.htm" class="footer__link">Publications</a></li>
+                            <li class='footer__listItem'><a href="/foia/about_foia.htm" class="footer__link">Freedom of Information (FOIA)</a></li>
+                            <li class='footer__listItem'><a href="https://oig.federalreserve.gov/" class="footer__link">Office of Inspector General</a></li>
+                            <li class='footer__listItem'><a href="/publications/annual-report.htm" class="footer__link">Budget &amp; Performance</a> | <a href="/regreform/audit.htm" class="footer__link">Audit</a></li>
+                            <li class='footer__listItem'><a href="/eeo.htm" class="footer__link">No FEAR Act</a></li>
+                            <li class='footer__listItem'><a href="/espanol.htm" class="footer__link">Espa&ntilde;ol</a></li>
+                            <li class='footer__listItem'><a href="/website-linking-policies.htm" class="footer__link">Website Policies</a>  | <a href="/privacy.htm" class="footer__link">Privacy Program</a></li>
+                            <li class='footer__listItem'><a href="/accessibility.htm" class="footer__link">Accessibility</a></li>
+                        </ul>
+                    </div>
+                    <div class="col-xs-12 col-sm-4">
+                        <div class="footer__social">
+                            <h6 class="text-uppercase footer__heading footer__heading--social">Stay Connected</h6>
+                            
+            <a
+              class="icon__md icon footer__btn icon-facebook-color"
+              href="https://www.facebook.com/federalreserve"
+              ><span class="sr-only"
+                >Federal Reserve Facebook Page</span
+              ></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-instagram"
+              href="https://www.instagram.com/federalreserveboard/"
+              ><span class="sr-only"
+                >Federal Reserve Instagram Page</span
+              ></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-youtube-color"
+              href="https://www.youtube.com/federalreserve"
+              ><span class="sr-only"
+                >Federal Reserve YouTube Page</span
+              ></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-flickr-color"
+              href="https://www.flickr.com/photos/federalreserve/"
+              ><span class="sr-only"
+                >Federal Reserve Flickr Page</span
+              ></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-linkedin-color"
+              href="https://www.linkedin.com/company/federal-reserve-board"
+              ><span class="sr-only">Federal Reserve LinkedIn Page</span></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-threads"
+              href="https://www.threads.net/@federalreserveboard"
+              ><span class="sr-only">Federal Reserve Threads Page</span></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-social-x"
+              href="https://x.com/federalreserve"
+              ><span class="sr-only"
+                >Link to Federal Reserve X Page</span
+              ></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-bluesky"
+              href="https://bsky.app/profile/federalreserve.gov"
+              ><span class="sr-only"
+                >Link to Federal Reserve Bluesky Page</span
+              ></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-rss-color"
+              href="/feeds/feeds.htm"
+              ><span class="sr-only">Subscribe to RSS</span></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-email-color"
+              href="/subscribe.htm"
+              ><span class="sr-only">Subscribe to Email</span></a
+            >
+ 
+                        </div>
+                        <a href="https://www.usa.gov/" target="_blank" title="Link to USA.gov">
+                            <img class='footer__image' src="/images/USAGov%402x.png" alt="Link to USA.gov" />
+                        </a>
+                        <a href="/open/open.htm" target="_blank" title="Link to Open.gov">
+                            <img class='footer__image' src="/images/OpenGov%402x.png" alt="Link to Open.gov" />
+                        </a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-xs-12 footer__footer">
+                        <p class="text-uppercase footer__text footer__text--left">Board of Governors <em class="text-lowercase">of the</em> Federal Reserve System</p>
+                        <p class="footer__text footer__text--right">20th Street and Constitution Avenue N.W., Washington, DC 20551</p>
+                    </div>
+                </div>
+            </footer>
+            
+            <script src="/js/jquery.min.js" type="text/javascript"></script>
+            <script src="/js/bootstrap.min.js" type="text/javascript"></script>
+            <script src="/js/scripts.js" type="text/javascript"></script>
+            <script src="/js/modal.js" type="text/javascript"></script>
+            <script src="/js/sticky-tables.js" type="text/javascript"></script>
+            <script type="text/javascript" src="/js/slides/ekko-lightbox.min.js"></script>
+            <script src="/js/t4-nav-controller.js" type="text/javascript"></script>
+                     
+            <script type="text/javascript">
+                $(document).ready(function($) {
+                    // delegate calls to data-toggle="lightbox"
+                    $(document).delegate('*[data-toggle="lightbox"]:not([data-gallery="navigateTo"])', 'click', function(event) {
+                        event.preventDefault();
+                        $(this).ekkoLightbox();
+                    });
+                    $('a[data-click="false"]').click(function(e) {
+                        e.preventDefault();
+                        var target = $(this).data('target');
+                        $(target).click();
+                    });
+                });
+            </script>          
+
+            
+        
+        <!--PAGEWATCH--><!--4/15/2026--><!--/PAGEWATCH-->        
+        <!--<ul><li>/monetarypolicy/beigebook202604.htm</li><li>/monetarypolicy/beigebook202602.htm</li><li>/monetarypolicy/beigebook202601.htm</li><li>/monetarypolicy/beigebook202511.htm</li><li>/monetarypolicy/beigebook202510.htm</li><li>/monetarypolicy/beigebook202508.htm</li><li>/monetarypolicy/beigebook202507.htm</li><li>/monetarypolicy/beigebook202505.htm</li><li>/monetarypolicy/beigebook202504.htm</li><li>/monetarypolicy/beigebook202502.htm</li><li>/monetarypolicy/beigebook202501.htm</li><li>/monetarypolicy/beigebook202411.htm</li><li>/monetarypolicy/beigebook202410.htm</li><li>/monetarypolicy/beigebook202408.htm</li><li>/monetarypolicy/beigebook202407.htm</li><li>/monetarypolicy/beigebook202405.htm</li><li>/monetarypolicy/beigebook202404.htm</li><li>/monetarypolicy/beigebook202402.htm</li><li>/monetarypolicy/beigebook202401.htm</li><li>/monetarypolicy/beigebook202311.htm</li><li>/monetarypolicy/beigebook202310.htm</li><li>/monetarypolicy/beigebook202309.htm</li><li>/monetarypolicy/beigebook202307.htm</li><li>/monetarypolicy/beigebook20230531.htm</li><li>/monetarypolicy/beigebook202304.htm</li><li>/monetarypolicy/beigebook202303.htm</li><li>/monetarypolicy/beigebook202301.htm</li><li>/monetarypolicy/beigebook202211.htm</li><li>/monetarypolicy/beigebook202210.htm</li><li>/monetarypolicy/beigebook202209.htm</li><li>/monetarypolicy/beigebook202207.htm</li><li>/monetarypolicy/beigebook202206.htm</li><li>/monetarypolicy/beigebook202204.htm</li><li>/monetarypolicy/beigebook202203.htm</li><li>/monetarypolicy/beigebook202201.htm</li><li>/monetarypolicy/beige-book-faqs.htm</li><li>/monetarypolicy/beige-book-archive.htm</li><li>/monetarypolicy/beigebook201701.htm</li><li>/monetarypolicy/beigebook201703.htm</li><li>/monetarypolicy/beigebook201704.htm</li><li>/monetarypolicy/beigebook201705.htm</li><li>/monetarypolicy/beigebook201707.htm</li><li>/monetarypolicy/beigebook201709.htm</li><li>/monetarypolicy/beigebook201710.htm</li><li>/monetarypolicy/beigebook201711.htm</li><li>/monetarypolicy/beigebook201801.htm</li><li>/monetarypolicy/beigebook201803.htm</li><li>/monetarypolicy/beigebook201804.htm</li><li>/monetarypolicy/beigebook201807.htm</li><li>/monetarypolicy/beigebook201805.htm</li><li>/monetarypolicy/beigebook201809.htm</li><li>/monetarypolicy/beigebook201810.htm</li><li>/monetarypolicy/beigebook201812.htm</li><li>/monetarypolicy/beigebook201901.htm</li><li>/monetarypolicy/beigebook201903.htm</li><li>/monetarypolicy/beigebook201904.htm</li><li>/monetarypolicy/beigebook201906.htm</li><li>/monetarypolicy/beigebook201907.htm</li><li>/monetarypolicy/beigebook201909.htm</li><li>/monetarypolicy/beigebook201910.htm</li><li>/monetarypolicy/beigebook201911.htm</li><li>/monetarypolicy/beigebook202001.htm</li><li>/monetarypolicy/beigebook202003.htm</li><li>/monetarypolicy/beigebook202004.htm</li><li>/monetarypolicy/beigebook202005.htm</li><li>/monetarypolicy/beigebook202007.htm</li><li>/monetarypolicy/beigebook202009.htm</li><li>/monetarypolicy/beigebook202010.htm</li><li>/monetarypolicy/beigebook202012.htm</li><li>/monetarypolicy/beigebook202101.htm</li><li>/monetarypolicy/beigebook202103.htm</li><li>/monetarypolicy/beigebook202104.htm</li><li>/monetarypolicy/beigebook202106.htm</li><li>/monetarypolicy/beigebook202107.htm</li><li>/monetarypolicy/beigebook202109.htm</li><li>/monetarypolicy/beigebook202110.htm</li><li>/monetarypolicy/beigebook202112.htm</li></ul> -->
+    <script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'9f71869d4c8ecd0f',t:'MTc3ODAwMjc3OQ=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>
+ 

--- a/tests/fixtures/fed_beige_book_sample.html
+++ b/tests/fixtures/fed_beige_book_sample.html
@@ -1,0 +1,1573 @@
+﻿<!doctype html>
+<html lang="en" class="no-js" data-ng-app="pubwebApp">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.6, user-scalable=1"/>
+        <meta name="keywords" content="Board of Governors of the Federal Reserve System, Federal Reserve Board of Governors, Federal Reserve Board, Federal Reserve" />
+        <meta name="description" content="The Federal Reserve Board of Governors in Washington DC." />
+        <meta property="og:site_name" content="Board of Governors of the Federal Reserve System"/>
+        <meta property="og:type" content="article" /> 
+        <meta property="og:title" content="National Summary"/>    
+        <meta property="og:image" content="https://www.federalreserve.gov/images/social-media/social-default-image-opengraph.jpg" />
+        <meta property="og:image:alt" content="Board of Governors of the Federal Reserve System" />
+        <meta property="og:description" content="The Federal Reserve Board of Governors in Washington DC."/>
+        <meta property="og:url" content="https://www.federalreserve.gov/monetarypolicy/beigebook202601-summary.htm" />
+        <meta name="twitter:card" content="summary" />    
+        <meta name="twitter:title" content="National Summary" />
+        <meta name="twitter:image" content="https://www.federalreserve.gov/images/social-media/social-default-image-twitter.jpg" />
+        <meta name="twitter:image:alt" content="Board of Governors of the Federal Reserve System" />
+        <meta name="twitter:description" content="The Federal Reserve Board of Governors in Washington DC." />
+        
+        <title>The Fed - Monetary Policy: Beige Book (Branch)</title>
+        
+        <link href="/css/bootstrap.css" rel="stylesheet" type="text/css">
+        <link href="/css/bluesteel-theme.css" rel="stylesheet" type="text/css">
+        <link rel="stylesheet" href="/assets/main.css">
+        <script src="/assets/main.js" defer type="module"></script>
+        <script src="/js/modernizr-latest.js" type="text/javascript"></script>
+        <link href="/css/icons.data.svg.css" rel="stylesheet">           
+        <script src="/js/angular.min.js" type="text/javascript"></script>
+        <script src="/js/app.js" type="text/javascript"></script>
+        
+        <!-- For Linear Gradients in IE9 or greater -->
+        <!--[if gte IE 9]>
+            <style type="text/css">
+              .gradient {
+                 filter: none;
+              }
+            </style>
+        <![endif]-->
+
+ 
+    </head>
+    <body>
+        <a href="#content" class="globalskip">Skip to main content</a>
+<nav class="nav-primary-mobile" id="nav-primary-mobile"></nav>
+<div id='top-banner' data-hydrate='true'><link rel="preload" as="image" href="/images/icon-us-flag.svg"/><link rel="preload" as="image" href="/images/expand_more.svg"/><link rel="preload" as="image" href="https://designsystem.digital.gov/assets/img/icon-dot-gov.svg"/><link rel="preload" as="image" href="https://designsystem.digital.gov/assets/img/icon-https.svg"/><div class="custom-banner"><div class="custom-banner__header"><div class="custom-banner__left"><img class="custom-banner__flag" src="/images/icon-us-flag.svg" width="20" height="20" alt="US Flag"/><p class="custom-banner__text">An official website of the United States Government</p></div><button type="button" class="custom-banner__button"><span class="custom-banner__button-text">Here&#x27;s how you know</span><img id="banner-caret-_R_0_" class="custom-banner__caret " src="/images/expand_more.svg" alt="Expand More"/></button></div><div class="custom-banner__content " id="banner-content-_R_0_"><div class="custom-banner__info"><div class="info-block"><img src="https://designsystem.digital.gov/assets/img/icon-dot-gov.svg" alt=".gov icon"/><p><strong>Official websites use .gov</strong><br/>A <strong>.gov</strong> website belongs to an official government organization in the United States.</p></div><div class="info-block"><img src="https://designsystem.digital.gov/assets/img/icon-https.svg" alt="HTTPS icon"/><p><strong>Secure .gov websites use HTTPS</strong><br/>A <strong>lock</strong> (<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" role="img" aria-labelledby="banner-lock-description-_R_0_" focusable="false"><title id="banner-lock-title-_R_0_">Lock</title><desc id="banner-lock-description-_R_0_">Locked padlock icon</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"></path></svg></span>) or <strong>https://</strong> means you&#x27;ve safely connected to the .gov website. Share sensitive information only on official, secure websites.</p></div></div></div></div></div><div class="t1_nav navbar navbar-default navbar-fixed-top" role="navigation">
+    <div class="t1_container clearfix">
+        <a id="logo" class="btn btn-default icon-FRB_logo-bw visible-xs-table-cell t1__btnlogo" href="/default.htm" role="button"><span class="sr-only">Back to Home</span></a>
+        <a href="/default.htm" id="banner" class="visible-xs-table-cell t1__banner" title="Link to Home Page" role="button">Board of Governors of the Federal Reserve System</a>
+        <ul class="nav navbar-nav visible-md visible-lg t1_toplinks">
+            <li class="navbar-text navbar-text__social">
+                <span class="navbar-link" tabindex="0">Stay Connected</span>
+            <ul class="nav navbar-nav t1_social social_ten">
+              <li class="social__item">
+                <a
+                  data-icon="facebook"
+                  href="https://www.facebook.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-facebook-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Facebook Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="instagram"
+                  href="https://www.instagram.com/federalreserveboard/"
+                  class="noIcon"
+                >
+                  <div class="icon-instagram icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Instagram Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="youtube"
+                  href="https://www.youtube.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-youtube-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve YouTube Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="flickr"
+                  href="https://www.flickr.com/photos/federalreserve/"
+                  class="noIcon"
+                >
+                  <div class="icon-flickr-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Flickr Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="linkedin"
+                  href="https://www.linkedin.com/company/federal-reserve-board"
+                  class="noIcon"
+                >
+                  <div class="icon-linkedin-color icon icon__sm"></div>
+                  <span class="sr-only">Federal Reserve LinkedIn Page</span></a
+                >
+              </li>
+              <li class="social__item">
+                <a data-icon="threads" href="https://www.threads.net/@federalreserveboard" class="noIcon">
+                  <div class="icon-threads icon icon__sm"></div>
+                  <span class="sr-only">Federal Reserve Threads Page</span></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="twitter"
+                  href="https://x.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-social-x icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve X Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="bluesky"
+                  href="https://bsky.app/profile/federalreserve.gov"
+                  class="noIcon"
+                >
+                  <div class="icon-bluesky icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Bluesky Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a data-icon="rss" href="/feeds/feeds.htm" class="noIcon">
+                  <div class="icon-rss-color icon icon__sm"></div>
+                  <span class="sr-only">Subscribe to RSS</span></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a data-icon="email" href="/subscribe.htm" class="noIcon">
+                  <div class="icon-email-color icon icon__sm"></div>
+                  <span class="sr-only">Subscribe to Email</span></a
+                >
+              </li>
+                </ul>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/recentpostings.htm">Recent Postings</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/newsevents/calendar.htm">Calendar</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/publications.htm">Publications</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/sitemap.htm">Site Map</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/azindex.htm">A-Z index</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/careers.htm">Careers</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/faqs.htm">FAQs</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/videos.htm">Videos</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/aboutthefed/contact-us-topics.htm">Contact</a>
+            </li>
+        </ul>
+        <form class="nav navbar-form hidden-xs nav__search" role="search" action="//www.fedsearch.org/board_public/search"  method="get">
+            <div class="form-group input-group input-group-sm">
+                <label for="t1search" class="sr-only">Search</label>
+                <input id="t1search" class="nav__input form-control" name="text" placeholder="Search" type="text" />
+                <span class="input-group-btn">
+                    <button type="submit" class="nav__button btn btn-default" id="headerTopLinksSearchFormSubmit" name="Search">
+                        <span class="sr-only">Submit Search Button</span>
+                        <span class="icon-magnifying-glass icon icon__xs icon--right"></span>
+                    </button>
+                </span>
+            </div>
+            <div class="nav__advanced">
+                <a class="noIcon" href="//www.fedsearch.org/board_public/">Advanced</a>
+            </div>
+        </form>
+        <div class="btn-group visible-xs-table-cell visible-sm-table-cell t1__dropdown">
+            <span class="icon icon__md icon--right dropdown-toggle icon-options-nav" data-toggle="dropdown">
+                <span class="sr-only">Toggle Dropdown Menu</span>
+            </span>
+        </div>
+    </div>
+</div>
+<header class="jumbotron hidden-xs">
+    <a class="jumbotron__link" href="/default.htm" title="Link to Home Page">
+        <div class="container-fluid">
+            <h1 class="jumbotron__heading">Board of Governors of the Federal Reserve System
+            </h1>
+            <p class="jumbotron__content">
+                <em>The Federal Reserve, the central bank of the United States, provides
+          the nation with a safe, flexible, and stable monetary and financial
+          system.</em>
+            </p>
+        </div>
+    </a>
+</header>
+<div class="t2__offcanvas visible-xs-block">
+    <div class="navbar-header">
+        <button type="button" class="offcanvas__toggle icon-offcanvas-nav" data-toggle="offcanvas" data-target="#offcanvasT2Menu" data-canvas="body">
+            <span class="sr-only">Main Menu Toggle Button</span>
+        </button>
+        <span class="navbar-brand offcanvas__title">Sections</span>
+        <button type="button" class="offcanvas__search icon-search-nav" data-toggle="collapse" data-target="#navbar-collapse">
+            <span class="sr-only">Search Toggle Button</span>
+        </button>
+    </div>
+    <div class="navbar-collapse collapse mobile-form" id="navbar-collapse">
+        <form method="get" class="navbar-form" role="search" action="//www.fedsearch.org/board_public/search">
+            <div class="form-group input-group mobileSearch">
+                <label class="sr-only" for="t2search">Search</label>
+                <input id="t2search" name="text" class="form-control" placeholder="Search" type="text" />
+                <span class="input-group-btn">
+                    <span class="sr-only">Search Submit Button</span>
+                    <button type="submit" class="btn btn-default">Submit</button>
+                </span>
+            </div>
+        </form>
+    </div>
+</div>
+<nav class="nav-primary navbar hidden-xs nav-nine" id="nav-primary" role="navigation">
+    <ul class="nav navbar-nav" role="menubar">
+        <li role="menuitem" class="dropdown nav-about dropdown--3Col">
+            <a href="/aboutthefed.htm" class="sr-only-focusable" aria-haspopup="true" id="aboutMenu">About<br />the Fed</a>
+            <ul aria-labelledby="aboutMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fedexplained/who-we-are.htm">Structure of the Federal Reserve System</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/the-fed-explained.htm">The Fed Explained</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/bios/board/default.htm">Board Members</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/advisorydefault.htm">Advisory Councils</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/federal-reserve-system.htm">Federal Reserve Banks</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/directors/about.htm">Federal Reserve Bank and Branch Directors</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fract.htm">Federal Reserve Act</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/currency.htm">Currency</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/boardmeetings/meetingdates.htm">Board Meetings</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/boardvotes.htm">Board Votes</a>
+                            </li>
+
+                            
+
+                            <li>
+                                <a class="sr-only-focusable" href="/careers.htm">Careers</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/procurement/tips.htm">Do Business with the Board</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/k8.htm">Holidays Observed - K.8</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/ethics-values.htm">Ethics & Values</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/contact-us-topics.htm">Contact</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/foia/about_foia.htm">Requesting Information (FOIA)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/faqs.htm">FAQs</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/educational-tools/default.htm">Economic Education</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fed-financial-statements.htm">Fed Financial Statements</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/financial-innovation.htm">Financial Innovation</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-news dropdown--1Col">
+            <a href="/newsevents.htm" class="sr-only-focusable" aria-haspopup="true" id="newsMenu">News<br />& Events</a>
+            <ul aria-labelledby="newsMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/pressreleases.htm">Press Releases</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/speeches-testimony.htm">Speeches & Testimony</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/calendar.htm">Calendar</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/videos.htm">Videos</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/photogallery.htm">Photo Gallery</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/conferences.htm">Conferences</a>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-monetary dropdown--2Col">
+            <a href="/monetarypolicy.htm" class="sr-only-focusable" aria-haspopup="true" id="monetaryMenu">Monetary<br />Policy</a>
+            <ul aria-labelledby="monetaryMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Federal Open Market Committee</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc.htm">About the FOMC</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomccalendars.htm">Meeting calendars and information</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc_historical.htm">Transcripts and other historical materials</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc_projectionsfaqs.htm">FAQs</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Monetary Policy Principles and Practice</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/monetary-policy-principles-and-practice.htm">Notes</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Policy Implementation</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/policy-normalization.htm">Policy Normalization</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/policytools.htm">Policy Tools</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Reports</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/mpr_default.htm">Monetary Policy Report</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/beige-book-default.htm">Beige Book</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/balance-sheet-developments-report.htm">Federal Reserve Balance Sheet Developments</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Review of Monetary Policy Strategy, Tools, and Communications</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/review-of-monetary-policy-strategy-tools-and-communications-2025.htm">Overview</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-supervision dropdown--fw">
+    <a href="/supervisionreg.htm" class="sr-only-focusable" id="supervisionMenu"
+        aria-haspopup="true">Supervision<br />& Regulation</a>
+    <ul aria-labelledby="supervisionMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+        <li>
+            <div class="row">
+                <ul class="col-sm-3 col-nav list-unstyled">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Supervision</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/community-banks.htm">
+                            Community Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/regional-and-small-foreign-banks.htm">
+                            Regional Banks and Foreign Banks with U.S. Assets < $100 Billion</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/large-banks-and-large-foreign-banks.htm">
+                            Large Banks and Large Foreign Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/global-systemically-important-banks.htm">
+                            Global Systemically Important Banks</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/financial-market-utility-supervision.htm">Financial Market
+                            Utilities</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/consumer-compliance.htm">Consumer
+                            Compliance</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/resources-for-supervised-institutions.htm">
+                            Resources for Supervised Institutions</a>
+                    </li>
+
+                    
+
+                    <li class="nav__header">
+                        <p>
+                            <strong>Reports</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/publications/supervision-and-regulation-report.htm">Federal Reserve
+                            Supervision and Regulation Report</a>
+                    </li>
+                </ul>
+                <ul class="col-sm-3 list-unstyled col-nav">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Reporting Forms</strong>
+                        </p>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportingforms/recentupdates">Recent Reporting Form Updates</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportingforms/home/review">Information Collections
+                            Under Review</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["1"]'>Financial
+                            Statements</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["7"]'>Securities Exchange Act of 1934</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable"
+                            href='/apps/ReportingForms/?reportTypesIdsJson=["2"]'>Applications/Structure Change</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["3"]'>FFIEC</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["8"]'>Municipal and
+                            Government Securities</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["9"]'>Activities Monitoring</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/mdrm/'>Micro Data Reference Manual</a>
+                    </li>
+
+                     
+
+                </ul>
+
+
+
+
+                <ul class="col-sm-3 list-unstyled col-nav">
+
+<li class="nav__header">
+                        <p>
+                            <strong>Legal Developments</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/legal-developments.htm">Enforcement Actions and
+                            Legal Developments</a>
+                    </li>
+
+
+                     <li class="nav__header">
+                        <p>
+                            <strong>Mergers, Acquisitions, and Other Applications</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/application-process.htm">Process</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/afi/afi.htm">Filing
+                            Information</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/board-and-reserve-bank-actions.htm">Board and Reserve
+                            Bank Actions</a>
+                    </li>
+
+                
+                    
+                    
+                    
+                </ul>
+
+                <ul class="col-sm-3 list-unstyled col-nav">
+
+<li class="nav__header">
+                        <p>
+                            <strong>Supervision and Regulation Letters</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/srletters/srletters.htm">By Year</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/topics/topics.htm">By Topic</a>
+                    </li>
+
+
+                    <li class="nav__header">
+                        <p>
+                            <strong>Regulatory and Policy Resources</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/aboutthefed/fract.htm">Federal Reserve Act</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/frrs/regulations/bank-holding-company-act-of-1956.htm">Bank Holding Company Act</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/reglisting.htm">Regulations</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/publications/supmanual.htm">Supervision Manuals</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/frrs/federal-reserve-regulatory-service.htm">Federal Reserve Regulatory Service</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/disaster-preparedness-and-recovery-resources.htm">Disaster Preparedness and Recovery Resources
+     </a>
+                    </li>
+
+
+                    
+                </ul>
+                <ul class="col-sm-3 list-unstyled col-nav">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Banking and Data Structure</strong>
+                        </p>
+                    </li>
+
+                    
+
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportforms/insider.aspx">Beneficial Ownership
+                            Reports</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/releases/lbr/">Large Commercial Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/minority-depository-institutions.htm">Minority Depository
+                            Institutions</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/releases/iba/">U.S. Offices of Foreign Entities</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/fhc.htm">Financial Holding
+                            Companies</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/isb-default.htm">Interstate
+                            Branching</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/suds.htm">Securities
+                            Underwriting and Dealing Subsidiaries</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/state-member-banks-supervised-federal-reserve.htm">State Member Banks Supervised by the Federal Reserve</a>
+                    </li>
+
+                    
+                </ul>
+            </div>
+        </li>
+    </ul>
+</li>
+
+
+
+
+
+
+        <li role="menuitem" class="dropdown nav-stability dropdown--2Col">
+            <a href="/financial-stability.htm" class="sr-only-focusable" aria-haspopup="true" id="stabilityMenu">Financial<br />Stability</a>
+            <ul aria-labelledby="stabilityMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <div class="row">
+                    <ul class="col-sm-6 list-unstyled">
+                        <li class="nav__header">
+                            <p>
+                                <strong>Financial Stability Assessments </strong>
+                            </p>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/what-is-financial-stability.htm">About Financial Stability</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/types-of-financial-system-vulnerabilities-and-risks.htm">Types of Financial System Vulnerabilities & Risks</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/monitoring-risk-across-the-financial-system.htm">Monitoring Risk Across the Financial System</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/proactive-monitoring-of-markets-and-institutions.htm">Proactive Monitoring of Markets & Institutions</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/financial-stability-and-stress-testing.htm">Financial Stability & Stress Testing</a>
+                        </li>
+                    </ul>
+                    <ul class="col-sm-6 list-unstyled">
+                        <li class="nav__header">
+                            <p>
+                                <strong>Financial Stability Coordination & Actions</strong>
+                            </p>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/responding-to-financial-system-emergencies.htm">Responding to Financial System Emergencies</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/cooperation-on-financial-stability.htm">Cooperation on Financial Stability</a>
+                        </li>
+                        <li class="nav__header">
+                            <p>
+                                <strong>Reports</strong>
+                            </p>
+                        </li>
+
+                        <li>
+                            <a class="sr-only-focusable" href="/publications/financial-stability-report.htm">Financial Stability Report</a>
+                        </li>
+                    </ul>
+                </div>
+            </ul>
+        </li>
+        <li role="menuitem" class="dropdown nav-payment dropdown--fw">
+            <a href="/paymentsystems.htm" class="sr-only-focusable" id="paymentMenu" aria-haspopup="true">Payment<br />Systems</a>
+            <ul aria-labelledby="paymentMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 col-nav list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Regulations & Statutes</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/regcc-about.htm">Regulation CC (Availability of Funds and Collection of Checks)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/regii-about.htm">Regulation II (Debit Card Interchange Fees and Routing)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/reghh-about.htm">Regulation HH (Financial Market Utilities)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/other-regulations.htm">Other Regulations and Statutes</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Payment Policies</strong>
+                                </p>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/pfs_about.htm">Federal Reserve's Key Policies for the Provision of Financial Services</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/joint_requests.htm">Guidelines for Evaluating Joint Account Requests</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/oo_about.htm">Overnight Overdrafts</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/psr_about.htm">Payment System Risk</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/telecomm.htm">Sponsorship for Priority Telecommunication Services</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Reserve Bank Payment Services & Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedach_about.htm">Automated Clearinghouse Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/check_about.htm">Check Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/coin_about.htm">Currency and Coin Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/psr_data.htm">Daylight Overdrafts and Fees</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fednow_about.htm">FedNow<sup>&reg;</sup> Service</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedfunds_about.htm">Fedwire Funds Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedsecs_about.htm">Fedwire Securities Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fisagy_about.htm">Fiscal Agency Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/master-account-and-services-database-about.htm">Master Account and Services Database</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/natl_about.htm">National Settlement Service</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Financial Market Utilities & Infrastructures</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/over_about.htm">Supervision & Oversight of Financial Market Infrastructures</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/designated_fmu_about.htm">Designated Financial Market Utilities</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/int_standards.htm">International Standards for Financial Market Infrastructures</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Research, Reports, & Committees</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fr-payments-study.htm">Federal Reserve Payments Study (FRPS)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/payres_about.htm">Payments Research</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/reports.htm">Reports</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/pspa_committee.htm">Payments System Policy Advisory Committee</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-econ dropdown--right dropdown--2Col">
+            <a href="/econres.htm" class="sr-only-focusable" aria-haspopup="true" id="econMenu">Economic<br />Research</a>
+            <ul aria-labelledby="econMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-6 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/researchers.htm">Meet the Researchers</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Working Papers and Notes</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/feds/index.htm">Finance and Economics Discussion Series (FEDS)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/notes/feds-notes/default.htm">FEDS Notes</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/ifdp/index.htm">International Finance Discussion Papers (IFDP)</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Data, Models and Tools</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/economic-research-data.htm">Economic Research Data</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/us-models-about.htm">FRB/US Model</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/edo-models-about.htm">Estimated Dynamic Optimization (EDO) Model</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/scfindex.htm">Survey of Consumer Finances (SCF)</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-data dropdown--right dropdown--fw">
+            <a href="/data.htm" class="sr-only-focusable" id="dataMenu" aria-haspopup="true">Data</a>
+            <ul aria-labelledby="dataMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 col-nav list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/datadownload"><span class="icon icon-ddp icon__sm"></span>Data Download Program</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Bank Assets and Liabilities</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h3/current/default.htm">Aggregate Reserves of Depository Institutions and the Monetary Base - H.3</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h8/current/default.htm">Assets and Liabilities of Commercial Banks in the U.S. - H.8</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/assetliab/current.htm">Assets and Liabilities of U.S. Branches and Agencies of Foreign Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/chargeoff/">Charge-Off and Delinquency Rates on Loans and Leases at Commercial Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/sfos/sfos.htm">Senior Financial Officer Survey</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/sloos.htm">Senior Loan Officer Opinion Survey on Bank Lending Practices</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Bank Structure Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/lbr/">Large Commercial Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/minority-depository-institutions.htm">Minority Depository Institutions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/iba/default.htm">Structure and Share Data for the U.S. Offices of Foreign Banks</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Business Finance</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/cp/">Commercial Paper</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g20/current/default.htm">Finance Companies - G.20</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/govsecure/current.htm">New Security Issues, State and Local Governments</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/corpsecure/current.htm">New Security Issues, U.S. Corporations</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Dealer Financing Terms</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/scoos.htm">Senior Credit Officer Opinion Survey on Dealer Financing Terms</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Exchange Rates and International Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h10/current/">Foreign Exchange Rates - H.10/G.5</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/intlsumm/current.htm">International Summary Statistics</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/secholdtrans/current.htm">Securities Holdings and Transactions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/statbanksus/current.htm">Statistics Reported by Banks and Other Financial Firms in the United States</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/iba/default.htm">Structure and Share Data for U.S. Offices of Foreign Banks</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Financial Accounts</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/z1/default.htm">Financial Accounts of the United States - Z.1</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Household Finance</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g19/current/default.htm">Consumer Credit - G.19</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/DSR">Household Debt Service Ratios</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/mortoutstand/current.htm">Mortgage Debt Outstanding</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/scfindex.htm">Survey of Consumer Finances (SCF)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/shed.htm">Survey of Household Economics and Decisionmaking</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Industrial Activity</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g17/current/default.htm">Industrial Production and Capacity Utilization - G.17</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Interest Rates</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h15/">Selected Interest Rates - H.15</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Micro Data Reference Manual (MDRM)</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/mdrm.htm">Micro and Macro Data Collections</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Money Stock and Reserve Balances</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h41/">Factors Affecting Reserve Balances - H.4.1</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h6/current/default.htm">Money Stock Measures - H.6</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Other</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/yield-curve-models.htm">Yield Curve Models and Data</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-consumer dropdown--right dropdown--4Col">
+            <a href="/consumerscommunities.htm" class="sr-only-focusable" aria-haspopup="true" id="consumerMenu">Consumers<br /> & Communities</a>
+            <ul aria-labelledby="consumerMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Regulations</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/cra_about.htm">Community Reinvestment Act (CRA)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/reglisting.htm">All Regulations</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Supervision & Enforcement</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/caletters/caletters.htm">CA Letters</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/apps/enforcementactions/default.aspx">Enforcement Actions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/independent-foreclosure-review.htm">Independent Foreclosure Review</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Community Development</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/neighborhood-revitalization.htm">Housing and Neighborhood Revitalization</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/small-business-and-entrepreneurship.htm">Small Business and Entrepreneurship</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/workforce.htm">Employment and Workforce Development</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/cdf.htm">Community Development Finance</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/rural-community-economic-development.htm">Rural Community and Economic Development</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/conferences.htm">Conferences</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Research & Analysis</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/shed.htm">Survey of Household Economics and Decisionmaking</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/community-development-publications.htm">Research Publications & Data Analysis</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/cac.htm">Community Advisory Council</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Resources for Consumers</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/fraud-scams.htm">Frauds and Scams</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/foreclosure.htm">Mortgage and Foreclosure Resources</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/comm-dev-system-map.htm">Federal Reserve Community Development Resources</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+    </ul>
+</nav>
+        <!-- BODY CONTENT -->
+        <div id="content" class="container container__main" role="main">
+            <div class="row">
+                <div class="page-header">
+                    <ol class="breadcrumb ">
+                        
+                            <li class='breadcrumb__item'><a class="breadcrumb__link" href="/default.htm">Home</a></li>
+                            
+                                                    <li class='breadcrumb__item'><a class="breadcrumb__link" href="/monetarypolicy.htm">Monetary Policy</a></li>
+                                                    
+                    
+                                                    <li class='breadcrumb__item'><a class="breadcrumb__link" href="/monetarypolicy/publications/beige-book-default.htm">Beige Book</a></li>
+                                                    
+                                                    <li class='breadcrumb__item'><a class="breadcrumb__link" href="/monetarypolicy/beigebook202601.htm">January 2026</a></li>
+                                                    
+                                                
+                                                
+                
+                                                
+                        
+                    </ol>
+                    <div class="header-group">
+                        <div id="page-title" class="page-title">
+                            <h2>Beige Book - January 2026</h2>
+                        </div>
+                        
+                        <div class="shareDL">            
+                                
+                            <a href="/monetarypolicy/files/BeigeBook_20260114.pdf" class="btn shareDL__button">
+                                <span class="icon icon__sm icon--centered icon-download-header"></span>
+                                <span class="shareDL__iconTitle">PDF</span>
+                            </a>                                
+                                        
+                        </div>
+                                
+                    </div>
+                </div><!-- / .page-header -->
+            </div><!-- / .row -->
+              
+            
+            
+            <div class='row'>
+                
+                <!-- T4 Nav - Vertical List of Links -->
+                <div class="col-xs-12 col-sm-4 col-md-3">
+                    <div id="t4_nav" class="t4_nav list-group sticky">
+                        <!-- InstanceBeginEditable name="T4_Links" -->
+                        
+<a href="/monetarypolicy/beigebook202601.htm" class="list-group-item" title="">About This Publication</a><a href="/monetarypolicy/beigebook202601-summary.htm" class="list-group-item active" title="">National Summary</a><a href="/monetarypolicy/beigebook202601-boston.htm" class="list-group-item" title="">Federal Reserve Bank of Boston</a><a href="/monetarypolicy/beigebook202601-new-york.htm" class="list-group-item" title="">Federal Reserve Bank of New York</a><a href="/monetarypolicy/beigebook202601-philadelphia.htm" class="list-group-item" title="">Federal Reserve Bank of Philadelphia</a><a href="/monetarypolicy/beigebook202601-cleveland.htm" class="list-group-item" title="">Federal Reserve Bank of Cleveland</a><a href="/monetarypolicy/beigebook202601-richmond.htm" class="list-group-item" title="">Federal Reserve Bank of Richmond</a><a href="/monetarypolicy/beigebook202601-atlanta.htm" class="list-group-item" title="">Federal Reserve Bank of Atlanta</a><a href="/monetarypolicy/beigebook202601-chicago.htm" class="list-group-item" title="">Federal Reserve Bank of Chicago</a><a href="/monetarypolicy/beigebook202601-st-louis.htm" class="list-group-item" title="">Federal Reserve Bank of St. Louis</a><a href="/monetarypolicy/beigebook202601-minneapolis.htm" class="list-group-item" title="">Federal Reserve Bank of Minneapolis</a><a href="/monetarypolicy/beigebook202601-kansas-city.htm" class="list-group-item" title="">Federal Reserve Bank of Kansas City</a><a href="/monetarypolicy/beigebook202601-dallas.htm" class="list-group-item" title="">Federal Reserve Bank of Dallas</a><a href="/monetarypolicy/beigebook202601-san-francisco.htm" class="list-group-item" title="">Federal Reserve Bank of San Francisco</a>
+                    </div>
+                </div>
+                <!-- / End T4 Nav -->
+                
+                <!-- Article Area -->
+                <div id="article" class="col-xs-12 col-md-9">
+                    <div  class="col-xs-12 col-sm-8 col-md-5 pull-right">
+                        
+                              
+                    </div>           
+                    
+                    <h3>National Summary</h3>
+                                    
+                    <h4 id="xsubsection-152-28faa767">Overall Economic Activity</h4>
+
+<p>Overall economic activity increased at a slight to modest pace in eight of the twelve Federal Reserve Districts, with three Districts reporting no change and one reporting a modest decline. This marks an improvement over the last three report cycles where a majority of Districts reported little change. Most banks reported slight to modest growth in consumer spending this cycle, largely attributed to the holiday shopping season. Several Districts also noted that spending was stronger among higher-income consumers with increased spending on luxury goods, travel, tourism, and experiential activities. Meanwhile, low to moderate income consumers were seen to be increasingly price sensitive and hesitant to spend on nonessential goods and services. Auto sales were little changed to down across most Districts. Manufacturing activity varied with five Districts reporting growth and six reporting contraction. Nonfinancial services demand was generally seen as steady to increasing somewhat. Banking conditions were generally reported as stable or improving, with some increased demand coming from credit cards, home equity loans, and commercial lending. Residential real estate sales, construction, and lending activity softened in the majority of Districts that report on the sector. Agriculture conditions were largely unchanged with only Atlanta reporting a modest decline due to weaker demand for exported commodities. Energy demand and production was flat to down slightly. Outlooks for future activity were mildly optimistic with most expecting slight to modest growth in coming months.</p>
+
+<h4 id="xsubsection-153-28fac35a">Labor Markets</h4>
+
+<p>Employment was mostly unchanged in the most recent period, with eight of the twelve Districts reporting no changes in hiring. Multiple Districts reported an increase in the usage of temporary workers, with one contact reporting this allows them "to stay flexible in uncertain times." When firms were hiring, it was mostly to backfill vacancies rather than create new positions. Firms reported continued challenges finding skilled labor, particularly in engineering, health care, and other trades. Several reports mentioned that fewer workers were switching jobs. Multiple contacts reported exploring AI implementation primarily for productivity enhancement and potential future workforce management. AI's current impact on employment was limited, with more significant effects anticipated in the coming years rather than immediately. Wages grew at a moderate pace, with multiple contacts reporting that wage growth had returned to "normal" levels.</p>
+
+<h4 id="xsubsection-154-28fad3ef">Prices</h4>
+
+<p>Prices grew at a moderate rate across a large majority of Districts, with only two Districts reporting slight price growth. Cost pressures due to tariffs were a consistent theme across all Districts. Several contacts that initially absorbed tariff-related costs were beginning to pass them on to customers as pre-tariff inventories became depleted or as pressures to preserve margins grew more acute. But contacts in a few industries—like retail and restaurants—were reluctant to pass costs along to price-sensitive customers. Energy and insurance costs continued to be a significant strain on margins. Looking ahead, firms expect some moderation in price growth, but anticipated prices to remain elevated as they work through increased costs.</p>
+
+<h4 id="xsubsection-155-28fae276">Highlights by Federal Reserve District</h4>
+
+<h5 id="xsubsection-1552-28faedec">Boston</h5>
+
+<p>Economic activity increased slightly despite a moderate decline in home sales. Consumer spending rose slightly overall, with strong growth for high-end goods and services. Employment and wages were flat, with only selective layoffs. Prices rose further at a modest pace overall, with ongoing cost pressures reported for some goods and services. The outlook trended slightly more optimistic.</p>
+
+<h5 id="xsubsection-1552-28faedec">New York</h5>
+
+<p>Economic activity continued to decline modestly. Employment declined slightly and wage growth remained modest, with ongoing reports of layoffs at major employers in the region. The pace of price increases picked up further but remained moderate. Consumer spending was up slightly over the holiday season, buoyed by strong spending from higher-income consumers. Businesses generally expected little improvement in the months ahead, though manufacturers were more optimistic.</p>
+
+<h5 id="xsubsection-1552-28faedec">Philadelphia</h5>
+
+<p>Economic activity in the Third District rebounded to a slight pace of growth from a modest decline during the prior period. Employment levels also appeared to rise modestly. Wage increases have eased and are failing to keep pace with price increases—stressing low- and middle-income households.</p>
+
+<h5 id="xsubsection-1552-28faedec">Cleveland</h5>
+
+<p>Fourth District business activity increased slightly in recent weeks, with expectations for continued slight growth in the months ahead. Several manufacturing and construction contacts noted increased confidence among businesses despite lingering uncertainty. Meanwhile, consumer spending declined modestly. Nonlabor cost pressures remained robust, while selling prices continued to increase moderately.</p>
+
+<h5 id="xsubsection-1552-28faedec">Richmond</h5>
+
+<p>The regional economy continued to grow modestly in recent weeks. Consumer spending on retail, travel, and tourism increased moderately but auto sales declined. Manufacturing activity declined slightly this cycle. Residential real estate slowed modestly while commercial real estate activity picked up slightly. Employment was unchanged and wage growth remained moderate. On balance, prices continued to grow at a moderate rate.</p>
+
+<h5 id="xsubsection-1552-28faedec">Atlanta</h5>
+
+<p>The Sixth District economy grew slightly. Employment levels were flat to slightly down. Prices grew slightly. Retail sales improved, and travel rose modestly. Home sales improved, but commercial real estate declined. Transportation activity was flat to slightly down, while manufacturing activity was flat to slightly up. Energy demand was flat.</p>
+
+<h5 id="xsubsection-1552-28faedec">Chicago</h5>
+
+<p>Economic activity in the Seventh District was little changed over the reporting period. Consumer spending and construction and real estate demand rose slightly; employment was flat; nonbusiness contacts saw no change in economic activity; business spending fell slightly; and manufacturing activity declined modestly. Prices rose moderately, wages were up modestly, and financial conditions loosened modestly. Net farm income in 2025 was similar to 2024.</p>
+
+<h5 id="xsubsection-1552-28faedec">St. Louis</h5>
+
+<p>Economic activity has modestly increased since our previous report. The uptick in activity was attributed to the end of the government shutdown and strong late-holiday sales. Employment levels were unchanged. Prices continued to increase moderately.</p>
+
+<h5 id="xsubsection-1552-28faedec">Minneapolis</h5>
+
+<p>District economic activity was flat. Employment declined slightly and more firms were cutting head counts than increasing them, particularly larger firms. Prices increased slightly but some firms were planning increases in the new year. Holiday spending was solid despite harsh weather, which benefited winter tourism. Manufacturing activity contracted.</p>
+
+<h5 id="xsubsection-1552-28faedec">Kansas City</h5>
+
+<p>Economic activity rose slightly, reflecting gains in service sector sales and manufacturing orders. The labor market remains stable and balanced, while prices have gone up modestly from input costs and labor cost pressures. Energy activity declined as oil prices remained below profitable levels. Agriculture remains mixed, with weak crop profitability offset by strong cattle prices.</p>
+
+<h5 id="xsubsection-1552-28faedec">Dallas</h5>
+
+<p>Economic activity in the Eleventh District held steady over the reporting period. Little change was seen in manufacturing, retail, nonfinancial services, and real estate. The banking sector was a bright spot, with loan volumes increasing over the past six weeks. Employment was largely unchanged, and prices increased moderately. Outlooks remained cautious, dampened by concern over the level of demand and the inflationary impact of tariffs.</p>
+
+<h5 id="xsubsection-1552-28faedec">San Francisco</h5>
+
+<p>Economic activity expanded modestly. Employment levels largely held steady, and wages grew somewhat. The pace of price increases intensified, shifting from modest to moderate. Retail sales grew modestly, with strong holiday shopping driven by high-income households. Activity in services, real estate, and agriculture was stable on net. Manufacturing activity softened somewhat, while lending activity increased slightly.</p>
+
+<p>&nbsp;</p>
+
+<p id="f2">Note: This report was prepared at the Federal Reserve Bank of Richmond based on information collected on or before January 5, 2026. This document summarizes comments received from contacts outside the Federal Reserve System and is not a commentary on the views of Federal Reserve officials.</p>
+
+<p>&nbsp;</p>
+                    
+                    
+                </div>
+            </div>            
+            <a id="back-top" class="icon__backTop icon-backtop" href="#" title="Scroll To Top"><span class="sr-only">Back to Top</span></a>
+            <div class="row">
+                <div class='lastUpdate' id="lastUpdate">
+                    Last Update:
+                    January 14, 2026
+                </div>
+            </div>
+        </div><!-- / #content .container -->
+                    <footer class="container footer">
+                <div class="row footer__content">
+                    <div class="col-xs-12 col-sm-4">
+                        <h6 class="footer__heading"><span class="text-uppercase">Board of Governors</span> <em>of the</em> <span class="text-uppercase">Federal Reserve System</span></h6>
+                        <ul class="list-unstyled">
+                            <li class='footer__listItem'><a class="footer__link" href="/aboutthefed.htm">About the Fed</a></li><li class='footer__listItem'><a class="footer__link" href="/newsevents.htm">News & Events</a></li><li class='footer__listItem'><a class="footer__link" href="/monetarypolicy.htm">Monetary Policy</a></li><li class='footer__listItem'><a class="footer__link" href="/supervisionreg.htm">Supervision & Regulation</a></li><li class='footer__listItem'><a class="footer__link" href="/financial-stability.htm">Financial Stability</a></li><li class='footer__listItem'><a class="footer__link" href="/paymentsystems.htm">Payment Systems</a></li><li class='footer__listItem'><a class="footer__link" href="/econres.htm">Economic Research</a></li><li class='footer__listItem'><a class="footer__link" href="/data.htm">Data</a></li><li class='footer__listItem'><a class="footer__link" href="/consumerscommunities.htm">Consumers & Communities</a></li><li class='footer__listItem'><a class="footer__link" href="/aboutthefed/aroundtheboard/stayconnected-qr-code-2.htm">Connect with the Board</a></li> 
+                        </ul>
+                    </div>
+                    <div class="col-xs-12 col-sm-4">
+                        <h6 class="text-uppercase footer__heading">Tools and Information</h6>
+                        <ul class="list-unstyled">
+                             <li class='footer__listItem'><a href="/aboutthefed/contact-us-topics.htm" class="footer__link">Contact</a></li>
+                            <li class='footer__listItem'><a href="/publications.htm" class="footer__link">Publications</a></li>
+                            <li class='footer__listItem'><a href="/foia/about_foia.htm" class="footer__link">Freedom of Information (FOIA)</a></li>
+                            <li class='footer__listItem'><a href="https://oig.federalreserve.gov/" class="footer__link">Office of Inspector General</a></li>
+                            <li class='footer__listItem'><a href="/publications/annual-report.htm" class="footer__link">Budget &amp; Performance</a> | <a href="/regreform/audit.htm" class="footer__link">Audit</a></li>
+                            <li class='footer__listItem'><a href="/eeo.htm" class="footer__link">No FEAR Act</a></li>
+                            <li class='footer__listItem'><a href="/espanol.htm" class="footer__link">Espa&ntilde;ol</a></li>
+                            <li class='footer__listItem'><a href="/website-linking-policies.htm" class="footer__link">Website Policies</a>  | <a href="/privacy.htm" class="footer__link">Privacy Program</a></li>
+                            <li class='footer__listItem'><a href="/accessibility.htm" class="footer__link">Accessibility</a></li>
+                        </ul>
+                    </div>
+                    <div class="col-xs-12 col-sm-4">
+                        <div class="footer__social">
+                            <h6 class="text-uppercase footer__heading footer__heading--social">Stay Connected</h6>
+                            
+            <a
+              class="icon__md icon footer__btn icon-facebook-color"
+              href="https://www.facebook.com/federalreserve"
+              ><span class="sr-only"
+                >Federal Reserve Facebook Page</span
+              ></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-instagram"
+              href="https://www.instagram.com/federalreserveboard/"
+              ><span class="sr-only"
+                >Federal Reserve Instagram Page</span
+              ></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-youtube-color"
+              href="https://www.youtube.com/federalreserve"
+              ><span class="sr-only"
+                >Federal Reserve YouTube Page</span
+              ></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-flickr-color"
+              href="https://www.flickr.com/photos/federalreserve/"
+              ><span class="sr-only"
+                >Federal Reserve Flickr Page</span
+              ></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-linkedin-color"
+              href="https://www.linkedin.com/company/federal-reserve-board"
+              ><span class="sr-only">Federal Reserve LinkedIn Page</span></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-threads"
+              href="https://www.threads.net/@federalreserveboard"
+              ><span class="sr-only">Federal Reserve Threads Page</span></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-social-x"
+              href="https://x.com/federalreserve"
+              ><span class="sr-only"
+                >Link to Federal Reserve X Page</span
+              ></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-bluesky"
+              href="https://bsky.app/profile/federalreserve.gov"
+              ><span class="sr-only"
+                >Link to Federal Reserve Bluesky Page</span
+              ></a
+            >
+            <a
+              class="icon__md icon footer__btn icon-rss-color"
+              href="/feeds/feeds.htm"
+              ><span class="sr-only">Subscribe to RSS</span></a
+            >
+
+            <a
+              class="icon__md icon footer__btn icon-email-color"
+              href="/subscribe.htm"
+              ><span class="sr-only">Subscribe to Email</span></a
+            >
+ 
+                        </div>
+                        <a href="https://www.usa.gov/" target="_blank" title="Link to USA.gov">
+                            <img class='footer__image' src="/images/USAGov%402x.png" alt="Link to USA.gov" />
+                        </a>
+                        <a href="/open/open.htm" target="_blank" title="Link to Open.gov">
+                            <img class='footer__image' src="/images/OpenGov%402x.png" alt="Link to Open.gov" />
+                        </a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-xs-12 footer__footer">
+                        <p class="text-uppercase footer__text footer__text--left">Board of Governors <em class="text-lowercase">of the</em> Federal Reserve System</p>
+                        <p class="footer__text footer__text--right">20th Street and Constitution Avenue N.W., Washington, DC 20551</p>
+                    </div>
+                </div>
+            </footer>
+            
+            <script src="/js/jquery.min.js" type="text/javascript"></script>
+            <script src="/js/bootstrap.min.js" type="text/javascript"></script>
+            <script src="/js/scripts.js" type="text/javascript"></script>
+            <script src="/js/modal.js" type="text/javascript"></script>
+            <script src="/js/sticky-tables.js" type="text/javascript"></script>
+            <script type="text/javascript" src="/js/slides/ekko-lightbox.min.js"></script>
+            <script src="/js/t4-nav-controller.js" type="text/javascript"></script>
+                     
+            <script type="text/javascript">
+                $(document).ready(function($) {
+                    // delegate calls to data-toggle="lightbox"
+                    $(document).delegate('*[data-toggle="lightbox"]:not([data-gallery="navigateTo"])', 'click', function(event) {
+                        event.preventDefault();
+                        $(this).ekkoLightbox();
+                    });
+                    $('a[data-click="false"]').click(function(e) {
+                        e.preventDefault();
+                        var target = $(this).data('target');
+                        $(target).click();
+                    });
+                });
+            </script>          
+
+            
+                
+        <!--<ul></ul>-->
+    <script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'9f718b26cac4ae11',t:'MTc3ODAwMjk2NQ=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>
+ 

--- a/tests/unit/test_ingest_sources.py
+++ b/tests/unit/test_ingest_sources.py
@@ -7,6 +7,7 @@ import pytest
 
 from app.data import ingest_sources
 from app.data.source_type import (
+    SOURCE_TYPE_BEIGE_BOOK,
     SOURCE_TYPE_CHAIR_SPEECH,
     SOURCE_TYPE_CONGRESSIONAL_TESTIMONY,
     SOURCE_TYPE_FOMC_MINUTES,
@@ -165,3 +166,24 @@ def test_iter_scraped_records_assigns_press_conference_source_type(tmp_path: Pat
     assert len(pc_records) == 1
     assert pc_records[0]["source"] == "scraped_fed"
     assert pc_records[0]["title"] == "FOMC Press Conference"
+
+
+def test_iter_scraped_records_assigns_beige_book_source_type(tmp_path: Path) -> None:
+    rows = [
+        {
+            "date": "2024-03-01",
+            "title": "Beige Book - March 2024",
+            "text": "Full report body",
+            "document_type": "beige_book",
+            "url": "https://www.federalreserve.gov/monetarypolicy/beigebook202403-summary.htm",
+            "scraped_at_utc": "2024-03-01T12:00:00+00:00",
+        }
+    ]
+    (tmp_path / "beige_book.json").write_text(json.dumps(rows), encoding="utf-8")
+
+    records = ingest_sources._iter_scraped_records(tmp_path)
+
+    bb_records = [r for r in records if r["source_type"] == SOURCE_TYPE_BEIGE_BOOK]
+    assert len(bb_records) == 1
+    assert bb_records[0]["source"] == "scraped_fed"
+    assert bb_records[0]["title"] == "Beige Book - March 2024"

--- a/tests/unit/test_scraper_beige_book.py
+++ b/tests/unit/test_scraper_beige_book.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from app.services.scraper_beige_book import (
+    BeigeBookListingEntry,
+    ParsedBeigeBook,
+    extract_beige_book_listing,
+    parse_beige_book_page,
+    write_beige_book_json,
+)
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+def test_extract_beige_book_listing_returns_entries() -> None:
+    """The listing has both base and summary URLs; adapter returns deduplicated entries."""
+
+    html = (FIXTURES / "fed_beige_book_listing.html").read_text(encoding="utf-8")
+    entries = extract_beige_book_listing(html)
+
+    assert len(entries) >= 5
+    for entry in entries:
+        assert isinstance(entry, BeigeBookListingEntry)
+        assert entry.url.startswith("https://www.federalreserve.gov/monetarypolicy/beigebook")
+        assert entry.url.endswith(".htm")
+        assert entry.date  # ISO yyyy-mm-dd derived from URL
+
+
+def test_extract_beige_book_listing_returns_empty_on_unrelated_html() -> None:
+    assert extract_beige_book_listing("<html><body>nothing</body></html>") == []
+
+
+def test_extract_beige_book_listing_deduplicates_repeated_urls() -> None:
+    repeated = "/monetarypolicy/beigebook202401-summary.htm"
+    html = f'<html><body><a href="{repeated}">A</a><a href="{repeated}">B</a></body></html>'
+    entries = extract_beige_book_listing(html)
+    assert len(entries) == 1
+
+
+def test_parse_beige_book_page_extracts_substantive_text() -> None:
+    html = (FIXTURES / "fed_beige_book_sample.html").read_text(encoding="utf-8")
+    # The sample fixture is the January 2026 National Summary
+    source_url = "https://www.federalreserve.gov/monetarypolicy/beigebook202601-summary.htm"
+
+    parsed = parse_beige_book_page(html, source_url=source_url)
+
+    assert isinstance(parsed, ParsedBeigeBook)
+    assert parsed.date.startswith("20")
+    # Full Beige Book national summary is substantial — at least 5k chars of economic content
+    assert len(parsed.text) > 5000
+    assert parsed.url == source_url
+
+
+def test_write_beige_book_json_emits_one_row_per_parsed(tmp_path: Path) -> None:
+    parsed = [
+        ParsedBeigeBook(
+            date="2024-03-01",
+            title="Beige Book - March 2024",
+            text="Full body of the report " * 50,
+            url="https://www.federalreserve.gov/monetarypolicy/beigebook202403-summary.htm",
+        ),
+        ParsedBeigeBook(
+            date="",
+            title="Empty date",
+            text="something",
+            url="https://www.federalreserve.gov/monetarypolicy/beigebook202404-summary.htm",
+        ),
+    ]
+
+    output = tmp_path / "beige_book.json"
+    written = write_beige_book_json(parsed, output)
+
+    assert written == 1  # empty-date row is skipped
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert len(payload) == 1
+    assert payload[0]["document_type"] == "beige_book"


### PR DESCRIPTION
## Summary

Plan 11 of the 2026-05-05 scope extension. Fifth Fed-adjacent source for issue #32 (still partial — 1 source to go: regional research).

## What landed

- \`backend/app/services/scraper_beige_book.py\`: \`BeigeBookListingEntry\`, \`ParsedBeigeBook\`, \`extract_beige_book_listing\`, \`parse_beige_book_page\`, \`write_beige_book_json\`. Discovered URL pattern caveat (see below).
- \`backend/app/data/ingest_sources.py\` += \`beige_book.json\` in \`SCRAPED_FILES\`; filename override → \`source_type=beige_book\`.
- 5 new unit tests against captured fixtures.

## Methodology finding

The plan assumed \`/monetarypolicy/beigebook{YYYYMM}.htm\` was the full report. It's actually an "About This Publication" boilerplate page. The substantive content (the National Summary) lives at \`-summary.htm\`. The adapter:
1. Discovers base Beige Book URLs from \`<a href>\` links AND the CMS-embedded sitemap in the listing HTML.
2. Derives \`-summary.htm\` from each base URL for content fetching.
The external API mirrors the spec; only the internal URL-derivation strategy changed.

## Verification

- 198 unit tests pass.
- Live smoke: 3 recent Beige Books (2025-08, 2025-10, 2025-11) → 8,377 / 8,702 / 8,763 chars per entry (the National Summary content). All 3 ingested.
- Registry totals: 42 fomc_minutes + 6 fomc_statement + 5 chair_speech + 23 governor_speech + 5 congressional_testimony + 3 press_conference + 3 beige_book = **87 rows across 7 source_types**.

## Test plan

- [x] \`docker compose run --rm backend pytest tests/unit -v\` (198 passed)
- [x] Live: 3 Beige Books extracted and ingested as \`source_type=beige_book\`

## Issue tracking

- #32 stays OPEN — 1 source left: regional research.