### PR TITLE
Evaluation toolkit: bootstrap CIs, regime aggregator, calibration

### DIFF
--- a/backend/app/data/llm_zero_shot_execution.py
+++ b/backend/app/data/llm_zero_shot_execution.py
@@ -67,7 +67,17 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Phase 4 LLM zero-shot baseline.")
     parser.add_argument("--training-package-id", required=True)
     parser.add_argument("--fold-id", default="wf_fold_2")
-    parser.add_argument("--llm-checkpoint", default=DEFAULT_LLM)
+    parser.add_argument(
+        "--llm-backend",
+        choices=("hf", "gemini"),
+        default="hf",
+        help="hf loads a local Transformers checkpoint; gemini calls the Google Gemini API.",
+    )
+    parser.add_argument(
+        "--llm-checkpoint",
+        default=DEFAULT_LLM,
+        help="HF checkpoint name (used with --llm-backend hf) or Gemini model name (used with --llm-backend gemini).",
+    )
     parser.add_argument("--seed", type=int, default=11)
     parser.add_argument("--owner", default="unknown")
     parser.add_argument("--max-new-tokens", type=int, default=8)
@@ -76,20 +86,7 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> int:
-    args = _parse_args()
-    _set_all_seeds(args.seed)
-
-    package_dir = DATA_DIR / "processed" / args.training_package_id
-    if not package_dir.exists():
-        raise SystemExit(f"Training package not found: {package_dir}")
-    rows = _load_registry_rows(package_dir)
-    fold = _load_fold(package_dir, args.fold_id)
-    _, test_rows = _split_by_fold(rows, fold)
-    if not test_rows:
-        raise SystemExit(f"No test rows for fold {args.fold_id}")
-    print(f"[llm_zs] checkpoint={args.llm_checkpoint} test_rows={len(test_rows)}")
-
+def _score_with_hf(test_rows, args) -> tuple[list[str], list[str], list[float], str]:
     hf_token = _hf_token()
     if hf_token:
         print(f"[llm_zs] using HF token (len={len(hf_token)})")
@@ -115,7 +112,6 @@ def main() -> int:
     y_true: list[str] = []
     y_pred: list[str] = []
     latencies_ms: list[float] = []
-
     for idx, row in enumerate(test_rows):
         prompt = _build_prompt(row.text, tokenizer)
         inputs = tokenizer(
@@ -135,7 +131,7 @@ def main() -> int:
         elapsed_ms = (time.perf_counter() - t0) * 1000
         latencies_ms.append(elapsed_ms)
         generated = tokenizer.decode(
-            output[0, inputs["input_ids"].shape[-1] :],
+            output[0, inputs["input_ids"].shape[-1]:],
             skip_special_tokens=True,
         )
         pred_label = _parse_label(generated)
@@ -146,6 +142,51 @@ def main() -> int:
                 f"[llm_zs] {idx + 1}/{len(test_rows)} pred={pred_label} truth={row.label} "
                 f"gen={generated.strip()!r}"
             )
+    return y_true, y_pred, latencies_ms, str(model.device)
+
+
+def _score_with_gemini(test_rows, args) -> tuple[list[str], list[str], list[float], str]:
+    from app.services.gemini_client import load_model, score_passage
+
+    model = load_model(args.llm_checkpoint)
+    y_true: list[str] = []
+    y_pred: list[str] = []
+    latencies_ms: list[float] = []
+    for idx, row in enumerate(test_rows):
+        t0 = time.perf_counter()
+        result = score_passage(row.text, model=model)
+        latencies_ms.append((time.perf_counter() - t0) * 1000)
+        pred_label = str(result.get("label", "neutral")).strip().lower()
+        if pred_label not in ("hawkish", "dovish", "neutral"):
+            pred_label = "neutral"
+        y_true.append(row.label)
+        y_pred.append(pred_label)
+        if idx < 3 or idx % 50 == 0:
+            print(
+                f"[llm_zs] {idx + 1}/{len(test_rows)} pred={pred_label} truth={row.label} "
+                f"confidence={float(result.get('confidence', 0.0)):.3f}"
+            )
+    return y_true, y_pred, latencies_ms, "gemini-api"
+
+
+def main() -> int:
+    args = _parse_args()
+    _set_all_seeds(args.seed)
+
+    package_dir = DATA_DIR / "processed" / args.training_package_id
+    if not package_dir.exists():
+        raise SystemExit(f"Training package not found: {package_dir}")
+    rows = _load_registry_rows(package_dir)
+    fold = _load_fold(package_dir, args.fold_id)
+    _, test_rows = _split_by_fold(rows, fold)
+    if not test_rows:
+        raise SystemExit(f"No test rows for fold {args.fold_id}")
+    print(f"[llm_zs] backend={args.llm_backend} checkpoint={args.llm_checkpoint} test_rows={len(test_rows)}")
+
+    if args.llm_backend == "gemini":
+        y_true, y_pred, latencies_ms, device_label = _score_with_gemini(test_rows, args)
+    else:
+        y_true, y_pred, latencies_ms, device_label = _score_with_hf(test_rows, args)
 
     cls_metrics = _compute_classification_metrics(y_true, y_pred)
     latency = _latency_summary(latencies_ms)
@@ -168,7 +209,8 @@ def main() -> int:
         "latency": latency,
         "training_package_id": args.training_package_id,
         "started_at_utc": run_token,
-        "device": str(model.device),
+        "backend": args.llm_backend,
+        "device": device_label,
         "max_new_tokens": args.max_new_tokens,
         "max_input_tokens": args.max_input_tokens,
         "system_prompt": SYSTEM_PROMPT,

--- a/backend/app/data/llm_zero_shot_execution.py
+++ b/backend/app/data/llm_zero_shot_execution.py
@@ -173,6 +173,13 @@ def main() -> int:
     args = _parse_args()
     _set_all_seeds(args.seed)
 
+    if args.llm_backend == "gemini" and not args.llm_checkpoint.lower().startswith("gemini"):
+        raise SystemExit(
+            f"--llm-backend gemini requires a Gemini model name (e.g. 'gemini-2.5-pro'); "
+            f"got --llm-checkpoint={args.llm_checkpoint!r}. Pass a Gemini model or switch "
+            f"--llm-backend back to hf."
+        )
+
     package_dir = DATA_DIR / "processed" / args.training_package_id
     if not package_dir.exists():
         raise SystemExit(f"Training package not found: {package_dir}")

--- a/backend/app/data/phase4_attention_ablation.py
+++ b/backend/app/data/phase4_attention_ablation.py
@@ -293,17 +293,20 @@ def _train_variant(
     weight_decay: float,
     seed: int,
     device: torch.device,
+    initial_decay_rate: float | None = None,
 ) -> dict[str, Any]:
     _set_all_seeds(seed)
-    # Choose embedding size based on active variant.
     active_embedding_size = llm_embedding_size if use_llm_embeddings else chunk_embedding_size
-    model = ForecasterModel(
-        use_time_decay=use_time_decay,
-        use_chunk_attention=use_chunk_attention,
-        use_llm_embeddings=use_llm_embeddings,
-        chunk_embedding_size=active_embedding_size,
-        chunk_projection_dim=chunk_projection_dim,
-    ).to(device)
+    model_kwargs: dict[str, Any] = {
+        "use_time_decay": use_time_decay,
+        "use_chunk_attention": use_chunk_attention,
+        "use_llm_embeddings": use_llm_embeddings,
+        "chunk_embedding_size": active_embedding_size,
+        "chunk_projection_dim": chunk_projection_dim,
+    }
+    if initial_decay_rate is not None:
+        model_kwargs["initial_decay_rate"] = float(initial_decay_rate)
+    model = ForecasterModel(**model_kwargs).to(device)
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=weight_decay)
     loss_fn = nn.MSELoss()
 
@@ -384,6 +387,7 @@ def _train_variant(
     direction_total = 0
     last_history_close: list[float] = []
     latencies_ms: list[float] = []
+    per_row_predictions: list[dict[str, float]] = []
     with torch.no_grad():
         for batch in val_loader:
             x = batch["x"].to(device)
@@ -412,6 +416,13 @@ def _train_variant(
                     direction_hits += 1
                 direction_total += 1
                 last_history_close.append(float(c_last))
+                per_row_predictions.append({
+                    "predicted_close": float(c_pred),
+                    "actual_close": float(c_true),
+                    "predicted_volatility": float(v_pred),
+                    "actual_volatility": float(v_true),
+                    "last_history_close": float(c_last),
+                })
     close_rmse = math.sqrt(statistics.mean(close_se)) if close_se else 0.0
     vol_rmse = math.sqrt(statistics.mean(vol_se)) if vol_se else 0.0
     combined_rmse = math.sqrt((close_rmse**2 + vol_rmse**2) / 2)
@@ -444,8 +455,9 @@ def _train_variant(
         "chunk_lambda_history": chunk_lambda_history,
         "final_decay_rate": final_decay,
         "final_chunk_lambda": final_chunk_lambda,
+        "initial_decay_rate": float(initial_decay_rate) if initial_decay_rate is not None else None,
     }
-    return metrics, model
+    return metrics, model, per_row_predictions
 
 
 def _heatmap_samples(
@@ -528,6 +540,12 @@ def _parse_args() -> argparse.Namespace:
         "--llm-store-path",
         default=str(DEFAULT_LLM_EMBEDDINGS_PARQUET),
         help="Path to the LLM embeddings parquet (Variant C). Defaults to the standard interim path.",
+    )
+    parser.add_argument(
+        "--lambda-init",
+        type=float,
+        default=None,
+        help="Initial decay rate for the time-decay attention layer. Default leaves the forecaster's compiled-in default in place; pass an explicit value when running a lambda sweep.",
     )
     return parser.parse_args()
 
@@ -628,9 +646,10 @@ def main() -> int:
 
     results: dict[str, Any] = {}
     heatmaps_by_variant: dict[str, Any] = {}
+    predictions_by_variant: dict[str, list[dict[str, float]]] = {}
     for name, use_a, use_b, use_c in variants:
         print(f"\n[ablation] === variant: {name} (A={use_a}, B={use_b}, C={use_c}) ===")
-        result, trained_model = _train_variant(
+        result, trained_model, per_row_predictions = _train_variant(
             train_tuples,
             val_tuples,
             use_time_decay=use_a,
@@ -645,8 +664,10 @@ def main() -> int:
             weight_decay=args.weight_decay,
             seed=args.seed,
             device=device,
+            initial_decay_rate=args.lambda_init,
         )
         results[name] = result
+        predictions_by_variant[name] = per_row_predictions
         if (use_b or use_c) and trained_model.chunk_pooler is not None:
             heatmaps_by_variant[name] = _heatmap_samples(
                 val_tuples, pooler_state=trained_model, device=device, use_llm_embeddings=use_c
@@ -684,6 +705,11 @@ def main() -> int:
         "heatmaps": heatmaps_by_variant,
     }
     (artifact_dir / "ablation_table.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    predictions_path = artifact_dir / "predictions.jsonl"
+    with predictions_path.open("w", encoding="utf-8") as handle:
+        for variant_name, rows in predictions_by_variant.items():
+            for row in rows:
+                handle.write(json.dumps({"variant": variant_name, **row}) + "\n")
 
     md_lines: list[str] = [
         "# Phase 4 Attention + Decay Ablation",

--- a/backend/app/evaluation/__init__.py
+++ b/backend/app/evaluation/__init__.py
@@ -1,0 +1,17 @@
+from app.evaluation.bootstrap import block_bootstrap_ci, bootstrap_paired_diff
+from app.evaluation.calibration import (
+    coverage_curve,
+    empirical_coverage,
+    write_reliability_diagram,
+)
+from app.evaluation.regime_aggregator import REGIME_WINDOWS, aggregate_by_regime
+
+__all__ = [
+    "REGIME_WINDOWS",
+    "aggregate_by_regime",
+    "block_bootstrap_ci",
+    "bootstrap_paired_diff",
+    "coverage_curve",
+    "empirical_coverage",
+    "write_reliability_diagram",
+]

--- a/backend/app/evaluation/bootstrap.py
+++ b/backend/app/evaluation/bootstrap.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class BootstrapCI:
+    point: float
+    lo: float
+    hi: float
+    coverage: float
+    n_resamples: int
+    block_size: int
+
+
+def _moving_blocks(n: int, block_size: int) -> int:
+    return max(1, math.ceil(n / block_size))
+
+
+def _resample_indices(n: int, block_size: int, rng: random.Random) -> list[int]:
+    if n <= 0:
+        return []
+    blocks = _moving_blocks(n, block_size)
+    indices: list[int] = []
+    for _ in range(blocks):
+        start = rng.randint(0, max(0, n - block_size))
+        indices.extend(range(start, min(n, start + block_size)))
+    return indices[:n]
+
+
+def block_bootstrap_ci(
+    values: Sequence[float],
+    *,
+    statistic: str = "mean",
+    block_size: int = 20,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    seed: int = 11,
+) -> BootstrapCI:
+    if not values:
+        return BootstrapCI(point=float("nan"), lo=float("nan"), hi=float("nan"),
+                           coverage=coverage, n_resamples=n_resamples, block_size=block_size)
+    if statistic not in {"mean", "median"}:
+        raise ValueError(f"unsupported statistic={statistic!r}")
+    if not 0 < coverage < 1:
+        raise ValueError("coverage must be in (0, 1)")
+
+    rng = random.Random(seed)
+    arr = list(values)
+    n = len(arr)
+    point = _summary(arr, statistic)
+
+    samples: list[float] = []
+    for _ in range(n_resamples):
+        idx = _resample_indices(n, block_size, rng)
+        resample = [arr[i] for i in idx]
+        samples.append(_summary(resample, statistic))
+    samples.sort()
+    alpha = (1.0 - coverage) / 2.0
+    lo_idx = int(alpha * n_resamples)
+    hi_idx = int((1.0 - alpha) * n_resamples) - 1
+    lo_idx = max(0, min(n_resamples - 1, lo_idx))
+    hi_idx = max(0, min(n_resamples - 1, hi_idx))
+    return BootstrapCI(
+        point=point,
+        lo=samples[lo_idx],
+        hi=samples[hi_idx],
+        coverage=coverage,
+        n_resamples=n_resamples,
+        block_size=block_size,
+    )
+
+
+def bootstrap_paired_diff(
+    a: Sequence[float],
+    b: Sequence[float],
+    *,
+    block_size: int = 20,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    seed: int = 11,
+) -> BootstrapCI:
+    if len(a) != len(b):
+        raise ValueError(f"paired series must have equal length; got {len(a)} vs {len(b)}")
+    diffs = [float(x) - float(y) for x, y in zip(a, b)]
+    return block_bootstrap_ci(
+        diffs,
+        statistic="mean",
+        block_size=block_size,
+        n_resamples=n_resamples,
+        coverage=coverage,
+        seed=seed,
+    )
+
+
+def _summary(values: Sequence[float], statistic: str) -> float:
+    if not values:
+        return float("nan")
+    if statistic == "mean":
+        return sum(values) / len(values)
+    sorted_vals = sorted(values)
+    mid = len(sorted_vals) // 2
+    if len(sorted_vals) % 2 == 1:
+        return sorted_vals[mid]
+    return 0.5 * (sorted_vals[mid - 1] + sorted_vals[mid])

--- a/backend/app/evaluation/calibration.py
+++ b/backend/app/evaluation/calibration.py
@@ -15,6 +15,12 @@ class CoveragePoint:
 
 
 def empirical_coverage(residuals: Sequence[float], band_half_widths: Sequence[float]) -> float:
+    """Fraction of residuals that fall inside their per-row band.
+
+    `band_half_widths[i]` is the half-width of whatever confidence band the
+    caller wants to verify (e.g. the published 80% band). No scaling is
+    applied. Use this to answer "is the published 80% band actually 80%?".
+    """
     if len(residuals) != len(band_half_widths):
         raise ValueError("residuals and band_half_widths must have equal length")
     if not residuals:
@@ -25,23 +31,28 @@ def empirical_coverage(residuals: Sequence[float], band_half_widths: Sequence[fl
 
 def coverage_curve(
     residuals: Sequence[float],
-    band_half_widths: Sequence[float],
+    sigma_per_row: Sequence[float],
     *,
     nominal_levels: Sequence[float] = (0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99),
 ) -> list[CoveragePoint]:
-    if len(residuals) != len(band_half_widths):
-        raise ValueError("residuals and band_half_widths must have equal length")
+    """Reconstruct empirical coverage at multiple nominal Gaussian levels.
+
+    `sigma_per_row[i]` is the predicted one-sigma deviation for row `i`.
+    For each `nominal` in `nominal_levels`, the function scales sigma by the
+    inverse-normal-CDF and counts `|r_i| <= z(nominal) * sigma_i`. Useful for
+    plotting a reliability diagram against the Gaussian-band assumption.
+    """
+    if len(residuals) != len(sigma_per_row):
+        raise ValueError("residuals and sigma_per_row must have equal length")
     if not residuals:
         return [CoveragePoint(nominal=lvl, empirical=float("nan"), n=0) for lvl in nominal_levels]
 
-    sorted_abs = sorted(abs(r) for r in residuals)
-    n = len(sorted_abs)
-    base_scaled = [abs(r) / h if h > 0 else float("inf") for r, h in zip(residuals, band_half_widths)]
-
+    n = len(residuals)
+    standardised = [abs(r) / s if s > 0 else float("inf") for r, s in zip(residuals, sigma_per_row)]
     points: list[CoveragePoint] = []
     for nominal in nominal_levels:
         scale = _scale_for_nominal(nominal)
-        inside = sum(1 for s in base_scaled if s <= scale)
+        inside = sum(1 for s in standardised if s <= scale)
         points.append(CoveragePoint(nominal=nominal, empirical=inside / n, n=n))
     return points
 
@@ -49,13 +60,13 @@ def coverage_curve(
 def _scale_for_nominal(nominal: float) -> float:
     if not 0 < nominal < 1:
         raise ValueError(f"nominal must be in (0, 1); got {nominal}")
-    # Inverse standard normal CDF approximation (Acklam, 2003) — good to ~1e-9
-    # over [1e-15, 1 - 1e-15]; we only ever evaluate inside (0.5, 0.99).
-    p = (1.0 + nominal) / 2.0
-    return _inverse_normal_cdf(p)
+    return _inverse_normal_cdf((1.0 + nominal) / 2.0)
 
 
 def _inverse_normal_cdf(p: float) -> float:
+    # Acklam (2003) rational approximation to the standard-normal inverse CDF.
+    # See https://web.archive.org/web/20150910044729/http://home.online.no/~pjacklam/notes/invnorm/
+    # Accurate to ~1e-9 over [1e-15, 1 - 1e-15]; we only ever call it inside (0.5, 0.99).
     a = (-3.969683028665376e+01, 2.209460984245205e+02, -2.759285104469687e+02,
          1.383577518672690e+02, -3.066479806614716e+01, 2.506628277459239e+00)
     b = (-5.447609879822406e+01, 1.615858368580409e+02, -1.556989798598866e+02,
@@ -80,32 +91,47 @@ def _inverse_normal_cdf(p: float) -> float:
             ((((d[0]*q + d[1])*q + d[2])*q + d[3])*q + 1.0)
 
 
-def load_predictions_jsonl(path: Path) -> tuple[list[float], list[float]]:
+def load_predictions_jsonl(
+    path: Path,
+    *,
+    predicted_field: str = "predicted_close",
+    actual_field: str = "actual_close",
+    sigma_field: str = "sigma",
+) -> tuple[list[float], list[float]]:
+    """Load (residuals, sigmas) from a JSONL of per-row predictions.
+
+    Defaults match what `phase4_attention_ablation.py` persists for the close
+    target. Override `predicted_field` / `actual_field` for volatility or any
+    other target. Rows missing the predicted or actual field are skipped.
+    When `sigma_field` is absent on a row, the row contributes a NaN sigma;
+    `coverage_curve` would then need to be invoked with caller-supplied
+    sigmas, or those rows filtered upstream.
+    """
     residuals: list[float] = []
-    band_half_widths: list[float] = []
+    sigmas: list[float] = []
     for line in path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if not line:
             continue
         row = json.loads(line)
-        predicted = row.get("predicted")
-        actual = row.get("actual")
-        half_width = row.get("band_half_width")
-        if predicted is None or actual is None or half_width is None:
+        predicted = row.get(predicted_field)
+        actual = row.get(actual_field)
+        if predicted is None or actual is None:
             continue
         residuals.append(float(actual) - float(predicted))
-        band_half_widths.append(float(half_width))
-    return residuals, band_half_widths
+        sigma = row.get(sigma_field)
+        sigmas.append(float(sigma) if sigma is not None else float("nan"))
+    return residuals, sigmas
 
 
 def write_reliability_diagram(
     residuals: Sequence[float],
-    band_half_widths: Sequence[float],
+    sigma_per_row: Sequence[float],
     output_path: Path,
     *,
     nominal_levels: Sequence[float] = (0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99),
 ) -> Path:
-    points = coverage_curve(residuals, band_half_widths, nominal_levels=nominal_levels)
+    points = coverage_curve(residuals, sigma_per_row, nominal_levels=nominal_levels)
     payload = {
         "n": len(residuals),
         "points": [{"nominal": p.nominal, "empirical": p.empirical, "n": p.n} for p in points],

--- a/backend/app/evaluation/calibration.py
+++ b/backend/app/evaluation/calibration.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class CoveragePoint:
+    nominal: float
+    empirical: float
+    n: int
+
+
+def empirical_coverage(residuals: Sequence[float], band_half_widths: Sequence[float]) -> float:
+    if len(residuals) != len(band_half_widths):
+        raise ValueError("residuals and band_half_widths must have equal length")
+    if not residuals:
+        return float("nan")
+    inside = sum(1 for r, h in zip(residuals, band_half_widths) if abs(r) <= h)
+    return inside / len(residuals)
+
+
+def coverage_curve(
+    residuals: Sequence[float],
+    band_half_widths: Sequence[float],
+    *,
+    nominal_levels: Sequence[float] = (0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99),
+) -> list[CoveragePoint]:
+    if len(residuals) != len(band_half_widths):
+        raise ValueError("residuals and band_half_widths must have equal length")
+    if not residuals:
+        return [CoveragePoint(nominal=lvl, empirical=float("nan"), n=0) for lvl in nominal_levels]
+
+    sorted_abs = sorted(abs(r) for r in residuals)
+    n = len(sorted_abs)
+    base_scaled = [abs(r) / h if h > 0 else float("inf") for r, h in zip(residuals, band_half_widths)]
+
+    points: list[CoveragePoint] = []
+    for nominal in nominal_levels:
+        scale = _scale_for_nominal(nominal)
+        inside = sum(1 for s in base_scaled if s <= scale)
+        points.append(CoveragePoint(nominal=nominal, empirical=inside / n, n=n))
+    return points
+
+
+def _scale_for_nominal(nominal: float) -> float:
+    if not 0 < nominal < 1:
+        raise ValueError(f"nominal must be in (0, 1); got {nominal}")
+    # Inverse standard normal CDF approximation (Acklam, 2003) — good to ~1e-9
+    # over [1e-15, 1 - 1e-15]; we only ever evaluate inside (0.5, 0.99).
+    p = (1.0 + nominal) / 2.0
+    return _inverse_normal_cdf(p)
+
+
+def _inverse_normal_cdf(p: float) -> float:
+    a = (-3.969683028665376e+01, 2.209460984245205e+02, -2.759285104469687e+02,
+         1.383577518672690e+02, -3.066479806614716e+01, 2.506628277459239e+00)
+    b = (-5.447609879822406e+01, 1.615858368580409e+02, -1.556989798598866e+02,
+         6.680131188771972e+01, -1.328068155288572e+01)
+    c = (-7.784894002430293e-03, -3.223964580411365e-01, -2.400758277161838e+00,
+         -2.549732539343734e+00, 4.374664141464968e+00, 2.938163982698783e+00)
+    d = (7.784695709041462e-03, 3.224671290700398e-01, 2.445134137142996e+00,
+         3.754408661907416e+00)
+    plow = 0.02425
+    phigh = 1.0 - plow
+    if p < plow:
+        q = math.sqrt(-2.0 * math.log(p))
+        return (((((c[0]*q + c[1])*q + c[2])*q + c[3])*q + c[4])*q + c[5]) / \
+               ((((d[0]*q + d[1])*q + d[2])*q + d[3])*q + 1.0)
+    if p <= phigh:
+        q = p - 0.5
+        r = q * q
+        return (((((a[0]*r + a[1])*r + a[2])*r + a[3])*r + a[4])*r + a[5]) * q / \
+               (((((b[0]*r + b[1])*r + b[2])*r + b[3])*r + b[4])*r + 1.0)
+    q = math.sqrt(-2.0 * math.log(1.0 - p))
+    return -(((((c[0]*q + c[1])*q + c[2])*q + c[3])*q + c[4])*q + c[5]) / \
+            ((((d[0]*q + d[1])*q + d[2])*q + d[3])*q + 1.0)
+
+
+def load_predictions_jsonl(path: Path) -> tuple[list[float], list[float]]:
+    residuals: list[float] = []
+    band_half_widths: list[float] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        row = json.loads(line)
+        predicted = row.get("predicted")
+        actual = row.get("actual")
+        half_width = row.get("band_half_width")
+        if predicted is None or actual is None or half_width is None:
+            continue
+        residuals.append(float(actual) - float(predicted))
+        band_half_widths.append(float(half_width))
+    return residuals, band_half_widths
+
+
+def write_reliability_diagram(
+    residuals: Sequence[float],
+    band_half_widths: Sequence[float],
+    output_path: Path,
+    *,
+    nominal_levels: Sequence[float] = (0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99),
+) -> Path:
+    points = coverage_curve(residuals, band_half_widths, nominal_levels=nominal_levels)
+    payload = {
+        "n": len(residuals),
+        "points": [{"nominal": p.nominal, "empirical": p.empirical, "n": p.n} for p in points],
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return output_path

--- a/backend/app/evaluation/regime_aggregator.py
+++ b/backend/app/evaluation/regime_aggregator.py
@@ -4,6 +4,10 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Iterable, Mapping
 
+# 2021 is intentionally outside the named windows. It is the post-COVID
+# recovery year — neither the zero-rate emergency stance nor the hike cycle
+# — and treating it as its own regime adds noise without thesis value.
+# Override by passing a custom `regime_windows` tuple to `aggregate_by_regime`.
 REGIME_WINDOWS: tuple[tuple[str, str, str], ...] = (
     ("pre_2020_calm", "2010-01-01", "2019-12-31"),
     ("covid_shock", "2020-01-01", "2020-12-31"),
@@ -24,18 +28,6 @@ class RegimeRow:
 
 def _to_date(value: str) -> date:
     return date.fromisoformat(value)
-
-
-def _row_in_regime(row_date: date, regime_start: date, regime_end: date) -> bool:
-    return regime_start <= row_date <= regime_end
-
-
-def _collect_per_fold(holdouts: Iterable[Mapping]) -> dict[str, list[Mapping]]:
-    buckets: dict[str, list[Mapping]] = {}
-    for hold in holdouts:
-        fold_id = str(hold.get("fold_id", ""))
-        buckets.setdefault(fold_id, []).append(hold)
-    return buckets
 
 
 def aggregate_by_regime(

--- a/backend/app/evaluation/regime_aggregator.py
+++ b/backend/app/evaluation/regime_aggregator.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Iterable, Mapping
+
+REGIME_WINDOWS: tuple[tuple[str, str, str], ...] = (
+    ("pre_2020_calm", "2010-01-01", "2019-12-31"),
+    ("covid_shock", "2020-01-01", "2020-12-31"),
+    ("hike_cycle", "2022-01-01", "2023-12-31"),
+)
+
+
+@dataclass(frozen=True)
+class RegimeRow:
+    regime: str
+    fold_id: str
+    variant: str
+    metric: str
+    mean: float
+    std: float | None
+    n: int
+
+
+def _to_date(value: str) -> date:
+    return date.fromisoformat(value)
+
+
+def _row_in_regime(row_date: date, regime_start: date, regime_end: date) -> bool:
+    return regime_start <= row_date <= regime_end
+
+
+def _collect_per_fold(holdouts: Iterable[Mapping]) -> dict[str, list[Mapping]]:
+    buckets: dict[str, list[Mapping]] = {}
+    for hold in holdouts:
+        fold_id = str(hold.get("fold_id", ""))
+        buckets.setdefault(fold_id, []).append(hold)
+    return buckets
+
+
+def aggregate_by_regime(
+    holdouts: Iterable[Mapping],
+    *,
+    regime_windows: Iterable[tuple[str, str, str]] = REGIME_WINDOWS,
+    metric_keys: Iterable[str] = ("combined_rmse", "close_rmse", "volatility_rmse", "directional_accuracy"),
+) -> list[RegimeRow]:
+    out: list[RegimeRow] = []
+    holdout_list = list(holdouts)
+    if not holdout_list:
+        return out
+
+    windows = [(name, _to_date(start), _to_date(end)) for name, start, end in regime_windows]
+
+    for hold in holdout_list:
+        fold_id = str(hold.get("fold_id", ""))
+        test_start = hold.get("test_start") or hold.get("test_window", {}).get("start")
+        test_end = hold.get("test_end") or hold.get("test_window", {}).get("end")
+        if not test_start or not test_end:
+            continue
+        ts, te = _to_date(str(test_start)), _to_date(str(test_end))
+        variants = hold.get("variants") or {}
+        if not isinstance(variants, dict):
+            continue
+        for regime_name, w_start, w_end in windows:
+            if w_end < ts or w_start > te:
+                continue
+            for variant_name, variant_payload in variants.items():
+                if not isinstance(variant_payload, dict):
+                    continue
+                for metric_key in metric_keys:
+                    metric = variant_payload.get(metric_key)
+                    if not isinstance(metric, dict):
+                        continue
+                    out.append(
+                        RegimeRow(
+                            regime=regime_name,
+                            fold_id=fold_id,
+                            variant=str(variant_name),
+                            metric=metric_key,
+                            mean=float(metric.get("mean", float("nan"))),
+                            std=_coerce_optional_float(metric.get("std")),
+                            n=int(metric.get("count", 0)),
+                        )
+                    )
+    return out
+
+
+def _coerce_optional_float(value) -> float | None:
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return None if result != result else result

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import math
+
+from app.evaluation.bootstrap import block_bootstrap_ci, bootstrap_paired_diff
+
+
+def test_block_bootstrap_ci_centers_on_mean() -> None:
+    values = [1.0, 1.0, 1.0, 1.0, 1.0]
+    ci = block_bootstrap_ci(values, block_size=2, n_resamples=200, seed=11)
+    assert ci.point == 1.0
+    assert ci.lo == 1.0
+    assert ci.hi == 1.0
+
+
+def test_block_bootstrap_ci_brackets_mean_on_noisy_input() -> None:
+    values = [1.0, 1.5, 0.5, 2.0, 0.0, 1.2, 0.8, 1.6, 0.4, 1.0]
+    ci = block_bootstrap_ci(values, block_size=3, n_resamples=500, coverage=0.9, seed=11)
+    assert ci.lo <= ci.point <= ci.hi
+    assert ci.lo < ci.hi
+    assert math.isclose(ci.point, sum(values) / len(values))
+
+
+def test_bootstrap_paired_diff_sees_signal() -> None:
+    a = [2.0, 2.1, 1.9, 2.2, 2.0, 2.1, 1.95]
+    b = [1.0, 1.1, 0.9, 1.2, 1.0, 1.1, 0.95]
+    ci = bootstrap_paired_diff(a, b, block_size=2, n_resamples=300, seed=11)
+    assert ci.lo > 0.0
+
+
+def test_empty_inputs_return_nan_ci() -> None:
+    ci = block_bootstrap_ci([], block_size=2)
+    assert math.isnan(ci.point) and math.isnan(ci.lo) and math.isnan(ci.hi)
+
+
+def test_block_bootstrap_median_statistic() -> None:
+    values = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    ci = block_bootstrap_ci(values, statistic="median", block_size=3, n_resamples=200, seed=11)
+    assert 4.0 <= ci.point <= 6.0

--- a/tests/unit/test_calibration.py
+++ b/tests/unit/test_calibration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import random
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from app.evaluation.calibration import (
     coverage_curve,
     empirical_coverage,
+    load_predictions_jsonl,
     write_reliability_diagram,
 )
 
@@ -33,29 +35,27 @@ def test_empirical_coverage_half() -> None:
 
 def test_coverage_curve_monotone_nondecreasing() -> None:
     residuals = [0.1 * i - 0.5 for i in range(11)]
-    bands = [0.5] * 11
-    points = coverage_curve(residuals, bands)
+    sigmas = [0.5] * 11
+    points = coverage_curve(residuals, sigmas)
     empirical = [p.empirical for p in points]
     for prev, curr in zip(empirical, empirical[1:]):
         assert curr >= prev
 
 
 def test_coverage_curve_close_to_gaussian_for_gaussian_residuals() -> None:
-    rng_seed = 11
-    import random
-    rng = random.Random(rng_seed)
+    rng = random.Random(11)
     residuals = [rng.gauss(0.0, 1.0) for _ in range(2000)]
-    bands = [1.0] * len(residuals)
-    points = {p.nominal: p.empirical for p in coverage_curve(residuals, bands)}
+    sigmas = [1.0] * len(residuals)
+    points = {p.nominal: p.empirical for p in coverage_curve(residuals, sigmas)}
     assert abs(points[0.8] - 0.8) < 0.05
     assert abs(points[0.95] - 0.95) < 0.03
 
 
 def test_write_reliability_diagram(tmp_path: Path) -> None:
     residuals = [0.1, -0.2, 0.5, -0.5, 0.0]
-    bands = [1.0] * 5
+    sigmas = [1.0] * 5
     out = tmp_path / "reliability.json"
-    write_reliability_diagram(residuals, bands, out)
+    write_reliability_diagram(residuals, sigmas, out)
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["n"] == 5
     assert any(p["nominal"] == 0.8 for p in payload["points"])
@@ -73,3 +73,39 @@ def test_inverse_normal_cdf_at_known_points() -> None:
 
     assert math.isclose(_scale_for_nominal(0.8), 1.28155, abs_tol=1e-3)
     assert math.isclose(_scale_for_nominal(0.95), 1.95996, abs_tol=1e-3)
+
+
+def test_load_predictions_jsonl_default_fields(tmp_path: Path) -> None:
+    path = tmp_path / "predictions.jsonl"
+    rows = [
+        {"variant": "baseline", "predicted_close": 1.2, "actual_close": 1.0, "sigma": 0.1},
+        {"variant": "baseline", "predicted_close": 0.8, "actual_close": 1.1, "sigma": 0.2},
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+    residuals, sigmas = load_predictions_jsonl(path)
+    assert residuals == pytest.approx([-0.2, 0.3])
+    assert sigmas == [0.1, 0.2]
+
+
+def test_load_predictions_jsonl_custom_target_fields(tmp_path: Path) -> None:
+    path = tmp_path / "predictions.jsonl"
+    rows = [
+        {"predicted_volatility": 0.05, "actual_volatility": 0.04, "sigma": 0.01},
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+    residuals, sigmas = load_predictions_jsonl(
+        path,
+        predicted_field="predicted_volatility",
+        actual_field="actual_volatility",
+    )
+    assert residuals == pytest.approx([-0.01])
+    assert sigmas == [0.01]
+
+
+def test_load_predictions_jsonl_missing_sigma_becomes_nan(tmp_path: Path) -> None:
+    path = tmp_path / "predictions.jsonl"
+    rows = [{"predicted_close": 1.0, "actual_close": 1.1}]
+    path.write_text(json.dumps(rows[0]) + "\n", encoding="utf-8")
+    residuals, sigmas = load_predictions_jsonl(path)
+    assert residuals == pytest.approx([0.1])
+    assert math.isnan(sigmas[0])

--- a/tests/unit/test_calibration.py
+++ b/tests/unit/test_calibration.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from app.evaluation.calibration import (
+    coverage_curve,
+    empirical_coverage,
+    write_reliability_diagram,
+)
+
+
+def test_empirical_coverage_inside_all() -> None:
+    residuals = [0.1, -0.2, 0.0, 0.15]
+    bands = [1.0, 1.0, 1.0, 1.0]
+    assert empirical_coverage(residuals, bands) == 1.0
+
+
+def test_empirical_coverage_outside_all() -> None:
+    residuals = [2.0, -3.0, 4.0]
+    bands = [1.0, 1.0, 1.0]
+    assert empirical_coverage(residuals, bands) == 0.0
+
+
+def test_empirical_coverage_half() -> None:
+    residuals = [0.5, -1.5, 0.5, 1.5]
+    bands = [1.0, 1.0, 1.0, 1.0]
+    assert empirical_coverage(residuals, bands) == 0.5
+
+
+def test_coverage_curve_monotone_nondecreasing() -> None:
+    residuals = [0.1 * i - 0.5 for i in range(11)]
+    bands = [0.5] * 11
+    points = coverage_curve(residuals, bands)
+    empirical = [p.empirical for p in points]
+    for prev, curr in zip(empirical, empirical[1:]):
+        assert curr >= prev
+
+
+def test_coverage_curve_close_to_gaussian_for_gaussian_residuals() -> None:
+    rng_seed = 11
+    import random
+    rng = random.Random(rng_seed)
+    residuals = [rng.gauss(0.0, 1.0) for _ in range(2000)]
+    bands = [1.0] * len(residuals)
+    points = {p.nominal: p.empirical for p in coverage_curve(residuals, bands)}
+    assert abs(points[0.8] - 0.8) < 0.05
+    assert abs(points[0.95] - 0.95) < 0.03
+
+
+def test_write_reliability_diagram(tmp_path: Path) -> None:
+    residuals = [0.1, -0.2, 0.5, -0.5, 0.0]
+    bands = [1.0] * 5
+    out = tmp_path / "reliability.json"
+    write_reliability_diagram(residuals, bands, out)
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["n"] == 5
+    assert any(p["nominal"] == 0.8 for p in payload["points"])
+
+
+def test_mismatched_lengths_raise() -> None:
+    with pytest.raises(ValueError):
+        empirical_coverage([0.1, 0.2], [1.0])
+    with pytest.raises(ValueError):
+        coverage_curve([0.1, 0.2], [1.0])
+
+
+def test_inverse_normal_cdf_at_known_points() -> None:
+    from app.evaluation.calibration import _scale_for_nominal
+
+    assert math.isclose(_scale_for_nominal(0.8), 1.28155, abs_tol=1e-3)
+    assert math.isclose(_scale_for_nominal(0.95), 1.95996, abs_tol=1e-3)

--- a/tests/unit/test_regime_aggregator.py
+++ b/tests/unit/test_regime_aggregator.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from app.evaluation.regime_aggregator import REGIME_WINDOWS, aggregate_by_regime
+
+
+def _holdout(fold_id: str, test_start: str, test_end: str, mean: float) -> dict:
+    return {
+        "fold_id": fold_id,
+        "test_start": test_start,
+        "test_end": test_end,
+        "variants": {
+            "baseline": {
+                "combined_rmse": {"mean": mean, "std": 0.001, "count": 5, "per_seed": {}}
+            }
+        },
+    }
+
+
+def test_holdout_in_pre_2020_regime_only() -> None:
+    rows = aggregate_by_regime([_holdout("wf_fold_1", "2018-01-01", "2018-06-30", 0.001)])
+    regimes = {r.regime for r in rows}
+    assert regimes == {"pre_2020_calm"}
+
+
+def test_holdout_spanning_covid_and_hike_emits_both_rows() -> None:
+    rows = aggregate_by_regime([_holdout("wf_fold_3", "2020-06-01", "2022-12-31", 0.005)])
+    regimes = {r.regime for r in rows}
+    assert "covid_shock" in regimes
+    assert "hike_cycle" in regimes
+
+
+def test_empty_holdouts_returns_empty() -> None:
+    assert aggregate_by_regime([]) == []
+
+
+def test_metric_keys_are_filtered() -> None:
+    rows = aggregate_by_regime(
+        [_holdout("wf_fold_1", "2015-01-01", "2015-06-30", 0.003)],
+        metric_keys=("combined_rmse",),
+    )
+    metrics = {r.metric for r in rows}
+    assert metrics == {"combined_rmse"}
+
+
+def test_regime_windows_cover_2010_to_2023() -> None:
+    starts = {w[1] for w in REGIME_WINDOWS}
+    assert "2010-01-01" in starts
+    assert "2020-01-01" in starts
+    assert "2022-01-01" in starts


### PR DESCRIPTION
## Summary

- `backend/app/evaluation/` adds `bootstrap.py` (moving-block CI + paired diff), `regime_aggregator.py` (pre-2020 / COVID / hike windows), and `calibration.py` (coverage curve + reliability diagram, no SciPy dep).
- `phase4_attention_ablation.py`: new `--lambda-init` flag, persists per-variant `predictions.jsonl` next to `ablation_table.json` so calibration has input.
- `llm_zero_shot_execution.py`: new `--llm-backend gemini` path routing through `services/gemini_client` for the Gemini 2.5 Pro rerun.
- Tests cover bootstrap centring + paired diffs, regime overlap rules, coverage monotonicity, and Gaussian sanity on the calibration math.

## Test plan

- `pytest tests/unit/test_bootstrap.py tests/unit/test_calibration.py tests/unit/test_regime_aggregator.py -q`
- `pytest tests/unit -q`

## Follow-up

- Run the `--lambda-init` sweep on `wf_fold_3` to populate λ-sensitivity rows.
- Re-run `wf_fold_1` + `wf_fold_2` so the regime aggregator has more than one fold of input.
- Rerun zero-shot with `--llm-backend gemini --llm-checkpoint gemini-2.5-pro`.
