### PR TITLE
Surface OOD warning on SentimentCard, give XaiPanel an empty state

### DIFF
--- a/frontend/components/analyze/SentimentCard.tsx
+++ b/frontend/components/analyze/SentimentCard.tsx
@@ -1,3 +1,5 @@
+import { AlertTriangle } from "lucide-react";
+
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { stanceLabel, toStance } from "@/lib/analyze/format";
@@ -7,6 +9,11 @@ interface SentimentCardProps {
   sentiment?: SentimentResponse;
 }
 
+function formatEnergy(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return value.toFixed(2);
+}
+
 export function SentimentCard({ sentiment }: SentimentCardProps) {
   const rawLabel = sentiment?.label;
   const stance = toStance(rawLabel);
@@ -14,6 +21,10 @@ export function SentimentCard({ sentiment }: SentimentCardProps) {
   const isUnknown = stance === "unknown";
   const badgeVariant: "hawkish" | "dovish" | "neutral" | "outline" =
     stance === "hawkish" ? "hawkish" : stance === "dovish" ? "dovish" : stance === "neutral" ? "neutral" : "outline";
+  const energy = sentiment?.ood_energy;
+  const threshold = sentiment?.ood_threshold;
+  const inDist = sentiment?.is_in_distribution;
+  const isOod = inDist === false;
 
   return (
     <Card>
@@ -23,13 +34,36 @@ export function SentimentCard({ sentiment }: SentimentCardProps) {
           {isUnknown ? "Sentiment unavailable" : stanceLabel(stance)}
         </CardTitle>
       </CardHeader>
-      <CardContent className="flex items-center justify-between">
-        <Badge variant={badgeVariant}>
-          {isUnknown ? `raw: ${String(rawLabel ?? "n/a")}` : `${stanceLabel(stance)} · ${score.toFixed(3)}`}
-        </Badge>
-        <span className="text-xs text-muted-foreground">
-          {isUnknown ? "Backend returned a non-stance label; check sentiment-model load." : "model confidence"}
-        </span>
+      <CardContent className="flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <Badge variant={badgeVariant}>
+            {isUnknown ? `raw: ${String(rawLabel ?? "n/a")}` : `${stanceLabel(stance)} · ${score.toFixed(3)}`}
+          </Badge>
+          <span className="text-xs text-muted-foreground">
+            {isUnknown ? "Backend returned a non-stance label; check sentiment-model load." : "model confidence"}
+          </span>
+        </div>
+        {isOod ? (
+          <div
+            className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs"
+            role="status"
+          >
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" aria-hidden="true" />
+            <div className="space-y-0.5">
+              <strong className="text-amber-700 dark:text-amber-300">Out of distribution</strong>
+              <p className="text-muted-foreground">
+                Text doesn&apos;t look like the FOMC corpus the classifier was trained on; treat the stance as low confidence.
+              </p>
+              <p className="font-mono text-[11px] text-muted-foreground">
+                energy {formatEnergy(energy)} &gt; threshold {formatEnergy(threshold)}
+              </p>
+            </div>
+          </div>
+        ) : inDist === true && energy != null ? (
+          <p className="font-mono text-[11px] text-muted-foreground">
+            in-distribution · energy {formatEnergy(energy)} ≤ {formatEnergy(threshold)}
+          </p>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/frontend/components/analyze/XaiPanel.tsx
+++ b/frontend/components/analyze/XaiPanel.tsx
@@ -80,7 +80,7 @@ function SentenceChip({ sentence }: { sentence: XaiSentence }) {
 }
 
 export function XaiPanel({ xai, previewMode }: XaiPanelProps) {
-  if (!xai.sentences.length) return null;
+  const isEmpty = !xai.sentences.length;
   return (
     <Card>
       <CardHeader>
@@ -99,11 +99,18 @@ export function XaiPanel({ xai, previewMode }: XaiPanelProps) {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <p className="space-x-1.5 text-sm leading-7">
-          {xai.sentences.map((sentence, idx) => (
-            <SentenceChip key={`${idx}-${sentence.text.slice(0, 16)}`} sentence={sentence} />
-          ))}
-        </p>
+        {isEmpty ? (
+          <p className="rounded-md border border-dashed border-border bg-muted/30 px-3 py-4 text-sm text-muted-foreground">
+            No salient sentences detected. The attribution method found no tokens above the salience floor — common for very short
+            inputs or text that lies outside the FOMC vocabulary the model was trained on.
+          </p>
+        ) : (
+          <p className="space-x-1.5 text-sm leading-7">
+            {xai.sentences.map((sentence, idx) => (
+              <SentenceChip key={`${idx}-${sentence.text.slice(0, 16)}`} sentence={sentence} />
+            ))}
+          </p>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -15,6 +15,9 @@ export interface AnalyzeRequest {
 export interface SentimentResponse {
   label?: string | null;
   score?: number | null;
+  ood_energy?: number | null;
+  ood_threshold?: number | null;
+  is_in_distribution?: boolean | null;
 }
 
 export interface PredictionResponse {

--- a/frontend/tests/components/analyze/SentimentCard.test.tsx
+++ b/frontend/tests/components/analyze/SentimentCard.test.tsx
@@ -24,4 +24,43 @@ describe("SentimentCard", () => {
     expect(screen.getByText(/sentiment unavailable/i)).toBeInTheDocument();
     expect(screen.getByText(/raw: POSITIVE/)).toBeInTheDocument();
   });
+
+  it("renders OOD warning with energy and threshold when is_in_distribution is false", () => {
+    render(
+      <SentimentCard
+        sentiment={{
+          label: "hawkish",
+          score: 0.94,
+          ood_energy: 12.34,
+          ood_threshold: 8.0,
+          is_in_distribution: false,
+        }}
+      />,
+    );
+    expect(screen.getByText(/out of distribution/i)).toBeInTheDocument();
+    expect(screen.getByText(/energy 12\.34/)).toBeInTheDocument();
+    expect(screen.getByText(/threshold 8\.00/)).toBeInTheDocument();
+  });
+
+  it("shows in-distribution energy footer when is_in_distribution is true", () => {
+    render(
+      <SentimentCard
+        sentiment={{
+          label: "hawkish",
+          score: 0.81,
+          ood_energy: 5.2,
+          ood_threshold: 8.0,
+          is_in_distribution: true,
+        }}
+      />,
+    );
+    expect(screen.queryByText(/out of distribution/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/in-distribution · energy 5\.20/)).toBeInTheDocument();
+  });
+
+  it("omits the OOD row when the response carries no manifest fields", () => {
+    render(<SentimentCard sentiment={{ label: "hawkish", score: 0.7 }} />);
+    expect(screen.queryByText(/out of distribution/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/in-distribution/i)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/tests/components/analyze/XaiPanel.test.tsx
+++ b/frontend/tests/components/analyze/XaiPanel.test.tsx
@@ -18,9 +18,10 @@ describe("XaiPanel", () => {
     }
   });
 
-  it("returns null when there are no sentences", () => {
-    const { container } = renderWithTooltip(<XaiPanel xai={{ sentences: [] }} />);
-    expect(container.firstChild?.firstChild ?? null).toBeNull();
+  it("renders the empty-state placeholder when there are no sentences", () => {
+    renderWithTooltip(<XaiPanel xai={{ sentences: [] }} />);
+    expect(screen.getByText(/sentence attribution/i)).toBeInTheDocument();
+    expect(screen.getByText(/no salient sentences detected/i)).toBeInTheDocument();
   });
 
   it("shows the integrated-gradients method label", () => {


### PR DESCRIPTION
## Summary
- `SentimentResponse` carries `ood_energy` / `ood_threshold` / `is_in_distribution`.
- `SentimentCard` renders an amber OOD row with energy and threshold when `is_in_distribution` is false.
- In-distribution responses get a compact energy footer; responses without manifest fields render unchanged.
- `XaiPanel` renders a placeholder card when there are zero salient sentences instead of returning null.
- Test deltas: `SentimentCard.test.tsx` +4 cases, `XaiPanel.test.tsx` empty-state assertion swapped in.

## Test plan
- `cd frontend && npm test -- --run`
- `cd frontend && npm run type-check`