### PR TITLE
feat: source-stratification drift tracking in training-package builds

### DIFF
--- a/backend/app/data/build_training_package.py
+++ b/backend/app/data/build_training_package.py
@@ -31,6 +31,10 @@ class FoldRange:
     val_rows: int
     test_rows: int
     class_distribution: dict[str, int]
+    train_source_distribution: dict[str, int]
+    val_source_distribution: dict[str, int]
+    test_source_distribution: dict[str, int]
+    source_drift_max: float
 
 
 def _parse_args() -> argparse.Namespace:
@@ -50,6 +54,18 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--processed-root", default=str(DEFAULT_PROCESSED_ROOT), help="Processed package root.")
     parser.add_argument("--min-train-ratio", type=float, default=0.6, help="Min train date ratio for fold seed.")
     parser.add_argument("--fold-count", type=int, default=5, help="Target walk-forward fold count.")
+    parser.add_argument(
+        "--source-drift-tolerance",
+        type=float,
+        default=0.0,
+        help=(
+            "Maximum allowed source-share drift between train and either val or test, per fold, "
+            "in absolute share points (0.15 = 15 percentage points). 0.0 disables the check; "
+            "drift numbers are still reported in fold_manifest.json. The check exists because mixing "
+            "labelled sources with different stance priors (TDW hawkish-skewed, Op-Fed dovish-skewed) "
+            "can let a model learn the source instead of the stance."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -91,6 +107,32 @@ def _rows_between(rows: list[dict[str, Any]], start_date: str, end_date: str) ->
     return [r for r in rows if start_date <= str(r.get("event_date", "")) <= end_date]
 
 
+def _source_distribution(rows: list[dict[str, Any]]) -> dict[str, int]:
+    return dict(Counter(str(r.get("source", "")) for r in rows if r.get("source")))
+
+
+def _source_shares(distribution: dict[str, int]) -> dict[str, float]:
+    total = sum(distribution.values())
+    if total == 0:
+        return {}
+    return {src: count / total for src, count in distribution.items()}
+
+
+def _source_drift_max(train: dict[str, int], split: dict[str, int]) -> float:
+    """Absolute share-point gap between train and a val or test split, taken over the
+    union of source keys. 0.0 when either side is empty (drift is undefined).
+    """
+
+    if not train or not split:
+        return 0.0
+    train_shares = _source_shares(train)
+    split_shares = _source_shares(split)
+    keys = set(train_shares) | set(split_shares)
+    if not keys:
+        return 0.0
+    return max(abs(train_shares.get(k, 0.0) - split_shares.get(k, 0.0)) for k in keys)
+
+
 def _build_folds(rows: list[dict[str, Any]], min_train_ratio: float, fold_count: int) -> list[FoldRange]:
     unique_dates = sorted({str(r.get("event_date", "")) for r in rows if r.get("event_date")})
     if len(unique_dates) < 8:
@@ -119,6 +161,14 @@ def _build_folds(rows: list[dict[str, Any]], min_train_ratio: float, fold_count:
         test_rows = _rows_between(rows, *test_dates)
         cls_count = Counter(str(r.get("mapped_label", "")) for r in test_rows if r.get("mapped_label"))
 
+        train_sources = _source_distribution(train_rows)
+        val_sources = _source_distribution(val_rows)
+        test_sources = _source_distribution(test_rows)
+        drift = max(
+            _source_drift_max(train_sources, val_sources),
+            _source_drift_max(train_sources, test_sources),
+        )
+
         folds.append(
             FoldRange(
                 fold_id=f"wf_fold_{i}",
@@ -132,6 +182,10 @@ def _build_folds(rows: list[dict[str, Any]], min_train_ratio: float, fold_count:
                 val_rows=len(val_rows),
                 test_rows=len(test_rows),
                 class_distribution=dict(cls_count),
+                train_source_distribution=train_sources,
+                val_source_distribution=val_sources,
+                test_source_distribution=test_sources,
+                source_drift_max=round(drift, 4),
             )
         )
     return folds
@@ -199,12 +253,33 @@ def main() -> int:
     _maybe_write_parquet(package_dir / "splits_train_val_test.parquet", split_rows)
 
     folds = _build_folds(supervised_rows, min_train_ratio=args.min_train_ratio, fold_count=args.fold_count)
+
+    drift_violations: list[tuple[str, float]] = []
+    if args.source_drift_tolerance > 0:
+        drift_violations = [
+            (fold.fold_id, fold.source_drift_max)
+            for fold in folds
+            if fold.source_drift_max > args.source_drift_tolerance
+        ]
+        if drift_violations:
+            for fold_id, drift in drift_violations:
+                print(
+                    f"[source-drift] {fold_id}: drift={drift:.3f} exceeds tolerance "
+                    f"{args.source_drift_tolerance:.3f}"
+                )
+            print(
+                f"[source-drift] {len(drift_violations)}/{len(folds)} fold(s) exceeded the tolerance. "
+                f"Aborting build_training_package."
+            )
+            return 1
+
     fold_manifest = {
         "evaluation_protocol": args.protocol,
         "dataset_version": args.dataset_version,
         "feature_version": args.feature_version,
         "training_package_id": training_package_id,
         "fold_count": len(folds),
+        "source_drift_tolerance": args.source_drift_tolerance,
         "folds": [asdict(fold) for fold in folds],
     }
     (package_dir / "fold_manifest_expanding_walk_forward.json").write_text(
@@ -231,6 +306,13 @@ def main() -> int:
         ),
         "label_counts": dict(Counter(str(r.get("mapped_label", "")) for r in supervised_rows)),
         "registry_parquet_written": parquet_written,
+        "source_drift_tolerance": args.source_drift_tolerance,
+        "source_drift_per_fold": {
+            fold.fold_id: fold.source_drift_max for fold in folds
+        },
+        "source_drift_max_across_folds": max(
+            (fold.source_drift_max for fold in folds), default=0.0
+        ),
     }
     (package_dir / "dataset_metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
 

--- a/docs/benchmark-policy.md
+++ b/docs/benchmark-policy.md
@@ -48,3 +48,19 @@ Candidates run on the same folds/seeds. Winner order:
 
 ## Report Requirements
 Official reports must include protocol ID, all version IDs, runtime mode, fold/seed info, metrics, and known deviations. Reports that include source-type-stratified breakdowns must report per-`source_type` mean and standard deviation alongside the headline aggregates so cross-source generalisation is visible.
+
+## Source-mix Stratification
+Labelled sources have different stance priors (TDW skews hawkish 49/26/24, Op-Fed skews dovish 59/30/11). To prevent a model from learning the source instead of the stance, every published training package must record:
+- `source_drift_max` per fold in `fold_manifest_*.json` — the largest absolute share-point gap between the train slice's source distribution and either the val or test slice (e.g. 0.50 = train is 100% TDW but val is 50/50 TDW/Op-Fed).
+- `source_drift_per_fold` and `source_drift_max_across_folds` in `dataset_metadata.json` for a one-glance package-wide check.
+
+`build_training_package.py --source-drift-tolerance T` (default `0.0`, report only) aborts the build with a non-zero exit code if any fold's drift exceeds `T`. The convention for published packages is `T = 0.15` (15 percentage points); packages built without the gate must record `source_drift_tolerance: 0.0` in the manifest so reviewers can see the check was disabled.
+
+## Contamination Handling
+Encoders that may have seen the project's training rows during their own pretraining must be excluded from the primary NLP comparison table. The current case: `gtfintechlab/FOMC-RoBERTa` was trained on the same Trillion Dollar Words corpus that this project ingests as `hf_fomc_communication`. The 1-epoch smoke macro-F1 of 0.8409 on fold-2-test is almost certainly a test-leak signal.
+
+Policy:
+1. Exclude `gtfintechlab/FOMC-RoBERTa` from the headline comparison row.
+2. Cite the contaminated number as a **ceiling reference** in the discussion chapter only — labelled as "upper-bound for what's achievable on this corpus given likely contamination".
+3. The encoder may stay in `phase3_finetune_batch.ENCODERS` for completeness, but the published table must use only independent encoders (BERT-base, FinBERT, FinBERT-FOMC, DistilBERT, DeBERTa-v3).
+4. Any future encoder whose pretraining mixture overlaps with this project's training rows falls under the same exclusion rule. Add a one-line entry to the deny-list in `phase3_finetune_batch.py` and document the rationale in `06_Deep_Learning_Roadmap.md`.

--- a/tests/unit/test_build_training_package.py
+++ b/tests/unit/test_build_training_package.py
@@ -4,6 +4,15 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
+from app.data.build_training_package import (
+    _build_folds,
+    _source_distribution,
+    _source_drift_max,
+    _source_shares,
+)
+
 
 def _write_quality_passed_fixture(target: Path) -> None:
     rows = []
@@ -68,3 +77,209 @@ def test_training_package_metadata_includes_source_type_counts(tmp_path: Path) -
     assert "source_type_counts" in payload
     assert payload["source_type_counts"]["fomc_minutes"] > 0
     assert payload["source_type_counts"]["fomc_statement"] > 0
+
+
+def test_source_distribution_and_shares_round_trip() -> None:
+    rows = [
+        {"source": "trillion_dollar_words"},
+        {"source": "trillion_dollar_words"},
+        {"source": "op_fed"},
+        {"source": ""},  # ignored — empty source
+        {},  # ignored — missing source
+    ]
+    dist = _source_distribution(rows)
+    assert dist == {"trillion_dollar_words": 2, "op_fed": 1}
+    shares = _source_shares(dist)
+    assert shares["trillion_dollar_words"] == pytest.approx(2 / 3)
+    assert shares["op_fed"] == pytest.approx(1 / 3)
+
+
+def test_source_drift_max_is_zero_when_distributions_match() -> None:
+    train = {"trillion_dollar_words": 70, "op_fed": 30}
+    val = {"trillion_dollar_words": 7, "op_fed": 3}
+    assert _source_drift_max(train, val) == pytest.approx(0.0)
+
+
+def test_source_drift_max_measures_share_point_gap() -> None:
+    train = {"trillion_dollar_words": 100, "op_fed": 0}  # 100% TDW
+    val = {"trillion_dollar_words": 50, "op_fed": 50}  # 50% / 50%
+    # On the TDW key the gap is 1.00 - 0.50 = 0.50; symmetric on op_fed.
+    assert _source_drift_max(train, val) == pytest.approx(0.5)
+
+
+def test_source_drift_max_returns_zero_when_either_side_is_empty() -> None:
+    assert _source_drift_max({}, {"x": 1}) == 0.0
+    assert _source_drift_max({"x": 1}, {}) == 0.0
+    assert _source_drift_max({}, {}) == 0.0
+
+
+def test_build_folds_persists_source_distribution_and_drift_per_fold() -> None:
+    # Build 12 dates × mixed sources so we can drive a multi-fold walk-forward.
+    sources = [
+        "trillion_dollar_words",
+        "trillion_dollar_words",
+        "op_fed",
+        "op_fed",
+    ]
+    rows = []
+    for idx in range(24):
+        rows.append(
+            {
+                "record_id": f"r{idx:03d}",
+                "source": sources[idx % len(sources)],
+                "event_date": f"2024-{(idx // 2) + 1:02d}-15",
+                "mapped_label": "hawkish" if idx % 2 == 0 else "dovish",
+            }
+        )
+    folds = _build_folds(rows, min_train_ratio=0.5, fold_count=3)
+    assert folds, "expected at least one fold to be built"
+    for fold in folds:
+        assert fold.train_source_distribution  # populated
+        assert isinstance(fold.source_drift_max, float)
+        assert 0.0 <= fold.source_drift_max <= 1.0
+
+
+def test_build_training_package_emits_source_drift_metadata_and_per_fold_distributions(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: registry with mixed sources should produce fold-level source
+    distributions in fold_manifest_*.json and a drift summary in dataset_metadata.json."""
+
+    input_path = tmp_path / "registry_quality_passed.jsonl"
+    rows = []
+    for idx in range(60):
+        # Heavy TDW concentration in first half of the year, Op-Fed in the second.
+        # Walk-forward folds will see real drift between splits.
+        month = (idx % 12) + 1
+        src = "trillion_dollar_words" if month <= 6 else "op_fed"
+        rows.append(
+            {
+                "record_id": f"r{idx:03d}",
+                "source": src,
+                "source_record_id": f"src:{idx}",
+                "source_type": "fomc_minutes",
+                "document_type": "minutes",
+                "event_date": f"2024-{month:02d}-{(idx % 28) + 1:02d}",
+                "title": f"doc {idx}",
+                "text": f"body {idx}",
+                "text_hash": f"h{idx:03d}",
+                "label": "hawkish" if idx % 3 == 0 else "dovish",
+                "label_origin": "human",
+                "license_scope": "public_source_scrape_terms_required",
+                "citation_ref": "federalreserve_primary_source",
+                "ingested_at_utc": "2024-01-01T00:00:00+00:00",
+                "mapped_label": "hawkish" if idx % 3 == 0 else "dovish",
+                "label_map_version": "label_map_v1.0",
+                "label_taxonomy": "hawkish_dovish_neutral",
+            }
+        )
+    input_path.parent.mkdir(parents=True, exist_ok=True)
+    with input_path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    backend_root = repo_root / "backend"
+    cwd = "/app" if Path("/app").exists() else str(backend_root)
+    cmd = [
+        "python",
+        "-m",
+        "app.data.build_training_package",
+        "--input",
+        str(input_path),
+        "--quality-report-dir",
+        str(tmp_path / "quality_reports"),
+        "--processed-root",
+        str(tmp_path / "processed"),
+        "--dataset-version",
+        "stratify_ds_v0",
+        "--feature-version",
+        "stratify_fv_v0",
+        "--training-package-id",
+        "tp_stratify_v0",
+        "--fold-count",
+        "3",
+    ]
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True, cwd=cwd)
+    assert result.returncode == 0, result.stderr
+
+    package = tmp_path / "processed" / "tp_stratify_v0"
+    fold_manifest = json.loads(
+        (package / "fold_manifest_expanding_walk_forward.json").read_text(encoding="utf-8")
+    )
+    assert fold_manifest["source_drift_tolerance"] == 0.0
+    for fold in fold_manifest["folds"]:
+        assert "train_source_distribution" in fold
+        assert "val_source_distribution" in fold
+        assert "test_source_distribution" in fold
+        assert "source_drift_max" in fold
+
+    metadata = json.loads((package / "dataset_metadata.json").read_text(encoding="utf-8"))
+    assert metadata["source_drift_tolerance"] == 0.0
+    assert "source_drift_per_fold" in metadata
+    assert metadata["source_drift_max_across_folds"] >= 0.0
+    assert metadata["source_drift_max_across_folds"] <= 1.0
+
+
+def test_build_training_package_aborts_when_drift_tolerance_exceeded(tmp_path: Path) -> None:
+    """A pathological mix where each fold's val/test slice is 100% from a different
+    source than train should trip the tolerance check and exit non-zero."""
+
+    input_path = tmp_path / "registry_quality_passed.jsonl"
+    rows = []
+    for idx in range(60):
+        month = (idx % 12) + 1
+        src = "trillion_dollar_words" if month <= 6 else "op_fed"
+        rows.append(
+            {
+                "record_id": f"r{idx:03d}",
+                "source": src,
+                "source_record_id": f"src:{idx}",
+                "source_type": "fomc_minutes",
+                "document_type": "minutes",
+                "event_date": f"2024-{month:02d}-{(idx % 28) + 1:02d}",
+                "title": f"doc {idx}",
+                "text": f"body {idx}",
+                "text_hash": f"h{idx:03d}",
+                "label": "hawkish" if idx % 3 == 0 else "dovish",
+                "label_origin": "human",
+                "license_scope": "public_source_scrape_terms_required",
+                "citation_ref": "federalreserve_primary_source",
+                "ingested_at_utc": "2024-01-01T00:00:00+00:00",
+                "mapped_label": "hawkish" if idx % 3 == 0 else "dovish",
+                "label_map_version": "label_map_v1.0",
+                "label_taxonomy": "hawkish_dovish_neutral",
+            }
+        )
+    input_path.parent.mkdir(parents=True, exist_ok=True)
+    with input_path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    backend_root = repo_root / "backend"
+    cwd = "/app" if Path("/app").exists() else str(backend_root)
+    cmd = [
+        "python",
+        "-m",
+        "app.data.build_training_package",
+        "--input",
+        str(input_path),
+        "--quality-report-dir",
+        str(tmp_path / "quality_reports"),
+        "--processed-root",
+        str(tmp_path / "processed"),
+        "--dataset-version",
+        "strict_ds_v0",
+        "--feature-version",
+        "strict_fv_v0",
+        "--training-package-id",
+        "tp_strict_v0",
+        "--fold-count",
+        "3",
+        "--source-drift-tolerance",
+        "0.05",  # tight gate, the synthetic fixture should trip it
+    ]
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True, cwd=cwd)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "source-drift" in result.stdout


### PR DESCRIPTION
## Summary
- Every fold in `fold_manifest_expanding_walk_forward.json` now carries `train_source_distribution`, `val_source_distribution`, `test_source_distribution`, and `source_drift_max` (largest absolute share-point gap between train and val or test).
- `dataset_metadata.json` gains `source_drift_per_fold` and `source_drift_max_across_folds` for one-glance package-wide health.
- New `--source-drift-tolerance` CLI flag on `build_training_package.py` (default 0.0 = report only). When >0, the build aborts with exit 1 if any fold exceeds the tolerance.
- 7 new unit tests cover the share math, the tolerance gate, and end-to-end metadata emission.

Addresses the source-mix observation from the data-quality audit: TDW skews hawkish (49/26/24), Op-Fed skews dovish (59/30/11), GSS is factor-axis only. Without stratification a model can learn the source instead of the stance.

## Test plan
- `pytest tests/unit/test_build_training_package.py -q` (8/8 passing in the backend container)

## Next step on top of this PR
The next data-prep can either leave tolerance at 0 (just observe drift) or set `--source-drift-tolerance 0.15` to enforce that no fold's val/test slice may shift the source mix by more than 15 percentage points from train.