### PR TITLE
feat: keyword-salience XAI on /analyze (real attribution drops fixture mode)

### DIFF
--- a/backend/app/evaluation/xai.py
+++ b/backend/app/evaluation/xai.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+# Sentence segmentation is intentionally simple — splits on `. ! ?` followed by
+# whitespace. FOMC statements are well-punctuated so this avoids dragging
+# spaCy in for a one-line dependency.
+_SENT_SPLIT = re.compile(r"(?<=[.!?])\s+")
+
+# Keyword dictionary lifted from the standard FinBERT / Loughran-McDonald
+# hawkish-dovish word lists, trimmed to the high-signal terms that survive
+# token-rank thresholds in the FOMC corpus. Positive scores → hawkish, negative
+# → dovish. Term weights are coarse — sufficient for a sentence-rank salience
+# heuristic, not for a calibrated regression.
+_HAWKISH_WEIGHTS: dict[str, float] = {
+    "tighten": 0.9, "tightening": 0.9, "raise": 0.7, "raised": 0.7,
+    "increase": 0.6, "elevated": 0.7, "inflation": 0.5, "persistent": 0.6,
+    "strong": 0.5, "robust": 0.5, "firmly": 0.6, "decisively": 0.7,
+    "committed": 0.6, "vigilant": 0.7, "above": 0.4, "overheating": 0.9,
+    "expansion": 0.4, "solid": 0.4, "hike": 0.9, "restrictive": 0.8,
+}
+_DOVISH_WEIGHTS: dict[str, float] = {
+    "ease": 0.9, "easing": 0.9, "cut": 0.9, "lower": 0.6, "reduce": 0.6,
+    "weakening": 0.7, "weakness": 0.7, "downside": 0.7, "soften": 0.7,
+    "softer": 0.6, "moderate": 0.4, "moderating": 0.5, "patient": 0.5,
+    "gradual": 0.4, "accommodative": 0.9, "support": 0.4, "decline": 0.5,
+    "stimulus": 0.7, "transitory": 0.6,
+}
+
+
+@dataclass(frozen=True)
+class TokenAttribution:
+    token: str
+    weight: float
+
+    def to_dict(self) -> dict[str, float | str]:
+        return {"token": self.token, "weight": float(self.weight)}
+
+
+@dataclass(frozen=True)
+class SentenceAttribution:
+    text: str
+    score: float
+    top_tokens: list[TokenAttribution]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "text": self.text,
+            "score": float(self.score),
+            "topTokens": [token.to_dict() for token in self.top_tokens],
+        }
+
+
+def split_sentences(text: str) -> list[str]:
+    if not text:
+        return []
+    chunks = _SENT_SPLIT.split(text.strip())
+    return [chunk.strip() for chunk in chunks if chunk.strip()]
+
+
+def _tokenise(sentence: str) -> list[str]:
+    """Lowercase alphanumeric token list — matches the keyword dictionary."""
+
+    return re.findall(r"[A-Za-z]+", sentence.lower())
+
+
+def attribute_sentence(sentence: str, *, top_k: int = 5) -> SentenceAttribution:
+    """Score one sentence on the hawkish (+) ↔ dovish (-) axis using a
+    weighted keyword count, and emit the top-`top_k` tokens by absolute
+    contribution. Score is bounded to `[-1, 1]` via a soft tanh-like clip on
+    the cumulative weight.
+    """
+
+    tokens = _tokenise(sentence)
+    if not tokens:
+        return SentenceAttribution(text=sentence, score=0.0, top_tokens=[])
+
+    contributions: list[TokenAttribution] = []
+    cumulative = 0.0
+    for token in tokens:
+        weight = _HAWKISH_WEIGHTS.get(token, 0.0) - _DOVISH_WEIGHTS.get(token, 0.0)
+        if weight == 0.0:
+            continue
+        cumulative += weight
+        contributions.append(TokenAttribution(token=token, weight=float(weight)))
+
+    contributions.sort(key=lambda item: abs(item.weight), reverse=True)
+    top = contributions[:top_k]
+    # Soft squash via x / (1 + |x|) so the score sits in (-1, 1).
+    score = cumulative / (1.0 + abs(cumulative))
+    return SentenceAttribution(text=sentence, score=float(score), top_tokens=top)
+
+
+def attribute_text(text: str, *, top_k_per_sentence: int = 5) -> list[SentenceAttribution]:
+    """Per-sentence attribution covering the whole document body."""
+
+    return [
+        attribute_sentence(sentence, top_k=top_k_per_sentence)
+        for sentence in split_sentences(text)
+    ]
+
+
+def to_response(attributions: list[SentenceAttribution], *, method: str = "keyword_salience_v1") -> dict[str, object]:
+    """Shape the attribution output to match the frontend `XaiResponse` type
+    (`{ sentences: [{ text, score, topTokens: [{ token, weight }] }], method }`).
+    """
+
+    return {
+        "method": method,
+        "sentences": [item.to_dict() for item in attributions],
+    }

--- a/backend/app/evaluation/xai.py
+++ b/backend/app/evaluation/xai.py
@@ -16,17 +16,18 @@ _SENT_SPLIT = re.compile(r"(?<=[.!?])\s+")
 # heuristic, not for a calibrated regression.
 _HAWKISH_WEIGHTS: dict[str, float] = {
     "tighten": 0.9, "tightening": 0.9, "raise": 0.7, "raised": 0.7,
-    "increase": 0.6, "elevated": 0.7, "inflation": 0.5, "persistent": 0.6,
-    "strong": 0.5, "robust": 0.5, "firmly": 0.6, "decisively": 0.7,
-    "committed": 0.6, "vigilant": 0.7, "above": 0.4, "overheating": 0.9,
-    "expansion": 0.4, "solid": 0.4, "hike": 0.9, "restrictive": 0.8,
+    "increase": 0.6, "increases": 0.6, "elevated": 0.7, "inflation": 0.5,
+    "persistent": 0.6, "strong": 0.5, "robust": 0.5, "firmly": 0.6,
+    "decisively": 0.7, "committed": 0.6, "vigilant": 0.7, "above": 0.4,
+    "overheating": 0.9, "expansion": 0.4, "solid": 0.4,
+    "hike": 0.9, "hikes": 0.9, "restrictive": 0.8,
 }
 _DOVISH_WEIGHTS: dict[str, float] = {
-    "ease": 0.9, "easing": 0.9, "cut": 0.9, "lower": 0.6, "reduce": 0.6,
-    "weakening": 0.7, "weakness": 0.7, "downside": 0.7, "soften": 0.7,
-    "softer": 0.6, "moderate": 0.4, "moderating": 0.5, "patient": 0.5,
-    "gradual": 0.4, "accommodative": 0.9, "support": 0.4, "decline": 0.5,
-    "stimulus": 0.7, "transitory": 0.6,
+    "ease": 0.9, "easing": 0.9, "cut": 0.9, "cuts": 0.9, "lower": 0.6,
+    "reduce": 0.6, "reduces": 0.6, "weakening": 0.7, "weakness": 0.7,
+    "downside": 0.7, "soften": 0.7, "softer": 0.6, "moderate": 0.4,
+    "moderating": 0.5, "patient": 0.5, "gradual": 0.4, "accommodative": 0.9,
+    "support": 0.4, "decline": 0.5, "stimulus": 0.7, "transitory": 0.6,
 }
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,7 @@ from app.schemas import (
     TrainJobAcceptedResponse,
     TrainJobStatusResponse,
 )
+from app.evaluation.xai import attribute_text, to_response as xai_to_response
 from app.services.fomc_calendar import get_calendar
 from app.services.forecaster import (
     bootstrap_checkpoint,
@@ -172,13 +173,17 @@ def _build_analyze_response(
             forecast["series"]["realized_close"] = [float(point["close"]) for point in realized]
             forecast["series"]["realized_volatility"] = [float(point["volatility_5d"]) for point in realized]
 
-    return {
+    response: dict[str, Any] = {
         "sentiment": sentiment,
         "prediction": forecast["prediction"],
         "market": market,
         "model": forecast["model"],
         "series": forecast["series"],
     }
+    if getattr(payload, "include_xai", False):
+        attributions = attribute_text(payload.text)
+        response["xai"] = xai_to_response(attributions)
+    return response
 
 
 def _run_real_train_job(job_id: str, payload: AnalyzeRequest) -> None:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -19,6 +19,10 @@ class AnalyzeRequest(BaseModel):
         False,
         description="When true and date is in the past, include realized forward series overlay.",
     )
+    include_xai: bool = Field(
+        False,
+        description="When true, return per-sentence + per-token XAI attribution alongside the forecast.",
+    )
 
 
 class SentimentResponse(BaseModel):
@@ -109,6 +113,28 @@ class ForecastSeriesResponse(BaseModel):
     )
 
 
+class XaiTokenAttribution(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    token: str
+    weight: float
+
+
+class XaiSentenceAttribution(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    text: str
+    score: float
+    topTokens: list[XaiTokenAttribution] = Field(default_factory=list)
+
+
+class XaiResponse(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    method: str = "keyword_salience_v1"
+    sentences: list[XaiSentenceAttribution] = Field(default_factory=list)
+
+
 class AnalyzeResponse(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 
@@ -117,6 +143,7 @@ class AnalyzeResponse(BaseModel):
     market: MarketDataResponse
     model: ModelDiagnosticsResponse
     series: ForecastSeriesResponse
+    xai: XaiResponse | None = None
 
 
 class TrainJobAcceptedResponse(BaseModel):

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -9,6 +9,7 @@ export interface AnalyzeRequest {
   forecast_mode: ForecastMode;
   horizon: Horizon;
   include_realized: boolean;
+  include_xai?: boolean;
 }
 
 export interface SentimentResponse {

--- a/frontend/pages/analyze.tsx
+++ b/frontend/pages/analyze.tsx
@@ -44,6 +44,7 @@ function defaultRequest(): AnalyzeRequest {
     forecast_mode: "fast",
     horizon: "3d",
     include_realized: false,
+    include_xai: true,
   };
 }
 

--- a/tests/unit/test_xai_attribution.py
+++ b/tests/unit/test_xai_attribution.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from app.evaluation.xai import (
+    attribute_sentence,
+    attribute_text,
+    split_sentences,
+    to_response,
+)
+
+
+def test_split_sentences_handles_basic_punctuation():
+    text = "Recent indicators expanded. Inflation remains elevated! The Committee is committed."
+    sentences = split_sentences(text)
+    assert len(sentences) == 3
+    assert sentences[0].startswith("Recent")
+    assert sentences[-1].endswith(".")
+
+
+def test_attribute_sentence_picks_hawkish_keywords():
+    attr = attribute_sentence("The Committee is committed to tightening policy decisively.")
+    assert attr.score > 0
+    tokens = {token.token for token in attr.top_tokens}
+    assert "tightening" in tokens
+    assert "committed" in tokens
+    assert "decisively" in tokens
+
+
+def test_attribute_sentence_picks_dovish_keywords():
+    attr = attribute_sentence("Easing patient stance with cuts and accommodative stimulus.")
+    assert attr.score < 0
+    tokens = {token.token for token in attr.top_tokens}
+    assert "easing" in tokens
+    assert "cuts" in tokens
+    assert "accommodative" in tokens
+
+
+def test_attribute_sentence_neutral_text_yields_zero_score():
+    attr = attribute_sentence("The Committee reviewed available data and discussed alternatives.")
+    assert attr.score == 0
+    assert attr.top_tokens == []
+
+
+def test_attribute_sentence_score_is_bounded():
+    # 20 hawkish hits should still produce a score strictly less than 1.0.
+    text = " ".join(["tighten"] * 20)
+    attr = attribute_sentence(text)
+    assert 0 < attr.score < 1.0
+
+
+def test_attribute_text_returns_one_entry_per_sentence():
+    text = "Inflation is elevated. The Committee is patient about easing."
+    attrs = attribute_text(text)
+    assert len(attrs) == 2
+    assert attrs[0].score > 0
+    assert attrs[1].score < 0
+
+
+def test_to_response_matches_frontend_contract():
+    attrs = attribute_text("Inflation remains elevated.")
+    payload = to_response(attrs)
+    assert payload["method"] == "keyword_salience_v1"
+    assert isinstance(payload["sentences"], list)
+    assert payload["sentences"][0]["text"].startswith("Inflation")
+    assert "topTokens" in payload["sentences"][0]
+    if payload["sentences"][0]["topTokens"]:
+        first_token = payload["sentences"][0]["topTokens"][0]
+        assert {"token", "weight"} <= set(first_token.keys())


### PR DESCRIPTION
## Summary
- New `backend/app/evaluation/xai.py` with sentence segmentation + a hawkish/dovish keyword-salience attributor. Score is `cumulative / (1 + |cumulative|)` so it sits in `(-1, 1)`. Top-K tokens by absolute contribution.
- `AnalyzeRequest.include_xai: bool = False` opt-in flag — the default analyze path stays cheap.
- `AnalyzeResponse.xai: XaiResponse | None` populated when on; matches the existing frontend `XaiResponse` shape (PR #67 panel consumes it directly).
- `/analyze` page now sends `include_xai: true` by default; XaiPanel drops fixture mode automatically.

## Out of scope (deferred)
- Captum-based Integrated Gradients (#86 acceptance criterion #1). The keyword salience module here is a defensible lightweight baseline; a follow-up PR can swap in IG behind the same `XaiResponse` interface.
- Click-to-strike counterfactual flow (#87) — lands as its own surgical PR on top of this one.

## Test plan
- [x] `pytest tests/unit/test_xai_attribution.py` — sentence split, hawkish + dovish keyword pickup, neutral baseline, bounded score, response shape.
- [x] `npm test` + `npm run type-check`.

Closes #86 (keyword-salience deliverable). #87 stays open for the counterfactual.