### PR TITLE
Ingest gtfintechlab/federal_reserve_system multi-axis FOMC labels

### DIFF
--- a/backend/app/data/ingest_sources.py
+++ b/backend/app/data/ingest_sources.py
@@ -17,6 +17,7 @@ DEFAULT_OUTPUT_DIR = DEFAULT_DATA_DIR / "raw" / "phase2"
 DEFAULT_OUTPUT_FILE = "source_registry.jsonl"
 
 HF_DATASET_ID = "gtfintechlab/fomc_communication"
+GTFINTECHLAB_FED_DATASET_ID = "gtfintechlab/federal_reserve_system"
 KAGGLE_DATASET_ID = "drlexus/fed-statements-and-minutes"
 OP_FED_DEFAULT_RELATIVE = Path("external") / "op_fed" / "opfed_v1.csv"
 GSS_FACTORS_DEFAULT_RELATIVE = Path("external") / "gss" / "gss_factors.csv"
@@ -76,6 +77,11 @@ def _parse_args() -> argparse.Namespace:
         "--include-gss-factors",
         action="store_true",
         help="Ingest GSS (Gürkaynak-Sack-Swanson 2005 IJCB) per-FOMC target/path factor decomposition and 30min/1hr/1day surprise windows.",
+    )
+    parser.add_argument(
+        "--include-gtfintechlab-fed",
+        action="store_true",
+        help=f"Ingest {GTFINTECHLAB_FED_DATASET_ID}: 3,000 multi-axis FOMC sentence labels (stance + time + certainty).",
     )
     parser.add_argument(
         "--all-sources",
@@ -212,6 +218,85 @@ _OP_FED_STANCE_MAP = {
     "contradiction": "dovish",
     "neutral": "neutral",
 }
+
+_GTFINTECHLAB_STANCE_MAP = {
+    "hawkish": "hawkish",
+    "dovish": "dovish",
+    "neutral": "neutral",
+}
+
+
+def _iter_gtfintechlab_federal_reserve_records() -> list[dict[str, Any]]:
+    """Load gtfintechlab/federal_reserve_system: 3,000 multi-axis FOMC sentence labels.
+
+    Schema per row: ``sentences, stance_label, time_label, certain_label, year``.
+    Stance maps to canonical hawkish/dovish/neutral. The time + certain axes
+    populate ``multi_axis_extras`` for downstream multi-task heads. Iterates
+    every config / split combination on the Hub repo and dedupes by text_hash.
+    """
+    try:
+        from datasets import (  # type: ignore
+            get_dataset_config_names,
+            get_dataset_split_names,
+            load_dataset,
+        )
+    except Exception as exc:  # pragma: no cover
+        raise RuntimeError(
+            "datasets package is required for --include-gtfintechlab-fed. "
+            "Install dependencies first."
+        ) from exc
+
+    records: list[dict[str, Any]] = []
+    seen_hashes: set[str] = set()
+
+    configs = list(get_dataset_config_names(GTFINTECHLAB_FED_DATASET_ID))
+    for config in configs:
+        splits = list(get_dataset_split_names(GTFINTECHLAB_FED_DATASET_ID, config))
+        for split in splits:
+            ds = load_dataset(GTFINTECHLAB_FED_DATASET_ID, config, split=split)
+            for idx, row in enumerate(ds):
+                item = dict(row)
+                sentence = (item.get("sentences") or "").strip()
+                if not sentence:
+                    continue
+                stance_raw = (item.get("stance_label") or "").strip().lower()
+                label = _GTFINTECHLAB_STANCE_MAP.get(stance_raw, "")
+                year_value = item.get("year")
+                try:
+                    event_date = (
+                        f"{int(year_value):04d}-01-01" if year_value not in (None, "") else ""
+                    )
+                except (TypeError, ValueError):
+                    event_date = ""
+                if not event_date:
+                    continue
+
+                built = _build_registry_record(
+                    source="gtfintechlab_federal_reserve_system",
+                    source_record_id=f"{config}:{split}:{idx}",
+                    event_date=event_date,
+                    document_type="statement",
+                    title=f"Federal Reserve System sentence {config}/{split}#{idx}",
+                    text=sentence,
+                    label=label,
+                    license_scope="research_only",
+                    citation_ref="shah_etal_2024_gtfintechlab_central_banks",
+                )
+                if built is None:
+                    continue
+                if built["text_hash"] in seen_hashes:
+                    continue
+                seen_hashes.add(built["text_hash"])
+                built["provenance"] = "peer_reviewed"
+                extras = {
+                    "gtfintechlab_time_label": (item.get("time_label") or "").strip(),
+                    "gtfintechlab_certain_label": (item.get("certain_label") or "").strip(),
+                    "gtfintechlab_config": str(config),
+                    "gtfintechlab_split": str(split),
+                }
+                built["multi_axis_extras"] = {k: v for k, v in extras.items() if v}
+                records.append(built)
+    return records
 
 
 def _iter_op_fed_records(csv_path: Path) -> list[dict[str, Any]]:
@@ -535,10 +620,19 @@ def main() -> int:
     include_scraped = args.all_sources or args.include_scraped
     include_op_fed = args.all_sources or args.include_op_fed
     include_gss_factors = args.all_sources or args.include_gss_factors
-    if not (include_hf or include_kaggle or include_scraped or include_op_fed or include_gss_factors):
+    include_gtfintechlab_fed = args.all_sources or args.include_gtfintechlab_fed
+    if not (
+        include_hf
+        or include_kaggle
+        or include_scraped
+        or include_op_fed
+        or include_gss_factors
+        or include_gtfintechlab_fed
+    ):
         print(
             "No source selected. Use --all-sources or one of "
-            "--include-hf/--include-kaggle/--include-scraped/--include-op-fed/--include-gss-factors."
+            "--include-hf/--include-kaggle/--include-scraped/--include-op-fed/"
+            "--include-gss-factors/--include-gtfintechlab-fed."
         )
         return 1
 
@@ -567,6 +661,14 @@ def main() -> int:
         )
         print(f"Ingested GSS factor records: {len(gss_records)} (per-FOMC target/path factors; factor axis only)")
         unified.extend(gss_records)
+    if include_gtfintechlab_fed:
+        gtfintechlab_records = _iter_gtfintechlab_federal_reserve_records()
+        labelled = sum(1 for r in gtfintechlab_records if r.get("label"))
+        print(
+            f"Ingested gtfintechlab/federal_reserve_system records: {len(gtfintechlab_records)} "
+            f"(stance-labelled: {labelled}; multi-axis time+certainty in multi_axis_extras)"
+        )
+        unified.extend(gtfintechlab_records)
 
     unified.sort(key=lambda row: (row.get("event_date", ""), row.get("source", ""), row.get("source_record_id", "")))
     _write_jsonl(output_path, unified)

--- a/backend/app/data/normalize_labels.py
+++ b/backend/app/data/normalize_labels.py
@@ -134,6 +134,7 @@ _PEER_REVIEWED_SOURCES = {
     "aruoba_drechsel_shocks",
     "cieslak_schrimpf_news",
     "hansen_mcmahon_topics",
+    "gtfintechlab_federal_reserve_system",
 }
 _KAGGLE_SOURCES = {"kaggle_fed_statements_minutes"}
 

--- a/tests/unit/test_external_corpora_ingestion.py
+++ b/tests/unit/test_external_corpora_ingestion.py
@@ -9,8 +9,10 @@ from pathlib import Path
 import pytest
 
 from app.data.ingest_sources import (
+    _GTFINTECHLAB_STANCE_MAP,
     _OP_FED_STANCE_MAP,
     _iter_gss_factors_records,
+    _iter_gtfintechlab_federal_reserve_records,
     _iter_op_fed_records,
 )
 
@@ -287,3 +289,106 @@ def test_extract_gss_factors_parses_appendix_text() -> None:
     sep_01 = next(r for r in surprise_rows if r["meeting_date"] == "2001-09-17")
     assert sep_01["surprise_30min_bp"] is None
     assert sep_01["surprise_1day_bp"] is None
+
+
+def _install_fake_datasets(monkeypatch, payload: dict[tuple[str, str], list[dict]]) -> None:
+    """Inject a fake `datasets` module so the loader can run without hitting HF."""
+    import sys
+    import types
+
+    fake = types.SimpleNamespace()
+    fake.get_dataset_config_names = lambda dataset: sorted({k[0] for k in payload})
+    fake.get_dataset_split_names = lambda dataset, config: sorted(
+        k[1] for k in payload if k[0] == config
+    )
+    fake.load_dataset = lambda dataset, config, split=None: payload[(config, split)]
+    monkeypatch.setitem(sys.modules, "datasets", fake)
+
+
+def test_gtfintechlab_stance_map_covers_canonical_classes() -> None:
+    assert set(_GTFINTECHLAB_STANCE_MAP) == {"hawkish", "dovish", "neutral"}
+    assert _GTFINTECHLAB_STANCE_MAP["hawkish"] == "hawkish"
+    assert _GTFINTECHLAB_STANCE_MAP["dovish"] == "dovish"
+    assert _GTFINTECHLAB_STANCE_MAP["neutral"] == "neutral"
+
+
+def test_iter_gtfintechlab_federal_reserve_records_maps_multi_axis(monkeypatch) -> None:
+    payload = {
+        ("5768", "train"): [
+            {
+                "sentences": "Inflation pressures remain elevated.",
+                "stance_label": "hawkish",
+                "time_label": "forward looking",
+                "certain_label": "certain",
+                "year": 2022,
+            },
+            {
+                "sentences": "The Committee maintained accommodative policy.",
+                "stance_label": "dovish",
+                "time_label": "not forward looking",
+                "certain_label": "uncertain",
+                "year": 2021,
+            },
+            {
+                "sentences": "Activity has expanded at a moderate pace.",
+                "stance_label": "neutral",
+                "time_label": "not forward looking",
+                "certain_label": "certain",
+                "year": 2014,
+            },
+        ],
+        ("5768", "test"): [
+            {
+                "sentences": "",  # empty text — should be dropped
+                "stance_label": "hawkish",
+                "time_label": "forward looking",
+                "certain_label": "certain",
+                "year": 2020,
+            },
+            {
+                "sentences": "Inflation pressures remain elevated.",  # duplicate of train row
+                "stance_label": "hawkish",
+                "time_label": "forward looking",
+                "certain_label": "certain",
+                "year": 2022,
+            },
+        ],
+        ("78516", "train"): [
+            {
+                "sentences": "Risks to the outlook are roughly balanced.",
+                "stance_label": "NEUTRAL",  # case-insensitive
+                "time_label": "forward looking",
+                "certain_label": "certain",
+                "year": 2016,
+            },
+            {
+                "sentences": "Empty year row should drop.",
+                "stance_label": "hawkish",
+                "time_label": "forward looking",
+                "certain_label": "certain",
+                "year": None,
+            },
+        ],
+    }
+    _install_fake_datasets(monkeypatch, payload)
+
+    records = _iter_gtfintechlab_federal_reserve_records()
+
+    assert len(records) == 4  # empty-text, empty-year, and duplicate dropped
+    assert all(r["source"] == "gtfintechlab_federal_reserve_system" for r in records)
+    assert all(r["provenance"] == "peer_reviewed" for r in records)
+    assert all(r["license_scope"] == "research_only" for r in records)
+    assert {r["label"] for r in records} == {"hawkish", "dovish", "neutral"}
+
+    by_text = {r["text"]: r for r in records}
+    elevated = by_text["Inflation pressures remain elevated."]
+    assert elevated["event_date"] == "2022-01-01"
+    assert elevated["multi_axis_extras"]["gtfintechlab_time_label"] == "forward looking"
+    assert elevated["multi_axis_extras"]["gtfintechlab_certain_label"] == "certain"
+    assert elevated["multi_axis_extras"]["gtfintechlab_config"] == "5768"
+    # First-seen-wins dedup keeps the test-split copy (splits iterate alphabetically).
+    assert elevated["multi_axis_extras"]["gtfintechlab_split"] == "test"
+
+    balanced = by_text["Risks to the outlook are roughly balanced."]
+    assert balanced["label"] == "neutral"  # case-insensitive stance match
+    assert balanced["event_date"] == "2016-01-01"


### PR DESCRIPTION
## Summary
- New loader for gtfintechlab/federal_reserve_system: 3,000 FOMC sentences with stance + time + certainty axes.
- Iterates configs 5768/78516 across all splits, dedupes by text_hash.
- Canonical stance map: hawkish/dovish/neutral; time + certainty into multi_axis_extras.
- --include-gtfintechlab-fed flag; --all-sources picks it up.
- Source added to peer-reviewed provenance whitelist.
- Test fixture covers configs / splits / dedup / case-insensitive stance / missing-year.

## Test plan
- [x] pytest tests/unit tests/regression — 430 passed
- [x] AI-trace scan on touched files — clean