### PR TITLE
Ingest vtasca/fomc-statements-minutes for credibility archive

### DIFF
--- a/backend/app/data/ingest_sources.py
+++ b/backend/app/data/ingest_sources.py
@@ -17,6 +17,7 @@ DEFAULT_OUTPUT_DIR = DEFAULT_DATA_DIR / "raw" / "phase2"
 DEFAULT_OUTPUT_FILE = "source_registry.jsonl"
 
 HF_DATASET_ID = "gtfintechlab/fomc_communication"
+VTASCA_FOMC_ARCHIVE_DATASET_ID = "vtasca/fomc-statements-minutes"
 KAGGLE_DATASET_ID = "drlexus/fed-statements-and-minutes"
 OP_FED_DEFAULT_RELATIVE = Path("external") / "op_fed" / "opfed_v1.csv"
 GSS_FACTORS_DEFAULT_RELATIVE = Path("external") / "gss" / "gss_factors.csv"
@@ -76,6 +77,11 @@ def _parse_args() -> argparse.Namespace:
         "--include-gss-factors",
         action="store_true",
         help="Ingest GSS (Gürkaynak-Sack-Swanson 2005 IJCB) per-FOMC target/path factor decomposition and 30min/1hr/1day surprise windows.",
+    )
+    parser.add_argument(
+        "--include-fomc-archive",
+        action="store_true",
+        help=f"Ingest {VTASCA_FOMC_ARCHIVE_DATASET_ID}: full FOMC statement + minutes archive (unlabelled, for credibility drift).",
     )
     parser.add_argument(
         "--all-sources",
@@ -212,6 +218,70 @@ _OP_FED_STANCE_MAP = {
     "contradiction": "dovish",
     "neutral": "neutral",
 }
+
+
+_FOMC_ARCHIVE_TYPE_MAP = {
+    "statement": "statement",
+    "minutes": "minutes",
+    "minute": "minutes",
+}
+
+
+def _iter_fomc_archive_records() -> list[dict[str, Any]]:
+    """Load vtasca/fomc-statements-minutes: 463 whole-document FOMC texts.
+
+    Schema per row: ``Date, Release Date, Type, Text``. Rows are *unlabelled*
+    — they feed the credibility module (drift of one statement vs the prior
+    four meetings) and supplement the continued-pretraining substrate. Routed
+    through ``provenance="scraped"`` so they receive ``sample_weight=0`` and
+    do not enter the supervised training pool.
+    """
+    try:
+        from datasets import load_dataset  # type: ignore
+    except Exception as exc:  # pragma: no cover
+        raise RuntimeError(
+            "datasets package is required for --include-fomc-archive. Install dependencies first."
+        ) from exc
+
+    ds = load_dataset(VTASCA_FOMC_ARCHIVE_DATASET_ID, split="train")
+    records: list[dict[str, Any]] = []
+    seen_hashes: set[str] = set()
+
+    for idx, row in enumerate(ds):
+        item = dict(row)
+        raw_type = (item.get("Type") or "").strip().lower()
+        document_type = _FOMC_ARCHIVE_TYPE_MAP.get(raw_type, "")
+        if not document_type:
+            continue
+        event_date = _coerce_event_date(item, ("Date", "Release Date"))
+        if not event_date:
+            continue
+        text = (item.get("Text") or "").strip()
+        if not text:
+            continue
+        release_date = _coerce_event_date(item, ("Release Date",))
+
+        built = _build_registry_record(
+            source="vtasca_fomc_archive",
+            source_record_id=f"{event_date}:{document_type}",
+            event_date=event_date,
+            document_type=document_type,
+            title=f"FOMC {document_type} {event_date}",
+            text=text,
+            label="",
+            license_scope="public_source_scrape_terms_required",
+            citation_ref="vtasca_2024_fomc_statements_minutes",
+        )
+        if built is None:
+            continue
+        if built["text_hash"] in seen_hashes:
+            continue
+        seen_hashes.add(built["text_hash"])
+        built["provenance"] = "scraped"
+        if release_date and release_date != event_date:
+            built["multi_axis_extras"] = {"release_date": release_date}
+        records.append(built)
+    return records
 
 
 def _iter_op_fed_records(csv_path: Path) -> list[dict[str, Any]]:
@@ -535,10 +605,19 @@ def main() -> int:
     include_scraped = args.all_sources or args.include_scraped
     include_op_fed = args.all_sources or args.include_op_fed
     include_gss_factors = args.all_sources or args.include_gss_factors
-    if not (include_hf or include_kaggle or include_scraped or include_op_fed or include_gss_factors):
+    include_fomc_archive = args.all_sources or args.include_fomc_archive
+    if not (
+        include_hf
+        or include_kaggle
+        or include_scraped
+        or include_op_fed
+        or include_gss_factors
+        or include_fomc_archive
+    ):
         print(
             "No source selected. Use --all-sources or one of "
-            "--include-hf/--include-kaggle/--include-scraped/--include-op-fed/--include-gss-factors."
+            "--include-hf/--include-kaggle/--include-scraped/--include-op-fed/"
+            "--include-gss-factors/--include-fomc-archive."
         )
         return 1
 
@@ -567,6 +646,15 @@ def main() -> int:
         )
         print(f"Ingested GSS factor records: {len(gss_records)} (per-FOMC target/path factors; factor axis only)")
         unified.extend(gss_records)
+    if include_fomc_archive:
+        archive_records = _iter_fomc_archive_records()
+        statement_count = sum(1 for r in archive_records if r.get("document_type") == "statement")
+        minutes_count = sum(1 for r in archive_records if r.get("document_type") == "minutes")
+        print(
+            f"Ingested vtasca/fomc-statements-minutes records: {len(archive_records)} "
+            f"(statements: {statement_count}, minutes: {minutes_count}; unlabelled, credibility-only)"
+        )
+        unified.extend(archive_records)
 
     unified.sort(key=lambda row: (row.get("event_date", ""), row.get("source", ""), row.get("source_record_id", "")))
     _write_jsonl(output_path, unified)

--- a/tests/unit/test_external_corpora_ingestion.py
+++ b/tests/unit/test_external_corpora_ingestion.py
@@ -10,6 +10,7 @@ import pytest
 
 from app.data.ingest_sources import (
     _OP_FED_STANCE_MAP,
+    _iter_fomc_archive_records,
     _iter_gss_factors_records,
     _iter_op_fed_records,
 )
@@ -287,3 +288,94 @@ def test_extract_gss_factors_parses_appendix_text() -> None:
     sep_01 = next(r for r in surprise_rows if r["meeting_date"] == "2001-09-17")
     assert sep_01["surprise_30min_bp"] is None
     assert sep_01["surprise_1day_bp"] is None
+
+
+def _install_fake_datasets_module(monkeypatch, rows: list[dict]) -> None:
+    import sys
+    import types
+
+    fake = types.SimpleNamespace()
+    fake.load_dataset = lambda dataset_id, **kw: iter(rows)
+    monkeypatch.setitem(sys.modules, "datasets", fake)
+
+
+def test_iter_fomc_archive_records_routes_statements_and_minutes(monkeypatch) -> None:
+    _install_fake_datasets_module(
+        monkeypatch,
+        [
+            {
+                "Date": "2024-09-18",
+                "Release Date": "2024-09-18",
+                "Type": "Statement",
+                "Text": "Recent indicators suggest economic activity has been expanding.",
+            },
+            {
+                "Date": "2024-09-18",
+                "Release Date": "2024-10-09",
+                "Type": "Minutes",
+                "Text": "The Committee discussed the staff outlook for inflation.",
+            },
+            {
+                "Date": "2024-11-07",
+                "Release Date": "2024-11-07",
+                "Type": "Statement",
+                "Text": "",  # empty text → dropped
+            },
+            {
+                "Date": "",  # missing Date falls back to Release Date.
+                "Release Date": "",
+                "Type": "Statement",
+                "Text": "No date at all — should drop.",
+            },
+            {
+                "Date": "2024-12-18",
+                "Release Date": "2024-12-18",
+                "Type": "Speech",  # unrecognised type → dropped
+                "Text": "Speech text.",
+            },
+        ],
+    )
+
+    records = _iter_fomc_archive_records()
+
+    assert len(records) == 2
+    assert all(r["source"] == "vtasca_fomc_archive" for r in records)
+    assert all(r["provenance"] == "scraped" for r in records)
+    assert all(r["license_scope"] == "public_source_scrape_terms_required" for r in records)
+    assert all(r["label"] == "" for r in records)
+    assert all(r["label_origin"] == "pseudo" for r in records)
+
+    by_type = {r["document_type"]: r for r in records}
+    assert by_type["statement"]["source_type"] == "fomc_statement"
+    assert by_type["minutes"]["source_type"] == "fomc_minutes"
+
+    minutes_row = by_type["minutes"]
+    # Minutes release on 2024-10-09 differs from event_date 2024-09-18 — flagged in extras.
+    assert minutes_row["multi_axis_extras"]["release_date"] == "2024-10-09"
+    statement_row = by_type["statement"]
+    # Statement release equals event date — no extras populated.
+    assert "multi_axis_extras" not in statement_row or not statement_row.get("multi_axis_extras")
+
+
+def test_iter_fomc_archive_records_dedupes_by_text_hash(monkeypatch) -> None:
+    _install_fake_datasets_module(
+        monkeypatch,
+        [
+            {
+                "Date": "2024-09-18",
+                "Release Date": "2024-09-18",
+                "Type": "Statement",
+                "Text": "Duplicate statement text.",
+            },
+            {
+                "Date": "2024-09-18",
+                "Release Date": "2024-09-18",
+                "Type": "Statement",
+                "Text": "Duplicate statement text.",
+            },
+        ],
+    )
+
+    records = _iter_fomc_archive_records()
+
+    assert len(records) == 1


### PR DESCRIPTION
## Summary
- New loader for vtasca/fomc-statements-minutes: 463 whole-document FOMC statements + minutes.
- Statement / Minutes Type routed to canonical document_type + source_type.
- Release Date preserved in multi_axis_extras when distinct from event Date.
- Unlabelled (sample_weight=0); feeds credibility drift, not the supervised pool.
- Pivoted from alea-institute/kl3m-data — that dataset ships pre-tokenized arrays under a 0-download KL3M tokenizer, vtasca ships raw text.
- --include-fomc-archive flag; --all-sources picks it up.
- Tests cover routing, drop-on-missing-date, unrecognised-type filter, text-hash dedup.

## Test plan
- [x] pytest tests/unit tests/regression — 430 passed
- [x] Wiki inventory updated to mark kl3m as ABANDONED and vtasca as ingestion-ready
- [x] AI-trace scan — clean