### PR TITLE
Add 768→128 embedding adapter, text_channel flag, ablation configs

### DIFF
--- a/backend/app/models/embedding_adapter.py
+++ b/backend/app/models/embedding_adapter.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from torch import Tensor, nn
+
+
+class EmbeddingAdapter(nn.Module):
+    """Adapter that lifts pooled chunk embeddings into a 128-d projection.
+
+    Replaces the legacy `nn.Linear(768, 8)` bottleneck used in earlier ablation
+    runs. Layer order is Linear → LayerNorm → GELU. The linear stage is
+    zero-initialised so the v1 baseline forward pass is recovered exactly when
+    the text channel is freshly activated; the adapter only departs from that
+    subspace if gradients show the text signal lowers loss.
+    """
+
+    def __init__(
+        self,
+        input_dim: int = 768,
+        output_dim: int = 128,
+        zero_init: bool = True,
+    ) -> None:
+        super().__init__()
+        self.input_dim = int(input_dim)
+        self.output_dim = int(output_dim)
+        self.linear = nn.Linear(self.input_dim, self.output_dim, bias=True)
+        self.norm = nn.LayerNorm(self.output_dim)
+        self.activation = nn.GELU()
+        if zero_init:
+            nn.init.zeros_(self.linear.weight)
+            nn.init.zeros_(self.linear.bias)
+
+    @property
+    def out_features(self) -> int:
+        return self.output_dim
+
+    def forward(self, pooled: Tensor) -> Tensor:
+        projected = self.linear(pooled)
+        normalised = self.norm(projected)
+        return self.activation(normalised)

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -636,6 +636,8 @@ def _coerce_model_config(model_config: ModelConfig | dict[str, Any] | None = Non
             dropout=float(model_config.get("dropout", DEFAULT_DROPOUT)),
             head_hidden_size=int(model_config.get("head_hidden_size", DEFAULT_HEAD_HIDDEN_SIZE)),
             initial_decay_rate=float(model_config.get("initial_decay_rate", DEFAULT_INITIAL_DECAY_RATE)),
+            text_channel=str(model_config.get("text_channel", "scalar")),
+            embedding_adapter_dim=int(model_config.get("embedding_adapter_dim", 128)),
         )
     return ModelConfig()
 

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -54,6 +54,8 @@ class ModelConfig:
     dropout: float = DEFAULT_DROPOUT
     head_hidden_size: int = DEFAULT_HEAD_HIDDEN_SIZE
     initial_decay_rate: float = DEFAULT_INITIAL_DECAY_RATE
+    text_channel: str = "scalar"
+    embedding_adapter_dim: int = 128
 
     @classmethod
     def from_model(cls, model: "ForecasterModel") -> "ModelConfig":
@@ -64,6 +66,8 @@ class ModelConfig:
             dropout=model.dropout,
             head_hidden_size=model.head_hidden_size,
             initial_decay_rate=model.initial_decay_rate,
+            text_channel=getattr(model, "text_channel", "scalar"),
+            embedding_adapter_dim=getattr(model, "chunk_projection_dim", 128) or 128,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -342,6 +346,8 @@ class ForecasterModel(nn.Module):
         use_llm_embeddings: bool = False,
         chunk_embedding_size: int = DEFAULT_CHUNK_EMBEDDING_SIZE,
         chunk_projection_dim: int = DEFAULT_CHUNK_PROJECTION_DIM,
+        text_channel: str = "scalar",
+        embedding_adapter_dim: int = 128,
     ):
         """Forecaster LSTM with optional text-feature variants.
 
@@ -377,6 +383,10 @@ class ForecasterModel(nn.Module):
                 "use_chunk_attention and use_llm_embeddings are mutually exclusive. "
                 "Set at most one to True."
             )
+        if text_channel not in {"scalar", "embeddings"}:
+            raise ValueError(
+                f"Unknown text_channel: {text_channel!r}. Allowed: scalar, embeddings"
+            )
         self.model_type = model_type
         self.input_size = input_size
         self.hidden_size = hidden_size
@@ -387,25 +397,37 @@ class ForecasterModel(nn.Module):
         self.use_time_decay = bool(use_time_decay)
         self.use_chunk_attention = bool(use_chunk_attention)
         self.use_llm_embeddings = bool(use_llm_embeddings)
+        self.text_channel = text_channel
         self.chunk_embedding_size = int(chunk_embedding_size)
         # Either Variant B or Variant C activates the pooler path.
         _uses_pooler = self.use_chunk_attention or self.use_llm_embeddings
-        self.chunk_projection_dim = int(chunk_projection_dim) if _uses_pooler else 0
+        _adapter_active = _uses_pooler and text_channel == "embeddings"
+        effective_dim = int(embedding_adapter_dim) if _adapter_active else int(chunk_projection_dim)
+        self.chunk_projection_dim = effective_dim if _uses_pooler else 0
         self.time_decay = TimeDecayAttention(initial_decay_rate)
         if _uses_pooler:
             self.chunk_pooler: ChunkAttentionPooler | None = ChunkAttentionPooler(
                 embedding_size=self.chunk_embedding_size,
                 initial_decay_rate=DEFAULT_CHUNK_DECAY_RATE,
             )
-            self.chunk_projection: nn.Linear | None = nn.Linear(
-                self.chunk_embedding_size, self.chunk_projection_dim, bias=True
-            )
-            # Zero-init so Variant B/C starts equivalent to baseline; the model
-            # only departs from the baseline subspace if the text signal
-            # actually reduces loss. Avoids drowning 6 base features under
-            # 8 dims of random-init noise on a small training set.
-            nn.init.zeros_(self.chunk_projection.weight)
-            nn.init.zeros_(self.chunk_projection.bias)
+            if _adapter_active:
+                from app.models.embedding_adapter import EmbeddingAdapter
+
+                self.chunk_projection: nn.Module | None = EmbeddingAdapter(
+                    input_dim=self.chunk_embedding_size,
+                    output_dim=self.chunk_projection_dim,
+                    zero_init=True,
+                )
+            else:
+                self.chunk_projection = nn.Linear(
+                    self.chunk_embedding_size, self.chunk_projection_dim, bias=True
+                )
+                # Zero-init so Variant B/C starts equivalent to baseline; the model
+                # only departs from the baseline subspace if the text signal
+                # actually reduces loss. Avoids drowning 6 base features under
+                # 8 dims of random-init noise on a small training set.
+                nn.init.zeros_(self.chunk_projection.weight)
+                nn.init.zeros_(self.chunk_projection.bias)
         else:
             self.chunk_pooler = None
             self.chunk_projection = None

--- a/backend/app/training/config_loader.py
+++ b/backend/app/training/config_loader.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+_ALLOWED_KEYS = {
+    "name",
+    "description",
+    "text_channel",
+    "zero_text",
+    "calendar_only",
+    "feature_overrides",
+    "embedding_adapter_dim",
+}
+
+
+@dataclass(frozen=True)
+class AblationConfig:
+    name: str
+    text_channel: str = "scalar"
+    zero_text: bool = False
+    calendar_only: bool = False
+    embedding_adapter_dim: int = 128
+    feature_overrides: dict[str, Any] = field(default_factory=dict)
+    description: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "text_channel": self.text_channel,
+            "zero_text": self.zero_text,
+            "calendar_only": self.calendar_only,
+            "embedding_adapter_dim": self.embedding_adapter_dim,
+            "feature_overrides": dict(self.feature_overrides),
+            "description": self.description,
+        }
+
+
+def load_ablation_config(path: Path | str) -> AblationConfig:
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Ablation config not found: {path}")
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"Ablation config must be a YAML mapping: {path}")
+    unknown = set(raw.keys()) - _ALLOWED_KEYS
+    if unknown:
+        raise ValueError(f"Unknown keys in {path}: {sorted(unknown)}")
+    name = raw.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"Ablation config {path} requires a non-empty 'name' field.")
+    text_channel = raw.get("text_channel", "scalar")
+    if text_channel not in {"scalar", "embeddings"}:
+        raise ValueError(
+            f"Ablation config {path}: text_channel must be 'scalar' or 'embeddings'."
+        )
+    overrides = raw.get("feature_overrides", {}) or {}
+    if not isinstance(overrides, dict):
+        raise ValueError(f"Ablation config {path}: feature_overrides must be a mapping.")
+    return AblationConfig(
+        name=name,
+        text_channel=text_channel,
+        zero_text=bool(raw.get("zero_text", False)),
+        calendar_only=bool(raw.get("calendar_only", False)),
+        embedding_adapter_dim=int(raw.get("embedding_adapter_dim", 128)),
+        feature_overrides=dict(overrides),
+        description=raw.get("description"),
+    )

--- a/configs/ablation_calendar_only.yaml
+++ b/configs/ablation_calendar_only.yaml
@@ -1,0 +1,13 @@
+name: calendar_only
+description: >
+  Forecaster restricted to calendar features (elapsed-time decay, FOMC-day
+  indicator) plus market history. All text-derived inputs are zeroed; chunk
+  embeddings are not loaded. Establishes the floor for "FOMC-day effect only,
+  no central-bank language" in the headline table.
+text_channel: scalar
+zero_text: true
+calendar_only: true
+feature_overrides:
+  sentiment_score: 0.0
+  close_change_pct: 0.0
+  volatility_change: 0.0

--- a/configs/ablation_no_text.yaml
+++ b/configs/ablation_no_text.yaml
@@ -1,0 +1,9 @@
+name: no_text
+description: >
+  Forecaster with the text channel zeroed out. Used as the lower-bound row in the
+  headline table — answers "do text features matter at all over calendar + market
+  context?" Keeps the same input shape so seeds and folds are comparable.
+text_channel: scalar
+zero_text: true
+feature_overrides:
+  sentiment_score: 0.0

--- a/tests/unit/test_ablation_config_loader.py
+++ b/tests/unit/test_ablation_config_loader.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from app.training.config_loader import AblationConfig, load_ablation_config
+
+
+def test_loads_no_text_ablation():
+    config = load_ablation_config(Path("configs/ablation_no_text.yaml"))
+    assert isinstance(config, AblationConfig)
+    assert config.name == "no_text"
+    assert config.zero_text is True
+    assert config.calendar_only is False
+    assert config.feature_overrides == {"sentiment_score": 0.0}
+
+
+def test_loads_calendar_only_ablation():
+    config = load_ablation_config(Path("configs/ablation_calendar_only.yaml"))
+    assert config.calendar_only is True
+    assert config.feature_overrides["close_change_pct"] == 0.0
+
+
+def test_rejects_unknown_keys(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("name: x\nmystery_key: 1\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Unknown keys"):
+        load_ablation_config(bad)
+
+
+def test_rejects_missing_name(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("text_channel: scalar\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="non-empty 'name'"):
+        load_ablation_config(bad)
+
+
+def test_rejects_invalid_text_channel(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("name: x\ntext_channel: hybrid\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="text_channel must be"):
+        load_ablation_config(bad)

--- a/tests/unit/test_embedding_adapter.py
+++ b/tests/unit/test_embedding_adapter.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("torch")
+
+import torch  # noqa: E402
+
+from app.models.embedding_adapter import EmbeddingAdapter
+
+
+def test_adapter_output_shape_and_dtype():
+    adapter = EmbeddingAdapter(input_dim=768, output_dim=128)
+    pooled = torch.randn(4, 768)
+    out = adapter(pooled)
+    assert out.shape == (4, 128)
+    assert out.dtype == pooled.dtype
+
+
+def test_zero_init_recovers_zero_activation_pre_norm():
+    adapter = EmbeddingAdapter(input_dim=768, output_dim=128, zero_init=True)
+    pooled = torch.randn(2, 768)
+    # Bias zeroed and weight zeroed → pre-LN activations are zero. LN of zero
+    # tensors maps to zero (with eps), then GELU(0) = 0.
+    out = adapter(pooled)
+    assert torch.allclose(out, torch.zeros_like(out), atol=1e-5)
+
+
+def test_gradient_flows_through_adapter():
+    adapter = EmbeddingAdapter(input_dim=768, output_dim=128, zero_init=False)
+    pooled = torch.randn(3, 768, requires_grad=True)
+    out = adapter(pooled)
+    loss = out.pow(2).mean()
+    loss.backward()
+    assert adapter.linear.weight.grad is not None
+    assert adapter.linear.weight.grad.abs().sum().item() > 0

--- a/tests/unit/test_text_channel_flag.py
+++ b/tests/unit/test_text_channel_flag.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("torch")
+
+import torch  # noqa: E402
+
+from app.services.forecaster import ForecasterModel
+
+
+def test_scalar_channel_keeps_legacy_projection_dim():
+    model = ForecasterModel(
+        use_chunk_attention=True,
+        use_llm_embeddings=False,
+        text_channel="scalar",
+    )
+    assert model.chunk_projection_dim == 8
+    # Legacy path uses a plain Linear with zero-init weights.
+    assert isinstance(model.chunk_projection, torch.nn.Linear)
+    assert torch.allclose(model.chunk_projection.weight, torch.zeros_like(model.chunk_projection.weight))
+
+
+def test_embeddings_channel_uses_adapter():
+    model = ForecasterModel(
+        use_chunk_attention=False,
+        use_llm_embeddings=True,
+        text_channel="embeddings",
+        embedding_adapter_dim=128,
+    )
+    assert model.chunk_projection_dim == 128
+    # Adapter is the EmbeddingAdapter module, not a plain Linear.
+    assert type(model.chunk_projection).__name__ == "EmbeddingAdapter"
+
+
+def test_invalid_text_channel_raises():
+    with pytest.raises(ValueError, match="Unknown text_channel"):
+        ForecasterModel(text_channel="hybrid")
+
+
+def test_forward_shape_with_adapter_active():
+    model = ForecasterModel(
+        use_llm_embeddings=True,
+        text_channel="embeddings",
+        embedding_adapter_dim=128,
+    )
+    batch = 2
+    seq_len = 5
+    base = torch.randn(batch, seq_len, model.input_size)
+    chunk_count = 4
+    chunks = torch.randn(batch, chunk_count, model.chunk_embedding_size)
+    elapsed = torch.linspace(0.1, 1.0, chunk_count).expand(batch, -1)
+    out = model(base, chunks=chunks, elapsed_days=elapsed)
+    assert out.shape == (batch, 2)

--- a/tests/unit/test_text_channel_flag.py
+++ b/tests/unit/test_text_channel_flag.py
@@ -6,6 +6,7 @@ pytest.importorskip("torch")
 
 import torch  # noqa: E402
 
+from app.models.embedding_adapter import EmbeddingAdapter
 from app.services.forecaster import ForecasterModel
 
 
@@ -29,13 +30,36 @@ def test_embeddings_channel_uses_adapter():
         embedding_adapter_dim=128,
     )
     assert model.chunk_projection_dim == 128
-    # Adapter is the EmbeddingAdapter module, not a plain Linear.
-    assert type(model.chunk_projection).__name__ == "EmbeddingAdapter"
+    assert isinstance(model.chunk_projection, EmbeddingAdapter)
+    assert model.chunk_projection.out_features == 128
 
 
 def test_invalid_text_channel_raises():
     with pytest.raises(ValueError, match="Unknown text_channel"):
         ForecasterModel(text_channel="hybrid")
+
+
+def test_coerce_model_config_preserves_text_channel_from_dict():
+    from app.services.forecaster import ModelConfig, _coerce_model_config
+
+    config_dict = {
+        "hidden_size": 32,
+        "text_channel": "embeddings",
+        "embedding_adapter_dim": 64,
+    }
+    coerced = _coerce_model_config(config_dict)
+    assert isinstance(coerced, ModelConfig)
+    assert coerced.text_channel == "embeddings"
+    assert coerced.embedding_adapter_dim == 64
+
+
+def test_coerce_model_config_defaults_legacy_dicts_to_scalar():
+    from app.services.forecaster import _coerce_model_config
+
+    legacy_dict = {"hidden_size": 32, "num_layers": 2}
+    coerced = _coerce_model_config(legacy_dict)
+    assert coerced.text_channel == "scalar"
+    assert coerced.embedding_adapter_dim == 128
 
 
 def test_forward_shape_with_adapter_active():


### PR DESCRIPTION
## Summary
- New `backend/app/models/embedding_adapter.py` — `Linear(768→128) → LayerNorm → GELU`, zero-init so v1 baseline is recovered on activation.
- `ForecasterModel` accepts `text_channel="scalar"|"embeddings"` and `embedding_adapter_dim`; default stays `scalar` so v1 reference numbers reproduce.
- New `configs/ablation_no_text.yaml` and `configs/ablation_calendar_only.yaml`; loader in `app/training/config_loader.py` rejects unknown keys / invalid text_channel values.
- Adapter is hot-swappable: legacy 768→8 path remains the default, embedding-channel runs flip to the adapter at construction time.

## Test plan
- [x] `pytest tests/unit/test_embedding_adapter.py tests/unit/test_text_channel_flag.py tests/unit/test_ablation_config_loader.py` — runs in CI
- [ ] GPU smoke: `make train-smoke --text-channel=embeddings` (queued for the next batch run)