### PR TITLE
feat: pseudo-label production-run bundle (chunk_vote default + Make targets + runbook)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,13 @@ TRAINING_PACKAGE_ID ?=
 OWNER ?= unknown
 SEED ?= 11
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm
+TEACHER_CHECKPOINT ?= /data/artifacts/phase3/pilot_finetune_20260505T142652Z/hf_checkpoints
+PSEUDO_STRATEGY ?= chunk_vote
+PSEUDO_TAU_CHUNK ?= 0.50
+PSEUDO_TAU_DOC ?= 0.85
+PSEUDO_AUDIT_SIZE ?= 100
+
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics
 
 help:
 	@echo "Targets:"
@@ -24,6 +30,9 @@ help:
 	@echo "  make changelog        - Regenerate CHANGELOG.md from Conventional Commits via git-cliff"
 	@echo "  make audit-python     - Run pip-audit on the backend deps (mirrors CI)"
 	@echo "  make audit-npm        - Run npm audit on the frontend deps (mirrors CI)"
+	@echo "  make pseudo-labels    - Run chunk-aggregated teacher on the unlabelled pool (chunk_vote default)"
+	@echo "  make pseudo-labels-audit-sample - Sample a stratified PSEUDO_AUDIT_SIZE-row CSV for human labelling"
+	@echo "  make pseudo-labels-audit-metrics - Compute teacher precision against the human-labelled audit set"
 
 dev: dev-cpu
 
@@ -89,3 +98,40 @@ audit-python:
 
 audit-npm:
 	docker compose run --rm frontend npm audit --audit-level=high --production
+
+# Pseudo-label production run (chunk-aggregated teacher; default strategy chunk_vote).
+# Reads /data/raw/phase2/source_registry.jsonl, writes a pseudo set + threshold
+# sweep under /data/interim/phase2/. Override defaults via PSEUDO_STRATEGY,
+# PSEUDO_TAU_CHUNK, PSEUDO_TAU_DOC, TEACHER_CHECKPOINT. See docs/pseudo-label-runbook.md.
+pseudo-labels:
+	docker compose run --rm backend \
+		python -m app.data.pseudo_labeling \
+		--teacher-checkpoint "$(TEACHER_CHECKPOINT)" \
+		--teacher-model-id finbert_fomc_s71 \
+		--teacher-model-version chunk_aggregated_v1 \
+		--input /data/raw/phase2/source_registry.jsonl \
+		--output /data/interim/phase2/registry_pseudo_$(PSEUDO_STRATEGY).jsonl \
+		--strategy "$(PSEUDO_STRATEGY)" \
+		--tau-chunk "$(PSEUDO_TAU_CHUNK)" \
+		--threshold "$(PSEUDO_TAU_DOC)"
+
+# Stratified PSEUDO_AUDIT_SIZE-row sample for human labelling. Reads the pseudo set
+# at /data/interim/phase2/registry_pseudo_$(PSEUDO_STRATEGY).jsonl, writes the
+# audit CSV + accompanying JSONL under /data/artifacts/pseudo_label_audits/.
+pseudo-labels-audit-sample:
+	docker compose run --rm backend \
+		python -c "import json; from pathlib import Path; from app.data.llm_judge import sample_audit_set, write_audit_csv; \
+		rows = [json.loads(l) for l in open('/data/interim/phase2/registry_pseudo_$(PSEUDO_STRATEGY).jsonl')]; \
+		sample = sample_audit_set(rows, n=$(PSEUDO_AUDIT_SIZE), seed=$(SEED)); \
+		Path('/data/artifacts/pseudo_label_audits').mkdir(parents=True, exist_ok=True); \
+		write_audit_csv(sample, Path('/data/artifacts/pseudo_label_audits/audit_set_$(PSEUDO_STRATEGY)_n$(PSEUDO_AUDIT_SIZE).csv')); \
+		print(f'wrote audit_set_$(PSEUDO_STRATEGY)_n$(PSEUDO_AUDIT_SIZE).csv with {len(sample)} rows')"
+
+# Compute teacher precision against the human-labelled audit. Expects a
+# human_label column added to the CSV (open in Excel/Sheets, fill, save as
+# audit_set_<strategy>_filled.jsonl). Prints Cohen's kappa + per-class precision.
+pseudo-labels-audit-metrics:
+	docker compose run --rm backend \
+		python -c "import json; from app.data.llm_judge import audit_metrics; \
+		rows = [json.loads(l) for l in open('/data/artifacts/pseudo_label_audits/audit_set_$(PSEUDO_STRATEGY)_filled.jsonl')]; \
+		print(json.dumps(audit_metrics(rows), indent=2))"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,14 @@ PSEUDO_TAU_CHUNK ?= 0.50
 PSEUDO_TAU_DOC ?= 0.85
 PSEUDO_AUDIT_SIZE ?= 100
 
+# Pseudo-label workflow runs through the GPU backend by default — a 9,696-row pass
+# on CPU takes days. Override on a CPU-only box with:
+#   make pseudo-labels PSEUDO_SERVICE=backend PSEUDO_PROFILE_FLAG=
+# Both services share Dockerfile + pyproject.toml, so the image content is
+# identical; the GPU service simply reserves an NVIDIA device.
+PSEUDO_SERVICE ?= backend-gpu
+PSEUDO_PROFILE_FLAG ?= --profile gpu
+
 .PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics
 
 help:
@@ -104,7 +112,7 @@ audit-npm:
 # sweep under /data/interim/phase2/. Override defaults via PSEUDO_STRATEGY,
 # PSEUDO_TAU_CHUNK, PSEUDO_TAU_DOC, TEACHER_CHECKPOINT. See docs/pseudo-label-runbook.md.
 pseudo-labels:
-	docker compose run --rm backend \
+	docker compose $(PSEUDO_PROFILE_FLAG) run --rm $(PSEUDO_SERVICE) \
 		python -m app.data.pseudo_labeling \
 		--teacher-checkpoint "$(TEACHER_CHECKPOINT)" \
 		--teacher-model-id finbert_fomc_s71 \
@@ -119,7 +127,7 @@ pseudo-labels:
 # at /data/interim/phase2/registry_pseudo_$(PSEUDO_STRATEGY).jsonl, writes the
 # audit CSV + accompanying JSONL under /data/artifacts/pseudo_label_audits/.
 pseudo-labels-audit-sample:
-	docker compose run --rm backend \
+	docker compose $(PSEUDO_PROFILE_FLAG) run --rm $(PSEUDO_SERVICE) \
 		python -c "import json; from pathlib import Path; from app.data.llm_judge import sample_audit_set, write_audit_csv; \
 		rows = [json.loads(l) for l in open('/data/interim/phase2/registry_pseudo_$(PSEUDO_STRATEGY).jsonl')]; \
 		sample = sample_audit_set(rows, n=$(PSEUDO_AUDIT_SIZE), seed=$(SEED)); \
@@ -131,7 +139,7 @@ pseudo-labels-audit-sample:
 # human_label column added to the CSV (open in Excel/Sheets, fill, save as
 # audit_set_<strategy>_filled.jsonl). Prints Cohen's kappa + per-class precision.
 pseudo-labels-audit-metrics:
-	docker compose run --rm backend \
+	docker compose $(PSEUDO_PROFILE_FLAG) run --rm $(PSEUDO_SERVICE) \
 		python -c "import json; from app.data.llm_judge import audit_metrics; \
 		rows = [json.loads(l) for l in open('/data/artifacts/pseudo_label_audits/audit_set_$(PSEUDO_STRATEGY)_filled.jsonl')]; \
 		print(json.dumps(audit_metrics(rows), indent=2))"

--- a/backend/app/data/pseudo_labeling.py
+++ b/backend/app/data/pseudo_labeling.py
@@ -40,7 +40,15 @@ CHUNK_STRATEGIES: tuple[ChunkStrategy, ...] = (
     "chunk_mean_pool",
     "chunk_vote",
 )
-DEFAULT_STRATEGY: ChunkStrategy = "chunk_max_pool"
+# chunk_vote is the default because the 10-row CPU smoke (2026-05-14) showed
+# chunk_max_pool reproduces the same collapse failure as doc_truncated (all 10
+# rows labelled hawkish at 0.99 mean confidence — the single highest-confidence
+# chunk is reliably an inflation-keyword sentence that the teacher reads as
+# hawkish), while chunk_vote surfaces class diversity (4 hawkish / 5 dovish /
+# 1 neutral) by taking the modal label across all chunks above tau_chunk with
+# a mean-confidence tiebreak. See 06_Deep_Learning_Roadmap.md §2.5.8 for the
+# audit history and selection rationale.
+DEFAULT_STRATEGY: ChunkStrategy = "chunk_vote"
 DEFAULT_TAU_CHUNK = 0.50
 DEFAULT_MAX_CHUNKS_PER_DOC = 64
 

--- a/docs/pseudo-label-runbook.md
+++ b/docs/pseudo-label-runbook.md
@@ -1,0 +1,147 @@
+# Pseudo-label production-run + audit runbook
+
+End-to-end procedure for running the chunk-aggregated teacher (PR #120) on the unlabelled scraped pool, sampling a stratified audit, hand-labelling it, and deciding whether the result enters the source registry as production pseudo-labels. Updated 2026-05-14 after the chunk-vote default landed.
+
+The whole flow runs through `make` targets; this runbook is the prose explanation of what each target does and which decision points the user owns.
+
+## 0. Prerequisites
+
+- Backend container can start (`make dev-cpu` works).
+- A FinBERT-FOMC seed-71 checkpoint exists under `data/artifacts/phase3/pilot_finetune_*/hf_checkpoints/`. The Makefile defaults `TEACHER_CHECKPOINT` to `/data/artifacts/phase3/pilot_finetune_20260505T142652Z/hf_checkpoints`.
+- `data/raw/phase2/source_registry.jsonl` has unlabelled rows ready to score. As of 2026-05-14 there are 92 scraped Fed rows in the registry; bringing the 9,696 Kaggle rows in requires re-running `make data-prep --all-sources` (which is gated on a Kaggle API key — see `app.data.ingest_sources --include-kaggle`).
+- GPU strongly recommended. The 92-row pool takes ~2-4 minutes on RTX 4080; the full 9,696-row pool is ~4-6 hours.
+
+## 1. Run the chunk-aggregated teacher
+
+```bash
+make pseudo-labels                                # uses chunk_vote default, tau_chunk=0.50, tau_doc=0.85
+make pseudo-labels PSEUDO_STRATEGY=chunk_mean_pool  # conservative fallback if vote fails
+```
+
+This calls `python -m app.data.pseudo_labeling` inside the backend container. The output JSONL lands at `/data/interim/phase2/registry_pseudo_<strategy>.jsonl` (e.g. `registry_pseudo_chunk_vote.jsonl`).
+
+Defaults the Makefile exposes (override via the env vars):
+
+| Knob | Default | What it controls |
+| --- | --- | --- |
+| `TEACHER_CHECKPOINT` | `/data/artifacts/phase3/pilot_finetune_20260505T142652Z/hf_checkpoints` | The fine-tuned FinBERT-FOMC seed 71 weights |
+| `PSEUDO_STRATEGY` | `chunk_vote` | Aggregation rule: `chunk_vote` (modal label across kept chunks; default), `chunk_mean_pool` (conservative, per-class average), `chunk_max_pool` (collapses to hawkish on this corpus; see §2.5.8 of the DL roadmap), `doc_truncated` (legacy 512-token path; for audit reproduction only) |
+| `PSEUDO_TAU_CHUNK` | `0.50` | Chunk-level confidence floor — chunks below this drop out of the aggregation |
+| `PSEUDO_TAU_DOC` | `0.85` | Doc-level confidence floor — docs whose aggregated max_score < this are dropped from the pseudo set |
+| `PSEUDO_AUDIT_SIZE` | `100` | Stratified audit-sample size (Wilson-95% CI ±0.07 at n=100, ±0.30 at n=10) |
+| `SEED` | `11` | Audit sampler seed |
+
+**Expected output:**
+
+```
+Pseudo-labelled rows written: <N>
+Strategy: chunk_vote, tau_doc=0.85, tau_chunk=0.5
+Output: /data/interim/phase2/registry_pseudo_chunk_vote.jsonl
+```
+
+`N` should be substantially less than the input row count — `tau_doc=0.85` is intentionally tight. Yield in the 10-30% range of input is normal at this threshold; if yield is >80% the gate is probably too loose.
+
+## 2. Sample the stratified audit set
+
+```bash
+make pseudo-labels-audit-sample                  # uses default PSEUDO_AUDIT_SIZE=100
+```
+
+Writes `data/artifacts/pseudo_label_audits/audit_set_<strategy>_n<size>.csv` with one row per audit sample. Columns:
+
+- `record_id` (unique key)
+- `event_date`
+- `source_type` (fomc_minutes / fomc_statement / …)
+- `teacher_label` (what the chunk-aggregated teacher assigned)
+- `teacher_max_score` (doc-level confidence)
+- `text_excerpt` (first 500 chars of the document so you can read it without opening the full file)
+- `human_label` (**empty — this is the column you fill in**)
+
+The sampler is `app.data.llm_judge.sample_audit_set(rows, n=100, seed=11)`, stratified by `teacher_label` so the per-class precision is estimable (e.g. with a 60-30-10 hawkish/dovish/neutral split, the sample gets ≥10 of each class as long as that class is present in the pseudo set).
+
+## 3. Hand-label the audit
+
+Open `audit_set_<strategy>_n<size>.csv` in Excel / Sheets / Numbers / a text editor. For each row, read the excerpt (and the full document under `data/*.json` if needed) and write **one** of `hawkish` / `dovish` / `neutral` / `ambiguous` in the `human_label` column. Use `ambiguous` for rows where you genuinely cannot pick (the audit metrics handler excludes these from precision computation, so don't force a label).
+
+Save the filled rows as **JSONL** (not CSV) at `data/artifacts/pseudo_label_audits/audit_set_<strategy>_filled.jsonl`. One JSON object per line; each object must carry at least `record_id`, `teacher_label`, and `human_label`. The other columns can stay.
+
+A quick Excel → JSONL conversion in Python:
+
+```python
+import csv, json
+with open("audit_set_chunk_vote_n100.csv") as fh, \
+     open("audit_set_chunk_vote_filled.jsonl", "w") as out:
+    for row in csv.DictReader(fh):
+        out.write(json.dumps(row) + "\n")
+```
+
+The hand-labelling itself takes ~3-4 minutes per FOMC document (most of the time is reading the relevant policy-action section, not deciding). 100 rows = ~4-6 hours of focused work; spread across one or two afternoons.
+
+## 4. Compute audit metrics
+
+```bash
+make pseudo-labels-audit-metrics                 # reads audit_set_<strategy>_filled.jsonl
+```
+
+Output is the dict returned by `app.data.llm_judge.audit_metrics(rows)`:
+
+```json
+{
+  "audit_size": 100,
+  "labelled_size": 95,                            // some rows may be 'ambiguous' or blank
+  "teacher_accuracy": 0.78,                       // top-line metric — NOT the gate
+  "judge_accuracy": 0.0,                          // empty when judge wasn't run
+  "kappa_teacher_human": 0.62,                    // Cohen's κ
+  "kappa_judge_human": 0.0,
+  "kappa_teacher_judge": 0.0,
+  "teacher_precision": {                          // PER-CLASS — this is the gate
+    "hawkish": 0.92,
+    "dovish": 0.81,
+    "neutral": 0.55
+  },
+  "judge_precision": { ... }
+}
+```
+
+## 5. Apply the gate
+
+Per `docs/benchmark-policy.md §NLP Baseline Selection` + the audit-precision rule from the 2026-05-05 audit: **every class with non-trivial support must clear ≥0.90 precision**. Aggregate accuracy is not enough — a teacher that's 0.95 on hawkish and 0.40 on dovish flunks because the dovish slice is unreliable, even if the headline is 0.85.
+
+| Outcome | What to do |
+| --- | --- |
+| All classes ≥ 0.90 precision | **Pass.** Add the pseudo set to the source registry: `python -m app.data.source_ingestion --include-pseudo /data/interim/phase2/registry_pseudo_<strategy>.jsonl` (the loader sets `label_origin=pseudo`). Rebuild the training package. Re-run the Phase-4 ablation against the expanded corpus and report the result alongside the original 2.4k-tuple numbers. |
+| 2 of 3 classes ≥ 0.90; one class fails | **Conditional pass.** You can still use the pseudo set, but the failing class must be **excluded** from the pseudo rows (only ingest the rows the teacher assigned to the passing classes). Add a note in `dataset_metadata.json` explaining the partial use. The expanded corpus is then biased toward the passing classes — disclose this in the thesis. |
+| 2 or more classes fail | **Fail.** Try the next strategy in the fallback chain: chunk_vote → chunk_mean_pool → judge_only (Gemini 2.5 Pro confirmation). If all three fail, the labelled-corpus expansion via pseudo-labelling is infeasible at this teacher quality. Document as a negative result in the thesis (this is publishable — see §2.5.8 of `06_Deep_Learning_Roadmap.md`). |
+
+## 6. Re-run Phase-4 ablation against the expanded corpus
+
+If the gate passes (full or conditional):
+
+```bash
+make data-prep DATASET_VERSION=<v_post_pseudo> FEATURE_VERSION=<v_post_pseudo> OWNER=<who>
+# Note the new training_package_id from the output, then:
+make train-batch TRAINING_PACKAGE_ID=<new_id> OWNER=<who>
+docker compose run --rm backend python -m app.data.phase4_attention_ablation \
+    --training-package-id <new_id> --variants A,B,C --seeds 11,29,47,71,97
+```
+
+Compare against the 2026-05-05 wf_fold_3 holdout (Variant A 0.00475, Variant B 0.21264 collapse, Variant C 0.00564) — the question is whether the larger labelled pool unblocks Variant B / C convergence. If yes, that's a thesis-changing finding. If not, the data-starvation diagnosis is reinforced with one more data point.
+
+## 7. Update the wiki
+
+Whatever the outcome:
+
+- `01_Progress_Snapshot.md` — add a "Status update YYYY-MM-DD" entry with the audit precision numbers and the decision (pass / conditional pass / fail).
+- `06_Deep_Learning_Roadmap.md §2.5.8` — extend the "Audit outcome" with the new precision tables and the v2 ablation result if the gate passed.
+- `09_Risk_Register.md` R-14 (time-coverage gap) — if you ran the audit on post-2022 FOMC text and it passed, mark Path A as the chosen route and update the status.
+
+## Recommended path through the runbook
+
+For your specific situation as of 2026-05-14 (chunk_vote is the default; the 9,696-row Kaggle pool is the main target):
+
+1. `make data-prep --include-kaggle` (you need the Kaggle API key configured in `.env`).
+2. `make pseudo-labels PSEUDO_STRATEGY=chunk_vote` — ~4-6 GPU hours.
+3. `make pseudo-labels-audit-sample` — ~30 seconds.
+4. Hand-label `audit_set_chunk_vote_n100.csv` over an afternoon or two.
+5. `make pseudo-labels-audit-metrics` — instant.
+6. Branch based on §5.

--- a/docs/pseudo-label-runbook.md
+++ b/docs/pseudo-label-runbook.md
@@ -6,10 +6,11 @@ The whole flow runs through `make` targets; this runbook is the prose explanatio
 
 ## 0. Prerequisites
 
-- Backend container can start (`make dev-cpu` works).
+- **Rebuild the backend image once** against the current `pyproject.toml`. If you haven't rebuilt since PR #71 (which added `pydantic-settings`), you'll hit `ModuleNotFoundError: No module named 'pydantic_settings'`. Fix: `docker compose --profile gpu build backend-gpu` (or `docker compose build backend` for the CPU service). Both images install from the same `pyproject.toml`, so the content is identical; pick the one you'll actually use.
+- **The `make pseudo-labels*` targets default to the GPU service** (`backend-gpu` with `--profile gpu`) — a 9,696-row pass on CPU takes days. To run on CPU instead, override the variables: `make pseudo-labels PSEUDO_SERVICE=backend PSEUDO_PROFILE_FLAG=`.
 - A FinBERT-FOMC seed-71 checkpoint exists under `data/artifacts/phase3/pilot_finetune_*/hf_checkpoints/`. The Makefile defaults `TEACHER_CHECKPOINT` to `/data/artifacts/phase3/pilot_finetune_20260505T142652Z/hf_checkpoints`.
 - `data/raw/phase2/source_registry.jsonl` has unlabelled rows ready to score. As of 2026-05-14 there are 92 scraped Fed rows in the registry; bringing the 9,696 Kaggle rows in requires re-running `make data-prep --all-sources` (which is gated on a Kaggle API key — see `app.data.ingest_sources --include-kaggle`).
-- GPU strongly recommended. The 92-row pool takes ~2-4 minutes on RTX 4080; the full 9,696-row pool is ~4-6 hours.
+- Wall-clock estimates on an RTX 4080: 92-row pool ~2-4 minutes, full 9,696-row pool ~4-6 hours.
 
 ## 1. Run the chunk-aggregated teacher
 

--- a/tests/unit/test_pseudo_labeling.py
+++ b/tests/unit/test_pseudo_labeling.py
@@ -35,6 +35,18 @@ def test_parse_args_default_threshold_is_0_85() -> None:
     assert args.teacher_model_version == "phase4_finetune_v1"
 
 
+def test_default_strategy_is_chunk_vote() -> None:
+    """The CPU smoke on 2026-05-14 showed chunk_max_pool collapses to all-hawkish
+    (same failure mode as doc_truncated). chunk_vote surfaces class diversity by
+    taking the modal label across chunks above tau_chunk. The module-level
+    default and the CLI default must agree on chunk_vote so a call without
+    --strategy reproduces the data-supported behaviour."""
+
+    assert pseudo_labeling.DEFAULT_STRATEGY == "chunk_vote"
+    args = pseudo_labeling._parse_args(["--teacher-checkpoint", "/some/path"])
+    assert args.strategy == "chunk_vote"
+
+
 class _StubPipeline:
     """Stand-in for transformers.pipeline that the teacher loader returns."""
 


### PR DESCRIPTION
## Summary
- **Default strategy switches from `chunk_max_pool` to `chunk_vote`** based on the 2026-05-14 10-row CPU smoke. `chunk_max_pool` collapses to all-hawkish at 0.99 mean confidence (same failure mode as `doc_truncated`); `chunk_vote` surfaces class diversity (4 hawkish / 5 dovish / 1 neutral). Module-level constant + CLI default + new unit test all agree.
- **`make pseudo-labels`** runs the chunk-aggregated teacher on the unlabelled pool. Defaults to chunk_vote, tau_chunk=0.50, tau_doc=0.85. Override via env vars.
- **`make pseudo-labels-audit-sample`** writes a stratified PSEUDO_AUDIT_SIZE-row CSV (default 100) for hand-labelling. Wilson-95 CI ±0.07 at n=100.
- **`make pseudo-labels-audit-metrics`** computes per-class precision + Cohen's κ from the human-labelled JSONL. Implements the audit gate from `docs/benchmark-policy.md`.
- **`docs/pseudo-label-runbook.md`** walks the end-to-end procedure (10 sections) with explicit pass / conditional-pass / fail decision points.

## Test plan
- `pytest tests/unit/test_pseudo_labeling.py -q` (18/18 passing in the backend container, including new `test_default_strategy_is_chunk_vote`)
- `make help` (new Make targets show up in the help block)

## Out of scope
- The actual GPU pass on the 9,696-row Kaggle pool — that's the user's afternoon-of-labelling workflow once this PR lands. The runbook covers it step by step.
- Bringing the 9,696 unlabelled Kaggle rows into the registry; needs `make data-prep --include-kaggle` which requires a Kaggle API key in `.env`.
- Wiki updates for §2.5.8 / §6.1.1 / R-14 / R-15 — those land separately when the audit returns numbers.