### PR TITLE
Differentiate conformal vs Gaussian bands; add /performance tracker

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -35,6 +35,7 @@ from app.schemas import (
     HistoryDetail,
     HistoryEntry,
     HistoryList,
+    HistoryRealizedResponse,
     TrainJobAcceptedResponse,
     TrainJobStatusResponse,
 )
@@ -468,6 +469,33 @@ def get_history_run(run_id: str, session: Session = Depends(get_session)) -> His
 def delete_history_run(run_id: str, session: Session = Depends(get_session)) -> None:
     if not delete_run(session, run_id):
         raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+
+
+@app.get("/history/{run_id}/realized", response_model=HistoryRealizedResponse)
+def get_history_run_realized(
+    run_id: str, session: Session = Depends(get_session)
+) -> HistoryRealizedResponse:
+    row = get_run(session, run_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+    steps = parse_horizon_steps(row.horizon)
+    try:
+        realized = fetch_realized_forward(
+            target_date=row.document_date,
+            symbol=row.symbol,
+            steps=steps,
+        )
+    except Exception as exc:  # pragma: no cover — yfinance failures bubble as 502
+        raise HTTPException(status_code=502, detail=f"Market lookup failed: {exc}") from exc
+    return HistoryRealizedResponse(
+        run_id=row.id,
+        symbol=row.symbol,
+        document_date=row.document_date,
+        horizon=row.horizon,
+        timestamps=[str(point["date"]) for point in realized],
+        close=[float(point["close"]) for point in realized],
+        volatility=[float(point["volatility_5d"]) for point in realized],
+    )
 
 
 @app.get("/fomc/calendar", response_model=FomcCalendarResponse)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -199,6 +199,16 @@ class HistoryList(BaseModel):
     offset: int
 
 
+class HistoryRealizedResponse(BaseModel):
+    run_id: str
+    symbol: str
+    document_date: str
+    horizon: str
+    timestamps: list[str]
+    close: list[float]
+    volatility: list[float]
+
+
 class FomcMeetingResponse(BaseModel):
     meeting_date: str
     meeting_type: str

--- a/frontend/components/shell/header.tsx
+++ b/frontend/components/shell/header.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Activity, BookOpen, Calendar, GitCompare, Github, History as HistoryIcon } from "lucide-react";
+import { Activity, BookOpen, Calendar, GitCompare, Github, History as HistoryIcon, LineChart } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -9,6 +9,7 @@ const NAV_ITEMS: Array<{ href: string; label: string; icon: React.ComponentType<
   { href: "/analyze", label: "Analyze", icon: Activity },
   { href: "/history", label: "History", icon: HistoryIcon },
   { href: "/compare", label: "Compare", icon: GitCompare },
+  { href: "/performance", label: "Performance", icon: LineChart },
   { href: "/calendar", label: "Calendar", icon: Calendar },
 ];
 

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -6,6 +6,7 @@ import type {
   HistoryDetail,
   HistoryList,
   HistoryQuery,
+  HistoryRealizedResponse,
   TrainJobState,
 } from "./types";
 
@@ -67,6 +68,14 @@ export async function fetchHistoryRun(
 
 export async function deleteHistoryRun(baseUrl: string, runId: string): Promise<void> {
   await axios.delete(`${baseUrl}/history/${runId}`);
+}
+
+export async function fetchHistoryRealized(
+  baseUrl: string,
+  runId: string
+): Promise<HistoryRealizedResponse> {
+  const response = await axios.get(`${baseUrl}/history/${runId}/realized`);
+  return response.data as HistoryRealizedResponse;
 }
 
 export async function fetchFomcCalendar(

--- a/frontend/lib/analyze/performance.ts
+++ b/frontend/lib/analyze/performance.ts
@@ -1,0 +1,113 @@
+import type { HistoryEntry } from "./types";
+
+export interface RunPerformance {
+  id: string;
+  symbol: string;
+  document_date: string;
+  horizon: string;
+  predicted_close: number | null;
+  spot_close: number | null;
+  realized_close: number | null;
+  direction_correct: boolean | null;
+  absolute_error: number | null;
+  percent_error: number | null;
+}
+
+export interface PerformanceAggregate {
+  total: number;
+  resolved: number;
+  hitRate: number | null;
+  mape: number | null;
+  mae: number | null;
+  bySymbol: Array<{
+    symbol: string;
+    resolved: number;
+    hitRate: number | null;
+    mape: number | null;
+  }>;
+}
+
+export function computeRunPerformance(
+  row: HistoryEntry,
+  realizedClose: number | null
+): RunPerformance {
+  const predicted = row.predicted_close ?? null;
+  const spot = row.current_close ?? null;
+
+  let directionCorrect: boolean | null = null;
+  if (predicted != null && spot != null && realizedClose != null) {
+    const predictedDir = Math.sign(predicted - spot);
+    const realizedDir = Math.sign(realizedClose - spot);
+    directionCorrect = predictedDir !== 0 && predictedDir === realizedDir;
+  }
+
+  let absoluteError: number | null = null;
+  let percentError: number | null = null;
+  if (predicted != null && realizedClose != null) {
+    absoluteError = Math.abs(predicted - realizedClose);
+    if (Math.abs(realizedClose) > 1e-9) {
+      percentError = absoluteError / Math.abs(realizedClose);
+    }
+  }
+
+  return {
+    id: row.id,
+    symbol: row.symbol,
+    document_date: row.document_date,
+    horizon: row.horizon,
+    predicted_close: predicted,
+    spot_close: spot,
+    realized_close: realizedClose,
+    direction_correct: directionCorrect,
+    absolute_error: absoluteError,
+    percent_error: percentError,
+  };
+}
+
+export function aggregatePerformance(rows: RunPerformance[]): PerformanceAggregate {
+  const resolved = rows.filter((row) => row.realized_close != null);
+  const directional = resolved.filter((row) => row.direction_correct != null);
+  const hits = directional.filter((row) => row.direction_correct === true).length;
+
+  const mapeValues = resolved
+    .map((row) => row.percent_error)
+    .filter((value): value is number => value != null);
+  const maeValues = resolved
+    .map((row) => row.absolute_error)
+    .filter((value): value is number => value != null);
+
+  const bySymbolMap = new Map<string, RunPerformance[]>();
+  for (const row of rows) {
+    const list = bySymbolMap.get(row.symbol) ?? [];
+    list.push(row);
+    bySymbolMap.set(row.symbol, list);
+  }
+  const bySymbol = [...bySymbolMap.entries()].map(([symbol, group]) => {
+    const groupResolved = group.filter((row) => row.realized_close != null);
+    const groupDirectional = groupResolved.filter((row) => row.direction_correct != null);
+    const groupHits = groupDirectional.filter((row) => row.direction_correct === true).length;
+    const groupMape = groupResolved
+      .map((row) => row.percent_error)
+      .filter((value): value is number => value != null);
+    return {
+      symbol,
+      resolved: groupResolved.length,
+      hitRate: groupDirectional.length > 0 ? groupHits / groupDirectional.length : null,
+      mape: groupMape.length > 0 ? mean(groupMape) : null,
+    };
+  });
+
+  return {
+    total: rows.length,
+    resolved: resolved.length,
+    hitRate: directional.length > 0 ? hits / directional.length : null,
+    mape: mapeValues.length > 0 ? mean(mapeValues) : null,
+    mae: maeValues.length > 0 ? mean(maeValues) : null,
+    bySymbol: bySymbol.sort((a, b) => b.resolved - a.resolved),
+  };
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -68,6 +68,18 @@ export interface SeriesResponse {
   realized_volatility?: number[];
   forecast_confidence_level?: number;
   volatility_scale?: { suggested_ymin?: number; suggested_ymax?: number };
+  forecast_band_source?: "gaussian_z" | "conformal" | null;
+  conformal_coverage?: number | null;
+}
+
+export interface HistoryRealizedResponse {
+  run_id: string;
+  symbol: string;
+  document_date: string;
+  horizon: string;
+  timestamps: string[];
+  close: number[];
+  volatility: number[];
 }
 
 export type StanceAxis = "hawkish" | "dovish" | "neutral";

--- a/frontend/pages/analyze.tsx
+++ b/frontend/pages/analyze.tsx
@@ -156,7 +156,8 @@ export default function AnalyzePage() {
   const splitTimestamp = result?.series?.timestamps?.[result.series.timestamps.length - 1];
   const volScale = result?.series?.volatility_scale || { suggested_ymin: 0.0, suggested_ymax: 1.0 };
   const confidenceLevel = Math.round(Number(result?.series?.forecast_confidence_level || 0.8) * 100);
-  const confidenceLabel = `${confidenceLevel}% confidence band`;
+  const bandKind = result?.series?.forecast_band_source === "conformal" ? "conformal" : "Gaussian";
+  const confidenceLabel = `${confidenceLevel}% ${bandKind} band`;
   const hasCloseConfidence = Boolean(result?.series?.forecast_close_lower?.length);
   const hasVolConfidence = Boolean(result?.series?.forecast_volatility_lower?.length);
 

--- a/frontend/pages/history/[id].tsx
+++ b/frontend/pages/history/[id].tsx
@@ -83,7 +83,8 @@ export default function HistoryDetailPage() {
   const errorMetrics = React.useMemo(() => computeErrorMetrics(result), [result]);
   const splitTimestamp = result?.series?.timestamps?.[result.series.timestamps.length - 1];
   const confidenceLevel = Math.round(Number(result?.series?.forecast_confidence_level || 0.8) * 100);
-  const confidenceLabel = `${confidenceLevel}% confidence band`;
+  const bandKind = result?.series?.forecast_band_source === "conformal" ? "conformal" : "Gaussian";
+  const confidenceLabel = `${confidenceLevel}% ${bandKind} band`;
   const hasCloseConfidence = Boolean(result?.series?.forecast_close_lower?.length);
   const hasVolConfidence = Boolean(result?.series?.forecast_volatility_lower?.length);
   const volScale = result?.series?.volatility_scale || { suggested_ymin: 0.0, suggested_ymax: 1.0 };

--- a/frontend/pages/performance.tsx
+++ b/frontend/pages/performance.tsx
@@ -1,0 +1,265 @@
+import * as React from "react";
+import Head from "next/head";
+import Link from "next/link";
+import { ArrowDownRight, ArrowUpRight, Target } from "lucide-react";
+import { toast } from "sonner";
+
+import { Header } from "@/components/shell/header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  fetchHistory,
+  fetchHistoryRealized,
+  resolveApiBaseUrl,
+} from "@/lib/analyze/api";
+import { formatPrice } from "@/lib/analyze/format";
+import {
+  aggregatePerformance,
+  computeRunPerformance,
+  type RunPerformance,
+} from "@/lib/analyze/performance";
+import type { HistoryEntry } from "@/lib/analyze/types";
+
+const HISTORY_LIMIT = 50;
+
+function formatPercent(value: number | null): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export default function PerformancePage() {
+  const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+  const [rows, setRows] = React.useState<RunPerformance[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [totalRuns, setTotalRuns] = React.useState(0);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const list = await fetchHistory(apiBaseUrl, { limit: HISTORY_LIMIT });
+        if (cancelled) return;
+        setTotalRuns(list.total);
+        const resolvedRows: RunPerformance[] = await Promise.all(
+          list.items.map(async (entry: HistoryEntry) => {
+            try {
+              const realized = await fetchHistoryRealized(apiBaseUrl, entry.id);
+              const last = realized.close.length
+                ? realized.close[realized.close.length - 1]
+                : null;
+              return computeRunPerformance(entry, last);
+            } catch {
+              return computeRunPerformance(entry, null);
+            }
+          })
+        );
+        if (!cancelled) setRows(resolvedRows);
+      } catch (err) {
+        if (!cancelled) {
+          toast.error((err as Error).message || "Failed to load performance data.");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBaseUrl]);
+
+  const aggregate = React.useMemo(() => aggregatePerformance(rows), [rows]);
+
+  return (
+    <>
+      <Head>
+        <title>Performance — Fed Pulse</title>
+      </Head>
+      <div className="min-h-screen bg-background text-foreground">
+        <Header />
+        <main className="container space-y-6 py-8">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold tracking-tight">Performance</h1>
+            <p className="max-w-2xl text-muted-foreground">
+              Past predictions resolved against realized close. Direction = sign of (predicted − spot) vs sign of (realized − spot).
+            </p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-4">
+            <SummaryCard
+              title="Runs scanned"
+              value={`${rows.length}`}
+              caption={totalRuns > rows.length ? `of ${totalRuns} total` : "all runs"}
+              icon={<Target className="h-4 w-4 text-muted-foreground" />}
+            />
+            <SummaryCard
+              title="Resolved"
+              value={`${aggregate.resolved}`}
+              caption={aggregate.resolved < rows.length ? `${rows.length - aggregate.resolved} still pending` : "complete"}
+              icon={<Target className="h-4 w-4 text-muted-foreground" />}
+            />
+            <SummaryCard
+              title="Directional hit rate"
+              value={formatPercent(aggregate.hitRate)}
+              caption={aggregate.hitRate != null && aggregate.hitRate >= 0.5 ? "above coin-flip" : "below coin-flip"}
+              icon={
+                aggregate.hitRate != null && aggregate.hitRate >= 0.5 ? (
+                  <ArrowUpRight className="h-4 w-4 text-emerald-500" />
+                ) : (
+                  <ArrowDownRight className="h-4 w-4 text-rose-500" />
+                )
+              }
+            />
+            <SummaryCard
+              title="MAPE"
+              value={formatPercent(aggregate.mape)}
+              caption="mean absolute % error"
+              icon={<Target className="h-4 w-4 text-muted-foreground" />}
+            />
+          </div>
+
+          {loading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : rows.length === 0 ? (
+            <Card>
+              <CardContent className="py-10 text-center text-muted-foreground">
+                No runs in history yet — submit analyses on the Analyze page to populate this view.
+              </CardContent>
+            </Card>
+          ) : (
+            <>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Per-asset breakdown</CardTitle>
+                  <CardDescription>Hit rate and MAPE for each symbol that has at least one resolved run.</CardDescription>
+                </CardHeader>
+                <CardContent className="p-0">
+                  <table className="w-full text-sm">
+                    <thead className="border-b border-border bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
+                      <tr>
+                        <th className="px-4 py-2 text-left">Symbol</th>
+                        <th className="px-4 py-2 text-right">Resolved</th>
+                        <th className="px-4 py-2 text-right">Hit rate</th>
+                        <th className="px-4 py-2 text-right">MAPE</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {aggregate.bySymbol.map((entry) => (
+                        <tr key={entry.symbol} className="border-b border-border last:border-0">
+                          <td className="px-4 py-2 font-medium">{entry.symbol}</td>
+                          <td className="px-4 py-2 text-right font-mono text-muted-foreground">
+                            {entry.resolved}
+                          </td>
+                          <td className="px-4 py-2 text-right font-mono">{formatPercent(entry.hitRate)}</td>
+                          <td className="px-4 py-2 text-right font-mono">{formatPercent(entry.mape)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Run-level detail</CardTitle>
+                  <CardDescription>Each scanned history run with predicted, spot, realized, and direction.</CardDescription>
+                </CardHeader>
+                <CardContent className="p-0">
+                  <table className="w-full text-sm">
+                    <thead className="border-b border-border bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
+                      <tr>
+                        <th className="px-4 py-2 text-left">Date</th>
+                        <th className="px-4 py-2 text-left">Symbol</th>
+                        <th className="px-4 py-2 text-left">Horizon</th>
+                        <th className="px-4 py-2 text-right">Spot</th>
+                        <th className="px-4 py-2 text-right">Predicted</th>
+                        <th className="px-4 py-2 text-right">Realized</th>
+                        <th className="px-4 py-2 text-right">% error</th>
+                        <th className="px-4 py-2 text-center">Direction</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rows.map((row) => (
+                        <tr key={row.id} className="border-b border-border last:border-0 hover:bg-muted/40">
+                          <td className="px-4 py-2 font-mono text-xs">
+                            <Link href={`/history/${row.id}`} className="hover:underline">
+                              {row.document_date}
+                            </Link>
+                          </td>
+                          <td className="px-4 py-2 font-medium">{row.symbol}</td>
+                          <td className="px-4 py-2 text-muted-foreground">{row.horizon}</td>
+                          <td className="px-4 py-2 text-right font-mono text-muted-foreground">
+                            {formatPrice(row.spot_close)}
+                          </td>
+                          <td className="px-4 py-2 text-right font-mono">{formatPrice(row.predicted_close)}</td>
+                          <td className="px-4 py-2 text-right font-mono text-muted-foreground">
+                            {formatPrice(row.realized_close)}
+                          </td>
+                          <td className="px-4 py-2 text-right font-mono">{formatPercent(row.percent_error)}</td>
+                          <td className="px-4 py-2 text-center">
+                            {row.direction_correct == null ? (
+                              <Badge variant="outline">—</Badge>
+                            ) : row.direction_correct ? (
+                              <Badge variant="hawkish">Hit</Badge>
+                            ) : (
+                              <Badge variant="dovish">Miss</Badge>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </CardContent>
+              </Card>
+            </>
+          )}
+
+          <div className="flex justify-end">
+            <Button asChild variant="outline" size="sm">
+              <Link href="/history">Back to history</Link>
+            </Button>
+          </div>
+        </main>
+      </div>
+    </>
+  );
+}
+
+function SummaryCard({
+  title,
+  value,
+  caption,
+  icon,
+}: {
+  title: string;
+  value: string;
+  caption: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {title}
+        </CardTitle>
+        {icon}
+      </CardHeader>
+      <CardContent>
+        <div className="font-mono text-2xl font-semibold">{value}</div>
+        <p className="text-xs text-muted-foreground">{caption}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/tests/lib/analyze/performance.test.ts
+++ b/frontend/tests/lib/analyze/performance.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  aggregatePerformance,
+  computeRunPerformance,
+} from "@/lib/analyze/performance";
+import type { HistoryEntry } from "@/lib/analyze/types";
+
+function makeEntry(overrides: Partial<HistoryEntry> = {}): HistoryEntry {
+  return {
+    id: "run-1",
+    created_at: "2024-09-18T12:00:00Z",
+    symbol: "^GSPC",
+    document_date: "2024-09-18",
+    horizon: "3d",
+    forecast_mode: "fast",
+    stance: "hawkish",
+    sentiment_score: 0.7,
+    predicted_close: 5500,
+    current_close: 5400,
+    predicted_volatility: 0.012,
+    text_excerpt: null,
+    ...overrides,
+  };
+}
+
+describe("computeRunPerformance", () => {
+  it("marks direction correct when predicted and realized move the same way from spot", () => {
+    const result = computeRunPerformance(makeEntry(), 5520);
+    expect(result.direction_correct).toBe(true);
+    expect(result.absolute_error).toBeCloseTo(20, 5);
+    expect(result.percent_error).toBeCloseTo(20 / 5520, 5);
+  });
+
+  it("marks direction incorrect when realized moves opposite to predicted", () => {
+    const result = computeRunPerformance(makeEntry(), 5380);
+    expect(result.direction_correct).toBe(false);
+  });
+
+  it("returns null fields when realized close is missing", () => {
+    const result = computeRunPerformance(makeEntry(), null);
+    expect(result.direction_correct).toBeNull();
+    expect(result.absolute_error).toBeNull();
+    expect(result.percent_error).toBeNull();
+  });
+
+  it("guards percent_error against a zero realized close", () => {
+    const result = computeRunPerformance(makeEntry(), 0);
+    expect(result.absolute_error).toBeCloseTo(5500, 5);
+    expect(result.percent_error).toBeNull();
+  });
+});
+
+describe("aggregatePerformance", () => {
+  it("computes hit rate, MAPE, and per-symbol breakdown from resolved rows", () => {
+    const rows = [
+      computeRunPerformance(makeEntry({ id: "a", symbol: "^GSPC", predicted_close: 5500, current_close: 5400 }), 5520),
+      computeRunPerformance(makeEntry({ id: "b", symbol: "^GSPC", predicted_close: 5500, current_close: 5400 }), 5380),
+      computeRunPerformance(makeEntry({ id: "c", symbol: "^NDX", predicted_close: 18000, current_close: 17900 }), 18100),
+      computeRunPerformance(makeEntry({ id: "d", symbol: "^NDX", predicted_close: 18000, current_close: 17900 }), null),
+    ];
+    const agg = aggregatePerformance(rows);
+    expect(agg.total).toBe(4);
+    expect(agg.resolved).toBe(3);
+    expect(agg.hitRate).toBeCloseTo(2 / 3, 5);
+    expect(agg.mape).not.toBeNull();
+    const gspc = agg.bySymbol.find((entry) => entry.symbol === "^GSPC");
+    const ndx = agg.bySymbol.find((entry) => entry.symbol === "^NDX");
+    expect(gspc?.resolved).toBe(2);
+    expect(gspc?.hitRate).toBeCloseTo(0.5, 5);
+    expect(ndx?.resolved).toBe(1);
+    expect(ndx?.hitRate).toBeCloseTo(1, 5);
+  });
+
+  it("returns null hit rate and MAPE when no rows resolve", () => {
+    const rows = [computeRunPerformance(makeEntry({ id: "a" }), null)];
+    const agg = aggregatePerformance(rows);
+    expect(agg.resolved).toBe(0);
+    expect(agg.hitRate).toBeNull();
+    expect(agg.mape).toBeNull();
+  });
+});

--- a/frontend/tests/pages/performance.test.tsx
+++ b/frontend/tests/pages/performance.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  Toaster: () => null,
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: {},
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock("next/head", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const fetchHistoryMock = vi.fn();
+const fetchHistoryRealizedMock = vi.fn();
+
+vi.mock("@/lib/analyze/api", () => ({
+  resolveApiBaseUrl: () => "http://localhost:8000",
+  fetchHistory: (...args: unknown[]) => fetchHistoryMock(...args),
+  fetchHistoryRealized: (...args: unknown[]) => fetchHistoryRealizedMock(...args),
+}));
+
+const SAMPLE_ROWS = [
+  {
+    id: "run-1",
+    created_at: "2024-09-18T12:00:00Z",
+    symbol: "^GSPC",
+    document_date: "2024-09-18",
+    horizon: "3d",
+    forecast_mode: "fast",
+    stance: "hawkish",
+    sentiment_score: 0.7,
+    predicted_close: 5500,
+    current_close: 5400,
+    predicted_volatility: 0.012,
+    text_excerpt: null,
+  },
+  {
+    id: "run-2",
+    created_at: "2024-11-06T12:00:00Z",
+    symbol: "^GSPC",
+    document_date: "2024-11-06",
+    horizon: "3d",
+    forecast_mode: "fast",
+    stance: "dovish",
+    sentiment_score: 0.32,
+    predicted_close: 5800,
+    current_close: 5850,
+    predicted_volatility: 0.015,
+    text_excerpt: null,
+  },
+];
+
+describe("PerformancePage", () => {
+  beforeEach(() => {
+    fetchHistoryMock.mockReset();
+    fetchHistoryRealizedMock.mockReset();
+  });
+
+  it("renders empty-state when history is empty", async () => {
+    fetchHistoryMock.mockResolvedValue({ total: 0, limit: 50, offset: 0, items: [] });
+    const { default: PerformancePage } = await import("@/pages/performance");
+    render(<PerformancePage />);
+    await waitFor(() =>
+      expect(screen.getByText(/submit analyses on the Analyze page/i)).toBeInTheDocument()
+    );
+  });
+
+  it("renders aggregate hit-rate and run-level rows when realized data resolves", async () => {
+    fetchHistoryMock.mockResolvedValue({ total: 2, limit: 50, offset: 0, items: SAMPLE_ROWS });
+    fetchHistoryRealizedMock
+      .mockResolvedValueOnce({
+        run_id: "run-1",
+        symbol: "^GSPC",
+        document_date: "2024-09-18",
+        horizon: "3d",
+        timestamps: ["2024-09-19", "2024-09-20", "2024-09-23"],
+        close: [5520, 5540, 5560],
+        volatility: [0.011, 0.012, 0.013],
+      })
+      .mockResolvedValueOnce({
+        run_id: "run-2",
+        symbol: "^GSPC",
+        document_date: "2024-11-06",
+        horizon: "3d",
+        timestamps: ["2024-11-07", "2024-11-08", "2024-11-11"],
+        close: [5780, 5760, 5790],
+        volatility: [0.014, 0.015, 0.014],
+      });
+
+    const { default: PerformancePage } = await import("@/pages/performance");
+    render(<PerformancePage />);
+
+    await waitFor(() => expect(fetchHistoryRealizedMock).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText(/Directional hit rate/i)).toBeInTheDocument();
+    expect(screen.getByText(/Per-asset breakdown/i)).toBeInTheDocument();
+    expect(screen.getByText(/Run-level detail/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/^\^GSPC$/).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("still renders the table when one realized fetch fails", async () => {
+    fetchHistoryMock.mockResolvedValue({ total: 1, limit: 50, offset: 0, items: [SAMPLE_ROWS[0]] });
+    fetchHistoryRealizedMock.mockRejectedValue(new Error("Market lookup failed"));
+
+    const { default: PerformancePage } = await import("@/pages/performance");
+    render(<PerformancePage />);
+
+    await waitFor(() => expect(fetchHistoryRealizedMock).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(/Run-level detail/i)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/test_history_endpoints.py
+++ b/tests/unit/test_history_endpoints.py
@@ -100,6 +100,38 @@ def test_history_filter_by_stance_and_date(client):
     assert by_date.json()["total"] == 1
 
 
+def test_history_realized_endpoint(client, monkeypatch):
+    session_iter = db_module.get_session()
+    sess = next(session_iter)
+    try:
+        run = _seed(sess, document_date="2024-09-18")
+    finally:
+        sess.close()
+
+    monkeypatch.setattr(
+        main_mod,
+        "fetch_realized_forward",
+        lambda **_: [
+            {"date": "2024-09-19", "close": 5602.0, "volatility_5d": 0.0110},
+            {"date": "2024-09-20", "close": 5615.0, "volatility_5d": 0.0112},
+            {"date": "2024-09-23", "close": 5628.0, "volatility_5d": 0.0115},
+        ],
+    )
+
+    response = client.get(f"/history/{run.id}/realized")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == run.id
+    assert body["timestamps"] == ["2024-09-19", "2024-09-20", "2024-09-23"]
+    assert body["close"] == [5602.0, 5615.0, 5628.0]
+    assert body["volatility"] == [0.0110, 0.0112, 0.0115]
+
+
+def test_history_realized_endpoint_404_for_missing_run(client):
+    response = client.get("/history/does-not-exist/realized")
+    assert response.status_code == 404
+
+
 def test_fomc_calendar_endpoint_returns_past_and_upcoming(client):
     response = client.get("/fomc/calendar", params={"as_of": "2024-09-18"})
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Chart label switches between "X% conformal band" and "X% Gaussian band" based on series.forecast_band_source.
- New GET /history/{run_id}/realized endpoint returns realized close/volatility for stored forecast windows.
- New /performance page lists hit rate, MAPE, and per-asset breakdown over the last 50 history runs.
- frontend/lib/analyze/performance.ts hosts pure helpers (computeRunPerformance, aggregatePerformance) under unit test.
- Header gains a Performance nav link.

## Test plan
- [x] pytest tests/unit/test_history_endpoints.py — 6 passed
- [x] npm test (frontend) — 93 passed
- [x] npm run type-check && npm run build — clean