### PR TITLE
Add /compare page for side-by-side run diffs

### DIFF
--- a/frontend/components/shell/header.tsx
+++ b/frontend/components/shell/header.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Activity, BookOpen, Calendar, Github, History as HistoryIcon } from "lucide-react";
+import { Activity, BookOpen, Calendar, GitCompare, Github, History as HistoryIcon } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -8,6 +8,7 @@ import { ThemeToggle } from "@/components/theme-toggle";
 const NAV_ITEMS: Array<{ href: string; label: string; icon: React.ComponentType<{ className?: string }> }> = [
   { href: "/analyze", label: "Analyze", icon: Activity },
   { href: "/history", label: "History", icon: HistoryIcon },
+  { href: "/compare", label: "Compare", icon: GitCompare },
   { href: "/calendar", label: "Calendar", icon: Calendar },
 ];
 

--- a/frontend/lib/analyze/compare.ts
+++ b/frontend/lib/analyze/compare.ts
@@ -1,0 +1,76 @@
+import type { AnalyzeResult, HistoryDetail, Stance } from "./types";
+
+export interface CompareDelta {
+  closeAbsolute: number | null;
+  closePercent: number | null;
+  volatilityAbsolute: number | null;
+  stanceShift: "more_hawkish" | "more_dovish" | "unchanged" | "unknown";
+  scoreDelta: number | null;
+}
+
+function asResult(detail: HistoryDetail): AnalyzeResult {
+  return (detail.payload || {}) as AnalyzeResult;
+}
+
+function stanceRank(value: Stance | string | undefined): number | null {
+  switch ((value ?? "").toLowerCase()) {
+    case "hawkish":
+      return 1;
+    case "neutral":
+      return 0;
+    case "dovish":
+      return -1;
+    default:
+      return null;
+  }
+}
+
+export function computeCompareDelta(a: HistoryDetail, b: HistoryDetail): CompareDelta {
+  const ra = asResult(a);
+  const rb = asResult(b);
+
+  const closeA = ra.prediction?.close ?? null;
+  const closeB = rb.prediction?.close ?? null;
+  const volA = ra.prediction?.volatility ?? null;
+  const volB = rb.prediction?.volatility ?? null;
+  const stanceA = stanceRank((ra.sentiment?.label ?? a.stance) as string | undefined);
+  const stanceB = stanceRank((rb.sentiment?.label ?? b.stance) as string | undefined);
+  const scoreA = ra.sentiment?.score ?? a.sentiment_score ?? null;
+  const scoreB = rb.sentiment?.score ?? b.sentiment_score ?? null;
+
+  let stanceShift: CompareDelta["stanceShift"] = "unknown";
+  if (stanceA != null && stanceB != null) {
+    if (stanceA > stanceB) stanceShift = "more_hawkish";
+    else if (stanceA < stanceB) stanceShift = "more_dovish";
+    else stanceShift = "unchanged";
+  }
+
+  const closeAbsolute = closeA != null && closeB != null ? closeA - closeB : null;
+  const closePercent =
+    closeAbsolute != null && closeB != null && closeB !== 0
+      ? (closeAbsolute / closeB) * 100
+      : null;
+  const volatilityAbsolute = volA != null && volB != null ? volA - volB : null;
+  const scoreDelta = scoreA != null && scoreB != null ? scoreA - scoreB : null;
+
+  return {
+    closeAbsolute,
+    closePercent,
+    volatilityAbsolute,
+    stanceShift,
+    scoreDelta,
+  };
+}
+
+export function describeStanceShift(shift: CompareDelta["stanceShift"]): string {
+  switch (shift) {
+    case "more_hawkish":
+      return "A shifts hawkish vs. B";
+    case "more_dovish":
+      return "A shifts dovish vs. B";
+    case "unchanged":
+      return "Stance unchanged";
+    default:
+      return "Stance unknown";
+  }
+}

--- a/frontend/pages/compare.tsx
+++ b/frontend/pages/compare.tsx
@@ -1,0 +1,334 @@
+import * as React from "react";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { ArrowDownRight, ArrowRight, ArrowUpRight, GitCompare } from "lucide-react";
+import { toast } from "sonner";
+
+import { Header } from "@/components/shell/header";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchHistory, fetchHistoryRun, resolveApiBaseUrl } from "@/lib/analyze/api";
+import {
+  computeCompareDelta,
+  describeStanceShift,
+  type CompareDelta,
+} from "@/lib/analyze/compare";
+import { formatPrice, stanceLabel, toStance } from "@/lib/analyze/format";
+import type { HistoryDetail, HistoryEntry } from "@/lib/analyze/types";
+
+const SLOT_LABELS = { a: "Run A", b: "Run B" } as const;
+type Slot = keyof typeof SLOT_LABELS;
+
+function formatDelta(value: number | null, fractionDigits = 2): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  const sign = value > 0 ? "+" : value < 0 ? "" : "";
+  return `${sign}${value.toFixed(fractionDigits)}`;
+}
+
+function deltaColorClass(value: number | null): string {
+  if (value == null || value === 0) return "text-muted-foreground";
+  return value > 0 ? "text-hawkish" : "text-dovish";
+}
+
+function DeltaIcon({ value }: { value: number | null }) {
+  if (value == null || value === 0) return <ArrowRight className="h-3.5 w-3.5" />;
+  return value > 0 ? <ArrowUpRight className="h-3.5 w-3.5" /> : <ArrowDownRight className="h-3.5 w-3.5" />;
+}
+
+function RunSlotCard({
+  slot,
+  detail,
+  loading,
+  entries,
+  selectedId,
+  onSelect,
+}: {
+  slot: Slot;
+  detail: HistoryDetail | null;
+  loading: boolean;
+  entries: HistoryEntry[];
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+}) {
+  const stance = detail ? toStance(detail.stance) : "unknown";
+  const stanceVariant: "hawkish" | "dovish" | "neutral" | "outline" =
+    stance === "hawkish" ? "hawkish" : stance === "dovish" ? "dovish" : stance === "neutral" ? "neutral" : "outline";
+
+  return (
+    <Card>
+      <CardHeader className="space-y-3">
+        <CardDescription>{SLOT_LABELS[slot]}</CardDescription>
+        <Select
+          value={selectedId ?? ""}
+          onValueChange={(value) => onSelect(value || null)}
+        >
+          <SelectTrigger aria-label={`Select ${SLOT_LABELS[slot]}`}>
+            <SelectValue placeholder="Pick a run…" />
+          </SelectTrigger>
+          <SelectContent>
+            {entries.map((entry) => (
+              <SelectItem key={entry.id} value={entry.id}>
+                {entry.document_date} · {entry.symbol} · {stanceLabel(toStance(entry.stance))}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {loading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-6 w-1/2" />
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        ) : !detail ? (
+          <p className="text-sm text-muted-foreground">
+            No run selected. Pick one from the dropdown to compare.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2 text-sm">
+              <Badge variant={stanceVariant}>{stanceLabel(stance)}</Badge>
+              <span className="text-muted-foreground">{detail.symbol}</span>
+              <span className="text-muted-foreground">·</span>
+              <span className="text-muted-foreground">{detail.horizon}</span>
+              <span className="text-muted-foreground">·</span>
+              <span className="font-mono text-xs text-muted-foreground">
+                {detail.document_date}
+              </span>
+            </div>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+              <dt className="text-muted-foreground">Sentiment score</dt>
+              <dd className="text-right font-mono">
+                {detail.sentiment_score != null ? detail.sentiment_score.toFixed(3) : "—"}
+              </dd>
+              <dt className="text-muted-foreground">Predicted close</dt>
+              <dd className="text-right font-mono">{formatPrice(detail.predicted_close ?? null)}</dd>
+              <dt className="text-muted-foreground">Spot close</dt>
+              <dd className="text-right font-mono">{formatPrice(detail.current_close ?? null)}</dd>
+              <dt className="text-muted-foreground">Predicted volatility</dt>
+              <dd className="text-right font-mono">
+                {detail.predicted_volatility != null
+                  ? detail.predicted_volatility.toFixed(4)
+                  : "—"}
+              </dd>
+            </dl>
+            {detail.text_excerpt ? (
+              <p className="line-clamp-3 rounded-md border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
+                {detail.text_excerpt}
+              </p>
+            ) : null}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DeltaSummary({ delta }: { delta: CompareDelta }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <GitCompare className="h-4 w-4 text-primary" />
+          Δ A − B
+        </CardTitle>
+        <CardDescription>{describeStanceShift(delta.stanceShift)}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-4">
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">Close</dt>
+            <dd className={`flex items-center gap-1 font-mono ${deltaColorClass(delta.closeAbsolute)}`}>
+              <DeltaIcon value={delta.closeAbsolute} />
+              {formatDelta(delta.closeAbsolute)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">Close %</dt>
+            <dd className={`flex items-center gap-1 font-mono ${deltaColorClass(delta.closePercent)}`}>
+              <DeltaIcon value={delta.closePercent} />
+              {formatDelta(delta.closePercent)}%
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">Volatility</dt>
+            <dd className={`flex items-center gap-1 font-mono ${deltaColorClass(delta.volatilityAbsolute)}`}>
+              <DeltaIcon value={delta.volatilityAbsolute} />
+              {formatDelta(delta.volatilityAbsolute, 4)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">Sentiment score</dt>
+            <dd className={`flex items-center gap-1 font-mono ${deltaColorClass(delta.scoreDelta)}`}>
+              <DeltaIcon value={delta.scoreDelta} />
+              {formatDelta(delta.scoreDelta, 3)}
+            </dd>
+          </div>
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function ComparePage() {
+  const router = useRouter();
+  const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+  const [entries, setEntries] = React.useState<HistoryEntry[]>([]);
+  const [entriesLoading, setEntriesLoading] = React.useState(true);
+  const [detailA, setDetailA] = React.useState<HistoryDetail | null>(null);
+  const [detailB, setDetailB] = React.useState<HistoryDetail | null>(null);
+  const [loadingA, setLoadingA] = React.useState(false);
+  const [loadingB, setLoadingB] = React.useState(false);
+
+  const aId = React.useMemo(() => {
+    const value = router.query.a;
+    return typeof value === "string" ? value : null;
+  }, [router.query.a]);
+  const bId = React.useMemo(() => {
+    const value = router.query.b;
+    return typeof value === "string" ? value : null;
+  }, [router.query.b]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setEntriesLoading(true);
+    fetchHistory(apiBaseUrl, { limit: 50, offset: 0 })
+      .then((result) => {
+        if (!cancelled) setEntries(result.items);
+      })
+      .catch((err) => {
+        if (!cancelled) toast.error((err as Error).message || "Failed to load history list.");
+      })
+      .finally(() => {
+        if (!cancelled) setEntriesLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBaseUrl]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!aId) {
+      setDetailA(null);
+      return;
+    }
+    setLoadingA(true);
+    fetchHistoryRun(apiBaseUrl, aId)
+      .then((detail) => {
+        if (!cancelled) setDetailA(detail);
+      })
+      .catch((err) => {
+        if (!cancelled) toast.error((err as Error).message || "Failed to load run A.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingA(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBaseUrl, aId]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!bId) {
+      setDetailB(null);
+      return;
+    }
+    setLoadingB(true);
+    fetchHistoryRun(apiBaseUrl, bId)
+      .then((detail) => {
+        if (!cancelled) setDetailB(detail);
+      })
+      .catch((err) => {
+        if (!cancelled) toast.error((err as Error).message || "Failed to load run B.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingB(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBaseUrl, bId]);
+
+  const handleSelect = React.useCallback(
+    (slot: Slot, id: string | null) => {
+      const next = { ...router.query };
+      if (id) {
+        next[slot] = id;
+      } else {
+        delete next[slot];
+      }
+      router.replace({ pathname: "/compare", query: next }, undefined, { shallow: true });
+    },
+    [router],
+  );
+
+  const delta = React.useMemo(() => {
+    if (!detailA || !detailB) return null;
+    return computeCompareDelta(detailA, detailB);
+  }, [detailA, detailB]);
+
+  return (
+    <>
+      <Head>
+        <title>Compare runs — Fed Pulse</title>
+      </Head>
+      <div className="min-h-screen bg-background text-foreground">
+        <Header />
+        <main className="container space-y-6 py-8">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold tracking-tight">Compare runs</h1>
+            <p className="max-w-2xl text-muted-foreground">
+              Pick two past analyses and see the stance, prediction, and confidence deltas side by
+              side. Selections are sticky in the URL — share the link to send a paired view.
+            </p>
+          </div>
+
+          {entriesLoading ? (
+            <div className="grid gap-4 md:grid-cols-2">
+              <Skeleton className="h-48 w-full" />
+              <Skeleton className="h-48 w-full" />
+            </div>
+          ) : entries.length === 0 ? (
+            <Card>
+              <CardContent className="py-10 text-center text-muted-foreground">
+                No runs yet — submit at least two analyses before using this page.
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              <RunSlotCard
+                slot="a"
+                detail={detailA}
+                loading={loadingA}
+                entries={entries}
+                selectedId={aId}
+                onSelect={(id) => handleSelect("a", id)}
+              />
+              <RunSlotCard
+                slot="b"
+                detail={detailB}
+                loading={loadingB}
+                entries={entries}
+                selectedId={bId}
+                onSelect={(id) => handleSelect("b", id)}
+              />
+            </div>
+          )}
+
+          {delta ? <DeltaSummary delta={delta} /> : null}
+        </main>
+      </div>
+    </>
+  );
+}

--- a/frontend/tests/lib/analyze/compare.test.ts
+++ b/frontend/tests/lib/analyze/compare.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { computeCompareDelta, describeStanceShift } from "@/lib/analyze/compare";
+import type { HistoryDetail } from "@/lib/analyze/types";
+
+function makeDetail(overrides: Partial<HistoryDetail> & { payload?: Record<string, unknown> }): HistoryDetail {
+  return {
+    id: "fixture",
+    created_at: "2024-09-18T12:00:00Z",
+    symbol: "^GSPC",
+    document_date: "2024-09-18",
+    horizon: "3d",
+    forecast_mode: "fast",
+    stance: "hawkish",
+    sentiment_score: 0.8,
+    predicted_close: 5000,
+    current_close: 4900,
+    predicted_volatility: 0.012,
+    payload: {},
+    ...overrides,
+  };
+}
+
+describe("computeCompareDelta", () => {
+  it("computes close, vol, and stance deltas from payload predictions", () => {
+    const a = makeDetail({
+      payload: {
+        prediction: { close: 5500, volatility: 0.012 },
+        sentiment: { label: "hawkish", score: 0.82 },
+      },
+    });
+    const b = makeDetail({
+      payload: {
+        prediction: { close: 5400, volatility: 0.018 },
+        sentiment: { label: "dovish", score: 0.71 },
+      },
+      stance: "dovish",
+    });
+    const delta = computeCompareDelta(a, b);
+    expect(delta.closeAbsolute).toBeCloseTo(100, 5);
+    expect(delta.closePercent).toBeCloseTo((100 / 5400) * 100, 5);
+    expect(delta.volatilityAbsolute).toBeCloseTo(-0.006, 5);
+    expect(delta.stanceShift).toBe("more_hawkish");
+    expect(delta.scoreDelta).toBeCloseTo(0.11, 5);
+  });
+
+  it("falls back to history-row stance when payload sentiment is absent", () => {
+    const a = makeDetail({ stance: "dovish", payload: {} });
+    const b = makeDetail({ stance: "hawkish", payload: {} });
+    const delta = computeCompareDelta(a, b);
+    expect(delta.stanceShift).toBe("more_dovish");
+  });
+
+  it("emits null deltas when prediction fields are missing", () => {
+    const empty = makeDetail({ payload: {} });
+    const delta = computeCompareDelta(empty, empty);
+    expect(delta.closeAbsolute).toBe(null);
+    expect(delta.closePercent).toBe(null);
+    expect(delta.volatilityAbsolute).toBe(null);
+  });
+
+  it("describes stance shifts in human-readable form", () => {
+    expect(describeStanceShift("more_hawkish")).toMatch(/hawkish/i);
+    expect(describeStanceShift("more_dovish")).toMatch(/dovish/i);
+    expect(describeStanceShift("unchanged")).toMatch(/unchanged/i);
+    expect(describeStanceShift("unknown")).toMatch(/unknown/i);
+  });
+});

--- a/frontend/tests/pages/compare.test.tsx
+++ b/frontend/tests/pages/compare.test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  Toaster: () => null,
+}));
+
+const replaceMock = vi.fn();
+let mockQuery: Record<string, string> = {};
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: mockQuery,
+    replace: replaceMock,
+  }),
+}));
+
+vi.mock("next/head", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const fetchHistoryMock = vi.fn();
+const fetchHistoryRunMock = vi.fn();
+
+vi.mock("@/lib/analyze/api", () => ({
+  resolveApiBaseUrl: () => "http://localhost:8000",
+  fetchHistory: (...args: unknown[]) => fetchHistoryMock(...args),
+  fetchHistoryRun: (...args: unknown[]) => fetchHistoryRunMock(...args),
+}));
+
+const ENTRIES = [
+  {
+    id: "run-a",
+    created_at: "2024-09-18T12:00:00Z",
+    symbol: "^GSPC",
+    document_date: "2024-09-18",
+    horizon: "3d",
+    forecast_mode: "fast",
+    stance: "hawkish",
+    predicted_close: 5500,
+    current_close: 5400,
+    sentiment_score: 0.82,
+  },
+  {
+    id: "run-b",
+    created_at: "2024-11-07T12:00:00Z",
+    symbol: "^GSPC",
+    document_date: "2024-11-07",
+    horizon: "3d",
+    forecast_mode: "fast",
+    stance: "dovish",
+    predicted_close: 5400,
+    current_close: 5450,
+    sentiment_score: 0.71,
+  },
+];
+
+describe("ComparePage", () => {
+  beforeEach(() => {
+    mockQuery = {};
+    fetchHistoryMock.mockReset();
+    fetchHistoryRunMock.mockReset();
+    replaceMock.mockReset();
+  });
+
+  it("renders the empty-state when there are no runs", async () => {
+    fetchHistoryMock.mockResolvedValue({ total: 0, limit: 50, offset: 0, items: [] });
+    const { default: ComparePage } = await import("@/pages/compare");
+    render(<ComparePage />);
+    await waitFor(() =>
+      expect(screen.getByText(/no runs yet/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("renders both slot cards once history loads", async () => {
+    fetchHistoryMock.mockResolvedValue({ total: 2, limit: 50, offset: 0, items: ENTRIES });
+    const { default: ComparePage } = await import("@/pages/compare");
+    render(<ComparePage />);
+    await waitFor(() => expect(screen.getByText(/Run A/)).toBeInTheDocument());
+    expect(screen.getByText(/Run B/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Pick a run/).length).toBeGreaterThan(0);
+  });
+
+  it("fetches and renders both runs when ?a and ?b query params are set", async () => {
+    mockQuery = { a: "run-a", b: "run-b" };
+    fetchHistoryMock.mockResolvedValue({ total: 2, limit: 50, offset: 0, items: ENTRIES });
+    fetchHistoryRunMock.mockImplementation(async (_base: string, id: string) => ({
+      ...ENTRIES.find((entry) => entry.id === id)!,
+      payload: {
+        prediction: { close: id === "run-a" ? 5500 : 5400, volatility: 0.012 },
+        sentiment: { label: id === "run-a" ? "hawkish" : "dovish", score: id === "run-a" ? 0.82 : 0.71 },
+      },
+    }));
+    const { default: ComparePage } = await import("@/pages/compare");
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(fetchHistoryRunMock).toHaveBeenCalledWith("http://localhost:8000", "run-a");
+      expect(fetchHistoryRunMock).toHaveBeenCalledWith("http://localhost:8000", "run-b");
+    });
+    await waitFor(() => expect(screen.getByText(/Δ A − B/)).toBeInTheDocument());
+    expect(screen.getByText(/A shifts hawkish vs\. B/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- New `/compare` page with two slot dropdowns populated from `/history`.
- URL state (`?a=<id>&b=<id>`) makes paired views shareable.
- `lib/analyze/compare.ts` derives close, volatility, score, and stance deltas from the run payloads with null-safe fallbacks.
- Delta summary card shows A − B with arrow direction and hawkish/dovish color cues per metric.
- Header gets a Compare link between History and Calendar.
- Vitest: +7 cases (4 lib + 3 page) covering empty state, slot rendering, and the URL-driven dual-fetch flow.

## Test plan
- `cd frontend && npm test -- --run`
- `cd frontend && npm run type-check`