### PR TITLE
feat: judge-pass incremental writes, progress logging, --resume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,8 @@ pseudo-labels-judge-pass:
 		--output /data/interim/phase2/registry_pseudo_$(PSEUDO_STRATEGY)_judged.jsonl \
 		--judge-model "$(JUDGE_MODEL)" \
 		--judge-model-version "$(JUDGE_MODEL_VERSION)" \
-		--request-interval-seconds "$(JUDGE_REQUEST_INTERVAL)"
+		--request-interval-seconds "$(JUDGE_REQUEST_INTERVAL)" \
+		--resume
 
 # Judge-only audit: use the Gemini judge labels as gold and compute
 # teacher per-class precision + Cohen's kappa(teacher, judge). Pass

--- a/backend/app/data/llm_judge.py
+++ b/backend/app/data/llm_judge.py
@@ -49,6 +49,15 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=0.0,
         help="Sleep this many seconds between Gemini calls to respect rate limits. 0 = no sleep.",
     )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help=(
+            "Skip rows whose record_id already appears in the output JSONL. "
+            "Combined with append-mode incremental writes, re-running this "
+            "command after a crash picks up where the previous run died."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -81,36 +90,101 @@ def run_judge(
     judge_model_version: str,
     max_rows: int = 0,
     request_interval_seconds: float = 0.0,
+    resume: bool = False,
+    progress_writer=None,
 ) -> int:
-    """Score every row in input_path, write judged rows to output_path.
+    """Score every row in ``input_path`` and write judged rows incrementally
+    to ``output_path``. Returns the number of rows written *by this
+    invocation* (resumed rows are not counted).
 
-    Each output row preserves all input fields and adds judge_label,
-    judge_confidence, judge_model_id, judge_model_version. Returns the
-    number of rows written.
+    Per-row behaviour:
 
-    request_interval_seconds: sleep between successive Gemini calls
-    (skipped after the final call). Use this to respect free-tier
-    rate limits — e.g. 35.0 keeps under the gemini-2.5-flash 2 req/min cap.
+    - Prints one line per row to stdout so the operator can see progress
+      ("[judge] 17/91  hawkish  ...").
+    - Catches any exception from the Gemini SDK (transient 429/503 are
+      common at scale) and persists the row with ``judge_label=""``
+      rather than crashing the run. The audit step counts blank rows as
+      parse / API failures.
+    - Writes one row at a time in append mode and flushes after each
+      write, so an interrupted run keeps every completed row on disk.
+
+    ``resume`` rereads ``output_path`` and skips rows whose
+    ``record_id`` already appears there. Combined with the per-row
+    write semantics this means re-running the same Make target after a
+    crash picks up where the previous run died.
+
+    ``progress_writer`` is an optional callable that receives each
+    progress line (defaults to the built-in ``print``). Tests inject a
+    list-appender to avoid noisy stdout.
+
+    ``request_interval_seconds`` spaces successive Gemini calls; use
+    ``35.0`` for the free-tier flash 2-req/min cap, ``0.0`` for paid.
     """
+
+    if progress_writer is None:
+        def progress_writer(line: str) -> None:
+            print(line, flush=True)
 
     rows = _read_jsonl(input_path)
     if max_rows > 0:
         rows = rows[:max_rows]
+    total = len(rows)
 
-    judged: list[dict[str, Any]] = []
-    for index, row in enumerate(rows):
-        prediction = score_passage(row.get("text", ""), model=gemini_model)
-        out = dict(row)
-        out["judge_label"] = prediction["label"]
-        out["judge_confidence"] = float(prediction["confidence"])
-        out["judge_model_id"] = judge_model_id
-        out["judge_model_version"] = judge_model_version
-        judged.append(out)
-        if request_interval_seconds > 0 and index < len(rows) - 1:
-            time.sleep(request_interval_seconds)
+    completed_record_ids: set[str] = set()
+    if resume and output_path.exists():
+        for existing in _read_jsonl(output_path):
+            rid = str(existing.get("record_id", "")).strip()
+            if rid:
+                completed_record_ids.add(rid)
 
-    _write_jsonl(output_path, judged)
-    return len(judged)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    open_mode = "a" if (resume and completed_record_ids) else "w"
+
+    written = 0
+    with output_path.open(open_mode, encoding="utf-8") as handle:
+        for index, row in enumerate(rows):
+            record_id = str(row.get("record_id", "")).strip()
+            short_id = record_id[:16] if record_id else "(no-id)"
+
+            if record_id and record_id in completed_record_ids:
+                progress_writer(f"[judge] {index + 1}/{total}  skip      {short_id}  (resumed)")
+                continue
+
+            try:
+                prediction = score_passage(row.get("text", ""), model=gemini_model)
+                label = str(prediction.get("label", "") or "")
+                confidence = float(prediction.get("confidence", 0.0) or 0.0)
+                error_kind = ""
+            except Exception as exc:  # noqa: BLE001 — we want every API failure to land in the output
+                label = ""
+                confidence = 0.0
+                error_kind = type(exc).__name__
+                progress_writer(
+                    f"[judge] {index + 1}/{total}  ERROR     {short_id}  "
+                    f"({error_kind}): {str(exc)[:160]}"
+                )
+
+            out = dict(row)
+            out["judge_label"] = label
+            out["judge_confidence"] = confidence
+            out["judge_model_id"] = judge_model_id
+            out["judge_model_version"] = judge_model_version
+            if error_kind:
+                out["judge_error"] = error_kind
+
+            handle.write(json.dumps(out) + "\n")
+            handle.flush()
+            written += 1
+
+            if not error_kind:
+                progress_writer(
+                    f"[judge] {index + 1}/{total}  {label or 'blank':<8}  {short_id}"
+                )
+
+            if request_interval_seconds > 0 and index < total - 1:
+                time.sleep(request_interval_seconds)
+
+    return written
 
 
 GATING_POLICIES = ("confidence_only", "confidence_and_judge", "judge_only")
@@ -420,6 +494,7 @@ def main() -> int:
         judge_model_version=args.judge_model_version,
         max_rows=args.max_rows,
         request_interval_seconds=args.request_interval_seconds,
+        resume=args.resume,
     )
     print(f"Judged rows written: {written}")
 

--- a/tests/unit/test_llm_judge.py
+++ b/tests/unit/test_llm_judge.py
@@ -91,6 +91,205 @@ def test_run_judge_persists_judge_label_and_confidence_per_row(tmp_path: Path) -
     assert rows[0]["teacher_model_id"] == "fomc_roberta_s71"
 
 
+class _FlakyGeminiModel:
+    """Stub model that raises on a configurable subset of calls.
+
+    `fail_on_indices` is a set of call-indexes that raise; everything
+    else returns the next canned response. Used to test the run_judge
+    per-row try/except behaviour when the Gemini API returns 503/429
+    mid-batch.
+    """
+
+    def __init__(self, responses: list[str], fail_on_indices: set[int]):
+        self._responses = list(responses)
+        self._fail_on = set(fail_on_indices)
+        self._index = -1
+
+    def generate_content(self, _prompt):  # pragma: no cover - matches SDK shape
+        self._index += 1
+        if self._index in self._fail_on:
+            raise RuntimeError(f"503 UNAVAILABLE on call {self._index}")
+        text = self._responses.pop(0)
+
+        class _Response:
+            def __init__(self, txt):
+                self.text = txt
+
+        return _Response(text)
+
+
+def test_run_judge_writes_one_progress_line_per_row(tmp_path: Path) -> None:
+    """A row-by-row progress writer collects one line per input row."""
+
+    input_path = tmp_path / "registry_pseudo.jsonl"
+    output_path = tmp_path / "judged.jsonl"
+    _write_pseudo_fixture(input_path)
+
+    model = _StubGeminiModel(
+        [
+            '{"label": "hawkish", "confidence": 0.95}',
+            '{"label": "neutral", "confidence": 0.62}',
+        ]
+    )
+    lines: list[str] = []
+    written = llm_judge.run_judge(
+        input_path=input_path,
+        output_path=output_path,
+        gemini_model=model,
+        judge_model_id="gemini-2.5-pro",
+        judge_model_version="20260514_v1",
+        progress_writer=lines.append,
+    )
+    assert written == 2
+    assert len(lines) == 2
+    assert "1/2" in lines[0] and "hawkish" in lines[0]
+    assert "2/2" in lines[1] and "neutral" in lines[1]
+
+
+def test_run_judge_writes_incrementally_one_row_per_line(tmp_path: Path) -> None:
+    """Each completed row hits disk before the next call — verified by
+    flushing-after-write semantics. We check the file is non-empty
+    immediately after a single-row run + the JSONL parses cleanly."""
+
+    input_path = tmp_path / "registry_pseudo.jsonl"
+    output_path = tmp_path / "judged.jsonl"
+    _write_pseudo_fixture(input_path)
+
+    model = _StubGeminiModel(
+        [
+            '{"label": "hawkish", "confidence": 0.95}',
+            '{"label": "dovish", "confidence": 0.81}',
+        ]
+    )
+    llm_judge.run_judge(
+        input_path=input_path,
+        output_path=output_path,
+        gemini_model=model,
+        judge_model_id="gemini-2.5-pro",
+        judge_model_version="v1",
+        progress_writer=lambda _line: None,
+    )
+    raw_lines = output_path.read_text(encoding="utf-8").splitlines()
+    assert len(raw_lines) == 2
+    rows = [json.loads(ln) for ln in raw_lines]
+    assert rows[0]["judge_label"] == "hawkish"
+    assert rows[1]["judge_label"] == "dovish"
+
+
+def test_run_judge_continues_after_api_error_marks_row_with_blank_judge_label(tmp_path: Path) -> None:
+    """A transient API failure on row 1 must NOT crash the run; the
+    failing row lands with judge_label='' + judge_error=type-name, and
+    row 2 still runs."""
+
+    input_path = tmp_path / "registry_pseudo.jsonl"
+    output_path = tmp_path / "judged.jsonl"
+    _write_pseudo_fixture(input_path)
+
+    model = _FlakyGeminiModel(
+        responses=['{"label": "dovish", "confidence": 0.77}'],
+        fail_on_indices={0},  # first call raises
+    )
+    lines: list[str] = []
+    written = llm_judge.run_judge(
+        input_path=input_path,
+        output_path=output_path,
+        gemini_model=model,
+        judge_model_id="gemini-2.5-pro",
+        judge_model_version="v1",
+        progress_writer=lines.append,
+    )
+    assert written == 2  # both rows persisted (the first as a blank)
+    rows = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+    assert rows[0]["judge_label"] == ""
+    assert rows[0]["judge_confidence"] == 0.0
+    assert rows[0]["judge_error"] == "RuntimeError"
+    assert rows[1]["judge_label"] == "dovish"
+    # Progress writer reported the error
+    assert any("ERROR" in line for line in lines)
+
+
+def test_run_judge_resume_skips_record_ids_already_in_output(tmp_path: Path) -> None:
+    """When resume=True and the output file already contains row 'r1',
+    only the second row is scored on the re-run."""
+
+    input_path = tmp_path / "registry_pseudo.jsonl"
+    output_path = tmp_path / "judged.jsonl"
+    _write_pseudo_fixture(input_path)
+    # Pre-seed the output with the first row already judged.
+    output_path.write_text(
+        json.dumps(
+            {
+                "record_id": "r1",
+                "label": "hawkish",
+                "text": "first",
+                "judge_label": "hawkish",
+                "judge_confidence": 0.99,
+                "judge_model_id": "gemini-2.5-pro",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    model = _StubGeminiModel(['{"label": "neutral", "confidence": 0.60}'])
+    lines: list[str] = []
+    written = llm_judge.run_judge(
+        input_path=input_path,
+        output_path=output_path,
+        gemini_model=model,
+        judge_model_id="gemini-2.5-pro",
+        judge_model_version="v1",
+        resume=True,
+        progress_writer=lines.append,
+    )
+    # Only r2 ran in this invocation (return value excludes resumed rows)
+    assert written == 1
+    raw = output_path.read_text(encoding="utf-8").splitlines()
+    assert len(raw) == 2
+    rows = [json.loads(ln) for ln in raw]
+    record_ids = {r["record_id"] for r in rows}
+    assert record_ids == {"r1", "r2"}
+    # Progress writer mentioned the skip on r1
+    skip_lines = [ln for ln in lines if "skip" in ln]
+    assert skip_lines, lines
+
+
+def test_run_judge_resume_with_no_existing_output_runs_everything(tmp_path: Path) -> None:
+    """resume=True with a missing output JSONL should behave like a
+    fresh run (no skips)."""
+
+    input_path = tmp_path / "registry_pseudo.jsonl"
+    output_path = tmp_path / "judged.jsonl"  # does not exist
+    _write_pseudo_fixture(input_path)
+
+    model = _StubGeminiModel(
+        [
+            '{"label": "hawkish", "confidence": 0.95}',
+            '{"label": "neutral", "confidence": 0.50}',
+        ]
+    )
+    written = llm_judge.run_judge(
+        input_path=input_path,
+        output_path=output_path,
+        gemini_model=model,
+        judge_model_id="gemini-2.5-pro",
+        judge_model_version="v1",
+        resume=True,
+        progress_writer=lambda _: None,
+    )
+    assert written == 2
+
+
+def test_parse_args_resume_flag_default_is_false() -> None:
+    args = llm_judge._parse_args(["--input", "/some/path"])
+    assert args.resume is False
+
+
+def test_parse_args_resume_flag_set_true() -> None:
+    args = llm_judge._parse_args(["--input", "/some/path", "--resume"])
+    assert args.resume is True
+
+
 def test_parse_args_requires_input() -> None:
     with pytest.raises(SystemExit):
         llm_judge._parse_args([])


### PR DESCRIPTION
## Summary
- Per-row stdout progress in `run_judge`: `[judge] 17/91 hawkish ...`
- Per-row try/except: API errors land the row with `judge_label=""` + `judge_error`
- Append-mode incremental writes with flush per row
- New `--resume` flag: skips `record_id`s already in output JSONL
- Make target `pseudo-labels-judge-pass` now passes `--resume`
- 7 new tests covering progress, errors, resume, incremental writes

## Test plan
- `pytest tests/unit/test_llm_judge.py -q`