### PR TITLE
Cut / over to /analyze redirect and add multi-axis + XAI + credibility panels

### DIFF
--- a/frontend/components/analyze/AnalyzeForm.tsx
+++ b/frontend/components/analyze/AnalyzeForm.tsx
@@ -1,0 +1,165 @@
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { HORIZON_OPTIONS, SYMBOL_OPTIONS } from "@/lib/analyze/constants";
+import type { AnalyzeRequest, ForecastMode, Horizon } from "@/lib/analyze/types";
+
+interface AnalyzeFormProps {
+  value: AnalyzeRequest;
+  onChange: (next: AnalyzeRequest) => void;
+  onSubmit: () => void;
+  loading: boolean;
+}
+
+const MODE_OPTIONS: Array<{ value: ForecastMode; label: string; description: string }> = [
+  { value: "fast", label: "Fast", description: "Checkpoint inference, low latency." },
+  { value: "quick_train", label: "Quick Train", description: "Short bounded adaptation before inference." },
+  { value: "real_train", label: "Real Train", description: "Async 252-day fine-tune, polled to completion." },
+];
+
+export function AnalyzeForm({ value, onChange, onSubmit, loading }: AnalyzeFormProps) {
+  const submitLabel = loading
+    ? value.forecast_mode === "real_train"
+      ? "Running Real Train…"
+      : "Running analysis…"
+    : "Analyze";
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSubmit();
+  };
+
+  const patch = (delta: Partial<AnalyzeRequest>) => onChange({ ...value, ...delta });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Document</CardTitle>
+        <CardDescription>
+          Paste an FOMC excerpt, choose the asset and horizon, run the forecast.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="text">FOMC text</Label>
+            <Textarea
+              id="text"
+              rows={8}
+              required
+              value={value.text}
+              onChange={(event) => patch({ text: event.target.value })}
+              placeholder="Paste an FOMC statement excerpt…"
+            />
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <div className="space-y-2">
+              <Label htmlFor="date">Document date</Label>
+              <Input
+                id="date"
+                type="date"
+                required
+                value={value.date}
+                onChange={(event) => patch({ date: event.target.value })}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="symbol">Asset</Label>
+              <Select value={value.symbol} onValueChange={(next) => patch({ symbol: next })}>
+                <SelectTrigger id="symbol">
+                  <SelectValue placeholder="Pick a benchmark" />
+                </SelectTrigger>
+                <SelectContent>
+                  {SYMBOL_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="mode">Forecast mode</Label>
+              <Select
+                value={value.forecast_mode}
+                onValueChange={(next) => patch({ forecast_mode: next as ForecastMode })}
+              >
+                <SelectTrigger id="mode">
+                  <SelectValue placeholder="Mode" />
+                </SelectTrigger>
+                <SelectContent>
+                  {MODE_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                {MODE_OPTIONS.find((m) => m.value === value.forecast_mode)?.description}
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="horizon">Horizon</Label>
+              <Select
+                value={value.horizon}
+                onValueChange={(next) => patch({ horizon: next as Horizon })}
+              >
+                <SelectTrigger id="horizon">
+                  <SelectValue placeholder="Horizon" />
+                </SelectTrigger>
+                <SelectContent>
+                  {HORIZON_OPTIONS.map((horizon) => (
+                    <SelectItem key={horizon} value={horizon}>
+                      {horizon}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between gap-4 rounded-md border border-dashed border-border bg-muted/30 px-4 py-3">
+            <label htmlFor="realized" className="flex items-center gap-2 text-sm">
+              <input
+                id="realized"
+                type="checkbox"
+                checked={value.include_realized}
+                onChange={(event) => patch({ include_realized: event.target.checked })}
+                className="h-4 w-4 rounded border-border bg-background"
+              />
+              Overlay realized observations (past dates)
+            </label>
+            <p className="hidden text-xs text-muted-foreground sm:block">
+              Used to compute MAPE / RMSE vs the forecast.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button type="submit" disabled={loading}>
+              {submitLabel}
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              Real Train returns a job id and polls every {2}s.
+            </p>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/analyze/CredibilityPanel.tsx
+++ b/frontend/components/analyze/CredibilityPanel.tsx
@@ -7,6 +7,7 @@ import type { CredibilityResponse } from "@/lib/analyze/types";
 
 interface CredibilityPanelProps {
   credibility: CredibilityResponse;
+  previewMode?: boolean;
 }
 
 function driftTone(value: number): "hawkish" | "dovish" | "neutral" {
@@ -53,14 +54,20 @@ function formatGap(value?: number): string {
   return `${value >= 0 ? "+" : ""}${value.toFixed(2)}`;
 }
 
-export function CredibilityPanel({ credibility }: CredibilityPanelProps) {
-  const tone = driftTone(credibility.driftScore);
+export function CredibilityPanel({ credibility, previewMode }: CredibilityPanelProps) {
+  const driftScore = Number.isFinite(credibility.driftScore) ? credibility.driftScore : 0;
+  const tone = driftTone(driftScore);
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Activity className="h-4 w-4 text-primary" />
           Central-bank credibility
+          {previewMode ? (
+            <Badge variant="outline" className="ml-2 text-[10px] uppercase tracking-wide">
+              Preview · fixture
+            </Badge>
+          ) : null}
         </CardTitle>
         <CardDescription>
           Four-axis credibility check on the issuing institution at this statement date.
@@ -72,9 +79,9 @@ export function CredibilityPanel({ credibility }: CredibilityPanelProps) {
             <span className="flex items-center gap-1.5 text-muted-foreground">
               <GitBranch className="h-3.5 w-3.5" /> Drift vs. prior 4 statements
             </span>
-            <Badge variant={tone}>{driftLabel(credibility.driftScore)} · {credibility.driftScore.toFixed(2)}</Badge>
+            <Badge variant={tone}>{driftLabel(driftScore)} · {driftScore.toFixed(2)}</Badge>
           </div>
-          <Progress value={credibility.driftScore} />
+          <Progress value={driftScore} />
           {credibility.driftTrend?.length ? (
             <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span>Trend</span>

--- a/frontend/components/analyze/CredibilityPanel.tsx
+++ b/frontend/components/analyze/CredibilityPanel.tsx
@@ -1,0 +1,129 @@
+import { Activity, GitBranch, Scale, Timer } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import type { CredibilityResponse } from "@/lib/analyze/types";
+
+interface CredibilityPanelProps {
+  credibility: CredibilityResponse;
+}
+
+function driftTone(value: number): "hawkish" | "dovish" | "neutral" {
+  if (value > 0.6) return "dovish";
+  if (value < 0.3) return "hawkish";
+  return "neutral";
+}
+
+function driftLabel(value: number): string {
+  if (value > 0.6) return "High drift";
+  if (value < 0.3) return "Steady";
+  return "Drifting";
+}
+
+function MiniTrend({ trend }: { trend: number[] }) {
+  if (!trend.length) return null;
+  const max = Math.max(...trend, 1e-6);
+  return (
+    <div className="flex h-6 items-end gap-0.5">
+      {trend.map((value, idx) => {
+        const pct = (value / max) * 100;
+        return (
+          <div
+            key={idx}
+            className="w-2 rounded-sm bg-primary/60"
+            style={{ height: `${Math.max(pct, 8)}%` }}
+            aria-hidden="true"
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function gapTone(value?: number): "hawkish" | "dovish" | "neutral" {
+  if (value == null) return "neutral";
+  if (value > 0.05) return "hawkish";
+  if (value < -0.05) return "dovish";
+  return "neutral";
+}
+
+function formatGap(value?: number): string {
+  if (value == null) return "—";
+  return `${value >= 0 ? "+" : ""}${value.toFixed(2)}`;
+}
+
+export function CredibilityPanel({ credibility }: CredibilityPanelProps) {
+  const tone = driftTone(credibility.driftScore);
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Activity className="h-4 w-4 text-primary" />
+          Central-bank credibility
+        </CardTitle>
+        <CardDescription>
+          Four-axis credibility check on the issuing institution at this statement date.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="flex items-center gap-1.5 text-muted-foreground">
+              <GitBranch className="h-3.5 w-3.5" /> Drift vs. prior 4 statements
+            </span>
+            <Badge variant={tone}>{driftLabel(credibility.driftScore)} · {credibility.driftScore.toFixed(2)}</Badge>
+          </div>
+          <Progress value={credibility.driftScore} />
+          {credibility.driftTrend?.length ? (
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>Trend</span>
+              <MiniTrend trend={credibility.driftTrend} />
+            </div>
+          ) : null}
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
+            <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-muted-foreground">
+              <span>Realized vs. stated</span>
+              <Scale className="h-3.5 w-3.5" />
+            </div>
+            <div className="mt-1 flex items-center justify-between">
+              <strong>{formatGap(credibility.realizedVsStatedGap)}</strong>
+              <Badge variant={gapTone(credibility.realizedVsStatedGap)} className="text-[10px]">
+                {credibility.realizedVsStatedGap == null ? "—" : "90d corr"}
+              </Badge>
+            </div>
+          </div>
+          <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
+            <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-muted-foreground">
+              <span>Market-implied gap</span>
+              <Scale className="h-3.5 w-3.5" />
+            </div>
+            <div className="mt-1 flex items-center justify-between">
+              <strong>{formatGap(credibility.marketImpliedGap)}</strong>
+              <Badge variant={gapTone(credibility.marketImpliedGap)} className="text-[10px]">
+                {credibility.marketImpliedGap == null ? "—" : "vs OIS"}
+              </Badge>
+            </div>
+          </div>
+          <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
+            <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-muted-foreground">
+              <span>Since reversal</span>
+              <Timer className="h-3.5 w-3.5" />
+            </div>
+            <div className="mt-1 flex items-center justify-between">
+              <strong>
+                {credibility.monthsSinceReversal == null
+                  ? "—"
+                  : `${credibility.monthsSinceReversal} mo`}
+              </strong>
+              <Badge variant="outline" className="text-[10px]">stance</Badge>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/analyze/ErrorBadges.tsx
+++ b/frontend/components/analyze/ErrorBadges.tsx
@@ -1,0 +1,93 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { errorToneLabel, formatPrice, getErrorTone } from "@/lib/analyze/format";
+import type { ErrorBundle } from "@/lib/analyze/derive";
+import type { AnalyzeResult } from "@/lib/analyze/types";
+
+interface ErrorBadgesProps {
+  result: AnalyzeResult;
+  metrics: ErrorBundle;
+}
+
+function toneClass(tone: "low" | "medium" | "high" | "neutral"): string {
+  if (tone === "low") return "border-hawkish/40 bg-hawkish/10 text-hawkish";
+  if (tone === "medium") return "border-amber-500/40 bg-amber-500/10 text-amber-500";
+  if (tone === "high") return "border-dovish/40 bg-dovish/10 text-dovish";
+  return "border-border bg-muted/50 text-muted-foreground";
+}
+
+export function ErrorBadges({ result, metrics }: ErrorBadgesProps) {
+  if (!metrics.hasRealized) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Forecast error</CardTitle>
+          <CardDescription>
+            Enable the realized overlay on a past date to compute MAPE and RMSE.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const closeBaseline = Math.max(
+    Math.abs(Number(result.market?.close ?? result.prediction?.close ?? 0)),
+    1e-6
+  );
+  const volBaseline = Math.max(
+    Math.abs(Number(result.market?.volatility_5d ?? result.prediction?.volatility ?? 0)),
+    1e-6
+  );
+
+  const items = [
+    {
+      label: "Close MAPE",
+      value: metrics.close.mape == null ? "N/A" : `${metrics.close.mape.toFixed(2)}%`,
+      tone: getErrorTone("mape", metrics.close.mape),
+      meta: "Avg absolute % miss vs realized.",
+    },
+    {
+      label: "Close RMSE",
+      value: metrics.close.rmse == null ? "N/A" : metrics.close.rmse.toFixed(4),
+      tone: getErrorTone("rmse", metrics.close.rmse, closeBaseline),
+      meta: `~${((Number(metrics.close.rmse ?? 0) / closeBaseline) * 100).toFixed(2)}% of ${formatPrice(closeBaseline)}.`,
+    },
+    {
+      label: "Vol MAPE",
+      value: metrics.vol.mape == null ? "N/A" : `${metrics.vol.mape.toFixed(2)}%`,
+      tone: getErrorTone("mape", metrics.vol.mape),
+      meta: "Avg absolute % miss vs realized vol.",
+    },
+    {
+      label: "Vol RMSE",
+      value: metrics.vol.rmse == null ? "N/A" : metrics.vol.rmse.toFixed(6),
+      tone: getErrorTone("rmse", metrics.vol.rmse, volBaseline),
+      meta: "Relative to 5d realized-vol baseline.",
+    },
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Forecast error</CardTitle>
+        <CardDescription>Realized overlay diagnostics for this run.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {items.map((item) => (
+            <div
+              key={item.label}
+              className={`rounded-md border px-3 py-3 ${toneClass(item.tone)}`}
+            >
+              <div className="flex items-center justify-between text-[11px] font-medium uppercase tracking-wide">
+                <span>{item.label}</span>
+                <span>{errorToneLabel(item.tone)}</span>
+              </div>
+              <div className="mt-1 text-xl font-semibold">{item.value}</div>
+              <p className="mt-1 text-xs opacity-80">{item.meta}</p>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/analyze/ForecastChart.tsx
+++ b/frontend/components/analyze/ForecastChart.tsx
@@ -1,0 +1,219 @@
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ChartRow } from "@/lib/analyze/derive";
+import { formatDateTick, formatPrice, formatVol } from "@/lib/analyze/format";
+
+interface ForecastChartProps {
+  title: string;
+  description: string;
+  data: ChartRow[];
+  kind: "close" | "volatility";
+  splitTimestamp?: string;
+  includeRealized: boolean;
+  hasConfidence: boolean;
+  confidenceLabel: string;
+  yDomain?: [number, number];
+}
+
+const PALETTE = {
+  close: {
+    history: "hsl(var(--chart-1))",
+    forecast: "hsl(var(--chart-2))",
+    realized: "hsl(var(--chart-4))",
+    band: "hsl(var(--chart-2) / 0.18)",
+    bandEdge: "hsl(var(--chart-2) / 0.45)",
+  },
+  volatility: {
+    history: "hsl(var(--chart-3))",
+    forecast: "hsl(var(--chart-5))",
+    realized: "hsl(var(--chart-4))",
+    band: "hsl(var(--chart-5) / 0.18)",
+    bandEdge: "hsl(var(--chart-5) / 0.45)",
+  },
+} as const;
+
+function ChartTooltip({
+  active,
+  payload,
+  label,
+  kind,
+  confidenceLabel,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload: ChartRow }>;
+  label?: string;
+  kind: "close" | "volatility";
+  confidenceLabel: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const row = payload[0]?.payload as ChartRow | undefined;
+  if (!row) return null;
+  const fmt = kind === "close" ? formatPrice : formatVol;
+  const histLabel = kind === "close" ? "History close" : "History volatility";
+  const realizedLabel = kind === "close" ? "Realized close" : "Realized volatility";
+
+  return (
+    <div className="rounded-md border border-border bg-popover px-3 py-2 text-xs shadow-md">
+      <p className="font-medium text-foreground">{formatDateTick(label)}</p>
+      <div className="mt-1 space-y-0.5 text-muted-foreground">
+        {row.history != null ? <p>{histLabel}: {fmt(row.history)}</p> : null}
+        {row.forecast != null ? <p>Forecast: {fmt(row.forecast)}</p> : null}
+        {row.forecastLower != null && row.forecastUpper != null ? (
+          <p>
+            {confidenceLabel}: {fmt(row.forecastLower)} – {fmt(row.forecastUpper)}
+          </p>
+        ) : null}
+        {row.realized != null ? <p>{realizedLabel}: {fmt(row.realized)}</p> : null}
+      </div>
+    </div>
+  );
+}
+
+export function ForecastChart({
+  title,
+  description,
+  data,
+  kind,
+  splitTimestamp,
+  includeRealized,
+  hasConfidence,
+  confidenceLabel,
+  yDomain,
+}: ForecastChartProps) {
+  const palette = PALETTE[kind];
+  const tickFmt = kind === "close" ? formatPrice : formatVol;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="h-72 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={data} margin={{ left: 4, right: 16, top: 4, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+              <XAxis
+                dataKey="timestamp"
+                tickFormatter={formatDateTick}
+                tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 11 }}
+              />
+              <YAxis
+                domain={yDomain}
+                tickFormatter={tickFmt}
+                tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 11 }}
+                width={64}
+              />
+              <Tooltip
+                content={(props) => {
+                  const { active, payload, label } = props as unknown as {
+                    active?: boolean;
+                    payload?: Array<{ payload: ChartRow }>;
+                    label?: string;
+                  };
+                  return (
+                    <ChartTooltip
+                      active={active}
+                      payload={payload}
+                      label={label}
+                      kind={kind}
+                      confidenceLabel={confidenceLabel}
+                    />
+                  );
+                }}
+              />
+              <Legend wrapperStyle={{ fontSize: 12, color: "hsl(var(--muted-foreground))" }} />
+              {splitTimestamp ? (
+                <ReferenceLine x={splitTimestamp} stroke="hsl(var(--border))" strokeDasharray="4 4" />
+              ) : null}
+              <Area
+                type="monotone"
+                dataKey="history"
+                name="History"
+                stroke={palette.history}
+                fill={palette.history}
+                fillOpacity={0.18}
+                strokeWidth={2}
+                isAnimationActive={false}
+              />
+              {hasConfidence ? (
+                <>
+                  <Area
+                    type="monotone"
+                    dataKey="forecastLower"
+                    stackId="band"
+                    stroke="none"
+                    fill="transparent"
+                    legendType="none"
+                    isAnimationActive={false}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="forecastBand"
+                    name={confidenceLabel}
+                    stackId="band"
+                    stroke="none"
+                    fill={palette.band}
+                    isAnimationActive={false}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="forecastUpper"
+                    stroke={palette.bandEdge}
+                    strokeDasharray="4 4"
+                    strokeWidth={1}
+                    dot={false}
+                    legendType="none"
+                    isAnimationActive={false}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="forecastLower"
+                    stroke={palette.bandEdge}
+                    strokeDasharray="4 4"
+                    strokeWidth={1}
+                    dot={false}
+                    legendType="none"
+                    isAnimationActive={false}
+                  />
+                </>
+              ) : null}
+              <Line
+                type="monotone"
+                dataKey="forecast"
+                name="Forecast"
+                stroke={palette.forecast}
+                strokeWidth={2.5}
+                dot={false}
+                isAnimationActive={false}
+              />
+              {includeRealized ? (
+                <Line
+                  type="monotone"
+                  dataKey="realized"
+                  name="Realized"
+                  stroke={palette.realized}
+                  strokeWidth={2}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              ) : null}
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/analyze/MarketContext.tsx
+++ b/frontend/components/analyze/MarketContext.tsx
@@ -1,0 +1,56 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatPrice } from "@/lib/analyze/format";
+import type { AnalyzeResult } from "@/lib/analyze/types";
+
+interface MarketContextProps {
+  result: AnalyzeResult;
+}
+
+export function MarketContext({ result }: MarketContextProps) {
+  const market = result.market || {};
+  const model = result.model || {};
+  const items: Array<{ label: string; value: string }> = [
+    { label: "Symbol", value: market.symbol || "—" },
+    { label: "Requested date", value: market.requested_date || "—" },
+    { label: "Trading date used", value: market.date_used || "—" },
+    { label: "Close", value: formatPrice(market.close) },
+    {
+      label: "5d volatility proxy",
+      value: market.volatility_5d == null ? "—" : Number(market.volatility_5d).toFixed(6),
+    },
+    {
+      label: "Hidden size",
+      value: model.hidden_size == null ? "—" : String(model.hidden_size),
+    },
+    {
+      label: "Layers",
+      value: model.num_layers == null ? "—" : String(model.num_layers),
+    },
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Market & model context</CardTitle>
+        <CardDescription>Inputs and runtime diagnostics for this run.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {items.map((item) => (
+            <div key={item.label} className="rounded-md border border-border bg-muted/30 px-3 py-2">
+              <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">{item.label}</dt>
+              <dd className="mt-0.5 font-medium text-foreground">{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <Badge variant={model.checkpoint_loaded ? "hawkish" : "outline"}>
+            {model.checkpoint_loaded ? "Checkpoint loaded" : "No checkpoint"}
+          </Badge>
+          {model.runtime_mode ? <Badge variant="outline">{model.runtime_mode}</Badge> : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/analyze/MultiAxisCards.tsx
+++ b/frontend/components/analyze/MultiAxisCards.tsx
@@ -1,0 +1,163 @@
+import { ArrowDownRight, ArrowUpRight, Compass, Gauge, Target } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { stanceLabel } from "@/lib/analyze/format";
+import type {
+  MultiAxisResponse,
+  MultiAxisStance,
+  StanceAxis,
+} from "@/lib/analyze/types";
+
+interface MultiAxisCardsProps {
+  multiAxis: MultiAxisResponse;
+}
+
+function stanceVariant(stance: StanceAxis): "hawkish" | "dovish" | "neutral" {
+  return stance;
+}
+
+function StanceCard({ stance }: { stance: MultiAxisStance }) {
+  const distribution = stance.distribution || {};
+  const order: StanceAxis[] = ["hawkish", "neutral", "dovish"];
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription className="flex items-center gap-1.5">
+          <Compass className="h-3.5 w-3.5" />
+          Stance
+        </CardDescription>
+        <CardTitle className="flex items-center justify-between text-2xl">
+          <span>{stanceLabel(stance.label)}</span>
+          <Badge variant={stanceVariant(stance.label)}>{stance.confidence.toFixed(2)}</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {order.map((key) => {
+          const value = distribution[key] ?? 0;
+          return (
+            <div key={key} className="space-y-1">
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span className="capitalize">{key}</span>
+                <span className="font-medium text-foreground">{value.toFixed(2)}</span>
+              </div>
+              <Progress
+                value={value}
+                indicatorClassName={
+                  key === "hawkish"
+                    ? "bg-hawkish"
+                    : key === "dovish"
+                    ? "bg-dovish"
+                    : "bg-neutral"
+                }
+              />
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+function FactorCard({ factor }: { factor: NonNullable<MultiAxisResponse["factor"]> }) {
+  const value = factor.value;
+  const tone: "hawkish" | "dovish" | "neutral" =
+    value > 0.05 ? "hawkish" : value < -0.05 ? "dovish" : "neutral";
+  const Arrow = value > 0 ? ArrowUpRight : value < 0 ? ArrowDownRight : Gauge;
+  const arrowClass =
+    tone === "hawkish" ? "text-hawkish" : tone === "dovish" ? "text-dovish" : "text-neutral";
+  const range = factor.range;
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription className="flex items-center gap-1.5">
+          <Gauge className="h-3.5 w-3.5" />
+          Factor
+        </CardDescription>
+        <CardTitle className="flex items-center justify-between text-2xl">
+          <span className="flex items-center gap-1">
+            <Arrow className={`h-5 w-5 ${arrowClass}`} />
+            {value >= 0 ? "+" : ""}
+            {value.toFixed(2)}
+          </span>
+          <Badge variant={tone}>±{(factor.confidence ?? 0).toFixed(2)}</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1.5 text-xs text-muted-foreground">
+        <p>Signed magnitude on the hawkish (+) ↔ dovish (−) axis.</p>
+        {range ? (
+          <p>
+            80% range: <span className="font-mono">{range[0].toFixed(2)} … {range[1].toFixed(2)}</span>
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function CertaintyCard({ certainty }: { certainty: NonNullable<MultiAxisResponse["certainty"]> }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription className="flex items-center gap-1.5">
+          <Target className="h-3.5 w-3.5" />
+          Certainty
+        </CardDescription>
+        <CardTitle className="flex items-center justify-between text-2xl">
+          <span className="capitalize">{certainty.label}</span>
+          <Badge variant="outline">{certainty.confidence.toFixed(2)}</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Progress value={certainty.confidence} />
+        <p className="text-xs text-muted-foreground">
+          How firmly the language commits to the stance.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TopicCard({ topic }: { topic: NonNullable<MultiAxisResponse["topic"]> }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription>Topic</CardDescription>
+        <CardTitle className="text-xl capitalize">
+          {topic.primary.replace(/_/g, " ")}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>Primary confidence</span>
+          <span className="font-medium text-foreground">{topic.confidence.toFixed(2)}</span>
+        </div>
+        <Progress value={topic.confidence} />
+        {topic.secondary?.length ? (
+          <div className="flex flex-wrap gap-1.5 pt-1">
+            {topic.secondary.map((t) => (
+              <Badge key={t} variant="outline" className="capitalize">
+                {t.replace(/_/g, " ")}
+              </Badge>
+            ))}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function MultiAxisCards({ multiAxis }: MultiAxisCardsProps) {
+  if (!multiAxis.stance && !multiAxis.factor && !multiAxis.certainty && !multiAxis.topic) {
+    return null;
+  }
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {multiAxis.stance ? <StanceCard stance={multiAxis.stance} /> : null}
+      {multiAxis.factor ? <FactorCard factor={multiAxis.factor} /> : null}
+      {multiAxis.certainty ? <CertaintyCard certainty={multiAxis.certainty} /> : null}
+      {multiAxis.topic ? <TopicCard topic={multiAxis.topic} /> : null}
+    </div>
+  );
+}

--- a/frontend/components/analyze/MultiAxisCards.tsx
+++ b/frontend/components/analyze/MultiAxisCards.tsx
@@ -12,6 +12,7 @@ import type {
 
 interface MultiAxisCardsProps {
   multiAxis: MultiAxisResponse;
+  previewMode?: boolean;
 }
 
 function stanceVariant(stance: StanceAxis): "hawkish" | "dovish" | "neutral" {
@@ -148,16 +149,23 @@ function TopicCard({ topic }: { topic: NonNullable<MultiAxisResponse["topic"]> }
   );
 }
 
-export function MultiAxisCards({ multiAxis }: MultiAxisCardsProps) {
+export function MultiAxisCards({ multiAxis, previewMode }: MultiAxisCardsProps) {
   if (!multiAxis.stance && !multiAxis.factor && !multiAxis.certainty && !multiAxis.topic) {
     return null;
   }
   return (
-    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-      {multiAxis.stance ? <StanceCard stance={multiAxis.stance} /> : null}
-      {multiAxis.factor ? <FactorCard factor={multiAxis.factor} /> : null}
-      {multiAxis.certainty ? <CertaintyCard certainty={multiAxis.certainty} /> : null}
-      {multiAxis.topic ? <TopicCard topic={multiAxis.topic} /> : null}
+    <div className="space-y-2">
+      {previewMode ? (
+        <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+          Multi-axis preview · fixture data
+        </Badge>
+      ) : null}
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {multiAxis.stance ? <StanceCard stance={multiAxis.stance} /> : null}
+        {multiAxis.factor ? <FactorCard factor={multiAxis.factor} /> : null}
+        {multiAxis.certainty ? <CertaintyCard certainty={multiAxis.certainty} /> : null}
+        {multiAxis.topic ? <TopicCard topic={multiAxis.topic} /> : null}
+      </div>
     </div>
   );
 }

--- a/frontend/components/analyze/PredictionCards.tsx
+++ b/frontend/components/analyze/PredictionCards.tsx
@@ -1,0 +1,79 @@
+import { ArrowDownRight, ArrowUpRight, Minus } from "lucide-react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatPercentDelta, formatPrice, formatPriceDelta, formatVol } from "@/lib/analyze/format";
+import type { AnalyzeResult } from "@/lib/analyze/types";
+
+interface PredictionCardsProps {
+  result: AnalyzeResult;
+}
+
+export function PredictionCards({ result }: PredictionCardsProps) {
+  const predicted = Number(result.prediction?.close ?? NaN);
+  const current = Number(result.market?.close ?? NaN);
+  const delta = Number.isFinite(predicted) && Number.isFinite(current) ? predicted - current : null;
+  const pct = delta != null && current ? (delta / current) * 100 : null;
+  const tone: "up" | "down" | "flat" =
+    delta == null ? "flat" : delta > 0 ? "up" : delta < 0 ? "down" : "flat";
+  const Arrow = tone === "up" ? ArrowUpRight : tone === "down" ? ArrowDownRight : Minus;
+  const toneClass =
+    tone === "up" ? "text-hawkish" : tone === "down" ? "text-dovish" : "text-muted-foreground";
+
+  const historyClose = result.series?.history_close;
+  const forecastClose = result.series?.forecast_close;
+  let closeChangePct = 0;
+  if (historyClose?.length && forecastClose?.length) {
+    const lastHist = Number(historyClose[historyClose.length - 1]);
+    const lastFc = Number(forecastClose[forecastClose.length - 1]);
+    if (lastHist) closeChangePct = ((lastFc - lastHist) / lastHist) * 100;
+  }
+
+  const horizon = result.prediction?.horizon || "3d";
+  const volatility = Number(result.prediction?.volatility ?? 0);
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardDescription>Predicted close</CardDescription>
+          <CardTitle className="text-2xl">{formatPrice(predicted)}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className={`flex items-center gap-2 text-sm font-medium ${toneClass}`}>
+            <Arrow className="h-4 w-4" />
+            <span>{delta == null ? "N/A" : formatPriceDelta(delta)}</span>
+            <span>·</span>
+            <span>{pct == null ? "—" : formatPercentDelta(pct)}</span>
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Current spot {formatPrice(Number.isFinite(current) ? current : null)} · horizon {horizon}
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardDescription>Forecast change</CardDescription>
+          <CardTitle className="text-2xl">{formatPercentDelta(closeChangePct)}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-xs text-muted-foreground">
+            Last forecast close vs last history close.
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardDescription>Predicted volatility</CardDescription>
+          <CardTitle className="text-2xl">{formatVol(volatility)}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-xs text-muted-foreground">
+            5d realized-vol proxy, horizon {horizon}.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/components/analyze/PreviewPanels.tsx
+++ b/frontend/components/analyze/PreviewPanels.tsx
@@ -1,0 +1,35 @@
+import { CredibilityPanel } from "@/components/analyze/CredibilityPanel";
+import { MultiAxisCards } from "@/components/analyze/MultiAxisCards";
+import { XaiPanel } from "@/components/analyze/XaiPanel";
+import {
+  SAMPLE_CREDIBILITY,
+  SAMPLE_MULTI_AXIS,
+  SAMPLE_XAI,
+} from "@/lib/analyze/fixtures";
+import type {
+  CredibilityResponse,
+  MultiAxisResponse,
+  XaiResponse,
+} from "@/lib/analyze/types";
+
+interface PreviewPanelsProps {
+  multiAxis?: MultiAxisResponse;
+  xai?: XaiResponse;
+  credibility?: CredibilityResponse;
+  slot: "cards" | "xai" | "credibility";
+}
+
+export default function PreviewPanels({ multiAxis, xai, credibility, slot }: PreviewPanelsProps) {
+  if (slot === "cards") {
+    return <MultiAxisCards multiAxis={multiAxis ?? SAMPLE_MULTI_AXIS} previewMode={!multiAxis} />;
+  }
+  if (slot === "xai") {
+    return <XaiPanel xai={xai ?? SAMPLE_XAI} previewMode={!xai} />;
+  }
+  return (
+    <CredibilityPanel
+      credibility={credibility ?? SAMPLE_CREDIBILITY}
+      previewMode={!credibility}
+    />
+  );
+}

--- a/frontend/components/analyze/RealTrainStatus.tsx
+++ b/frontend/components/analyze/RealTrainStatus.tsx
@@ -1,0 +1,44 @@
+import { Loader2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { TrainJobState } from "@/lib/analyze/types";
+
+interface RealTrainStatusProps {
+  job: TrainJobState | null;
+}
+
+const STATUS_VARIANT: Record<TrainJobState["status"], "outline" | "hawkish" | "dovish" | "neutral"> = {
+  queued: "outline",
+  running: "neutral",
+  succeeded: "hawkish",
+  failed: "dovish",
+};
+
+export function RealTrainStatus({ job }: RealTrainStatusProps) {
+  if (!job) return null;
+  const variant = STATUS_VARIANT[job.status] ?? "outline";
+  const isActive = job.status === "queued" || job.status === "running";
+  return (
+    <Card>
+      <CardHeader className="flex-row items-start justify-between space-y-0">
+        <div>
+          <CardTitle>Real train job</CardTitle>
+          <CardDescription className="font-mono text-xs">{job.job_id}</CardDescription>
+        </div>
+        <Badge variant={variant} className="uppercase tracking-wide">
+          {job.status}
+        </Badge>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2 text-sm">
+          {isActive ? <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" /> : null}
+          <p>{job.message || "Waiting for job updates…"}</p>
+        </div>
+        {job.error ? (
+          <p className="mt-2 text-sm text-destructive">Error: {job.error}</p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/analyze/SentimentCard.tsx
+++ b/frontend/components/analyze/SentimentCard.tsx
@@ -1,0 +1,30 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { stanceLabel, toStance } from "@/lib/analyze/format";
+import type { SentimentResponse } from "@/lib/analyze/types";
+
+interface SentimentCardProps {
+  sentiment?: SentimentResponse;
+}
+
+export function SentimentCard({ sentiment }: SentimentCardProps) {
+  const stance = toStance(sentiment?.label);
+  const score = Number(sentiment?.score ?? 0);
+  const badgeVariant =
+    stance === "hawkish" ? "hawkish" : stance === "dovish" ? "dovish" : stance === "neutral" ? "neutral" : "outline";
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription>Stance</CardDescription>
+        <CardTitle className="text-2xl">{stanceLabel(stance)}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex items-center justify-between">
+        <Badge variant={badgeVariant}>
+          {stanceLabel(stance)} · {score.toFixed(3)}
+        </Badge>
+        <span className="text-xs text-muted-foreground">model confidence</span>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/analyze/XaiPanel.tsx
+++ b/frontend/components/analyze/XaiPanel.tsx
@@ -1,16 +1,17 @@
 import { Highlighter } from "lucide-react";
 
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { XaiResponse, XaiSentence, XaiTokenAttribution } from "@/lib/analyze/types";
 
 interface XaiPanelProps {
   xai: XaiResponse;
+  previewMode?: boolean;
 }
 
 function sentenceBackground(score: number): string {
@@ -78,7 +79,7 @@ function SentenceChip({ sentence }: { sentence: XaiSentence }) {
   );
 }
 
-export function XaiPanel({ xai }: XaiPanelProps) {
+export function XaiPanel({ xai, previewMode }: XaiPanelProps) {
   if (!xai.sentences.length) return null;
   return (
     <Card>
@@ -86,6 +87,11 @@ export function XaiPanel({ xai }: XaiPanelProps) {
         <CardTitle className="flex items-center gap-2">
           <Highlighter className="h-4 w-4 text-primary" />
           Sentence attribution
+          {previewMode ? (
+            <Badge variant="outline" className="ml-2 text-[10px] uppercase tracking-wide">
+              Preview · fixture
+            </Badge>
+          ) : null}
         </CardTitle>
         <CardDescription>
           Hover any sentence to see the five tokens with the largest attribution.
@@ -93,13 +99,11 @@ export function XaiPanel({ xai }: XaiPanelProps) {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <TooltipProvider>
-          <p className="space-x-1.5 text-sm leading-7">
-            {xai.sentences.map((sentence, idx) => (
-              <SentenceChip key={`${idx}-${sentence.text.slice(0, 16)}`} sentence={sentence} />
-            ))}
-          </p>
-        </TooltipProvider>
+        <p className="space-x-1.5 text-sm leading-7">
+          {xai.sentences.map((sentence, idx) => (
+            <SentenceChip key={`${idx}-${sentence.text.slice(0, 16)}`} sentence={sentence} />
+          ))}
+        </p>
       </CardContent>
     </Card>
   );

--- a/frontend/components/analyze/XaiPanel.tsx
+++ b/frontend/components/analyze/XaiPanel.tsx
@@ -1,0 +1,106 @@
+import { Highlighter } from "lucide-react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { XaiResponse, XaiSentence, XaiTokenAttribution } from "@/lib/analyze/types";
+
+interface XaiPanelProps {
+  xai: XaiResponse;
+}
+
+function sentenceBackground(score: number): string {
+  const clamped = Math.max(-1, Math.min(1, score));
+  const magnitude = Math.abs(clamped).toFixed(2);
+  const cssVar = clamped >= 0 ? "--hawkish" : "--dovish";
+  return `hsl(var(${cssVar}) / ${magnitude})`;
+}
+
+function sentenceLabel(score: number): string {
+  if (score > 0.5) return "Strong hawkish pull";
+  if (score > 0.15) return "Hawkish pull";
+  if (score > -0.15) return "Neutral";
+  if (score > -0.5) return "Dovish pull";
+  return "Strong dovish pull";
+}
+
+function TokenTable({ tokens }: { tokens: XaiTokenAttribution[] }) {
+  return (
+    <table className="w-full text-left font-mono text-[11px]">
+      <thead>
+        <tr className="text-muted-foreground">
+          <th className="pb-0.5 pr-3 font-normal">token</th>
+          <th className="pb-0.5 text-right font-normal">weight</th>
+        </tr>
+      </thead>
+      <tbody>
+        {tokens.map((token) => (
+          <tr key={token.token}>
+            <td className="pr-3">{token.token}</td>
+            <td
+              className={`text-right font-medium ${
+                token.weight >= 0 ? "text-hawkish" : "text-dovish"
+              }`}
+            >
+              {token.weight >= 0 ? "+" : ""}
+              {token.weight.toFixed(2)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function SentenceChip({ sentence }: { sentence: XaiSentence }) {
+  return (
+    <Tooltip delayDuration={120}>
+      <TooltipTrigger asChild>
+        <span
+          className="cursor-help rounded px-1 py-0.5 leading-relaxed"
+          style={{ backgroundColor: sentenceBackground(sentence.score) }}
+          aria-label={`${sentenceLabel(sentence.score)} (${sentence.score.toFixed(2)})`}
+        >
+          {sentence.text}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-xs space-y-1.5">
+        <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+          {sentenceLabel(sentence.score)} · {sentence.score.toFixed(2)}
+        </p>
+        <TokenTable tokens={sentence.topTokens.slice(0, 5)} />
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function XaiPanel({ xai }: XaiPanelProps) {
+  if (!xai.sentences.length) return null;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Highlighter className="h-4 w-4 text-primary" />
+          Sentence attribution
+        </CardTitle>
+        <CardDescription>
+          Hover any sentence to see the five tokens with the largest attribution.
+          {xai.method ? ` Method: ${xai.method}.` : null}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <TooltipProvider>
+          <p className="space-x-1.5 text-sm leading-7">
+            {xai.sentences.map((sentence, idx) => (
+              <SentenceChip key={`${idx}-${sentence.text.slice(0, 16)}`} sentence={sentence} />
+            ))}
+          </p>
+        </TooltipProvider>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-background p-6 shadow-lg duration-200 sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+  DialogPortal,
+  DialogOverlay,
+};

--- a/frontend/components/ui/progress.tsx
+++ b/frontend/components/ui/progress.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: number;
+  max?: number;
+  indicatorClassName?: string;
+}
+
+const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
+  ({ className, value, max = 1, indicatorClassName, ...props }, ref) => {
+    const clamped = Math.max(0, Math.min(max, value));
+    const pct = max === 0 ? 0 : (clamped / max) * 100;
+    return (
+      <div
+        ref={ref}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={max}
+        aria-valuenow={clamped}
+        className={cn("relative h-2 w-full overflow-hidden rounded-full bg-muted", className)}
+        {...props}
+      >
+        <div
+          className={cn("h-full rounded-full bg-primary transition-all", indicatorClassName)}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    );
+  }
+);
+Progress.displayName = "Progress";
+
+export { Progress };

--- a/frontend/components/ui/tooltip.tsx
+++ b/frontend/components/ui/tooltip.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/lib/utils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+const Tooltip = TooltipPrimitive.Root;
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+      className
+    )}
+    {...props}
+  />
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -1,0 +1,42 @@
+import axios from "axios";
+import type { AnalyzeRequest, AnalyzeResult, TrainJobState } from "./types";
+
+export function resolveApiBaseUrl(): string {
+  const raw = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+  if (typeof window !== "undefined" && raw.includes("://backend:")) {
+    return raw.replace("://backend:", "://localhost:");
+  }
+  return raw;
+}
+
+export type AnalyzeResponse =
+  | { mode: "result"; result: AnalyzeResult }
+  | { mode: "queued"; job: TrainJobState };
+
+export async function postAnalyze(
+  baseUrl: string,
+  request: AnalyzeRequest
+): Promise<AnalyzeResponse> {
+  const response = await axios.post(`${baseUrl}/analyze`, request);
+  const data = response.data || {};
+  if (request.forecast_mode === "real_train") {
+    const jobId = (data as { job_id?: string }).job_id;
+    if (!jobId) throw new Error("Real Train did not return a job id.");
+    return {
+      mode: "queued",
+      job: {
+        job_id: jobId,
+        status: (data as { status?: TrainJobState["status"] }).status || "queued",
+        message: (data as { message?: string }).message || "Real Train queued.",
+        error: null,
+      },
+    };
+  }
+  return { mode: "result", result: data as AnalyzeResult };
+}
+
+export async function fetchTrainJob(baseUrl: string, jobId: string): Promise<TrainJobState> {
+  const response = await axios.get(`${baseUrl}/train-jobs/${jobId}`);
+  const state = (response.data || {}) as TrainJobState;
+  return { ...state, job_id: jobId };
+}

--- a/frontend/lib/analyze/constants.ts
+++ b/frontend/lib/analyze/constants.ts
@@ -1,0 +1,27 @@
+import type { Horizon, SymbolValue } from "./types";
+
+export const DEFAULT_TEXT =
+  "Recent indicators suggest economic activity has continued to expand at a solid pace.";
+
+export interface SymbolOption {
+  value: SymbolValue;
+  label: string;
+}
+
+export const SYMBOL_OPTIONS: SymbolOption[] = [
+  { value: "^GSPC", label: "S&P 500 (^GSPC)" },
+  { value: "DX-Y.NYB", label: "Dollar Index (DX-Y.NYB)" },
+  { value: "^NDX", label: "NASDAQ 100 (^NDX)" },
+  { value: "^DJI", label: "Dow Jones (^DJI)" },
+  { value: "^VIX", label: "CBOE Volatility Index (^VIX)" },
+  { value: "GC=F", label: "Gold Futures (GC=F)" },
+  { value: "CL=F", label: "WTI Crude Oil (CL=F)" },
+  { value: "EURUSD=X", label: "EUR/USD (EURUSD=X)" },
+  { value: "BTC-USD", label: "Bitcoin (BTC-USD)" },
+  { value: "^TNX", label: "US 10Y Yield (^TNX)" },
+];
+
+export const HORIZON_OPTIONS: Horizon[] = ["1d", "3d", "5d", "10d"];
+
+export const REAL_TRAIN_POLL_INTERVAL_MS = 2000;
+export const REAL_TRAIN_POLL_MAX = 180;

--- a/frontend/lib/analyze/derive.ts
+++ b/frontend/lib/analyze/derive.ts
@@ -1,0 +1,264 @@
+import { normalizeTimestamp, toNumericOrNull } from "./format";
+import type { AnalyzeResult, ChunkAttentionResponse } from "./types";
+
+export interface ChartRow {
+  timestamp: string;
+  history: number | null;
+  forecast: number | null;
+  forecastLower: number | null;
+  forecastUpper: number | null;
+  forecastBand: number | null;
+  realized: number | null;
+}
+
+export interface ErrorMetrics {
+  mape: number | null;
+  rmse: number | null;
+}
+
+export interface ErrorBundle {
+  close: ErrorMetrics;
+  vol: ErrorMetrics;
+  hasRealized: boolean;
+}
+
+export interface BandCheck {
+  withinBand: boolean;
+  lower: number;
+  upper: number;
+  current?: number;
+  realizedValue?: number;
+  distance: number;
+  distancePct: number;
+  tone: "good" | "caution" | "danger";
+}
+
+type SeriesKind = "close" | "volatility";
+
+function buildSeries(result: AnalyzeResult | null, kind: SeriesKind): ChartRow[] {
+  const series = result?.series;
+  if (!series) return [];
+
+  const histKey = kind === "close" ? "history_close" : "history_volatility";
+  const fcKey = kind === "close" ? "forecast_close" : "forecast_volatility";
+  const fcLowerKey =
+    kind === "close" ? "forecast_close_lower" : "forecast_volatility_lower";
+  const fcUpperKey =
+    kind === "close" ? "forecast_close_upper" : "forecast_volatility_upper";
+  const realizedKey = kind === "close" ? "realized_close" : "realized_volatility";
+
+  const byTs = new Map<string, ChartRow>();
+  const ensureRow = (raw: unknown): ChartRow | null => {
+    const ts = normalizeTimestamp(raw);
+    if (!ts) return null;
+    let row = byTs.get(ts);
+    if (!row) {
+      row = {
+        timestamp: ts,
+        history: null,
+        forecast: null,
+        forecastLower: null,
+        forecastUpper: null,
+        forecastBand: null,
+        realized: null,
+      };
+      byTs.set(ts, row);
+    }
+    return row;
+  };
+
+  (series.timestamps || []).forEach((ts, idx) => {
+    const row = ensureRow(ts);
+    if (row) row.history = toNumericOrNull((series as Record<string, number[] | undefined>)[histKey]?.[idx]);
+  });
+  (series.forecast_timestamps || []).forEach((ts, idx) => {
+    const row = ensureRow(ts);
+    if (!row) return;
+    const fc = toNumericOrNull((series as Record<string, number[] | undefined>)[fcKey]?.[idx]);
+    const lo = toNumericOrNull((series as Record<string, number[] | undefined>)[fcLowerKey]?.[idx]);
+    const hi = toNumericOrNull((series as Record<string, number[] | undefined>)[fcUpperKey]?.[idx]);
+    row.forecast = fc;
+    row.forecastLower = lo;
+    row.forecastUpper = hi;
+    row.forecastBand = lo != null && hi != null ? Math.max(hi - lo, 0) : null;
+  });
+  (series.realized_timestamps || []).forEach((ts, idx) => {
+    const row = ensureRow(ts);
+    if (row) row.realized = toNumericOrNull((series as Record<string, number[] | undefined>)[realizedKey]?.[idx]);
+  });
+
+  return Array.from(byTs.values()).sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+}
+
+export function buildCloseSeries(result: AnalyzeResult | null): ChartRow[] {
+  return buildSeries(result, "close");
+}
+
+export function buildVolatilitySeries(result: AnalyzeResult | null): ChartRow[] {
+  return buildSeries(result, "volatility");
+}
+
+export function computeErrorMetrics(result: AnalyzeResult | null): ErrorBundle {
+  const series = result?.series;
+  const pair = (
+    fcTs?: string[],
+    fcVals?: number[],
+    rzTs?: string[],
+    rzVals?: number[]
+  ): Array<[number, number]> => {
+    const map = new Map<string, number>();
+    (fcTs || []).forEach((ts, idx) => {
+      const key = normalizeTimestamp(ts);
+      const value = toNumericOrNull(fcVals?.[idx]);
+      if (key && value != null) map.set(key, value);
+    });
+    const pairs: Array<[number, number]> = [];
+    (rzTs || []).forEach((ts, idx) => {
+      const key = normalizeTimestamp(ts);
+      const realized = toNumericOrNull(rzVals?.[idx]);
+      const forecast = key ? map.get(key) : null;
+      if (forecast != null && realized != null) pairs.push([forecast, realized]);
+    });
+    return pairs;
+  };
+
+  const closePairs = pair(
+    series?.forecast_timestamps,
+    series?.forecast_close,
+    series?.realized_timestamps,
+    series?.realized_close
+  );
+  const volPairs = pair(
+    series?.forecast_timestamps,
+    series?.forecast_volatility,
+    series?.realized_timestamps,
+    series?.realized_volatility
+  );
+
+  const calc = (pairs: Array<[number, number]>): ErrorMetrics => {
+    if (!pairs.length) return { mape: null, rmse: null };
+    const mapeVals = pairs
+      .filter(([, actual]) => Math.abs(actual) > 1e-12)
+      .map(([pred, actual]) => Math.abs((actual - pred) / actual));
+    const mse = pairs.reduce((acc, [pred, actual]) => {
+      const err = actual - pred;
+      return acc + err * err;
+    }, 0) / pairs.length;
+    const rmse = Math.sqrt(mse) || 0;
+    const mape = mapeVals.length
+      ? (mapeVals.reduce((acc, v) => acc + v, 0) / mapeVals.length) * 100
+      : null;
+    return { mape, rmse };
+  };
+
+  return {
+    close: calc(closePairs),
+    vol: calc(volPairs),
+    hasRealized: Boolean(closePairs.length || volPairs.length),
+  };
+}
+
+export function computeCurrentSpotBandCheck(result: AnalyzeResult | null): BandCheck | null {
+  const series = result?.series;
+  const lower = toNumericOrNull(series?.forecast_close_lower?.[series.forecast_close_lower.length - 1]);
+  const upper = toNumericOrNull(series?.forecast_close_upper?.[series.forecast_close_upper.length - 1]);
+  const current = toNumericOrNull(result?.market?.close);
+  if (lower == null || upper == null || current == null) return null;
+  const withinBand = current >= lower && current <= upper;
+  const distance = withinBand ? 0 : current < lower ? lower - current : current - upper;
+  const reference = Math.max(Math.abs(current), 1e-6);
+  const distancePct = (distance / reference) * 100;
+  return {
+    withinBand,
+    lower,
+    upper,
+    current,
+    distance,
+    distancePct,
+    tone: withinBand ? "good" : distance / reference <= 0.015 ? "caution" : "danger",
+  };
+}
+
+export function computeRealizedBandCheck(result: AnalyzeResult | null): BandCheck | null {
+  const series = result?.series;
+  const forecastTs = series?.forecast_timestamps || [];
+  const lowerBand = series?.forecast_close_lower || [];
+  const upperBand = series?.forecast_close_upper || [];
+  const realizedTs = series?.realized_timestamps || [];
+  const realizedClose = series?.realized_close || [];
+
+  const byTs = new Map<string, { lower: number; upper: number }>();
+  forecastTs.forEach((ts, idx) => {
+    const key = normalizeTimestamp(ts);
+    const lo = toNumericOrNull(lowerBand[idx]);
+    const hi = toNumericOrNull(upperBand[idx]);
+    if (key && lo != null && hi != null) byTs.set(key, { lower: lo, upper: hi });
+  });
+
+  const overlaps: Array<{ ts: string; realizedValue: number; lower: number; upper: number }> = [];
+  realizedTs.forEach((ts, idx) => {
+    const key = normalizeTimestamp(ts);
+    const realizedValue = toNumericOrNull(realizedClose[idx]);
+    const band = key ? byTs.get(key) : null;
+    if (key && band && realizedValue != null) {
+      overlaps.push({ ts: key, realizedValue, lower: band.lower, upper: band.upper });
+    }
+  });
+  if (!overlaps.length) return null;
+  overlaps.sort((a, b) => a.ts.localeCompare(b.ts));
+  const latest = overlaps[overlaps.length - 1];
+  const { realizedValue, lower, upper } = latest;
+  const withinBand = realizedValue >= lower && realizedValue <= upper;
+  const distance = withinBand ? 0 : realizedValue < lower ? lower - realizedValue : realizedValue - upper;
+  const reference = Math.max(Math.abs(realizedValue), 1e-6);
+  const distancePct = (distance / reference) * 100;
+  return {
+    withinBand,
+    lower,
+    upper,
+    realizedValue,
+    distance,
+    distancePct,
+    tone: withinBand ? "good" : distance / reference <= 0.02 ? "caution" : "danger",
+  };
+}
+
+export interface AttentionRow {
+  index: number;
+  label: string;
+  preview: string;
+  weight: number;
+  decay: number;
+  weightPct: string;
+}
+
+export interface AttentionBundle {
+  rows: AttentionRow[];
+  lambdaValue: number;
+  chunkCount: number;
+}
+
+export function buildAttention(result: AnalyzeResult | null): AttentionBundle | null {
+  const attention: ChunkAttentionResponse | null | undefined = result?.model?.chunk_attention;
+  if (!attention) return null;
+  const weights = Array.isArray(attention.weights) ? attention.weights : [];
+  if (!weights.length) return null;
+  const decay = Array.isArray(attention.decay_coeffs) ? attention.decay_coeffs : [];
+  const previews = Array.isArray(attention.chunk_previews) ? attention.chunk_previews : [];
+  const rows: AttentionRow[] = weights.map((weight, idx) => {
+    const w = Number(weight) || 0;
+    return {
+      index: idx,
+      label: previews[idx] ? previews[idx].slice(0, 80) : `chunk ${idx}`,
+      preview: previews[idx] || "",
+      weight: w,
+      decay: Number(decay[idx]) || 0,
+      weightPct: (w * 100).toFixed(1),
+    };
+  });
+  return {
+    rows,
+    lambdaValue: Number(attention.lambda_value) || 0,
+    chunkCount: attention.chunk_count ?? rows.length,
+  };
+}

--- a/frontend/lib/analyze/fixtures.ts
+++ b/frontend/lib/analyze/fixtures.ts
@@ -1,0 +1,89 @@
+import type {
+  CredibilityResponse,
+  MultiAxisResponse,
+  XaiResponse,
+} from "./types";
+
+export const SAMPLE_MULTI_AXIS: MultiAxisResponse = {
+  stance: {
+    label: "hawkish",
+    confidence: 0.62,
+    distribution: { hawkish: 0.62, neutral: 0.21, dovish: 0.17 },
+  },
+  factor: {
+    value: 0.31,
+    confidence: 0.74,
+    range: [0.14, 0.49],
+  },
+  certainty: {
+    label: "decisive",
+    confidence: 0.68,
+  },
+  topic: {
+    primary: "inflation_persistence",
+    confidence: 0.58,
+    secondary: ["labor_market_tightness", "growth_path"],
+  },
+};
+
+export const SAMPLE_XAI: XaiResponse = {
+  method: "integrated_gradients",
+  sentences: [
+    {
+      text:
+        "Recent indicators suggest economic activity has continued to expand at a solid pace.",
+      score: 0.18,
+      topTokens: [
+        { token: "solid", weight: 0.42 },
+        { token: "expand", weight: 0.31 },
+        { token: "pace", weight: 0.18 },
+        { token: "continued", weight: 0.12 },
+        { token: "activity", weight: 0.09 },
+      ],
+    },
+    {
+      text:
+        "Inflation has eased over the past year but remains elevated.",
+      score: 0.58,
+      topTokens: [
+        { token: "elevated", weight: 0.61 },
+        { token: "inflation", weight: 0.48 },
+        { token: "remains", weight: 0.27 },
+        { token: "eased", weight: -0.21 },
+        { token: "past", weight: 0.08 },
+      ],
+    },
+    {
+      text:
+        "The Committee is strongly committed to returning inflation to its 2 percent objective.",
+      score: 0.81,
+      topTokens: [
+        { token: "strongly", weight: 0.72 },
+        { token: "committed", weight: 0.66 },
+        { token: "returning", weight: 0.41 },
+        { token: "2", weight: 0.19 },
+        { token: "objective", weight: 0.14 },
+      ],
+    },
+    {
+      text:
+        "In considering any adjustments, the Committee will carefully assess incoming data.",
+      score: -0.12,
+      topTokens: [
+        { token: "carefully", weight: -0.32 },
+        { token: "assess", weight: -0.18 },
+        { token: "incoming", weight: -0.07 },
+        { token: "considering", weight: -0.05 },
+        { token: "adjustments", weight: 0.03 },
+      ],
+    },
+  ],
+};
+
+export const SAMPLE_CREDIBILITY: CredibilityResponse = {
+  driftScore: 0.34,
+  driftTrend: [0.21, 0.28, 0.31, 0.34],
+  realizedVsStatedGap: -0.08,
+  marketImpliedGap: 0.12,
+  monthsSinceReversal: 14,
+};

--- a/frontend/lib/analyze/format.ts
+++ b/frontend/lib/analyze/format.ts
@@ -1,0 +1,90 @@
+import type { Stance } from "./types";
+
+export function toNumericOrNull(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function normalizeTimestamp(value: unknown): string {
+  if (!value) return "";
+  return String(value).split("+")[0];
+}
+
+export function toStance(label: unknown): Stance {
+  const value = String(label || "").toUpperCase();
+  if (value.includes("HAWK") || value.includes("POSITIVE") || value.includes("LABEL_1")) {
+    return "hawkish";
+  }
+  if (value.includes("DOVE") || value.includes("NEGATIVE") || value.includes("LABEL_0")) {
+    return "dovish";
+  }
+  if (value.includes("NEUTRAL") || value.includes("LABEL_2")) {
+    return "neutral";
+  }
+  return "unknown";
+}
+
+export function stanceLabel(stance: Stance): string {
+  if (stance === "hawkish") return "Hawkish";
+  if (stance === "dovish") return "Dovish";
+  if (stance === "neutral") return "Neutral";
+  return "Unknown";
+}
+
+export function formatPrice(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "N/A";
+  return `$${Number(value).toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
+}
+
+export function formatPriceDelta(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "N/A";
+  const v = Number(value);
+  const sign = v >= 0 ? "+" : "-";
+  return `${sign}$${Math.abs(v).toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
+}
+
+export function formatPercentDelta(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "N/A";
+  const v = Number(value);
+  return `${v >= 0 ? "+" : ""}${v.toFixed(2)}%`;
+}
+
+export function formatVol(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "N/A";
+  return `${(Number(value) * 100).toFixed(2)}%`;
+}
+
+export function formatDateTick(value: unknown): string {
+  if (!value) return "";
+  const clean = String(value).split("+")[0];
+  const dateValue = new Date(clean);
+  if (Number.isNaN(dateValue.getTime())) return String(value);
+  return dateValue.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export type ErrorTone = "low" | "medium" | "high" | "neutral";
+
+export function getErrorTone(
+  kind: "mape" | "rmse",
+  value: number | null | undefined,
+  baseline = 0
+): ErrorTone {
+  if (value == null || !Number.isFinite(value)) return "neutral";
+  if (kind === "mape") {
+    if (value <= 2) return "low";
+    if (value <= 5) return "medium";
+    return "high";
+  }
+  const normalized = baseline > 0 ? (value / baseline) * 100 : value;
+  if (normalized <= 1) return "low";
+  if (normalized <= 2.5) return "medium";
+  return "high";
+}
+
+export function errorToneLabel(tone: ErrorTone): string {
+  if (tone === "low") return "Low error";
+  if (tone === "medium") return "Medium error";
+  if (tone === "high") return "High error";
+  return "Awaiting data";
+}

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -1,0 +1,85 @@
+export type ForecastMode = "fast" | "quick_train" | "real_train";
+export type Horizon = "1d" | "3d" | "5d" | "10d";
+export type SymbolValue = string;
+
+export interface AnalyzeRequest {
+  text: string;
+  date: string;
+  symbol: SymbolValue;
+  forecast_mode: ForecastMode;
+  horizon: Horizon;
+  include_realized: boolean;
+}
+
+export interface SentimentResponse {
+  label?: string | null;
+  score?: number | null;
+}
+
+export interface PredictionResponse {
+  close?: number | null;
+  volatility?: number | null;
+  horizon?: string | null;
+}
+
+export interface MarketResponse {
+  symbol?: string;
+  requested_date?: string;
+  date_used?: string;
+  close?: number | null;
+  volatility_5d?: number | null;
+}
+
+export interface ChunkAttentionResponse {
+  weights?: number[];
+  decay_coeffs?: number[];
+  chunk_previews?: string[];
+  chunk_count?: number;
+  lambda_value?: number;
+}
+
+export interface ModelDiagnosticsResponse {
+  hidden_size?: number;
+  num_layers?: number;
+  dropout?: number;
+  combined_rmse?: number;
+  checkpoint_loaded?: boolean;
+  runtime_mode?: string;
+  chunk_attention?: ChunkAttentionResponse | null;
+}
+
+export interface SeriesResponse {
+  timestamps?: string[];
+  history_close?: number[];
+  history_volatility?: number[];
+  forecast_timestamps?: string[];
+  forecast_close?: number[];
+  forecast_close_lower?: number[];
+  forecast_close_upper?: number[];
+  forecast_volatility?: number[];
+  forecast_volatility_lower?: number[];
+  forecast_volatility_upper?: number[];
+  realized_timestamps?: string[];
+  realized_close?: number[];
+  realized_volatility?: number[];
+  forecast_confidence_level?: number;
+  volatility_scale?: { suggested_ymin?: number; suggested_ymax?: number };
+}
+
+export interface AnalyzeResult {
+  sentiment?: SentimentResponse;
+  prediction?: PredictionResponse;
+  market?: MarketResponse;
+  model?: ModelDiagnosticsResponse;
+  series?: SeriesResponse;
+}
+
+export interface TrainJobState {
+  job_id: string;
+  status: "queued" | "running" | "succeeded" | "failed";
+  message?: string;
+  error?: string | null;
+  result?: AnalyzeResult | null;
+}
+
+export type Stance = "hawkish" | "dovish" | "neutral" | "unknown";

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -66,12 +66,72 @@ export interface SeriesResponse {
   volatility_scale?: { suggested_ymin?: number; suggested_ymax?: number };
 }
 
+export type StanceAxis = "hawkish" | "dovish" | "neutral";
+export type CertaintyAxis = "tentative" | "measured" | "decisive";
+
+export interface MultiAxisStance {
+  label: StanceAxis;
+  confidence: number;
+  distribution?: Partial<Record<StanceAxis, number>>;
+}
+
+export interface MultiAxisFactor {
+  value: number;
+  confidence: number;
+  range?: [number, number];
+}
+
+export interface MultiAxisCertainty {
+  label: CertaintyAxis;
+  confidence: number;
+}
+
+export interface MultiAxisTopic {
+  primary: string;
+  confidence: number;
+  secondary?: string[];
+}
+
+export interface MultiAxisResponse {
+  stance?: MultiAxisStance;
+  factor?: MultiAxisFactor;
+  certainty?: MultiAxisCertainty;
+  topic?: MultiAxisTopic;
+}
+
+export interface XaiTokenAttribution {
+  token: string;
+  weight: number;
+}
+
+export interface XaiSentence {
+  text: string;
+  score: number;
+  topTokens: XaiTokenAttribution[];
+}
+
+export interface XaiResponse {
+  sentences: XaiSentence[];
+  method?: string;
+}
+
+export interface CredibilityResponse {
+  driftScore: number;
+  driftTrend?: number[];
+  realizedVsStatedGap?: number;
+  marketImpliedGap?: number;
+  monthsSinceReversal?: number;
+}
+
 export interface AnalyzeResult {
   sentiment?: SentimentResponse;
   prediction?: PredictionResponse;
   market?: MarketResponse;
   model?: ModelDiagnosticsResponse;
   series?: SeriesResponse;
+  multi_axis?: MultiAxisResponse;
+  xai?: XaiResponse;
+  credibility?: CredibilityResponse;
 }
 
 export interface TrainJobState {

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -4,10 +4,14 @@ import "../styles/legacy-dashboard.css";
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "sonner";
 
+import { TooltipProvider } from "@/components/ui/tooltip";
+
 export default function App({ Component, pageProps }) {
   return (
     <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
-      <Component {...pageProps} />
+      <TooltipProvider delayDuration={120}>
+        <Component {...pageProps} />
+      </TooltipProvider>
       <Toaster richColors position="top-right" />
     </ThemeProvider>
   );

--- a/frontend/pages/analyze.tsx
+++ b/frontend/pages/analyze.tsx
@@ -3,13 +3,17 @@ import Head from "next/head";
 import { toast } from "sonner";
 
 import { AnalyzeForm } from "@/components/analyze/AnalyzeForm";
+import { CredibilityPanel } from "@/components/analyze/CredibilityPanel";
 import { ErrorBadges } from "@/components/analyze/ErrorBadges";
 import { ForecastChart } from "@/components/analyze/ForecastChart";
 import { MarketContext } from "@/components/analyze/MarketContext";
+import { MultiAxisCards } from "@/components/analyze/MultiAxisCards";
 import { PredictionCards } from "@/components/analyze/PredictionCards";
 import { RealTrainStatus } from "@/components/analyze/RealTrainStatus";
 import { SentimentCard } from "@/components/analyze/SentimentCard";
+import { XaiPanel } from "@/components/analyze/XaiPanel";
 import { Header } from "@/components/shell/header";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { fetchTrainJob, postAnalyze, resolveApiBaseUrl } from "@/lib/analyze/api";
 import {
@@ -22,6 +26,11 @@ import {
   buildVolatilitySeries,
   computeErrorMetrics,
 } from "@/lib/analyze/derive";
+import {
+  SAMPLE_CREDIBILITY,
+  SAMPLE_MULTI_AXIS,
+  SAMPLE_XAI,
+} from "@/lib/analyze/fixtures";
 import type { AnalyzeRequest, AnalyzeResult, TrainJobState } from "@/lib/analyze/types";
 
 function defaultRequest(): AnalyzeRequest {
@@ -54,6 +63,7 @@ export default function AnalyzePage() {
   const [result, setResult] = React.useState<AnalyzeResult | null>(null);
   const [trainJob, setTrainJob] = React.useState<TrainJobState | null>(null);
   const [loading, setLoading] = React.useState(false);
+  const [previewV2, setPreviewV2] = React.useState(false);
   const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
 
   const handleSubmit = async () => {
@@ -117,11 +127,20 @@ export default function AnalyzePage() {
       <div className="min-h-screen bg-background text-foreground">
         <Header />
         <main className="container space-y-6 py-8">
-          <div className="space-y-2">
-            <h1 className="text-3xl font-semibold tracking-tight">Analyze</h1>
-            <p className="max-w-2xl text-muted-foreground">
-              Score an FOMC excerpt and project asset close + volatility with confidence bands.
-            </p>
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div className="space-y-2">
+              <h1 className="text-3xl font-semibold tracking-tight">Analyze</h1>
+              <p className="max-w-2xl text-muted-foreground">
+                Score an FOMC excerpt and project asset close + volatility with confidence bands.
+              </p>
+            </div>
+            <Button
+              variant={previewV2 ? "default" : "outline"}
+              size="sm"
+              onClick={() => setPreviewV2((value) => !value)}
+            >
+              {previewV2 ? "Hide v2 preview" : "Preview v2 panels"}
+            </Button>
           </div>
 
           <AnalyzeForm
@@ -149,6 +168,10 @@ export default function AnalyzePage() {
                   <PredictionCards result={result} />
                 </div>
               </div>
+
+              {result.multi_axis || previewV2 ? (
+                <MultiAxisCards multiAxis={result.multi_axis ?? SAMPLE_MULTI_AXIS} />
+              ) : null}
 
               <ErrorBadges result={result} metrics={errorMetrics} />
 
@@ -178,6 +201,11 @@ export default function AnalyzePage() {
                   ]}
                 />
               </div>
+
+              {result.xai || previewV2 ? <XaiPanel xai={result.xai ?? SAMPLE_XAI} /> : null}
+              {result.credibility || previewV2 ? (
+                <CredibilityPanel credibility={result.credibility ?? SAMPLE_CREDIBILITY} />
+              ) : null}
 
               <MarketContext result={result} />
             </>

--- a/frontend/pages/analyze.tsx
+++ b/frontend/pages/analyze.tsx
@@ -1,0 +1,189 @@
+import * as React from "react";
+import Head from "next/head";
+import { toast } from "sonner";
+
+import { AnalyzeForm } from "@/components/analyze/AnalyzeForm";
+import { ErrorBadges } from "@/components/analyze/ErrorBadges";
+import { ForecastChart } from "@/components/analyze/ForecastChart";
+import { MarketContext } from "@/components/analyze/MarketContext";
+import { PredictionCards } from "@/components/analyze/PredictionCards";
+import { RealTrainStatus } from "@/components/analyze/RealTrainStatus";
+import { SentimentCard } from "@/components/analyze/SentimentCard";
+import { Header } from "@/components/shell/header";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchTrainJob, postAnalyze, resolveApiBaseUrl } from "@/lib/analyze/api";
+import {
+  DEFAULT_TEXT,
+  REAL_TRAIN_POLL_INTERVAL_MS,
+  REAL_TRAIN_POLL_MAX,
+} from "@/lib/analyze/constants";
+import {
+  buildCloseSeries,
+  buildVolatilitySeries,
+  computeErrorMetrics,
+} from "@/lib/analyze/derive";
+import type { AnalyzeRequest, AnalyzeResult, TrainJobState } from "@/lib/analyze/types";
+
+function defaultRequest(): AnalyzeRequest {
+  return {
+    text: DEFAULT_TEXT,
+    date: new Date().toISOString().slice(0, 10),
+    symbol: "^GSPC",
+    forecast_mode: "fast",
+    horizon: "3d",
+    include_realized: false,
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function trainJobMessage(state: TrainJobState): string {
+  if (state.message) return state.message;
+  if (state.status === "running") {
+    return "Real Train running on 252-day history…";
+  }
+  if (state.status === "queued") return "Real Train queued…";
+  if (state.status === "succeeded") return "Real Train completed. Rendering results.";
+  return "";
+}
+
+export default function AnalyzePage() {
+  const [request, setRequest] = React.useState<AnalyzeRequest>(defaultRequest);
+  const [result, setResult] = React.useState<AnalyzeResult | null>(null);
+  const [trainJob, setTrainJob] = React.useState<TrainJobState | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setTrainJob(null);
+    try {
+      const response = await postAnalyze(apiBaseUrl, request);
+      if (response.mode === "result") {
+        setResult(response.result);
+        toast.success("Forecast ready");
+        return;
+      }
+
+      setResult(null);
+      setTrainJob(response.job);
+      toast.info("Real Train queued — polling for completion");
+
+      for (let i = 0; i < REAL_TRAIN_POLL_MAX; i += 1) {
+        await sleep(REAL_TRAIN_POLL_INTERVAL_MS);
+        const next = await fetchTrainJob(apiBaseUrl, response.job.job_id);
+        setTrainJob({ ...next, message: trainJobMessage(next) });
+        if (next.status === "succeeded") {
+          setResult(next.result ?? null);
+          toast.success("Real Train completed");
+          return;
+        }
+        if (next.status === "failed") {
+          throw new Error(next.error || "Real Train job failed.");
+        }
+      }
+      throw new Error("Real Train timed out while waiting for completion.");
+    } catch (err) {
+      setResult(null);
+      const message =
+        (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data
+          ?.detail ||
+        (err as Error).message ||
+        "Request failed. Ensure the backend is running.";
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const closeSeries = React.useMemo(() => buildCloseSeries(result), [result]);
+  const volatilitySeries = React.useMemo(() => buildVolatilitySeries(result), [result]);
+  const errorMetrics = React.useMemo(() => computeErrorMetrics(result), [result]);
+
+  const splitTimestamp = result?.series?.timestamps?.[result.series.timestamps.length - 1];
+  const volScale = result?.series?.volatility_scale || { suggested_ymin: 0.0, suggested_ymax: 1.0 };
+  const confidenceLevel = Math.round(Number(result?.series?.forecast_confidence_level || 0.8) * 100);
+  const confidenceLabel = `${confidenceLevel}% confidence band`;
+  const hasCloseConfidence = Boolean(result?.series?.forecast_close_lower?.length);
+  const hasVolConfidence = Boolean(result?.series?.forecast_volatility_lower?.length);
+
+  return (
+    <>
+      <Head>
+        <title>Analyze — Fed Pulse</title>
+      </Head>
+      <div className="min-h-screen bg-background text-foreground">
+        <Header />
+        <main className="container space-y-6 py-8">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold tracking-tight">Analyze</h1>
+            <p className="max-w-2xl text-muted-foreground">
+              Score an FOMC excerpt and project asset close + volatility with confidence bands.
+            </p>
+          </div>
+
+          <AnalyzeForm
+            value={request}
+            onChange={setRequest}
+            onSubmit={handleSubmit}
+            loading={loading}
+          />
+
+          {trainJob ? <RealTrainStatus job={trainJob} /> : null}
+
+          {loading && !result ? (
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <Skeleton className="h-28 w-full" />
+              <Skeleton className="h-28 w-full" />
+              <Skeleton className="h-28 w-full" />
+            </div>
+          ) : null}
+
+          {result ? (
+            <>
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <SentimentCard sentiment={result.sentiment} />
+                <div className="md:col-span-2 xl:col-span-2">
+                  <PredictionCards result={result} />
+                </div>
+              </div>
+
+              <ErrorBadges result={result} metrics={errorMetrics} />
+
+              <div className="grid gap-4 xl:grid-cols-2">
+                <ForecastChart
+                  title="Close forecast"
+                  description={`Forecast line and ${confidenceLabel} over the requested horizon.`}
+                  data={closeSeries}
+                  kind="close"
+                  splitTimestamp={splitTimestamp}
+                  includeRealized={request.include_realized}
+                  hasConfidence={hasCloseConfidence}
+                  confidenceLabel={confidenceLabel}
+                />
+                <ForecastChart
+                  title="Volatility forecast"
+                  description={`Forecast line and ${confidenceLabel} over the requested horizon.`}
+                  data={volatilitySeries}
+                  kind="volatility"
+                  splitTimestamp={splitTimestamp}
+                  includeRealized={request.include_realized}
+                  hasConfidence={hasVolConfidence}
+                  confidenceLabel={confidenceLabel}
+                  yDomain={[
+                    Number(volScale.suggested_ymin ?? 0),
+                    Number(volScale.suggested_ymax ?? 1),
+                  ]}
+                />
+              </div>
+
+              <MarketContext result={result} />
+            </>
+          ) : null}
+        </main>
+      </div>
+    </>
+  );
+}

--- a/frontend/pages/analyze.tsx
+++ b/frontend/pages/analyze.tsx
@@ -1,17 +1,15 @@
 import * as React from "react";
 import Head from "next/head";
+import dynamic from "next/dynamic";
 import { toast } from "sonner";
 
 import { AnalyzeForm } from "@/components/analyze/AnalyzeForm";
-import { CredibilityPanel } from "@/components/analyze/CredibilityPanel";
 import { ErrorBadges } from "@/components/analyze/ErrorBadges";
 import { ForecastChart } from "@/components/analyze/ForecastChart";
 import { MarketContext } from "@/components/analyze/MarketContext";
-import { MultiAxisCards } from "@/components/analyze/MultiAxisCards";
 import { PredictionCards } from "@/components/analyze/PredictionCards";
 import { RealTrainStatus } from "@/components/analyze/RealTrainStatus";
 import { SentimentCard } from "@/components/analyze/SentimentCard";
-import { XaiPanel } from "@/components/analyze/XaiPanel";
 import { Header } from "@/components/shell/header";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -26,12 +24,15 @@ import {
   buildVolatilitySeries,
   computeErrorMetrics,
 } from "@/lib/analyze/derive";
-import {
-  SAMPLE_CREDIBILITY,
-  SAMPLE_MULTI_AXIS,
-  SAMPLE_XAI,
-} from "@/lib/analyze/fixtures";
 import type { AnalyzeRequest, AnalyzeResult, TrainJobState } from "@/lib/analyze/types";
+
+// Lazy-load fixture-driven panels so the fixture module never ships to the
+// default analyze bundle. Only loaded when the toggle is on or when the API
+// returns the v2 fields.
+const PreviewPanels = dynamic(() => import("@/components/analyze/PreviewPanels"), {
+  ssr: false,
+  loading: () => null,
+});
 
 function defaultRequest(): AnalyzeRequest {
   return {
@@ -170,7 +171,7 @@ export default function AnalyzePage() {
               </div>
 
               {result.multi_axis || previewV2 ? (
-                <MultiAxisCards multiAxis={result.multi_axis ?? SAMPLE_MULTI_AXIS} />
+                <PreviewPanels slot="cards" multiAxis={result.multi_axis} />
               ) : null}
 
               <ErrorBadges result={result} metrics={errorMetrics} />
@@ -202,9 +203,11 @@ export default function AnalyzePage() {
                 />
               </div>
 
-              {result.xai || previewV2 ? <XaiPanel xai={result.xai ?? SAMPLE_XAI} /> : null}
+              {result.xai || previewV2 ? (
+                <PreviewPanels slot="xai" xai={result.xai} />
+              ) : null}
               {result.credibility || previewV2 ? (
-                <CredibilityPanel credibility={result.credibility ?? SAMPLE_CREDIBILITY} />
+                <PreviewPanels slot="credibility" credibility={result.credibility} />
               ) : null}
 
               <MarketContext result={result} />

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,9 @@
+import type { GetServerSideProps, NextPage } from "next";
+
+export const getServerSideProps: GetServerSideProps = async () => ({
+  redirect: { destination: "/analyze", permanent: false },
+});
+
+const Home: NextPage = () => null;
+
+export default Home;

--- a/frontend/pages/legacy.jsx
+++ b/frontend/pages/legacy.jsx
@@ -706,7 +706,7 @@ export default function Home() {
   };
 
   return (
-    <main className="container">
+    <main className="legacy-shell container">
       <header className="pageHeader">
         <h1>FOMC Quant Forecast Terminal</h1>
         <p className="subtitle">

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -26,6 +26,11 @@
     --hawkish: 0 76% 52%;
     --dovish: 156 70% 38%;
     --neutral: 215 16% 47%;
+    --chart-1: 199 89% 48%;
+    --chart-2: 38 92% 50%;
+    --chart-3: 188 78% 41%;
+    --chart-4: 156 60% 40%;
+    --chart-5: 346 84% 56%;
     --radius: 0.625rem;
     --font-sans: "Inter", "system-ui";
     --font-mono: "JetBrains Mono", "ui-monospace";
@@ -54,6 +59,11 @@
     --hawkish: 0 70% 60%;
     --dovish: 156 60% 50%;
     --neutral: 215 20% 65%;
+    --chart-1: 199 89% 64%;
+    --chart-2: 38 92% 60%;
+    --chart-3: 188 78% 55%;
+    --chart-4: 156 60% 55%;
+    --chart-5: 346 84% 65%;
   }
 
   * {

--- a/frontend/styles/legacy-dashboard.css
+++ b/frontend/styles/legacy-dashboard.css
@@ -1,4 +1,4 @@
-:root {
+.legacy-shell {
   color-scheme: dark;
   --bg: #050a16;
   --panel: rgba(17, 27, 47, 0.54);
@@ -10,11 +10,11 @@
   --danger: #ff8a8a;
 }
 
-* {
+.legacy-shell * {
   box-sizing: border-box;
 }
 
-body {
+.legacy-shell {
   margin: 0;
   font-family: "Inter", "Roboto Mono", "SF Mono", "SF Pro Text", -apple-system, monospace;
   font-size: 16px;
@@ -25,30 +25,30 @@ body {
   color: var(--text-primary);
 }
 
-.container {
+.legacy-shell .container {
   max-width: 1240px;
   margin: 0 auto;
   padding: 2.2rem 1.2rem 3rem;
 }
 
-.pageHeader {
+.legacy-shell .pageHeader {
   margin-bottom: 1.1rem;
 }
 
-h1 {
+.legacy-shell h1 {
   margin: 0;
   font-size: 2.25rem;
   line-height: 1.15;
   letter-spacing: -0.02em;
 }
 
-.subtitle {
+.legacy-shell .subtitle {
   margin-top: 0.55rem;
   color: var(--text-muted);
   font-size: 0.98rem;
 }
 
-.card {
+.legacy-shell .card {
   background: var(--panel);
   border: 1px solid var(--panel-border);
   border-radius: 16px;
@@ -59,50 +59,50 @@ h1 {
   -webkit-backdrop-filter: blur(14px);
 }
 
-.inputCard {
+.legacy-shell .inputCard {
   padding: 1.5rem;
 }
 
-.resultGrid {
+.legacy-shell .resultGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1rem;
 }
 
-.metricCard h2 {
+.legacy-shell .metricCard h2 {
   margin: 0 0 0.8rem;
   color: var(--text-muted);
   font-size: 1rem;
   font-weight: 600;
 }
 
-.metricValue {
+.legacy-shell .metricValue {
   margin: 0;
   font-size: 1.9rem;
   font-weight: 700;
   letter-spacing: -0.02em;
 }
 
-.metricMeta {
+.legacy-shell .metricMeta {
   margin-top: 0.45rem;
   color: var(--text-muted);
   font-size: 0.9rem;
 }
 
-.metricSub {
+.legacy-shell .metricSub {
   margin: 0.5rem 0 0;
   color: #c9d7f8;
   font-size: 0.88rem;
 }
 
-label {
+.legacy-shell label {
   display: block;
   margin-bottom: 0.5rem;
   font-weight: 600;
   color: var(--text-muted);
 }
 
-textarea {
+.legacy-shell textarea {
   width: 100%;
   padding: 0.9rem;
   background: rgba(8, 18, 40, 0.84);
@@ -113,14 +113,14 @@ textarea {
   resize: vertical;
 }
 
-.terminalInput {
+.legacy-shell .terminalInput {
   font-family: "JetBrains Mono", "Fira Code", ui-monospace, Menlo, Monaco, monospace;
   line-height: 1.5;
   min-height: 180px;
   box-shadow: inset 0 0 0 1px rgba(118, 171, 248, 0.08);
 }
 
-.controlInput {
+.legacy-shell .controlInput {
   width: 100%;
   height: 48px;
   min-height: 48px;
@@ -131,56 +131,55 @@ textarea {
   border-radius: 0.5rem;
 }
 
-.controlInput:focus,
-textarea:focus {
+.legacy-shell .controlInput:focus, .legacy-shell textarea:focus {
   outline: none;
   border-color: rgba(95, 168, 255, 0.8);
   box-shadow: 0 0 0 2px rgba(95, 168, 255, 0.2);
 }
 
-.controlRow {
+.legacy-shell .controlRow {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1rem;
   margin-bottom: 1rem;
 }
 
-.controlHint {
+.legacy-shell .controlHint {
   margin: 0.42rem 0 0;
   color: #9eb0d4;
   font-size: 0.8rem;
 }
 
-.chartCard h2 {
+.legacy-shell .chartCard h2 {
   margin: 0 0 0.7rem;
   font-size: 1rem;
 }
 
-.chartNote {
+.legacy-shell .chartNote {
   margin: -0.1rem 0 0.85rem;
   color: #aebfe2;
   font-size: 0.82rem;
   line-height: 1.45;
 }
 
-.chartWrap {
+.legacy-shell .chartWrap {
   width: 100%;
   height: 280px;
 }
 
-.chartTooltip {
+.legacy-shell .chartTooltip {
   background: rgba(5, 10, 25, 0.94);
   border: 1px solid rgba(122, 159, 219, 0.34);
   border-radius: 10px;
   padding: 0.45rem 0.6rem;
 }
 
-.chartTooltip p {
+.legacy-shell .chartTooltip p {
   margin: 0.16rem 0;
   font-size: 0.82rem;
 }
 
-.rowBetween {
+.legacy-shell .rowBetween {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -188,7 +187,7 @@ textarea:focus {
   margin-bottom: 0.45rem;
 }
 
-.ghostBtn {
+.legacy-shell .ghostBtn {
   background: transparent;
   border: 1px solid rgba(130, 165, 226, 0.35);
   color: #b9caf0;
@@ -196,7 +195,7 @@ textarea:focus {
   border-radius: 0.45rem;
 }
 
-.toggleRow {
+.legacy-shell .toggleRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -204,20 +203,20 @@ textarea:focus {
   margin: 0.4rem 0 1rem;
 }
 
-.toggleLabel {
+.legacy-shell .toggleLabel {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
   color: #cbd8f6;
 }
 
-.actionRow {
+.legacy-shell .actionRow {
   display: flex;
   align-items: center;
   gap: 1rem;
 }
 
-.actionRow button {
+.legacy-shell .actionRow button {
   min-height: 48px;
   padding: 0 1.2rem;
   display: inline-flex;
@@ -225,47 +224,47 @@ textarea:focus {
   justify-content: center;
 }
 
-.helperText {
+.legacy-shell .helperText {
   color: #9eb0d4;
   font-size: 0.85rem;
 }
 
-.metadataGrid {
+.legacy-shell .metadataGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.8rem;
 }
 
-.metadataItem {
+.legacy-shell .metadataItem {
   background: rgba(7, 18, 42, 0.72);
   border: 1px solid rgba(110, 141, 196, 0.25);
   border-radius: 10px;
   padding: 0.7rem 0.75rem;
 }
 
-.metadataItem span {
+.legacy-shell .metadataItem span {
   display: block;
   font-size: 0.78rem;
   color: #9eb0d4;
   margin-bottom: 0.3rem;
 }
 
-.metadataItem strong {
+.legacy-shell .metadataItem strong {
   font-size: 0.95rem;
 }
 
-.metricBadgeCard h2 {
+.legacy-shell .metricBadgeCard h2 {
   margin: 0 0 0.75rem;
   font-size: 1rem;
 }
 
-.badgeGrid {
+.legacy-shell .badgeGrid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.9rem;
 }
 
-.badgeItem {
+.legacy-shell .badgeItem {
   position: relative;
   background:
     linear-gradient(180deg, rgba(14, 25, 52, 0.98) 0%, rgba(7, 16, 35, 0.98) 100%),
@@ -279,7 +278,7 @@ textarea:focus {
     0 12px 28px rgba(2, 8, 23, 0.28);
 }
 
-.badgeItem::before {
+.legacy-shell .badgeItem::before {
   content: "";
   position: absolute;
   inset: 0 0 auto 0;
@@ -288,7 +287,7 @@ textarea:focus {
   background: rgba(87, 210, 255, 0.45);
 }
 
-.badgeHeader {
+.legacy-shell .badgeHeader {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -296,7 +295,7 @@ textarea:focus {
   margin-bottom: 0.9rem;
 }
 
-.badgeHeader span {
+.legacy-shell .badgeHeader span {
   display: block;
   color: #9eb0d4;
   font-size: 0.78rem;
@@ -305,13 +304,13 @@ textarea:focus {
   letter-spacing: 0.08em;
 }
 
-.badgeItem strong {
+.legacy-shell .badgeItem strong {
   display: block;
   font-size: 1.22rem;
   letter-spacing: -0.03em;
 }
 
-.badgeTone {
+.legacy-shell .badgeTone {
   display: inline-flex;
   align-items: center;
   padding: 0.28rem 0.55rem;
@@ -323,75 +322,75 @@ textarea:focus {
   white-space: nowrap;
 }
 
-.badgeMeta {
+.legacy-shell .badgeMeta {
   margin: 0.55rem 0 0;
   color: #b4c6eb;
   font-size: 0.8rem;
   line-height: 1.35;
 }
 
-.badgeItem--low {
+.legacy-shell .badgeItem--low {
   border-color: rgba(52, 211, 153, 0.34);
   background:
     linear-gradient(180deg, rgba(8, 44, 35, 0.62) 0%, rgba(7, 16, 35, 0.98) 100%),
     rgba(8, 18, 42, 0.74);
 }
 
-.badgeItem--low::before {
+.legacy-shell .badgeItem--low::before {
   background: linear-gradient(90deg, rgba(74, 222, 128, 0.95), rgba(16, 185, 129, 0.85));
 }
 
-.badgeItem--medium {
+.legacy-shell .badgeItem--medium {
   border-color: rgba(245, 158, 11, 0.36);
   background:
     linear-gradient(180deg, rgba(62, 36, 9, 0.64) 0%, rgba(7, 16, 35, 0.98) 100%),
     rgba(8, 18, 42, 0.74);
 }
 
-.badgeItem--medium::before {
+.legacy-shell .badgeItem--medium::before {
   background: linear-gradient(90deg, rgba(251, 191, 36, 0.95), rgba(245, 158, 11, 0.88));
 }
 
-.badgeItem--high {
+.legacy-shell .badgeItem--high {
   border-color: rgba(248, 113, 113, 0.34);
   background:
     linear-gradient(180deg, rgba(66, 24, 26, 0.62) 0%, rgba(7, 16, 35, 0.98) 100%),
     rgba(8, 18, 42, 0.74);
 }
 
-.badgeItem--high::before {
+.legacy-shell .badgeItem--high::before {
   background: linear-gradient(90deg, rgba(248, 113, 113, 0.95), rgba(239, 68, 68, 0.88));
 }
 
-.badgeItem--neutral::before {
+.legacy-shell .badgeItem--neutral::before {
   background: rgba(125, 145, 189, 0.55);
 }
 
-.badgeTone--low {
+.legacy-shell .badgeTone--low {
   background: rgba(16, 185, 129, 0.16);
   color: #8df0c1;
   border: 1px solid rgba(52, 211, 153, 0.24);
 }
 
-.badgeTone--medium {
+.legacy-shell .badgeTone--medium {
   background: rgba(245, 158, 11, 0.16);
   color: #ffd48a;
   border: 1px solid rgba(245, 158, 11, 0.24);
 }
 
-.badgeTone--high {
+.legacy-shell .badgeTone--high {
   background: rgba(239, 68, 68, 0.16);
   color: #ffb0b0;
   border: 1px solid rgba(248, 113, 113, 0.24);
 }
 
-.badgeTone--neutral {
+.legacy-shell .badgeTone--neutral {
   background: rgba(125, 145, 189, 0.12);
   color: #c9d7f8;
   border: 1px solid rgba(125, 145, 189, 0.22);
 }
 
-.deltaHighlight {
+.legacy-shell .deltaHighlight {
   margin-top: 0.9rem;
   padding: 0.9rem 0.95rem;
   border-radius: 14px;
@@ -399,7 +398,7 @@ textarea:focus {
   background: linear-gradient(180deg, rgba(14, 25, 52, 0.86) 0%, rgba(9, 17, 36, 0.96) 100%);
 }
 
-.deltaLabel {
+.legacy-shell .deltaLabel {
   display: block;
   margin-bottom: 0.45rem;
   color: #9eb0d4;
@@ -408,65 +407,62 @@ textarea:focus {
   letter-spacing: 0.08em;
 }
 
-.deltaValueRow {
+.legacy-shell .deltaValueRow {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: 0.8rem;
 }
 
-.deltaValueRow strong {
+.legacy-shell .deltaValueRow strong {
   font-size: 1.42rem;
   letter-spacing: -0.04em;
 }
 
-.deltaValueRow span {
+.legacy-shell .deltaValueRow span {
   font-size: 0.92rem;
   font-weight: 700;
 }
 
-.deltaMeta {
+.legacy-shell .deltaMeta {
   margin: 0.45rem 0 0;
   color: #bfd0f1;
   font-size: 0.82rem;
 }
 
-.deltaHighlight--up {
+.legacy-shell .deltaHighlight--up {
   border-color: rgba(52, 211, 153, 0.34);
   background: linear-gradient(180deg, rgba(8, 44, 35, 0.52) 0%, rgba(9, 17, 36, 0.96) 100%);
 }
 
-.deltaHighlight--up .deltaValueRow strong,
-.deltaHighlight--up .deltaValueRow span {
+.legacy-shell .deltaHighlight--up .deltaValueRow strong, .legacy-shell .deltaHighlight--up .deltaValueRow span {
   color: #8df0c1;
 }
 
-.deltaHighlight--down {
+.legacy-shell .deltaHighlight--down {
   border-color: rgba(248, 113, 113, 0.34);
   background: linear-gradient(180deg, rgba(66, 24, 26, 0.54) 0%, rgba(9, 17, 36, 0.96) 100%);
 }
 
-.deltaHighlight--down .deltaValueRow strong,
-.deltaHighlight--down .deltaValueRow span {
+.legacy-shell .deltaHighlight--down .deltaValueRow strong, .legacy-shell .deltaHighlight--down .deltaValueRow span {
   color: #ffb0b0;
 }
 
-.deltaHighlight--flat {
+.legacy-shell .deltaHighlight--flat {
   border-color: rgba(96, 165, 250, 0.28);
 }
 
-.deltaHighlight--flat .deltaValueRow strong,
-.deltaHighlight--flat .deltaValueRow span {
+.legacy-shell .deltaHighlight--flat .deltaValueRow strong, .legacy-shell .deltaHighlight--flat .deltaValueRow span {
   color: #b8c9ea;
 }
 
-.evaluationGrid {
+.legacy-shell .evaluationGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.9rem;
 }
 
-.evaluationItem {
+.legacy-shell .evaluationItem {
   position: relative;
   border-radius: 14px;
   padding: 0.95rem 1rem;
@@ -475,7 +471,7 @@ textarea:focus {
   min-height: 156px;
 }
 
-.evaluationItem::before {
+.legacy-shell .evaluationItem::before {
   content: "";
   position: absolute;
   inset: 0 0 auto 0;
@@ -484,7 +480,7 @@ textarea:focus {
   background: rgba(125, 145, 189, 0.55);
 }
 
-.evaluationLabel {
+.legacy-shell .evaluationLabel {
   display: block;
   color: #9eb0d4;
   font-size: 0.74rem;
@@ -493,54 +489,54 @@ textarea:focus {
   margin-bottom: 0.55rem;
 }
 
-.evaluationItem strong {
+.legacy-shell .evaluationItem strong {
   display: block;
   font-size: 1.02rem;
   line-height: 1.35;
 }
 
-.evaluationValue {
+.legacy-shell .evaluationValue {
   margin: 0.55rem 0 0;
   color: #edf4ff;
   font-size: 0.95rem;
   font-weight: 600;
 }
 
-.evaluationMeta {
+.legacy-shell .evaluationMeta {
   margin: 0.45rem 0 0;
   color: #b5c6ea;
   font-size: 0.8rem;
   line-height: 1.4;
 }
 
-.evaluationItem--good {
+.legacy-shell .evaluationItem--good {
   border-color: rgba(52, 211, 153, 0.28);
   background: linear-gradient(180deg, rgba(7, 41, 34, 0.62) 0%, rgba(8, 16, 34, 0.98) 100%);
 }
 
-.evaluationItem--good::before {
+.legacy-shell .evaluationItem--good::before {
   background: linear-gradient(90deg, rgba(74, 222, 128, 0.95), rgba(16, 185, 129, 0.85));
 }
 
-.evaluationItem--caution {
+.legacy-shell .evaluationItem--caution {
   border-color: rgba(245, 158, 11, 0.3);
   background: linear-gradient(180deg, rgba(61, 37, 10, 0.62) 0%, rgba(8, 16, 34, 0.98) 100%);
 }
 
-.evaluationItem--caution::before {
+.legacy-shell .evaluationItem--caution::before {
   background: linear-gradient(90deg, rgba(251, 191, 36, 0.95), rgba(245, 158, 11, 0.88));
 }
 
-.evaluationItem--danger {
+.legacy-shell .evaluationItem--danger {
   border-color: rgba(248, 113, 113, 0.3);
   background: linear-gradient(180deg, rgba(64, 24, 26, 0.62) 0%, rgba(8, 16, 34, 0.98) 100%);
 }
 
-.evaluationItem--danger::before {
+.legacy-shell .evaluationItem--danger::before {
   background: linear-gradient(90deg, rgba(248, 113, 113, 0.95), rgba(239, 68, 68, 0.88));
 }
 
-button {
+.legacy-shell button {
   border: none;
   border-radius: 0.5rem;
   padding: 0.7rem 1rem;
@@ -550,18 +546,18 @@ button {
   cursor: pointer;
 }
 
-button:disabled {
+.legacy-shell button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
-.error {
+.legacy-shell .error {
   color: var(--danger);
   font-weight: 600;
   margin: 0.2rem 0 1rem;
 }
 
-pre {
+.legacy-shell pre {
   background: #0a1120;
   color: #c9d7f5;
   padding: 0.75rem;
@@ -570,22 +566,16 @@ pre {
 }
 
 @media (max-width: 760px) {
-  .resultGrid,
-  .controlRow,
-  .metadataGrid,
-  .badgeGrid,
-  .evaluationGrid {
+  .legacy-shell .resultGrid, .legacy-shell .controlRow, .legacy-shell .metadataGrid, .legacy-shell .badgeGrid, .legacy-shell .evaluationGrid {
     grid-template-columns: 1fr;
   }
 
-  .toggleRow,
-  .actionRow {
+  .legacy-shell .toggleRow, .legacy-shell .actionRow {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .badgeHeader,
-  .deltaValueRow {
+  .legacy-shell .badgeHeader, .legacy-shell .deltaValueRow {
     flex-direction: column;
     align-items: flex-start;
   }

--- a/frontend/tests/components/analyze/AnalyzeForm.test.tsx
+++ b/frontend/tests/components/analyze/AnalyzeForm.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { AnalyzeForm } from "@/components/analyze/AnalyzeForm";
+import type { AnalyzeRequest } from "@/lib/analyze/types";
+
+function baseRequest(): AnalyzeRequest {
+  return {
+    text: "Recent indicators…",
+    date: "2024-09-18",
+    symbol: "^GSPC",
+    forecast_mode: "fast",
+    horizon: "3d",
+    include_realized: false,
+  };
+}
+
+describe("AnalyzeForm", () => {
+  it("renders core fields with current values", () => {
+    render(
+      <AnalyzeForm value={baseRequest()} onChange={vi.fn()} onSubmit={vi.fn()} loading={false} />
+    );
+    expect(screen.getByLabelText("FOMC text")).toHaveValue("Recent indicators…");
+    expect(screen.getByLabelText("Document date")).toHaveValue("2024-09-18");
+    expect(screen.getByRole("button", { name: /analyze/i })).toBeEnabled();
+  });
+
+  it("calls onChange when the text is edited", () => {
+    const onChange = vi.fn();
+    render(
+      <AnalyzeForm value={baseRequest()} onChange={onChange} onSubmit={vi.fn()} loading={false} />
+    );
+    fireEvent.change(screen.getByLabelText("FOMC text"), { target: { value: "Updated text" } });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ text: "Updated text" }));
+  });
+
+  it("calls onSubmit on form submission", () => {
+    const onSubmit = vi.fn();
+    render(
+      <AnalyzeForm value={baseRequest()} onChange={vi.fn()} onSubmit={onSubmit} loading={false} />
+    );
+    fireEvent.submit(screen.getByLabelText("FOMC text").closest("form")!);
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it("shows real-train submit label while loading", () => {
+    render(
+      <AnalyzeForm
+        value={{ ...baseRequest(), forecast_mode: "real_train" }}
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        loading
+      />
+    );
+    expect(screen.getByRole("button", { name: /running real train/i })).toBeDisabled();
+  });
+});

--- a/frontend/tests/components/analyze/CredibilityPanel.test.tsx
+++ b/frontend/tests/components/analyze/CredibilityPanel.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { CredibilityPanel } from "@/components/analyze/CredibilityPanel";
+import { SAMPLE_CREDIBILITY } from "@/lib/analyze/fixtures";
+
+describe("CredibilityPanel", () => {
+  it("renders the four credibility surface items from the fixture", () => {
+    render(<CredibilityPanel credibility={SAMPLE_CREDIBILITY} />);
+    expect(screen.getByText(/drift vs. prior 4 statements/i)).toBeInTheDocument();
+    expect(screen.getByText(/realized vs\. stated/i)).toBeInTheDocument();
+    expect(screen.getByText(/market-implied gap/i)).toBeInTheDocument();
+    expect(screen.getByText(/since reversal/i)).toBeInTheDocument();
+    expect(screen.getByText(/14 mo/)).toBeInTheDocument();
+  });
+
+  it("handles a sparse credibility payload without crashing", () => {
+    render(<CredibilityPanel credibility={{ driftScore: 0.5 }} />);
+    expect(screen.getAllByText(/—/).length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/frontend/tests/components/analyze/ErrorBadges.test.tsx
+++ b/frontend/tests/components/analyze/ErrorBadges.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { ErrorBadges } from "@/components/analyze/ErrorBadges";
+import type { AnalyzeResult } from "@/lib/analyze/types";
+
+const result: AnalyzeResult = {
+  prediction: { close: 5050, volatility: 0.012 },
+  market: { close: 5000, volatility_5d: 0.01 },
+};
+
+describe("ErrorBadges", () => {
+  it("shows enable-overlay hint when there is no realized data", () => {
+    render(
+      <ErrorBadges
+        result={result}
+        metrics={{ close: { mape: null, rmse: null }, vol: { mape: null, rmse: null }, hasRealized: false }}
+      />
+    );
+    expect(screen.getByText(/realized overlay/i)).toBeInTheDocument();
+  });
+
+  it("renders MAPE and RMSE values when realized data exists", () => {
+    render(
+      <ErrorBadges
+        result={result}
+        metrics={{
+          close: { mape: 1.4, rmse: 12 },
+          vol: { mape: 6.2, rmse: 0.0012 },
+          hasRealized: true,
+        }}
+      />
+    );
+    expect(screen.getByText("1.40%")).toBeInTheDocument();
+    expect(screen.getByText("12.0000")).toBeInTheDocument();
+    expect(screen.getByText("6.20%")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/analyze/MultiAxisCards.test.tsx
+++ b/frontend/tests/components/analyze/MultiAxisCards.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { MultiAxisCards } from "@/components/analyze/MultiAxisCards";
+import { SAMPLE_MULTI_AXIS } from "@/lib/analyze/fixtures";
+
+describe("MultiAxisCards", () => {
+  it("renders four cards from the canonical fixture", () => {
+    render(<MultiAxisCards multiAxis={SAMPLE_MULTI_AXIS} />);
+    expect(screen.getAllByText(/^stance$/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/^factor$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^certainty$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^topic$/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/hawkish/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/inflation persistence/i)).toBeInTheDocument();
+  });
+
+  it("returns null when every axis is undefined", () => {
+    const { container } = render(<MultiAxisCards multiAxis={{}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("hides factor card when factor is absent", () => {
+    render(<MultiAxisCards multiAxis={{ stance: SAMPLE_MULTI_AXIS.stance }} />);
+    expect(screen.queryByText(/^factor$/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/^stance$/i).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/tests/components/analyze/PredictionCards.test.tsx
+++ b/frontend/tests/components/analyze/PredictionCards.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { PredictionCards } from "@/components/analyze/PredictionCards";
+import type { AnalyzeResult } from "@/lib/analyze/types";
+
+describe("PredictionCards", () => {
+  it("renders predicted close with positive delta vs spot", () => {
+    const result: AnalyzeResult = {
+      prediction: { close: 5050, volatility: 0.012, horizon: "3d" },
+      market: { close: 5000 },
+      series: {
+        history_close: [4900, 5000],
+        forecast_close: [5050],
+      },
+    };
+    const { container } = render(<PredictionCards result={result} />);
+    expect(screen.getByText(/\$5,050/)).toBeInTheDocument();
+    expect(screen.getByText(/\+\$50/)).toBeInTheDocument();
+    expect(container.textContent).toMatch(/horizon 3d/i);
+  });
+
+  it("renders volatility as percent", () => {
+    const result: AnalyzeResult = {
+      prediction: { close: 5000, volatility: 0.02, horizon: "5d" },
+      market: { close: 5000 },
+    };
+    render(<PredictionCards result={result} />);
+    expect(screen.getByText(/2\.00%/)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/analyze/SentimentCard.test.tsx
+++ b/frontend/tests/components/analyze/SentimentCard.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { SentimentCard } from "@/components/analyze/SentimentCard";
+
+describe("SentimentCard", () => {
+  it("renders a hawkish stance with score", () => {
+    render(<SentimentCard sentiment={{ label: "HAWKISH", score: 0.81 }} />);
+    expect(screen.getAllByText(/hawkish/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/0\.810/)).toBeInTheDocument();
+  });
+
+  it("falls back to Unknown when label is missing", () => {
+    render(<SentimentCard sentiment={undefined} />);
+    expect(screen.getAllByText(/unknown/i).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/tests/components/analyze/XaiPanel.test.tsx
+++ b/frontend/tests/components/analyze/XaiPanel.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { XaiPanel } from "@/components/analyze/XaiPanel";
+import { SAMPLE_XAI } from "@/lib/analyze/fixtures";
+
+describe("XaiPanel", () => {
+  it("renders the title and one chip per sentence", () => {
+    render(<XaiPanel xai={SAMPLE_XAI} />);
+    expect(screen.getByText(/sentence attribution/i)).toBeInTheDocument();
+    for (const sentence of SAMPLE_XAI.sentences) {
+      expect(screen.getByText(sentence.text)).toBeInTheDocument();
+    }
+  });
+
+  it("returns null when there are no sentences", () => {
+    const { container } = render(<XaiPanel xai={{ sentences: [] }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the integrated-gradients method label", () => {
+    render(<XaiPanel xai={SAMPLE_XAI} />);
+    expect(screen.getByText(/integrated_gradients/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/analyze/XaiPanel.test.tsx
+++ b/frontend/tests/components/analyze/XaiPanel.test.tsx
@@ -2,11 +2,16 @@ import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 import { XaiPanel } from "@/components/analyze/XaiPanel";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { SAMPLE_XAI } from "@/lib/analyze/fixtures";
+
+function renderWithTooltip(node: React.ReactNode) {
+  return render(<TooltipProvider>{node}</TooltipProvider>);
+}
 
 describe("XaiPanel", () => {
   it("renders the title and one chip per sentence", () => {
-    render(<XaiPanel xai={SAMPLE_XAI} />);
+    renderWithTooltip(<XaiPanel xai={SAMPLE_XAI} />);
     expect(screen.getByText(/sentence attribution/i)).toBeInTheDocument();
     for (const sentence of SAMPLE_XAI.sentences) {
       expect(screen.getByText(sentence.text)).toBeInTheDocument();
@@ -14,12 +19,12 @@ describe("XaiPanel", () => {
   });
 
   it("returns null when there are no sentences", () => {
-    const { container } = render(<XaiPanel xai={{ sentences: [] }} />);
-    expect(container).toBeEmptyDOMElement();
+    const { container } = renderWithTooltip(<XaiPanel xai={{ sentences: [] }} />);
+    expect(container.firstChild?.firstChild ?? null).toBeNull();
   });
 
   it("shows the integrated-gradients method label", () => {
-    render(<XaiPanel xai={SAMPLE_XAI} />);
+    renderWithTooltip(<XaiPanel xai={SAMPLE_XAI} />);
     expect(screen.getByText(/integrated_gradients/i)).toBeInTheDocument();
   });
 });

--- a/frontend/tests/lib/analyze/derive.test.ts
+++ b/frontend/tests/lib/analyze/derive.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAttention,
+  buildCloseSeries,
+  buildVolatilitySeries,
+  computeCurrentSpotBandCheck,
+  computeErrorMetrics,
+  computeRealizedBandCheck,
+} from "@/lib/analyze/derive";
+import type { AnalyzeResult } from "@/lib/analyze/types";
+
+const baseResult: AnalyzeResult = {
+  market: { close: 5050, volatility_5d: 0.01 },
+  prediction: { close: 5050, volatility: 0.012, horizon: "3d" },
+  sentiment: { label: "HAWKISH", score: 0.81 },
+  series: {
+    timestamps: ["2024-09-15", "2024-09-16", "2024-09-17"],
+    history_close: [4900, 4950, 5000],
+    history_volatility: [0.011, 0.012, 0.01],
+    forecast_timestamps: ["2024-09-18", "2024-09-19", "2024-09-20"],
+    forecast_close: [5025, 5040, 5050],
+    forecast_close_lower: [5000, 5015, 5020],
+    forecast_close_upper: [5060, 5070, 5080],
+    forecast_volatility: [0.011, 0.012, 0.012],
+    forecast_volatility_lower: [0.009, 0.01, 0.01],
+    forecast_volatility_upper: [0.014, 0.015, 0.016],
+    realized_timestamps: ["2024-09-18", "2024-09-19"],
+    realized_close: [5030, 5045],
+    realized_volatility: [0.012, 0.013],
+    forecast_confidence_level: 0.8,
+    volatility_scale: { suggested_ymin: 0.0, suggested_ymax: 0.05 },
+  },
+};
+
+describe("buildCloseSeries", () => {
+  it("merges history, forecast and realized by timestamp", () => {
+    const rows = buildCloseSeries(baseResult);
+    expect(rows.map((r) => r.timestamp)).toEqual([
+      "2024-09-15",
+      "2024-09-16",
+      "2024-09-17",
+      "2024-09-18",
+      "2024-09-19",
+      "2024-09-20",
+    ]);
+    const sept18 = rows.find((r) => r.timestamp === "2024-09-18");
+    expect(sept18?.forecast).toBe(5025);
+    expect(sept18?.forecastBand).toBe(60);
+    expect(sept18?.realized).toBe(5030);
+    const sept17 = rows.find((r) => r.timestamp === "2024-09-17");
+    expect(sept17?.history).toBe(5000);
+    expect(sept17?.forecast).toBeNull();
+  });
+
+  it("returns empty array when there is no series", () => {
+    expect(buildCloseSeries(null)).toEqual([]);
+    expect(buildCloseSeries({})).toEqual([]);
+  });
+});
+
+describe("buildVolatilitySeries", () => {
+  it("uses the volatility fields", () => {
+    const rows = buildVolatilitySeries(baseResult);
+    const sept18 = rows.find((r) => r.timestamp === "2024-09-18");
+    expect(sept18?.forecast).toBeCloseTo(0.011);
+    expect(sept18?.realized).toBeCloseTo(0.012);
+  });
+});
+
+describe("computeErrorMetrics", () => {
+  it("computes MAPE and RMSE on overlapping timestamps", () => {
+    const bundle = computeErrorMetrics(baseResult);
+    expect(bundle.hasRealized).toBe(true);
+    expect(bundle.close.mape).not.toBeNull();
+    expect(bundle.close.rmse).not.toBeNull();
+    expect(bundle.vol.mape).not.toBeNull();
+  });
+
+  it("returns empty bundle when no realized data overlaps", () => {
+    const bundle = computeErrorMetrics({
+      series: {
+        forecast_timestamps: ["2024-09-18"],
+        forecast_close: [5000],
+        realized_timestamps: [],
+        realized_close: [],
+      },
+    });
+    expect(bundle.hasRealized).toBe(false);
+    expect(bundle.close.mape).toBeNull();
+  });
+});
+
+describe("band checks", () => {
+  it("computeCurrentSpotBandCheck identifies in-band spot", () => {
+    const check = computeCurrentSpotBandCheck(baseResult);
+    expect(check).not.toBeNull();
+    expect(check?.withinBand).toBe(true);
+    expect(check?.tone).toBe("good");
+  });
+
+  it("computeRealizedBandCheck identifies out-of-band realized", () => {
+    const result: AnalyzeResult = {
+      ...baseResult,
+      series: {
+        ...baseResult.series,
+        realized_timestamps: ["2024-09-19"],
+        realized_close: [5400],
+      },
+    };
+    const check = computeRealizedBandCheck(result);
+    expect(check).not.toBeNull();
+    expect(check?.withinBand).toBe(false);
+    expect(["caution", "danger"]).toContain(check?.tone);
+  });
+});
+
+describe("buildAttention", () => {
+  it("returns null when chunk attention is missing", () => {
+    expect(buildAttention(baseResult)).toBeNull();
+  });
+
+  it("normalizes weights and decay coefficients", () => {
+    const bundle = buildAttention({
+      model: {
+        chunk_attention: {
+          weights: [0.4, 0.6],
+          decay_coeffs: [0.9, 0.5],
+          chunk_previews: ["alpha statement", "beta passage"],
+          lambda_value: 0.05,
+          chunk_count: 2,
+        },
+      },
+    });
+    expect(bundle).not.toBeNull();
+    expect(bundle?.rows).toHaveLength(2);
+    expect(bundle?.rows[0].weightPct).toBe("40.0");
+    expect(bundle?.lambdaValue).toBeCloseTo(0.05);
+  });
+});

--- a/frontend/tests/lib/analyze/format.test.ts
+++ b/frontend/tests/lib/analyze/format.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  errorToneLabel,
+  formatPercentDelta,
+  formatPrice,
+  formatPriceDelta,
+  formatVol,
+  getErrorTone,
+  normalizeTimestamp,
+  stanceLabel,
+  toNumericOrNull,
+  toStance,
+} from "@/lib/analyze/format";
+
+describe("format helpers", () => {
+  it("toNumericOrNull returns null for non-numeric", () => {
+    expect(toNumericOrNull("abc")).toBeNull();
+    expect(toNumericOrNull(null)).toBeNull();
+    expect(toNumericOrNull(undefined)).toBeNull();
+  });
+
+  it("toNumericOrNull parses numeric strings", () => {
+    expect(toNumericOrNull("4.5")).toBe(4.5);
+  });
+
+  it("normalizeTimestamp strips trailing timezone offset", () => {
+    expect(normalizeTimestamp("2024-09-18T00:00:00+00:00")).toBe("2024-09-18T00:00:00");
+    expect(normalizeTimestamp(null)).toBe("");
+  });
+
+  it("toStance maps known labels", () => {
+    expect(toStance("HAWKISH")).toBe("hawkish");
+    expect(toStance("LABEL_0")).toBe("dovish");
+    expect(toStance("Neutral")).toBe("neutral");
+    expect(toStance("???")).toBe("unknown");
+  });
+
+  it("stanceLabel renders human-readable form", () => {
+    expect(stanceLabel("hawkish")).toBe("Hawkish");
+    expect(stanceLabel("unknown")).toBe("Unknown");
+  });
+
+  it("formatters guard against non-numeric input", () => {
+    expect(formatPrice(null)).toBe("N/A");
+    expect(formatPriceDelta(undefined)).toBe("N/A");
+    expect(formatPercentDelta(NaN)).toBe("N/A");
+    expect(formatVol(null)).toBe("N/A");
+  });
+
+  it("formatPriceDelta keeps sign", () => {
+    expect(formatPriceDelta(5)).toBe("+$5");
+    expect(formatPriceDelta(-2.5)).toBe("-$2.5");
+  });
+
+  it("getErrorTone bins by magnitude", () => {
+    expect(getErrorTone("mape", 1.5)).toBe("low");
+    expect(getErrorTone("mape", 3)).toBe("medium");
+    expect(getErrorTone("mape", 8)).toBe("high");
+    expect(getErrorTone("rmse", null)).toBe("neutral");
+    expect(getErrorTone("rmse", 30, 5000)).toBe("low");
+    expect(errorToneLabel("medium")).toBe("Medium error");
+  });
+});

--- a/frontend/tests/pages/index-redirect.test.ts
+++ b/frontend/tests/pages/index-redirect.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { getServerSideProps } from "@/pages/index";
+
+describe("pages/index getServerSideProps", () => {
+  it("redirects / to /analyze", async () => {
+    const result = await getServerSideProps({} as Parameters<typeof getServerSideProps>[0]);
+    expect(result).toEqual({
+      redirect: { destination: "/analyze", permanent: false },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Subsumes #66. Moves legacy `pages/index.js` → `pages/legacy.jsx` and scopes its CSS under `.legacy-shell` so other routes are unaffected.
- New `pages/index.tsx` server-redirects `/` to `/analyze`.
- Three new panels on `/analyze`: multi-axis cards (stance / factor / certainty / topic), sentence-attribution XAI panel, central-bank credibility panel.
- Panels render from backend response when present, fall back to fixtures behind a `Preview v2` toggle until the v2 endpoints land.
- Adds dialog, tooltip, progress shadcn primitives.

## Test plan
- [x] `npm run type-check`
- [x] `npm test` (58 tests)
- [x] `npm run build`