### PR TITLE
feat: retry transient Gemini errors + resume re-runs errored rows

### DIFF
--- a/backend/app/data/llm_judge.py
+++ b/backend/app/data/llm_judge.py
@@ -81,6 +81,68 @@ def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
             handle.write(json.dumps(row) + "\n")
 
 
+# Gemini error signatures that warrant an in-row retry. The SDK raises
+# concrete ServerError / ClientError subclasses whose names include the
+# status — easiest classifier is to grep the string for known transient
+# tokens. Conservative on what counts as transient; everything else
+# fails fast and gets recorded as an error.
+_TRANSIENT_ERROR_TOKENS = (
+    "429",
+    "503",
+    "UNAVAILABLE",
+    "RESOURCE_EXHAUSTED",
+    "DEADLINE_EXCEEDED",
+    "INTERNAL",
+    "ConnectionError",
+    "Timeout",
+    "RemoteDisconnect",
+)
+_RETRY_ATTEMPTS_DEFAULT = 4
+_RETRY_BASE_DELAY_DEFAULT = 1.0
+_RETRY_MAX_DELAY_DEFAULT = 64.0
+
+
+def _is_transient_error(exc: BaseException) -> bool:
+    if isinstance(exc, (ConnectionError, TimeoutError)):
+        return True
+    haystack = f"{type(exc).__name__}: {exc!s}"
+    return any(token in haystack for token in _TRANSIENT_ERROR_TOKENS)
+
+
+def _score_with_retry(
+    text: str,
+    model: Any,
+    *,
+    max_attempts: int = _RETRY_ATTEMPTS_DEFAULT,
+    base_delay: float = _RETRY_BASE_DELAY_DEFAULT,
+    max_delay: float = _RETRY_MAX_DELAY_DEFAULT,
+    on_retry=None,
+    sleep_fn=time.sleep,
+) -> tuple[dict[str, Any] | None, BaseException | None]:
+    """Call score_passage with exponential backoff on transient Gemini errors.
+
+    Returns (prediction, None) on success. Returns (None, exception) when
+    the call fails after ``max_attempts`` or hits a non-transient error
+    (which is not retried — fails fast). ``on_retry`` receives
+    ``(attempt_index, exc, delay)`` so the caller can log each backoff.
+    """
+
+    last_exc: BaseException | None = None
+    for attempt in range(max_attempts):
+        try:
+            prediction = score_passage(text, model=model)
+            return prediction, None
+        except Exception as exc:  # noqa: BLE001
+            last_exc = exc
+            if not _is_transient_error(exc) or attempt == max_attempts - 1:
+                return None, exc
+            delay = min(base_delay * (4 ** attempt), max_delay)
+            if on_retry is not None:
+                on_retry(attempt + 1, exc, delay)
+            sleep_fn(delay)
+    return None, last_exc
+
+
 def run_judge(
     *,
     input_path: Path,
@@ -109,9 +171,10 @@ def run_judge(
       write, so an interrupted run keeps every completed row on disk.
 
     ``resume`` rereads ``output_path`` and skips rows whose
-    ``record_id`` already appears there. Combined with the per-row
-    write semantics this means re-running the same Make target after a
-    crash picks up where the previous run died.
+    ``record_id`` is present AND has a non-empty ``judge_label``.
+    Rows previously recorded with a ``judge_error`` (transient API
+    failure) get retried on the next invocation — the only rows
+    treated as durably done are the ones with a real judge label.
 
     ``progress_writer`` is an optional callable that receives each
     progress line (defaults to the built-in ``print``). Tests inject a
@@ -130,15 +193,41 @@ def run_judge(
         rows = rows[:max_rows]
     total = len(rows)
 
-    completed_record_ids: set[str] = set()
+    successful_record_ids: set[str] = set()
+    error_record_ids: set[str] = set()
     if resume and output_path.exists():
         for existing in _read_jsonl(output_path):
             rid = str(existing.get("record_id", "")).strip()
-            if rid:
-                completed_record_ids.add(rid)
+            if not rid:
+                continue
+            label_present = str(existing.get("judge_label", "")).strip()
+            if label_present:
+                successful_record_ids.add(rid)
+            else:
+                error_record_ids.add(rid)
 
+    # When resuming we keep the existing successful rows by appending the
+    # new content. If we are NOT resuming (or the output is empty) the
+    # old content gets overwritten. Errored rows always get re-tried;
+    # they will be re-written into the file as new rows, so on resume we
+    # also need to drop the previous errored rows from the file. The
+    # simplest implementation: when resuming, rewrite the file from
+    # scratch with only the successful rows, then append.
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    open_mode = "a" if (resume and completed_record_ids) else "w"
+    if resume and error_record_ids:
+        kept = [
+            existing
+            for existing in _read_jsonl(output_path)
+            if str(existing.get("judge_label", "")).strip()
+        ]
+        with output_path.open("w", encoding="utf-8") as handle:
+            for kept_row in kept:
+                handle.write(json.dumps(kept_row) + "\n")
+        open_mode = "a"
+    else:
+        open_mode = "a" if (resume and successful_record_ids) else "w"
+
+    completed_record_ids = successful_record_ids  # alias to keep the loop readable
 
     written = 0
     with output_path.open(open_mode, encoding="utf-8") as handle:
@@ -150,18 +239,29 @@ def run_judge(
                 progress_writer(f"[judge] {index + 1}/{total}  skip      {short_id}  (resumed)")
                 continue
 
-            try:
-                prediction = score_passage(row.get("text", ""), model=gemini_model)
+            def _log_retry(attempt: int, exc: BaseException, delay: float) -> None:
+                progress_writer(
+                    f"[judge] {index + 1}/{total}  retry {attempt}/{_RETRY_ATTEMPTS_DEFAULT - 1}  "
+                    f"{short_id}  ({type(exc).__name__} — backoff {delay:.1f}s)"
+                )
+
+            prediction, exc = _score_with_retry(
+                row.get("text", ""),
+                gemini_model,
+                on_retry=_log_retry,
+            )
+            if prediction is not None:
                 label = str(prediction.get("label", "") or "")
                 confidence = float(prediction.get("confidence", 0.0) or 0.0)
                 error_kind = ""
-            except Exception as exc:  # noqa: BLE001 — we want every API failure to land in the output
+            else:
                 label = ""
                 confidence = 0.0
-                error_kind = type(exc).__name__
+                error_kind = type(exc).__name__ if exc is not None else "Unknown"
+                msg = str(exc)[:160] if exc is not None else ""
                 progress_writer(
                     f"[judge] {index + 1}/{total}  ERROR     {short_id}  "
-                    f"({error_kind}): {str(exc)[:160]}"
+                    f"({error_kind}): {msg}"
                 )
 
             out = dict(row)

--- a/backend/app/data/llm_judge.py
+++ b/backend/app/data/llm_judge.py
@@ -103,7 +103,7 @@ _RETRY_MAX_DELAY_DEFAULT = 64.0
 
 
 def _is_transient_error(exc: BaseException) -> bool:
-    if isinstance(exc, (ConnectionError, TimeoutError)):
+    if isinstance(exc, ConnectionError | TimeoutError):
         return True
     haystack = f"{type(exc).__name__}: {exc!s}"
     return any(token in haystack for token in _TRANSIENT_ERROR_TOKENS)
@@ -239,10 +239,18 @@ def run_judge(
                 progress_writer(f"[judge] {index + 1}/{total}  skip      {short_id}  (resumed)")
                 continue
 
-            def _log_retry(attempt: int, exc: BaseException, delay: float) -> None:
+            def _log_retry(
+                attempt: int,
+                exc: BaseException,
+                delay: float,
+                *,
+                _index: int = index,
+                _total: int = total,
+                _short_id: str = short_id,
+            ) -> None:
                 progress_writer(
-                    f"[judge] {index + 1}/{total}  retry {attempt}/{_RETRY_ATTEMPTS_DEFAULT - 1}  "
-                    f"{short_id}  ({type(exc).__name__} — backoff {delay:.1f}s)"
+                    f"[judge] {_index + 1}/{_total}  retry {attempt}/{_RETRY_ATTEMPTS_DEFAULT - 1}  "
+                    f"{_short_id}  ({type(exc).__name__} — backoff {delay:.1f}s)"
                 )
 
             prediction, exc = _score_with_retry(

--- a/tests/unit/test_llm_judge.py
+++ b/tests/unit/test_llm_judge.py
@@ -95,20 +95,29 @@ class _FlakyGeminiModel:
     """Stub model that raises on a configurable subset of calls.
 
     `fail_on_indices` is a set of call-indexes that raise; everything
-    else returns the next canned response. Used to test the run_judge
-    per-row try/except behaviour when the Gemini API returns 503/429
-    mid-batch.
+    else returns the next canned response. ``error_message`` controls
+    the raised string — use it to choose between transient ('503
+    UNAVAILABLE') and non-transient ('ValueError on row N') signatures
+    so callers can pick which retry codepath gets exercised.
     """
 
-    def __init__(self, responses: list[str], fail_on_indices: set[int]):
+    def __init__(
+        self,
+        responses: list[str],
+        fail_on_indices: set[int],
+        error_message: str = "ValueError on call",
+    ):
         self._responses = list(responses)
         self._fail_on = set(fail_on_indices)
+        self._error_message = error_message
         self._index = -1
+        self.calls = 0
 
     def generate_content(self, _prompt):  # pragma: no cover - matches SDK shape
         self._index += 1
+        self.calls += 1
         if self._index in self._fail_on:
-            raise RuntimeError(f"503 UNAVAILABLE on call {self._index}")
+            raise RuntimeError(f"{self._error_message} {self._index}")
         text = self._responses.pop(0)
 
         class _Response:
@@ -176,10 +185,14 @@ def test_run_judge_writes_incrementally_one_row_per_line(tmp_path: Path) -> None
     assert rows[1]["judge_label"] == "dovish"
 
 
-def test_run_judge_continues_after_api_error_marks_row_with_blank_judge_label(tmp_path: Path) -> None:
-    """A transient API failure on row 1 must NOT crash the run; the
-    failing row lands with judge_label='' + judge_error=type-name, and
-    row 2 still runs."""
+def test_run_judge_continues_after_non_transient_error_marks_row_with_blank_judge_label(
+    tmp_path: Path,
+) -> None:
+    """A non-transient API failure (e.g. malformed-prompt / invalid auth)
+    on row 1 must NOT crash the run; the failing row lands with
+    judge_label='' + judge_error=type-name, and row 2 still runs.
+    Retry is not attempted because the error is not in the transient
+    signature set."""
 
     input_path = tmp_path / "registry_pseudo.jsonl"
     output_path = tmp_path / "judged.jsonl"
@@ -187,7 +200,8 @@ def test_run_judge_continues_after_api_error_marks_row_with_blank_judge_label(tm
 
     model = _FlakyGeminiModel(
         responses=['{"label": "dovish", "confidence": 0.77}'],
-        fail_on_indices={0},  # first call raises
+        fail_on_indices={0},  # first call raises a non-transient error
+        error_message="ValueError on call",
     )
     lines: list[str] = []
     written = llm_judge.run_judge(
@@ -198,14 +212,240 @@ def test_run_judge_continues_after_api_error_marks_row_with_blank_judge_label(tm
         judge_model_version="v1",
         progress_writer=lines.append,
     )
-    assert written == 2  # both rows persisted (the first as a blank)
+    assert written == 2
     rows = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
     assert rows[0]["judge_label"] == ""
     assert rows[0]["judge_confidence"] == 0.0
     assert rows[0]["judge_error"] == "RuntimeError"
     assert rows[1]["judge_label"] == "dovish"
-    # Progress writer reported the error
+    # Only the first generate_content call was attempted (no retry)
+    assert model.calls == 2
     assert any("ERROR" in line for line in lines)
+    assert not any("retry" in line for line in lines)
+
+
+def test_run_judge_retries_transient_error_then_succeeds(tmp_path: Path) -> None:
+    """A 503 UNAVAILABLE on the first attempt should trigger the retry
+    helper, succeed on attempt 2, and persist the row as a real label."""
+
+    input_path = tmp_path / "registry_pseudo.jsonl"
+    output_path = tmp_path / "judged.jsonl"
+    _write_pseudo_fixture(input_path)
+
+    # 4 responses queued; 1 transient failure on call 0 -> attempt 2 succeeds
+    # for row 1; row 2 succeeds first try.
+    model = _FlakyGeminiModel(
+        responses=[
+            '{"label": "hawkish", "confidence": 0.92}',  # row 1, attempt 2
+            '{"label": "dovish", "confidence": 0.77}',   # row 2, attempt 1
+        ],
+        fail_on_indices={0},
+        error_message="503 UNAVAILABLE high demand on call",
+    )
+    lines: list[str] = []
+    # Stub the sleep so the test doesn't actually wait 1s.
+    import app.data.llm_judge as judge_module
+
+    real_sleep = judge_module.time.sleep
+    judge_module.time.sleep = lambda _seconds: None  # type: ignore[assignment]
+    try:
+        written = llm_judge.run_judge(
+            input_path=input_path,
+            output_path=output_path,
+            gemini_model=model,
+            judge_model_id="gemini-2.5-pro",
+            judge_model_version="v1",
+            progress_writer=lines.append,
+        )
+    finally:
+        judge_module.time.sleep = real_sleep
+
+    assert written == 2
+    rows = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+    assert rows[0]["judge_label"] == "hawkish"
+    assert "judge_error" not in rows[0]  # retry succeeded
+    assert rows[1]["judge_label"] == "dovish"
+    # 3 total calls: row 1 attempt 1 (fails) + attempt 2 (succeeds) + row 2 attempt 1
+    assert model.calls == 3
+    # Retry was logged
+    assert any("retry" in line for line in lines)
+
+
+def test_run_judge_exhausts_retries_then_records_error(tmp_path: Path) -> None:
+    """When every retry attempt for a row hits a transient error, the
+    row is persisted with judge_label='' and judge_error, and the loop
+    moves on."""
+
+    input_path = tmp_path / "registry_pseudo.jsonl"
+    output_path = tmp_path / "judged.jsonl"
+    _write_pseudo_fixture(input_path)
+
+    # All 4 attempts of row 1 fail. Row 2 succeeds first try.
+    model = _FlakyGeminiModel(
+        responses=['{"label": "neutral", "confidence": 0.50}'],
+        fail_on_indices={0, 1, 2, 3},
+        error_message="503 UNAVAILABLE on call",
+    )
+    import app.data.llm_judge as judge_module
+
+    real_sleep = judge_module.time.sleep
+    judge_module.time.sleep = lambda _seconds: None  # type: ignore[assignment]
+    try:
+        written = llm_judge.run_judge(
+            input_path=input_path,
+            output_path=output_path,
+            gemini_model=model,
+            judge_model_id="gemini-2.5-pro",
+            judge_model_version="v1",
+            progress_writer=lambda _line: None,
+        )
+    finally:
+        judge_module.time.sleep = real_sleep
+
+    rows = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+    assert written == 2
+    assert rows[0]["judge_label"] == ""
+    assert rows[0]["judge_error"] == "RuntimeError"
+    assert rows[1]["judge_label"] == "neutral"
+    # Row 1 burned all 4 attempts; row 2 succeeded on first call
+    assert model.calls == 5
+
+
+def test_run_judge_resume_re_runs_previously_errored_rows(tmp_path: Path) -> None:
+    """On resume, rows recorded with judge_label='' (transient API
+    failure last run) should be re-attempted, not skipped. Only rows
+    with a real judge_label count as durably done."""
+
+    input_path = tmp_path / "registry_pseudo.jsonl"
+    output_path = tmp_path / "judged.jsonl"
+    _write_pseudo_fixture(input_path)
+    # Pre-seed: r1 successfully judged last run; r2 errored.
+    output_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "record_id": "r1",
+                        "label": "hawkish",
+                        "text": "first",
+                        "judge_label": "hawkish",
+                        "judge_confidence": 0.99,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "record_id": "r2",
+                        "label": "neutral",
+                        "text": "second",
+                        "judge_label": "",
+                        "judge_confidence": 0.0,
+                        "judge_error": "RuntimeError",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    model = _StubGeminiModel(['{"label": "neutral", "confidence": 0.66}'])
+    lines: list[str] = []
+    written = llm_judge.run_judge(
+        input_path=input_path,
+        output_path=output_path,
+        gemini_model=model,
+        judge_model_id="gemini-2.5-pro",
+        judge_model_version="v1",
+        resume=True,
+        progress_writer=lines.append,
+    )
+    # Only r2 ran in this invocation (r1 skipped as successful)
+    assert written == 1
+    raw = output_path.read_text(encoding="utf-8").splitlines()
+    rows = [json.loads(ln) for ln in raw]
+    # File should contain both rows; r2 now has a real judge_label and
+    # no judge_error.
+    by_id = {r["record_id"]: r for r in rows}
+    assert by_id["r1"]["judge_label"] == "hawkish"
+    assert by_id["r2"]["judge_label"] == "neutral"
+    assert "judge_error" not in by_id["r2"]
+    # The progress writer should NOT include 'skip' for r2 (we re-ran it)
+    assert not any("skip" in ln and "r2" in ln for ln in lines)
+
+
+def test_is_transient_error_classifies_known_signatures() -> None:
+    """Spot-check the classifier on the signatures we care about."""
+
+    transient = [
+        RuntimeError("503 UNAVAILABLE — high demand"),
+        RuntimeError("429 RESOURCE_EXHAUSTED"),
+        RuntimeError("DEADLINE_EXCEEDED"),
+        ConnectionError("Connection reset by peer"),
+        TimeoutError("Request timed out"),
+    ]
+    for exc in transient:
+        assert llm_judge._is_transient_error(exc), f"expected transient: {exc!r}"
+
+    non_transient = [
+        ValueError("malformed prompt"),
+        KeyError("missing field"),
+        RuntimeError("400 Bad Request — invalid auth"),
+    ]
+    for exc in non_transient:
+        assert not llm_judge._is_transient_error(exc), f"expected non-transient: {exc!r}"
+
+
+def test_score_with_retry_uses_exponential_backoff_delays() -> None:
+    """Verify the backoff schedule: delays are 1s, 4s, 16s (capped at
+    max_delay=64) — matches the helper's intent."""
+
+    delays: list[float] = []
+
+    def _on_retry(_attempt, _exc, delay):
+        delays.append(delay)
+
+    class _AlwaysFail:
+        def generate_content(self, _prompt):
+            raise RuntimeError("503 UNAVAILABLE on attempt")
+
+    sleep_calls: list[float] = []
+    prediction, exc = llm_judge._score_with_retry(
+        "text",
+        _AlwaysFail(),
+        max_attempts=4,
+        base_delay=1.0,
+        max_delay=64.0,
+        on_retry=_on_retry,
+        sleep_fn=sleep_calls.append,
+    )
+    assert prediction is None
+    assert exc is not None
+    # 4 attempts → 3 retries (the last attempt doesn't sleep)
+    assert delays == [1.0, 4.0, 16.0]
+    assert sleep_calls == [1.0, 4.0, 16.0]
+
+
+def test_score_with_retry_returns_immediately_on_non_transient_error() -> None:
+    """A ValueError doesn't trigger retry — fast-fail path."""
+
+    class _AlwaysFail:
+        def __init__(self):
+            self.calls = 0
+
+        def generate_content(self, _prompt):
+            self.calls += 1
+            raise ValueError("malformed prompt")
+
+    model = _AlwaysFail()
+    prediction, exc = llm_judge._score_with_retry(
+        "text",
+        model,
+        max_attempts=4,
+        base_delay=1.0,
+        sleep_fn=lambda _: None,
+    )
+    assert prediction is None
+    assert isinstance(exc, ValueError)
+    assert model.calls == 1
 
 
 def test_run_judge_resume_skips_record_ids_already_in_output(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- New `_score_with_retry`: 4-attempt exponential backoff on 429/503/UNAVAILABLE/timeout
- Non-transient errors (ValueError, 400) fail fast — no retry
- Progress log emits one line per retry with the backoff delay
- Resume now re-attempts rows with `judge_error`; only rows with a real `judge_label` skip
- 8 new tests; 35 pass in `test_llm_judge.py`

## Test plan
- `pytest tests/unit/test_llm_judge.py -q`