### PR TITLE
fix: TDW label-swap at ingestion (CRITICAL — hawkish/neutral inverted on classes 1 and 2)

### DIFF
--- a/backend/app/data/normalize_labels.py
+++ b/backend/app/data/normalize_labels.py
@@ -16,14 +16,36 @@ DEFAULT_EXCEPTIONS = DEFAULT_DATA_DIR / "interim" / "phase2" / "label_mapping_ex
 DEFAULT_META = DEFAULT_DATA_DIR / "interim" / "phase2" / "label_mapping_metadata.json"
 MAPPING_VERSION = "label_map_v1.0"
 
+#
+# CRITICAL — Trillion Dollar Words (gtfintechlab/fomc_communication) canonical
+# integer mapping verified 2026-05-14 by sampling rows per integer class and
+# reading the sentences:
+#
+#     class 0 (515 train rows) -> dovish ("Low inflation readings...",
+#                                  "raising inflation to 2 percent")
+#     class 1 (492 train rows) -> hawkish ("rising wage pressures",
+#                                  "recession ended", "inflation higher this year")
+#     class 2 (977 train rows) -> neutral ("Broad equity price indexes fell",
+#                                  "no need for tightening", academic citations)
+#
+# Earlier versions of this file mapped "2" -> hawkish and "1" -> neutral,
+# which is the INVERSE of the canonical TDW mapping for classes 1 and 2.
+# Every fine-tune trained on the ingested registry learned the right
+# class distinctions but with the wrong name attached to the output index.
+# Live `/analyze` would say "hawkish 0.997" on textbook-neutral input and
+# "neutral 0.998" on textbook-hawkish input. Macro-F1 is unchanged (the
+# metric does not depend on label names); per-class precision/recall tables
+# in earlier Phase 3/4 results have hawkish <-> neutral swapped throughout.
+# See `09_Risk_Register.md` R-16 for the impact assessment.
+#
 HAWKISH_TOKENS = {
     "hawkish",
     "hawk",
     "tightening",
     "restrictive",
     "positive",
-    "label_2",
-    "2",
+    "label_1",
+    "1",
 }
 DOVISH_TOKENS = {
     "dovish",
@@ -38,8 +60,8 @@ NEUTRAL_TOKENS = {
     "neutral",
     "mixed",
     "balanced",
-    "label_1",
-    "1",
+    "label_2",
+    "2",
 }
 
 

--- a/backend/app/data/phase3_finetune_pilot.py
+++ b/backend/app/data/phase3_finetune_pilot.py
@@ -36,7 +36,14 @@ from app.training.manifest import write_run_manifest
 
 DEFAULT_ARTIFACT_ROOT = DEFAULT_DATA_DIR / "artifacts" / "phase3"
 
-LABELS = ("dovish", "neutral", "hawkish")
+# Class order matches the canonical Trillion Dollar Words integer mapping
+# verified 2026-05-14 (dovish=0, hawkish=1, neutral=2). Earlier this tuple
+# was ("dovish", "neutral", "hawkish") which inverted classes 1 and 2 vs
+# TDW, producing the silent label-swap bug documented in
+# backend/app/data/normalize_labels.py. Future fine-tunes pick up the
+# correct ordering from this tuple; existing on-disk checkpoints were
+# patched in place by scripts/patch_checkpoint_id2label.py.
+LABELS = ("dovish", "hawkish", "neutral")
 LABEL2ID = {label: idx for idx, label in enumerate(LABELS)}
 ID2LABEL = dict(enumerate(LABELS))
 

--- a/scripts/patch_checkpoint_id2label.py
+++ b/scripts/patch_checkpoint_id2label.py
@@ -1,0 +1,88 @@
+"""One-shot post-hoc fix for a fine-tuned checkpoint whose ``id2label`` was
+written with the inverse of the Trillion Dollar Words canonical class
+ordering (the 2026-05-14 root-cause bug — see
+``backend/app/data/normalize_labels.py`` for the audit notes and TDW
+sample verification).
+
+The model on disk learned the correct CLASS DISTINCTIONS but with the
+wrong NAMES attached to class indices 1 and 2. After running this
+script the model's output indices are unchanged; only the human-
+readable label names attached to those indices are corrected.
+
+Usage:
+
+    docker compose --profile gpu run --rm backend-gpu \\
+        python -m scripts.patch_checkpoint_id2label \\
+        /data/artifacts/phase3/pilot_finetune_20260505T142652Z/hf_checkpoints
+
+The script edits ``config.json`` in place. It refuses to act if the
+config doesn't match the known inverted shape, so re-running is a
+no-op.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+INVERTED_ID2LABEL = {"0": "dovish", "1": "neutral", "2": "hawkish"}
+CORRECT_ID2LABEL = {"0": "dovish", "1": "hawkish", "2": "neutral"}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "checkpoint_dir",
+        type=Path,
+        help="Path to the HF checkpoint directory containing config.json.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the diff without writing.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    config_path = args.checkpoint_dir / "config.json"
+    if not config_path.exists():
+        print(f"config.json not found at {config_path}", file=sys.stderr)
+        return 1
+
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    current_id2label = {str(k): v for k, v in (payload.get("id2label") or {}).items()}
+
+    if current_id2label == CORRECT_ID2LABEL:
+        print(f"[patch] {config_path} already canonical — no changes needed.")
+        return 0
+    if current_id2label != INVERTED_ID2LABEL:
+        print(
+            f"[patch] refusing to act: current id2label={current_id2label!r} "
+            f"does not match the known-inverted shape {INVERTED_ID2LABEL!r} "
+            f"or canonical {CORRECT_ID2LABEL!r}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    payload["id2label"] = CORRECT_ID2LABEL
+    payload["label2id"] = {label: int(idx) for idx, label in CORRECT_ID2LABEL.items()}
+
+    if args.dry_run:
+        print("[patch] dry-run — would write:")
+        print(f"  id2label: {INVERTED_ID2LABEL} -> {CORRECT_ID2LABEL}")
+        print(f"  label2id: {payload['label2id']}")
+        return 0
+
+    config_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"[patch] wrote canonical id2label to {config_path}")
+    print(f"  id2label: {CORRECT_ID2LABEL}")
+    print(f"  label2id: {payload['label2id']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_normalize_labels_tdw_mapping.py
+++ b/tests/unit/test_normalize_labels_tdw_mapping.py
@@ -1,0 +1,84 @@
+"""Regression guard for the 2026-05-14 label-swap bug.
+
+Trillion Dollar Words ships with raw integer labels:
+
+    class 0 (515 train rows)  -> dovish
+    class 1 (492 train rows)  -> hawkish
+    class 2 (977 train rows)  -> neutral
+
+Earlier this project mapped class 2 -> hawkish and class 1 -> neutral
+(the inverse of TDW). The model learned the right classes but the
+display labels were swapped for two out of three classes — live
+/analyze returned "hawkish 0.997" on textbook-neutral input. This
+test asserts the canonical mapping at the source so the bug can't
+regress.
+
+Cross-reference: 09_Risk_Register.md R-16, scripts/patch_checkpoint_id2label.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.data.normalize_labels import (
+    DOVISH_TOKENS,
+    HAWKISH_TOKENS,
+    NEUTRAL_TOKENS,
+    _map_label,
+)
+
+
+@pytest.mark.parametrize(
+    "raw_label, expected",
+    [
+        # TDW canonical integer labels (verified by inspecting sample sentences
+        # in test_data/tdw_sample_per_class.txt).
+        ("0", "dovish"),
+        ("LABEL_0", "dovish"),
+        ("1", "hawkish"),
+        ("LABEL_1", "hawkish"),
+        ("2", "neutral"),
+        ("LABEL_2", "neutral"),
+        # Common string labels — case-insensitive
+        ("hawkish", "hawkish"),
+        ("HAWKISH", "hawkish"),
+        ("dovish", "dovish"),
+        ("DOVISH", "dovish"),
+        ("neutral", "neutral"),
+        ("NEUTRAL", "neutral"),
+        # Soft-matching for compound labels
+        ("tightening", "hawkish"),
+        ("hawk", "hawkish"),
+        ("easing", "dovish"),
+        ("dove", "dovish"),
+        ("mixed", "neutral"),
+        ("balanced", "neutral"),
+    ],
+)
+def test_map_label_matches_tdw_canonical(raw_label: str, expected: str) -> None:
+    """Each raw label must map to its TDW canonical class name."""
+
+    assert _map_label(raw_label) == expected
+
+
+def test_integer_tokens_partition_correctly() -> None:
+    """LABEL_0/0 -> dovish; LABEL_1/1 -> hawkish; LABEL_2/2 -> neutral.
+    Critical: integer-token sets must not overlap across classes."""
+
+    assert "0" in DOVISH_TOKENS and "label_0" in DOVISH_TOKENS
+    assert "1" in HAWKISH_TOKENS and "label_1" in HAWKISH_TOKENS
+    assert "2" in NEUTRAL_TOKENS and "label_2" in NEUTRAL_TOKENS
+
+    overlaps = (
+        (HAWKISH_TOKENS & DOVISH_TOKENS, "HAWKISH ∩ DOVISH"),
+        (HAWKISH_TOKENS & NEUTRAL_TOKENS, "HAWKISH ∩ NEUTRAL"),
+        (DOVISH_TOKENS & NEUTRAL_TOKENS, "DOVISH ∩ NEUTRAL"),
+    )
+    for shared, name in overlaps:
+        assert not shared, f"{name} should be disjoint but shares {shared!r}"
+
+
+def test_unmappable_label_returns_none() -> None:
+    assert _map_label("") is None
+    assert _map_label("garbage") is None
+    assert _map_label("LABEL_99") is None


### PR DESCRIPTION
## What broke

Live `/analyze` returned `Hawkish 0.997` on textbook-neutral text and `Neutral 0.998` on textbook-hawkish text. The user reported it; raw-logit probing showed the model was outputting the **correct class index** for each input — only the human-readable label attached to that index was wrong.

```
HAWKISH_SHORT  argmax_class_idx=1  probs=[0.000, 0.998, 0.001]  display="neutral"  ← model is right; label is wrong
NEUTRAL_SHORT  argmax_class_idx=2  probs=[0.002, 0.001, 0.997]  display="hawkish"  ← model is right; label is wrong
DOVISH_SHORT   argmax_class_idx=0  probs=[0.985, 0.009, 0.006]  display="dovish"   ← correct
```

## Root cause

Inspecting `gtfintechlab/fomc_communication` directly confirmed TDW's canonical integer order:

| Class | Train rows | TDW semantic |
| --- | --- | --- |
| 0 | 515 | dovish |
| 1 | 492 | **hawkish** |
| 2 | 977 | **neutral** |

`normalize_labels.py` historically mapped `"2"/"LABEL_2" → hawkish` and `"1"/"LABEL_1" → neutral` — the inverse for classes 1 and 2. Every fine-tune trained on the ingested registry learned correct class distinctions with hawkish ↔ neutral names swapped.

## Fixes
- `normalize_labels.py`: `HAWKISH_TOKENS` gains `label_1`/`1`; `NEUTRAL_TOKENS` gains `label_2`/`2`. Detailed audit comment block.
- `phase3_finetune_pilot.py::LABELS`: `("dovish", "neutral", "hawkish")` → `("dovish", "hawkish", "neutral")`. Future fine-tunes pick up the canonical order.
- `scripts/patch_checkpoint_id2label.py`: one-shot post-hoc fix swaps `id2label[1] ↔ id2label[2]` and `label2id` in `config.json`. Model weights unchanged.
- `tests/unit/test_normalize_labels_tdw_mapping.py`: 20 regression tests asserting canonical TDW mapping + set-disjointness.

## Effects on the project
- **Live `/analyze` now returns correct labels.** Re-probed 6 controlled inputs after running `patch_checkpoint_id2label` on the local FinBERT-FOMC seed-71 checkpoint; every probe matches its semantic.
- **Macro-F1, accuracy, AUC and any name-independent metric in earlier Phase 3 / 4 results are unchanged.** The metric doesn't care about label names; the model classifies correctly.
- **Per-class precision / recall tables in Phase 3 / 4 result snapshots have hawkish and neutral columns swapped.** When citing these numbers in the thesis, swap the two column labels.
- **91-row `registry_pseudo_chunk_vote.jsonl`:** rows currently labelled `hawkish` are semantically neutral; rows labelled `neutral` are semantically hawkish; dovish is correct.

Tracked in [`09_Risk_Register.md` R-16 (exposure 20)](https://github.com/yusufizzetmurat/fed-pulse/wiki/09_Risk_Register#row-r-16).

## Test plan
- `pytest tests/unit/test_normalize_labels_tdw_mapping.py -q` (20/20 in `backend-gpu`)
- Manual: `make dev-gpu` → POST `/analyze` with "Further rate hikes are warranted" → returns `hawkish`, not `neutral`.

## Follow-up
- Re-run the chunk-aggregated teacher on the unlabelled pool with the patched checkpoint to refresh `registry_pseudo_chunk_vote.jsonl` with the right names. The judge-only audit PR (B option) lands after this fix.