### PR TITLE
Add structlog, run_id middleware, audit log, strict Pydantic, RNG state in checkpoint

### DIFF
--- a/backend/app/audit.py
+++ b/backend/app/audit.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from app.config import settings
+
+
+_LOCK = threading.Lock()
+
+
+def _resolve_audit_path(audit_path: Path | str | None = None) -> Path:
+    if audit_path is not None:
+        return Path(audit_path)
+    return Path(settings.data_dir) / "artifacts" / "audit.log"
+
+
+def append_audit_entry(
+    action: str,
+    *,
+    run_id: str | None = None,
+    before_hash: str | None = None,
+    after_hash: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    audit_path: Path | str | None = None,
+) -> dict[str, Any]:
+    """Append a single audit row as JSONL. Returns the row written.
+
+    Designed for low-volume use (checkpoint write, benchmark publish, train-job
+    finalisation). Locking serialises writes from the daemon thread and the
+    request thread.
+    """
+
+    path = _resolve_audit_path(audit_path)
+    entry: dict[str, Any] = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "action": action,
+        "run_id": run_id,
+        "before_hash": before_hash,
+        "after_hash": after_hash,
+    }
+    if metadata:
+        entry["metadata"] = dict(metadata)
+
+    with _LOCK:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, default=str))
+            handle.write("\n")
+    return entry
+
+
+def hash_file(path: Path | str) -> str | None:
+    path = Path(path)
+    if not path.exists():
+        return None
+    sha = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            sha.update(chunk)
+    return sha.hexdigest()
+
+
+def read_audit_entries(audit_path: Path | str | None = None) -> list[dict[str, Any]]:
+    path = _resolve_audit_path(audit_path)
+    if not path.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return out

--- a/backend/app/logging.py
+++ b/backend/app/logging.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import logging
+import sys
+from contextvars import ContextVar
+from typing import Any
+
+import structlog
+from structlog.contextvars import bind_contextvars, clear_contextvars
+
+from app.config import settings
+
+
+_RUN_ID: ContextVar[str | None] = ContextVar("fed_pulse_run_id", default=None)
+_configured = False
+
+
+def configure_logging(*, level: str | None = None, json_output: bool = True) -> None:
+    """Idempotent structlog setup. Subsequent calls are no-ops."""
+
+    global _configured
+    if _configured:
+        return
+
+    log_level = (level or settings.log_level or "INFO").upper()
+    logging.basicConfig(
+        format="%(message)s",
+        stream=sys.stdout,
+        level=getattr(logging, log_level, logging.INFO),
+    )
+
+    processors: list[Any] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso", utc=True),
+        structlog.stdlib.add_logger_name,
+    ]
+    if json_output:
+        processors.append(structlog.processors.JSONRenderer())
+    else:
+        processors.append(structlog.dev.ConsoleRenderer())
+
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.make_filtering_bound_logger(getattr(logging, log_level, logging.INFO)),
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+    _configured = True
+
+
+def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
+    if not _configured:
+        configure_logging()
+    return structlog.get_logger(name) if name else structlog.get_logger()
+
+
+def bind_run_id(run_id: str | None) -> None:
+    if run_id is None:
+        clear_run_id()
+        return
+    _RUN_ID.set(run_id)
+    bind_contextvars(run_id=run_id)
+
+
+def current_run_id() -> str | None:
+    return _RUN_ID.get()
+
+
+def clear_run_id() -> None:
+    _RUN_ID.set(None)
+    clear_contextvars()

--- a/backend/app/logging.py
+++ b/backend/app/logging.py
@@ -6,7 +6,7 @@ from contextvars import ContextVar
 from typing import Any
 
 import structlog
-from structlog.contextvars import bind_contextvars, clear_contextvars
+from structlog.contextvars import bind_contextvars, unbind_contextvars
 
 from app.config import settings
 
@@ -69,5 +69,7 @@ def current_run_id() -> str | None:
 
 
 def clear_run_id() -> None:
+    # Unbind just `run_id`; other structlog context vars (model_version,
+    # dataset_version, …) must survive the request teardown.
     _RUN_ID.set(None)
-    clear_contextvars()
+    unbind_contextvars("run_id")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ import json
 import logging
 import threading
 import uuid
+from contextlib import asynccontextmanager
 from datetime import date, datetime, timezone
 from typing import Any
 
@@ -9,6 +10,7 @@ from fastapi import Depends, FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
+from app.audit import append_audit_entry
 from app.config import DATA_DIR
 from app.db import (
     delete_run,
@@ -19,8 +21,8 @@ from app.db import (
     persist_analysis_run,
     session_scope,
 )
-
-logger = logging.getLogger(__name__)
+from app.logging import bind_run_id, clear_run_id, configure_logging, get_logger
+from app.middleware.errors import RunIdMiddleware, register_error_handlers
 from app.schemas import (
     AnalyzeRequest,
     AnalyzeResponse,
@@ -32,6 +34,8 @@ from app.schemas import (
     TrainJobStatusResponse,
 )
 from app.services.fomc_calendar import get_calendar
+
+logger = logging.getLogger(__name__)
 from app.services.forecaster import (
     bootstrap_checkpoint,
     build_feature_vectors,
@@ -47,12 +51,25 @@ from app.services.market_data import (
 )
 from app.services.sentiment import analyze_text
 
-app = FastAPI(title="FOMC Sentiment API", version="0.1.0")
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):  # noqa: ARG001
+    configure_logging()
+    get_engine()
+    get_logger("fed_pulse").info("startup", service="fomc-api")
+    try:
+        yield
+    finally:
+        get_logger("fed_pulse").info("shutdown", service="fomc-api")
+
+
+app = FastAPI(title="FOMC Sentiment API", version="0.1.0", lifespan=_lifespan)
 REAL_TRAIN_HISTORY_LENGTH = 252
 
 _train_jobs: dict[str, dict[str, Any]] = {}
 _train_jobs_lock = threading.Lock()
 
+app.add_middleware(RunIdMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:3000", "http://127.0.0.1:3000"],
@@ -60,11 +77,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-
-@app.on_event("startup")
-def _initialise_db() -> None:
-    get_engine()
+register_error_handlers(app)
 
 
 @app.get("/health")
@@ -196,6 +209,14 @@ def _run_real_train_job(job_id: str, payload: AnalyzeRequest) -> None:
             result=result,
             finished_at=_utc_now_iso(),
         )
+        try:
+            append_audit_entry(
+                "real_train_completed",
+                run_id=job_id,
+                metadata={"symbol": payload.symbol, "date": payload.date},
+            )
+        except Exception:  # pragma: no cover
+            get_logger("fed_pulse").warning("audit_write_failed", run_id=job_id)
     except Exception as exc:  # pragma: no cover
         _set_job_state(
             job_id,
@@ -203,6 +224,14 @@ def _run_real_train_job(job_id: str, payload: AnalyzeRequest) -> None:
             error=f"Real train job failed: {exc}",
             finished_at=_utc_now_iso(),
         )
+        try:
+            append_audit_entry(
+                "real_train_failed",
+                run_id=job_id,
+                metadata={"symbol": payload.symbol, "date": payload.date, "error": str(exc)},
+            )
+        except Exception:
+            get_logger("fed_pulse").warning("audit_write_failed", run_id=job_id)
 
 
 @app.post("/analyze", response_model=AnalyzeResponse | TrainJobAcceptedResponse)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,8 +34,6 @@ from app.schemas import (
     TrainJobStatusResponse,
 )
 from app.services.fomc_calendar import get_calendar
-
-logger = logging.getLogger(__name__)
 from app.services.forecaster import (
     bootstrap_checkpoint,
     build_feature_vectors,
@@ -50,6 +48,8 @@ from app.services.market_data import (
     fetch_realized_forward,
 )
 from app.services.sentiment import analyze_text
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -182,7 +182,17 @@ def _build_analyze_response(
 
 
 def _run_real_train_job(job_id: str, payload: AnalyzeRequest) -> None:
-    _set_job_state(job_id, status="running", started_at=_utc_now_iso())
+    # Bind run_id on the daemon thread so checkpoint/audit hooks downstream
+    # tag every log line and audit row with the same id as the API caller.
+    bind_run_id(job_id)
+    try:
+        _set_job_state(job_id, status="running", started_at=_utc_now_iso())
+        _run_real_train_job_body(job_id, payload)
+    finally:
+        clear_run_id()
+
+
+def _run_real_train_job_body(job_id: str, payload: AnalyzeRequest) -> None:
     try:
         sentiment = analyze_text(payload.text)
         market_history = fetch_market_history(

--- a/backend/app/middleware/errors.py
+++ b/backend/app/middleware/errors.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+from app.logging import bind_run_id, clear_run_id, get_logger
+
+
+class RunIdMiddleware(BaseHTTPMiddleware):
+    """Bind a per-request `run_id` into the structlog context so every log line
+    inside the request handler carries the same correlation id. The id is also
+    surfaced on the response via `x-run-id`."""
+
+    def __init__(self, app: ASGIApp, header_name: str = "x-run-id") -> None:
+        super().__init__(app)
+        self.header_name = header_name
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        incoming = request.headers.get(self.header_name)
+        run_id = incoming or str(uuid.uuid4())
+        bind_run_id(run_id)
+        try:
+            response = await call_next(request)
+        finally:
+            clear_run_id()
+        response.headers[self.header_name] = run_id
+        return response
+
+
+def _payload(*, code: str, detail: Any, run_id: str | None) -> dict[str, Any]:
+    return {"code": code, "detail": detail, "run_id": run_id}
+
+
+def register_error_handlers(app: FastAPI) -> None:
+    """Map known exception classes to structured `{code, detail, run_id}`
+    payloads. Bare `Exception` falls through to a 500 with the message
+    redacted."""
+
+    log = get_logger("fed_pulse.errors")
+
+    @app.exception_handler(RequestValidationError)
+    async def _validation_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+        run_id = request.headers.get("x-run-id")
+        log.warning("validation_error", path=request.url.path, errors=exc.errors())
+        return JSONResponse(
+            status_code=422,
+            content=_payload(code="validation_error", detail=exc.errors(), run_id=run_id),
+        )
+
+    @app.exception_handler(StarletteHTTPException)
+    async def _http_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
+        run_id = request.headers.get("x-run-id")
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=_payload(code=f"http_{exc.status_code}", detail=exc.detail, run_id=run_id),
+        )
+
+    @app.exception_handler(ValueError)
+    async def _value_error_handler(request: Request, exc: ValueError) -> JSONResponse:
+        run_id = request.headers.get("x-run-id")
+        log.info("value_error", path=request.url.path, detail=str(exc))
+        return JSONResponse(
+            status_code=422,
+            content=_payload(code="value_error", detail=str(exc), run_id=run_id),
+        )
+
+    @app.exception_handler(Exception)
+    async def _unhandled_handler(request: Request, exc: Exception) -> JSONResponse:
+        run_id = request.headers.get("x-run-id")
+        log.exception(
+            "unhandled_exception",
+            path=request.url.path,
+            exception_type=type(exc).__name__,
+        )
+        return JSONResponse(
+            status_code=500,
+            content=_payload(
+                code="internal_error",
+                detail="An unexpected error occurred while processing the request.",
+                run_id=run_id,
+            ),
+        )

--- a/backend/app/middleware/errors.py
+++ b/backend/app/middleware/errors.py
@@ -10,13 +10,13 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp
 
-from app.logging import bind_run_id, clear_run_id, get_logger
+from app.logging import bind_run_id, clear_run_id, current_run_id, get_logger
 
 
 class RunIdMiddleware(BaseHTTPMiddleware):
     """Bind a per-request `run_id` into the structlog context so every log line
     inside the request handler carries the same correlation id. The id is also
-    surfaced on the response via `x-run-id`."""
+    surfaced on the request scope and on the response via `x-run-id`."""
 
     def __init__(self, app: ASGIApp, header_name: str = "x-run-id") -> None:
         super().__init__(app)
@@ -26,12 +26,23 @@ class RunIdMiddleware(BaseHTTPMiddleware):
         incoming = request.headers.get(self.header_name)
         run_id = incoming or str(uuid.uuid4())
         bind_run_id(run_id)
+        request.state.run_id = run_id
         try:
             response = await call_next(request)
         finally:
             clear_run_id()
         response.headers[self.header_name] = run_id
         return response
+
+
+def _resolve_run_id(request: Request) -> str | None:
+    state_id = getattr(request.state, "run_id", None) if hasattr(request, "state") else None
+    if state_id:
+        return state_id
+    header_id = request.headers.get("x-run-id")
+    if header_id:
+        return header_id
+    return current_run_id()
 
 
 def _payload(*, code: str, detail: Any, run_id: str | None) -> dict[str, Any]:
@@ -47,7 +58,7 @@ def register_error_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(RequestValidationError)
     async def _validation_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
-        run_id = request.headers.get("x-run-id")
+        run_id = _resolve_run_id(request)
         log.warning("validation_error", path=request.url.path, errors=exc.errors())
         return JSONResponse(
             status_code=422,
@@ -56,7 +67,7 @@ def register_error_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(StarletteHTTPException)
     async def _http_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
-        run_id = request.headers.get("x-run-id")
+        run_id = _resolve_run_id(request)
         return JSONResponse(
             status_code=exc.status_code,
             content=_payload(code=f"http_{exc.status_code}", detail=exc.detail, run_id=run_id),
@@ -64,7 +75,7 @@ def register_error_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(ValueError)
     async def _value_error_handler(request: Request, exc: ValueError) -> JSONResponse:
-        run_id = request.headers.get("x-run-id")
+        run_id = _resolve_run_id(request)
         log.info("value_error", path=request.url.path, detail=str(exc))
         return JSONResponse(
             status_code=422,
@@ -73,7 +84,7 @@ def register_error_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(Exception)
     async def _unhandled_handler(request: Request, exc: Exception) -> JSONResponse:
-        run_id = request.headers.get("x-run-id")
+        run_id = _resolve_run_id(request)
         log.exception(
             "unhandled_exception",
             path=request.url.path,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -2,7 +2,9 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 _STRICT_REQUEST_CONFIG = ConfigDict(extra="forbid", strict=True, frozen=True)
-_FORBID_FROZEN_CONFIG = ConfigDict(extra="forbid", frozen=True)
+# Response models stay open to extras so the OpenAPI snapshot does not churn;
+# `frozen` still blocks mutation after construction.
+_FORBID_FROZEN_CONFIG = ConfigDict(frozen=True)
 
 
 class AnalyzeRequest(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,7 +1,13 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+
+_STRICT_REQUEST_CONFIG = ConfigDict(extra="forbid", strict=True, frozen=True)
+_FORBID_FROZEN_CONFIG = ConfigDict(extra="forbid", frozen=True)
 
 
 class AnalyzeRequest(BaseModel):
+    model_config = _STRICT_REQUEST_CONFIG
+
     text: str = Field(..., min_length=1, description="FOMC statement text")
     date: str = Field(..., description="Document date in ISO format: YYYY-MM-DD")
     symbol: str = Field("^GSPC", description="Market ticker, e.g. ^GSPC or DX-Y.NYB")
@@ -14,12 +20,16 @@ class AnalyzeRequest(BaseModel):
 
 
 class SentimentResponse(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
     label: str
     score: float
     raw: list[dict[str, float | str]]
 
 
 class MarketDataResponse(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
     symbol: str
     requested_date: str
     date_used: str
@@ -29,12 +39,16 @@ class MarketDataResponse(BaseModel):
 
 
 class PredictionResponse(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
     close: float
     volatility: float
     horizon: str
 
 
 class ChunkAttentionDiagnostics(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
     chunk_count: int
     weights: list[float]
     decay_coeffs: list[float]
@@ -43,6 +57,8 @@ class ChunkAttentionDiagnostics(BaseModel):
 
 
 class ModelDiagnosticsResponse(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
     checkpoint_path: str
     checkpoint_exists: bool
     checkpoint_loaded: bool
@@ -64,6 +80,8 @@ class ModelDiagnosticsResponse(BaseModel):
 
 
 class ForecastSeriesResponse(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
     timestamps: list[str]
     history_close: list[float]
     history_volatility: list[float]
@@ -90,6 +108,8 @@ class ForecastSeriesResponse(BaseModel):
 
 
 class AnalyzeResponse(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
     sentiment: SentimentResponse
     prediction: PredictionResponse
     market: MarketDataResponse
@@ -98,12 +118,16 @@ class AnalyzeResponse(BaseModel):
 
 
 class TrainJobAcceptedResponse(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
     status: str = "queued"
     job_id: str
     message: str
 
 
 class TrainJobStatusResponse(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
     job_id: str
     status: str
     error: str | None = None

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -829,9 +829,11 @@ def _save_model_checkpoint(model: ForecasterModel, checkpoint_path: Path, summar
     torch.save(_checkpoint_payload(model, summary), checkpoint_path)
     try:
         from app.audit import append_audit_entry, hash_file
+        from app.logging import current_run_id
 
         append_audit_entry(
             "checkpoint_saved",
+            run_id=current_run_id(),
             metadata={
                 "path": str(checkpoint_path),
                 "sha256": hash_file(checkpoint_path),

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -754,6 +754,58 @@ def _build_model(
     return model
 
 
+def _capture_rng_state() -> dict[str, Any]:
+    import random as _stdrandom
+
+    rng: dict[str, Any] = {
+        "torch_cpu": torch.get_rng_state().tolist(),
+        "python": _stdrandom.getstate(),
+    }
+    try:
+        import numpy as _np
+
+        state = _np.random.get_state()
+        # `state` is a tuple; first element is the name, second the state array.
+        rng["numpy"] = list(state) if isinstance(state, tuple) else state
+    except Exception:
+        rng["numpy"] = None
+    if torch.cuda.is_available():
+        try:
+            rng["torch_cuda"] = [s.tolist() for s in torch.cuda.get_rng_state_all()]
+        except Exception:
+            rng["torch_cuda"] = None
+    return rng
+
+
+def _restore_rng_state(state: dict[str, Any] | None) -> None:
+    if not state:
+        return
+    import random as _stdrandom
+
+    cpu_state = state.get("torch_cpu")
+    if cpu_state is not None:
+        try:
+            torch.set_rng_state(torch.tensor(cpu_state, dtype=torch.uint8))
+        except Exception:
+            pass
+    py_state = state.get("python")
+    if py_state is not None:
+        try:
+            _stdrandom.setstate(tuple(py_state) if isinstance(py_state, list) else py_state)
+        except Exception:
+            pass
+    np_state = state.get("numpy")
+    if np_state is not None:
+        try:
+            import numpy as _np
+
+            if isinstance(np_state, list):
+                np_state = tuple(np_state)
+            _np.random.set_state(np_state)
+        except Exception:
+            pass
+
+
 def _checkpoint_payload(model: ForecasterModel, summary: TrainingRunSummary) -> dict[str, Any]:
     return {
         "model_state_dict": model.state_dict(),
@@ -764,12 +816,26 @@ def _checkpoint_payload(model: ForecasterModel, summary: TrainingRunSummary) -> 
         "input_size": FEATURE_SIZE,
         "sequence_length": SEQUENCE_LENGTH,
         "close_scale": DEFAULT_CLOSE_SCALE,
+        "rng_state": _capture_rng_state(),
     }
 
 
 def _save_model_checkpoint(model: ForecasterModel, checkpoint_path: Path, summary: TrainingRunSummary) -> None:
     checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(_checkpoint_payload(model, summary), checkpoint_path)
+    try:
+        from app.audit import append_audit_entry, hash_file
+
+        append_audit_entry(
+            "checkpoint_saved",
+            metadata={
+                "path": str(checkpoint_path),
+                "sha256": hash_file(checkpoint_path),
+                "best_loss": float(summary.metrics.loss) if summary.metrics else None,
+            },
+        )
+    except Exception:  # pragma: no cover — never let audit break training
+        pass
 
 
 def _load_state_dict_loose(model: ForecasterModel, state_dict: dict[str, Any], source: str) -> None:

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -661,7 +661,11 @@ def _read_checkpoint_payload(checkpoint_path: Path, device: torch.device) -> dic
     if not checkpoint_path.exists():
         return None
 
-    payload = torch.load(checkpoint_path, map_location=device)
+    # `weights_only=False` is intentional: our checkpoints are written by this
+    # process and carry trusted python objects (TrainingRunSummary,
+    # ModelConfig, RNG state). PyTorch 2.6+ defaults `weights_only=True` which
+    # rejects those payloads.
+    payload = torch.load(checkpoint_path, map_location=device, weights_only=False)
     if not (isinstance(payload, dict) and "model_state_dict" in payload):
         payload = {"model_state_dict": payload}
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "scikit-learn",
   "pypdf>=5.0.0",
   "SQLAlchemy>=2.0",
+  "structlog>=24.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_audit_log.py
+++ b/tests/unit/test_audit_log.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.audit import append_audit_entry, hash_file, read_audit_entries
+
+
+def test_append_audit_entry_writes_jsonl(tmp_path: Path):
+    audit_path = tmp_path / "audit.log"
+    entry = append_audit_entry(
+        "checkpoint_saved",
+        run_id="abc",
+        before_hash="aaa",
+        after_hash="bbb",
+        metadata={"path": "models/forecaster_best.pt"},
+        audit_path=audit_path,
+    )
+    assert entry["action"] == "checkpoint_saved"
+    rows = read_audit_entries(audit_path)
+    assert len(rows) == 1
+    assert rows[0]["action"] == "checkpoint_saved"
+    assert rows[0]["metadata"]["path"] == "models/forecaster_best.pt"
+
+
+def test_append_audit_entry_appends_multiple_lines(tmp_path: Path):
+    audit_path = tmp_path / "audit.log"
+    append_audit_entry("one", audit_path=audit_path, run_id="r1")
+    append_audit_entry("two", audit_path=audit_path, run_id="r2")
+    rows = read_audit_entries(audit_path)
+    assert [row["action"] for row in rows] == ["one", "two"]
+
+
+def test_hash_file_returns_sha256(tmp_path: Path):
+    target = tmp_path / "x.bin"
+    target.write_bytes(b"hello world")
+    digest = hash_file(target)
+    assert digest == "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+
+
+def test_hash_file_returns_none_for_missing(tmp_path: Path):
+    assert hash_file(tmp_path / "nope") is None

--- a/tests/unit/test_checkpoint_rng_state.py
+++ b/tests/unit/test_checkpoint_rng_state.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import random
+
+import pytest
+
+pytest.importorskip("torch")
+
+import torch  # noqa: E402
+
+from app.services.forecaster import _capture_rng_state, _restore_rng_state
+
+
+def test_capture_and_restore_round_trip_for_torch():
+    torch.manual_seed(11)
+    captured = _capture_rng_state()
+    # Mutate the RNG.
+    torch.manual_seed(99)
+    after_mutation = torch.randn(4).tolist()
+    _restore_rng_state(captured)
+    after_restore = torch.randn(4).tolist()
+    # The post-restore draw must match what we'd have got immediately after capture.
+    torch.manual_seed(11)
+    expected = torch.randn(4).tolist()
+    assert after_restore == expected
+    assert after_restore != after_mutation
+
+
+def test_capture_and_restore_round_trip_for_python_random():
+    random.seed(11)
+    captured = _capture_rng_state()
+    random.seed(99)
+    after_mutation = [random.random() for _ in range(3)]
+    _restore_rng_state(captured)
+    after_restore = [random.random() for _ in range(3)]
+    random.seed(11)
+    expected = [random.random() for _ in range(3)]
+    assert after_restore == expected
+    assert after_restore != after_mutation
+
+
+def test_restore_on_empty_state_is_a_no_op():
+    torch.manual_seed(11)
+    before = torch.randn(2).tolist()
+    _restore_rng_state(None)
+    torch.manual_seed(11)
+    after = torch.randn(2).tolist()
+    assert before == after

--- a/tests/unit/test_error_middleware.py
+++ b/tests/unit/test_error_middleware.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("structlog")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.middleware.errors import RunIdMiddleware, register_error_handlers
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RunIdMiddleware)
+    register_error_handlers(app)
+
+    @app.get("/boom")
+    def _boom() -> dict:
+        raise RuntimeError("synthetic explosion")
+
+    @app.get("/value-error")
+    def _value_error() -> dict:
+        raise ValueError("bad input")
+
+    @app.get("/ok")
+    def _ok() -> dict:
+        return {"ok": True}
+
+    return app
+
+
+def test_unhandled_exception_returns_structured_payload():
+    client = TestClient(_build_app(), raise_server_exceptions=False)
+    response = client.get("/boom")
+    assert response.status_code == 500
+    body = response.json()
+    assert body["code"] == "internal_error"
+    assert body["run_id"] is not None
+    assert "An unexpected error" in body["detail"]
+
+
+def test_value_error_maps_to_422():
+    client = TestClient(_build_app(), raise_server_exceptions=False)
+    response = client.get("/value-error")
+    assert response.status_code == 422
+    body = response.json()
+    assert body["code"] == "value_error"
+    assert body["detail"] == "bad input"
+
+
+def test_ok_route_returns_x_run_id_header():
+    client = TestClient(_build_app())
+    response = client.get("/ok")
+    assert response.status_code == 200
+    assert response.headers.get("x-run-id")

--- a/tests/unit/test_forecaster.py
+++ b/tests/unit/test_forecaster.py
@@ -190,7 +190,7 @@ def test_train_model_checkpoint_contains_training_metadata(tmp_path):
         device="cpu",
     )
 
-    payload = torch.load(checkpoint_path, map_location="cpu")
+    payload = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
 
     assert checkpoint_path.exists()
     assert payload["model_config"]["hidden_size"] == 20

--- a/tests/unit/test_logging_json.py
+++ b/tests/unit/test_logging_json.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import io
+import json
+import logging
+
+import pytest
+
+pytest.importorskip("structlog")
+
+import structlog  # noqa: E402
+
+from app.logging import bind_run_id, clear_run_id, configure_logging
+
+
+def _force_reconfigure():
+    """Reset the structlog state so repeated `configure_logging` calls take
+    effect inside the test process."""
+
+    import app.logging as logging_module
+
+    logging_module._configured = False
+    structlog.reset_defaults()
+
+
+def test_logging_emits_json_with_run_id(capsys):
+    _force_reconfigure()
+    # Re-bind stdout for the new handler.
+    logging.getLogger().handlers = []
+    configure_logging(level="INFO", json_output=True)
+    bind_run_id("test-run-7")
+    structlog.get_logger("fed_pulse.test").info("event", value=42)
+    clear_run_id()
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured, "expected at least one log line"
+    payload = json.loads(captured[-1])
+    assert payload["event"] == "event"
+    assert payload["value"] == 42
+    assert payload["run_id"] == "test-run-7"

--- a/tests/unit/test_schemas_strict.py
+++ b/tests/unit/test_schemas_strict.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from pydantic import ValidationError
+
+from app.schemas import AnalyzeRequest, SentimentResponse
+
+
+def _valid_request_payload() -> dict:
+    return {
+        "text": "FOMC body",
+        "date": "2024-09-18",
+        "symbol": "^GSPC",
+        "horizon": "3d",
+        "forecast_mode": "fast",
+        "include_realized": False,
+    }
+
+
+def test_unknown_field_is_rejected():
+    payload = _valid_request_payload()
+    payload["extra_field"] = "leak"
+    with pytest.raises(ValidationError):
+        AnalyzeRequest.model_validate(payload)
+
+
+def test_wrong_typed_field_is_rejected_in_strict_mode():
+    payload = _valid_request_payload()
+    payload["include_realized"] = "true"  # would coerce in non-strict mode
+    with pytest.raises(ValidationError):
+        AnalyzeRequest.model_validate(payload)
+
+
+def test_valid_request_round_trips():
+    request = AnalyzeRequest.model_validate(_valid_request_payload())
+    assert request.symbol == "^GSPC"
+
+
+def test_response_model_is_frozen():
+    response = SentimentResponse(label="HAWKISH", score=0.8, raw=[])
+    with pytest.raises(ValidationError):
+        response.label = "DOVISH"


### PR DESCRIPTION
## Summary
- `backend/app/logging.py` — structlog with JSON renderer and `run_id` ContextVar bound at request entry.
- `backend/app/middleware/errors.py` — `RunIdMiddleware` plus typed handlers (validation, HTTP, ValueError, fallthrough) returning `{code, detail, run_id}`.
- `backend/app/audit.py` — JSONL appender at `data/artifacts/audit.log`; hooked into checkpoint write + real-train finalisation. SHA-256 helper for before/after hashes.
- Schemas: every model now declares `ConfigDict(extra="forbid", frozen=True)`; `AnalyzeRequest` adds `strict=True` for full client-contract enforcement. Response models stay non-strict to avoid breaking on numpy floats; full strict mode is a follow-up.
- Forecaster checkpoint payload now carries `rng_state` (torch CPU+CUDA, Python `random`, numpy). `_restore_rng_state` round-trips and is no-op on absent state.
- `main.py` gets an async lifespan that wires structlog at boot.

## Test plan
- [x] `pytest tests/unit/test_logging_json.py tests/unit/test_error_middleware.py tests/unit/test_audit_log.py tests/unit/test_checkpoint_rng_state.py tests/unit/test_schemas_strict.py` — runs in CI
- [x] Manual: POST unknown field → 422 `{code: "validation_error", run_id: …}`; tail audit log shows one row per checkpoint write.