### PR TITLE
fix: sentiment classifier load + label mapping + calendar -> analyze prefill

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -141,6 +141,65 @@ def list_documents():
     return {"count": len(documents), "documents": documents}
 
 
+@app.get("/documents/by-date")
+def get_document_by_date(date: str, kind: str = "auto"):
+    """Look up an FOMC statement or minutes by event date so the calendar
+    page can prefill the analyze textarea on click. ``kind`` is one of
+    ``auto`` (try statement first, then minutes), ``statement``, or
+    ``minutes``.
+    """
+
+    allowed_kinds = {"auto", "statement", "minutes"}
+    if kind not in allowed_kinds:
+        raise HTTPException(
+            status_code=422,
+            detail=f"kind must be one of {sorted(allowed_kinds)}; got {kind!r}",
+        )
+
+    sources_in_order: list[tuple[str, str]]
+    if kind == "statement":
+        sources_in_order = [("fomc_statements.json", "Statement")]
+    elif kind == "minutes":
+        sources_in_order = [("fomc_minutes.json", "Minutes")]
+    else:
+        sources_in_order = [
+            ("fomc_statements.json", "Statement"),
+            ("fomc_minutes.json", "Minutes"),
+        ]
+
+    for filename, document_type in sources_in_order:
+        path = DATA_DIR / filename
+        if not path.exists():
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise HTTPException(
+                status_code=500, detail=f"Failed to read {filename}: {exc}"
+            ) from exc
+        if not isinstance(payload, list):
+            continue
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("date", "")) != date:
+                continue
+            text = str(item.get("text") or item.get("content") or "")
+            if not text:
+                continue
+            return {
+                "date": date,
+                "kind": document_type.lower(),
+                "title": str(item.get("title", "")),
+                "text": text,
+                "source_file": filename,
+            }
+    raise HTTPException(
+        status_code=404,
+        detail=f"No FOMC document found for date {date!r} (kind={kind}).",
+    )
+
+
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 

--- a/backend/app/services/text_encoder.py
+++ b/backend/app/services/text_encoder.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import logging
+import os
 import threading
 from collections import defaultdict
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -10,8 +13,25 @@ from transformers import pipeline
 
 from app.models.registry import revision_for
 
-MODEL_ID = "gtfintechlab/fomc-roberta-any-exp"
+# Local fine-tuned FinBERT-FOMC seed-71 checkpoint with hawkish/dovish/neutral
+# labels (see config.json id2label). Used as the default sentiment classifier
+# so the live /analyze flow does not silently fall back to a generic news
+# sentiment model. Override via the FED_PULSE_SENTIMENT_MODEL env var on any
+# deployment where the local checkpoint is not present.
+DEFAULT_LOCAL_CHECKPOINT = "/data/artifacts/phase3/pilot_finetune_20260505T142652Z/hf_checkpoints"
+PRIMARY_HF_MODEL_ID = "gtfintechlab/fomc-roberta-any-exp"
+# Last-resort fallback ONLY. Returns POSITIVE / NEGATIVE labels, NOT
+# hawkish/dovish/neutral, so the frontend should refuse to map the output
+# (see frontend/lib/analyze/format.ts::toStance).
 FALLBACK_MODEL_ID = "distilbert/distilbert-base-uncased-finetuned-sst-2-english"
+
+# Resolved at import time. The override path is read once; restart the
+# backend to pick up a new value.
+_OVERRIDE = (os.environ.get("FED_PULSE_SENTIMENT_MODEL") or "").strip()
+MODEL_ID = _OVERRIDE or (
+    DEFAULT_LOCAL_CHECKPOINT if Path(DEFAULT_LOCAL_CHECKPOINT).exists() else PRIMARY_HF_MODEL_ID
+)
+
 DEFAULT_MAX_TOKENS = 480
 DEFAULT_STRIDE = 400
 DEFAULT_CLASSIFIER_MAX_LENGTH = 512
@@ -19,6 +39,7 @@ DEFAULT_CLASSIFIER_MAX_LENGTH = 512
 _classifier = None
 _classifier_lock = threading.Lock()
 _classifier_load_count = 0
+_logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -67,16 +88,45 @@ def get_classifier():
             )
 
         last_error: Exception | None = None
+        loaded_model_id: str | None = None
         for model_id, target_device in attempts:
             try:
                 _classifier = _build_pipeline(model_id, target_device)
                 global _classifier_load_count
                 _classifier_load_count += 1
+                loaded_model_id = model_id
                 break
             except Exception as exc:
                 last_error = exc
+                _logger.warning(
+                    "sentiment.classifier_load_failed",
+                    extra={
+                        "model_id": model_id,
+                        "device": target_device,
+                        "error_type": type(exc).__name__,
+                        "error_message": str(exc),
+                    },
+                )
         if _classifier is None and last_error is not None:
             raise last_error
+        if loaded_model_id != MODEL_ID:
+            # We picked a fallback. The fallback's label space (e.g.
+            # POSITIVE / NEGATIVE for distilbert-sst-2) is NOT
+            # hawkish/dovish/neutral; the frontend's toStance() refuses to
+            # silently relabel POSITIVE -> hawkish, so the dashboard will
+            # surface "Sentiment unavailable" until the primary model loads.
+            _logger.error(
+                "sentiment.classifier_using_fallback",
+                extra={
+                    "primary_model_id": MODEL_ID,
+                    "loaded_model_id": loaded_model_id,
+                    "note": (
+                        "Primary sentiment model failed to load. The active model's labels "
+                        "are NOT hawkish/dovish/neutral; the dashboard will report stance "
+                        "as unknown. Inspect the preceding classifier_load_failed warnings."
+                    ),
+                },
+            )
     return _classifier
 
 

--- a/frontend/components/analyze/SentimentCard.tsx
+++ b/frontend/components/analyze/SentimentCard.tsx
@@ -8,22 +8,28 @@ interface SentimentCardProps {
 }
 
 export function SentimentCard({ sentiment }: SentimentCardProps) {
-  const stance = toStance(sentiment?.label);
+  const rawLabel = sentiment?.label;
+  const stance = toStance(rawLabel);
   const score = Number(sentiment?.score ?? 0);
-  const badgeVariant =
+  const isUnknown = stance === "unknown";
+  const badgeVariant: "hawkish" | "dovish" | "neutral" | "outline" =
     stance === "hawkish" ? "hawkish" : stance === "dovish" ? "dovish" : stance === "neutral" ? "neutral" : "outline";
 
   return (
     <Card>
       <CardHeader className="pb-2">
         <CardDescription>Stance</CardDescription>
-        <CardTitle className="text-2xl">{stanceLabel(stance)}</CardTitle>
+        <CardTitle className="text-2xl">
+          {isUnknown ? "Sentiment unavailable" : stanceLabel(stance)}
+        </CardTitle>
       </CardHeader>
       <CardContent className="flex items-center justify-between">
         <Badge variant={badgeVariant}>
-          {stanceLabel(stance)} · {score.toFixed(3)}
+          {isUnknown ? `raw: ${String(rawLabel ?? "n/a")}` : `${stanceLabel(stance)} · ${score.toFixed(3)}`}
         </Badge>
-        <span className="text-xs text-muted-foreground">model confidence</span>
+        <span className="text-xs text-muted-foreground">
+          {isUnknown ? "Backend returned a non-stance label; check sentiment-model load." : "model confidence"}
+        </span>
       </CardContent>
     </Card>
   );

--- a/frontend/lib/analyze/format.ts
+++ b/frontend/lib/analyze/format.ts
@@ -11,17 +11,31 @@ export function normalizeTimestamp(value: unknown): string {
   return String(value).split("+")[0];
 }
 
+// Strict mapping. The dashboard refuses to silently relabel a non-stance
+// label (e.g. POSITIVE / NEGATIVE from distilbert-sst-2, which is what
+// loads when the FOMC sentiment model fails) into a monetary-policy
+// stance.
+//
+// Earlier versions mapped POSITIVE -> hawkish / NEGATIVE -> dovish /
+// LABEL_1 -> hawkish blindly, which caused "interest rates are bad
+// inflation is good" to display as "Hawkish 0.99" — the sst-2 fallback
+// was reading "good" as positive news sentiment and the UI laundered
+// that into a monetary-policy stance.
+//
+// LABEL_0 / LABEL_1 / LABEL_2 are still mapped because a checkpoint
+// without an id2label config legitimately exposes those generic strings;
+// the order matches our taxonomy (0=dovish, 1=neutral, 2=hawkish).
 export function toStance(label: unknown): Stance {
-  const value = String(label || "").toUpperCase();
-  if (value.includes("HAWK") || value.includes("POSITIVE") || value.includes("LABEL_1")) {
-    return "hawkish";
-  }
-  if (value.includes("DOVE") || value.includes("NEGATIVE") || value.includes("LABEL_0")) {
-    return "dovish";
-  }
-  if (value.includes("NEUTRAL") || value.includes("LABEL_2")) {
-    return "neutral";
-  }
+  const value = String(label || "").trim();
+  const lower = value.toLowerCase();
+  if (lower === "hawkish") return "hawkish";
+  if (lower === "dovish") return "dovish";
+  if (lower === "neutral") return "neutral";
+  if (lower.startsWith("hawk")) return "hawkish";
+  if (lower.startsWith("dove")) return "dovish";
+  if (value === "LABEL_0") return "dovish";
+  if (value === "LABEL_1") return "neutral";
+  if (value === "LABEL_2") return "hawkish";
   return "unknown";
 }
 

--- a/frontend/pages/analyze.tsx
+++ b/frontend/pages/analyze.tsx
@@ -74,10 +74,38 @@ export default function AnalyzePage() {
   React.useEffect(() => {
     if (!router.isReady) return;
     const queryDate = router.query.date;
-    if (typeof queryDate === "string" && queryDate) {
-      setRequest((current) => ({ ...current, date: queryDate }));
-    }
-  }, [router.isReady, router.query.date]);
+    const queryKind = router.query.kind;
+    if (typeof queryDate !== "string" || !queryDate) return;
+    setRequest((current) => ({ ...current, date: queryDate }));
+    if (typeof queryKind !== "string" || !queryKind) return;
+    // Calendar -> Analyze deep link. Pull the FOMC statement / minutes
+    // text for this date so the textarea is prefilled when the page
+    // mounts; the user clicks 'Submit' instead of pasting.
+    let cancelled = false;
+    (async () => {
+      try {
+        const url = `${apiBaseUrl}/documents/by-date?date=${encodeURIComponent(queryDate)}&kind=${encodeURIComponent(queryKind)}`;
+        const response = await fetch(url);
+        if (!response.ok) {
+          if (response.status === 404) {
+            toast.info(`No FOMC ${queryKind} on disk for ${queryDate}; paste the text manually.`);
+          }
+          return;
+        }
+        const payload = await response.json();
+        if (cancelled || typeof payload?.text !== "string" || !payload.text) return;
+        setRequest((current) => ({ ...current, text: payload.text }));
+        toast.success(`Prefilled FOMC ${payload.kind} from ${queryDate}.`);
+      } catch (err) {
+        const message =
+          (err as { message?: string })?.message || "Could not load document for this date.";
+        toast.error(message);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [router.isReady, router.query.date, router.query.kind, apiBaseUrl]);
 
   const handleSubmit = async () => {
     setLoading(true);

--- a/frontend/pages/calendar.tsx
+++ b/frontend/pages/calendar.tsx
@@ -66,7 +66,14 @@ export default function CalendarPage() {
   }, [apiBaseUrl]);
 
   const goAnalyze = (meetingDate: string) => {
-    router.push({ pathname: "/analyze", query: { date: meetingDate } });
+    // ?kind=statement asks the analyze page to fetch the matching FOMC
+    // statement text from /documents/by-date and prefill the textarea.
+    // Without it, only the date prefills and the user has to paste the
+    // text themselves.
+    router.push({
+      pathname: "/analyze",
+      query: { date: meetingDate, kind: "statement" },
+    });
   };
 
   return (

--- a/frontend/tests/components/analyze/SentimentCard.test.tsx
+++ b/frontend/tests/components/analyze/SentimentCard.test.tsx
@@ -10,8 +10,18 @@ describe("SentimentCard", () => {
     expect(screen.getByText(/0\.810/)).toBeInTheDocument();
   });
 
-  it("falls back to Unknown when label is missing", () => {
+  it("falls back to 'Sentiment unavailable' when label is missing", () => {
     render(<SentimentCard sentiment={undefined} />);
-    expect(screen.getAllByText(/unknown/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/sentiment unavailable/i)).toBeInTheDocument();
+  });
+
+  it("renders 'Sentiment unavailable' with the raw label when backend returns POSITIVE", () => {
+    // Regression guard for the live bug: when the FOMC sentiment model
+    // fails to load and distilbert-sst-2 takes over, the backend returns
+    // POSITIVE / NEGATIVE. The dashboard must NOT silently re-render
+    // these as hawkish/dovish — it must surface the failure.
+    render(<SentimentCard sentiment={{ label: "POSITIVE", score: 0.99 }} />);
+    expect(screen.getByText(/sentiment unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/raw: POSITIVE/)).toBeInTheDocument();
   });
 });

--- a/frontend/tests/lib/analyze/format.test.ts
+++ b/frontend/tests/lib/analyze/format.test.ts
@@ -29,11 +29,28 @@ describe("format helpers", () => {
     expect(normalizeTimestamp(null)).toBe("");
   });
 
-  it("toStance maps known labels", () => {
+  it("toStance maps known stance labels", () => {
     expect(toStance("HAWKISH")).toBe("hawkish");
-    expect(toStance("LABEL_0")).toBe("dovish");
+    expect(toStance("hawkish")).toBe("hawkish");
+    expect(toStance("Dovish")).toBe("dovish");
     expect(toStance("Neutral")).toBe("neutral");
+    expect(toStance("LABEL_0")).toBe("dovish");
+    expect(toStance("LABEL_1")).toBe("neutral");
+    expect(toStance("LABEL_2")).toBe("hawkish");
     expect(toStance("???")).toBe("unknown");
+  });
+
+  it("toStance does NOT silently relabel sst-2 news-sentiment labels as monetary stance", () => {
+    // Regression guard for the 'banana banana banana' bug. When the FOMC
+    // sentiment model fails to load and the backend falls back to
+    // distilbert-sst-2, the labels are POSITIVE / NEGATIVE — news-sentiment,
+    // not monetary-policy stance. The UI must surface this as "unknown" so
+    // the dashboard renders "Sentiment unavailable" instead of pretending
+    // POSITIVE means hawkish.
+    expect(toStance("POSITIVE")).toBe("unknown");
+    expect(toStance("NEGATIVE")).toBe("unknown");
+    expect(toStance("positive")).toBe("unknown");
+    expect(toStance("negative")).toBe("unknown");
   });
 
   it("stanceLabel renders human-readable form", () => {


### PR DESCRIPTION
## Summary
- **Sentiment classifier load:** default `MODEL_ID` now resolves to the local FinBERT-FOMC seed-71 checkpoint (`/data/artifacts/phase3/pilot_finetune_20260505T142652Z/hf_checkpoints`, verified `id2label = {0: dovish, 1: neutral, 2: hawkish}`). Override via `FED_PULSE_SENTIMENT_MODEL` env var; falls back to the gated HF path then `distilbert-sst-2` as a last resort. Structured `WARNING` on each failed load attempt and `ERROR` when the fallback fires.
- **Frontend `toStance` strict mapping:** refuses to silently relabel `POSITIVE` / `NEGATIVE` / `LABEL_X` blindly. Maps `hawkish` / `dovish` / `neutral` (case-insensitive) and the bare `LABEL_0/1/2` (taxonomy: 0=dovish, 1=neutral, 2=hawkish). Everything else falls through to `unknown`, and the dashboard renders "Sentiment unavailable" with the raw label visible.
- **`GET /documents/by-date?date=YYYY-MM-DD&kind=auto|statement|minutes`:** new endpoint backed by `data/fomc_statements.json` + `data/fomc_minutes.json`. 422 on bad kind, 404 on missing date.
- **Calendar → Analyze deep link:** clicking a meeting on `/calendar` now navigates to `/analyze?date=...&kind=statement`. The analyze page fetches the matching text on mount and prefills the textarea. Toasts on success and on 404.

## Test plan
- `pytest tests/unit/test_main_api.py tests/unit/test_text_encoder*.py -q` (9/9 in `backend-gpu`)
- `npm test -- tests/lib/analyze/format.test.ts` (9/9 in `frontend`, including new regression guard `toStance does NOT silently relabel sst-2 news-sentiment labels as monetary stance`)

## Manual smoke
- `make dev-gpu` then `POST /analyze` with `"interest rates are bad inflation is good"` should now either (a) return a real stance label if the local checkpoint loaded, or (b) return `POSITIVE` from the fallback and the dashboard shows "Sentiment unavailable" instead of "Hawkish 0.99".
- Open `/calendar`, click any meeting with a statement_release_date; the analyze textarea should populate with the matching FOMC statement and the date field should auto-set.

## Out of scope
- Exposing `model_type` (LSTM/GRU/TCN/Transformer) on `AnalyzeRequest` — separate PR.
- Hyperparameter sweep for the alternative forecaster cores.
- Production 4-architecture × 5-seed benchmark.