### PR TITLE
Sprint 1: corpus expansion (federal_reserve_system + cross-bank + BIS substrate + vtasca archive + FRED)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,3 +175,38 @@ pseudo-labels-audit-metrics-judge:
 		python -c "import json; from app.data.llm_judge import audit_metrics_judge_only; \
 		rows = [json.loads(l) for l in open('/data/interim/phase2/registry_pseudo_$(PSEUDO_STRATEGY)_judged.jsonl')]; \
 		print(json.dumps(audit_metrics_judge_only(rows), indent=2))"
+
+# Continued pretraining (FinBERT-FedAdjacent).
+# Defaults to samchain/BIS_speeches_97_23_MLM as the substrate (909,877 NSP pairs).
+# Override with SUBSTRATE=local for the legacy 44-doc JSON corpus.
+# Override with SUBSTRATE=both to mix BIS + local in a single run.
+SUBSTRATE ?= bis
+PRETRAIN_SEED ?= 11
+PRETRAIN_EPOCHS ?= 2
+PRETRAIN_BATCH_SIZE ?= 8
+PRETRAIN_BLOCK_SIZE ?= 256
+PRETRAIN_LR ?= 2e-5
+PRETRAIN_MAX_ROWS ?= 0
+PRETRAIN_OBJECTIVE ?= mlm_nsp
+finbert-fed-adjacent-pretrain:
+	docker compose run --rm backend \
+		python -m app.data.continued_pretraining \
+		--substrate "$(SUBSTRATE)" \
+		--seed "$(PRETRAIN_SEED)" \
+		--epochs "$(PRETRAIN_EPOCHS)" \
+		--batch-size "$(PRETRAIN_BATCH_SIZE)" \
+		--block-size "$(PRETRAIN_BLOCK_SIZE)" \
+		--learning-rate "$(PRETRAIN_LR)" \
+		--max-rows "$(PRETRAIN_MAX_ROWS)" \
+		--objective "$(PRETRAIN_OBJECTIVE)"
+
+finbert-fed-adjacent-pretrain-smoke:
+	docker compose run --rm backend \
+		python -m app.data.continued_pretraining \
+		--substrate bis \
+		--streaming \
+		--max-rows 200 \
+		--epochs 1 \
+		--batch-size 4 \
+		--block-size 128 \
+		--objective mlm

--- a/backend/app/data/continued_pretraining.py
+++ b/backend/app/data/continued_pretraining.py
@@ -1,3 +1,20 @@
+"""Continued pretraining for FinBERT-FedAdjacent.
+
+Primary substrate is ``samchain/BIS_speeches_97_23_MLM`` — 909,877 NSP-formatted
+sentence pairs from BIS central bank speeches (1997-2023). The dataset is
+pre-chunked and pre-labelled for the MLM + Next-Sentence-Prediction joint
+objective, which is the recipe Devlin et al. and Araci used for FinBERT.
+
+Why the switch from the local JSON corpus: the 44-doc local corpus produced
+~5.8M effective tokens after chunking. BIS speeches at this scale produce
+~365M tokens of in-domain monetary-policy language — two orders of magnitude
+larger and within range of FinBERT's original pretraining substrate.
+
+The legacy local JSON corpus is preserved as an optional auxiliary substrate
+via ``--auxiliary-local-dir`` for ablation studies; pass ``--substrate local``
+to use it as the sole substrate (reproduces the pre-Sprint-1B behaviour).
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -14,7 +31,9 @@ from app.training.manifest import write_run_manifest
 DEFAULT_BASE_CHECKPOINT = "ProsusAI/finbert"
 DEFAULT_OUT_NAME = "finbert_fed_adjacent"
 DEFAULT_ARTIFACT_ROOT = DATA_DIR / "artifacts" / "continued_pretraining"
-DEFAULT_CORPUS_FILES = (
+DEFAULT_BIS_DATASET_ID = "samchain/BIS_speeches_97_23_MLM"
+DEFAULT_BIS_DATASET_REVISION: str | None = None  # pin once first run reports the resolved sha
+DEFAULT_LOCAL_CORPUS_FILES: tuple[str, ...] = (
     "chair_speeches.json",
     "governor_speeches.json",
     "congressional_testimonies.json",
@@ -22,10 +41,12 @@ DEFAULT_CORPUS_FILES = (
     "beige_book.json",
     "regional_research.json",
 )
+_VALID_SUBSTRATES = ("bis", "local", "both")
 
 
-def _iter_corpus_texts(data_dir: Path, files: Iterable[str]) -> list[str]:
-    texts: list[str] = []
+def _iter_local_pairs(data_dir: Path, files: Iterable[str]) -> list[dict[str, Any]]:
+    """Adapt the local JSON corpus into the same {sequenceA, sequenceB, next_sentence_label} shape."""
+    pairs: list[dict[str, Any]] = []
     for filename in files:
         path = data_dir / filename
         if not path.exists():
@@ -41,14 +62,43 @@ def _iter_corpus_texts(data_dir: Path, files: Iterable[str]) -> list[str]:
                 continue
             text = str(item.get("text") or item.get("body") or "").strip()
             if text:
-                texts.append(text)
-    return texts
+                # Each doc becomes a degenerate pair where B is unused but the
+                # NSP label is fixed at 0 so the model treats it as non-paired.
+                pairs.append({"sequenceA": text, "sequenceB": "", "next_sentence_label": 0})
+    return pairs
+
+
+def _bis_pair_stream(
+    dataset_id: str,
+    revision: str | None,
+    *,
+    streaming: bool,
+    max_rows: int,
+):
+    """Yield {sequenceA, sequenceB, next_sentence_label} rows from the BIS dataset."""
+    from datasets import load_dataset  # type: ignore
+
+    kwargs: dict[str, Any] = {"split": "train", "streaming": streaming}
+    if revision:
+        kwargs["revision"] = revision
+    ds = load_dataset(dataset_id, **kwargs)
+
+    seen = 0
+    for row in ds:
+        if max_rows and seen >= max_rows:
+            break
+        a = (row.get("sequenceA") or "").strip()
+        b = (row.get("sequenceB") or "").strip()
+        if not a:
+            continue
+        yield {"sequenceA": a, "sequenceB": b, "next_sentence_label": int(row.get("next_sentence_label") or 0)}
+        seen += 1
 
 
 def run_mlm(
     *,
     base_checkpoint: str,
-    texts: list[str],
+    pair_records: list[dict[str, Any]],
     output_dir: Path,
     epochs: int,
     learning_rate: float,
@@ -56,17 +106,28 @@ def run_mlm(
     block_size: int,
     seed: int,
     hf_token: str | None,
+    objective: str,
 ) -> dict[str, Any]:
+    """Run the joint MLM + NSP continued pretrain over pre-built sentence pairs.
+
+    ``objective`` selects the head: ``"mlm_nsp"`` uses ``BertForPreTraining``
+    (Devlin/Araci recipe); ``"mlm"`` uses ``AutoModelForMaskedLM`` and drops
+    the NSP label. MLM-only is provided for ablation against the joint loss.
+    """
     import numpy as np
     import torch
     from transformers import (
         AutoModelForMaskedLM,
         AutoTokenizer,
+        BertForPreTraining,
         DataCollatorForLanguageModeling,
         Trainer,
         TrainingArguments,
     )
     from torch.utils.data import Dataset
+
+    if objective not in {"mlm", "mlm_nsp"}:
+        raise ValueError(f"Unknown objective: {objective!r}; expected one of 'mlm', 'mlm_nsp'.")
 
     torch.manual_seed(seed)
     np.random.seed(seed)
@@ -79,25 +140,49 @@ def run_mlm(
         model_kwargs["revision"] = revision
 
     tokenizer = AutoTokenizer.from_pretrained(base_checkpoint, **tokenizer_kwargs)
-    model = AutoModelForMaskedLM.from_pretrained(base_checkpoint, **model_kwargs)
+    if objective == "mlm_nsp":
+        model = BertForPreTraining.from_pretrained(base_checkpoint, **model_kwargs)
+    else:
+        model = AutoModelForMaskedLM.from_pretrained(base_checkpoint, **model_kwargs)
 
-    class _SimpleTextDataset(Dataset):
-        def __init__(self, texts: list[str], tokenizer, block_size: int) -> None:
-            self._encodings = tokenizer(
-                texts,
-                truncation=True,
-                padding="max_length",
-                max_length=block_size,
-                return_special_tokens_mask=True,
+    class _PairDataset(Dataset):
+        def __init__(self, pairs: list[dict[str, Any]], tokenizer, block_size: int, use_nsp: bool) -> None:
+            seq_a = [p["sequenceA"] for p in pairs]
+            seq_b = [p.get("sequenceB") or "" for p in pairs] if use_nsp else None
+            if use_nsp:
+                # text_pair tokenisation: [CLS] A [SEP] B [SEP] with token_type_ids.
+                self._enc = tokenizer(
+                    seq_a,
+                    text_pair=seq_b,
+                    truncation=True,
+                    padding="max_length",
+                    max_length=block_size,
+                    return_special_tokens_mask=True,
+                    return_token_type_ids=True,
+                )
+            else:
+                self._enc = tokenizer(
+                    seq_a,
+                    truncation=True,
+                    padding="max_length",
+                    max_length=block_size,
+                    return_special_tokens_mask=True,
+                )
+            self._nsp_labels = (
+                [int(p.get("next_sentence_label") or 0) for p in pairs] if use_nsp else None
             )
 
         def __len__(self) -> int:
-            return len(self._encodings["input_ids"])
+            return len(self._enc["input_ids"])
 
         def __getitem__(self, idx: int) -> dict[str, Any]:
-            return {key: value[idx] for key, value in self._encodings.items()}
+            item = {key: value[idx] for key, value in self._enc.items()}
+            if self._nsp_labels is not None:
+                item["next_sentence_label"] = self._nsp_labels[idx]
+            return item
 
-    dataset = _SimpleTextDataset(texts, tokenizer, block_size=block_size)
+    use_nsp = objective == "mlm_nsp"
+    dataset = _PairDataset(pair_records, tokenizer, block_size=block_size, use_nsp=use_nsp)
     collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=True, mlm_probability=0.15)
     output_dir.mkdir(parents=True, exist_ok=True)
     training_args = TrainingArguments(
@@ -106,7 +191,7 @@ def run_mlm(
         per_device_train_batch_size=batch_size,
         learning_rate=learning_rate,
         save_strategy="no",
-        logging_steps=50,
+        logging_steps=200,
         seed=seed,
         report_to=[],
     )
@@ -121,6 +206,7 @@ def run_mlm(
         "learning_rate": learning_rate,
         "batch_size": batch_size,
         "block_size": block_size,
+        "objective": objective,
         "train_runtime_s": float(getattr(train_result, "metrics", {}).get("train_runtime", 0.0)),
         "train_loss": float(getattr(train_result, "training_loss", 0.0) or 0.0),
         "num_examples": len(dataset),
@@ -136,7 +222,7 @@ def _hf_token() -> str | None:
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Continue-pretrain a FinBERT checkpoint on the unlabelled Fed-adjacent corpus."
+        description="Continue-pretrain a FinBERT checkpoint on the BIS central bank speeches MLM+NSP corpus."
     )
     parser.add_argument("--base-checkpoint", default=DEFAULT_BASE_CHECKPOINT)
     parser.add_argument("--data-dir", default=str(DATA_DIR))
@@ -148,36 +234,93 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--block-size", type=int, default=256)
     parser.add_argument("--seed", type=int, default=11)
     parser.add_argument(
+        "--substrate",
+        choices=_VALID_SUBSTRATES,
+        default="bis",
+        help="bis (default; samchain/BIS_speeches_97_23_MLM), local (legacy JSON corpus), or both.",
+    )
+    parser.add_argument(
+        "--bis-dataset-id",
+        default=DEFAULT_BIS_DATASET_ID,
+        help="HF dataset id for the BIS substrate.",
+    )
+    parser.add_argument(
+        "--bis-dataset-revision",
+        default=DEFAULT_BIS_DATASET_REVISION,
+        help="HF dataset revision (commit SHA) for reproducibility; first run resolves and reports.",
+    )
+    parser.add_argument(
+        "--streaming",
+        action="store_true",
+        help="Stream the BIS dataset rather than caching to disk (slower per-step but no local 365MB cache).",
+    )
+    parser.add_argument(
+        "--auxiliary-local-dir",
+        default=None,
+        help="Override directory for the legacy local JSON corpus (used when --substrate is local or both).",
+    )
+    parser.add_argument(
         "--corpus-files",
         nargs="+",
-        default=list(DEFAULT_CORPUS_FILES),
-        help="JSON files under --data-dir to read text from.",
+        default=list(DEFAULT_LOCAL_CORPUS_FILES),
+        help="JSON files under --data-dir (or --auxiliary-local-dir) for the local substrate.",
     )
     parser.add_argument(
         "--max-rows",
         type=int,
         default=0,
-        help="Cap the number of training rows (0 = use all).",
+        help="Cap the number of training pairs (0 = use all). Useful for smoke tests.",
+    )
+    parser.add_argument(
+        "--objective",
+        choices=("mlm", "mlm_nsp"),
+        default="mlm_nsp",
+        help="Joint MLM+NSP (default, Devlin/Araci recipe) or MLM-only ablation.",
     )
     return parser.parse_args(argv)
 
 
+def _collect_pairs(args: argparse.Namespace) -> list[dict[str, Any]]:
+    pairs: list[dict[str, Any]] = []
+    if args.substrate in {"bis", "both"}:
+        bis_iter = _bis_pair_stream(
+            args.bis_dataset_id,
+            args.bis_dataset_revision,
+            streaming=args.streaming,
+            max_rows=args.max_rows,
+        )
+        pairs.extend(list(bis_iter))
+    if args.substrate in {"local", "both"}:
+        local_dir = Path(args.auxiliary_local_dir) if args.auxiliary_local_dir else Path(args.data_dir)
+        local_pairs = _iter_local_pairs(local_dir, args.corpus_files)
+        if args.max_rows and (len(pairs) + len(local_pairs)) > args.max_rows:
+            local_pairs = local_pairs[: max(0, args.max_rows - len(pairs))]
+        pairs.extend(local_pairs)
+    return pairs
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
-    data_dir = Path(args.data_dir)
-    texts = _iter_corpus_texts(data_dir, args.corpus_files)
-    if args.max_rows and len(texts) > args.max_rows:
-        texts = texts[: args.max_rows]
-    if not texts:
-        raise SystemExit(f"No texts loaded from {data_dir}; check --corpus-files arguments.")
+    try:
+        pairs = _collect_pairs(args)
+    except Exception as exc:  # pragma: no cover — surfaced as a CLI error
+        raise SystemExit(f"Failed to collect training pairs: {exc}") from exc
+    if not pairs:
+        raise SystemExit(
+            f"No training pairs loaded for substrate={args.substrate!r}. "
+            "Check --bis-dataset-id, --data-dir, or --corpus-files."
+        )
 
     run_token = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    run_dir = Path(args.artifact_root) / f"{args.checkpoint_name}_{run_token}"
-    print(f"[mlm] base={args.base_checkpoint} texts={len(texts)} out={run_dir}")
+    run_dir = Path(args.artifact_root) / f"{args.checkpoint_name}_{run_token}_s{args.seed}"
+    print(
+        f"[mlm] base={args.base_checkpoint} substrate={args.substrate} pairs={len(pairs)} "
+        f"objective={args.objective} out={run_dir}"
+    )
 
     result = run_mlm(
         base_checkpoint=args.base_checkpoint,
-        texts=texts,
+        pair_records=pairs,
         output_dir=run_dir,
         epochs=args.epochs,
         learning_rate=args.learning_rate,
@@ -185,11 +328,12 @@ def main(argv: list[str] | None = None) -> int:
         block_size=args.block_size,
         seed=args.seed,
         hf_token=_hf_token(),
+        objective=args.objective,
     )
     (run_dir / "metrics.json").write_text(json.dumps(result, indent=2), encoding="utf-8")
     write_run_manifest(
         run_dir,
-        run_id=f"finbert_fed_adjacent_{run_token}_s{args.seed}",
+        run_id=f"{args.checkpoint_name}_{run_token}_s{args.seed}",
         version_ids={"model_version": args.checkpoint_name},
         seeds=[args.seed],
         hyperparameters={
@@ -198,14 +342,18 @@ def main(argv: list[str] | None = None) -> int:
             "learning_rate": args.learning_rate,
             "batch_size": args.batch_size,
             "block_size": args.block_size,
+            "objective": args.objective,
+            "substrate": args.substrate,
+            "bis_dataset_id": args.bis_dataset_id,
+            "bis_dataset_revision": args.bis_dataset_revision,
         },
-        inputs=[data_dir / name for name in args.corpus_files],
+        inputs=[args.bis_dataset_id] if args.substrate in {"bis", "both"} else [],
         extra={"num_examples": result["num_examples"]},
     )
     print(f"[mlm] checkpoint at {result['checkpoint_path']}")
     print(
-        "[mlm] register the new SHA in backend/app/models/registry.yaml under "
-        f"alias 'finbert_fed_adjacent' before using it in fine-tunes."
+        f"[mlm] register the new SHA in backend/app/models/registry.yaml under "
+        f"alias '{args.checkpoint_name}' before using it in fine-tunes."
     )
     return 0
 

--- a/backend/app/data/continued_pretraining.py
+++ b/backend/app/data/continued_pretraining.py
@@ -183,7 +183,28 @@ def run_mlm(
 
     use_nsp = objective == "mlm_nsp"
     dataset = _PairDataset(pair_records, tokenizer, block_size=block_size, use_nsp=use_nsp)
-    collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=True, mlm_probability=0.15)
+    mlm_collator = DataCollatorForLanguageModeling(
+        tokenizer=tokenizer, mlm=True, mlm_probability=0.15
+    )
+    if use_nsp:
+        # DataCollatorForLanguageModeling routes batches through tokenizer.pad(),
+        # which keeps only tokenizer-output keys — next_sentence_label would be
+        # silently dropped before reaching BertForPreTraining. Wrap to pop NSP
+        # labels first, then re-attach as a torch tensor after MLM masking.
+        def collator(features: list[dict[str, Any]]):  # type: ignore[no-redef]
+            import torch as _torch
+
+            nsp_labels: list[int] = []
+            for feat in features:
+                if isinstance(feat, dict):
+                    nsp_labels.append(int(feat.pop("next_sentence_label", 0)))
+                else:
+                    nsp_labels.append(0)
+            batch = mlm_collator(features)
+            batch["next_sentence_label"] = _torch.tensor(nsp_labels, dtype=_torch.long)
+            return batch
+    else:
+        collator = mlm_collator
     output_dir.mkdir(parents=True, exist_ok=True)
     training_args = TrainingArguments(
         output_dir=str(output_dir / "trainer"),
@@ -281,22 +302,66 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def _collect_pairs(args: argparse.Namespace) -> list[dict[str, Any]]:
+    """Build the training-pair list under the requested substrate(s).
+
+    --substrate both: local pairs (small, finite) load first to guarantee
+    representation, then BIS fills the remainder of --max-rows. Earlier
+    behaviour (BIS first) silently emptied the local slice whenever BIS
+    filled the cap, making --substrate both --max-rows N indistinguishable
+    from --substrate bis.
+    """
     pairs: list[dict[str, Any]] = []
-    if args.substrate in {"bis", "both"}:
-        bis_iter = _bis_pair_stream(
-            args.bis_dataset_id,
-            args.bis_dataset_revision,
-            streaming=args.streaming,
-            max_rows=args.max_rows,
-        )
-        pairs.extend(list(bis_iter))
+
     if args.substrate in {"local", "both"}:
         local_dir = Path(args.auxiliary_local_dir) if args.auxiliary_local_dir else Path(args.data_dir)
         local_pairs = _iter_local_pairs(local_dir, args.corpus_files)
-        if args.max_rows and (len(pairs) + len(local_pairs)) > args.max_rows:
-            local_pairs = local_pairs[: max(0, args.max_rows - len(pairs))]
+        if args.substrate == "local" and args.max_rows and len(local_pairs) > args.max_rows:
+            local_pairs = local_pairs[: args.max_rows]
         pairs.extend(local_pairs)
+
+    if args.substrate in {"bis", "both"}:
+        if args.substrate == "both" and args.max_rows:
+            remaining = max(0, args.max_rows - len(pairs))
+            bis_cap = remaining
+            if remaining == 0:
+                import warnings as _warnings
+
+                _warnings.warn(
+                    f"--substrate both --max-rows {args.max_rows} was reached by local "
+                    f"({len(pairs)} pairs); BIS substrate dropped. Raise --max-rows or "
+                    "use --substrate bis to override.",
+                    stacklevel=2,
+                )
+        else:
+            bis_cap = args.max_rows
+        if bis_cap != 0:
+            bis_iter = _bis_pair_stream(
+                args.bis_dataset_id,
+                args.bis_dataset_revision,
+                streaming=args.streaming,
+                max_rows=bis_cap,
+            )
+            pairs.extend(list(bis_iter))
+
     return pairs
+
+
+def _resolve_dataset_sha(dataset_id: str, revision: str | None) -> str | None:
+    """Resolve the actual commit SHA the HF Hub serves for (dataset_id, revision).
+
+    When the user passes --bis-dataset-revision explicitly, that's what we
+    persist. When they don't, we query the Hub for the dataset's latest commit
+    so the manifest still carries a concrete sha rather than null.
+    """
+    if revision:
+        return revision
+    try:
+        from huggingface_hub import HfApi  # type: ignore
+
+        info = HfApi().dataset_info(dataset_id)
+        return getattr(info, "sha", None)
+    except Exception:  # pragma: no cover — manifest still records None on failure
+        return None
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -311,11 +376,17 @@ def main(argv: list[str] | None = None) -> int:
             "Check --bis-dataset-id, --data-dir, or --corpus-files."
         )
 
+    resolved_revision = (
+        _resolve_dataset_sha(args.bis_dataset_id, args.bis_dataset_revision)
+        if args.substrate in {"bis", "both"}
+        else None
+    )
+
     run_token = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     run_dir = Path(args.artifact_root) / f"{args.checkpoint_name}_{run_token}_s{args.seed}"
     print(
         f"[mlm] base={args.base_checkpoint} substrate={args.substrate} pairs={len(pairs)} "
-        f"objective={args.objective} out={run_dir}"
+        f"objective={args.objective} bis_revision={resolved_revision} out={run_dir}"
     )
 
     result = run_mlm(
@@ -345,7 +416,8 @@ def main(argv: list[str] | None = None) -> int:
             "objective": args.objective,
             "substrate": args.substrate,
             "bis_dataset_id": args.bis_dataset_id,
-            "bis_dataset_revision": args.bis_dataset_revision,
+            "bis_dataset_revision_requested": args.bis_dataset_revision,
+            "bis_dataset_revision_resolved": resolved_revision,
         },
         inputs=[args.bis_dataset_id] if args.substrate in {"bis", "both"} else [],
         extra={"num_examples": result["num_examples"]},

--- a/backend/app/data/ingest_sources.py
+++ b/backend/app/data/ingest_sources.py
@@ -85,6 +85,15 @@ def _parse_args() -> argparse.Namespace:
         help=f"Ingest {GTFINTECHLAB_FED_DATASET_ID}: 3,000 multi-axis FOMC sentence labels (stance + time + certainty).",
     )
     parser.add_argument(
+        "--include-gtfintechlab-cross-bank",
+        action="store_true",
+        help=(
+            "Ingest gtfintechlab cross-bank datasets (ECB / BoJ / BoE / BoC / RBA): "
+            "~15,000 multi-axis sentences held out from FOMC training (sample_weight=0) "
+            "for the cross-CB generalization study."
+        ),
+    )
+    parser.add_argument(
         "--include-fomc-archive",
         action="store_true",
         help=f"Ingest {VTASCA_FOMC_ARCHIVE_DATASET_ID}: full FOMC statement + minutes archive (unlabelled, for credibility drift).",
@@ -232,13 +241,38 @@ _GTFINTECHLAB_STANCE_MAP = {
 }
 
 
-def _iter_gtfintechlab_federal_reserve_records() -> list[dict[str, Any]]:
-    """Load gtfintechlab/federal_reserve_system: 3,000 multi-axis FOMC sentence labels.
+# Cross-bank gtfintechlab datasets — same 3,000-row {sentences, stance_label,
+# time_label, certain_label, year} schema as federal_reserve_system. Held out
+# from the FOMC headline training pool via provenance="peer_reviewed_cross_bank"
+# (sample_weight 0.0) so they only contribute to the cross-bank generalization
+# evaluation.
+GTFINTECHLAB_CROSS_BANK_DATASETS: tuple[tuple[str, str, str], ...] = (
+    # (bank_key, hf_dataset_id, document_type_hint)
+    ("european_central_bank", "gtfintechlab/european_central_bank", "ecb_communication"),
+    ("bank_of_japan", "gtfintechlab/bank_of_japan", "boj_communication"),
+    ("bank_of_england", "gtfintechlab/bank_of_england", "boe_communication"),
+    ("bank_of_canada", "gtfintechlab/bank_of_canada", "boc_communication"),
+    ("reserve_bank_of_australia", "gtfintechlab/reserve_bank_of_australia", "rba_communication"),
+)
 
-    Schema per row: ``sentences, stance_label, time_label, certain_label, year``.
-    Stance maps to canonical hawkish/dovish/neutral. The time + certain axes
-    populate ``multi_axis_extras`` for downstream multi-task heads. Iterates
-    every config / split combination on the Hub repo and dedupes by text_hash.
+
+def _iter_gtfintechlab_records(
+    *,
+    dataset_id: str,
+    source_name: str,
+    provenance: str,
+    document_type: str,
+    title_prefix: str,
+    citation_ref: str = "shah_etal_2024_gtfintechlab_central_banks",
+    license_scope: str = "research_only",
+) -> list[dict[str, Any]]:
+    """Generic loader for the gtfintechlab multi-axis schema.
+
+    Every dataset under the gtfintechlab umbrella that hosts central-bank
+    sentence annotations shares the row shape ``sentences, stance_label,
+    time_label, certain_label, year``. This function walks every config /
+    split combination, normalises stance, populates ``multi_axis_extras``
+    with the time + certainty axes, and dedupes by ``text_hash``.
     """
     try:
         from datasets import (  # type: ignore
@@ -248,18 +282,18 @@ def _iter_gtfintechlab_federal_reserve_records() -> list[dict[str, Any]]:
         )
     except Exception as exc:  # pragma: no cover
         raise RuntimeError(
-            "datasets package is required for --include-gtfintechlab-fed. "
+            "datasets package is required for the gtfintechlab loader. "
             "Install dependencies first."
         ) from exc
 
     records: list[dict[str, Any]] = []
     seen_hashes: set[str] = set()
 
-    configs = list(get_dataset_config_names(GTFINTECHLAB_FED_DATASET_ID))
+    configs = list(get_dataset_config_names(dataset_id))
     for config in configs:
-        splits = list(get_dataset_split_names(GTFINTECHLAB_FED_DATASET_ID, config))
+        splits = list(get_dataset_split_names(dataset_id, config))
         for split in splits:
-            ds = load_dataset(GTFINTECHLAB_FED_DATASET_ID, config, split=split)
+            ds = load_dataset(dataset_id, config, split=split)
             for idx, row in enumerate(ds):
                 item = dict(row)
                 sentence = (item.get("sentences") or "").strip()
@@ -278,22 +312,22 @@ def _iter_gtfintechlab_federal_reserve_records() -> list[dict[str, Any]]:
                     continue
 
                 built = _build_registry_record(
-                    source="gtfintechlab_federal_reserve_system",
+                    source=source_name,
                     source_record_id=f"{config}:{split}:{idx}",
                     event_date=event_date,
-                    document_type="statement",
-                    title=f"Federal Reserve System sentence {config}/{split}#{idx}",
+                    document_type=document_type,
+                    title=f"{title_prefix} sentence {config}/{split}#{idx}",
                     text=sentence,
                     label=label,
-                    license_scope="research_only",
-                    citation_ref="shah_etal_2024_gtfintechlab_central_banks",
+                    license_scope=license_scope,
+                    citation_ref=citation_ref,
                 )
                 if built is None:
                     continue
                 if built["text_hash"] in seen_hashes:
                     continue
                 seen_hashes.add(built["text_hash"])
-                built["provenance"] = "peer_reviewed"
+                built["provenance"] = provenance
                 extras = {
                     "gtfintechlab_time_label": (item.get("time_label") or "").strip(),
                     "gtfintechlab_certain_label": (item.get("certain_label") or "").strip(),
@@ -302,6 +336,37 @@ def _iter_gtfintechlab_federal_reserve_records() -> list[dict[str, Any]]:
                 }
                 built["multi_axis_extras"] = {k: v for k, v in extras.items() if v}
                 records.append(built)
+    return records
+
+
+def _iter_gtfintechlab_federal_reserve_records() -> list[dict[str, Any]]:
+    """Load gtfintechlab/federal_reserve_system into the FOMC training pool."""
+    return _iter_gtfintechlab_records(
+        dataset_id=GTFINTECHLAB_FED_DATASET_ID,
+        source_name="gtfintechlab_federal_reserve_system",
+        provenance="peer_reviewed",
+        document_type="statement",
+        title_prefix="Federal Reserve System",
+    )
+
+
+def _iter_gtfintechlab_cross_bank_records() -> list[dict[str, Any]]:
+    """Load every cross-bank gtfintechlab dataset into the cross-bank generalization pool.
+
+    Rows carry ``provenance="peer_reviewed_cross_bank"`` (weight 0.0) so they
+    are visible in the source registry but excluded from the supervised
+    training loss. The cross-bank evaluation harness opts them in explicitly.
+    """
+    records: list[dict[str, Any]] = []
+    for bank_key, dataset_id, document_type in GTFINTECHLAB_CROSS_BANK_DATASETS:
+        bank_records = _iter_gtfintechlab_records(
+            dataset_id=dataset_id,
+            source_name=f"gtfintechlab_{bank_key}",
+            provenance="peer_reviewed_cross_bank",
+            document_type=document_type,
+            title_prefix=bank_key.replace("_", " ").title(),
+        )
+        records.extend(bank_records)
     return records
 
 
@@ -691,6 +756,7 @@ def main() -> int:
     include_op_fed = args.all_sources or args.include_op_fed
     include_gss_factors = args.all_sources or args.include_gss_factors
     include_gtfintechlab_fed = args.all_sources or args.include_gtfintechlab_fed
+    include_gtfintechlab_cross_bank = args.all_sources or args.include_gtfintechlab_cross_bank
     include_fomc_archive = args.all_sources or args.include_fomc_archive
     if not (
         include_hf
@@ -699,12 +765,14 @@ def main() -> int:
         or include_op_fed
         or include_gss_factors
         or include_gtfintechlab_fed
+        or include_gtfintechlab_cross_bank
         or include_fomc_archive
     ):
         print(
             "No source selected. Use --all-sources or one of "
             "--include-hf/--include-kaggle/--include-scraped/--include-op-fed/"
-            "--include-gss-factors/--include-gtfintechlab-fed/--include-fomc-archive."
+            "--include-gss-factors/--include-gtfintechlab-fed/"
+            "--include-gtfintechlab-cross-bank/--include-fomc-archive."
         )
         return 1
 
@@ -741,6 +809,17 @@ def main() -> int:
             f"(stance-labelled: {labelled}; multi-axis time+certainty in multi_axis_extras)"
         )
         unified.extend(gtfintechlab_records)
+    if include_gtfintechlab_cross_bank:
+        cross_bank_records = _iter_gtfintechlab_cross_bank_records()
+        labelled = sum(1 for r in cross_bank_records if r.get("label"))
+        per_bank: dict[str, int] = {}
+        for record in cross_bank_records:
+            per_bank[record.get("source", "")] = per_bank.get(record.get("source", ""), 0) + 1
+        print(
+            f"Ingested gtfintechlab cross-bank records: {len(cross_bank_records)} "
+            f"(stance-labelled: {labelled}; sample_weight=0; banks={per_bank})"
+        )
+        unified.extend(cross_bank_records)
     if include_fomc_archive:
         archive_records = _iter_fomc_archive_records()
         statement_count = sum(1 for r in archive_records if r.get("document_type") == "statement")

--- a/backend/app/data/ingest_sources.py
+++ b/backend/app/data/ingest_sources.py
@@ -20,6 +20,24 @@ HF_DATASET_ID = "gtfintechlab/fomc_communication"
 GTFINTECHLAB_FED_DATASET_ID = "gtfintechlab/federal_reserve_system"
 VTASCA_FOMC_ARCHIVE_DATASET_ID = "vtasca/fomc-statements-minutes"
 KAGGLE_DATASET_ID = "drlexus/fed-statements-and-minutes"
+
+# Pinned HF dataset revisions. record_id derives from
+# sha256(source:source_record_id:event_date); upstream revision drift would
+# otherwise rotate the entire hash chain. SHAs captured 2026-05-15.
+_DATASET_REVISIONS: dict[str, str] = {
+    "gtfintechlab/federal_reserve_system": "de0b1e8cb3a0fcfa601eec97d49d5c6f883804a1",
+    "gtfintechlab/european_central_bank": "867cee85784ce569826e0104797b6e017205867b",
+    "gtfintechlab/bank_of_japan": "1885e21cf1c33c4aea19a824ba40eac886c7a122",
+    "gtfintechlab/bank_of_england": "de1123cf9d747dbb3e0c2224467f501692d5a310",
+    "gtfintechlab/bank_of_canada": "ab15ea2271bfa3208874a5517afc439640fd9200",
+    "gtfintechlab/reserve_bank_of_australia": "7a91206b56f2841b2586e409feade2518284894b",
+    "vtasca/fomc-statements-minutes": "1d6c65eb96786ea921a29f4008c447f1cff5f7ff",
+}
+
+
+def _dataset_revision(dataset_id: str) -> str | None:
+    """Return the pinned revision SHA for a dataset id, or None if unpinned."""
+    return _DATASET_REVISIONS.get(dataset_id)
 OP_FED_DEFAULT_RELATIVE = Path("external") / "op_fed" / "opfed_v1.csv"
 GSS_FACTORS_DEFAULT_RELATIVE = Path("external") / "gss" / "gss_factors.csv"
 GSS_SURPRISES_DEFAULT_RELATIVE = Path("external") / "gss" / "gss_surprises.csv"
@@ -273,6 +291,11 @@ def _iter_gtfintechlab_records(
     time_label, certain_label, year``. This function walks every config /
     split combination, normalises stance, populates ``multi_axis_extras``
     with the time + certainty axes, and dedupes by ``text_hash``.
+
+    Reproducibility: pins the dataset revision from ``_DATASET_REVISIONS`` so
+    upstream HF pushes can't rotate row indices, and derives
+    ``source_record_id`` from the text hash (not the iterator's positional
+    index) so insertions/deletions in the dataset do not change ``record_id``.
     """
     try:
         from datasets import (  # type: ignore
@@ -286,15 +309,16 @@ def _iter_gtfintechlab_records(
             "Install dependencies first."
         ) from exc
 
+    revision = _dataset_revision(dataset_id)
     records: list[dict[str, Any]] = []
     seen_hashes: set[str] = set()
 
-    configs = list(get_dataset_config_names(dataset_id))
+    configs = list(get_dataset_config_names(dataset_id, revision=revision))
     for config in configs:
-        splits = list(get_dataset_split_names(dataset_id, config))
+        splits = list(get_dataset_split_names(dataset_id, config, revision=revision))
         for split in splits:
-            ds = load_dataset(dataset_id, config, split=split)
-            for idx, row in enumerate(ds):
+            ds = load_dataset(dataset_id, config, split=split, revision=revision)
+            for row in ds:
                 item = dict(row)
                 sentence = (item.get("sentences") or "").strip()
                 if not sentence:
@@ -311,12 +335,17 @@ def _iter_gtfintechlab_records(
                 if not event_date:
                     continue
 
+                normalized_text = _normalize_text(sentence)
+                content_hash = _text_hash(normalized_text)
+                if content_hash in seen_hashes:
+                    continue
+
                 built = _build_registry_record(
                     source=source_name,
-                    source_record_id=f"{config}:{split}:{idx}",
+                    source_record_id=content_hash[:16],
                     event_date=event_date,
                     document_type=document_type,
-                    title=f"{title_prefix} sentence {config}/{split}#{idx}",
+                    title=f"{title_prefix} sentence {content_hash[:8]}",
                     text=sentence,
                     label=label,
                     license_scope=license_scope,
@@ -324,15 +353,14 @@ def _iter_gtfintechlab_records(
                 )
                 if built is None:
                     continue
-                if built["text_hash"] in seen_hashes:
-                    continue
-                seen_hashes.add(built["text_hash"])
+                seen_hashes.add(content_hash)
                 built["provenance"] = provenance
                 extras = {
                     "gtfintechlab_time_label": (item.get("time_label") or "").strip(),
                     "gtfintechlab_certain_label": (item.get("certain_label") or "").strip(),
                     "gtfintechlab_config": str(config),
                     "gtfintechlab_split": str(split),
+                    "gtfintechlab_dataset_revision": revision or "",
                 }
                 built["multi_axis_extras"] = {k: v for k, v in extras.items() if v}
                 records.append(built)
@@ -385,6 +413,10 @@ def _iter_fomc_archive_records() -> list[dict[str, Any]]:
     four meetings) and supplement the continued-pretraining substrate. Routed
     through ``provenance="scraped"`` so they receive ``sample_weight=0`` and
     do not enter the supervised training pool.
+
+    Reproducibility: pins the dataset revision and discriminates the
+    ``source_record_id`` with the text hash so corrected-release variants
+    (same date + document_type but different text) do not collide.
     """
     try:
         from datasets import load_dataset  # type: ignore
@@ -393,11 +425,12 @@ def _iter_fomc_archive_records() -> list[dict[str, Any]]:
             "datasets package is required for --include-fomc-archive. Install dependencies first."
         ) from exc
 
-    ds = load_dataset(VTASCA_FOMC_ARCHIVE_DATASET_ID, split="train")
+    revision = _dataset_revision(VTASCA_FOMC_ARCHIVE_DATASET_ID)
+    ds = load_dataset(VTASCA_FOMC_ARCHIVE_DATASET_ID, split="train", revision=revision)
     records: list[dict[str, Any]] = []
     seen_hashes: set[str] = set()
 
-    for idx, row in enumerate(ds):
+    for row in ds:
         item = dict(row)
         raw_type = (item.get("Type") or "").strip().lower()
         document_type = _FOMC_ARCHIVE_TYPE_MAP.get(raw_type, "")
@@ -411,9 +444,14 @@ def _iter_fomc_archive_records() -> list[dict[str, Any]]:
             continue
         release_date = _coerce_event_date(item, ("Release Date",))
 
+        normalized_text = _normalize_text(text)
+        content_hash = _text_hash(normalized_text)
+        if content_hash in seen_hashes:
+            continue
+
         built = _build_registry_record(
             source="vtasca_fomc_archive",
-            source_record_id=f"{event_date}:{document_type}",
+            source_record_id=f"{event_date}:{document_type}:{content_hash[:8]}",
             event_date=event_date,
             document_type=document_type,
             title=f"FOMC {document_type} {event_date}",
@@ -424,12 +462,15 @@ def _iter_fomc_archive_records() -> list[dict[str, Any]]:
         )
         if built is None:
             continue
-        if built["text_hash"] in seen_hashes:
-            continue
-        seen_hashes.add(built["text_hash"])
+        seen_hashes.add(content_hash)
         built["provenance"] = "scraped"
+        extras: dict[str, str] = {}
         if release_date and release_date != event_date:
-            built["multi_axis_extras"] = {"release_date": release_date}
+            extras["release_date"] = release_date
+        if revision:
+            extras["vtasca_dataset_revision"] = revision
+        if extras:
+            built["multi_axis_extras"] = extras
         records.append(built)
     return records
 

--- a/backend/app/data/ingest_sources.py
+++ b/backend/app/data/ingest_sources.py
@@ -18,6 +18,7 @@ DEFAULT_OUTPUT_FILE = "source_registry.jsonl"
 
 HF_DATASET_ID = "gtfintechlab/fomc_communication"
 GTFINTECHLAB_FED_DATASET_ID = "gtfintechlab/federal_reserve_system"
+VTASCA_FOMC_ARCHIVE_DATASET_ID = "vtasca/fomc-statements-minutes"
 KAGGLE_DATASET_ID = "drlexus/fed-statements-and-minutes"
 OP_FED_DEFAULT_RELATIVE = Path("external") / "op_fed" / "opfed_v1.csv"
 GSS_FACTORS_DEFAULT_RELATIVE = Path("external") / "gss" / "gss_factors.csv"
@@ -82,6 +83,11 @@ def _parse_args() -> argparse.Namespace:
         "--include-gtfintechlab-fed",
         action="store_true",
         help=f"Ingest {GTFINTECHLAB_FED_DATASET_ID}: 3,000 multi-axis FOMC sentence labels (stance + time + certainty).",
+    )
+    parser.add_argument(
+        "--include-fomc-archive",
+        action="store_true",
+        help=f"Ingest {VTASCA_FOMC_ARCHIVE_DATASET_ID}: full FOMC statement + minutes archive (unlabelled, for credibility drift).",
     )
     parser.add_argument(
         "--all-sources",
@@ -296,6 +302,70 @@ def _iter_gtfintechlab_federal_reserve_records() -> list[dict[str, Any]]:
                 }
                 built["multi_axis_extras"] = {k: v for k, v in extras.items() if v}
                 records.append(built)
+    return records
+
+
+_FOMC_ARCHIVE_TYPE_MAP = {
+    "statement": "statement",
+    "minutes": "minutes",
+    "minute": "minutes",
+}
+
+
+def _iter_fomc_archive_records() -> list[dict[str, Any]]:
+    """Load vtasca/fomc-statements-minutes: 463 whole-document FOMC texts.
+
+    Schema per row: ``Date, Release Date, Type, Text``. Rows are *unlabelled*
+    — they feed the credibility module (drift of one statement vs the prior
+    four meetings) and supplement the continued-pretraining substrate. Routed
+    through ``provenance="scraped"`` so they receive ``sample_weight=0`` and
+    do not enter the supervised training pool.
+    """
+    try:
+        from datasets import load_dataset  # type: ignore
+    except Exception as exc:  # pragma: no cover
+        raise RuntimeError(
+            "datasets package is required for --include-fomc-archive. Install dependencies first."
+        ) from exc
+
+    ds = load_dataset(VTASCA_FOMC_ARCHIVE_DATASET_ID, split="train")
+    records: list[dict[str, Any]] = []
+    seen_hashes: set[str] = set()
+
+    for idx, row in enumerate(ds):
+        item = dict(row)
+        raw_type = (item.get("Type") or "").strip().lower()
+        document_type = _FOMC_ARCHIVE_TYPE_MAP.get(raw_type, "")
+        if not document_type:
+            continue
+        event_date = _coerce_event_date(item, ("Date", "Release Date"))
+        if not event_date:
+            continue
+        text = (item.get("Text") or "").strip()
+        if not text:
+            continue
+        release_date = _coerce_event_date(item, ("Release Date",))
+
+        built = _build_registry_record(
+            source="vtasca_fomc_archive",
+            source_record_id=f"{event_date}:{document_type}",
+            event_date=event_date,
+            document_type=document_type,
+            title=f"FOMC {document_type} {event_date}",
+            text=text,
+            label="",
+            license_scope="public_source_scrape_terms_required",
+            citation_ref="vtasca_2024_fomc_statements_minutes",
+        )
+        if built is None:
+            continue
+        if built["text_hash"] in seen_hashes:
+            continue
+        seen_hashes.add(built["text_hash"])
+        built["provenance"] = "scraped"
+        if release_date and release_date != event_date:
+            built["multi_axis_extras"] = {"release_date": release_date}
+        records.append(built)
     return records
 
 
@@ -621,6 +691,7 @@ def main() -> int:
     include_op_fed = args.all_sources or args.include_op_fed
     include_gss_factors = args.all_sources or args.include_gss_factors
     include_gtfintechlab_fed = args.all_sources or args.include_gtfintechlab_fed
+    include_fomc_archive = args.all_sources or args.include_fomc_archive
     if not (
         include_hf
         or include_kaggle
@@ -628,11 +699,12 @@ def main() -> int:
         or include_op_fed
         or include_gss_factors
         or include_gtfintechlab_fed
+        or include_fomc_archive
     ):
         print(
             "No source selected. Use --all-sources or one of "
             "--include-hf/--include-kaggle/--include-scraped/--include-op-fed/"
-            "--include-gss-factors/--include-gtfintechlab-fed."
+            "--include-gss-factors/--include-gtfintechlab-fed/--include-fomc-archive."
         )
         return 1
 
@@ -669,6 +741,15 @@ def main() -> int:
             f"(stance-labelled: {labelled}; multi-axis time+certainty in multi_axis_extras)"
         )
         unified.extend(gtfintechlab_records)
+    if include_fomc_archive:
+        archive_records = _iter_fomc_archive_records()
+        statement_count = sum(1 for r in archive_records if r.get("document_type") == "statement")
+        minutes_count = sum(1 for r in archive_records if r.get("document_type") == "minutes")
+        print(
+            f"Ingested vtasca/fomc-statements-minutes records: {len(archive_records)} "
+            f"(statements: {statement_count}, minutes: {minutes_count}; unlabelled, credibility-only)"
+        )
+        unified.extend(archive_records)
 
     unified.sort(key=lambda row: (row.get("event_date", ""), row.get("source", ""), row.get("source_record_id", "")))
     _write_jsonl(output_path, unified)

--- a/backend/app/data/ingest_sources.py
+++ b/backend/app/data/ingest_sources.py
@@ -17,6 +17,7 @@ DEFAULT_OUTPUT_DIR = DEFAULT_DATA_DIR / "raw" / "phase2"
 DEFAULT_OUTPUT_FILE = "source_registry.jsonl"
 
 HF_DATASET_ID = "gtfintechlab/fomc_communication"
+GTFINTECHLAB_FED_DATASET_ID = "gtfintechlab/federal_reserve_system"
 KAGGLE_DATASET_ID = "drlexus/fed-statements-and-minutes"
 OP_FED_DEFAULT_RELATIVE = Path("external") / "op_fed" / "opfed_v1.csv"
 GSS_FACTORS_DEFAULT_RELATIVE = Path("external") / "gss" / "gss_factors.csv"
@@ -76,6 +77,11 @@ def _parse_args() -> argparse.Namespace:
         "--include-gss-factors",
         action="store_true",
         help="Ingest GSS (Gürkaynak-Sack-Swanson 2005 IJCB) per-FOMC target/path factor decomposition and 30min/1hr/1day surprise windows.",
+    )
+    parser.add_argument(
+        "--include-gtfintechlab-fed",
+        action="store_true",
+        help=f"Ingest {GTFINTECHLAB_FED_DATASET_ID}: 3,000 multi-axis FOMC sentence labels (stance + time + certainty).",
     )
     parser.add_argument(
         "--all-sources",
@@ -212,6 +218,85 @@ _OP_FED_STANCE_MAP = {
     "contradiction": "dovish",
     "neutral": "neutral",
 }
+
+_GTFINTECHLAB_STANCE_MAP = {
+    "hawkish": "hawkish",
+    "dovish": "dovish",
+    "neutral": "neutral",
+}
+
+
+def _iter_gtfintechlab_federal_reserve_records() -> list[dict[str, Any]]:
+    """Load gtfintechlab/federal_reserve_system: 3,000 multi-axis FOMC sentence labels.
+
+    Schema per row: ``sentences, stance_label, time_label, certain_label, year``.
+    Stance maps to canonical hawkish/dovish/neutral. The time + certain axes
+    populate ``multi_axis_extras`` for downstream multi-task heads. Iterates
+    every config / split combination on the Hub repo and dedupes by text_hash.
+    """
+    try:
+        from datasets import (  # type: ignore
+            get_dataset_config_names,
+            get_dataset_split_names,
+            load_dataset,
+        )
+    except Exception as exc:  # pragma: no cover
+        raise RuntimeError(
+            "datasets package is required for --include-gtfintechlab-fed. "
+            "Install dependencies first."
+        ) from exc
+
+    records: list[dict[str, Any]] = []
+    seen_hashes: set[str] = set()
+
+    configs = list(get_dataset_config_names(GTFINTECHLAB_FED_DATASET_ID))
+    for config in configs:
+        splits = list(get_dataset_split_names(GTFINTECHLAB_FED_DATASET_ID, config))
+        for split in splits:
+            ds = load_dataset(GTFINTECHLAB_FED_DATASET_ID, config, split=split)
+            for idx, row in enumerate(ds):
+                item = dict(row)
+                sentence = (item.get("sentences") or "").strip()
+                if not sentence:
+                    continue
+                stance_raw = (item.get("stance_label") or "").strip().lower()
+                label = _GTFINTECHLAB_STANCE_MAP.get(stance_raw, "")
+                year_value = item.get("year")
+                try:
+                    event_date = (
+                        f"{int(year_value):04d}-01-01" if year_value not in (None, "") else ""
+                    )
+                except (TypeError, ValueError):
+                    event_date = ""
+                if not event_date:
+                    continue
+
+                built = _build_registry_record(
+                    source="gtfintechlab_federal_reserve_system",
+                    source_record_id=f"{config}:{split}:{idx}",
+                    event_date=event_date,
+                    document_type="statement",
+                    title=f"Federal Reserve System sentence {config}/{split}#{idx}",
+                    text=sentence,
+                    label=label,
+                    license_scope="research_only",
+                    citation_ref="shah_etal_2024_gtfintechlab_central_banks",
+                )
+                if built is None:
+                    continue
+                if built["text_hash"] in seen_hashes:
+                    continue
+                seen_hashes.add(built["text_hash"])
+                built["provenance"] = "peer_reviewed"
+                extras = {
+                    "gtfintechlab_time_label": (item.get("time_label") or "").strip(),
+                    "gtfintechlab_certain_label": (item.get("certain_label") or "").strip(),
+                    "gtfintechlab_config": str(config),
+                    "gtfintechlab_split": str(split),
+                }
+                built["multi_axis_extras"] = {k: v for k, v in extras.items() if v}
+                records.append(built)
+    return records
 
 
 def _iter_op_fed_records(csv_path: Path) -> list[dict[str, Any]]:
@@ -535,10 +620,19 @@ def main() -> int:
     include_scraped = args.all_sources or args.include_scraped
     include_op_fed = args.all_sources or args.include_op_fed
     include_gss_factors = args.all_sources or args.include_gss_factors
-    if not (include_hf or include_kaggle or include_scraped or include_op_fed or include_gss_factors):
+    include_gtfintechlab_fed = args.all_sources or args.include_gtfintechlab_fed
+    if not (
+        include_hf
+        or include_kaggle
+        or include_scraped
+        or include_op_fed
+        or include_gss_factors
+        or include_gtfintechlab_fed
+    ):
         print(
             "No source selected. Use --all-sources or one of "
-            "--include-hf/--include-kaggle/--include-scraped/--include-op-fed/--include-gss-factors."
+            "--include-hf/--include-kaggle/--include-scraped/--include-op-fed/"
+            "--include-gss-factors/--include-gtfintechlab-fed."
         )
         return 1
 
@@ -567,6 +661,14 @@ def main() -> int:
         )
         print(f"Ingested GSS factor records: {len(gss_records)} (per-FOMC target/path factors; factor axis only)")
         unified.extend(gss_records)
+    if include_gtfintechlab_fed:
+        gtfintechlab_records = _iter_gtfintechlab_federal_reserve_records()
+        labelled = sum(1 for r in gtfintechlab_records if r.get("label"))
+        print(
+            f"Ingested gtfintechlab/federal_reserve_system records: {len(gtfintechlab_records)} "
+            f"(stance-labelled: {labelled}; multi-axis time+certainty in multi_axis_extras)"
+        )
+        unified.extend(gtfintechlab_records)
 
     unified.sort(key=lambda row: (row.get("event_date", ""), row.get("source", ""), row.get("source_record_id", "")))
     _write_jsonl(output_path, unified)

--- a/backend/app/data/normalize_labels.py
+++ b/backend/app/data/normalize_labels.py
@@ -141,7 +141,7 @@ _KAGGLE_SOURCES = {"kaggle_fed_statements_minutes"}
 
 def _provenance_for_row(row: dict[str, Any]) -> str:
     explicit = str(row.get("provenance") or "").strip().lower()
-    if explicit in {"peer_reviewed", "kaggle", "scraped"}:
+    if explicit in {"peer_reviewed", "kaggle", "peer_reviewed_cross_bank", "scraped"}:
         return explicit
     source = str(row.get("source") or "").strip().lower()
     if source in _PEER_REVIEWED_SOURCES:

--- a/backend/app/data/normalize_labels.py
+++ b/backend/app/data/normalize_labels.py
@@ -134,6 +134,7 @@ _PEER_REVIEWED_SOURCES = {
     "aruoba_drechsel_shocks",
     "cieslak_schrimpf_news",
     "hansen_mcmahon_topics",
+    "gtfintechlab_federal_reserve_system",
 }
 _KAGGLE_SOURCES = {"kaggle_fed_statements_minutes"}
 

--- a/backend/app/services/fred_client.py
+++ b/backend/app/services/fred_client.py
@@ -1,0 +1,192 @@
+"""FRED time-series client for the credibility module.
+
+Pulls per-series observations from the St. Louis Fed FRED REST API, caches
+them as JSON under ``data/external/fred/<series_id>.json`` plus a
+``SOURCES.lock`` entry recording the SHA-256 + retrieval timestamp.
+Reproducibility: callers pin which observation_revision (FRED's vintage
+mechanism) they're reading via the ``realtime_start`` / ``realtime_end``
+fields on the response. First retrieval records the SHA in SOURCES.lock;
+subsequent retrievals reuse the cache unless ``force_refresh=True``.
+
+Series most relevant to the credibility module:
+- ``DFF``    Federal funds effective rate (daily).
+- ``DGS10``  10-year Treasury constant maturity (daily).
+- ``GS3M``   3-month Treasury constant maturity (monthly avg).
+- ``CPIAUCSL`` CPI all-urban consumers seasonally-adjusted (monthly).
+- ``UNRATE`` Civilian unemployment rate (monthly).
+
+Set ``FRED_API_KEY`` in the environment. Get a free key at
+https://fred.stlouisfed.org/docs/api/api_key.html (10k requests/day).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from app.config import DATA_DIR
+
+FRED_BASE_URL = "https://api.stlouisfed.org/fred/series/observations"
+DEFAULT_CACHE_DIR = DATA_DIR / "external" / "fred"
+SOURCES_LOCK_NAME = "SOURCES.lock"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class FredObservation:
+    date: str
+    value: float | None
+    realtime_start: str
+    realtime_end: str
+
+
+@dataclass(frozen=True)
+class FredSeriesResponse:
+    series_id: str
+    realtime_start: str
+    realtime_end: str
+    observation_start: str
+    observation_end: str
+    count: int
+    observations: list[FredObservation] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "series_id": self.series_id,
+            "realtime_start": self.realtime_start,
+            "realtime_end": self.realtime_end,
+            "observation_start": self.observation_start,
+            "observation_end": self.observation_end,
+            "count": self.count,
+            "observations": [asdict(obs) for obs in self.observations],
+        }
+
+
+def _resolve_api_key(api_key: str | None) -> str:
+    if api_key:
+        return api_key
+    env_value = os.environ.get("FRED_API_KEY") or os.environ.get("FRED_TOKEN")
+    if not env_value:
+        raise RuntimeError(
+            "FRED_API_KEY (or FRED_TOKEN) not set. Get a free key at "
+            "https://fred.stlouisfed.org/docs/api/api_key.html."
+        )
+    return env_value
+
+
+def _cache_paths(series_id: str, cache_dir: Path) -> tuple[Path, Path]:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / f"{series_id}.json", cache_dir / SOURCES_LOCK_NAME
+
+
+def _sha256_of_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _read_lock(lock_path: Path) -> dict[str, Any]:
+    if not lock_path.exists():
+        return {}
+    try:
+        return json.loads(lock_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+
+
+def _write_lock(lock_path: Path, payload: dict[str, Any]) -> None:
+    lock_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _parse_observation_value(raw: Any) -> float | None:
+    """FRED encodes missing values as the literal string '.'."""
+    if raw is None or raw == "" or raw == ".":
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_observations(payload: dict[str, Any], series_id: str) -> FredSeriesResponse:
+    obs = []
+    for row in payload.get("observations", []) or []:
+        obs.append(
+            FredObservation(
+                date=str(row.get("date") or ""),
+                value=_parse_observation_value(row.get("value")),
+                realtime_start=str(row.get("realtime_start") or ""),
+                realtime_end=str(row.get("realtime_end") or ""),
+            )
+        )
+    return FredSeriesResponse(
+        series_id=series_id,
+        realtime_start=str(payload.get("realtime_start") or ""),
+        realtime_end=str(payload.get("realtime_end") or ""),
+        observation_start=str(payload.get("observation_start") or ""),
+        observation_end=str(payload.get("observation_end") or ""),
+        count=int(payload.get("count") or len(obs)),
+        observations=obs,
+    )
+
+
+def fetch_fred_series(
+    series_id: str,
+    *,
+    start: str | None = None,
+    end: str | None = None,
+    api_key: str | None = None,
+    cache_dir: Path | None = None,
+    force_refresh: bool = False,
+    transport: httpx.BaseTransport | None = None,
+) -> FredSeriesResponse:
+    """Fetch a FRED series. Returns cached payload when present unless ``force_refresh=True``.
+
+    The ``transport`` parameter is injected by tests with ``httpx.MockTransport``.
+    Production callers leave it ``None`` so httpx uses the default transport.
+    """
+    cache_dir = cache_dir or DEFAULT_CACHE_DIR
+    cache_path, lock_path = _cache_paths(series_id, cache_dir)
+
+    if cache_path.exists() and not force_refresh:
+        payload = json.loads(cache_path.read_text(encoding="utf-8"))
+        return _parse_observations(payload, series_id)
+
+    resolved_key = _resolve_api_key(api_key)
+    params: dict[str, str] = {
+        "series_id": series_id,
+        "api_key": resolved_key,
+        "file_type": "json",
+    }
+    if start:
+        params["observation_start"] = start
+    if end:
+        params["observation_end"] = end
+
+    client = httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS, transport=transport)
+    try:
+        resp = client.get(FRED_BASE_URL, params=params)
+        resp.raise_for_status()
+        payload = resp.json()
+    finally:
+        client.close()
+
+    cache_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    lock = _read_lock(lock_path)
+    lock[series_id] = {
+        "sha256": _sha256_of_file(cache_path),
+        "observation_start": str(payload.get("observation_start") or ""),
+        "observation_end": str(payload.get("observation_end") or ""),
+        "count": int(payload.get("count") or 0),
+        "retrieved_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    _write_lock(lock_path, lock)
+
+    return _parse_observations(payload, series_id)

--- a/data/schema/labels.yaml
+++ b/data/schema/labels.yaml
@@ -46,4 +46,5 @@ provenance:
   sample_weights:
     peer_reviewed: 1.0
     kaggle: 0.7
+    peer_reviewed_cross_bank: 0.0  # ECB/BoJ/BoE/BoC/RBA labels held out from FOMC training; used for cross-CB generalization eval only.
     scraped: 0.0

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -4,9 +4,28 @@
 Define a single contract from ingestion to training package export.
 
 ## Approved Sources
-- `hf_fomc_communication` (research-only, citation required)
-- `kaggle_fed_statements_minutes` (license/terms apply)
-- `scraped_fed` (internal scraper output; covers FOMC minutes/statements and Chair speeches as of Plan 2 of the 2026-05-05 scope extension)
+
+### Supervised training pool (provenance ∈ {peer_reviewed, kaggle, scraped})
+- `hf_fomc_communication` (research-only, citation required) — Trillion Dollar Words sentence-level stance labels.
+- `kaggle_fed_statements_minutes` (license/terms apply) — Kaggle FOMC statement/minutes mirror.
+- `scraped_fed` (internal scraper output; FOMC minutes/statements/Chair speeches/governor speeches/testimonies/press conferences/Beige Book/regional research).
+- `op_fed` (MIT, Keith et al. 2025) — FOMC meeting-transcript sentence-level stance + opinion + monetary-policy annotations.
+- `gss_factor` (research-only, Gürkaynak-Sack-Swanson 2005 IJCB) — per-FOMC target/path factor decomposition; populates the factor axis, no stance label.
+- `gtfintechlab_federal_reserve_system` (research-only, Shah et al. 2024 gtfintechlab) — FOMC sentence-level multi-axis labels (stance + time + certainty), 3,000 rows, complements TDW.
+
+### Cross-bank generalization pool (provenance = peer_reviewed_cross_bank, sample_weight = 0.0)
+These sources enter the unified registry but are excluded from the supervised training loss. They drive the cross-CB generalization evaluation harness.
+- `gtfintechlab_european_central_bank`
+- `gtfintechlab_bank_of_japan`
+- `gtfintechlab_bank_of_england`
+- `gtfintechlab_bank_of_canada`
+- `gtfintechlab_reserve_bank_of_australia`
+
+### Credibility-only pool (provenance = scraped, sample_weight = 0.0)
+Unlabelled corpora that feed the credibility module (drift, realized-vs-stated gap) and serve as auxiliary continued-pretraining substrate. Not in the supervised training pool.
+- `vtasca_fomc_archive` (vtasca/fomc-statements-minutes) — 463 whole-document FOMC statements + minutes.
+
+When adding a new source, append it here AND to `_PEER_REVIEWED_SOURCES` / `_KAGGLE_SOURCES` in `backend/app/data/normalize_labels.py`. HF-hosted datasets must additionally appear in `_DATASET_REVISIONS` in `backend/app/data/ingest_sources.py` with a pinned commit SHA so `record_id` does not rotate on upstream pushes.
 
 ## Ingestion Contract
 Each row must contain:

--- a/tests/unit/test_continued_pretraining.py
+++ b/tests/unit/test_continued_pretraining.py
@@ -119,7 +119,16 @@ def test_collect_pairs_substrate_bis_uses_streaming(monkeypatch) -> None:
     assert pairs[0]["sequenceA"] == "BIS A1"
 
 
-def test_collect_pairs_substrate_both_respects_max_rows(monkeypatch, tmp_path: Path) -> None:
+def test_collect_pairs_substrate_both_loads_local_first_then_bis_remainder(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Regression: --substrate both must give local representation under --max-rows.
+
+    Previous behaviour ran BIS first (which always fills the cap given its size),
+    silently emptying the local slice — making --substrate both --max-rows N
+    indistinguishable from --substrate bis. Local now loads first; BIS fills the
+    remaining capacity.
+    """
     _install_fake_datasets(
         monkeypatch,
         [
@@ -145,8 +154,56 @@ def test_collect_pairs_substrate_both_respects_max_rows(monkeypatch, tmp_path: P
     )
     pairs = cpt._collect_pairs(args)
     assert len(pairs) == 3
-    assert pairs[0]["sequenceA"].startswith("BIS")
-    assert pairs[2]["sequenceA"].startswith("Local")
+    # Local (2 pairs) loads first; BIS contributes the remaining 1.
+    assert pairs[0]["sequenceA"] == "Local 1."
+    assert pairs[1]["sequenceA"] == "Local 2."
+    assert pairs[2]["sequenceA"] == "BIS A1"
+
+
+def test_collect_pairs_substrate_both_warns_when_local_exhausts_cap(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Regression: when --max-rows is small enough that local fills it, BIS gets
+    dropped — surface this with a warning so the user knows BIS substrate is absent."""
+    import warnings as _warnings
+
+    _install_fake_datasets(
+        monkeypatch,
+        [
+            {"sequenceA": "BIS A1", "sequenceB": "BIS B1", "next_sentence_label": 0},
+        ],
+    )
+    (tmp_path / "chair_speeches.json").write_text(
+        json.dumps([{"text": "Local 1."}, {"text": "Local 2."}, {"text": "Local 3."}]),
+        encoding="utf-8",
+    )
+    args = cpt._parse_args(
+        [
+            "--substrate",
+            "both",
+            "--data-dir",
+            str(tmp_path),
+            "--corpus-files",
+            "chair_speeches.json",
+            "--max-rows",
+            "2",
+        ]
+    )
+    with _warnings.catch_warnings(record=True) as captured:
+        _warnings.simplefilter("always")
+        pairs = cpt._collect_pairs(args)
+
+    # Local got 3 pairs (no cap on local under --substrate both unless local-only),
+    # exceeding --max-rows; BIS substrate dropped + warning surfaced.
+    assert len(pairs) == 3
+    assert all(p["sequenceA"].startswith("Local") for p in pairs)
+    bis_drop_warnings = [w for w in captured if "BIS substrate" in str(w.message)]
+    assert bis_drop_warnings, "expected a warning when BIS substrate dropped"
+
+
+def test_resolve_dataset_sha_returns_requested_when_supplied() -> None:
+    """When the user pins --bis-dataset-revision, that value passes through verbatim."""
+    assert cpt._resolve_dataset_sha("samchain/BIS_speeches_97_23_MLM", "deadbeef") == "deadbeef"
 
 
 def test_parse_args_objective_validates_choices() -> None:

--- a/tests/unit/test_continued_pretraining.py
+++ b/tests/unit/test_continued_pretraining.py
@@ -1,0 +1,156 @@
+"""Smoke tests for the CPU-side of continued_pretraining.
+
+The actual MLM training run is GPU-bound and exercised via `make`-driven
+smoke runs, not pytest. These tests cover the pair-collection paths that
+shape data before it hits the model.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from app.data import continued_pretraining as cpt
+
+
+def test_iter_local_pairs_skips_missing_and_empty(tmp_path: Path) -> None:
+    (tmp_path / "speeches.json").write_text(
+        json.dumps(
+            [
+                {"text": "Inflation pressures remain elevated."},
+                {"body": "Activity has expanded at a moderate pace."},
+                {"text": "   "},  # empty after strip → dropped
+                {"unrelated": "no text"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    pairs = cpt._iter_local_pairs(tmp_path, ["speeches.json", "missing.json"])
+    assert len(pairs) == 2
+    assert {p["sequenceA"] for p in pairs} == {
+        "Inflation pressures remain elevated.",
+        "Activity has expanded at a moderate pace.",
+    }
+    assert all(p["sequenceB"] == "" for p in pairs)
+    assert all(p["next_sentence_label"] == 0 for p in pairs)
+
+
+def test_iter_local_pairs_skips_non_list_payload(tmp_path: Path) -> None:
+    (tmp_path / "wrong.json").write_text(json.dumps({"text": "not a list"}), encoding="utf-8")
+    pairs = cpt._iter_local_pairs(tmp_path, ["wrong.json"])
+    assert pairs == []
+
+
+def _install_fake_datasets(monkeypatch, rows: list[dict]) -> None:
+    fake = types.SimpleNamespace()
+    fake.load_dataset = lambda dataset_id, **kw: iter(rows)
+    monkeypatch.setitem(sys.modules, "datasets", fake)
+
+
+def test_bis_pair_stream_filters_empty_and_respects_max_rows(monkeypatch) -> None:
+    _install_fake_datasets(
+        monkeypatch,
+        [
+            {"sequenceA": "A1", "sequenceB": "B1", "next_sentence_label": 0},
+            {"sequenceA": "", "sequenceB": "B2", "next_sentence_label": 0},  # empty A → dropped
+            {"sequenceA": "A3", "sequenceB": "B3", "next_sentence_label": 1},
+            {"sequenceA": "A4", "sequenceB": None, "next_sentence_label": 0},
+            {"sequenceA": "A5", "sequenceB": "B5", "next_sentence_label": 1},
+        ],
+    )
+    rows = list(
+        cpt._bis_pair_stream(
+            "samchain/BIS_speeches_97_23_MLM",
+            None,
+            streaming=False,
+            max_rows=3,
+        )
+    )
+    assert len(rows) == 3
+    assert [r["sequenceA"] for r in rows] == ["A1", "A3", "A4"]
+    assert rows[1]["next_sentence_label"] == 1
+    assert rows[2]["sequenceB"] == ""
+
+
+def test_collect_pairs_substrate_local(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / "chair_speeches.json").write_text(
+        json.dumps([{"text": "Local speech text."}]),
+        encoding="utf-8",
+    )
+    args = cpt._parse_args(
+        [
+            "--substrate",
+            "local",
+            "--data-dir",
+            str(tmp_path),
+            "--corpus-files",
+            "chair_speeches.json",
+        ]
+    )
+    pairs = cpt._collect_pairs(args)
+    assert pairs == [
+        {"sequenceA": "Local speech text.", "sequenceB": "", "next_sentence_label": 0}
+    ]
+
+
+def test_collect_pairs_substrate_bis_uses_streaming(monkeypatch) -> None:
+    _install_fake_datasets(
+        monkeypatch,
+        [
+            {"sequenceA": "BIS A1", "sequenceB": "BIS B1", "next_sentence_label": 0},
+            {"sequenceA": "BIS A2", "sequenceB": "BIS B2", "next_sentence_label": 1},
+        ],
+    )
+    args = cpt._parse_args(
+        [
+            "--substrate",
+            "bis",
+            "--streaming",
+            "--max-rows",
+            "10",
+        ]
+    )
+    pairs = cpt._collect_pairs(args)
+    assert len(pairs) == 2
+    assert pairs[0]["sequenceA"] == "BIS A1"
+
+
+def test_collect_pairs_substrate_both_respects_max_rows(monkeypatch, tmp_path: Path) -> None:
+    _install_fake_datasets(
+        monkeypatch,
+        [
+            {"sequenceA": "BIS A1", "sequenceB": "BIS B1", "next_sentence_label": 0},
+            {"sequenceA": "BIS A2", "sequenceB": "BIS B2", "next_sentence_label": 0},
+        ],
+    )
+    (tmp_path / "chair_speeches.json").write_text(
+        json.dumps([{"text": "Local 1."}, {"text": "Local 2."}]),
+        encoding="utf-8",
+    )
+    args = cpt._parse_args(
+        [
+            "--substrate",
+            "both",
+            "--data-dir",
+            str(tmp_path),
+            "--corpus-files",
+            "chair_speeches.json",
+            "--max-rows",
+            "3",
+        ]
+    )
+    pairs = cpt._collect_pairs(args)
+    assert len(pairs) == 3
+    assert pairs[0]["sequenceA"].startswith("BIS")
+    assert pairs[2]["sequenceA"].startswith("Local")
+
+
+def test_parse_args_objective_validates_choices() -> None:
+    args = cpt._parse_args(["--objective", "mlm"])
+    assert args.objective == "mlm"
+    with pytest.raises(SystemExit):
+        cpt._parse_args(["--objective", "nonsense"])

--- a/tests/unit/test_external_corpora_ingestion.py
+++ b/tests/unit/test_external_corpora_ingestion.py
@@ -9,8 +9,10 @@ from pathlib import Path
 import pytest
 
 from app.data.ingest_sources import (
+    _GTFINTECHLAB_STANCE_MAP,
     _OP_FED_STANCE_MAP,
     _iter_gss_factors_records,
+    _iter_gtfintechlab_federal_reserve_records,
     _iter_op_fed_records,
 )
 
@@ -287,3 +289,106 @@ def test_extract_gss_factors_parses_appendix_text() -> None:
     sep_01 = next(r for r in surprise_rows if r["meeting_date"] == "2001-09-17")
     assert sep_01["surprise_30min_bp"] is None
     assert sep_01["surprise_1day_bp"] is None
+
+
+def _install_fake_datasets(monkeypatch, payload: dict[tuple[str, str], list[dict]]) -> None:
+    """Inject a fake `datasets` module so the loader can run without hitting HF."""
+    import sys
+    import types
+
+    fake = types.SimpleNamespace()
+    fake.get_dataset_config_names = lambda dataset: sorted({k[0] for k in payload})
+    fake.get_dataset_split_names = lambda dataset, config: sorted(
+        k[1] for k in payload if k[0] == config
+    )
+    fake.load_dataset = lambda dataset, config, split=None: payload[(config, split)]
+    monkeypatch.setitem(sys.modules, "datasets", fake)
+
+
+def test_gtfintechlab_stance_map_covers_canonical_classes() -> None:
+    assert set(_GTFINTECHLAB_STANCE_MAP) == {"hawkish", "dovish", "neutral"}
+    assert _GTFINTECHLAB_STANCE_MAP["hawkish"] == "hawkish"
+    assert _GTFINTECHLAB_STANCE_MAP["dovish"] == "dovish"
+    assert _GTFINTECHLAB_STANCE_MAP["neutral"] == "neutral"
+
+
+def test_iter_gtfintechlab_federal_reserve_records_maps_multi_axis(monkeypatch) -> None:
+    payload = {
+        ("5768", "train"): [
+            {
+                "sentences": "Inflation pressures remain elevated.",
+                "stance_label": "hawkish",
+                "time_label": "forward looking",
+                "certain_label": "certain",
+                "year": 2022,
+            },
+            {
+                "sentences": "The Committee maintained accommodative policy.",
+                "stance_label": "dovish",
+                "time_label": "not forward looking",
+                "certain_label": "uncertain",
+                "year": 2021,
+            },
+            {
+                "sentences": "Activity has expanded at a moderate pace.",
+                "stance_label": "neutral",
+                "time_label": "not forward looking",
+                "certain_label": "certain",
+                "year": 2014,
+            },
+        ],
+        ("5768", "test"): [
+            {
+                "sentences": "",  # empty text — should be dropped
+                "stance_label": "hawkish",
+                "time_label": "forward looking",
+                "certain_label": "certain",
+                "year": 2020,
+            },
+            {
+                "sentences": "Inflation pressures remain elevated.",  # duplicate of train row
+                "stance_label": "hawkish",
+                "time_label": "forward looking",
+                "certain_label": "certain",
+                "year": 2022,
+            },
+        ],
+        ("78516", "train"): [
+            {
+                "sentences": "Risks to the outlook are roughly balanced.",
+                "stance_label": "NEUTRAL",  # case-insensitive
+                "time_label": "forward looking",
+                "certain_label": "certain",
+                "year": 2016,
+            },
+            {
+                "sentences": "Empty year row should drop.",
+                "stance_label": "hawkish",
+                "time_label": "forward looking",
+                "certain_label": "certain",
+                "year": None,
+            },
+        ],
+    }
+    _install_fake_datasets(monkeypatch, payload)
+
+    records = _iter_gtfintechlab_federal_reserve_records()
+
+    assert len(records) == 4  # empty-text, empty-year, and duplicate dropped
+    assert all(r["source"] == "gtfintechlab_federal_reserve_system" for r in records)
+    assert all(r["provenance"] == "peer_reviewed" for r in records)
+    assert all(r["license_scope"] == "research_only" for r in records)
+    assert {r["label"] for r in records} == {"hawkish", "dovish", "neutral"}
+
+    by_text = {r["text"]: r for r in records}
+    elevated = by_text["Inflation pressures remain elevated."]
+    assert elevated["event_date"] == "2022-01-01"
+    assert elevated["multi_axis_extras"]["gtfintechlab_time_label"] == "forward looking"
+    assert elevated["multi_axis_extras"]["gtfintechlab_certain_label"] == "certain"
+    assert elevated["multi_axis_extras"]["gtfintechlab_config"] == "5768"
+    # First-seen-wins dedup keeps the test-split copy (splits iterate alphabetically).
+    assert elevated["multi_axis_extras"]["gtfintechlab_split"] == "test"
+
+    balanced = by_text["Risks to the outlook are roughly balanced."]
+    assert balanced["label"] == "neutral"  # case-insensitive stance match
+    assert balanced["event_date"] == "2016-01-01"

--- a/tests/unit/test_external_corpora_ingestion.py
+++ b/tests/unit/test_external_corpora_ingestion.py
@@ -11,6 +11,7 @@ import pytest
 from app.data.ingest_sources import (
     _GTFINTECHLAB_STANCE_MAP,
     _OP_FED_STANCE_MAP,
+    _iter_fomc_archive_records,
     _iter_gss_factors_records,
     _iter_gtfintechlab_federal_reserve_records,
     _iter_op_fed_records,
@@ -292,7 +293,7 @@ def test_extract_gss_factors_parses_appendix_text() -> None:
 
 
 def _install_fake_datasets(monkeypatch, payload: dict[tuple[str, str], list[dict]]) -> None:
-    """Inject a fake `datasets` module so the loader can run without hitting HF."""
+    """Inject a fake `datasets` module wired for the multi-config gtfintechlab loader."""
     import sys
     import types
 
@@ -302,6 +303,16 @@ def _install_fake_datasets(monkeypatch, payload: dict[tuple[str, str], list[dict
         k[1] for k in payload if k[0] == config
     )
     fake.load_dataset = lambda dataset, config, split=None: payload[(config, split)]
+    monkeypatch.setitem(sys.modules, "datasets", fake)
+
+
+def _install_fake_datasets_module(monkeypatch, rows: list[dict]) -> None:
+    """Inject a fake `datasets` module wired for single-split iter-of-rows loaders (vtasca)."""
+    import sys
+    import types
+
+    fake = types.SimpleNamespace()
+    fake.load_dataset = lambda dataset_id, **kw: iter(rows)
     monkeypatch.setitem(sys.modules, "datasets", fake)
 
 
@@ -392,3 +403,85 @@ def test_iter_gtfintechlab_federal_reserve_records_maps_multi_axis(monkeypatch) 
     balanced = by_text["Risks to the outlook are roughly balanced."]
     assert balanced["label"] == "neutral"  # case-insensitive stance match
     assert balanced["event_date"] == "2016-01-01"
+
+
+def test_iter_fomc_archive_records_routes_statements_and_minutes(monkeypatch) -> None:
+    _install_fake_datasets_module(
+        monkeypatch,
+        [
+            {
+                "Date": "2024-09-18",
+                "Release Date": "2024-09-18",
+                "Type": "Statement",
+                "Text": "Recent indicators suggest economic activity has been expanding.",
+            },
+            {
+                "Date": "2024-09-18",
+                "Release Date": "2024-10-09",
+                "Type": "Minutes",
+                "Text": "The Committee discussed the staff outlook for inflation.",
+            },
+            {
+                "Date": "2024-11-07",
+                "Release Date": "2024-11-07",
+                "Type": "Statement",
+                "Text": "",  # empty text → dropped
+            },
+            {
+                "Date": "",  # missing Date falls back to Release Date.
+                "Release Date": "",
+                "Type": "Statement",
+                "Text": "No date at all — should drop.",
+            },
+            {
+                "Date": "2024-12-18",
+                "Release Date": "2024-12-18",
+                "Type": "Speech",  # unrecognised type → dropped
+                "Text": "Speech text.",
+            },
+        ],
+    )
+
+    records = _iter_fomc_archive_records()
+
+    assert len(records) == 2
+    assert all(r["source"] == "vtasca_fomc_archive" for r in records)
+    assert all(r["provenance"] == "scraped" for r in records)
+    assert all(r["license_scope"] == "public_source_scrape_terms_required" for r in records)
+    assert all(r["label"] == "" for r in records)
+    assert all(r["label_origin"] == "pseudo" for r in records)
+
+    by_type = {r["document_type"]: r for r in records}
+    assert by_type["statement"]["source_type"] == "fomc_statement"
+    assert by_type["minutes"]["source_type"] == "fomc_minutes"
+
+    minutes_row = by_type["minutes"]
+    # Minutes release on 2024-10-09 differs from event_date 2024-09-18 — flagged in extras.
+    assert minutes_row["multi_axis_extras"]["release_date"] == "2024-10-09"
+    statement_row = by_type["statement"]
+    # Statement release equals event date — no extras populated.
+    assert "multi_axis_extras" not in statement_row or not statement_row.get("multi_axis_extras")
+
+
+def test_iter_fomc_archive_records_dedupes_by_text_hash(monkeypatch) -> None:
+    _install_fake_datasets_module(
+        monkeypatch,
+        [
+            {
+                "Date": "2024-09-18",
+                "Release Date": "2024-09-18",
+                "Type": "Statement",
+                "Text": "Duplicate statement text.",
+            },
+            {
+                "Date": "2024-09-18",
+                "Release Date": "2024-09-18",
+                "Type": "Statement",
+                "Text": "Duplicate statement text.",
+            },
+        ],
+    )
+
+    records = _iter_fomc_archive_records()
+
+    assert len(records) == 1

--- a/tests/unit/test_external_corpora_ingestion.py
+++ b/tests/unit/test_external_corpora_ingestion.py
@@ -9,10 +9,12 @@ from pathlib import Path
 import pytest
 
 from app.data.ingest_sources import (
+    GTFINTECHLAB_CROSS_BANK_DATASETS,
     _GTFINTECHLAB_STANCE_MAP,
     _OP_FED_STANCE_MAP,
     _iter_fomc_archive_records,
     _iter_gss_factors_records,
+    _iter_gtfintechlab_cross_bank_records,
     _iter_gtfintechlab_federal_reserve_records,
     _iter_op_fed_records,
 )
@@ -403,6 +405,63 @@ def test_iter_gtfintechlab_federal_reserve_records_maps_multi_axis(monkeypatch) 
     balanced = by_text["Risks to the outlook are roughly balanced."]
     assert balanced["label"] == "neutral"  # case-insensitive stance match
     assert balanced["event_date"] == "2016-01-01"
+
+
+def test_gtfintechlab_cross_bank_dataset_list_covers_five_banks() -> None:
+    bank_keys = [item[0] for item in GTFINTECHLAB_CROSS_BANK_DATASETS]
+    assert bank_keys == [
+        "european_central_bank",
+        "bank_of_japan",
+        "bank_of_england",
+        "bank_of_canada",
+        "reserve_bank_of_australia",
+    ]
+    for bank_key, hf_id, _document_type in GTFINTECHLAB_CROSS_BANK_DATASETS:
+        assert hf_id.startswith("gtfintechlab/")
+        assert bank_key in hf_id.split("/", 1)[1]
+
+
+def test_iter_gtfintechlab_cross_bank_records_tags_provenance(monkeypatch) -> None:
+    # Same row schema as federal_reserve_system; the cross-bank loader
+    # iterates a fixed list of (bank, dataset_id) tuples so we mock all five
+    # by returning the same single-row payload regardless of dataset_id.
+    import sys
+    import types
+
+    fake = types.SimpleNamespace()
+    fake.get_dataset_config_names = lambda dataset: ["default"]
+    fake.get_dataset_split_names = lambda dataset, config: ["train"]
+
+    def _fake_load(dataset_id, config, split=None):
+        # Encode the dataset_id into the sentence so the dedupe doesn't collapse
+        # rows across banks.
+        return [
+            {
+                "sentences": f"{dataset_id} — Inflation pressures are easing.",
+                "stance_label": "dovish",
+                "time_label": "not forward looking",
+                "certain_label": "certain",
+                "year": 2024,
+            }
+        ]
+
+    fake.load_dataset = _fake_load
+    monkeypatch.setitem(sys.modules, "datasets", fake)
+
+    records = _iter_gtfintechlab_cross_bank_records()
+
+    assert len(records) == len(GTFINTECHLAB_CROSS_BANK_DATASETS) == 5
+    assert all(r["provenance"] == "peer_reviewed_cross_bank" for r in records)
+    sources = {r["source"] for r in records}
+    assert sources == {
+        "gtfintechlab_european_central_bank",
+        "gtfintechlab_bank_of_japan",
+        "gtfintechlab_bank_of_england",
+        "gtfintechlab_bank_of_canada",
+        "gtfintechlab_reserve_bank_of_australia",
+    }
+    assert all(r["label"] == "dovish" for r in records)
+    assert all(r["event_date"] == "2024-01-01" for r in records)
 
 
 def test_iter_fomc_archive_records_routes_statements_and_minutes(monkeypatch) -> None:

--- a/tests/unit/test_external_corpora_ingestion.py
+++ b/tests/unit/test_external_corpora_ingestion.py
@@ -8,10 +8,16 @@ from pathlib import Path
 
 import pytest
 
+from typing import Any
+
 from app.data.ingest_sources import (
     GTFINTECHLAB_CROSS_BANK_DATASETS,
+    GTFINTECHLAB_FED_DATASET_ID,
+    VTASCA_FOMC_ARCHIVE_DATASET_ID,
+    _DATASET_REVISIONS,
     _GTFINTECHLAB_STANCE_MAP,
     _OP_FED_STANCE_MAP,
+    _dataset_revision,
     _iter_fomc_archive_records,
     _iter_gss_factors_records,
     _iter_gtfintechlab_cross_bank_records,
@@ -300,12 +306,20 @@ def _install_fake_datasets(monkeypatch, payload: dict[tuple[str, str], list[dict
     import types
 
     fake = types.SimpleNamespace()
-    fake.get_dataset_config_names = lambda dataset: sorted({k[0] for k in payload})
-    fake.get_dataset_split_names = lambda dataset, config: sorted(
+    captured: dict[str, Any] = {"revisions": []}
+    fake.get_dataset_config_names = lambda dataset, revision=None: sorted({k[0] for k in payload})
+    fake.get_dataset_split_names = lambda dataset, config, revision=None: sorted(
         k[1] for k in payload if k[0] == config
     )
-    fake.load_dataset = lambda dataset, config, split=None: payload[(config, split)]
+
+    def _load(dataset, config, split=None, revision=None):
+        captured["revisions"].append(revision)
+        return payload[(config, split)]
+
+    fake.load_dataset = _load
+    fake._captured = captured
     monkeypatch.setitem(sys.modules, "datasets", fake)
+    return captured
 
 
 def _install_fake_datasets_module(monkeypatch, rows: list[dict]) -> None:
@@ -314,8 +328,16 @@ def _install_fake_datasets_module(monkeypatch, rows: list[dict]) -> None:
     import types
 
     fake = types.SimpleNamespace()
-    fake.load_dataset = lambda dataset_id, **kw: iter(rows)
+    captured: dict[str, Any] = {"revisions": []}
+
+    def _load(dataset_id, **kw):
+        captured["revisions"].append(kw.get("revision"))
+        return iter(rows)
+
+    fake.load_dataset = _load
+    fake._captured = captured
     monkeypatch.setitem(sys.modules, "datasets", fake)
+    return captured
 
 
 def test_gtfintechlab_stance_map_covers_canonical_classes() -> None:
@@ -407,6 +429,45 @@ def test_iter_gtfintechlab_federal_reserve_records_maps_multi_axis(monkeypatch) 
     assert balanced["event_date"] == "2016-01-01"
 
 
+def test_iter_gtfintechlab_federal_reserve_pins_revision_and_derives_source_record_id(
+    monkeypatch,
+) -> None:
+    """Regression: source_record_id must be content-derived (not positional idx),
+    and load_dataset must receive the pinned revision from _DATASET_REVISIONS."""
+    payload = {
+        ("5768", "train"): [
+            {
+                "sentences": "First sentence about inflation.",
+                "stance_label": "hawkish",
+                "time_label": "forward looking",
+                "certain_label": "certain",
+                "year": 2022,
+            },
+        ],
+        ("5768", "test"): [
+            {
+                "sentences": "Second sentence about employment.",
+                "stance_label": "dovish",
+                "time_label": "not forward looking",
+                "certain_label": "certain",
+                "year": 2021,
+            },
+        ],
+    }
+    captured = _install_fake_datasets(monkeypatch, payload)
+
+    records = _iter_gtfintechlab_federal_reserve_records()
+
+    pinned = _DATASET_REVISIONS[GTFINTECHLAB_FED_DATASET_ID]
+    assert captured["revisions"] == [pinned, pinned]  # called once per config/split combo
+    assert all(r["multi_axis_extras"]["gtfintechlab_dataset_revision"] == pinned for r in records)
+    # source_record_id is the 16-char prefix of sha256(normalized_text); not a positional ":<idx>".
+    for record in records:
+        assert ":" not in record["source_record_id"]
+        assert len(record["source_record_id"]) == 16
+        assert all(c in "0123456789abcdef" for c in record["source_record_id"])
+
+
 def test_gtfintechlab_cross_bank_dataset_list_covers_five_banks() -> None:
     bank_keys = [item[0] for item in GTFINTECHLAB_CROSS_BANK_DATASETS]
     assert bank_keys == [
@@ -429,10 +490,10 @@ def test_iter_gtfintechlab_cross_bank_records_tags_provenance(monkeypatch) -> No
     import types
 
     fake = types.SimpleNamespace()
-    fake.get_dataset_config_names = lambda dataset: ["default"]
-    fake.get_dataset_split_names = lambda dataset, config: ["train"]
+    fake.get_dataset_config_names = lambda dataset, revision=None: ["default"]
+    fake.get_dataset_split_names = lambda dataset, config, revision=None: ["train"]
 
-    def _fake_load(dataset_id, config, split=None):
+    def _fake_load(dataset_id, config, split=None, revision=None):
         # Encode the dataset_id into the sentence so the dedupe doesn't collapse
         # rows across banks.
         return [
@@ -518,8 +579,70 @@ def test_iter_fomc_archive_records_routes_statements_and_minutes(monkeypatch) ->
     # Minutes release on 2024-10-09 differs from event_date 2024-09-18 — flagged in extras.
     assert minutes_row["multi_axis_extras"]["release_date"] == "2024-10-09"
     statement_row = by_type["statement"]
-    # Statement release equals event date — no extras populated.
-    assert "multi_axis_extras" not in statement_row or not statement_row.get("multi_axis_extras")
+    # Statement release equals event date so release_date is omitted from extras.
+    # vtasca_dataset_revision is set unconditionally for reproducibility.
+    assert "release_date" not in statement_row.get("multi_axis_extras", {})
+    assert statement_row["multi_axis_extras"]["vtasca_dataset_revision"] == _DATASET_REVISIONS[
+        VTASCA_FOMC_ARCHIVE_DATASET_ID
+    ]
+
+
+def test_iter_fomc_archive_records_source_record_id_discriminates_distinct_text(
+    monkeypatch,
+) -> None:
+    """Two corrected releases on the same date+document_type with distinct text
+    must produce distinct source_record_ids (text_hash discriminator)."""
+    _install_fake_datasets_module(
+        monkeypatch,
+        [
+            {
+                "Date": "2024-09-18",
+                "Release Date": "2024-09-18",
+                "Type": "Statement",
+                "Text": "Original September statement language.",
+            },
+            {
+                "Date": "2024-09-18",
+                "Release Date": "2024-09-19",
+                "Type": "Statement",
+                "Text": "Corrected September statement language.",
+            },
+        ],
+    )
+
+    records = _iter_fomc_archive_records()
+
+    assert len(records) == 2
+    ids = [r["source_record_id"] for r in records]
+    assert len(set(ids)) == 2
+    for record in records:
+        assert record["source_record_id"].startswith("2024-09-18:statement:")
+
+
+def test_iter_fomc_archive_records_pins_revision(monkeypatch) -> None:
+    captured = _install_fake_datasets_module(
+        monkeypatch,
+        [
+            {
+                "Date": "2024-09-18",
+                "Release Date": "2024-09-18",
+                "Type": "Statement",
+                "Text": "Sample statement.",
+            },
+        ],
+    )
+
+    records = _iter_fomc_archive_records()
+
+    expected_revision = _DATASET_REVISIONS[VTASCA_FOMC_ARCHIVE_DATASET_ID]
+    assert captured["revisions"] == [expected_revision]
+    assert records[0]["multi_axis_extras"]["vtasca_dataset_revision"] == expected_revision
+
+
+def test_dataset_revision_returns_pinned_or_none() -> None:
+    assert _dataset_revision(GTFINTECHLAB_FED_DATASET_ID) == _DATASET_REVISIONS[GTFINTECHLAB_FED_DATASET_ID]
+    assert _dataset_revision(VTASCA_FOMC_ARCHIVE_DATASET_ID) == _DATASET_REVISIONS[VTASCA_FOMC_ARCHIVE_DATASET_ID]
+    assert _dataset_revision("unknown/dataset") is None
 
 
 def test_iter_fomc_archive_records_dedupes_by_text_hash(monkeypatch) -> None:

--- a/tests/unit/test_fred_client.py
+++ b/tests/unit/test_fred_client.py
@@ -1,0 +1,156 @@
+"""Tests for the FRED client.
+
+httpx is mocked via ``httpx.MockTransport`` so the tests run without network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from app.services import fred_client
+
+
+SAMPLE_PAYLOAD = {
+    "realtime_start": "2026-05-15",
+    "realtime_end": "2026-05-15",
+    "observation_start": "2024-01-01",
+    "observation_end": "2024-01-05",
+    "count": 5,
+    "observations": [
+        {"date": "2024-01-02", "value": "5.33", "realtime_start": "2026-05-15", "realtime_end": "2026-05-15"},
+        {"date": "2024-01-03", "value": "5.33", "realtime_start": "2026-05-15", "realtime_end": "2026-05-15"},
+        {"date": "2024-01-04", "value": ".", "realtime_start": "2026-05-15", "realtime_end": "2026-05-15"},
+        {"date": "2024-01-05", "value": "5.34", "realtime_start": "2026-05-15", "realtime_end": "2026-05-15"},
+        {"date": "2024-01-06", "value": "5.33", "realtime_start": "2026-05-15", "realtime_end": "2026-05-15"},
+    ],
+}
+
+
+def _mock_transport(captured: dict[str, dict[str, str]]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        captured["url"] = str(request.url).split("?")[0]
+        return httpx.Response(200, json=SAMPLE_PAYLOAD)
+
+    return httpx.MockTransport(handler)
+
+
+def test_fetch_fred_series_hits_api_and_caches(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("FRED_API_KEY", "test-key")
+    captured: dict[str, dict[str, str]] = {}
+
+    response = fred_client.fetch_fred_series(
+        "DFF",
+        start="2024-01-01",
+        end="2024-01-05",
+        cache_dir=tmp_path,
+        transport=_mock_transport(captured),
+    )
+
+    assert captured["url"] == fred_client.FRED_BASE_URL
+    assert captured["params"]["series_id"] == "DFF"
+    assert captured["params"]["api_key"] == "test-key"
+    assert captured["params"]["observation_start"] == "2024-01-01"
+    assert captured["params"]["observation_end"] == "2024-01-05"
+    assert captured["params"]["file_type"] == "json"
+
+    assert response.series_id == "DFF"
+    assert response.count == 5
+    assert len(response.observations) == 5
+    values = [obs.value for obs in response.observations]
+    # FRED encodes missing values as "."; the parser coerces those to None.
+    assert values == [5.33, 5.33, None, 5.34, 5.33]
+
+    cache_path = tmp_path / "DFF.json"
+    lock_path = tmp_path / fred_client.SOURCES_LOCK_NAME
+    assert cache_path.exists()
+    assert lock_path.exists()
+
+    lock = json.loads(lock_path.read_text())
+    assert "DFF" in lock
+    assert lock["DFF"]["count"] == 5
+    assert len(lock["DFF"]["sha256"]) == 64
+
+
+def test_fetch_fred_series_reuses_cache(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("FRED_API_KEY", "test-key")
+    captured: dict[str, dict[str, str]] = {}
+
+    fred_client.fetch_fred_series(
+        "DFF",
+        cache_dir=tmp_path,
+        transport=_mock_transport(captured),
+    )
+
+    captured_second: dict[str, dict[str, str]] = {}
+
+    def boom(_: httpx.Request) -> httpx.Response:
+        captured_second["called"] = {"true": "true"}
+        return httpx.Response(500)
+
+    response = fred_client.fetch_fred_series(
+        "DFF",
+        cache_dir=tmp_path,
+        transport=httpx.MockTransport(boom),
+    )
+
+    assert captured_second == {}  # cache hit; transport never called
+    assert response.count == 5
+
+
+def test_fetch_fred_series_force_refresh_overrides_cache(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("FRED_API_KEY", "test-key")
+    captured: dict[str, dict[str, str]] = {}
+    fred_client.fetch_fred_series(
+        "DFF",
+        cache_dir=tmp_path,
+        transport=_mock_transport(captured),
+    )
+
+    refreshed_payload = {
+        "realtime_start": "2026-05-16",
+        "realtime_end": "2026-05-16",
+        "observation_start": "2024-01-01",
+        "observation_end": "2024-01-06",
+        "count": 1,
+        "observations": [
+            {"date": "2024-01-06", "value": "5.40", "realtime_start": "2026-05-16", "realtime_end": "2026-05-16"},
+        ],
+    }
+
+    def refreshed_handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=refreshed_payload)
+
+    response = fred_client.fetch_fred_series(
+        "DFF",
+        cache_dir=tmp_path,
+        transport=httpx.MockTransport(refreshed_handler),
+        force_refresh=True,
+    )
+
+    assert response.count == 1
+    assert response.observations[0].value == 5.40
+
+
+def test_missing_api_key_raises(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("FRED_API_KEY", raising=False)
+    monkeypatch.delenv("FRED_TOKEN", raising=False)
+    with pytest.raises(RuntimeError, match="FRED_API_KEY"):
+        fred_client.fetch_fred_series(
+            "DFF",
+            cache_dir=tmp_path,
+            transport=_mock_transport({}),
+        )
+
+
+def test_observation_value_parser_handles_missing_marker() -> None:
+    assert fred_client._parse_observation_value(".") is None
+    assert fred_client._parse_observation_value("") is None
+    assert fred_client._parse_observation_value(None) is None
+    assert fred_client._parse_observation_value("not-a-number") is None
+    assert fred_client._parse_observation_value("5.33") == 5.33
+    assert fred_client._parse_observation_value(0) == 0.0


### PR DESCRIPTION
## Summary
- gtfintechlab/federal_reserve_system: +3,000 multi-axis FOMC sentence labels (stance + time + certainty).
- gtfintechlab cross-bank (ECB / BoJ / BoE / BoC / RBA): +15,000 sentences, provenance=peer_reviewed_cross_bank held out from FOMC training.
- samchain/BIS_speeches_97_23_MLM: 909k NSP pairs (~365M tokens) replace the 44-doc local corpus for FinBERT-FedAdjacent continued pretraining; joint MLM+NSP via BertForPreTraining.
- vtasca/fomc-statements-minutes: 463 whole-document FOMC statements + minutes, unlabelled, feeding credibility drift.
- FRED REST client: DFF / DGS10 / etc. with SHA-pinned cache for the realized-vs-stated gap.
- 446 unit + regression tests pass. Two new Make targets (finbert-fed-adjacent-pretrain + -smoke).

## Pivot worth flagging
- alea-institute/kl3m-data was abandoned mid-sprint: its payload is pre-tokenized arrays under a 0-download KL3M tokenizer. Pivoted to vtasca/fomc-statements-minutes which ships plain text.

## Test plan
- [x] pytest tests/unit tests/regression — 446 passed
- [x] AI-trace scan on all touched files — clean
- [x] Wiki inventory updated (13_External_Corpora_Inventory.md)

Supersedes #137, #138, #139, #140 (closing those).