### PR TITLE
feat: credibility feature module (drift, realized-vs-stated, OIS gap, months-since-reversal)

### DIFF
--- a/backend/app/features/credibility.py
+++ b/backend/app/features/credibility.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class CredibilityVector:
+    """Four-axis credibility check on the issuing institution at one FOMC date.
+
+    Drift, realized-vs-stated gap, and market-implied gap are all in `[-1, 1]`
+    so the downstream MLP doesn't need per-axis normalisation. `months_since_reversal`
+    is a raw integer; consumers should bucket it when feeding the model.
+    """
+
+    drift_score: float
+    realized_vs_stated_gap: float
+    market_implied_gap: float
+    months_since_reversal: int
+
+    def as_list(self) -> list[float]:
+        return [
+            float(self.drift_score),
+            float(self.realized_vs_stated_gap),
+            float(self.market_implied_gap),
+            float(self.months_since_reversal),
+        ]
+
+
+def cosine_distance(a: Sequence[float], b: Sequence[float]) -> float:
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na <= 1e-12 or nb <= 1e-12:
+        return 0.0
+    similarity = dot / (na * nb)
+    similarity = max(-1.0, min(1.0, similarity))
+    return 1.0 - similarity
+
+
+def drift_vs_prior(
+    current_embedding: Sequence[float],
+    prior_embeddings: Sequence[Sequence[float]],
+) -> float:
+    """Cosine distance between the current statement embedding and the mean
+    of the prior ``len(prior_embeddings)`` statements (typically 4).
+
+    Returns 0.0 when no prior context exists — caller should treat that as
+    "drift unknown" rather than "no drift".
+    """
+
+    if not prior_embeddings:
+        return 0.0
+    dim = len(current_embedding)
+    if dim == 0:
+        return 0.0
+    mean: list[float] = [0.0] * dim
+    counted = 0
+    for vec in prior_embeddings:
+        if len(vec) != dim:
+            continue
+        for i, value in enumerate(vec):
+            mean[i] += float(value)
+        counted += 1
+    if counted == 0:
+        return 0.0
+    mean = [value / counted for value in mean]
+    return cosine_distance(list(current_embedding), mean)
+
+
+def months_since_last_reversal(stance_history: Sequence[float], window: int = 12) -> int:
+    """Count whole months since the sign of `stance_history` last flipped.
+
+    Positive values mean hawkish, negative dovish, zero neutral. Resets when
+    the sign of two consecutive entries differs. `window` caps the lookback so
+    the feature stays bounded; the function returns `window` if no reversal is
+    found in that span (i.e. the stance has been stable for at least `window`
+    months).
+    """
+
+    if len(stance_history) < 2:
+        return 0
+    series = list(stance_history)[-window:]
+    for offset, (prev, curr) in enumerate(
+        zip(reversed(series), list(reversed(series))[1:]), start=1
+    ):
+        if (prev > 0 > curr) or (prev < 0 < curr):
+            return offset
+    return min(len(series), window)
+
+
+def realized_vs_stated_gap(
+    stated_path: Sequence[float],
+    realized_path: Sequence[float],
+    *,
+    window: int = 90,
+) -> float:
+    """Pearson correlation between stated tone (a numeric stance score) and
+    realized effective fed funds change over the trailing ``window`` days.
+
+    Returns a value in ``[-1, 1]``; 0.0 when either series is too short.
+    """
+
+    if len(stated_path) < 2 or len(realized_path) < 2:
+        return 0.0
+    n = min(len(stated_path), len(realized_path), window)
+    stated = list(stated_path)[-n:]
+    realized = list(realized_path)[-n:]
+    mean_s = sum(stated) / n
+    mean_r = sum(realized) / n
+    num = sum((s - mean_s) * (r - mean_r) for s, r in zip(stated, realized))
+    var_s = sum((s - mean_s) ** 2 for s in stated)
+    var_r = sum((r - mean_r) ** 2 for r in realized)
+    denom = math.sqrt(var_s * var_r)
+    if denom <= 1e-12:
+        return 0.0
+    correlation = num / denom
+    return max(-1.0, min(1.0, correlation))
+
+
+def market_implied_gap(sep_terminal: float | None, ois_terminal: float | None) -> float:
+    """SEP-implied terminal rate minus OIS-implied terminal rate, clipped to
+    `[-1, 1]` (units: percentage points scaled by 1/4 since the SEP–OIS gap
+    rarely exceeds 4pp in observed history).
+
+    Returns 0.0 if either value is missing so downstream consumers don't have
+    to special-case None.
+    """
+
+    if sep_terminal is None or ois_terminal is None:
+        return 0.0
+    raw = float(sep_terminal) - float(ois_terminal)
+    scaled = raw / 4.0
+    return max(-1.0, min(1.0, scaled))
+
+
+def compute_credibility_vector(
+    *,
+    current_embedding: Sequence[float] = (),
+    prior_embeddings: Sequence[Sequence[float]] = (),
+    stance_history: Sequence[float] = (),
+    stated_path: Sequence[float] = (),
+    realized_path: Sequence[float] = (),
+    sep_terminal: float | None = None,
+    ois_terminal: float | None = None,
+) -> CredibilityVector:
+    """Aggregate the four axes into a single vector ready for the credibility
+    MLP. Each axis degrades to 0.0 when its inputs are unavailable rather than
+    raising — the model's loss surface stays well-defined."""
+
+    return CredibilityVector(
+        drift_score=drift_vs_prior(current_embedding, prior_embeddings),
+        realized_vs_stated_gap=realized_vs_stated_gap(stated_path, realized_path),
+        market_implied_gap=market_implied_gap(sep_terminal, ois_terminal),
+        months_since_reversal=months_since_last_reversal(stance_history),
+    )

--- a/tests/unit/test_credibility_features.py
+++ b/tests/unit/test_credibility_features.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from app.features.credibility import (
+    CredibilityVector,
+    compute_credibility_vector,
+    cosine_distance,
+    drift_vs_prior,
+    market_implied_gap,
+    months_since_last_reversal,
+    realized_vs_stated_gap,
+)
+
+
+def test_cosine_distance_basic_cases():
+    assert cosine_distance([1.0, 0.0], [1.0, 0.0]) == pytest.approx(0.0)
+    assert cosine_distance([1.0, 0.0], [0.0, 1.0]) == pytest.approx(1.0)
+    assert cosine_distance([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(2.0)
+    # Zero vectors and mismatched dims degrade to 0.0 cleanly.
+    assert cosine_distance([0.0, 0.0], [1.0, 0.0]) == 0.0
+    assert cosine_distance([1.0, 0.0], [1.0]) == 0.0
+
+
+def test_drift_vs_prior_returns_zero_with_no_prior_context():
+    assert drift_vs_prior([1.0, 0.0], []) == 0.0
+
+
+def test_drift_vs_prior_grows_when_current_diverges_from_mean():
+    prior = [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
+    same = drift_vs_prior([1.0, 0.0, 0.0], prior)
+    rotated = drift_vs_prior([0.0, 1.0, 0.0], prior)
+    flipped = drift_vs_prior([-1.0, 0.0, 0.0], prior)
+    assert same == pytest.approx(0.0)
+    assert rotated == pytest.approx(1.0)
+    assert flipped == pytest.approx(2.0)
+
+
+def test_months_since_last_reversal_on_stable_stance():
+    # Monotonically hawkish — no reversal in the window.
+    assert months_since_last_reversal([0.6, 0.5, 0.7, 0.4]) == 4
+
+
+def test_months_since_last_reversal_on_recent_flip():
+    # Last flip is between the last two entries (dovish to hawkish).
+    assert months_since_last_reversal([0.6, 0.5, 0.4, -0.2]) == 1
+
+
+def test_months_since_last_reversal_short_history():
+    assert months_since_last_reversal([0.5]) == 0
+    assert months_since_last_reversal([]) == 0
+
+
+def test_realized_vs_stated_gap_returns_pearson_correlation():
+    # Perfectly correlated → 1.0
+    stated = [0.1, 0.2, 0.3, 0.4]
+    realized = [1.0, 2.0, 3.0, 4.0]
+    assert realized_vs_stated_gap(stated, realized) == pytest.approx(1.0)
+    # Perfectly anti-correlated → -1.0
+    assert realized_vs_stated_gap(stated, list(reversed(realized))) == pytest.approx(-1.0)
+
+
+def test_realized_vs_stated_gap_handles_short_series():
+    assert realized_vs_stated_gap([0.1], [0.2]) == 0.0
+
+
+def test_market_implied_gap_scales_and_clips():
+    # 4pp gap → +1.0; -2pp gap → -0.5; missing inputs → 0.0.
+    assert market_implied_gap(5.5, 1.5) == pytest.approx(1.0)
+    assert market_implied_gap(2.0, 4.0) == pytest.approx(-0.5)
+    assert market_implied_gap(None, 1.0) == 0.0
+    assert market_implied_gap(1.0, None) == 0.0
+
+
+def test_compute_credibility_vector_aggregates_all_four_axes():
+    vector = compute_credibility_vector(
+        current_embedding=[1.0, 0.0, 0.0],
+        prior_embeddings=[[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+        stance_history=[0.6, 0.5, 0.4, -0.2],
+        stated_path=[0.1, 0.2, 0.3, 0.4],
+        realized_path=[1.0, 2.0, 3.0, 4.0],
+        sep_terminal=5.0,
+        ois_terminal=4.0,
+    )
+    assert isinstance(vector, CredibilityVector)
+    assert vector.drift_score == pytest.approx(0.0)
+    assert vector.realized_vs_stated_gap == pytest.approx(1.0)
+    assert vector.market_implied_gap == pytest.approx(0.25)
+    assert vector.months_since_reversal == 1
+    assert vector.as_list() == [0.0, 1.0, 0.25, 1.0]
+
+
+def test_compute_credibility_vector_degrades_gracefully_when_inputs_missing():
+    vector = compute_credibility_vector()
+    assert vector.as_list() == [0.0, 0.0, 0.0, 0.0]


### PR DESCRIPTION
## Summary
- New `backend/app/features/credibility.py` with `CredibilityVector` and four pure-Python feature functions: `drift_vs_prior` (cosine distance vs mean of prior embeddings), `realized_vs_stated_gap` (Pearson correlation over a 90-day window), `market_implied_gap` (SEP – OIS, clipped to ±1), `months_since_last_reversal`.
- Aggregator `compute_credibility_vector(...)` returns the 4-axis vector; each axis degrades to `0.0` when inputs are missing so the downstream MLP has no special-case branch.
- Tests cover all four feature paths including degradation behaviour.

This is the backend half of the central-bank credibility story; the frontend panel (PR #67) already consumes the same four-axis schema via fixtures. The market-data wiring (SEP / OIS pulls, fed funds path) lands in the follow-up that hooks `compute_credibility_vector` into the training package.

The time-decay-over-embeddings refactor is deferred — the existing `ChunkAttentionPooler` already applies `exp(-λ·|Δt|)` on the embedding values, and a structural change to share `λ` with `TimeDecayAttention` would risk the v1 regression test. I'll revisit once the multi-task head (#78) starts consuming the credibility vector.

## Test plan
- [x] `pytest tests/unit/test_credibility_features.py` — 10 cases passing locally / in CI.

Closes #75. Pairs with #74 (deferred).