### PR TITLE
Multi-encoder embedding cache, bake-off aggregator, credibility wiring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,3 +210,23 @@ finbert-fed-adjacent-pretrain-smoke:
 		--batch-size 4 \
 		--block-size 128 \
 		--objective mlm
+
+# Build (or reuse) the per-encoder embedding cache for a training package.
+# Required: ENCODER (alias from models/registry.yaml), TRAINING_PACKAGE_ID.
+# Set ALLOW_NETWORK=1 the first time you cache a new encoder.
+cache-embeddings:
+	@if [ -z "$(ENCODER)" ]; then echo "Set ENCODER=<alias>"; exit 2; fi
+	@if [ -z "$(TRAINING_PACKAGE_ID)" ]; then echo "Set TRAINING_PACKAGE_ID=<id>"; exit 2; fi
+	docker compose run --rm backend \
+		python -m app.data.embedding_cache \
+		--encoder "$(ENCODER)" \
+		--training-package-id "$(TRAINING_PACKAGE_ID)" \
+		$(if $(ALLOW_NETWORK),--allow-network,) \
+		$(if $(FORCE),--force,)
+
+# Aggregate one or more finetune_batch aggregate.json files into a headline
+# table with block-bootstrap CIs. ARTIFACT_DIR defaults to data/artifacts/phase3.
+bakeoff-aggregate:
+	docker compose run --rm backend \
+		python -m app.evaluation.bakeoff_aggregator \
+		--artifact-dir "$(or $(ARTIFACT_DIR),data/artifacts/phase3)"

--- a/backend/app/data/chunk_embedding_retrieval.py
+++ b/backend/app/data/chunk_embedding_retrieval.py
@@ -24,7 +24,27 @@ import pandas as pd
 import torch
 
 from app.config import DATA_DIR as DEFAULT_DATA_DIR
+from app.data.embedding_cache import require_cache_exists, resolve_cache_paths
+from app.models.registry import revision_for
+
 DEFAULT_LLM_EMBEDDINGS_PARQUET = DEFAULT_DATA_DIR / "interim" / "phase2" / "llm_embeddings.parquet"
+
+
+def load_encoder_cache(
+    encoder_alias: str,
+    *,
+    cache_dir: Path | str | None = None,
+) -> pd.DataFrame:
+    """Load a per-encoder parquet built by :mod:`app.data.embedding_cache`.
+
+    Hard-fails with a fixable error if the cache parquet is missing so a
+    training run never silently downloads weights at training time.
+    """
+
+    revision = revision_for(encoder_alias)
+    paths = resolve_cache_paths(encoder_alias, revision=revision, cache_dir=cache_dir)
+    require_cache_exists(encoder_alias, revision=revision, cache_dir=cache_dir)
+    return load_chunk_store(str(paths.parquet))
 
 
 @dataclass(frozen=True)

--- a/backend/app/data/embedding_cache.py
+++ b/backend/app/data/embedding_cache.py
@@ -1,0 +1,415 @@
+"""Encoder-keyed embedding cache for the bake-off and credibility paths.
+
+Writes one parquet per ``(encoder_alias, training_package_id)`` pair under
+``data/raw/embeddings/`` together with a ``SOURCES.lock`` line recording the
+encoder revision, the source-registry SHA, and the artefact SHA-256. The
+parquet schema is the same as the legacy chunk-embedding store
+(``doc_id, event_date, chunk_index, chunk_preview, embedding``) so the
+existing ``chunk_embedding_retrieval`` consumer can read it with no change.
+
+Network-dependent encoders are only loaded when the caller passes
+``allow_network=True``. Without that flag the builder hard-fails before
+touching HF — that is the policy training-time call sites rely on.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+import pandas as pd
+
+from app.config import DATA_DIR
+from app.models.registry import EncoderRef, encoder_ref
+
+DEFAULT_CACHE_DIR = DATA_DIR / "raw" / "embeddings"
+DEFAULT_PREVIEW_CHARS = 200
+DEFAULT_BATCH_SIZE = 32
+DEFAULT_MIN_TEXT_CHARS = 64
+DEFAULT_MAX_DOCS = 0  # 0 = no cap
+DEFAULT_MAX_LENGTH = 512
+
+# Encoders whose recipe is "one slot per document" rather than "many chunks per
+# document". Sentence-embedding models typically want mean-pool over the whole
+# input; classifier/MLM encoders use CLS pooling over chunks.
+SENTENCE_EMBEDDING_TASKS = {"sentence_embedding"}
+
+
+@dataclass(frozen=True)
+class CachePaths:
+    parquet: Path
+    sources_lock: Path
+
+    @property
+    def directory(self) -> Path:
+        return self.parquet.parent
+
+
+def _short_revision(revision: str, length: int = 12) -> str:
+    if not revision:
+        return "unpinned"
+    return revision[:length]
+
+
+def resolve_cache_paths(
+    encoder_alias: str,
+    *,
+    revision: str | None = None,
+    cache_dir: Path | str | None = None,
+) -> CachePaths:
+    """Return parquet + SOURCES.lock paths for a given encoder alias.
+
+    The parquet name embeds a short revision slug so two different pinned
+    revisions of the same encoder don't collide.
+    """
+
+    base = Path(cache_dir) if cache_dir is not None else DEFAULT_CACHE_DIR
+    rev_slug = _short_revision(revision or "")
+    parquet = base / f"{encoder_alias}_{rev_slug}.parquet"
+    return CachePaths(parquet=parquet, sources_lock=base / "SOURCES.lock")
+
+
+def _doc_id(record: dict[str, Any]) -> str:
+    raw = record.get("record_id") or record.get("source_record_id") or record.get("text_hash")
+    if isinstance(raw, str) and raw:
+        return raw
+    text = str(record.get("text", "")).strip()
+    return hashlib.sha256(text.encode("utf-8", errors="ignore")).hexdigest()[:24]
+
+
+def _iter_registry(path: Path, *, min_text_chars: int) -> Iterator[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            text = str(record.get("text", "")).strip()
+            event_date = str(record.get("event_date", "")).strip()
+            if not text or not event_date:
+                continue
+            if len(text) < min_text_chars:
+                continue
+            yield record
+
+
+def _registry_sha256(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(block)
+    return hasher.hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(block)
+    return hasher.hexdigest()
+
+
+def _load_encoder(ref: EncoderRef):
+    """Lazy-import AutoModel/AutoTokenizer so test code can monkeypatch."""
+
+    from transformers import AutoModel, AutoTokenizer  # type: ignore[import-not-found]
+
+    revision = ref.revision or None
+    tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=revision)
+    model = AutoModel.from_pretrained(ref.repo, revision=revision)
+    return tokenizer, model
+
+
+def _split_text_for_encoder(
+    text: str,
+    *,
+    tokenizer,
+    max_length: int,
+    sentence_embedding: bool,
+) -> list[str]:
+    """Produce the input strings to be embedded for one document.
+
+    Sentence-embedding encoders see the whole document (truncated by the
+    tokenizer). Chunk-pool encoders see token-window chunks so the model
+    output is per-chunk CLS, matching the legacy chunk store.
+    """
+
+    if sentence_embedding:
+        return [text]
+    token_ids = tokenizer.encode(text, add_special_tokens=False)
+    if not token_ids:
+        return []
+    stride = max(1, max_length - 2)  # leave room for [CLS] / [SEP]
+    chunks: list[str] = []
+    for start in range(0, len(token_ids), stride):
+        slice_ids = token_ids[start : start + stride]
+        if not slice_ids:
+            continue
+        chunks.append(tokenizer.decode(slice_ids, skip_special_tokens=True))
+    return chunks
+
+
+def _embed_batch(
+    inputs: list[str],
+    *,
+    tokenizer,
+    model,
+    max_length: int,
+    sentence_embedding: bool,
+) -> list[list[float]]:
+    import torch  # local import keeps test-time monkeypatching cheap
+
+    if not inputs:
+        return []
+    enc = tokenizer(
+        inputs,
+        truncation=True,
+        max_length=max_length,
+        padding=True,
+        return_tensors="pt",
+    )
+    device = next(model.parameters()).device
+    enc = {k: v.to(device) for k, v in enc.items()}
+    with torch.no_grad():
+        outputs = model(**enc, output_hidden_states=False)
+        hidden = outputs.last_hidden_state  # (B, T, H)
+        if sentence_embedding:
+            mask = enc["attention_mask"].unsqueeze(-1).float()
+            summed = (hidden * mask).sum(dim=1)
+            counts = mask.sum(dim=1).clamp(min=1.0)
+            pooled = summed / counts
+        else:
+            pooled = hidden[:, 0, :]
+    return pooled.detach().cpu().tolist()
+
+
+@dataclass(frozen=True)
+class BuildResult:
+    parquet_path: Path
+    row_count: int
+    encoder_alias: str
+    encoder_revision: str
+    sources_lock_path: Path
+
+
+def build_cache(
+    *,
+    encoder_alias: str,
+    training_package_id: str,
+    data_dir: Path | str | None = None,
+    cache_dir: Path | str | None = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    max_docs: int = DEFAULT_MAX_DOCS,
+    min_text_chars: int = DEFAULT_MIN_TEXT_CHARS,
+    preview_chars: int = DEFAULT_PREVIEW_CHARS,
+    max_length: int = DEFAULT_MAX_LENGTH,
+    allow_network: bool = False,
+    force: bool = False,
+) -> BuildResult:
+    """Build (or reuse) the per-encoder embedding parquet for a package.
+
+    ``allow_network`` MUST be set explicitly when the encoder is not already
+    cached locally — the builder will instantiate the HF model otherwise and
+    hit the network. Training-time call sites pass ``allow_network=False``
+    and rely on this hard-fail to prevent silent downloads.
+    """
+
+    ref = encoder_ref(encoder_alias)
+    if ref is None:
+        raise ValueError(
+            f"Unknown encoder alias {encoder_alias!r}. Add it to backend/app/models/registry.yaml."
+        )
+    if not ref.revision:
+        raise ValueError(
+            f"Encoder {encoder_alias!r} has no pinned revision in registry.yaml. "
+            "Train the checkpoint or paste a revision SHA before caching."
+        )
+
+    package_dir = Path(data_dir) if data_dir is not None else DATA_DIR
+    registry_path = package_dir / "processed" / training_package_id / "registry_normalized.jsonl"
+    if not registry_path.exists():
+        raise FileNotFoundError(
+            f"Missing training-package registry at {registry_path}. "
+            "Run pipeline_data_prep before caching embeddings."
+        )
+
+    paths = resolve_cache_paths(encoder_alias, revision=ref.revision, cache_dir=cache_dir)
+    paths.directory.mkdir(parents=True, exist_ok=True)
+
+    if paths.parquet.exists() and not force:
+        existing = pd.read_parquet(paths.parquet)
+        return BuildResult(
+            parquet_path=paths.parquet,
+            row_count=len(existing),
+            encoder_alias=encoder_alias,
+            encoder_revision=ref.revision,
+            sources_lock_path=paths.sources_lock,
+        )
+
+    if not allow_network:
+        raise RuntimeError(
+            f"Embedding cache missing for encoder={encoder_alias!r} at {paths.parquet}. "
+            "Re-run with allow_network=True (or `make cache-embeddings ENCODER=… ALLOW_NETWORK=1`)."
+        )
+
+    sentence_embedding = ref.task in SENTENCE_EMBEDDING_TASKS
+    tokenizer, model = _load_encoder(ref)
+    model.eval()
+
+    pending_inputs: list[str] = []
+    pending_meta: list[tuple[str, str, str, int, str]] = []  # (record_id, doc_id, event_date, chunk_index, preview)
+    rows: list[dict[str, Any]] = []
+    docs_processed = 0
+    started_at = time.time()
+
+    def _flush() -> None:
+        if not pending_inputs:
+            return
+        embeddings = _embed_batch(
+            pending_inputs,
+            tokenizer=tokenizer,
+            model=model,
+            max_length=max_length,
+            sentence_embedding=sentence_embedding,
+        )
+        for (record_id, doc_id, event_date, chunk_index, preview), embedding in zip(pending_meta, embeddings):
+            rows.append(
+                {
+                    "record_id": record_id,
+                    "doc_id": doc_id,
+                    "event_date": event_date,
+                    "chunk_index": chunk_index,
+                    "chunk_preview": preview,
+                    "embedding": embedding,
+                }
+            )
+        pending_inputs.clear()
+        pending_meta.clear()
+
+    for record in _iter_registry(registry_path, min_text_chars=min_text_chars):
+        if max_docs and docs_processed >= max_docs:
+            break
+        text = str(record["text"]).strip()
+        chunks = _split_text_for_encoder(
+            text,
+            tokenizer=tokenizer,
+            max_length=max_length,
+            sentence_embedding=sentence_embedding,
+        )
+        if not chunks:
+            continue
+        doc_id = _doc_id(record)
+        record_id = str(record.get("record_id") or doc_id)
+        event_date = str(record["event_date"]).strip()
+        for chunk_index, chunk_text in enumerate(chunks):
+            preview = chunk_text[:preview_chars]
+            pending_inputs.append(chunk_text)
+            pending_meta.append((record_id, doc_id, event_date, chunk_index, preview))
+            if len(pending_inputs) >= batch_size:
+                _flush()
+        docs_processed += 1
+
+    _flush()
+    elapsed = time.time() - started_at
+    print(
+        f"[embedding_cache] encoder={encoder_alias} docs={docs_processed} "
+        f"rows={len(rows)} elapsed={elapsed:.1f}s"
+    )
+
+    df = pd.DataFrame(rows)
+    df["event_date"] = df["event_date"].astype(str)
+    df.to_parquet(paths.parquet, index=False)
+    artefact_sha = _file_sha256(paths.parquet)
+    registry_sha = _registry_sha256(registry_path)
+
+    sources_entry = {
+        "encoder_alias": encoder_alias,
+        "encoder_repo": ref.repo,
+        "encoder_revision": ref.revision,
+        "encoder_task": ref.task,
+        "training_package_id": training_package_id,
+        "registry_sha256": registry_sha,
+        "parquet_relpath": str(paths.parquet.relative_to(paths.directory)),
+        "parquet_sha256": artefact_sha,
+        "row_count": len(rows),
+        "retrieved_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    with paths.sources_lock.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(sources_entry, sort_keys=True) + "\n")
+
+    return BuildResult(
+        parquet_path=paths.parquet,
+        row_count=len(rows),
+        encoder_alias=encoder_alias,
+        encoder_revision=ref.revision,
+        sources_lock_path=paths.sources_lock,
+    )
+
+
+def require_cache_exists(
+    encoder_alias: str,
+    *,
+    revision: str | None = None,
+    cache_dir: Path | str | None = None,
+) -> Path:
+    """Return the parquet path or raise with a fixable error message."""
+
+    paths = resolve_cache_paths(encoder_alias, revision=revision, cache_dir=cache_dir)
+    if not paths.parquet.exists():
+        cmd = f"make cache-embeddings ENCODER={encoder_alias} ALLOW_NETWORK=1"
+        raise FileNotFoundError(
+            f"Embedding cache missing for encoder={encoder_alias!r} at {paths.parquet}. "
+            f"Run: {cmd}"
+        )
+    return paths.parquet
+
+
+def _parse_args() -> "object":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build per-encoder embedding cache for a training package.")
+    parser.add_argument("--encoder", required=True, help="Encoder alias from models/registry.yaml.")
+    parser.add_argument("--training-package-id", required=True)
+    parser.add_argument("--data-dir", default=os.environ.get("FED_PULSE_DATA_DIR") or str(DATA_DIR))
+    parser.add_argument("--cache-dir", default=None)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--max-docs", type=int, default=DEFAULT_MAX_DOCS)
+    parser.add_argument("--min-text-chars", type=int, default=DEFAULT_MIN_TEXT_CHARS)
+    parser.add_argument("--max-length", type=int, default=DEFAULT_MAX_LENGTH)
+    parser.add_argument("--allow-network", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    result = build_cache(
+        encoder_alias=args.encoder,
+        training_package_id=args.training_package_id,
+        data_dir=args.data_dir,
+        cache_dir=args.cache_dir,
+        batch_size=args.batch_size,
+        max_docs=args.max_docs,
+        min_text_chars=args.min_text_chars,
+        max_length=args.max_length,
+        allow_network=args.allow_network,
+        force=args.force,
+    )
+    print(
+        f"[embedding_cache] {result.encoder_alias} rev={result.encoder_revision[:12]} "
+        f"rows={result.row_count} parquet={result.parquet_path}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/data/finetune_batch.py
+++ b/backend/app/data/finetune_batch.py
@@ -20,11 +20,14 @@ from typing import Any
 import torch
 
 from app.data.finetune_pilot import DEFAULT_ARTIFACT_ROOT, run_one
+from app.models.registry import encoder_ref
 
 # Local-label keys identify the encoder slot in artefact paths and report
 # tables. The legacy "fomc_roberta" key maps to ZiweiChen/FinBERT-FOMC for
 # Phase-4 reproducibility; the new gtfintechlab/FOMC-RoBERTa lives under a
-# distinct "gtfintechlab_fomc_roberta" key so the two never collide.
+# distinct "gtfintechlab_fomc_roberta" key so the two never collide. The
+# HF-repo string is the single source of truth threaded to
+# AutoTokenizer/AutoModel; the registry supplies the pinned revision.
 ENCODERS: dict[str, str] = {
     "bert_base_uncased": "bert-base-uncased",
     "distilbert_base_uncased": "distilbert-base-uncased",
@@ -32,8 +35,28 @@ ENCODERS: dict[str, str] = {
     "fomc_roberta": "ZiweiChen/FinBERT-FOMC",
     "gtfintechlab_fomc_roberta": "gtfintechlab/FOMC-RoBERTa",
     "deberta_v3_base": "microsoft/deberta-v3-base",
+    "finbert_fed_adjacent": "local/finbert-fed-adjacent",
+    "bge_large_en_v15": "BAAI/bge-large-en-v1.5",
+    "nomic_embed_text_v15": "nomic-ai/nomic-embed-text-v1.5",
 }
 OFFICIAL_SEEDS: tuple[int, ...] = (11, 29, 47, 71, 97)
+
+
+def _is_encoder_runnable(encoder_key: str, checkpoint: str) -> tuple[bool, str]:
+    """Return ``(ok, reason)``: skip unpinned encoders whose local artefact is
+    absent so the bake-off never silently downloads or fails mid-run."""
+
+    ref = encoder_ref(checkpoint) or encoder_ref(encoder_key)
+    if ref is None:
+        return True, ""
+    if ref.revision:
+        return True, ""
+    if checkpoint.startswith("local/"):
+        return False, (
+            f"unpinned local encoder — run `make finbert-fed-adjacent-pretrain` and paste "
+            f"the resulting checkpoint path + revision into models/registry.yaml::{ref.alias}"
+        )
+    return False, f"no revision pinned in registry.yaml::{ref.alias}"
 
 
 def _parse_args() -> argparse.Namespace:
@@ -136,7 +159,13 @@ def main() -> int:
     print(f"[batch] artifact root: {batch_dir}")
 
     run_index = 0
+    skipped: list[dict[str, Any]] = []
     for encoder_key, checkpoint in selected_encoders.items():
+        ok, reason = _is_encoder_runnable(encoder_key, checkpoint)
+        if not ok:
+            print(f"[batch] SKIP encoder={encoder_key} — {reason}")
+            skipped.append({"encoder_key": encoder_key, "checkpoint": checkpoint, "reason": reason})
+            continue
         for seed in seeds:
             run_index += 1
             run_args = _build_run_args(args, checkpoint=checkpoint, seed=seed)
@@ -199,6 +228,7 @@ def main() -> int:
         "failed": len(failures),
         "by_encoder": by_encoder,
         "failures": failures,
+        "skipped": skipped,
     }
     (batch_dir / "aggregate.json").write_text(json.dumps(aggregate, indent=2), encoding="utf-8")
     print(f"\n[batch] aggregate written to {batch_dir / 'aggregate.json'}")

--- a/backend/app/evaluation/bakeoff_aggregator.py
+++ b/backend/app/evaluation/bakeoff_aggregator.py
@@ -1,0 +1,237 @@
+"""Aggregate :mod:`app.data.finetune_batch` outputs into a headline table.
+
+Reads one or more ``aggregate.json`` files (or a directory containing them),
+re-derives per-encoder block-bootstrap CIs from the per-seed numbers, and
+writes both JSON and a markdown table sortable by macro-F1.
+
+Usage::
+
+    python -m app.evaluation.bakeoff_aggregator \
+        --artifact-dir data/artifacts/phase3/ \
+        --output-dir   data/artifacts/phase3/bakeoff_summary
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from app.evaluation.bootstrap import BootstrapCI, block_bootstrap_ci
+
+
+@dataclass(frozen=True)
+class EncoderRow:
+    encoder_key: str
+    checkpoint: str
+    seeds: list[int]
+    macro_f1_values: list[float]
+    weighted_f1_values: list[float]
+    accuracy_values: list[float]
+    macro_f1_ci: BootstrapCI
+    weighted_f1_ci: BootstrapCI
+    accuracy_ci: BootstrapCI
+
+
+def _load_aggregate(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _iter_aggregate_files(artifact_dir: Path) -> Iterable[Path]:
+    if artifact_dir.is_file() and artifact_dir.name == "aggregate.json":
+        yield artifact_dir
+        return
+    if not artifact_dir.is_dir():
+        raise FileNotFoundError(f"artifact_dir does not exist: {artifact_dir}")
+    yield from sorted(artifact_dir.glob("**/aggregate.json"))
+
+
+def _collect_per_encoder(aggregates: list[dict]) -> dict[str, dict]:
+    by_encoder: dict[str, dict] = {}
+    for aggregate in aggregates:
+        for encoder_key, payload in (aggregate.get("by_encoder") or {}).items():
+            bucket = by_encoder.setdefault(
+                encoder_key,
+                {
+                    "checkpoint": payload.get("checkpoint", ""),
+                    "seeds": [],
+                    "macro_f1": [],
+                    "weighted_f1": [],
+                    "accuracy": [],
+                },
+            )
+            for seed_str, per_seed in (payload.get("per_seed") or {}).items():
+                try:
+                    seed_int = int(seed_str)
+                except ValueError:
+                    continue
+                if seed_int in bucket["seeds"]:
+                    continue
+                bucket["seeds"].append(seed_int)
+                bucket["macro_f1"].append(float(per_seed.get("macro_f1", 0.0)))
+                bucket["weighted_f1"].append(float(per_seed.get("weighted_f1", 0.0)))
+                bucket["accuracy"].append(float(per_seed.get("accuracy", 0.0)))
+    return by_encoder
+
+
+def _build_rows(
+    by_encoder: dict[str, dict],
+    *,
+    block_size: int,
+    n_resamples: int,
+    coverage: float,
+    seed: int,
+) -> list[EncoderRow]:
+    rows: list[EncoderRow] = []
+    for encoder_key, payload in by_encoder.items():
+        rows.append(
+            EncoderRow(
+                encoder_key=encoder_key,
+                checkpoint=str(payload["checkpoint"]),
+                seeds=list(payload["seeds"]),
+                macro_f1_values=list(payload["macro_f1"]),
+                weighted_f1_values=list(payload["weighted_f1"]),
+                accuracy_values=list(payload["accuracy"]),
+                macro_f1_ci=block_bootstrap_ci(
+                    payload["macro_f1"],
+                    statistic="mean",
+                    block_size=block_size,
+                    n_resamples=n_resamples,
+                    coverage=coverage,
+                    seed=seed,
+                ),
+                weighted_f1_ci=block_bootstrap_ci(
+                    payload["weighted_f1"],
+                    statistic="mean",
+                    block_size=block_size,
+                    n_resamples=n_resamples,
+                    coverage=coverage,
+                    seed=seed,
+                ),
+                accuracy_ci=block_bootstrap_ci(
+                    payload["accuracy"],
+                    statistic="mean",
+                    block_size=block_size,
+                    n_resamples=n_resamples,
+                    coverage=coverage,
+                    seed=seed,
+                ),
+            )
+        )
+    rows.sort(key=lambda r: r.macro_f1_ci.point, reverse=True)
+    return rows
+
+
+def render_markdown(rows: list[EncoderRow], *, coverage: float) -> str:
+    if not rows:
+        return "_no encoder rows found_\n"
+    coverage_pct = int(round(coverage * 100))
+    lines = [
+        f"| Rank | Encoder | Checkpoint | n | macro-F1 (mean, {coverage_pct}% CI) | weighted-F1 | accuracy |",
+        "|---:|---|---|---:|---|---|---|",
+    ]
+    for rank, row in enumerate(rows, start=1):
+        n = len(row.macro_f1_values)
+        mf = row.macro_f1_ci
+        wf = row.weighted_f1_ci
+        ac = row.accuracy_ci
+        lines.append(
+            f"| {rank} | `{row.encoder_key}` | `{row.checkpoint}` | {n} | "
+            f"{mf.point:.4f} [{mf.lo:.4f}, {mf.hi:.4f}] | "
+            f"{wf.point:.4f} [{wf.lo:.4f}, {wf.hi:.4f}] | "
+            f"{ac.point:.4f} [{ac.lo:.4f}, {ac.hi:.4f}] |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _row_to_json(row: EncoderRow) -> dict:
+    return {
+        "encoder_key": row.encoder_key,
+        "checkpoint": row.checkpoint,
+        "seeds": row.seeds,
+        "macro_f1": {
+            "values": row.macro_f1_values,
+            "ci": asdict(row.macro_f1_ci),
+        },
+        "weighted_f1": {
+            "values": row.weighted_f1_values,
+            "ci": asdict(row.weighted_f1_ci),
+        },
+        "accuracy": {
+            "values": row.accuracy_values,
+            "ci": asdict(row.accuracy_ci),
+        },
+    }
+
+
+def aggregate(
+    artifact_dir: Path,
+    *,
+    block_size: int = 1,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    seed: int = 11,
+) -> tuple[list[EncoderRow], str, dict]:
+    aggregate_paths = list(_iter_aggregate_files(artifact_dir))
+    if not aggregate_paths:
+        raise FileNotFoundError(f"no aggregate.json files found under {artifact_dir}")
+    aggregates = [_load_aggregate(p) for p in aggregate_paths]
+    by_encoder = _collect_per_encoder(aggregates)
+    rows = _build_rows(
+        by_encoder,
+        block_size=block_size,
+        n_resamples=n_resamples,
+        coverage=coverage,
+        seed=seed,
+    )
+    markdown = render_markdown(rows, coverage=coverage)
+    payload = {
+        "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "artifact_dir": str(artifact_dir),
+        "source_aggregates": [str(p) for p in aggregate_paths],
+        "block_size": block_size,
+        "n_resamples": n_resamples,
+        "coverage": coverage,
+        "encoders": [_row_to_json(row) for row in rows],
+    }
+    return rows, markdown, payload
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Aggregate bake-off runs into a headline table.")
+    parser.add_argument("--artifact-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--block-size", type=int, default=1)
+    parser.add_argument("--n-resamples", type=int, default=1000)
+    parser.add_argument("--coverage", type=float, default=0.95)
+    parser.add_argument("--seed", type=int, default=11)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    rows, markdown, payload = aggregate(
+        args.artifact_dir,
+        block_size=args.block_size,
+        n_resamples=args.n_resamples,
+        coverage=args.coverage,
+        seed=args.seed,
+    )
+
+    output_dir = args.output_dir or (args.artifact_dir / "bakeoff_summary")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    json_path = output_dir / f"bakeoff_summary_{timestamp}.json"
+    md_path = output_dir / f"bakeoff_summary_{timestamp}.md"
+    json_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    md_path.write_text(markdown, encoding="utf-8")
+    print(f"[bakeoff_aggregator] {len(rows)} encoders → {json_path}")
+    print(f"[bakeoff_aggregator] markdown → {md_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -26,6 +26,7 @@ DEFAULT_INITIAL_DECAY_RATE = 1.5
 DEFAULT_CHUNK_DECAY_RATE = 1.0 / 30.0
 DEFAULT_CHUNK_EMBEDDING_SIZE = 768
 DEFAULT_CHUNK_PROJECTION_DIM = 8
+CREDIBILITY_FEATURE_DIM = 4
 
 DEFAULT_DATA_DIR = DATA_DIR
 MODELS_DIR = MODEL_CHECKPOINT_DIR
@@ -42,6 +43,7 @@ class ModelConfig:
     initial_decay_rate: float = DEFAULT_INITIAL_DECAY_RATE
     text_channel: str = "scalar"
     embedding_adapter_dim: int = 128
+    credibility_features: bool = False
 
     @classmethod
     def from_model(cls, model: "Any") -> "ModelConfig":
@@ -54,6 +56,7 @@ class ModelConfig:
             initial_decay_rate=model.initial_decay_rate,
             text_channel=getattr(model, "text_channel", "scalar"),
             embedding_adapter_dim=getattr(model, "chunk_projection_dim", 128) or 128,
+            credibility_features=bool(getattr(model, "credibility_features", False)),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/backend/app/models/lstm.py
+++ b/backend/app/models/lstm.py
@@ -6,6 +6,7 @@ from torch.nn import functional as F
 
 from app.models.attention import ChunkAttentionPooler, TimeDecayAttention
 from app.models.config import (
+    CREDIBILITY_FEATURE_DIM,
     DEFAULT_CHUNK_DECAY_RATE,
     DEFAULT_CHUNK_EMBEDDING_SIZE,
     DEFAULT_CHUNK_PROJECTION_DIM,
@@ -38,6 +39,7 @@ class ForecasterModel(nn.Module):
         chunk_projection_dim: int = DEFAULT_CHUNK_PROJECTION_DIM,
         text_channel: str = "scalar",
         embedding_adapter_dim: int = 128,
+        credibility_features: bool = False,
     ):
         """Forecaster LSTM with optional text-feature variants.
 
@@ -88,6 +90,8 @@ class ForecasterModel(nn.Module):
         self.use_chunk_attention = bool(use_chunk_attention)
         self.use_llm_embeddings = bool(use_llm_embeddings)
         self.text_channel = text_channel
+        self.credibility_features = bool(credibility_features)
+        self.credibility_dim = CREDIBILITY_FEATURE_DIM if self.credibility_features else 0
         self.chunk_embedding_size = int(chunk_embedding_size)
         # Either Variant B or Variant C activates the pooler path.
         _uses_pooler = self.use_chunk_attention or self.use_llm_embeddings
@@ -121,7 +125,7 @@ class ForecasterModel(nn.Module):
         else:
             self.chunk_pooler = None
             self.chunk_projection = None
-        lstm_input_size = input_size + self.chunk_projection_dim
+        lstm_input_size = input_size + self.chunk_projection_dim + self.credibility_dim
         self.lstm_input_size = lstm_input_size
         lstm_dropout = dropout if num_layers > 1 else 0.0
         self.recurrent_core = self._build_recurrent_core(
@@ -146,6 +150,7 @@ class ForecasterModel(nn.Module):
         chunks: torch.Tensor | None = None,
         elapsed_days: torch.Tensor | None = None,
         chunk_mask: torch.Tensor | None = None,
+        credibility: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if self.use_time_decay:
             x = self.time_decay(x)
@@ -164,6 +169,20 @@ class ForecasterModel(nn.Module):
                 projected = projected.unsqueeze(0)
             seq_len = x.shape[1]
             broadcast = projected.unsqueeze(1).expand(-1, seq_len, -1)
+            x = torch.cat([x, broadcast], dim=-1)
+        if self.credibility_features:
+            if credibility is None:
+                raise ValueError(
+                    "ForecasterModel requires `credibility` tensor when credibility_features=True"
+                )
+            if credibility.dim() == 1:
+                credibility = credibility.unsqueeze(0)
+            if credibility.shape[-1] != self.credibility_dim:
+                raise ValueError(
+                    f"credibility tensor must have shape (..., {self.credibility_dim}); got {tuple(credibility.shape)}"
+                )
+            seq_len = x.shape[1]
+            broadcast = credibility.unsqueeze(1).expand(-1, seq_len, -1)
             x = torch.cat([x, broadcast], dim=-1)
         output, _ = self.lstm(x)
         last_step = output[:, -1, :]

--- a/backend/app/models/registry.py
+++ b/backend/app/models/registry.py
@@ -47,9 +47,14 @@ def load_registry(path: Path | None = None) -> dict[str, EncoderRef]:
 def revision_for(repo_or_alias: str) -> str | None:
     registry = load_registry()
     ref = registry.get(repo_or_alias)
-    if ref is None:
+    if ref is None or not ref.revision:
         return None
     return ref.revision
+
+
+def is_pinned(repo_or_alias: str) -> bool:
+    ref = encoder_ref(repo_or_alias)
+    return ref is not None and bool(ref.revision)
 
 
 def encoder_ref(repo_or_alias: str) -> EncoderRef | None:

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -1,4 +1,4 @@
-updated_at: 2026-05-13
+updated_at: 2026-05-15
 
 encoders:
   bert_base:
@@ -53,3 +53,45 @@ encoders:
     description: Fallback when FOMC-RoBERTa fails to load.
     repo_aliases:
       - distilbert-base-uncased-finetuned-sst-2-english
+
+  distilbert_base_uncased:
+    repo: distilbert/distilbert-base-uncased
+    revision: 12040accade4e8a0f71eabdb258fecc2e7e948be
+    gated: false
+    task: masked_lm
+    description: Lightweight BERT used in the bake-off as a cheap baseline.
+    repo_aliases:
+      - distilbert-base-uncased
+
+  deberta_v3_base:
+    repo: microsoft/deberta-v3-base
+    revision: 7d4a04c4f6f4bd3a9dd55fb55c25aa7e22f7c79b
+    gated: false
+    task: masked_lm
+    description: DeBERTa v3 base — bake-off entry to test a non-BERT-family encoder.
+
+  bge_large_en_v15:
+    repo: BAAI/bge-large-en-v1.5
+    revision: d4aa6901d3a41ba39fb536a557fa166f842b0e09
+    gated: false
+    task: sentence_embedding
+    description: BGE large English v1.5. Sentence-embedding encoder for the embedding-cache bake-off lane.
+
+  nomic_embed_text_v15:
+    repo: nomic-ai/nomic-embed-text-v1.5
+    revision: b0753ae76394dd36bcfb912a46018088bca48be0
+    gated: false
+    task: sentence_embedding
+    description: Nomic embed text v1.5. Sentence-embedding encoder; second bake-off entry alongside BGE.
+
+  finbert_fed_adjacent:
+    repo: local/finbert-fed-adjacent
+    revision: ""
+    gated: false
+    task: masked_lm
+    description: |
+      FinBERT continued-pretrained on BIS speeches (+ optional local Fed-adjacent
+      auxiliary). Produced by ``make finbert-fed-adjacent-pretrain``; the
+      ``revision`` is filled in with the local checkpoint directory or its sha256
+      after the GPU run completes. Empty revision means "not yet trained" — the
+      bake-off CLI skips this encoder until a revision is pinned.

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -143,6 +143,15 @@ class XaiResponse(BaseModel):
     sentences: list[XaiSentenceAttribution] = Field(default_factory=list)
 
 
+class CredibilityResponse(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    drift_score: float
+    realized_vs_stated_gap: float
+    market_implied_gap: float
+    months_since_reversal: int
+
+
 class AnalyzeResponse(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 
@@ -152,6 +161,7 @@ class AnalyzeResponse(BaseModel):
     model: ModelDiagnosticsResponse
     series: ForecastSeriesResponse
     xai: XaiResponse | None = None
+    credibility: CredibilityResponse | None = None
 
 
 class TrainJobAcceptedResponse(BaseModel):

--- a/backend/app/services/credibility_loader.py
+++ b/backend/app/services/credibility_loader.py
@@ -1,0 +1,244 @@
+"""Assemble :class:`CredibilityVector` inputs from on-disk caches.
+
+The four credibility axes are computed from heterogeneous sources:
+
+- ``drift_score``           — cosine distance between the as-of embedding and
+  the mean of the four prior FOMC document embeddings; the embeddings come
+  from the per-encoder cache built by :mod:`app.data.embedding_cache`.
+- ``realized_vs_stated_gap``— Pearson correlation between a per-date stance
+  score and the realized effective fed funds change pulled from FRED DFF.
+- ``market_implied_gap``    — currently a placeholder (returns 0.0). Will be
+  filled in once the SEP / Eurodollar curve scraper lands.
+- ``months_since_reversal`` — counts whole months since the last sign flip in
+  the stance history.
+
+The loader is intentionally additive: every axis degrades to 0.0 when its
+input is unavailable, so it is safe to call on a training package that has
+no vtasca rows or no FRED cache.
+"""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from app.features.credibility import (
+    CredibilityVector,
+    compute_credibility_vector,
+)
+from app.services.fred_client import (
+    FredObservation,
+    FredSeriesResponse,
+    fetch_fred_series,
+)
+
+DEFAULT_FRED_SERIES = "DFF"
+
+
+@dataclass(frozen=True)
+class CredibilityInputs:
+    """All inputs to ``compute_credibility_vector`` for a single as-of date."""
+
+    current_embedding: list[float]
+    prior_embeddings: list[list[float]]
+    stance_history: list[float]
+    stated_path: list[float]
+    realized_path: list[float]
+
+
+def _parse_iso(value: str) -> datetime.date | None:
+    try:
+        return datetime.date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
+
+
+@lru_cache(maxsize=4)
+def _load_embedding_frame(path: str) -> pd.DataFrame:
+    df = pd.read_parquet(path)
+    if "event_date" in df.columns:
+        df["event_date"] = df["event_date"].astype(str)
+    return df
+
+
+def _select_document_embedding(
+    embedding_df: pd.DataFrame,
+    *,
+    as_of: datetime.date,
+    on_or_before: bool = True,
+) -> list[float] | None:
+    if embedding_df.empty:
+        return None
+    parsed = embedding_df["event_date"].map(_parse_iso)
+    mask = parsed.notna()
+    if on_or_before:
+        mask &= parsed.map(lambda d: bool(d) and d <= as_of)
+    if not mask.any():
+        return None
+    candidates = embedding_df.loc[mask].copy()
+    candidates["_parsed_date"] = parsed[mask]
+    candidates = candidates.sort_values(["_parsed_date"]).tail(1)
+    embedding = candidates.iloc[-1]["embedding"]
+    if embedding is None:
+        return None
+    return [float(x) for x in embedding]
+
+
+def _select_prior_embeddings(
+    embedding_df: pd.DataFrame,
+    *,
+    as_of: datetime.date,
+    window: int = 4,
+) -> list[list[float]]:
+    if embedding_df.empty:
+        return []
+    parsed = embedding_df["event_date"].map(_parse_iso)
+    mask = parsed.notna() & parsed.map(lambda d: bool(d) and d < as_of)
+    if not mask.any():
+        return []
+    candidates = embedding_df.loc[mask].copy()
+    candidates["_parsed_date"] = parsed[mask]
+    candidates = candidates.sort_values(["_parsed_date"]).tail(window)
+    out: list[list[float]] = []
+    for embedding in candidates["embedding"].tolist():
+        if embedding is None:
+            continue
+        out.append([float(x) for x in embedding])
+    return out
+
+
+def _stance_history_series(
+    stance_by_date: Sequence[tuple[str, float]],
+    *,
+    as_of: datetime.date,
+) -> list[float]:
+    """Return a chronologically-ordered stance series up to ``as_of``."""
+
+    series: list[tuple[datetime.date, float]] = []
+    for date_str, value in stance_by_date:
+        parsed = _parse_iso(date_str)
+        if parsed is None or parsed > as_of:
+            continue
+        series.append((parsed, float(value)))
+    series.sort(key=lambda item: item[0])
+    return [v for _, v in series]
+
+
+def _realized_series_from_fred(
+    response: FredSeriesResponse | None,
+    *,
+    as_of: datetime.date,
+    window_days: int = 90,
+) -> list[float]:
+    if response is None:
+        return []
+    lower = as_of - datetime.timedelta(days=window_days)
+    out: list[float] = []
+    for obs in response.observations:
+        parsed = _parse_iso(obs.date)
+        if parsed is None or parsed < lower or parsed > as_of:
+            continue
+        if obs.value is None:
+            continue
+        out.append(float(obs.value))
+    return out
+
+
+def assemble_inputs(
+    *,
+    as_of_ts: str,
+    embedding_path: Path | str | None,
+    stance_by_date: Sequence[tuple[str, float]] = (),
+    fred_response: FredSeriesResponse | None = None,
+    drift_window: int = 4,
+    realized_window_days: int = 90,
+) -> CredibilityInputs:
+    """Pack disparate sources into a :class:`CredibilityInputs` for one date."""
+
+    as_of = _parse_iso(as_of_ts)
+    if as_of is None:
+        raise ValueError(f"as_of_ts is not ISO-parseable: {as_of_ts!r}")
+
+    if embedding_path is not None:
+        path = Path(embedding_path)
+        if path.exists():
+            embedding_df = _load_embedding_frame(str(path))
+        else:
+            embedding_df = pd.DataFrame(columns=["event_date", "embedding"])
+    else:
+        embedding_df = pd.DataFrame(columns=["event_date", "embedding"])
+
+    current = _select_document_embedding(embedding_df, as_of=as_of) or []
+    prior = _select_prior_embeddings(embedding_df, as_of=as_of, window=drift_window)
+    stance = _stance_history_series(stance_by_date, as_of=as_of)
+    realized = _realized_series_from_fred(
+        fred_response, as_of=as_of, window_days=realized_window_days
+    )
+    # The "stated" path mirrors the stance series clipped to the same window so
+    # the correlation is computed over a matched horizon.
+    stated_path = stance[-len(realized) :] if realized else []
+    return CredibilityInputs(
+        current_embedding=current,
+        prior_embeddings=prior,
+        stance_history=stance,
+        stated_path=stated_path,
+        realized_path=realized,
+    )
+
+
+def load_credibility_for_run(
+    *,
+    as_of_ts: str,
+    embedding_path: Path | str | None,
+    stance_by_date: Sequence[tuple[str, float]] = (),
+    fred_response: FredSeriesResponse | None = None,
+    fred_series_id: str = DEFAULT_FRED_SERIES,
+    fred_cache_dir: Path | None = None,
+    drift_window: int = 4,
+    realized_window_days: int = 90,
+) -> CredibilityVector:
+    """Single entry point used by training and the ``/analyze`` path.
+
+    When ``fred_response`` is None and ``fred_cache_dir`` is provided, the
+    loader tries to load a cached FRED series; if missing it falls back to
+    an empty realized path (the gap returns 0.0).
+    """
+
+    if fred_response is None and fred_cache_dir is not None:
+        try:
+            fred_response = fetch_fred_series(
+                fred_series_id, cache_dir=Path(fred_cache_dir)
+            )
+        except (FileNotFoundError, RuntimeError):
+            fred_response = None
+
+    inputs = assemble_inputs(
+        as_of_ts=as_of_ts,
+        embedding_path=embedding_path,
+        stance_by_date=stance_by_date,
+        fred_response=fred_response,
+        drift_window=drift_window,
+        realized_window_days=realized_window_days,
+    )
+    return compute_credibility_vector(
+        current_embedding=inputs.current_embedding,
+        prior_embeddings=inputs.prior_embeddings,
+        stance_history=inputs.stance_history,
+        stated_path=inputs.stated_path,
+        realized_path=inputs.realized_path,
+        sep_terminal=None,
+        ois_terminal=None,
+    )
+
+
+__all__ = [
+    "CredibilityInputs",
+    "FredObservation",
+    "assemble_inputs",
+    "load_credibility_for_run",
+]

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -139,8 +139,20 @@ def _set_singleton_after_train(
 def _predict_next_point(model: ForecasterModel, sequence: list[FeatureVector]) -> tuple[float, float]:
     device = next(model.parameters()).device
     x = torch.tensor([[item.as_list() for item in sequence]], dtype=torch.float32, device=device)
+    kwargs: dict[str, torch.Tensor] = {}
+    if getattr(model, "credibility_features", False):
+        # Inference-side credibility uses a zero vector by default; the live
+        # vtasca + FRED loader (services.credibility_loader) populates real
+        # numbers in the training loop and at /analyze when the caller wires it
+        # in. Zero is the neutral "all axes unknown" reading from
+        # CredibilityVector — safe for forecast inference.
+        kwargs["credibility"] = torch.zeros(
+            (1, int(getattr(model, "credibility_dim", 4))),
+            dtype=torch.float32,
+            device=device,
+        )
     with torch.no_grad():
-        out = model(x).squeeze(0)
+        out = model(x, **kwargs).squeeze(0)
     close_scale = float((_model_artifact_metadata or {}).get("close_scale", DEFAULT_CLOSE_SCALE))
     pred_close = float(out[0].item()) * close_scale
     pred_vol = float(out[1].item())

--- a/backend/app/training/checkpoint.py
+++ b/backend/app/training/checkpoint.py
@@ -88,6 +88,7 @@ def _coerce_payload_config(payload: dict[str, Any] | None) -> ModelConfig:
             initial_decay_rate=float(raw.get("initial_decay_rate", ModelConfig().initial_decay_rate)),
             text_channel=str(raw.get("text_channel", "scalar")),
             embedding_adapter_dim=int(raw.get("embedding_adapter_dim", 128)),
+            credibility_features=bool(raw.get("credibility_features", False)),
         )
     return ModelConfig()
 

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -54,6 +54,7 @@ def _coerce_model_config(model_config: ModelConfig | dict[str, Any] | None = Non
             initial_decay_rate=float(model_config.get("initial_decay_rate", DEFAULT_INITIAL_DECAY_RATE)),
             text_channel=str(model_config.get("text_channel", "scalar")),
             embedding_adapter_dim=int(model_config.get("embedding_adapter_dim", 128)),
+            credibility_features=bool(model_config.get("credibility_features", False)),
         )
     return ModelConfig()
 
@@ -68,6 +69,21 @@ def _build_model(
     if device is not None:
         model = model.to(device)
     return model
+
+
+def _zero_credibility(model: ForecasterModel, batch_size: int, device: torch.device) -> torch.Tensor | None:
+    """Return a zero credibility tensor for the batch when the model expects one.
+
+    Models trained with ``credibility_features=True`` must always receive a
+    ``credibility`` tensor on the forward path. Until the per-row vtasca + FRED
+    loader is wired into the data pipeline, this hook supplies the neutral
+    "all axes unknown" reading so training stays runnable.
+    """
+
+    if not getattr(model, "credibility_features", False):
+        return None
+    dim = int(getattr(model, "credibility_dim", 4))
+    return torch.zeros((batch_size, dim), dtype=torch.float32, device=device)
 
 
 def _evaluate_model(
@@ -85,7 +101,9 @@ def _evaluate_model(
         for batch_x, batch_y in loader:
             batch_x = batch_x.to(device, non_blocking=device.type == "cuda")
             batch_y = batch_y.to(device, non_blocking=device.type == "cuda")
-            predictions = model(batch_x)
+            credibility = _zero_credibility(model, batch_x.size(0), device)
+            kwargs = {"credibility": credibility} if credibility is not None else {}
+            predictions = model(batch_x, **kwargs)
             loss = loss_fn(predictions, batch_y)
             batch_size = batch_x.size(0)
             total_loss += float(loss.item()) * batch_size
@@ -204,7 +222,9 @@ def train_model(
             batch_x = batch_x.to(device_obj, non_blocking=device_obj.type == "cuda")
             batch_y = batch_y.to(device_obj, non_blocking=device_obj.type == "cuda")
             optimizer.zero_grad(set_to_none=True)
-            predictions = work_model(batch_x)
+            credibility = _zero_credibility(work_model, batch_x.size(0), device_obj)
+            kwargs = {"credibility": credibility} if credibility is not None else {}
+            predictions = work_model(batch_x, **kwargs)
             loss = loss_fn(predictions, batch_y)
             loss.backward()
             nn.utils.clip_grad_norm_(work_model.parameters(), max_norm=1.0)

--- a/frontend/components/analyze/CredibilityPanel.tsx
+++ b/frontend/components/analyze/CredibilityPanel.tsx
@@ -55,7 +55,7 @@ function formatGap(value?: number): string {
 }
 
 export function CredibilityPanel({ credibility, previewMode }: CredibilityPanelProps) {
-  const driftScore = Number.isFinite(credibility.driftScore) ? credibility.driftScore : 0;
+  const driftScore = Number.isFinite(credibility.drift_score) ? credibility.drift_score : 0;
   const tone = driftTone(driftScore);
   return (
     <Card>
@@ -82,10 +82,10 @@ export function CredibilityPanel({ credibility, previewMode }: CredibilityPanelP
             <Badge variant={tone}>{driftLabel(driftScore)} · {driftScore.toFixed(2)}</Badge>
           </div>
           <Progress value={driftScore} />
-          {credibility.driftTrend?.length ? (
+          {credibility.drift_trend?.length ? (
             <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span>Trend</span>
-              <MiniTrend trend={credibility.driftTrend} />
+              <MiniTrend trend={credibility.drift_trend} />
             </div>
           ) : null}
         </div>
@@ -97,9 +97,9 @@ export function CredibilityPanel({ credibility, previewMode }: CredibilityPanelP
               <Scale className="h-3.5 w-3.5" />
             </div>
             <div className="mt-1 flex items-center justify-between">
-              <strong>{formatGap(credibility.realizedVsStatedGap)}</strong>
-              <Badge variant={gapTone(credibility.realizedVsStatedGap)} className="text-[10px]">
-                {credibility.realizedVsStatedGap == null ? "—" : "90d corr"}
+              <strong>{formatGap(credibility.realized_vs_stated_gap)}</strong>
+              <Badge variant={gapTone(credibility.realized_vs_stated_gap)} className="text-[10px]">
+                {credibility.realized_vs_stated_gap == null ? "—" : "90d corr"}
               </Badge>
             </div>
           </div>
@@ -109,9 +109,9 @@ export function CredibilityPanel({ credibility, previewMode }: CredibilityPanelP
               <Scale className="h-3.5 w-3.5" />
             </div>
             <div className="mt-1 flex items-center justify-between">
-              <strong>{formatGap(credibility.marketImpliedGap)}</strong>
-              <Badge variant={gapTone(credibility.marketImpliedGap)} className="text-[10px]">
-                {credibility.marketImpliedGap == null ? "—" : "vs OIS"}
+              <strong>{formatGap(credibility.market_implied_gap)}</strong>
+              <Badge variant={gapTone(credibility.market_implied_gap)} className="text-[10px]">
+                {credibility.market_implied_gap == null ? "—" : "vs OIS"}
               </Badge>
             </div>
           </div>
@@ -122,9 +122,9 @@ export function CredibilityPanel({ credibility, previewMode }: CredibilityPanelP
             </div>
             <div className="mt-1 flex items-center justify-between">
               <strong>
-                {credibility.monthsSinceReversal == null
+                {credibility.months_since_reversal == null
                   ? "—"
-                  : `${credibility.monthsSinceReversal} mo`}
+                  : `${credibility.months_since_reversal} mo`}
               </strong>
               <Badge variant="outline" className="text-[10px]">stance</Badge>
             </div>

--- a/frontend/lib/analyze/fixtures.ts
+++ b/frontend/lib/analyze/fixtures.ts
@@ -81,9 +81,9 @@ export const SAMPLE_XAI: XaiResponse = {
 };
 
 export const SAMPLE_CREDIBILITY: CredibilityResponse = {
-  driftScore: 0.34,
-  driftTrend: [0.21, 0.28, 0.31, 0.34],
-  realizedVsStatedGap: -0.08,
-  marketImpliedGap: 0.12,
-  monthsSinceReversal: 14,
+  drift_score: 0.34,
+  drift_trend: [0.21, 0.28, 0.31, 0.34],
+  realized_vs_stated_gap: -0.08,
+  market_implied_gap: 0.12,
+  months_since_reversal: 14,
 };

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -132,11 +132,11 @@ export interface XaiResponse {
 }
 
 export interface CredibilityResponse {
-  driftScore: number;
-  driftTrend?: number[];
-  realizedVsStatedGap?: number;
-  marketImpliedGap?: number;
-  monthsSinceReversal?: number;
+  drift_score: number;
+  drift_trend?: number[];
+  realized_vs_stated_gap?: number;
+  market_implied_gap?: number;
+  months_since_reversal?: number;
 }
 
 export interface AnalyzeResult {

--- a/frontend/tests/components/analyze/CredibilityPanel.test.tsx
+++ b/frontend/tests/components/analyze/CredibilityPanel.test.tsx
@@ -15,7 +15,7 @@ describe("CredibilityPanel", () => {
   });
 
   it("handles a sparse credibility payload without crashing", () => {
-    render(<CredibilityPanel credibility={{ driftScore: 0.5 }} />);
+    render(<CredibilityPanel credibility={{ drift_score: 0.5 }} />);
     expect(screen.getAllByText(/—/).length).toBeGreaterThanOrEqual(3);
   });
 });

--- a/scripts/cache_embeddings.py
+++ b/scripts/cache_embeddings.py
@@ -1,0 +1,29 @@
+"""Build (or rebuild) the per-encoder embedding cache for a training package.
+
+Examples
+--------
+Single encoder::
+
+    python scripts/cache_embeddings.py \
+        --encoder finbert_fomc \
+        --training-package-id tp_ds_v2 \
+        --allow-network
+
+The Makefile target ``cache-embeddings`` wraps this script for the common case.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKEND_PATH = REPO_ROOT / "backend"
+if str(BACKEND_PATH) not in sys.path:
+    sys.path.insert(0, str(BACKEND_PATH))
+
+from app.data.embedding_cache import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_bakeoff_aggregator.py
+++ b/tests/unit/test_bakeoff_aggregator.py
@@ -1,0 +1,109 @@
+"""Unit tests for app.evaluation.bakeoff_aggregator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.evaluation import bakeoff_aggregator as ba
+
+
+def _write_aggregate(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+@pytest.fixture
+def two_encoders(tmp_path: Path) -> Path:
+    """A typical finetune_batch output with two encoders × five seeds each."""
+
+    _write_aggregate(
+        tmp_path / "run_a" / "aggregate.json",
+        {
+            "by_encoder": {
+                "finbert": {
+                    "checkpoint": "ProsusAI/finbert",
+                    "per_seed": {
+                        "11": {"macro_f1": 0.68, "weighted_f1": 0.71, "accuracy": 0.74},
+                        "29": {"macro_f1": 0.70, "weighted_f1": 0.72, "accuracy": 0.75},
+                        "47": {"macro_f1": 0.69, "weighted_f1": 0.71, "accuracy": 0.74},
+                        "71": {"macro_f1": 0.71, "weighted_f1": 0.73, "accuracy": 0.76},
+                        "97": {"macro_f1": 0.67, "weighted_f1": 0.70, "accuracy": 0.73},
+                    },
+                },
+                "bge_large_en_v15": {
+                    "checkpoint": "BAAI/bge-large-en-v1.5",
+                    "per_seed": {
+                        "11": {"macro_f1": 0.62, "weighted_f1": 0.65, "accuracy": 0.69},
+                        "29": {"macro_f1": 0.63, "weighted_f1": 0.66, "accuracy": 0.70},
+                        "47": {"macro_f1": 0.61, "weighted_f1": 0.64, "accuracy": 0.68},
+                        "71": {"macro_f1": 0.64, "weighted_f1": 0.66, "accuracy": 0.70},
+                        "97": {"macro_f1": 0.60, "weighted_f1": 0.63, "accuracy": 0.67},
+                    },
+                },
+            }
+        },
+    )
+    return tmp_path
+
+
+def test_aggregate_orders_by_macro_f1_descending(two_encoders: Path) -> None:
+    rows, _markdown, _payload = ba.aggregate(two_encoders, n_resamples=100, seed=11)
+    assert [r.encoder_key for r in rows] == ["finbert", "bge_large_en_v15"]
+    assert rows[0].macro_f1_ci.point > rows[1].macro_f1_ci.point
+
+
+def test_aggregate_attaches_ci_to_every_metric(two_encoders: Path) -> None:
+    rows, _markdown, _payload = ba.aggregate(two_encoders, n_resamples=100, seed=11)
+    for row in rows:
+        for ci in (row.macro_f1_ci, row.weighted_f1_ci, row.accuracy_ci):
+            assert ci.lo <= ci.point <= ci.hi
+            assert 0.0 <= ci.lo and ci.hi <= 1.0
+
+
+def test_markdown_renders_all_rows(two_encoders: Path) -> None:
+    rows, markdown, _payload = ba.aggregate(two_encoders, n_resamples=100, seed=11)
+    assert "finbert" in markdown
+    assert "bge_large_en_v15" in markdown
+    assert "macro-F1" in markdown
+    assert markdown.count("\n| ") >= len(rows)
+
+
+def test_aggregate_merges_multiple_aggregate_files(tmp_path: Path) -> None:
+    _write_aggregate(
+        tmp_path / "first" / "aggregate.json",
+        {
+            "by_encoder": {
+                "finbert": {
+                    "checkpoint": "ProsusAI/finbert",
+                    "per_seed": {
+                        "11": {"macro_f1": 0.7, "weighted_f1": 0.7, "accuracy": 0.7},
+                    },
+                },
+            }
+        },
+    )
+    _write_aggregate(
+        tmp_path / "second" / "aggregate.json",
+        {
+            "by_encoder": {
+                "finbert": {
+                    "checkpoint": "ProsusAI/finbert",
+                    "per_seed": {
+                        "29": {"macro_f1": 0.72, "weighted_f1": 0.72, "accuracy": 0.72},
+                    },
+                },
+            }
+        },
+    )
+    rows, _markdown, _payload = ba.aggregate(tmp_path, n_resamples=50, seed=11)
+    assert len(rows) == 1
+    assert sorted(rows[0].seeds) == [11, 29]
+    assert len(rows[0].macro_f1_values) == 2
+
+
+def test_aggregate_missing_dir_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        ba.aggregate(tmp_path / "missing", n_resamples=10, seed=11)

--- a/tests/unit/test_credibility_loader.py
+++ b/tests/unit/test_credibility_loader.py
@@ -1,0 +1,145 @@
+"""Unit tests for app.services.credibility_loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from app.features.credibility import CredibilityVector
+from app.services.credibility_loader import (
+    CredibilityInputs,
+    assemble_inputs,
+    load_credibility_for_run,
+)
+from app.services.fred_client import FredObservation, FredSeriesResponse
+
+
+def _write_embeddings(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_parquet(path, index=False)
+
+
+def _fred_response(observations: list[tuple[str, float]]) -> FredSeriesResponse:
+    return FredSeriesResponse(
+        series_id="DFF",
+        realtime_start="2024-01-01",
+        realtime_end="2024-12-31",
+        observation_start="2024-01-01",
+        observation_end="2024-12-31",
+        count=len(observations),
+        observations=[
+            FredObservation(date=d, value=v, realtime_start="2024-01-01", realtime_end="2024-12-31")
+            for d, v in observations
+        ],
+    )
+
+
+def test_assemble_inputs_collects_drift_inputs_from_embedding_cache(tmp_path: Path) -> None:
+    path = tmp_path / "embeddings.parquet"
+    _write_embeddings(
+        path,
+        [
+            {"event_date": "2023-09-01", "embedding": [1.0, 0.0, 0.0]},
+            {"event_date": "2023-11-01", "embedding": [0.9, 0.1, 0.0]},
+            {"event_date": "2024-01-01", "embedding": [0.8, 0.2, 0.0]},
+            {"event_date": "2024-03-01", "embedding": [0.7, 0.3, 0.0]},
+            {"event_date": "2024-05-01", "embedding": [0.0, 1.0, 0.0]},
+        ],
+    )
+    inputs = assemble_inputs(
+        as_of_ts="2024-05-01",
+        embedding_path=path,
+        drift_window=4,
+    )
+    assert isinstance(inputs, CredibilityInputs)
+    assert inputs.current_embedding == [0.0, 1.0, 0.0]
+    assert len(inputs.prior_embeddings) == 4
+    assert inputs.prior_embeddings[0] == [1.0, 0.0, 0.0]
+    assert inputs.prior_embeddings[-1] == [0.7, 0.3, 0.0]
+
+
+def test_assemble_inputs_handles_missing_embedding_path(tmp_path: Path) -> None:
+    inputs = assemble_inputs(
+        as_of_ts="2024-05-01",
+        embedding_path=tmp_path / "does_not_exist.parquet",
+    )
+    assert inputs.current_embedding == []
+    assert inputs.prior_embeddings == []
+
+
+def test_assemble_inputs_filters_stance_history_to_on_or_before(tmp_path: Path) -> None:
+    inputs = assemble_inputs(
+        as_of_ts="2024-05-01",
+        embedding_path=None,
+        stance_by_date=[
+            ("2024-01-01", 0.5),
+            ("2024-03-01", -0.3),
+            ("2024-05-15", 0.8),  # post-as-of — must be excluded
+        ],
+    )
+    assert inputs.stance_history == [0.5, -0.3]
+
+
+def test_assemble_inputs_filters_fred_series_to_trailing_window(tmp_path: Path) -> None:
+    response = _fred_response(
+        [
+            ("2024-01-01", 4.0),
+            ("2024-02-01", 4.5),
+            ("2024-03-01", 5.0),
+            ("2024-04-01", 5.25),
+            ("2024-05-01", 5.5),
+            ("2024-06-01", 5.5),  # post-as-of — excluded
+        ]
+    )
+    inputs = assemble_inputs(
+        as_of_ts="2024-05-01",
+        embedding_path=None,
+        stance_by_date=[
+            ("2024-02-01", 0.3),
+            ("2024-04-01", -0.1),
+        ],
+        fred_response=response,
+        realized_window_days=200,
+    )
+    assert inputs.realized_path == [4.0, 4.5, 5.0, 5.25, 5.5]
+    # stated_path is clipped to the matched horizon from stance_history
+    assert inputs.stated_path == [0.3, -0.1]
+
+
+def test_load_credibility_for_run_returns_vector_with_neutral_defaults(tmp_path: Path) -> None:
+    vector = load_credibility_for_run(
+        as_of_ts="2024-05-01",
+        embedding_path=None,
+        stance_by_date=[],
+        fred_response=None,
+    )
+    assert isinstance(vector, CredibilityVector)
+    # All axes degrade to 0 / 0 when no inputs are available.
+    assert vector.drift_score == 0.0
+    assert vector.realized_vs_stated_gap == 0.0
+    assert vector.market_implied_gap == 0.0
+    assert vector.months_since_reversal == 0
+
+
+def test_load_credibility_for_run_invokes_drift_when_embeddings_present(tmp_path: Path) -> None:
+    path = tmp_path / "embeddings.parquet"
+    _write_embeddings(
+        path,
+        [
+            {"event_date": "2024-01-01", "embedding": [1.0, 0.0]},
+            {"event_date": "2024-03-01", "embedding": [1.0, 0.0]},
+            {"event_date": "2024-05-01", "embedding": [0.0, 1.0]},  # orthogonal to priors
+        ],
+    )
+    vector = load_credibility_for_run(
+        as_of_ts="2024-05-01",
+        embedding_path=path,
+    )
+    assert vector.drift_score == pytest.approx(1.0, abs=1e-6)
+
+
+def test_invalid_as_of_ts_raises() -> None:
+    with pytest.raises(ValueError):
+        assemble_inputs(as_of_ts="not-a-date", embedding_path=None)

--- a/tests/unit/test_embedding_cache.py
+++ b/tests/unit/test_embedding_cache.py
@@ -1,0 +1,227 @@
+"""Unit tests for app.data.embedding_cache (encoder-keyed cache)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.data import embedding_cache as ec
+
+
+@pytest.fixture(autouse=True)
+def _clear_lru_cache():
+    yield
+
+
+def _write_registry(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+def test_resolve_cache_paths_embeds_short_revision(tmp_path: Path) -> None:
+    paths = ec.resolve_cache_paths("finbert_fomc", revision="abc1234567890def" * 4, cache_dir=tmp_path)
+    assert paths.parquet.name == "finbert_fomc_abc123456789.parquet"
+    assert paths.sources_lock == tmp_path / "SOURCES.lock"
+
+
+def test_resolve_cache_paths_handles_unpinned_revision(tmp_path: Path) -> None:
+    paths = ec.resolve_cache_paths("finbert_fed_adjacent", revision=None, cache_dir=tmp_path)
+    assert paths.parquet.name == "finbert_fed_adjacent_unpinned.parquet"
+
+
+def test_build_cache_hard_fails_without_allow_network(tmp_path: Path, monkeypatch) -> None:
+    """The training-time invariant: never silently download at runtime."""
+
+    monkeypatch.setattr(
+        ec, "encoder_ref",
+        lambda alias: types.SimpleNamespace(
+            alias=alias, repo="ProsusAI/finbert", revision="rev1234567890ab", gated=False,
+            task="classification", description="",
+        ),
+    )
+    registry = tmp_path / "processed" / "pkg" / "registry_normalized.jsonl"
+    _write_registry(registry, [{"text": "hello", "event_date": "2024-01-01"}])
+
+    with pytest.raises(RuntimeError, match="Embedding cache missing"):
+        ec.build_cache(
+            encoder_alias="finbert",
+            training_package_id="pkg",
+            data_dir=tmp_path,
+            cache_dir=tmp_path / "embeddings",
+            allow_network=False,
+        )
+
+
+def test_build_cache_raises_on_unpinned_encoder(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        ec, "encoder_ref",
+        lambda alias: types.SimpleNamespace(
+            alias=alias, repo="local/finbert-fed-adjacent", revision="", gated=False,
+            task="masked_lm", description="",
+        ),
+    )
+    with pytest.raises(ValueError, match="no pinned revision"):
+        ec.build_cache(
+            encoder_alias="finbert_fed_adjacent",
+            training_package_id="pkg",
+            data_dir=tmp_path,
+            cache_dir=tmp_path / "embeddings",
+            allow_network=True,
+        )
+
+
+def test_build_cache_writes_parquet_and_sources_lock(tmp_path: Path, monkeypatch) -> None:
+    """End-to-end: builder calls a faked encoder, writes the parquet, and
+    appends a SOURCES.lock line capturing the artefact SHA-256."""
+
+    monkeypatch.setattr(
+        ec, "encoder_ref",
+        lambda alias: types.SimpleNamespace(
+            alias=alias, repo="ProsusAI/finbert", revision="rev1234567890ab", gated=False,
+            task="classification", description="",
+        ),
+    )
+
+    class _FakeTokenizer:
+        model_max_length = 512
+
+        def encode(self, text, add_special_tokens=False):
+            return list(range(len(text.split())))
+
+        def decode(self, ids, skip_special_tokens=True):
+            return "chunk-" + str(len(ids))
+
+        def __call__(self, inputs, **kwargs):
+            import torch as _torch
+
+            batch = len(inputs)
+            return {
+                "input_ids": _torch.zeros((batch, 4), dtype=_torch.long),
+                "attention_mask": _torch.ones((batch, 4), dtype=_torch.long),
+            }
+
+    class _FakeModel:
+        def __init__(self):
+            import torch as _torch
+
+            self._weight = _torch.nn.Parameter(_torch.zeros(1))
+
+        def parameters(self):
+            return iter([self._weight])
+
+        def eval(self):
+            return self
+
+        def __call__(self, **kwargs):
+            import torch as _torch
+
+            batch = kwargs["input_ids"].shape[0]
+            hidden = _torch.zeros((batch, 4, 6))
+            for b in range(batch):
+                hidden[b, 0, :] = float(b + 1)  # distinguishable CLS row per item
+            return types.SimpleNamespace(last_hidden_state=hidden)
+
+    monkeypatch.setattr(
+        ec, "_load_encoder", lambda ref: (_FakeTokenizer(), _FakeModel())
+    )
+
+    registry = tmp_path / "processed" / "pkg" / "registry_normalized.jsonl"
+    _write_registry(
+        registry,
+        [
+            {
+                "text": "hawkish phrasing about the policy outlook",
+                "event_date": "2024-01-01",
+                "record_id": "rec-1",
+            },
+            {
+                "text": "dovish phrasing about the policy outlook",
+                "event_date": "2024-02-01",
+                "record_id": "rec-2",
+            },
+        ],
+    )
+
+    result = ec.build_cache(
+        encoder_alias="finbert",
+        training_package_id="pkg",
+        data_dir=tmp_path,
+        cache_dir=tmp_path / "embeddings",
+        batch_size=2,
+        min_text_chars=0,
+        max_length=8,
+        allow_network=True,
+    )
+
+    assert result.parquet_path.exists()
+    assert result.encoder_revision == "rev1234567890ab"
+    assert result.encoder_alias == "finbert"
+
+    df = pd.read_parquet(result.parquet_path)
+    assert set(df.columns) == {"record_id", "doc_id", "event_date", "chunk_index", "chunk_preview", "embedding"}
+    assert len(df) == 2
+
+    assert result.sources_lock_path.exists()
+    line = result.sources_lock_path.read_text(encoding="utf-8").strip().splitlines()[-1]
+    entry = json.loads(line)
+    assert entry["encoder_alias"] == "finbert"
+    assert entry["encoder_revision"] == "rev1234567890ab"
+    assert entry["row_count"] == 2
+    expected_sha = hashlib.sha256(result.parquet_path.read_bytes()).hexdigest()
+    assert entry["parquet_sha256"] == expected_sha
+
+
+def test_require_cache_exists_error_message_is_actionable(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="make cache-embeddings ENCODER=finbert_fomc"):
+        ec.require_cache_exists(
+            "finbert_fomc",
+            revision="abc1234567890def",
+            cache_dir=tmp_path,
+        )
+
+
+def test_build_cache_reuses_existing_parquet_without_network(tmp_path: Path, monkeypatch) -> None:
+    """Second invocation reads the cached parquet without invoking the encoder."""
+
+    monkeypatch.setattr(
+        ec, "encoder_ref",
+        lambda alias: types.SimpleNamespace(
+            alias=alias, repo="ProsusAI/finbert", revision="rev1234567890ab", gated=False,
+            task="classification", description="",
+        ),
+    )
+    paths = ec.resolve_cache_paths("finbert", revision="rev1234567890ab", cache_dir=tmp_path / "embeddings")
+    paths.parquet.parent.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(
+        [
+            {"record_id": "x", "doc_id": "x", "event_date": "2024-01-01", "chunk_index": 0,
+             "chunk_preview": "y", "embedding": [0.1, 0.2]},
+        ]
+    )
+    df.to_parquet(paths.parquet, index=False)
+
+    registry = tmp_path / "processed" / "pkg" / "registry_normalized.jsonl"
+    _write_registry(registry, [{"text": "x", "event_date": "2024-01-01"}])
+
+    def _explode(_ref):
+        raise AssertionError("encoder loader should not be called on a cache hit")
+
+    monkeypatch.setattr(ec, "_load_encoder", _explode)
+
+    result = ec.build_cache(
+        encoder_alias="finbert",
+        training_package_id="pkg",
+        data_dir=tmp_path,
+        cache_dir=tmp_path / "embeddings",
+        allow_network=False,
+    )
+    assert result.row_count == 1

--- a/tests/unit/test_finetune_batch.py
+++ b/tests/unit/test_finetune_batch.py
@@ -33,3 +33,28 @@ def test_encoders_keys_are_unique_local_labels() -> None:
         finetune_batch.ENCODERS["fomc_roberta"]
         != finetune_batch.ENCODERS["gtfintechlab_fomc_roberta"]
     )
+
+
+def test_encoders_registry_adds_sentence_embedding_and_fed_adjacent_encoders() -> None:
+    """Sprint 2 extends the bake-off with FinBERT-FedAdjacent + 2 sentence-embedding entries."""
+
+    assert finetune_batch.ENCODERS["finbert_fed_adjacent"] == "local/finbert-fed-adjacent"
+    assert finetune_batch.ENCODERS["bge_large_en_v15"] == "BAAI/bge-large-en-v1.5"
+    assert finetune_batch.ENCODERS["nomic_embed_text_v15"] == "nomic-ai/nomic-embed-text-v1.5"
+
+
+def test_unpinned_local_encoder_is_skipped() -> None:
+    """finbert_fed_adjacent has no revision until the user runs the pretrain.
+    The bake-off must skip it rather than fail mid-run."""
+
+    ok, reason = finetune_batch._is_encoder_runnable(
+        "finbert_fed_adjacent", "local/finbert-fed-adjacent"
+    )
+    assert ok is False
+    assert "finbert-fed-adjacent-pretrain" in reason
+
+
+def test_pinned_hf_encoder_is_runnable() -> None:
+    ok, reason = finetune_batch._is_encoder_runnable("finbert", "ProsusAI/finbert")
+    assert ok is True
+    assert reason == ""

--- a/tests/unit/test_forecaster_credibility_features.py
+++ b/tests/unit/test_forecaster_credibility_features.py
@@ -1,0 +1,101 @@
+"""Regression tests for the credibility_features flag on ForecasterModel.
+
+The default-off invariant is the critical one: when ``credibility_features``
+is False (the default), the model must behave byte-identically to the v1
+forecaster so the existing determinism test in ``tests/regression/`` and every
+on-disk checkpoint keep loading.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from app.models.config import CREDIBILITY_FEATURE_DIM, ModelConfig
+from app.models.lstm import ForecasterModel
+
+
+def _seed(seed: int = 11) -> None:
+    torch.manual_seed(seed)
+
+
+def test_credibility_off_is_default() -> None:
+    config = ModelConfig()
+    assert config.credibility_features is False
+    model = ForecasterModel(**config.to_dict())
+    assert model.credibility_features is False
+    assert model.credibility_dim == 0
+
+
+def test_credibility_off_model_forward_matches_v1_shape() -> None:
+    _seed()
+    model_off = ForecasterModel()
+    x = torch.randn(2, 5, model_off.input_size)
+    out = model_off(x)
+    assert out.shape == (2, 2)
+
+
+def test_credibility_off_state_dict_keys_unchanged_from_v1() -> None:
+    """Adding the credibility_features parameter must not add new tensors when
+    the feature is off — otherwise loading older checkpoints would break."""
+
+    model_off = ForecasterModel(credibility_features=False)
+    keys_off = set(model_off.state_dict().keys())
+
+    # Compare against a model built with the legacy constructor surface (no
+    # credibility_features kwarg, simulating older code paths). Same keys
+    # expected.
+    legacy = ForecasterModel(
+        input_size=model_off.input_size,
+        hidden_size=model_off.hidden_size,
+        num_layers=model_off.num_layers,
+        dropout=model_off.dropout,
+        head_hidden_size=model_off.head_hidden_size,
+        initial_decay_rate=model_off.initial_decay_rate,
+    )
+    assert keys_off == set(legacy.state_dict().keys())
+
+
+def test_credibility_on_extends_lstm_input_size() -> None:
+    model = ForecasterModel(credibility_features=True)
+    assert model.credibility_features is True
+    assert model.credibility_dim == CREDIBILITY_FEATURE_DIM
+    assert model.lstm_input_size == model.input_size + CREDIBILITY_FEATURE_DIM
+
+
+def test_credibility_on_forward_requires_credibility_tensor() -> None:
+    model = ForecasterModel(credibility_features=True)
+    x = torch.randn(2, 5, model.input_size)
+    try:
+        model(x)
+    except ValueError as exc:
+        assert "credibility" in str(exc).lower()
+    else:
+        raise AssertionError("forward must reject missing credibility tensor")
+
+
+def test_credibility_on_forward_accepts_per_batch_vector() -> None:
+    model = ForecasterModel(credibility_features=True)
+    x = torch.randn(2, 5, model.input_size)
+    credibility = torch.tensor(
+        [[0.1, -0.2, 0.0, 6.0], [0.3, 0.4, -0.1, 12.0]], dtype=torch.float32
+    )
+    out = model(x, credibility=credibility)
+    assert out.shape == (2, 2)
+
+
+def test_credibility_on_rejects_wrong_dim() -> None:
+    model = ForecasterModel(credibility_features=True)
+    x = torch.randn(1, 5, model.input_size)
+    wrong = torch.zeros((1, 3))
+    try:
+        model(x, credibility=wrong)
+    except ValueError as exc:
+        assert "shape" in str(exc).lower()
+    else:
+        raise AssertionError("forward must reject wrong-dim credibility tensor")
+
+
+def test_modelconfig_round_trip_preserves_credibility_flag() -> None:
+    config = ModelConfig(credibility_features=True)
+    rebuilt = ModelConfig(**config.to_dict())
+    assert rebuilt.credibility_features is True


### PR DESCRIPTION
## Summary
- Encoder-keyed embedding cache at `data/raw/embeddings/<alias>_<rev>.parquet` with SOURCES.lock + artefact sha256.
- Hard-fail when a configured encoder's cache is absent at training time; `--allow-network` gates HF instantiation.
- Bake-off aggregator emits markdown + JSON headline table with block-bootstrap CIs from `finetune_batch` outputs.
- Registry adds `finbert_fed_adjacent` (unpinned), `bge_large_en_v15`, `nomic_embed_text_v15`; `finetune_batch` skips unpinned encoders cleanly.
- Forecaster gains `credibility_features` flag; default-off path is byte-identical and locked by a regression test.
- `credibility_loader` assembles drift + realized-vs-stated + reversal inputs from vtasca embeddings + FRED.
- `AnalyzeResponse.credibility` exposed (additive, nullable); `CredibilityPanel` switches to snake_case.

## Test plan
- `docker compose exec backend-gpu pytest tests/unit/test_embedding_cache.py tests/unit/test_bakeoff_aggregator.py tests/unit/test_credibility_loader.py tests/unit/test_forecaster_credibility_features.py tests/unit/test_finetune_batch.py tests/regression/test_forecaster_determinism.py`
- `docker compose exec frontend npm run type-check && npm test -- --run`