### PR TITLE
perf: preload HF classifier in lifespan, run /analyze hot path in threadpool

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from datetime import date, datetime, timezone
 from typing import Any
 
 from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
@@ -56,6 +57,14 @@ logger = logging.getLogger(__name__)
 async def _lifespan(app: FastAPI):  # noqa: ARG001
     configure_logging()
     get_engine()
+    # Pre-load the HF classifier so the first /analyze request doesn't pay
+    # the cold-start cost. The lazy module-level cache keeps this idempotent.
+    try:
+        from app.services.text_encoder import warmup_classifier
+
+        warmup_classifier()
+    except Exception:  # pragma: no cover — never let model warmup block startup
+        get_logger("fed_pulse").warning("classifier_warmup_failed", exc_info=True)
     get_logger("fed_pulse").info("startup", service="fomc-api")
     try:
         yield
@@ -245,7 +254,10 @@ def _run_real_train_job_body(job_id: str, payload: AnalyzeRequest) -> None:
 
 
 @app.post("/analyze", response_model=AnalyzeResponse | TrainJobAcceptedResponse)
-def analyze(payload: AnalyzeRequest):
+async def analyze(payload: AnalyzeRequest):
+    """Async handler — heavy sync work (transformers, yfinance, torch) runs in
+    the thread pool so the event loop stays responsive under load."""
+
     try:
         mode = payload.forecast_mode.strip().lower()
         if mode not in {"fast", "quick_train", "real_train"}:
@@ -278,32 +290,44 @@ def analyze(payload: AnalyzeRequest):
         history_length = 30
         if mode == "fast" and not checkpoint_exists():
             # Bootstrap a first checkpoint so fast-mode inference is not random on cold start.
-            warmup_sentiment = analyze_text(payload.text)
-            warmup_history = fetch_market_history(
-                target_date=payload.date,
-                symbol=payload.symbol,
-                history_length=REAL_TRAIN_HISTORY_LENGTH,
-            )
-            warmup_vectors = build_feature_vectors(
-                warmup_history,
-                sentiment_score=float(warmup_sentiment["score"]),
-                document_date=payload.date,
-            )
-            bootstrap_checkpoint(
-                vectors=warmup_vectors,
-                epochs=60,
-                batch_size=64,
-                learning_rate=4e-4,
-                early_stopping_patience=8,
-            )
+            await run_in_threadpool(_bootstrap_cold_start, payload)
 
-        response = _build_analyze_response(payload, mode=mode, history_length=history_length)
-        _record_history(payload, response)
+        response = await run_in_threadpool(
+            _build_analyze_response, payload, mode=mode, history_length=history_length
+        )
+        await run_in_threadpool(_record_history, payload, response)
         return response
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover
         raise HTTPException(status_code=500, detail=f"Analyze pipeline failed: {exc}") from exc
+
+
+def _bootstrap_cold_start(payload: AnalyzeRequest) -> None:
+    """Run the one-shot bootstrap training when the checkpoint is missing.
+
+    Synchronous — invoked via `run_in_threadpool` from the async handler so the
+    long-running fit doesn't block the event loop.
+    """
+
+    warmup_sentiment = analyze_text(payload.text)
+    warmup_history = fetch_market_history(
+        target_date=payload.date,
+        symbol=payload.symbol,
+        history_length=REAL_TRAIN_HISTORY_LENGTH,
+    )
+    warmup_vectors = build_feature_vectors(
+        warmup_history,
+        sentiment_score=float(warmup_sentiment["score"]),
+        document_date=payload.date,
+    )
+    bootstrap_checkpoint(
+        vectors=warmup_vectors,
+        epochs=60,
+        batch_size=64,
+        learning_rate=4e-4,
+        early_stopping_patience=8,
+    )
 
 
 @app.get("/train-jobs/{job_id}", response_model=TrainJobStatusResponse)

--- a/backend/app/services/text_encoder.py
+++ b/backend/app/services/text_encoder.py
@@ -18,6 +18,7 @@ DEFAULT_CLASSIFIER_MAX_LENGTH = 512
 
 _classifier = None
 _classifier_lock = threading.Lock()
+_classifier_load_count = 0
 
 
 @dataclass(frozen=True)
@@ -69,12 +70,31 @@ def get_classifier():
         for model_id, target_device in attempts:
             try:
                 _classifier = _build_pipeline(model_id, target_device)
+                global _classifier_load_count
+                _classifier_load_count += 1
                 break
             except Exception as exc:
                 last_error = exc
         if _classifier is None and last_error is not None:
             raise last_error
     return _classifier
+
+
+def classifier_load_count() -> int:
+    """How many times the underlying HF pipeline has been instantiated.
+
+    Used by the lifespan-cache test to assert the model only loads once across
+    repeated `/analyze` calls.
+    """
+
+    return _classifier_load_count
+
+
+def warmup_classifier() -> None:
+    """Force-load the classifier so the first `/analyze` request doesn't pay
+    the cold-start cost. Called from the FastAPI lifespan."""
+
+    get_classifier()
 
 
 def split_into_chunks(

--- a/tests/unit/test_lifespan_classifier_cache.py
+++ b/tests/unit/test_lifespan_classifier_cache.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("transformers")
+
+
+def test_classifier_loads_exactly_once_across_many_get_classifier_calls(monkeypatch):
+    """The lazy module-level cache should keep `classifier_load_count` at 1
+    no matter how many callers ask for the classifier. This is the invariant
+    the FastAPI lifespan relies on."""
+
+    from app.services import text_encoder
+
+    monkeypatch.setattr(text_encoder, "_classifier", None)
+    monkeypatch.setattr(text_encoder, "_classifier_load_count", 0)
+
+    build_calls = {"n": 0}
+
+    class _FakePipeline:
+        tokenizer = None
+        model = None
+
+        def __call__(self, *_args, **_kwargs):
+            return [{"label": "POSITIVE", "score": 0.5}]
+
+    def _fake_build(model_id, device):  # noqa: ARG001
+        build_calls["n"] += 1
+        return _FakePipeline()
+
+    monkeypatch.setattr(text_encoder, "_build_pipeline", _fake_build)
+
+    for _ in range(50):
+        text_encoder.get_classifier()
+
+    assert text_encoder.classifier_load_count() == 1
+    assert build_calls["n"] == 1
+
+
+def test_warmup_classifier_primes_the_cache(monkeypatch):
+    """`warmup_classifier()` (called from the FastAPI lifespan) must load the
+    pipeline so the first request doesn't pay the cold-start cost."""
+
+    from app.services import text_encoder
+
+    monkeypatch.setattr(text_encoder, "_classifier", None)
+    monkeypatch.setattr(text_encoder, "_classifier_load_count", 0)
+
+    class _FakePipeline:
+        tokenizer = None
+        model = None
+
+    monkeypatch.setattr(text_encoder, "_build_pipeline", lambda *_a, **_kw: _FakePipeline())
+
+    assert text_encoder.classifier_load_count() == 0
+    text_encoder.warmup_classifier()
+    assert text_encoder.classifier_load_count() == 1
+    # Subsequent calls hit the cache, no rebuild.
+    text_encoder.warmup_classifier()
+    assert text_encoder.classifier_load_count() == 1


### PR DESCRIPTION
## Summary
- `_lifespan` now calls `warmup_classifier()` so the HF pipeline loads at boot, not on first request.
- `/analyze` becomes `async` and wraps three sync hot-path calls (`_build_analyze_response`, `_record_history`, the cold-start bootstrap) in `fastapi.concurrency.run_in_threadpool` so the event loop never blocks.
- `text_encoder` gains a public `classifier_load_count()` for tests + observability.

## Test plan
- [x] `pytest tests/unit/test_lifespan_classifier_cache.py` — load count stays at 1 across 50 calls; `warmup_classifier` primes the cache.
- [ ] Manual: cold start emits the new `startup` log line before the first request is served.

Closes #102.