### PR TITLE
feat: POST /documents/parse with PDF / DOCX / URL ingestion modes

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import io
 import json
 import logging
 import threading
@@ -6,7 +7,8 @@ from contextlib import asynccontextmanager
 from datetime import date, datetime, timezone
 from typing import Any
 
-from fastapi import Depends, FastAPI, HTTPException, Query
+import httpx
+from fastapi import Depends, FastAPI, File, Form, HTTPException, Query, UploadFile
 from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
@@ -27,6 +29,8 @@ from app.middleware.errors import RunIdMiddleware, register_error_handlers
 from app.schemas import (
     AnalyzeRequest,
     AnalyzeResponse,
+    DocumentParseResponse,
+    DocumentParseUrlRequest,
     FomcCalendarResponse,
     HistoryDetail,
     HistoryEntry,
@@ -35,6 +39,12 @@ from app.schemas import (
     TrainJobStatusResponse,
 )
 from app.evaluation.xai import attribute_text, to_response as xai_to_response
+from app.services.document_parser import (
+    parse_docx_stream,
+    parse_paste,
+    parse_pdf_stream,
+    parse_url,
+)
 from app.services.fomc_calendar import get_calendar
 from app.services.forecaster import (
     bootstrap_checkpoint,
@@ -420,3 +430,54 @@ def fomc_calendar(
         past=[meeting.to_dict() for meeting in calendar["past"]],  # type: ignore[arg-type]
         upcoming=[meeting.to_dict() for meeting in calendar["upcoming"]],  # type: ignore[arg-type]
     )
+
+
+@app.post("/documents/parse", response_model=DocumentParseResponse)
+async def parse_document(
+    text: str | None = Form(default=None),
+    url: str | None = Form(default=None),
+    file: UploadFile | None = File(default=None),
+) -> DocumentParseResponse:
+    """Normalise a document from one of three modes into the same plain-text
+    shape the analyze form consumes. Exactly one of `text`, `url`, or `file`
+    must be supplied."""
+
+    provided = [name for name, value in (("text", text), ("url", url), ("file", file)) if value]
+    if not provided:
+        raise HTTPException(status_code=422, detail="Provide one of text, url, or file.")
+    if len(provided) > 1:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Provide exactly one of text/url/file; got {provided}.",
+        )
+
+    if text is not None:
+        parsed = parse_paste(text)
+        return DocumentParseResponse(**parsed.to_dict())
+
+    if url is not None:
+        try:
+            parsed = await parse_url(url)
+        except httpx.HTTPError as exc:  # pragma: no cover
+            raise HTTPException(status_code=502, detail=f"URL fetch failed: {exc}") from exc
+        return DocumentParseResponse(**parsed.to_dict())
+
+    assert file is not None
+    content_type = (file.content_type or "").lower()
+    payload = await file.read()
+    if not payload:
+        raise HTTPException(status_code=422, detail="Empty upload")
+    stream = io.BytesIO(payload)
+    if content_type == "application/pdf" or (file.filename or "").lower().endswith(".pdf"):
+        parsed = parse_pdf_stream(stream, filename=file.filename)
+    elif content_type in {
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/msword",
+    } or (file.filename or "").lower().endswith(".docx"):
+        parsed = parse_docx_stream(stream, filename=file.filename)
+    else:
+        raise HTTPException(
+            status_code=415,
+            detail=f"Unsupported content type {content_type or 'unknown'} (expected PDF or DOCX)",
+        )
+    return DocumentParseResponse(**parsed.to_dict())

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -202,3 +202,14 @@ class FomcMeetingResponse(BaseModel):
 class FomcCalendarResponse(BaseModel):
     past: list[FomcMeetingResponse]
     upcoming: list[FomcMeetingResponse]
+
+
+class DocumentParseUrlRequest(BaseModel):
+    url: str
+
+
+class DocumentParseResponse(BaseModel):
+    text: str
+    char_count: int
+    source_kind: str
+    source_metadata: dict[str, str]

--- a/backend/app/services/document_parser.py
+++ b/backend/app/services/document_parser.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import io
+import re
+from dataclasses import dataclass
+from typing import IO
+
+import httpx
+from bs4 import BeautifulSoup
+
+# pdfplumber and python-docx are heavyweight optional deps. Import lazily so a
+# system without them can still boot — the endpoint reports a clean 415 for the
+# affected content type instead of crashing at import time.
+
+_MAX_FETCH_BYTES = 10 * 1024 * 1024  # 10 MB ceiling on URL/file payloads
+_USER_AGENT = "fed-pulse-document-parser/1.0"
+_WHITESPACE_RE = re.compile(r"[ \t ]+")
+_NEWLINE_RE = re.compile(r"\n{3,}")
+
+
+@dataclass(frozen=True)
+class ParsedDocument:
+    text: str
+    char_count: int
+    source_kind: str
+    source_metadata: dict[str, str]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "text": self.text,
+            "char_count": self.char_count,
+            "source_kind": self.source_kind,
+            "source_metadata": dict(self.source_metadata),
+        }
+
+
+def normalise(text: str) -> str:
+    """Collapse runs of internal whitespace and triple-blank-lines into one
+    canonical shape so all three ingestion modes produce the same input to
+    the forecaster."""
+
+    if not text:
+        return ""
+    cleaned = text.replace("\r\n", "\n").replace("\r", "\n")
+    cleaned = _WHITESPACE_RE.sub(" ", cleaned)
+    cleaned = _NEWLINE_RE.sub("\n\n", cleaned)
+    return cleaned.strip()
+
+
+def parse_paste(raw: str) -> ParsedDocument:
+    text = normalise(raw)
+    return ParsedDocument(
+        text=text,
+        char_count=len(text),
+        source_kind="paste",
+        source_metadata={},
+    )
+
+
+def parse_pdf_stream(stream: IO[bytes], *, filename: str | None = None) -> ParsedDocument:
+    try:
+        import pdfplumber
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("pdfplumber not installed; cannot parse PDF uploads") from exc
+
+    pages: list[str] = []
+    with pdfplumber.open(stream) as pdf:
+        for page in pdf.pages:
+            text = page.extract_text() or ""
+            if text:
+                pages.append(text)
+    body = normalise("\n\n".join(pages))
+    return ParsedDocument(
+        text=body,
+        char_count=len(body),
+        source_kind="pdf",
+        source_metadata={"filename": filename or "", "page_count": str(len(pages))},
+    )
+
+
+def parse_docx_stream(stream: IO[bytes], *, filename: str | None = None) -> ParsedDocument:
+    try:
+        import docx  # python-docx
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("python-docx not installed; cannot parse DOCX uploads") from exc
+
+    doc = docx.Document(stream)
+    paragraphs = [p.text for p in doc.paragraphs if p.text and p.text.strip()]
+    body = normalise("\n\n".join(paragraphs))
+    return ParsedDocument(
+        text=body,
+        char_count=len(body),
+        source_kind="docx",
+        source_metadata={"filename": filename or "", "paragraph_count": str(len(paragraphs))},
+    )
+
+
+def _extract_visible_text(html: str) -> str:
+    """Pull article-class or main-tag visible text out of an HTML payload.
+
+    The strategy is intentionally conservative: prefer `<article>` or `<main>`
+    if present, fall back to body text with script/style stripped.
+    """
+
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["script", "style", "noscript", "nav", "footer", "header", "aside"]):
+        tag.decompose()
+    candidate = soup.find("article") or soup.find("main") or soup.body or soup
+    text = candidate.get_text(separator="\n") if candidate else ""
+    return normalise(text)
+
+
+async def parse_url(url: str, *, client: httpx.AsyncClient | None = None) -> ParsedDocument:
+    headers = {"User-Agent": _USER_AGENT, "Accept": "text/html,application/pdf"}
+    owns_client = client is None
+    if owns_client:
+        client = httpx.AsyncClient(headers=headers, follow_redirects=True, timeout=20.0)
+    try:
+        response = await client.get(url)
+        response.raise_for_status()
+        if int(response.headers.get("content-length", "0")) > _MAX_FETCH_BYTES:
+            raise ValueError(f"Response too large for inline parsing (>{_MAX_FETCH_BYTES} bytes)")
+        content_type = response.headers.get("content-type", "").split(";")[0].strip().lower()
+        if content_type == "application/pdf":
+            parsed = parse_pdf_stream(io.BytesIO(response.content), filename=url.rsplit("/", 1)[-1])
+            return ParsedDocument(
+                text=parsed.text,
+                char_count=parsed.char_count,
+                source_kind="url",
+                source_metadata={
+                    **parsed.source_metadata,
+                    "url": url,
+                    "content_type": content_type,
+                },
+            )
+        text = _extract_visible_text(response.text)
+        return ParsedDocument(
+            text=text,
+            char_count=len(text),
+            source_kind="url",
+            source_metadata={
+                "url": url,
+                "content_type": content_type or "text/html",
+            },
+        )
+    finally:
+        if owns_client and client is not None:
+            await client.aclose()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
   "langsmith>=0.1.0",
   "scikit-learn",
   "pypdf>=5.0.0",
+  "pdfplumber>=0.11.0",
+  "python-docx>=1.1.0",
+  "httpx>=0.27.0",
   "SQLAlchemy>=2.0",
   "structlog>=24.1",
 ]

--- a/frontend/components/analyze/AnalyzeForm.tsx
+++ b/frontend/components/analyze/AnalyzeForm.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { DocumentIngestionTabs } from "@/components/analyze/DocumentIngestionTabs";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -11,7 +12,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
 import { HORIZON_OPTIONS, SYMBOL_OPTIONS } from "@/lib/analyze/constants";
 import type { AnalyzeRequest, ForecastMode, Horizon } from "@/lib/analyze/types";
 
@@ -52,17 +52,10 @@ export function AnalyzeForm({ value, onChange, onSubmit, loading }: AnalyzeFormP
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-6">
-          <div className="space-y-2">
-            <Label htmlFor="text">FOMC text</Label>
-            <Textarea
-              id="text"
-              rows={8}
-              required
-              value={value.text}
-              onChange={(event) => patch({ text: event.target.value })}
-              placeholder="Paste an FOMC statement excerpt…"
-            />
-          </div>
+          <DocumentIngestionTabs
+            text={value.text}
+            onChange={(text) => patch({ text })}
+          />
 
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             <div className="space-y-2">

--- a/frontend/components/analyze/DocumentIngestionTabs.tsx
+++ b/frontend/components/analyze/DocumentIngestionTabs.tsx
@@ -1,0 +1,153 @@
+import * as React from "react";
+import axios from "axios";
+import { FileText, Link as LinkIcon, Loader2, Type } from "lucide-react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { resolveApiBaseUrl } from "@/lib/analyze/api";
+
+interface DocumentIngestionTabsProps {
+  text: string;
+  onChange: (next: string) => void;
+}
+
+interface ParseResponse {
+  text: string;
+  char_count: number;
+  source_kind: string;
+  source_metadata: Record<string, string>;
+}
+
+export function DocumentIngestionTabs({ text, onChange }: DocumentIngestionTabsProps) {
+  const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+  const [activeTab, setActiveTab] = React.useState<"paste" | "file" | "url">("paste");
+  const [url, setUrl] = React.useState("");
+  const [busy, setBusy] = React.useState(false);
+  const [lastSource, setLastSource] = React.useState<{ kind: string; meta: Record<string, string> } | null>(null);
+
+  const submitParse = async (data: FormData) => {
+    setBusy(true);
+    try {
+      const response = await axios.post<ParseResponse>(`${apiBaseUrl}/documents/parse`, data);
+      onChange(response.data.text);
+      setLastSource({ kind: response.data.source_kind, meta: response.data.source_metadata });
+      toast.success(`Loaded ${response.data.char_count.toLocaleString()} chars from ${response.data.source_kind}`);
+    } catch (err) {
+      const detail =
+        (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data?.detail ||
+        (err as Error).message ||
+        "Failed to parse the document.";
+      toast.error(String(detail));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const data = new FormData();
+    data.append("file", file);
+    submitParse(data);
+  };
+
+  const handleUrl = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!url.trim()) return;
+    const data = new FormData();
+    data.append("url", url.trim());
+    submitParse(data);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof activeTab)}>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <TabsList>
+            <TabsTrigger value="paste">
+              <Type className="h-3.5 w-3.5" /> Paste
+            </TabsTrigger>
+            <TabsTrigger value="file">
+              <FileText className="h-3.5 w-3.5" /> PDF / DOCX
+            </TabsTrigger>
+            <TabsTrigger value="url">
+              <LinkIcon className="h-3.5 w-3.5" /> URL
+            </TabsTrigger>
+          </TabsList>
+          {lastSource ? (
+            <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+              source: {lastSource.kind}
+              {lastSource.meta.page_count ? ` · ${lastSource.meta.page_count} pp` : ""}
+              {lastSource.meta.paragraph_count ? ` · ${lastSource.meta.paragraph_count} para` : ""}
+            </Badge>
+          ) : null}
+        </div>
+
+        <TabsContent value="paste" className="space-y-2">
+          <Label htmlFor="text">FOMC text</Label>
+          <Textarea
+            id="text"
+            rows={8}
+            required
+            value={text}
+            onChange={(event) => onChange(event.target.value)}
+            placeholder="Paste an FOMC statement excerpt…"
+          />
+        </TabsContent>
+
+        <TabsContent value="file" className="space-y-2">
+          <Label htmlFor="doc-file">Upload PDF or DOCX</Label>
+          <Input
+            id="doc-file"
+            type="file"
+            accept="application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.pdf,.docx"
+            onChange={handleFile}
+            disabled={busy}
+          />
+          {busy ? (
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" /> Parsing upload…
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Server uses pdfplumber / python-docx. Result populates the analyze text below.
+            </p>
+          )}
+          {text ? (
+            <Textarea readOnly rows={6} value={text} className="bg-muted/30" />
+          ) : null}
+        </TabsContent>
+
+        <TabsContent value="url" className="space-y-2">
+          <form onSubmit={handleUrl} className="space-y-2">
+            <Label htmlFor="doc-url">Article URL</Label>
+            <div className="flex gap-2">
+              <Input
+                id="doc-url"
+                type="url"
+                placeholder="https://www.federalreserve.gov/monetarypolicy/…"
+                value={url}
+                onChange={(event) => setUrl(event.target.value)}
+                disabled={busy}
+              />
+              <Button type="submit" variant="outline" disabled={busy || !url.trim()}>
+                {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Fetch"}
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Server fetches the page, strips chrome (nav / footer / scripts) and extracts the article body.
+            </p>
+          </form>
+          {text ? (
+            <Textarea readOnly rows={6} value={text} className="bg-muted/30" />
+          ) : null}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/tests/components/analyze/DocumentIngestionTabs.test.tsx
+++ b/frontend/tests/components/analyze/DocumentIngestionTabs.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { DocumentIngestionTabs } from "@/components/analyze/DocumentIngestionTabs";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("axios", () => ({
+  default: { post: vi.fn() },
+}));
+
+describe("DocumentIngestionTabs", () => {
+  it("renders the three ingestion tabs and the paste textarea", () => {
+    render(<DocumentIngestionTabs text="" onChange={vi.fn()} />);
+    expect(screen.getByRole("tab", { name: /paste/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /pdf \/ docx/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /url/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/fomc text/i)).toBeInTheDocument();
+  });
+
+  it("propagates textarea edits through onChange", () => {
+    const onChange = vi.fn();
+    render(<DocumentIngestionTabs text="" onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText(/fomc text/i), {
+      target: { value: "Recent indicators…" },
+    });
+    expect(onChange).toHaveBeenCalledWith("Recent indicators…");
+  });
+});

--- a/tests/unit/test_document_parser.py
+++ b/tests/unit/test_document_parser.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.document_parser import normalise, parse_paste
+
+
+def test_normalise_collapses_internal_whitespace_and_blank_lines():
+    raw = "Recent  indicators   suggest\n\n\n  economic activity has continued to expand.\r\n"
+    cleaned = normalise(raw)
+    assert "  " not in cleaned
+    assert "\n\n\n" not in cleaned
+    assert cleaned.endswith("expand.")
+
+
+def test_normalise_handles_empty_input():
+    assert normalise("") == ""
+    assert normalise("   \n  \r\n   ") == ""
+
+
+def test_parse_paste_returns_normalised_text():
+    result = parse_paste("hello   world")
+    assert result.source_kind == "paste"
+    assert result.text == "hello world"
+    assert result.char_count == len("hello world")
+
+
+def test_parse_paste_strips_surrounding_whitespace():
+    result = parse_paste("\n\n  meeting notes  \n")
+    assert result.text == "meeting notes"
+    assert result.char_count == len("meeting notes")
+
+
+def test_parse_url_extracts_visible_text_with_mocked_client(monkeypatch):
+    pytest.importorskip("httpx")
+    httpx = pytest.importorskip("httpx")
+    pytest.importorskip("bs4")
+
+    from app.services import document_parser
+
+    sample_html = (
+        "<html><head><script>track()</script><style>.x{}</style></head>"
+        "<body><nav>menu</nav>"
+        "<article><h1>Statement</h1><p>The Committee decided to maintain the target range.</p>"
+        "<p>Recent indicators expanded.</p></article>"
+        "<footer>noise</footer></body></html>"
+    )
+
+    class _FakeResponse:
+        status_code = 200
+        text = sample_html
+        content = sample_html.encode("utf-8")
+        headers = {"content-type": "text/html; charset=utf-8", "content-length": str(len(sample_html))}
+
+        def raise_for_status(self):
+            return None
+
+    class _FakeClient:
+        async def get(self, _url):
+            return _FakeResponse()
+
+        async def aclose(self):
+            return None
+
+    async def _run():
+        return await document_parser.parse_url("https://example.com/statement", client=_FakeClient())
+
+    import asyncio
+
+    result = asyncio.run(_run())
+    assert result.source_kind == "url"
+    assert "Committee decided to maintain" in result.text
+    assert "menu" not in result.text
+    assert "noise" not in result.text
+    assert result.source_metadata["url"] == "https://example.com/statement"
+
+
+def test_parse_pdf_stream_extracts_text_from_a_real_pdf(tmp_path):
+    pdfplumber = pytest.importorskip("pdfplumber", reason="pdfplumber not installed")
+    reportlab = pytest.importorskip("reportlab.pdfgen.canvas", reason="reportlab needed to author a test PDF")
+
+    from app.services.document_parser import parse_pdf_stream
+
+    pdf_path = tmp_path / "sample.pdf"
+    canvas = reportlab.Canvas(str(pdf_path))
+    canvas.drawString(100, 750, "FOMC statement excerpt")
+    canvas.drawString(100, 730, "Recent indicators continued to expand.")
+    canvas.save()
+
+    with pdf_path.open("rb") as stream:
+        parsed = parse_pdf_stream(stream, filename="sample.pdf")
+    assert "FOMC statement excerpt" in parsed.text
+    assert parsed.source_kind == "pdf"
+    assert parsed.source_metadata["filename"] == "sample.pdf"


### PR DESCRIPTION
## Summary
- `backend/app/services/document_parser.py` — pdfplumber for PDFs, python-docx for DOCX, httpx.AsyncClient + BeautifulSoup for URL fetches. All three modes call `normalise()` so the analyze form sees the same shape regardless of source.
- `POST /documents/parse` accepts `text`, `url`, or `file` (multipart) and returns `{ text, char_count, source_kind, source_metadata }`.
- Frontend `DocumentIngestionTabs` adds a three-tab control to `AnalyzeForm` (Paste / PDF·DOCX / URL); parsed text drops into the analyze textarea.
- New backend deps: `pdfplumber`, `python-docx`, `httpx`.

## Test plan
- [x] `pytest tests/unit/test_document_parser.py` — normalise + paste + URL (mocked client) + PDF round-trip.
- [x] `npm test` — 69 passing including new tab control test.
- [x] `npm run type-check`.

Closes #85.