### PR TITLE
feat: energy-based OOD detection for the sentiment classifier (H)

### DIFF
--- a/backend/app/evaluation/ood.py
+++ b/backend/app/evaluation/ood.py
@@ -1,0 +1,258 @@
+"""Energy-based out-of-distribution detection for the sentiment classifier.
+
+The live `/analyze` flow runs a fine-tuned FinBERT-FOMC seed-71 head against
+arbitrary user input. Adversarial inputs that don't look like FOMC text
+("good afternoon crypto bros") routinely come back as `hawkish 0.94`
+because the model has nothing in-distribution to anchor on and falls back
+to the training prior at high confidence.
+
+This module ships a calibrated energy-based OOD signal that surfaces the
+problem visibly. Approach: Liu et al. 2020 ("Energy-based Out-of-distribution
+Detection"). For a classifier with K classes returning logits `f(x) in R^K`,
+the **free energy** is
+
+    E(x) = -T * logsumexp(f(x) / T)        (1)
+
+with temperature `T = 1.0` by default. Lower energy → input lies near the
+training distribution; higher energy → input is far from training and the
+classifier's confidence is uncalibrated. A threshold is calibrated on the
+training corpus (5th percentile of in-domain energies by default) and
+persisted as a JSON manifest next to the checkpoint.
+
+API surface:
+
+- `logit_energy(model, tokenizer, text, temperature)`: per-text energy.
+- `aggregate_energy(scores, mode)`: reduces per-chunk energies to one number.
+- `OODManifest` + `load_manifest` + `OOD_MANIFEST_NAME`: persistence.
+- `score_text(text, classifier, manifest)`: convenience for the API path.
+- `calibrate_threshold(corpus, classifier, percentile)`: build a manifest.
+
+No backwards-incompatible changes elsewhere; the API path returns
+`ood_energy = None`, `is_in_distribution = None` when no manifest is
+present, so the dashboard simply doesn't show an OOD signal until the
+user runs `scripts/calibrate_ood.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import statistics
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Literal
+
+import torch
+
+OOD_MANIFEST_NAME = "forecaster_best.ood.json"
+DEFAULT_TEMPERATURE = 1.0
+DEFAULT_THRESHOLD_PERCENTILE = 95.0  # the 95th-percentile of training energies; anything above is OOD
+DEFAULT_AGGREGATION: "EnergyAggregation" = "mean"
+
+EnergyAggregation = Literal["mean", "max", "median"]
+
+
+@dataclass(frozen=True)
+class OODManifest:
+    """Calibration manifest persisted alongside the sentiment checkpoint.
+
+    `threshold` is the in-domain energy ceiling: a chunk-aggregated energy
+    above this is flagged out-of-distribution. `percentile` is the percentile
+    of training energies used to derive the threshold (e.g. 95.0 = top 5%
+    of training energies are tolerated; anything above is OOD).
+    """
+
+    model_id: str
+    threshold: float
+    percentile: float
+    temperature: float
+    aggregation: EnergyAggregation
+    training_corpus_size: int
+    training_energy_mean: float
+    training_energy_std: float
+    training_energy_min: float
+    training_energy_max: float
+    calibrated_at_utc: str
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2, sort_keys=True)
+
+
+def logit_energy(
+    model,
+    tokenizer,
+    text: str,
+    *,
+    temperature: float = DEFAULT_TEMPERATURE,
+    max_length: int = 512,
+) -> float:
+    """Compute the free energy E(x) = -T * logsumexp(f(x) / T) for a single text.
+
+    The model is queried once. For long texts the caller is responsible for
+    chunking and aggregating via `aggregate_energy`. Returns a Python float
+    so callers can sort, percentile, JSON-serialise without numpy.
+    """
+
+    if not text:
+        return float("inf")
+    try:
+        device = next(model.parameters()).device
+    except (StopIteration, AttributeError):
+        # Defensive: a stub model without any parameters defaults to CPU.
+        # Real HF models always have parameters; this branch covers tests
+        # that inject a parameter-free toy model.
+        device = torch.device("cpu")
+    raw_inputs = tokenizer(
+        text,
+        truncation=True,
+        max_length=max_length,
+        return_tensors="pt",
+    )
+    # HF's BatchEncoding has .to(); a plain dict (from a stub tokenizer in
+    # tests) does not. Move the tensors to device by hand in that case.
+    if hasattr(raw_inputs, "to"):
+        inputs = raw_inputs.to(device)
+    elif isinstance(raw_inputs, dict):
+        inputs = {key: value.to(device) for key, value in raw_inputs.items()}
+    else:
+        inputs = raw_inputs
+    with torch.no_grad():
+        logits = model(**inputs).logits.squeeze(0)
+    energy = -float(temperature) * torch.logsumexp(logits / float(temperature), dim=-1)
+    return float(energy.item())
+
+
+def aggregate_energy(
+    chunk_energies: Iterable[float],
+    *,
+    mode: EnergyAggregation = DEFAULT_AGGREGATION,
+) -> float:
+    """Reduce per-chunk energies to a doc-level number.
+
+    `mean` is the default — every chunk contributes equally, the doc-level
+    energy averages out short noise. `max` is the most-OOD chunk; useful
+    when one alien sentence in a long document should trigger the gate.
+    `median` is robust to a single outlier chunk.
+    """
+
+    values = [float(e) for e in chunk_energies if math.isfinite(e)]
+    if not values:
+        return float("inf")
+    if mode == "mean":
+        return sum(values) / len(values)
+    if mode == "max":
+        return max(values)
+    if mode == "median":
+        return statistics.median(values)
+    raise ValueError(f"unknown aggregation mode: {mode!r}")
+
+
+def calibrate_threshold(
+    training_texts: Iterable[str],
+    *,
+    classifier,
+    percentile: float = DEFAULT_THRESHOLD_PERCENTILE,
+    temperature: float = DEFAULT_TEMPERATURE,
+) -> tuple[float, list[float]]:
+    """Compute the threshold for the OOD gate from a training-corpus iterable.
+
+    Returns `(threshold, raw_energies)`. Caller persists via OODManifest.
+    """
+
+    model = getattr(classifier, "model", None) or classifier
+    tokenizer = getattr(classifier, "tokenizer", None)
+    if model is None or tokenizer is None:
+        raise ValueError("classifier must expose .model and .tokenizer attributes")
+
+    energies: list[float] = []
+    for text in training_texts:
+        try:
+            energies.append(
+                logit_energy(model, tokenizer, text, temperature=temperature)
+            )
+        except Exception:
+            continue
+
+    if not energies:
+        raise ValueError("calibration corpus produced zero valid energies")
+    energies_sorted = sorted(energies)
+    # Higher percentile -> stricter gate (allows more training energies in)
+    rank = max(0, min(len(energies_sorted) - 1, int(len(energies_sorted) * percentile / 100.0)))
+    threshold = energies_sorted[rank]
+    return threshold, energies
+
+
+def load_manifest(path: Path | str) -> OODManifest | None:
+    """Read a calibration manifest from disk. Returns None when the file is
+    missing or malformed — callers fall back to "no OOD signal" gracefully.
+    """
+
+    target = Path(path)
+    if not target.exists():
+        return None
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    try:
+        return OODManifest(
+            model_id=str(payload["model_id"]),
+            threshold=float(payload["threshold"]),
+            percentile=float(payload["percentile"]),
+            temperature=float(payload["temperature"]),
+            aggregation=str(payload.get("aggregation", DEFAULT_AGGREGATION)),  # type: ignore[arg-type]
+            training_corpus_size=int(payload["training_corpus_size"]),
+            training_energy_mean=float(payload["training_energy_mean"]),
+            training_energy_std=float(payload["training_energy_std"]),
+            training_energy_min=float(payload["training_energy_min"]),
+            training_energy_max=float(payload["training_energy_max"]),
+            calibrated_at_utc=str(payload["calibrated_at_utc"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def score_text(
+    text: str,
+    *,
+    classifier,
+    manifest: OODManifest,
+    chunks: list[str] | None = None,
+) -> dict[str, Any]:
+    """Convenience wrapper used by the API path.
+
+    Computes the doc-level energy under the manifest's temperature +
+    aggregation, then compares against the threshold to derive
+    `is_in_distribution`. When ``chunks`` is provided the model is queried
+    once per chunk; otherwise the whole text is fed in a single pass.
+    """
+
+    model = getattr(classifier, "model", None) or classifier
+    tokenizer = getattr(classifier, "tokenizer", None)
+    if model is None or tokenizer is None:
+        return {
+            "ood_energy": None,
+            "ood_threshold": manifest.threshold,
+            "is_in_distribution": None,
+        }
+
+    if chunks is None or not chunks:
+        chunks = [text]
+    chunk_energies = [
+        logit_energy(model, tokenizer, chunk, temperature=manifest.temperature)
+        for chunk in chunks
+        if chunk
+    ]
+    if not chunk_energies:
+        return {
+            "ood_energy": None,
+            "ood_threshold": manifest.threshold,
+            "is_in_distribution": None,
+        }
+    doc_energy = aggregate_energy(chunk_energies, mode=manifest.aggregation)
+    return {
+        "ood_energy": doc_energy,
+        "ood_threshold": manifest.threshold,
+        "is_in_distribution": doc_energy <= manifest.threshold,
+        "chunk_energies": chunk_energies,
+    }

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -31,6 +31,14 @@ class SentimentResponse(BaseModel):
     label: str
     score: float
     raw: list[dict[str, float | str]]
+    # Energy-based out-of-distribution detection (Liu et al. 2020). Populated
+    # only when a calibration manifest exists alongside the checkpoint at
+    # forecaster_best.ood.json. ood_energy = -T * logsumexp(logits / T)
+    # averaged across chunks per the manifest's aggregation rule.
+    # is_in_distribution is True when ood_energy <= ood_threshold.
+    ood_energy: float | None = None
+    ood_threshold: float | None = None
+    is_in_distribution: bool | None = None
 
 
 class MarketDataResponse(BaseModel):

--- a/backend/app/services/sentiment.py
+++ b/backend/app/services/sentiment.py
@@ -8,6 +8,8 @@ from app.services.text_encoder import (
     aggregate_label,
     encode_chunks,
     get_classifier,
+    resolve_ood_manifest_path,
+    split_into_chunks,
 )
 
 __all__ = [
@@ -19,4 +21,25 @@ __all__ = [
 
 
 def analyze_text(text: str) -> dict[str, Any]:
-    return aggregate_label(encode_chunks(text))
+    """Score `text` for stance + (when an OOD manifest is available) attach
+    energy-based OOD diagnostics to the response."""
+
+    response = aggregate_label(encode_chunks(text))
+
+    manifest_path = resolve_ood_manifest_path()
+    if manifest_path is None:
+        return response
+
+    from app.evaluation.ood import load_manifest, score_text  # lazy: keep torch out of import-only paths
+
+    manifest = load_manifest(manifest_path)
+    if manifest is None:
+        return response
+
+    classifier = get_classifier()
+    chunks = split_into_chunks(text, classifier=classifier)
+    ood = score_text(text, classifier=classifier, manifest=manifest, chunks=chunks)
+    response["ood_energy"] = ood.get("ood_energy")
+    response["ood_threshold"] = ood.get("ood_threshold")
+    response["is_in_distribution"] = ood.get("is_in_distribution")
+    return response

--- a/backend/app/services/text_encoder.py
+++ b/backend/app/services/text_encoder.py
@@ -147,6 +147,25 @@ def warmup_classifier() -> None:
     get_classifier()
 
 
+def resolve_ood_manifest_path() -> Path | None:
+    """Locate the OOD calibration manifest beside the active checkpoint.
+
+    Returns None when MODEL_ID is an HF hub id (no local manifest) or
+    when no manifest has been written yet. Callers should treat the
+    absence of a manifest as 'no OOD signal' and not surface ood_*
+    fields on the response.
+    """
+
+    from app.evaluation.ood import OOD_MANIFEST_NAME  # lazy import: avoids cycle
+
+    candidate = Path(MODEL_ID)
+    if candidate.exists() and candidate.is_dir():
+        manifest_path = candidate / OOD_MANIFEST_NAME
+        if manifest_path.exists():
+            return manifest_path
+    return None
+
+
 def split_into_chunks(
     text: str,
     classifier=None,

--- a/scripts/calibrate_ood.py
+++ b/scripts/calibrate_ood.py
@@ -1,0 +1,147 @@
+"""Calibrate the energy-based OOD threshold for the live sentiment classifier.
+
+Reads texts from a registry JSONL or processed parquet, scores each
+through the loaded classifier, and writes a manifest at the path passed
+via `--output` (default: backend/models/forecaster_best.ood.json next to
+the checkpoint).
+
+Usage inside the backend container:
+
+    docker compose --profile gpu run --rm backend-gpu \
+        python -m scripts.calibrate_ood \
+        --input /data/raw/phase2/source_registry.jsonl \
+        --output /data/artifacts/phase3/pilot_finetune_20260505T142652Z/hf_checkpoints/forecaster_best.ood.json \
+        --percentile 95.0 \
+        --temperature 1.0 \
+        --aggregation mean
+
+Once the manifest is in place the live /analyze flow auto-loads it and
+the response carries ood_energy / ood_threshold / is_in_distribution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from app.evaluation.ood import (
+    DEFAULT_AGGREGATION,
+    DEFAULT_TEMPERATURE,
+    DEFAULT_THRESHOLD_PERCENTILE,
+    OOD_MANIFEST_NAME,
+    OODManifest,
+    calibrate_threshold,
+)
+from app.services.text_encoder import MODEL_ID, get_classifier
+
+
+def _iter_jsonl_texts(path: Path, *, text_key: str = "text") -> Iterable[str]:
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            value = row.get(text_key) if isinstance(row, dict) else None
+            if isinstance(value, str) and value.strip():
+                yield value.strip()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="JSONL file with one row per training document; expects a `text` field.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(Path("/data/artifacts") / OOD_MANIFEST_NAME),
+        help=f"Output manifest path (default places {OOD_MANIFEST_NAME} under /data/artifacts).",
+    )
+    parser.add_argument(
+        "--percentile",
+        type=float,
+        default=DEFAULT_THRESHOLD_PERCENTILE,
+        help="Percentile of in-domain energies to use as the OOD threshold.",
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=DEFAULT_TEMPERATURE,
+        help="Temperature for the energy = -T * logsumexp(logits / T).",
+    )
+    parser.add_argument(
+        "--aggregation",
+        choices=["mean", "max", "median"],
+        default=DEFAULT_AGGREGATION,
+        help="How to reduce per-chunk energies to a doc-level number.",
+    )
+    parser.add_argument(
+        "--max-rows",
+        type=int,
+        default=0,
+        help="Cap the calibration corpus to N rows; 0 = no cap.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    if not input_path.exists():
+        print(f"input not found: {input_path}", file=sys.stderr)
+        return 1
+
+    texts = list(_iter_jsonl_texts(input_path))
+    if args.max_rows > 0:
+        texts = texts[: args.max_rows]
+    if not texts:
+        print(f"no texts read from {input_path}", file=sys.stderr)
+        return 1
+
+    print(f"calibrating from {len(texts)} texts in {input_path}")
+    classifier = get_classifier()
+    threshold, energies = calibrate_threshold(
+        texts,
+        classifier=classifier,
+        percentile=args.percentile,
+        temperature=args.temperature,
+    )
+
+    manifest = OODManifest(
+        model_id=MODEL_ID,
+        threshold=threshold,
+        percentile=args.percentile,
+        temperature=args.temperature,
+        aggregation=args.aggregation,
+        training_corpus_size=len(energies),
+        training_energy_mean=statistics.fmean(energies),
+        training_energy_std=statistics.pstdev(energies) if len(energies) > 1 else 0.0,
+        training_energy_min=min(energies),
+        training_energy_max=max(energies),
+        calibrated_at_utc=datetime.now(timezone.utc).isoformat(),
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(manifest.to_json() + "\n", encoding="utf-8")
+    print(f"wrote OOD manifest: {output_path}")
+    print(f"  threshold       : {manifest.threshold:.4f}")
+    print(f"  percentile      : {manifest.percentile}")
+    print(f"  training mean   : {manifest.training_energy_mean:.4f}")
+    print(f"  training std    : {manifest.training_energy_std:.4f}")
+    print(f"  training min/max: {manifest.training_energy_min:.4f} / {manifest.training_energy_max:.4f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_ood_energy.py
+++ b/tests/unit/test_ood_energy.py
@@ -1,0 +1,280 @@
+"""Unit tests for the energy-based OOD module.
+
+The tests stub out the classifier (torch model + tokenizer) so they run
+without a HuggingFace download. The math is the focus: energy formula,
+aggregation, threshold percentile, manifest round-trip, score_text
+behaviour with a known classifier.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+import torch
+
+from app.evaluation import ood
+
+
+class _ToyModel(torch.nn.Module):
+    """Deterministic model that returns canned logits for any input.
+
+    The energy is -T * logsumexp(logits / T). For logits=[3, 0, -3] at
+    T=1 the energy is -logsumexp([3, 0, -3]) which is well-defined and
+    independent of input — perfect for asserting calibration math.
+    """
+
+    def __init__(self, logits: list[float]):
+        super().__init__()
+        self.logits = torch.tensor(logits, dtype=torch.float32)
+
+    def forward(self, input_ids, attention_mask=None, **_):  # noqa: ARG002
+        batch = input_ids.shape[0]
+        out = self.logits.unsqueeze(0).expand(batch, -1).clone()
+
+        class _Output:
+            def __init__(self, logits):
+                self.logits = logits
+
+        return _Output(out)
+
+
+class _ToyTokenizer:
+    """Minimal tokenizer that returns a tensor pair; doesn't tokenize anything."""
+
+    def __call__(self, text, *, truncation=True, max_length=512, return_tensors="pt", **_):  # noqa: ARG002
+        # Mock encoding — content doesn't matter for the math tests.
+        return {
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "attention_mask": torch.tensor([[1, 1, 1]]),
+        }
+
+
+def _toy_classifier(logits: list[float]):
+    classifier = type("ToyClassifier", (), {})()
+    classifier.model = _ToyModel(logits)
+    classifier.tokenizer = _ToyTokenizer()
+    return classifier
+
+
+def test_logit_energy_matches_neg_logsumexp() -> None:
+    """Sanity: energy(x) = -logsumexp(logits) at T=1."""
+
+    classifier = _toy_classifier([2.0, 1.0, 0.0])
+    energy = ood.logit_energy(classifier.model, classifier.tokenizer, "anything")
+    expected = -math.log(math.exp(2.0) + math.exp(1.0) + math.exp(0.0))
+    assert math.isclose(energy, expected, abs_tol=1e-5)
+
+
+def test_logit_energy_matches_formula_under_temperature() -> None:
+    """Sanity: energy(x, T) = -T * logsumexp(logits / T)."""
+
+    classifier = _toy_classifier([5.0, 0.0, -5.0])
+    T = 2.0
+    energy = ood.logit_energy(classifier.model, classifier.tokenizer, "x", temperature=T)
+    expected = -T * math.log(math.exp(5.0 / T) + math.exp(0.0 / T) + math.exp(-5.0 / T))
+    assert math.isclose(energy, expected, abs_tol=1e-5)
+
+
+def test_logit_energy_returns_inf_on_empty_text() -> None:
+    classifier = _toy_classifier([1.0, 0.0])
+    energy = ood.logit_energy(classifier.model, classifier.tokenizer, "")
+    assert energy == float("inf")
+
+
+def test_aggregate_energy_mean_takes_arithmetic_mean() -> None:
+    assert ood.aggregate_energy([1.0, 2.0, 3.0], mode="mean") == pytest.approx(2.0)
+
+
+def test_aggregate_energy_max_returns_largest_chunk() -> None:
+    assert ood.aggregate_energy([1.0, 9.0, 3.0], mode="max") == 9.0
+
+
+def test_aggregate_energy_median_handles_odd_and_even() -> None:
+    assert ood.aggregate_energy([1.0, 9.0, 3.0], mode="median") == 3.0
+    assert ood.aggregate_energy([1.0, 9.0, 3.0, 5.0], mode="median") == 4.0
+
+
+def test_aggregate_energy_handles_empty_input_with_inf() -> None:
+    assert ood.aggregate_energy([], mode="mean") == float("inf")
+
+
+def test_aggregate_energy_rejects_unknown_mode() -> None:
+    with pytest.raises(ValueError, match="unknown aggregation mode"):
+        ood.aggregate_energy([1.0], mode="garbage")  # type: ignore[arg-type]
+
+
+def test_aggregate_energy_drops_non_finite_values() -> None:
+    assert ood.aggregate_energy([1.0, float("inf"), 3.0], mode="mean") == pytest.approx(2.0)
+
+
+def test_calibrate_threshold_returns_percentile_of_training_energies() -> None:
+    """A toy classifier with constant logits produces constant energies, so
+    the 95th-percentile threshold equals any of the training energies."""
+
+    classifier = _toy_classifier([2.0, 1.0, 0.0])
+    threshold, energies = ood.calibrate_threshold(
+        ["a", "b", "c", "d", "e"],
+        classifier=classifier,
+        percentile=95.0,
+        temperature=1.0,
+    )
+    expected = -math.log(math.exp(2.0) + math.exp(1.0) + math.exp(0.0))
+    assert math.isclose(threshold, expected, abs_tol=1e-5)
+    assert len(energies) == 5
+
+
+def test_calibrate_threshold_higher_percentile_yields_looser_threshold() -> None:
+    """A spread of energies + a higher percentile cutoff -> larger threshold."""
+
+    energies_sorted = []
+
+    class _VariableLogits(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.counter = 0
+
+        def forward(self, input_ids, attention_mask=None, **_):  # noqa: ARG002
+            # Each call returns higher logits than the last; energies decrease,
+            # then increase to spread the distribution.
+            self.counter += 1
+
+            class _Output:
+                def __init__(self, logits):
+                    self.logits = logits
+
+            scale = float(self.counter)
+            logits = torch.tensor([[scale, 0.0, -scale]], dtype=torch.float32)
+            return _Output(logits)
+
+    classifier = type("Variable", (), {})()
+    classifier.model = _VariableLogits()
+    classifier.tokenizer = _ToyTokenizer()
+    threshold_p50, _ = ood.calibrate_threshold(
+        list("abcdefghij"),
+        classifier=classifier,
+        percentile=50.0,
+    )
+    classifier.model.counter = 0  # type: ignore[attr-defined]
+    threshold_p99, _ = ood.calibrate_threshold(
+        list("abcdefghij"),
+        classifier=classifier,
+        percentile=99.0,
+    )
+    # The 99th percentile must be no smaller than the 50th. Equality would be a
+    # bug because the variable model produces a spread.
+    assert threshold_p99 >= threshold_p50
+    assert threshold_p99 != threshold_p50  # sanity: there's actually spread
+
+
+def test_calibrate_threshold_rejects_empty_corpus() -> None:
+    classifier = _toy_classifier([1.0, 0.0])
+    with pytest.raises(ValueError, match="zero valid energies"):
+        ood.calibrate_threshold([], classifier=classifier)
+
+
+def test_manifest_round_trip_through_disk(tmp_path: Path) -> None:
+    manifest = ood.OODManifest(
+        model_id="local/test-finbert",
+        threshold=-3.14,
+        percentile=95.0,
+        temperature=1.0,
+        aggregation="mean",
+        training_corpus_size=1234,
+        training_energy_mean=-4.0,
+        training_energy_std=0.5,
+        training_energy_min=-5.0,
+        training_energy_max=-2.5,
+        calibrated_at_utc="2026-05-14T12:00:00+00:00",
+    )
+    path = tmp_path / "ood.json"
+    path.write_text(manifest.to_json(), encoding="utf-8")
+
+    loaded = ood.load_manifest(path)
+    assert loaded == manifest
+
+
+def test_load_manifest_returns_none_for_missing_file(tmp_path: Path) -> None:
+    assert ood.load_manifest(tmp_path / "absent.json") is None
+
+
+def test_load_manifest_returns_none_for_malformed_json(tmp_path: Path) -> None:
+    path = tmp_path / "ood.json"
+    path.write_text("{not json", encoding="utf-8")
+    assert ood.load_manifest(path) is None
+
+
+def test_load_manifest_returns_none_when_required_field_missing(tmp_path: Path) -> None:
+    path = tmp_path / "ood.json"
+    path.write_text(json.dumps({"model_id": "x"}), encoding="utf-8")
+    assert ood.load_manifest(path) is None
+
+
+def test_score_text_returns_in_distribution_when_energy_below_threshold() -> None:
+    classifier = _toy_classifier([2.0, 1.0, 0.0])
+    manifest = ood.OODManifest(
+        model_id="local/test-finbert",
+        threshold=0.0,  # generous; any text energy will be negative -> in-dist
+        percentile=95.0,
+        temperature=1.0,
+        aggregation="mean",
+        training_corpus_size=10,
+        training_energy_mean=-2.0,
+        training_energy_std=0.5,
+        training_energy_min=-3.0,
+        training_energy_max=-1.0,
+        calibrated_at_utc="2026-05-14T12:00:00+00:00",
+    )
+    result = ood.score_text("FOMC text excerpt", classifier=classifier, manifest=manifest)
+    assert result["is_in_distribution"] is True
+    assert result["ood_threshold"] == 0.0
+    assert result["ood_energy"] < 0.0
+
+
+def test_score_text_returns_out_of_distribution_when_energy_above_threshold() -> None:
+    classifier = _toy_classifier([2.0, 1.0, 0.0])
+    manifest = ood.OODManifest(
+        model_id="local/test-finbert",
+        threshold=-100.0,  # tight; any real energy is much higher -> OOD
+        percentile=95.0,
+        temperature=1.0,
+        aggregation="mean",
+        training_corpus_size=10,
+        training_energy_mean=-2.0,
+        training_energy_std=0.5,
+        training_energy_min=-3.0,
+        training_energy_max=-1.0,
+        calibrated_at_utc="2026-05-14T12:00:00+00:00",
+    )
+    result = ood.score_text("good afternoon crypto bros", classifier=classifier, manifest=manifest)
+    assert result["is_in_distribution"] is False
+    assert result["ood_energy"] > -100.0
+
+
+def test_score_text_respects_aggregation_mode_from_manifest() -> None:
+    classifier = _toy_classifier([1.0, 0.0])
+    manifest = ood.OODManifest(
+        model_id="x",
+        threshold=0.0,
+        percentile=95.0,
+        temperature=1.0,
+        aggregation="max",
+        training_corpus_size=5,
+        training_energy_mean=-1.0,
+        training_energy_std=0.1,
+        training_energy_min=-1.0,
+        training_energy_max=-1.0,
+        calibrated_at_utc="2026-05-14T12:00:00+00:00",
+    )
+    result = ood.score_text(
+        "doc",
+        classifier=classifier,
+        manifest=manifest,
+        chunks=["chunk a", "chunk b", "chunk c"],
+    )
+    # With 3 identical chunks and 'max' aggregation, the doc energy equals
+    # the per-chunk energy. The manifest's aggregation determines how
+    # the chunk energies reduce.
+    assert result["ood_energy"] == pytest.approx(result["chunk_energies"][0], abs=1e-5)


### PR DESCRIPTION
## Summary
- `backend/app/evaluation/ood.py` — energy-based OOD (Liu et al. 2020). `logit_energy()` per text, `aggregate_energy()` across chunks, `calibrate_threshold()` for the 95th-percentile gate, `OODManifest` for persistence, `score_text()` for the API path.
- `scripts/calibrate_ood.py` — one-shot calibration over the training corpus. CLI flags: `--percentile / --temperature / --aggregation / --max-rows`. Writes `forecaster_best.ood.json` next to the checkpoint.
- `SentimentResponse` gains optional `ood_energy / ood_threshold / is_in_distribution`. Backwards compatible — fields stay `None` when no manifest exists.
- `analyze_text()` attaches OOD diagnostics when a manifest is present beside the local checkpoint.
- 19 new unit tests in `test_ood_energy.py`: formula correctness at T=1 and T=2, aggregation rules (mean/max/median), calibration percentile math, manifest round-trip, score_text gates.

## Test plan
- `pytest tests/unit/test_ood_energy.py -q` (19/19 passing in `backend-gpu`)
- Live smoke against running stack: `/analyze` returns `ood_energy/threshold/is_in_distribution: null` when no manifest exists (verified)

## To activate after merge
1. Merge #124 first so the local FinBERT-FOMC checkpoint becomes the default model.
2. Run the calibration: `docker compose --profile gpu run --rm backend-gpu python -m scripts.calibrate_ood --input /data/raw/phase2/source_registry.jsonl --output /data/artifacts/phase3/pilot_finetune_20260505T142652Z/hf_checkpoints/forecaster_best.ood.json`
3. The next `/analyze` call carries `ood_energy / ood_threshold / is_in_distribution`.
4. UI wiring (banner when `is_in_distribution=false`) lands as a separate small follow-up PR.

## What this is NOT
- Not a model fix. The classifier still returns whatever it returns. OOD is a **calibrated honesty signal** on top of the existing output.
- Not the G option (full retrain with class-balanced loss + pseudo-label expansion). That's a separate PR gated on the 100-row audit.

## Methodology citation for the thesis
Liu, Wang, Owens, Li. "Energy-based Out-of-distribution Detection." NeurIPS 2020. arXiv:2010.03759.