### PR TITLE
Add pre-commit config and document VOYAGE_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,14 @@ GEMINI_API_KEY=
 # auto-evaluators (Plan 4 / #42). Free tier covers tracing and small
 # datasets. Sign up at https://smith.langchain.com/ -> Settings -> API Keys.
 LANGSMITH_API_KEY=
+
+# Voyage AI key, used once by scripts/cache_voyage_embeddings.py to build
+# the voyage-finance-2 embedding cache. Get one at https://www.voyageai.com/.
+VOYAGE_API_KEY=
+
+# Optional runtime overrides; defaults work for the standard docker setup.
+# FED_PULSE_DATA_DIR=/data
+# FED_PULSE_MODEL_CHECKPOINT_DIR=/app/models
+# FED_PULSE_MARKET_SOURCE=live
+# FED_PULSE_MARKET_SNAPSHOT_DIR=/data/raw/market
+# FED_PULSE_LOG_LEVEL=INFO

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+      - id: check-added-large-files
+        args: [--maxkb=2048]
+      - id: mixed-line-ending
+        args: [--fix=lf]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^backend/.*\.py$
+      - id: ruff-format
+        files: ^backend/.*\.py$
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Backend API docs: `http://localhost:8000/docs`
 - `docs/architecture-overview.md`
 - `docs/run-templates.md`
 
+## Local setup
+
+- Copy `.env.example` to `.env` and fill in the credentials you need.
+- Install [`pre-commit`](https://pre-commit.com/) (`pip install --user pre-commit`) and run `pre-commit install` once in this clone so every commit runs `ruff`, `ruff-format`, `gitleaks`, and the whitespace/file-shape hooks.
+
 ## Notes
 
 - Forecast modes: `fast`, `quick_train`, `real_train`


### PR DESCRIPTION
## Summary

- New `.pre-commit-config.yaml` runs four hook sets on every commit: standard `pre-commit-hooks` (end-of-file-fixer, trailing-whitespace, check-yaml/toml/json, check-added-large-files >2MB, mixed-line-ending → LF), `ruff` + `ruff-format` scoped to `backend/**/*.py`, and `gitleaks` for committed-secret scanning.
- Extend `.env.example` with `VOYAGE_API_KEY` and an optional override block for the new `FED_PULSE_*` runtime config variables so a new contributor sees every env var the backend understands.
- README gains a Local setup section: copy `.env.example`, install pre-commit, run `pre-commit install`.

## Test plan

- [ ] `pip install --user pre-commit && pre-commit install && pre-commit run --all-files` (gitleaks pulls its binary on first run)
- [ ] Plant a fake HF token in a scratch file and confirm `pre-commit run gitleaks` blocks the commit