### PR TITLE
Add history, FOMC calendar, and asset watchlist

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+from sqlalchemy import (
+    JSON,
+    Column,
+    DateTime,
+    Float,
+    Index,
+    String,
+    Text,
+    create_engine,
+    delete,
+    select,
+)
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+from app.config import settings
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class AnalysisRun(Base):
+    __tablename__ = "analysis_runs"
+
+    id = Column(String(36), primary_key=True)
+    created_at = Column(DateTime(timezone=True), nullable=False)
+    symbol = Column(String(32), nullable=False, index=True)
+    document_date = Column(String(10), nullable=False, index=True)
+    horizon = Column(String(8), nullable=False, index=True)
+    forecast_mode = Column(String(16), nullable=False)
+    stance = Column(String(16), nullable=False, index=True)
+    sentiment_score = Column(Float, nullable=True)
+    predicted_close = Column(Float, nullable=True)
+    current_close = Column(Float, nullable=True)
+    predicted_volatility = Column(Float, nullable=True)
+    payload = Column(JSON, nullable=False)
+    text_excerpt = Column(Text, nullable=True)
+
+    __table_args__ = (Index("ix_analysis_runs_created_symbol", "created_at", "symbol"),)
+
+    def to_summary(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "created_at": _isoformat(self.created_at),
+            "symbol": self.symbol,
+            "document_date": self.document_date,
+            "horizon": self.horizon,
+            "forecast_mode": self.forecast_mode,
+            "stance": self.stance,
+            "sentiment_score": self.sentiment_score,
+            "predicted_close": self.predicted_close,
+            "current_close": self.current_close,
+            "predicted_volatility": self.predicted_volatility,
+            "text_excerpt": self.text_excerpt,
+        }
+
+    def to_detail(self) -> dict[str, Any]:
+        summary = self.to_summary()
+        summary["payload"] = self.payload
+        return summary
+
+
+def _isoformat(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _resolve_database_url(database_url: str | None) -> tuple[str, Path | None]:
+    if database_url:
+        return database_url, None
+    data_dir = Path(settings.data_dir)
+    db_dir = data_dir / "db"
+    db_path = db_dir / "fed_pulse.db"
+    return f"sqlite:///{db_path}", db_path
+
+
+_engine: Engine | None = None
+_SessionLocal: sessionmaker[Session] | None = None
+
+
+def get_engine(database_url: str | None = None) -> Engine:
+    global _engine, _SessionLocal
+    if _engine is not None and database_url is None:
+        return _engine
+    url, db_path = _resolve_database_url(database_url)
+    if db_path is not None:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+    engine = create_engine(url, future=True)
+    Base.metadata.create_all(engine)
+    if database_url is None:
+        _engine = engine
+        _SessionLocal = sessionmaker(bind=engine, expire_on_commit=False, autoflush=False)
+    return engine
+
+
+def get_session() -> Iterator[Session]:
+    if _SessionLocal is None:
+        get_engine()
+    assert _SessionLocal is not None
+    session = _SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def reset_for_testing(database_url: str) -> Engine:
+    global _engine, _SessionLocal
+    _engine = create_engine(database_url, future=True)
+    Base.metadata.drop_all(_engine)
+    Base.metadata.create_all(_engine)
+    _SessionLocal = sessionmaker(bind=_engine, expire_on_commit=False, autoflush=False)
+    return _engine
+
+
+def persist_analysis_run(
+    session: Session,
+    *,
+    payload: dict[str, Any],
+    request: dict[str, Any],
+    response: dict[str, Any],
+) -> AnalysisRun:
+    stance = (response.get("sentiment", {}) or {}).get("label") or "unknown"
+    market = response.get("market", {}) or {}
+    prediction = response.get("prediction", {}) or {}
+    sentiment = response.get("sentiment", {}) or {}
+    excerpt = request.get("text", "")
+    if isinstance(excerpt, str) and len(excerpt) > 280:
+        excerpt = excerpt[:280] + "…"
+    record = AnalysisRun(
+        id=str(uuid.uuid4()),
+        created_at=datetime.now(timezone.utc),
+        symbol=market.get("symbol") or request.get("symbol", "unknown"),
+        document_date=request.get("date", ""),
+        horizon=request.get("horizon", ""),
+        forecast_mode=request.get("forecast_mode", ""),
+        stance=str(stance).lower(),
+        sentiment_score=_coerce_float(sentiment.get("score")),
+        predicted_close=_coerce_float(prediction.get("close")),
+        current_close=_coerce_float(market.get("close")),
+        predicted_volatility=_coerce_float(prediction.get("volatility")),
+        payload=payload,
+        text_excerpt=excerpt or None,
+    )
+    session.add(record)
+    session.commit()
+    session.refresh(record)
+    return record
+
+
+def list_runs(
+    session: Session,
+    *,
+    limit: int,
+    offset: int,
+    symbol: str | None = None,
+    horizon: str | None = None,
+    stance: str | None = None,
+    document_date: str | None = None,
+) -> tuple[list[AnalysisRun], int]:
+    stmt = select(AnalysisRun)
+    if symbol:
+        stmt = stmt.where(AnalysisRun.symbol == symbol)
+    if horizon:
+        stmt = stmt.where(AnalysisRun.horizon == horizon)
+    if stance:
+        stmt = stmt.where(AnalysisRun.stance == stance.lower())
+    if document_date:
+        stmt = stmt.where(AnalysisRun.document_date == document_date)
+
+    count_stmt = stmt.with_only_columns(AnalysisRun.id).order_by(None)
+    total = session.execute(count_stmt).scalars().all()
+    total_count = len(total)
+
+    stmt = stmt.order_by(AnalysisRun.created_at.desc()).limit(limit).offset(offset)
+    rows = list(session.execute(stmt).scalars().all())
+    return rows, total_count
+
+
+def get_run(session: Session, run_id: str) -> AnalysisRun | None:
+    return session.get(AnalysisRun, run_id)
+
+
+def delete_run(session: Session, run_id: str) -> bool:
+    result = session.execute(delete(AnalysisRun).where(AnalysisRun.id == run_id))
+    session.commit()
+    return result.rowcount > 0
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if result == result else None  # rejects NaN
+
+
+def serialise_payload(model: Any) -> dict[str, Any]:
+    if hasattr(model, "model_dump"):
+        return model.model_dump(mode="json")
+    return json.loads(json.dumps(model, default=str))

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
@@ -106,6 +107,25 @@ def get_engine(database_url: str | None = None) -> Engine:
 
 
 def get_session() -> Iterator[Session]:
+    if _SessionLocal is None:
+        get_engine()
+    assert _SessionLocal is not None
+    session = _SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    """Manual session helper for code paths outside FastAPI's ``Depends``.
+
+    Use this when persisting from a background thread or a hook (e.g.
+    ``_record_history``) so the ``finally`` cleanup always runs even when the
+    body raises before the second ``next()`` of the generator.
+    """
+
     if _SessionLocal is None:
         get_engine()
     assert _SessionLocal is not None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import threading
 import uuid
 from datetime import date, datetime, timezone
@@ -16,7 +17,10 @@ from app.db import (
     get_session,
     list_runs,
     persist_analysis_run,
+    session_scope,
 )
+
+logger = logging.getLogger(__name__)
 from app.schemas import (
     AnalyzeRequest,
     AnalyzeResponse,
@@ -273,23 +277,23 @@ def get_train_job(job_id: str):
 
 
 def _record_history(request: AnalyzeRequest, response: dict[str, Any]) -> None:
+    # Persistence must not break /analyze; log so silent failures (disk full,
+    # missing table, etc.) still show up in uvicorn output.
     try:
-        session_iter = get_session()
-        session = next(session_iter)
-        try:
+        with session_scope() as session:
             persist_analysis_run(
                 session,
                 payload=response,
                 request=request.model_dump(),
                 response=response,
             )
-        finally:
-            try:
-                next(session_iter)
-            except StopIteration:
-                pass
-    except Exception:  # pragma: no cover — never let history persistence break /analyze
-        pass
+    except Exception:
+        logger.warning(
+            "history persistence failed for symbol=%s date=%s",
+            request.symbol,
+            request.date,
+            exc_info=True,
+        )
 
 
 @app.get("/history", response_model=HistoryList)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,14 +1,33 @@
 import json
 import threading
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy.orm import Session
 
 from app.config import DATA_DIR
-from app.schemas import AnalyzeRequest, AnalyzeResponse, TrainJobAcceptedResponse, TrainJobStatusResponse
+from app.db import (
+    delete_run,
+    get_engine,
+    get_run,
+    get_session,
+    list_runs,
+    persist_analysis_run,
+)
+from app.schemas import (
+    AnalyzeRequest,
+    AnalyzeResponse,
+    FomcCalendarResponse,
+    HistoryDetail,
+    HistoryEntry,
+    HistoryList,
+    TrainJobAcceptedResponse,
+    TrainJobStatusResponse,
+)
+from app.services.fomc_calendar import get_calendar
 from app.services.forecaster import (
     bootstrap_checkpoint,
     build_feature_vectors,
@@ -37,6 +56,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.on_event("startup")
+def _initialise_db() -> None:
+    get_engine()
 
 
 @app.get("/health")
@@ -161,6 +185,7 @@ def _run_real_train_job(job_id: str, payload: AnalyzeRequest) -> None:
             early_stopping_patience=12,
         )
         result = _build_analyze_response(payload, mode="real_train", history_length=REAL_TRAIN_HISTORY_LENGTH)
+        _record_history(payload, result)
         _set_job_state(
             job_id,
             status="succeeded",
@@ -229,7 +254,9 @@ def analyze(payload: AnalyzeRequest):
                 early_stopping_patience=8,
             )
 
-        return _build_analyze_response(payload, mode=mode, history_length=history_length)
+        response = _build_analyze_response(payload, mode=mode, history_length=history_length)
+        _record_history(payload, response)
+        return response
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover
@@ -243,3 +270,81 @@ def get_train_job(job_id: str):
         if state is None:
             raise HTTPException(status_code=404, detail=f"Train job not found: {job_id}")
         return dict(state)
+
+
+def _record_history(request: AnalyzeRequest, response: dict[str, Any]) -> None:
+    try:
+        session_iter = get_session()
+        session = next(session_iter)
+        try:
+            persist_analysis_run(
+                session,
+                payload=response,
+                request=request.model_dump(),
+                response=response,
+            )
+        finally:
+            try:
+                next(session_iter)
+            except StopIteration:
+                pass
+    except Exception:  # pragma: no cover — never let history persistence break /analyze
+        pass
+
+
+@app.get("/history", response_model=HistoryList)
+def get_history(
+    symbol: str | None = Query(default=None),
+    horizon: str | None = Query(default=None),
+    stance: str | None = Query(default=None),
+    document_date: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    session: Session = Depends(get_session),
+) -> HistoryList:
+    rows, total = list_runs(
+        session,
+        limit=limit,
+        offset=offset,
+        symbol=symbol,
+        horizon=horizon,
+        stance=stance,
+        document_date=document_date,
+    )
+    items = [HistoryEntry(**row.to_summary()) for row in rows]
+    return HistoryList(items=items, total=total, limit=limit, offset=offset)
+
+
+@app.get("/history/{run_id}", response_model=HistoryDetail)
+def get_history_run(run_id: str, session: Session = Depends(get_session)) -> HistoryDetail:
+    row = get_run(session, run_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+    return HistoryDetail(**row.to_detail())
+
+
+@app.delete("/history/{run_id}", status_code=204)
+def delete_history_run(run_id: str, session: Session = Depends(get_session)) -> None:
+    if not delete_run(session, run_id):
+        raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+
+
+@app.get("/fomc/calendar", response_model=FomcCalendarResponse)
+def fomc_calendar(
+    upcoming_limit: int = Query(default=12, ge=1, le=60),
+    past_limit: int = Query(default=12, ge=0, le=60),
+    as_of: str | None = Query(default=None, description="YYYY-MM-DD; defaults to today"),
+) -> FomcCalendarResponse:
+    reference: date | None = None
+    if as_of:
+        try:
+            reference = date.fromisoformat(as_of)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail="as_of must be YYYY-MM-DD") from exc
+    calendar = get_calendar(
+        as_of=reference, upcoming_limit=upcoming_limit, past_limit=past_limit
+    )
+    return FomcCalendarResponse(
+        past=[meeting.to_dict() for meeting in calendar["past"]],  # type: ignore[arg-type]
+        upcoming=[meeting.to_dict() for meeting in calendar["upcoming"]],  # type: ignore[arg-type]
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -110,3 +110,42 @@ class TrainJobStatusResponse(BaseModel):
     started_at: str | None = None
     finished_at: str | None = None
     result: AnalyzeResponse | None = None
+
+
+class HistoryEntry(BaseModel):
+    id: str
+    created_at: str
+    symbol: str
+    document_date: str
+    horizon: str
+    forecast_mode: str
+    stance: str
+    sentiment_score: float | None = None
+    predicted_close: float | None = None
+    current_close: float | None = None
+    predicted_volatility: float | None = None
+    text_excerpt: str | None = None
+
+
+class HistoryDetail(HistoryEntry):
+    payload: dict
+
+
+class HistoryList(BaseModel):
+    items: list[HistoryEntry]
+    total: int
+    limit: int
+    offset: int
+
+
+class FomcMeetingResponse(BaseModel):
+    meeting_date: str
+    meeting_type: str
+    statement_release_date: str | None = None
+    minutes_release_date: str | None = None
+    notes: str | None = None
+
+
+class FomcCalendarResponse(BaseModel):
+    past: list[FomcMeetingResponse]
+    upcoming: list[FomcMeetingResponse]

--- a/backend/app/services/fomc_calendar.py
+++ b/backend/app/services/fomc_calendar.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass(frozen=True)
+class FomcMeeting:
+    meeting_date: date
+    meeting_type: str  # "scheduled" | "unscheduled"
+    statement_release_date: date | None
+    minutes_release_date: date | None
+    notes: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "meeting_date": self.meeting_date.isoformat(),
+            "meeting_type": self.meeting_type,
+            "statement_release_date": (
+                self.statement_release_date.isoformat() if self.statement_release_date else None
+            ),
+            "minutes_release_date": (
+                self.minutes_release_date.isoformat() if self.minutes_release_date else None
+            ),
+            "notes": self.notes,
+        }
+
+
+def _m(meeting: tuple[int, int, int], statement_offset_days: int = 0) -> FomcMeeting:
+    meeting_date = date(*meeting)
+    statement = date.fromordinal(meeting_date.toordinal() + statement_offset_days)
+    minutes = date.fromordinal(meeting_date.toordinal() + 21)
+    return FomcMeeting(
+        meeting_date=meeting_date,
+        meeting_type="scheduled",
+        statement_release_date=statement,
+        minutes_release_date=minutes,
+    )
+
+
+# Federal Reserve published FOMC meeting calendar. Two-day meetings; the statement
+# release falls on the second day. Minutes publish three weeks later.
+# Sourced from federalreserve.gov/monetarypolicy/fomccalendars.htm.
+_SCHEDULE: tuple[FomcMeeting, ...] = (
+    _m((2023, 1, 31), 1),
+    _m((2023, 3, 21), 1),
+    _m((2023, 5, 2), 1),
+    _m((2023, 6, 13), 1),
+    _m((2023, 7, 25), 1),
+    _m((2023, 9, 19), 1),
+    _m((2023, 10, 31), 1),
+    _m((2023, 12, 12), 1),
+    _m((2024, 1, 30), 1),
+    _m((2024, 3, 19), 1),
+    _m((2024, 4, 30), 1),
+    _m((2024, 6, 11), 1),
+    _m((2024, 7, 30), 1),
+    _m((2024, 9, 17), 1),
+    _m((2024, 11, 6), 1),
+    _m((2024, 12, 17), 1),
+    _m((2025, 1, 28), 1),
+    _m((2025, 3, 18), 1),
+    _m((2025, 4, 29), 1),
+    _m((2025, 6, 17), 1),
+    _m((2025, 7, 29), 1),
+    _m((2025, 9, 16), 1),
+    _m((2025, 10, 28), 1),
+    _m((2025, 12, 9), 1),
+    _m((2026, 1, 27), 1),
+    _m((2026, 3, 17), 1),
+    _m((2026, 4, 28), 1),
+    _m((2026, 6, 16), 1),
+    _m((2026, 7, 28), 1),
+    _m((2026, 9, 15), 1),
+    _m((2026, 10, 27), 1),
+    _m((2026, 12, 8), 1),
+)
+
+
+def get_calendar(
+    *,
+    as_of: date | None = None,
+    upcoming_limit: int = 12,
+    past_limit: int = 12,
+) -> dict[str, list[FomcMeeting]]:
+    reference = as_of or date.today()
+    past = [m for m in _SCHEDULE if m.meeting_date < reference]
+    upcoming = [m for m in _SCHEDULE if m.meeting_date >= reference]
+    past.sort(key=lambda m: m.meeting_date, reverse=True)
+    upcoming.sort(key=lambda m: m.meeting_date)
+    return {
+        "past": past[:past_limit],
+        "upcoming": upcoming[:upcoming_limit],
+    }
+
+
+def list_all_meetings() -> tuple[FomcMeeting, ...]:
+    return _SCHEDULE

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -62,6 +62,7 @@ ignore = [
   "F541",   # f-string without placeholders
   "F841",   # unused local variable
   "I001",   # import sorting — bulk reformat in follow-up
+  "B008",   # function-call default in argument — FastAPI's Depends() pattern
   "B905",   # zip without strict=
   "UP012",  # explicit encoding="utf-8" — intentional clarity, kept
   "UP017",  # datetime.timezone.utc → datetime.UTC (Python 3.11 idiom; adopt in cleanup)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "langsmith>=0.1.0",
   "scikit-learn",
   "pypdf>=5.0.0",
+  "SQLAlchemy>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/frontend/components/analyze/WatchlistChips.tsx
+++ b/frontend/components/analyze/WatchlistChips.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { Plus, X } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { addToWatchlist, readWatchlist, removeFromWatchlist } from "@/lib/watchlist";
+
+interface WatchlistChipsProps {
+  currentSymbol: string;
+  onSelect: (symbol: string) => void;
+}
+
+export function WatchlistChips({ currentSymbol, onSelect }: WatchlistChipsProps) {
+  const [symbols, setSymbols] = React.useState<string[]>([]);
+  const [hydrated, setHydrated] = React.useState(false);
+
+  React.useEffect(() => {
+    setSymbols(readWatchlist());
+    setHydrated(true);
+  }, []);
+
+  if (!hydrated) return null;
+
+  const handleAdd = () => {
+    if (!currentSymbol) return;
+    setSymbols(addToWatchlist(currentSymbol));
+  };
+  const handleRemove = (symbol: string) => {
+    setSymbols(removeFromWatchlist(symbol));
+  };
+
+  const alreadyPinned = symbols.includes(currentSymbol);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {symbols.map((symbol) => (
+        <Badge key={symbol} variant={symbol === currentSymbol ? "default" : "outline"} className="gap-1">
+          <button type="button" onClick={() => onSelect(symbol)} className="font-medium">
+            {symbol}
+          </button>
+          <button
+            type="button"
+            aria-label={`Remove ${symbol} from watchlist`}
+            onClick={() => handleRemove(symbol)}
+            className="opacity-60 hover:opacity-100"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </Badge>
+      ))}
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        onClick={handleAdd}
+        disabled={alreadyPinned || !currentSymbol}
+        className="h-7 px-2 text-xs"
+      >
+        <Plus className="h-3 w-3" />
+        Pin {currentSymbol}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/components/shell/header.tsx
+++ b/frontend/components/shell/header.tsx
@@ -1,14 +1,20 @@
 import Link from "next/link";
-import { Activity, BookOpen, Github } from "lucide-react";
+import { Activity, BookOpen, Calendar, Github, History as HistoryIcon } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/theme-toggle";
 
+const NAV_ITEMS: Array<{ href: string; label: string; icon: React.ComponentType<{ className?: string }> }> = [
+  { href: "/analyze", label: "Analyze", icon: Activity },
+  { href: "/history", label: "History", icon: HistoryIcon },
+  { href: "/calendar", label: "Calendar", icon: Calendar },
+];
+
 export function Header() {
   return (
     <header className="sticky top-0 z-40 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container flex h-14 items-center justify-between">
+      <div className="container flex h-14 items-center justify-between gap-4">
         <Link href="/" className="flex items-center gap-2 font-semibold tracking-tight">
           <Activity className="h-4 w-4 text-primary" />
           <span>Fed Pulse</span>
@@ -16,6 +22,16 @@ export function Header() {
             Research
           </Badge>
         </Link>
+        <nav className="hidden items-center gap-1 sm:flex">
+          {NAV_ITEMS.map(({ href, label, icon: Icon }) => (
+            <Button key={href} asChild variant="ghost" size="sm">
+              <Link href={href}>
+                <Icon className="h-4 w-4" />
+                {label}
+              </Link>
+            </Button>
+          ))}
+        </nav>
         <div className="flex items-center gap-1">
           <Button asChild variant="ghost" size="sm" className="hidden sm:inline-flex">
             <Link href="https://github.com/yusufizzetmurat/fed-pulse/wiki" target="_blank" rel="noopener noreferrer">

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -1,5 +1,13 @@
 import axios from "axios";
-import type { AnalyzeRequest, AnalyzeResult, TrainJobState } from "./types";
+import type {
+  AnalyzeRequest,
+  AnalyzeResult,
+  FomcCalendarResponse,
+  HistoryDetail,
+  HistoryList,
+  HistoryQuery,
+  TrainJobState,
+} from "./types";
 
 export function resolveApiBaseUrl(): string {
   const raw = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -39,4 +47,32 @@ export async function fetchTrainJob(baseUrl: string, jobId: string): Promise<Tra
   const response = await axios.get(`${baseUrl}/train-jobs/${jobId}`);
   const state = (response.data || {}) as TrainJobState;
   return { ...state, job_id: jobId };
+}
+
+export async function fetchHistory(
+  baseUrl: string,
+  query: HistoryQuery = {}
+): Promise<HistoryList> {
+  const response = await axios.get(`${baseUrl}/history`, { params: query });
+  return response.data as HistoryList;
+}
+
+export async function fetchHistoryRun(
+  baseUrl: string,
+  runId: string
+): Promise<HistoryDetail> {
+  const response = await axios.get(`${baseUrl}/history/${runId}`);
+  return response.data as HistoryDetail;
+}
+
+export async function deleteHistoryRun(baseUrl: string, runId: string): Promise<void> {
+  await axios.delete(`${baseUrl}/history/${runId}`);
+}
+
+export async function fetchFomcCalendar(
+  baseUrl: string,
+  params?: { upcoming_limit?: number; past_limit?: number; as_of?: string }
+): Promise<FomcCalendarResponse> {
+  const response = await axios.get(`${baseUrl}/fomc/calendar`, { params });
+  return response.data as FomcCalendarResponse;
 }

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -143,3 +143,51 @@ export interface TrainJobState {
 }
 
 export type Stance = "hawkish" | "dovish" | "neutral" | "unknown";
+
+export interface HistoryEntry {
+  id: string;
+  created_at: string;
+  symbol: string;
+  document_date: string;
+  horizon: string;
+  forecast_mode: string;
+  stance: string;
+  sentiment_score?: number | null;
+  predicted_close?: number | null;
+  current_close?: number | null;
+  predicted_volatility?: number | null;
+  text_excerpt?: string | null;
+}
+
+export interface HistoryDetail extends HistoryEntry {
+  payload: Record<string, unknown>;
+}
+
+export interface HistoryList {
+  items: HistoryEntry[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface HistoryQuery {
+  symbol?: string;
+  horizon?: string;
+  stance?: string;
+  document_date?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface FomcMeeting {
+  meeting_date: string;
+  meeting_type: string;
+  statement_release_date?: string | null;
+  minutes_release_date?: string | null;
+  notes?: string | null;
+}
+
+export interface FomcCalendarResponse {
+  past: FomcMeeting[];
+  upcoming: FomcMeeting[];
+}

--- a/frontend/lib/watchlist.ts
+++ b/frontend/lib/watchlist.ts
@@ -1,0 +1,69 @@
+const STORAGE_KEY = "fed-pulse:watchlist:v1";
+const MAX_ITEMS = 16;
+
+export interface WatchlistStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function defaultStorage(): WatchlistStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readWatchlist(storage: WatchlistStorage | null = defaultStorage()): string[] {
+  if (!storage) return [];
+  const raw = storage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((entry): entry is string => typeof entry === "string");
+  } catch {
+    return [];
+  }
+}
+
+export function writeWatchlist(
+  symbols: string[],
+  storage: WatchlistStorage | null = defaultStorage()
+): string[] {
+  const unique: string[] = [];
+  for (const sym of symbols) {
+    if (!sym) continue;
+    if (!unique.includes(sym)) unique.push(sym);
+    if (unique.length >= MAX_ITEMS) break;
+  }
+  if (!storage) return unique;
+  storage.setItem(STORAGE_KEY, JSON.stringify(unique));
+  return unique;
+}
+
+export function addToWatchlist(
+  symbol: string,
+  storage: WatchlistStorage | null = defaultStorage()
+): string[] {
+  if (!symbol) return readWatchlist(storage);
+  const current = readWatchlist(storage);
+  if (current.includes(symbol)) return current;
+  return writeWatchlist([...current, symbol], storage);
+}
+
+export function removeFromWatchlist(
+  symbol: string,
+  storage: WatchlistStorage | null = defaultStorage()
+): string[] {
+  const current = readWatchlist(storage);
+  const next = current.filter((entry) => entry !== symbol);
+  return writeWatchlist(next, storage);
+}
+
+export function clearWatchlist(storage: WatchlistStorage | null = defaultStorage()): void {
+  if (!storage) return;
+  storage.removeItem(STORAGE_KEY);
+}

--- a/frontend/pages/analyze.tsx
+++ b/frontend/pages/analyze.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import Head from "next/head";
 import dynamic from "next/dynamic";
+import { useRouter } from "next/router";
 import { toast } from "sonner";
 
 import { AnalyzeForm } from "@/components/analyze/AnalyzeForm";
@@ -10,6 +11,7 @@ import { MarketContext } from "@/components/analyze/MarketContext";
 import { PredictionCards } from "@/components/analyze/PredictionCards";
 import { RealTrainStatus } from "@/components/analyze/RealTrainStatus";
 import { SentimentCard } from "@/components/analyze/SentimentCard";
+import { WatchlistChips } from "@/components/analyze/WatchlistChips";
 import { Header } from "@/components/shell/header";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -60,12 +62,21 @@ function trainJobMessage(state: TrainJobState): string {
 }
 
 export default function AnalyzePage() {
+  const router = useRouter();
   const [request, setRequest] = React.useState<AnalyzeRequest>(defaultRequest);
   const [result, setResult] = React.useState<AnalyzeResult | null>(null);
   const [trainJob, setTrainJob] = React.useState<TrainJobState | null>(null);
   const [loading, setLoading] = React.useState(false);
   const [previewV2, setPreviewV2] = React.useState(false);
   const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+
+  React.useEffect(() => {
+    if (!router.isReady) return;
+    const queryDate = router.query.date;
+    if (typeof queryDate === "string" && queryDate) {
+      setRequest((current) => ({ ...current, date: queryDate }));
+    }
+  }, [router.isReady, router.query.date]);
 
   const handleSubmit = async () => {
     setLoading(true);
@@ -149,6 +160,11 @@ export default function AnalyzePage() {
             onChange={setRequest}
             onSubmit={handleSubmit}
             loading={loading}
+          />
+
+          <WatchlistChips
+            currentSymbol={request.symbol}
+            onSelect={(symbol) => setRequest((value) => ({ ...value, symbol }))}
           />
 
           {trainJob ? <RealTrainStatus job={trainJob} /> : null}

--- a/frontend/pages/calendar.tsx
+++ b/frontend/pages/calendar.tsx
@@ -1,0 +1,146 @@
+import * as React from "react";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { Calendar as CalendarIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import { Header } from "@/components/shell/header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchFomcCalendar, resolveApiBaseUrl } from "@/lib/analyze/api";
+import type { FomcCalendarResponse, FomcMeeting } from "@/lib/analyze/types";
+
+function MeetingRow({ meeting, onAnalyze }: { meeting: FomcMeeting; onAnalyze: (date: string) => void }) {
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-3 border-b border-border py-3 last:border-0">
+      <div className="space-y-0.5">
+        <p className="font-mono text-sm">{meeting.meeting_date}</p>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          {meeting.statement_release_date ? (
+            <span>Statement {meeting.statement_release_date}</span>
+          ) : null}
+          {meeting.minutes_release_date ? (
+            <span>Minutes {meeting.minutes_release_date}</span>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Badge variant="outline" className="capitalize">{meeting.meeting_type}</Badge>
+        <Button size="sm" variant="outline" onClick={() => onAnalyze(meeting.statement_release_date ?? meeting.meeting_date)}>
+          Analyze
+        </Button>
+      </div>
+    </li>
+  );
+}
+
+export default function CalendarPage() {
+  const router = useRouter();
+  const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+  const [data, setData] = React.useState<FomcCalendarResponse | null>(null);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    fetchFomcCalendar(apiBaseUrl)
+      .then((result) => {
+        if (!cancelled) setData(result);
+      })
+      .catch((err) => {
+        if (!cancelled) toast.error((err as Error).message || "Calendar fetch failed");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBaseUrl]);
+
+  const goAnalyze = (meetingDate: string) => {
+    router.push({ pathname: "/analyze", query: { date: meetingDate } });
+  };
+
+  return (
+    <>
+      <Head>
+        <title>FOMC calendar — Fed Pulse</title>
+      </Head>
+      <div className="min-h-screen bg-background text-foreground">
+        <Header />
+        <main className="container space-y-6 py-8">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold tracking-tight flex items-center gap-2">
+              <CalendarIcon className="h-7 w-7 text-primary" />
+              FOMC calendar
+            </h1>
+            <p className="max-w-2xl text-muted-foreground">
+              Scheduled FOMC meetings sourced from the Federal Reserve's published calendar.
+            </p>
+          </div>
+
+          {loading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-16 w-full" />
+              <Skeleton className="h-16 w-full" />
+              <Skeleton className="h-16 w-full" />
+            </div>
+          ) : data ? (
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Upcoming</CardTitle>
+                  <CardDescription>Next {data.upcoming.length} meetings</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {data.upcoming.length === 0 ? (
+                    <p className="text-muted-foreground">No upcoming meetings scheduled.</p>
+                  ) : (
+                    <ul>
+                      {data.upcoming.map((meeting) => (
+                        <MeetingRow
+                          key={`up-${meeting.meeting_date}`}
+                          meeting={meeting}
+                          onAnalyze={goAnalyze}
+                        />
+                      ))}
+                    </ul>
+                  )}
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Past</CardTitle>
+                  <CardDescription>Last {data.past.length} meetings</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {data.past.length === 0 ? (
+                    <p className="text-muted-foreground">No past meetings in window.</p>
+                  ) : (
+                    <ul>
+                      {data.past.map((meeting) => (
+                        <MeetingRow
+                          key={`past-${meeting.meeting_date}`}
+                          meeting={meeting}
+                          onAnalyze={goAnalyze}
+                        />
+                      ))}
+                    </ul>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          ) : null}
+        </main>
+      </div>
+    </>
+  );
+}

--- a/frontend/pages/history.tsx
+++ b/frontend/pages/history.tsx
@@ -1,0 +1,245 @@
+import * as React from "react";
+import Head from "next/head";
+import { Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Header } from "@/components/shell/header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  deleteHistoryRun,
+  fetchHistory,
+  resolveApiBaseUrl,
+} from "@/lib/analyze/api";
+import { formatPrice, stanceLabel, toStance } from "@/lib/analyze/format";
+import type { HistoryEntry, HistoryQuery } from "@/lib/analyze/types";
+
+const STANCE_OPTIONS = [
+  { value: "any", label: "Any stance" },
+  { value: "hawkish", label: "Hawkish" },
+  { value: "neutral", label: "Neutral" },
+  { value: "dovish", label: "Dovish" },
+];
+
+const HORIZON_OPTIONS = ["any", "1d", "3d", "5d", "10d"];
+
+export default function HistoryPage() {
+  const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+  const [items, setItems] = React.useState<HistoryEntry[]>([]);
+  const [total, setTotal] = React.useState(0);
+  const [loading, setLoading] = React.useState(false);
+  const [filters, setFilters] = React.useState<HistoryQuery>({ limit: 20, offset: 0 });
+
+  const reload = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await fetchHistory(apiBaseUrl, filters);
+      setItems(result.items);
+      setTotal(result.total);
+    } catch (err) {
+      const message = (err as Error).message || "Failed to load history.";
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [apiBaseUrl, filters]);
+
+  React.useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteHistoryRun(apiBaseUrl, id);
+      toast.success("Run deleted");
+      await reload();
+    } catch (err) {
+      toast.error((err as Error).message || "Delete failed");
+    }
+  };
+
+  const patchFilter = (delta: Partial<HistoryQuery>) =>
+    setFilters((value) => ({ ...value, offset: 0, ...delta }));
+
+  return (
+    <>
+      <Head>
+        <title>History — Fed Pulse</title>
+      </Head>
+      <div className="min-h-screen bg-background text-foreground">
+        <Header />
+        <main className="container space-y-6 py-8">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold tracking-tight">History</h1>
+            <p className="max-w-2xl text-muted-foreground">
+              Past analyses. Filter by asset, horizon, or stance; click an entry to drill in.
+            </p>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Filters</CardTitle>
+              <CardDescription>{total} total run{total === 1 ? "" : "s"}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-3 md:grid-cols-4">
+                <div className="space-y-1">
+                  <Label htmlFor="filter-symbol">Symbol</Label>
+                  <Input
+                    id="filter-symbol"
+                    placeholder="e.g. ^GSPC"
+                    value={filters.symbol ?? ""}
+                    onChange={(event) =>
+                      patchFilter({ symbol: event.target.value || undefined })
+                    }
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="filter-horizon">Horizon</Label>
+                  <Select
+                    value={filters.horizon ?? "any"}
+                    onValueChange={(value) =>
+                      patchFilter({ horizon: value === "any" ? undefined : value })
+                    }
+                  >
+                    <SelectTrigger id="filter-horizon">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {HORIZON_OPTIONS.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {option === "any" ? "Any horizon" : option}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="filter-stance">Stance</Label>
+                  <Select
+                    value={filters.stance ?? "any"}
+                    onValueChange={(value) =>
+                      patchFilter({ stance: value === "any" ? undefined : value })
+                    }
+                  >
+                    <SelectTrigger id="filter-stance">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {STANCE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="filter-date">Document date</Label>
+                  <Input
+                    id="filter-date"
+                    type="date"
+                    value={filters.document_date ?? ""}
+                    onChange={(event) =>
+                      patchFilter({ document_date: event.target.value || undefined })
+                    }
+                  />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {loading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : items.length === 0 ? (
+            <Card>
+              <CardContent className="py-10 text-center text-muted-foreground">
+                No runs yet — submit an analysis to populate the history.
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardContent className="p-0">
+                <table className="w-full text-sm">
+                  <thead className="border-b border-border bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
+                    <tr>
+                      <th className="px-4 py-2 text-left">Date</th>
+                      <th className="px-4 py-2 text-left">Symbol</th>
+                      <th className="px-4 py-2 text-left">Horizon</th>
+                      <th className="px-4 py-2 text-left">Stance</th>
+                      <th className="px-4 py-2 text-right">Predicted close</th>
+                      <th className="px-4 py-2 text-right">Spot</th>
+                      <th className="px-4 py-2" aria-label="actions" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {items.map((row) => {
+                      const stance = toStance(row.stance);
+                      const stanceVariant =
+                        stance === "hawkish"
+                          ? "hawkish"
+                          : stance === "dovish"
+                          ? "dovish"
+                          : stance === "neutral"
+                          ? "neutral"
+                          : "outline";
+                      return (
+                        <tr key={row.id} className="border-b border-border last:border-0">
+                          <td className="px-4 py-2 font-mono text-xs">
+                            {row.document_date}
+                          </td>
+                          <td className="px-4 py-2 font-medium">{row.symbol}</td>
+                          <td className="px-4 py-2 text-muted-foreground">{row.horizon}</td>
+                          <td className="px-4 py-2">
+                            <Badge variant={stanceVariant}>{stanceLabel(stance)}</Badge>
+                          </td>
+                          <td className="px-4 py-2 text-right font-mono">
+                            {formatPrice(row.predicted_close ?? null)}
+                          </td>
+                          <td className="px-4 py-2 text-right font-mono text-muted-foreground">
+                            {formatPrice(row.current_close ?? null)}
+                          </td>
+                          <td className="px-4 py-2 text-right">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              aria-label="Delete run"
+                              onClick={() => handleDelete(row.id)}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </CardContent>
+            </Card>
+          )}
+        </main>
+      </div>
+    </>
+  );
+}

--- a/frontend/tests/lib/watchlist.test.ts
+++ b/frontend/tests/lib/watchlist.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addToWatchlist,
+  clearWatchlist,
+  readWatchlist,
+  removeFromWatchlist,
+  writeWatchlist,
+  type WatchlistStorage,
+} from "@/lib/watchlist";
+
+function makeStorage(initial: Record<string, string> = {}): WatchlistStorage {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+  };
+}
+
+describe("watchlist localStorage helper", () => {
+  it("reads an empty list when nothing is stored", () => {
+    const storage = makeStorage();
+    expect(readWatchlist(storage)).toEqual([]);
+  });
+
+  it("ignores malformed JSON in storage", () => {
+    const storage = makeStorage({ "fed-pulse:watchlist:v1": "not-json" });
+    expect(readWatchlist(storage)).toEqual([]);
+  });
+
+  it("adds and dedupes symbols", () => {
+    const storage = makeStorage();
+    expect(addToWatchlist("^GSPC", storage)).toEqual(["^GSPC"]);
+    expect(addToWatchlist("^NDX", storage)).toEqual(["^GSPC", "^NDX"]);
+    expect(addToWatchlist("^GSPC", storage)).toEqual(["^GSPC", "^NDX"]);
+  });
+
+  it("removes symbols", () => {
+    const storage = makeStorage();
+    writeWatchlist(["^GSPC", "^NDX"], storage);
+    expect(removeFromWatchlist("^GSPC", storage)).toEqual(["^NDX"]);
+  });
+
+  it("caps the list at 16 items", () => {
+    const storage = makeStorage();
+    const tickers = Array.from({ length: 20 }, (_, i) => `T${i}`);
+    expect(writeWatchlist(tickers, storage)).toHaveLength(16);
+  });
+
+  it("clearWatchlist wipes the entry", () => {
+    const storage = makeStorage();
+    writeWatchlist(["^GSPC"], storage);
+    clearWatchlist(storage);
+    expect(readWatchlist(storage)).toEqual([]);
+  });
+});

--- a/frontend/tests/pages/calendar.test.tsx
+++ b/frontend/tests/pages/calendar.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  Toaster: () => null,
+}));
+
+const pushMock = vi.fn();
+vi.mock("next/router", () => ({
+  useRouter: () => ({ isReady: true, query: {}, push: pushMock }),
+}));
+
+vi.mock("next/head", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const fetchFomcCalendarMock = vi.fn();
+vi.mock("@/lib/analyze/api", () => ({
+  resolveApiBaseUrl: () => "http://localhost:8000",
+  fetchFomcCalendar: (...args: unknown[]) => fetchFomcCalendarMock(...args),
+}));
+
+describe("CalendarPage", () => {
+  beforeEach(() => {
+    fetchFomcCalendarMock.mockReset();
+    pushMock.mockReset();
+  });
+
+  it("renders upcoming and past meeting rows", async () => {
+    fetchFomcCalendarMock.mockResolvedValue({
+      upcoming: [
+        {
+          meeting_date: "2024-11-06",
+          meeting_type: "scheduled",
+          statement_release_date: "2024-11-07",
+          minutes_release_date: "2024-11-27",
+        },
+      ],
+      past: [
+        {
+          meeting_date: "2024-09-17",
+          meeting_type: "scheduled",
+          statement_release_date: "2024-09-18",
+        },
+      ],
+    });
+    const { default: CalendarPage } = await import("@/pages/calendar");
+    render(<CalendarPage />);
+    await waitFor(() => expect(screen.getByText("2024-11-06")).toBeInTheDocument());
+    expect(screen.getByText("2024-09-17")).toBeInTheDocument();
+    expect(screen.getAllByText(/^scheduled$/i).length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/frontend/tests/pages/history.test.tsx
+++ b/frontend/tests/pages/history.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  Toaster: () => null,
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: {},
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock("next/head", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const fetchHistoryMock = vi.fn();
+const deleteHistoryRunMock = vi.fn();
+
+vi.mock("@/lib/analyze/api", () => ({
+  resolveApiBaseUrl: () => "http://localhost:8000",
+  fetchHistory: (...args: unknown[]) => fetchHistoryMock(...args),
+  deleteHistoryRun: (...args: unknown[]) => deleteHistoryRunMock(...args),
+}));
+
+describe("HistoryPage", () => {
+  beforeEach(() => {
+    fetchHistoryMock.mockReset();
+    deleteHistoryRunMock.mockReset();
+  });
+
+  it("renders the rows returned by the backend", async () => {
+    fetchHistoryMock.mockResolvedValue({
+      total: 2,
+      limit: 20,
+      offset: 0,
+      items: [
+        {
+          id: "abc",
+          created_at: "2024-09-18T12:00:00Z",
+          symbol: "^GSPC",
+          document_date: "2024-09-18",
+          horizon: "3d",
+          forecast_mode: "fast",
+          stance: "hawkish",
+          predicted_close: 5050.5,
+          current_close: 5000.1,
+        },
+        {
+          id: "def",
+          created_at: "2024-11-06T12:00:00Z",
+          symbol: "^NDX",
+          document_date: "2024-11-06",
+          horizon: "5d",
+          forecast_mode: "real_train",
+          stance: "dovish",
+        },
+      ],
+    });
+    const { default: HistoryPage } = await import("@/pages/history");
+    render(<HistoryPage />);
+    await waitFor(() => expect(screen.getByText("^GSPC")).toBeInTheDocument());
+    expect(screen.getByText("^NDX")).toBeInTheDocument();
+    expect(screen.getByText("2024-09-18")).toBeInTheDocument();
+    expect(screen.getByText("2024-11-06")).toBeInTheDocument();
+    expect(screen.getAllByText(/hawkish/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders an empty-state when the backend returns no rows", async () => {
+    fetchHistoryMock.mockResolvedValue({ total: 0, limit: 20, offset: 0, items: [] });
+    const { default: HistoryPage } = await import("@/pages/history");
+    render(<HistoryPage />);
+    await waitFor(() => expect(screen.getByText(/no runs yet/i)).toBeInTheDocument());
+  });
+});

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,14 +4,15 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _isolated_history_db(tmp_path):
+def _isolated_history_db(tmp_path_factory):
     """Force every unit test that touches `app.db` onto a clean per-test SQLite
-    file so test order can't flake the suite and so every new SQLAlchemy
-    connection sees the same `analysis_runs` table (in-memory `:memory:` would
-    isolate each connection)."""
+    file so test order can't flake the suite. We use `tmp_path_factory` (not
+    `tmp_path`) so the db file lands in a separate directory; otherwise tests
+    that enumerate `tmp_path` for JSON fixtures would pick up the db file."""
 
     pytest.importorskip("sqlalchemy", reason="sqlalchemy not installed")
     from app import db as db_module
 
-    db_module.reset_for_testing(f"sqlite:///{tmp_path / 'fed_pulse_test.db'}")
+    db_dir = tmp_path_factory.mktemp("history_db")
+    db_module.reset_for_testing(f"sqlite:///{db_dir / 'fed_pulse_test.db'}")
     yield

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,12 +4,14 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _isolated_history_db():
-    """Force every unit test that touches `app.db` onto a clean in-memory SQLite
-    so test order can't flake the suite via a half-initialised file DB."""
+def _isolated_history_db(tmp_path):
+    """Force every unit test that touches `app.db` onto a clean per-test SQLite
+    file so test order can't flake the suite and so every new SQLAlchemy
+    connection sees the same `analysis_runs` table (in-memory `:memory:` would
+    isolate each connection)."""
 
-    sqlalchemy = pytest.importorskip("sqlalchemy", reason="sqlalchemy not installed")  # noqa: F841
+    pytest.importorskip("sqlalchemy", reason="sqlalchemy not installed")
     from app import db as db_module
 
-    db_module.reset_for_testing("sqlite:///:memory:")
+    db_module.reset_for_testing(f"sqlite:///{tmp_path / 'fed_pulse_test.db'}")
     yield

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_history_db():
+    """Force every unit test that touches `app.db` onto a clean in-memory SQLite
+    so test order can't flake the suite via a half-initialised file DB."""
+
+    sqlalchemy = pytest.importorskip("sqlalchemy", reason="sqlalchemy not installed")  # noqa: F841
+    from app import db as db_module
+
+    db_module.reset_for_testing("sqlite:///:memory:")
+    yield

--- a/tests/unit/test_analyze_persists_history.py
+++ b/tests/unit/test_analyze_persists_history.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import app.main as main_mod  # noqa: E402
+
+
+def _stub_market_path(monkeypatch):
+    monkeypatch.setattr(
+        main_mod,
+        "analyze_text",
+        lambda _: {
+            "label": "HAWKISH",
+            "score": 0.81,
+            "raw": [{"label": "HAWKISH", "score": 0.81}],
+        },
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "fetch_market_snapshot",
+        lambda **_: {
+            "symbol": "^GSPC",
+            "requested_date": "2026-03-15",
+            "date_used": "2026-03-13",
+            "lookback_days": 5,
+            "close": 5000.0,
+            "volatility_5d": 0.01,
+        },
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "fetch_market_history",
+        lambda **_: [
+            {"date": "2026-03-12", "close": 4980.0, "volatility_5d": 0.011},
+            {"date": "2026-03-13", "close": 5000.0, "volatility_5d": 0.010},
+        ],
+    )
+    monkeypatch.setattr(main_mod, "parse_horizon_steps", lambda _: 3)
+    monkeypatch.setattr(main_mod, "fetch_forward_trading_dates", lambda **_: ["2026-03-16", "2026-03-17", "2026-03-18"])
+    monkeypatch.setattr(
+        main_mod,
+        "forecast_quantitative_series",
+        lambda **_: {
+            "prediction": {"close": 5050.0, "volatility": 0.012, "horizon": "3d"},
+            "model": {
+                "checkpoint_path": "backend/models/forecaster_best.pt",
+                "checkpoint_exists": True,
+                "checkpoint_loaded": True,
+                "runtime_mode": "fast",
+                "hidden_size": 64,
+                "num_layers": 2,
+                "dropout": 0.15,
+                "head_hidden_size": 32,
+                "close_scale": 10000.0,
+                "sequence_length": 5,
+            },
+            "series": {
+                "timestamps": ["2026-03-12", "2026-03-13"],
+                "history_close": [4980.0, 5000.0],
+                "history_volatility": [0.011, 0.01],
+                "forecast_timestamps": ["2026-03-16", "2026-03-17", "2026-03-18"],
+                "forecast_close": [5020.0, 5040.0, 5050.0],
+                "forecast_close_lower": [5000.0, 5015.0, 5020.0],
+                "forecast_close_upper": [5040.0, 5060.0, 5080.0],
+                "forecast_volatility": [0.011, 0.012, 0.012],
+                "forecast_volatility_lower": [0.009, 0.010, 0.010],
+                "forecast_volatility_upper": [0.013, 0.014, 0.015],
+                "forecast_confidence_level": 0.8,
+                "volatility_scale": {"suggested_ymin": 0.0, "suggested_ymax": 0.02},
+            },
+        },
+    )
+
+
+def test_analyze_persists_a_history_row_visible_via_get_history(monkeypatch):
+    _stub_market_path(monkeypatch)
+    monkeypatch.setattr(main_mod, "checkpoint_exists", lambda: True)
+    client = TestClient(main_mod.app)
+    pre = client.get("/history").json()
+    assert pre["total"] == 0
+
+    response = client.post(
+        "/analyze",
+        json={
+            "text": "Recent indicators…",
+            "date": "2026-03-15",
+            "symbol": "^GSPC",
+            "forecast_mode": "fast",
+            "horizon": "3d",
+            "include_realized": False,
+        },
+    )
+    assert response.status_code == 200
+
+    listing = client.get("/history").json()
+    assert listing["total"] == 1
+    row = listing["items"][0]
+    assert row["symbol"] == "^GSPC"
+    assert row["stance"] == "hawkish"
+    assert row["predicted_close"] == pytest.approx(5050.0)
+    assert row["document_date"] == "2026-03-15"

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from app import db as db_module
+
+
+@pytest.fixture()
+def session(tmp_path):
+    database_url = f"sqlite:///{tmp_path / 'fed_pulse_test.db'}"
+    engine = db_module.reset_for_testing(database_url)
+    assert engine is not None
+    session_iter = db_module.get_session()
+    sess = next(session_iter)
+    try:
+        yield sess
+    finally:
+        sess.close()
+
+
+def _sample_request(**overrides):
+    base = {
+        "text": "Recent indicators suggest economic activity has continued to expand.",
+        "date": "2024-09-18",
+        "symbol": "^GSPC",
+        "horizon": "3d",
+        "forecast_mode": "fast",
+        "include_realized": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _sample_response(**overrides):
+    base = {
+        "sentiment": {"label": "HAWKISH", "score": 0.81, "raw": []},
+        "prediction": {"close": 5050.0, "volatility": 0.012, "horizon": "3d"},
+        "market": {
+            "symbol": "^GSPC",
+            "requested_date": "2024-09-18",
+            "date_used": "2024-09-18",
+            "lookback_days": 5,
+            "close": 5000.0,
+            "volatility_5d": 0.011,
+        },
+        "model": {},
+        "series": {},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_persist_and_list_runs(session):
+    db_module.persist_analysis_run(
+        session,
+        payload=_sample_response(),
+        request=_sample_request(),
+        response=_sample_response(),
+    )
+    db_module.persist_analysis_run(
+        session,
+        payload=_sample_response(),
+        request=_sample_request(symbol="^NDX"),
+        response=_sample_response(market={
+            "symbol": "^NDX",
+            "requested_date": "2024-09-18",
+            "date_used": "2024-09-18",
+            "lookback_days": 5,
+            "close": 19000.0,
+            "volatility_5d": 0.014,
+        }),
+    )
+    rows, total = db_module.list_runs(session, limit=10, offset=0)
+    assert total == 2
+    assert len(rows) == 2
+
+    filtered, total = db_module.list_runs(session, limit=10, offset=0, symbol="^NDX")
+    assert total == 1
+    assert filtered[0].symbol == "^NDX"
+
+
+def test_delete_run_returns_true_when_row_exists(session):
+    record = db_module.persist_analysis_run(
+        session,
+        payload=_sample_response(),
+        request=_sample_request(),
+        response=_sample_response(),
+    )
+    assert db_module.delete_run(session, record.id) is True
+    assert db_module.get_run(session, record.id) is None
+    assert db_module.delete_run(session, record.id) is False
+
+
+def test_text_excerpt_truncates_long_input(session):
+    long_text = "x" * 600
+    record = db_module.persist_analysis_run(
+        session,
+        payload=_sample_response(),
+        request=_sample_request(text=long_text),
+        response=_sample_response(),
+    )
+    assert record.text_excerpt is not None
+    assert len(record.text_excerpt) <= 281
+    assert record.text_excerpt.endswith("…")

--- a/tests/unit/test_fomc_calendar.py
+++ b/tests/unit/test_fomc_calendar.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import date
+
+from app.services.fomc_calendar import get_calendar, list_all_meetings
+
+
+def test_meeting_schedule_is_chronologically_ordered():
+    meetings = list_all_meetings()
+    dates = [meeting.meeting_date for meeting in meetings]
+    assert dates == sorted(dates)
+    assert len(meetings) >= 24  # at least 3 years × 8 meetings
+
+
+def test_get_calendar_splits_past_and_upcoming():
+    calendar = get_calendar(as_of=date(2024, 9, 18), upcoming_limit=4, past_limit=4)
+    assert len(calendar["upcoming"]) == 4
+    assert len(calendar["past"]) == 4
+    assert all(m.meeting_date < date(2024, 9, 18) for m in calendar["past"])
+    assert all(m.meeting_date >= date(2024, 9, 18) for m in calendar["upcoming"])
+    assert calendar["upcoming"][0].meeting_date == date(2024, 11, 6)
+
+
+def test_meeting_serialises_to_iso_dict():
+    meeting = list_all_meetings()[0]
+    payload = meeting.to_dict()
+    assert payload["meeting_date"] == meeting.meeting_date.isoformat()
+    assert payload["meeting_type"] in {"scheduled", "unscheduled"}
+    assert payload["statement_release_date"] is not None

--- a/tests/unit/test_history_endpoints.py
+++ b/tests/unit/test_history_endpoints.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("sqlalchemy")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import app.db as db_module  # noqa: E402
+import app.main as main_mod  # noqa: E402
+
+
+@pytest.fixture()
+def client(tmp_path):
+    db_module.reset_for_testing(f"sqlite:///{tmp_path / 'fed_pulse_history.db'}")
+    return TestClient(main_mod.app)
+
+
+def _seed(session, *, symbol="^GSPC", stance="HAWKISH", document_date="2024-09-18"):
+    return db_module.persist_analysis_run(
+        session,
+        payload={
+            "sentiment": {"label": stance, "score": 0.7, "raw": []},
+            "prediction": {"close": 5050.0, "volatility": 0.012, "horizon": "3d"},
+        },
+        request={
+            "text": "Recent indicators…",
+            "date": document_date,
+            "symbol": symbol,
+            "horizon": "3d",
+            "forecast_mode": "fast",
+            "include_realized": False,
+        },
+        response={
+            "sentiment": {"label": stance, "score": 0.7, "raw": []},
+            "prediction": {"close": 5050.0, "volatility": 0.012, "horizon": "3d"},
+            "market": {
+                "symbol": symbol,
+                "requested_date": document_date,
+                "date_used": document_date,
+                "lookback_days": 5,
+                "close": 5000.0,
+                "volatility_5d": 0.011,
+            },
+            "model": {},
+            "series": {},
+        },
+    )
+
+
+def test_history_endpoints_round_trip(client):
+    session_iter = db_module.get_session()
+    sess = next(session_iter)
+    try:
+        first = _seed(sess)
+        _seed(sess, symbol="^NDX")
+        _seed(sess, stance="DOVISH")
+    finally:
+        sess.close()
+
+    response = client.get("/history")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 3
+    assert len(body["items"]) == 3
+
+    filtered = client.get("/history", params={"symbol": "^NDX"})
+    assert filtered.status_code == 200
+    assert filtered.json()["total"] == 1
+
+    detail = client.get(f"/history/{first.id}")
+    assert detail.status_code == 200
+    assert detail.json()["id"] == first.id
+    assert "payload" in detail.json()
+
+    deletion = client.delete(f"/history/{first.id}")
+    assert deletion.status_code == 204
+
+    missing = client.get(f"/history/{first.id}")
+    assert missing.status_code == 404
+
+
+def test_history_filter_by_stance_and_date(client):
+    session_iter = db_module.get_session()
+    sess = next(session_iter)
+    try:
+        _seed(sess, stance="HAWKISH", document_date="2024-09-18")
+        _seed(sess, stance="DOVISH", document_date="2024-11-06")
+    finally:
+        sess.close()
+
+    response = client.get("/history", params={"stance": "dovish"})
+    assert response.status_code == 200
+    assert response.json()["total"] == 1
+    assert response.json()["items"][0]["stance"] == "dovish"
+
+    by_date = client.get("/history", params={"document_date": "2024-09-18"})
+    assert by_date.status_code == 200
+    assert by_date.json()["total"] == 1
+
+
+def test_fomc_calendar_endpoint_returns_past_and_upcoming(client):
+    response = client.get("/fomc/calendar", params={"as_of": "2024-09-18"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["upcoming"]
+    assert body["past"]
+    assert body["upcoming"][0]["meeting_date"] >= "2024-09-18"
+    assert body["past"][0]["meeting_date"] < "2024-09-18"
+
+
+def test_fomc_calendar_validates_as_of(client):
+    response = client.get("/fomc/calendar", params={"as_of": "not-a-date"})
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- SQLAlchemy 2.0 + SQLite at `data/db/fed_pulse.db`. `/analyze` success path persists every run.
- New endpoints: `GET /history`, `GET /history/{id}`, `DELETE /history/{id}`, `GET /fomc/calendar`.
- New `/history` and `/calendar` pages on the shadcn shell, plus a watchlist chip row on `/analyze`.
- FOMC schedule sourced from the Fed's published calendar (2023–2026).
- Stacked on top of the cutover PR; resolves cleanly once that lands.

## Test plan
- [x] `npm test` (67 tests)
- [x] `pytest tests/unit/test_db.py tests/unit/test_fomc_calendar.py tests/unit/test_history_endpoints.py` — runs in CI
- [x] `npm run build`