### PR TITLE
Add /history/[id] detail page and clickable rows

### DIFF
--- a/frontend/pages/history/[id].tsx
+++ b/frontend/pages/history/[id].tsx
@@ -1,0 +1,214 @@
+import * as React from "react";
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import dynamic from "next/dynamic";
+import { ArrowLeft, GitCompare } from "lucide-react";
+import { toast } from "sonner";
+
+import { ErrorBadges } from "@/components/analyze/ErrorBadges";
+import { ForecastChart } from "@/components/analyze/ForecastChart";
+import { MarketContext } from "@/components/analyze/MarketContext";
+import { PredictionCards } from "@/components/analyze/PredictionCards";
+import { SentimentCard } from "@/components/analyze/SentimentCard";
+import { Header } from "@/components/shell/header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchHistoryRun, resolveApiBaseUrl } from "@/lib/analyze/api";
+import {
+  buildCloseSeries,
+  buildVolatilitySeries,
+  computeErrorMetrics,
+} from "@/lib/analyze/derive";
+import { stanceLabel, toStance } from "@/lib/analyze/format";
+import type { AnalyzeResult, HistoryDetail } from "@/lib/analyze/types";
+
+const PreviewPanels = dynamic(() => import("@/components/analyze/PreviewPanels"), {
+  ssr: false,
+  loading: () => null,
+});
+
+function detailToResult(detail: HistoryDetail | null): AnalyzeResult | null {
+  if (!detail) return null;
+  return (detail.payload || {}) as AnalyzeResult;
+}
+
+export default function HistoryDetailPage() {
+  const router = useRouter();
+  const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+  const [detail, setDetail] = React.useState<HistoryDetail | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
+  const runId = React.useMemo(() => {
+    const value = router.query.id;
+    return typeof value === "string" ? value : null;
+  }, [router.query.id]);
+
+  React.useEffect(() => {
+    if (!router.isReady) return;
+    if (!runId) return;
+    let cancelled = false;
+    setLoading(true);
+    setErrorMessage(null);
+    fetchHistoryRun(apiBaseUrl, runId)
+      .then((data) => {
+        if (!cancelled) setDetail(data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const message = (err as Error).message || "Run not found.";
+        setErrorMessage(message);
+        toast.error(message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBaseUrl, router.isReady, runId]);
+
+  const result = React.useMemo(() => detailToResult(detail), [detail]);
+  const closeSeries = React.useMemo(() => buildCloseSeries(result), [result]);
+  const volatilitySeries = React.useMemo(() => buildVolatilitySeries(result), [result]);
+  const errorMetrics = React.useMemo(() => computeErrorMetrics(result), [result]);
+  const splitTimestamp = result?.series?.timestamps?.[result.series.timestamps.length - 1];
+  const confidenceLevel = Math.round(Number(result?.series?.forecast_confidence_level || 0.8) * 100);
+  const confidenceLabel = `${confidenceLevel}% confidence band`;
+  const hasCloseConfidence = Boolean(result?.series?.forecast_close_lower?.length);
+  const hasVolConfidence = Boolean(result?.series?.forecast_volatility_lower?.length);
+  const volScale = result?.series?.volatility_scale || { suggested_ymin: 0.0, suggested_ymax: 1.0 };
+  const stance = detail ? toStance(detail.stance) : "unknown";
+
+  return (
+    <>
+      <Head>
+        <title>{detail ? `Run ${detail.document_date} — Fed Pulse` : "History run — Fed Pulse"}</title>
+      </Head>
+      <div className="min-h-screen bg-background text-foreground">
+        <Header />
+        <main className="container space-y-6 py-8">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <Button asChild variant="ghost" size="sm">
+                <Link href="/history">
+                  <ArrowLeft className="h-4 w-4" />
+                  History
+                </Link>
+              </Button>
+              {detail ? (
+                <h1 className="flex flex-wrap items-center gap-2 text-2xl font-semibold tracking-tight">
+                  <span>{detail.document_date}</span>
+                  <Badge variant="outline">{detail.symbol}</Badge>
+                  <Badge variant="outline">{detail.horizon}</Badge>
+                  <Badge variant="outline" className="capitalize">{detail.forecast_mode}</Badge>
+                  <Badge variant={stance === "hawkish" ? "hawkish" : stance === "dovish" ? "dovish" : stance === "neutral" ? "neutral" : "outline"}>
+                    {stanceLabel(stance)}
+                  </Badge>
+                </h1>
+              ) : (
+                <h1 className="text-2xl font-semibold tracking-tight">History run</h1>
+              )}
+            </div>
+            {detail ? (
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/compare?a=${detail.id}`}>
+                  <GitCompare className="h-4 w-4" />
+                  Compare with…
+                </Link>
+              </Button>
+            ) : null}
+          </div>
+
+          {loading ? (
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <Skeleton className="h-28 w-full" />
+              <Skeleton className="h-28 w-full" />
+              <Skeleton className="h-28 w-full" />
+            </div>
+          ) : errorMessage ? (
+            <Card>
+              <CardContent className="py-10 text-center text-muted-foreground">
+                {errorMessage}
+              </CardContent>
+            </Card>
+          ) : detail && result ? (
+            <>
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <SentimentCard sentiment={result.sentiment} />
+                <div className="md:col-span-2 xl:col-span-2">
+                  <PredictionCards result={result} />
+                </div>
+              </div>
+
+              {result.multi_axis ? <PreviewPanels slot="cards" multiAxis={result.multi_axis} /> : null}
+
+              <ErrorBadges result={result} metrics={errorMetrics} />
+
+              <div className="grid gap-4 xl:grid-cols-2">
+                <ForecastChart
+                  title="Close forecast"
+                  description={`Forecast line and ${confidenceLabel} over the requested horizon.`}
+                  data={closeSeries}
+                  kind="close"
+                  splitTimestamp={splitTimestamp}
+                  includeRealized={Boolean(result.series?.realized_timestamps?.length)}
+                  hasConfidence={hasCloseConfidence}
+                  confidenceLabel={confidenceLabel}
+                />
+                <ForecastChart
+                  title="Volatility forecast"
+                  description={`Forecast line and ${confidenceLabel} over the requested horizon.`}
+                  data={volatilitySeries}
+                  kind="volatility"
+                  splitTimestamp={splitTimestamp}
+                  includeRealized={Boolean(result.series?.realized_timestamps?.length)}
+                  hasConfidence={hasVolConfidence}
+                  confidenceLabel={confidenceLabel}
+                  yDomain={[
+                    Number(volScale.suggested_ymin ?? 0),
+                    Number(volScale.suggested_ymax ?? 1),
+                  ]}
+                />
+              </div>
+
+              {result.xai ? <PreviewPanels slot="xai" xai={result.xai} /> : null}
+              {result.credibility ? <PreviewPanels slot="credibility" credibility={result.credibility} /> : null}
+
+              <MarketContext result={result} />
+
+              {detail.text_excerpt ? (
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Submitted text</CardTitle>
+                    <CardDescription>First {detail.text_excerpt.length} characters of the analysed document.</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="whitespace-pre-wrap rounded-md border border-border bg-muted/30 p-3 font-mono text-xs leading-relaxed">
+                      {detail.text_excerpt}
+                    </p>
+                  </CardContent>
+                </Card>
+              ) : null}
+            </>
+          ) : (
+            <Card>
+              <CardContent className="py-10 text-center text-muted-foreground">
+                Run not found.
+              </CardContent>
+            </Card>
+          )}
+        </main>
+      </div>
+    </>
+  );
+}

--- a/frontend/pages/history/index.tsx
+++ b/frontend/pages/history/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import Head from "next/head";
-import { Trash2 } from "lucide-react";
+import Link from "next/link";
+import { ChevronRight, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { Header } from "@/components/shell/header";
@@ -205,9 +206,11 @@ export default function HistoryPage() {
                           ? "neutral"
                           : "outline";
                       return (
-                        <tr key={row.id} className="border-b border-border last:border-0">
+                        <tr key={row.id} className="border-b border-border last:border-0 hover:bg-muted/40">
                           <td className="px-4 py-2 font-mono text-xs">
-                            {row.document_date}
+                            <Link href={`/history/${row.id}`} className="hover:underline">
+                              {row.document_date}
+                            </Link>
                           </td>
                           <td className="px-4 py-2 font-medium">{row.symbol}</td>
                           <td className="px-4 py-2 text-muted-foreground">{row.horizon}</td>
@@ -221,14 +224,21 @@ export default function HistoryPage() {
                             {formatPrice(row.current_close ?? null)}
                           </td>
                           <td className="px-4 py-2 text-right">
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              aria-label="Delete run"
-                              onClick={() => handleDelete(row.id)}
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
+                            <div className="flex items-center justify-end gap-1">
+                              <Button asChild variant="ghost" size="icon" aria-label="Open run">
+                                <Link href={`/history/${row.id}`}>
+                                  <ChevronRight className="h-4 w-4" />
+                                </Link>
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                aria-label="Delete run"
+                                onClick={() => handleDelete(row.id)}
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
                           </td>
                         </tr>
                       );

--- a/frontend/tests/pages/history-detail.test.tsx
+++ b/frontend/tests/pages/history-detail.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  Toaster: () => null,
+}));
+
+let mockQuery: Record<string, string> = {};
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: mockQuery,
+    replace: vi.fn(),
+  }),
+}));
+
+vi.mock("next/head", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("next/dynamic", () => ({
+  default: () => () => null,
+}));
+
+const fetchHistoryRunMock = vi.fn();
+
+vi.mock("@/lib/analyze/api", () => ({
+  resolveApiBaseUrl: () => "http://localhost:8000",
+  fetchHistoryRun: (...args: unknown[]) => fetchHistoryRunMock(...args),
+}));
+
+const DETAIL = {
+  id: "run-9",
+  created_at: "2024-09-18T12:00:00Z",
+  symbol: "^GSPC",
+  document_date: "2024-09-18",
+  horizon: "3d",
+  forecast_mode: "fast",
+  stance: "hawkish",
+  predicted_close: 5500,
+  current_close: 5400,
+  sentiment_score: 0.82,
+  predicted_volatility: 0.012,
+  text_excerpt: "September 18 statement excerpt …",
+  payload: {
+    sentiment: { label: "hawkish", score: 0.82 },
+    prediction: { close: 5500, volatility: 0.012, horizon: "3d" },
+    market: { symbol: "^GSPC", requested_date: "2024-09-18", date_used: "2024-09-18", close: 5400, volatility_5d: 0.01 },
+    model: { runtime_mode: "fast", checkpoint_loaded: true },
+    series: {
+      timestamps: ["2024-09-17T00:00:00Z"],
+      history_close: [5380],
+      history_volatility: [0.01],
+      forecast_timestamps: ["2024-09-18T00:00:00Z", "2024-09-19T00:00:00Z", "2024-09-20T00:00:00Z"],
+      forecast_close: [5450, 5475, 5500],
+      forecast_close_lower: [5400, 5410, 5430],
+      forecast_close_upper: [5500, 5540, 5570],
+      forecast_volatility: [0.011, 0.012, 0.013],
+      forecast_volatility_lower: [0.009, 0.010, 0.011],
+      forecast_volatility_upper: [0.013, 0.014, 0.015],
+      forecast_confidence_level: 0.8,
+      volatility_scale: { suggested_ymin: 0, suggested_ymax: 0.02 },
+    },
+  },
+};
+
+describe("HistoryDetailPage", () => {
+  beforeEach(() => {
+    mockQuery = { id: "run-9" };
+    fetchHistoryRunMock.mockReset();
+  });
+
+  it("renders the run header and submitted-text card on success", async () => {
+    fetchHistoryRunMock.mockResolvedValue(DETAIL);
+    const { default: HistoryDetailPage } = await import("@/pages/history/[id]");
+    render(<HistoryDetailPage />);
+    expect(await screen.findByText(/September 18 statement excerpt/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /2024-09-18/ })).toBeInTheDocument();
+  });
+
+  it("renders the not-found fallback when the backend rejects", async () => {
+    fetchHistoryRunMock.mockRejectedValue(new Error("Run does not exist"));
+    const { default: HistoryDetailPage } = await import("@/pages/history/[id]");
+    render(<HistoryDetailPage />);
+    await waitFor(() => expect(screen.getByText(/Run does not exist/)).toBeInTheDocument());
+  });
+
+  it("links the compare-with button to /compare?a=<id>", async () => {
+    fetchHistoryRunMock.mockResolvedValue(DETAIL);
+    const { default: HistoryDetailPage } = await import("@/pages/history/[id]");
+    render(<HistoryDetailPage />);
+    await waitFor(() => expect(screen.getByText(/Compare with/i)).toBeInTheDocument());
+    const link = screen.getByText(/Compare with/i).closest("a");
+    expect(link?.getAttribute("href")).toBe("/compare?a=run-9");
+  });
+});


### PR DESCRIPTION
## Summary
- New dynamic route at `frontend/pages/history/[id].tsx`; renames `pages/history.tsx` to `pages/history/index.tsx` to free the slot.
- Detail page fetches `/history/{id}` and renders the stored payload through the existing analyze components: SentimentCard, PredictionCards, ForecastChart x2, ErrorBadges, MarketContext, PreviewPanels.
- Header row shows date, symbol, horizon, forecast mode, and stance badges; a Compare-with button deep-links to `/compare?a=<id>`.
- A submitted-text card at the bottom surfaces the stored text excerpt.
- History list rows: the date cell is now a Link and a chevron action joins the trash button.
- Vitest: +3 cases (success render, not-found fallback, compare-link deep-link).

## Test plan
- `cd frontend && npm test -- --run`
- `cd frontend && npm run type-check`