### PR TITLE
Zero-shot cross-CB transfer evaluation harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,3 +210,16 @@ finbert-fed-adjacent-pretrain-smoke:
 		--batch-size 4 \
 		--block-size 128 \
 		--objective mlm
+
+# Zero-shot cross-CB transfer matrix for an NLP checkpoint.
+# Required: TRAINING_PACKAGE_ID, MODEL_CHECKPOINTS (alias=path[,alias=path]).
+# Optional: EVAL_BANKS (ecb,boj,boe,boc,rba; default = all 5), SEEDS.
+eval-cross-bank:
+	@if [ -z "$(TRAINING_PACKAGE_ID)" ]; then echo "Set TRAINING_PACKAGE_ID=<id>"; exit 2; fi
+	@if [ -z "$(MODEL_CHECKPOINTS)" ]; then echo "Set MODEL_CHECKPOINTS=alias=path[,alias=path]"; exit 2; fi
+	docker compose run --rm backend \
+		python -m app.evaluation.transfer_matrix \
+		--training-package-id "$(TRAINING_PACKAGE_ID)" \
+		--model-checkpoints "$(MODEL_CHECKPOINTS)" \
+		$(if $(EVAL_BANKS),--eval-banks "$(EVAL_BANKS)",) \
+		$(if $(SEEDS),--seeds "$(SEEDS)",)

--- a/backend/app/data/finetune_pilot.py
+++ b/backend/app/data/finetune_pilot.py
@@ -395,7 +395,7 @@ def run_one(args: argparse.Namespace, *, artifact_dir: Path | None = None) -> di
         hyperparameters={
             "checkpoint": args.checkpoint,
             "epochs": args.epochs,
-            "batch_size": args.batch_size,
+            "batch_size": args.train_batch_size,
             "learning_rate": args.learning_rate,
             "weight_decay": args.weight_decay,
             "fold_id": args.fold_id,

--- a/backend/app/data/finetune_pilot.py
+++ b/backend/app/data/finetune_pilot.py
@@ -56,6 +56,9 @@ class EvalRow:
     label: str
     event_date: str
     record_id: str = ""
+    source: str = ""
+    provenance: str = ""
+    sample_weight: float = 1.0
 
 
 def _set_all_seeds(seed: int) -> None:
@@ -71,7 +74,17 @@ def _hf_token() -> str | None:
     return os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_HUB_TOKEN") or None
 
 
-def _load_registry_rows(package_dir: Path) -> list[EvalRow]:
+def _load_registry_rows(
+    package_dir: Path, *, include_zero_weight: bool = False
+) -> list[EvalRow]:
+    """Load mapped-label rows from a training package.
+
+    ``include_zero_weight=False`` (the default) drops any row with
+    ``sample_weight == 0`` so cross-bank corpora (provenance
+    ``peer_reviewed_cross_bank``) never enter the training loss. The
+    cross-bank eval harness flips this flag to read them back in.
+    """
+
     path = package_dir / "registry_normalized.jsonl"
     rows: list[EvalRow] = []
     if not path.exists():
@@ -85,8 +98,26 @@ def _load_registry_rows(package_dir: Path) -> list[EvalRow]:
         text = str(payload.get("text", "")).strip()
         event_date = str(payload.get("event_date", "")).strip()
         record_id = str(payload.get("record_id", "")).strip()
+        source = str(payload.get("source", "")).strip()
+        provenance = str(payload.get("provenance", "")).strip()
+        try:
+            sample_weight = float(payload.get("sample_weight", 1.0))
+        except (TypeError, ValueError):
+            sample_weight = 1.0
+        if not include_zero_weight and sample_weight == 0.0:
+            continue
         if label in LABELS and text and event_date:
-            rows.append(EvalRow(text=text, label=label, event_date=event_date, record_id=record_id))
+            rows.append(
+                EvalRow(
+                    text=text,
+                    label=label,
+                    event_date=event_date,
+                    record_id=record_id,
+                    source=source,
+                    provenance=provenance,
+                    sample_weight=sample_weight,
+                )
+            )
     return rows
 
 

--- a/backend/app/evaluation/cross_bank_transfer.py
+++ b/backend/app/evaluation/cross_bank_transfer.py
@@ -230,6 +230,15 @@ def evaluate_cross_bank(
         raise ValueError(
             f"No labeled rows for {bank_source!r} in registry. Re-run ingest_sources to fetch."
         )
+    record_ids = [r.record_id for r in rows]
+    if len(record_ids) != len(set(record_ids)):
+        # Per-axis slicing builds a set of record_ids and back-projects to
+        # y_true / y_pred; duplicates would silently double-count support.
+        # The contract in docs/data-and-training-contracts.md requires unique
+        # record_ids per row — fail loud if the writer ever drifts.
+        raise ValueError(
+            f"Duplicate record_ids in {bank_source!r} — re-run ingest_sources to regenerate the registry."
+        )
 
     if predict_fn is None:
         y_true, y_pred, latencies = _predict_with_model(

--- a/backend/app/evaluation/cross_bank_transfer.py
+++ b/backend/app/evaluation/cross_bank_transfer.py
@@ -1,0 +1,266 @@
+"""Zero-shot cross-CB transfer evaluation.
+
+Given an NLP checkpoint trained on FOMC stance labels and a held-out central
+bank from the gtfintechlab cross-bank pool (ECB / BoJ / BoE / BoC / RBA),
+compute macro-F1, accuracy, per-class precision/recall, and per-axis metrics
+(stance + time + certainty when available) on that bank's labeled rows.
+
+The eval reads cross-bank rows directly from the training package's
+``registry_normalized.jsonl`` — they live there with ``sample_weight=0`` so
+they are masked from training but still indexable for evaluation.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from app.data.finetune_pilot import (
+    ID2LABEL,
+    LABEL2ID,
+    LABELS,
+    _compute_classification_metrics,
+    _latency_summary,
+    _load_registry_rows,
+    EvalRow,
+)
+
+CROSS_BANK_SOURCES = (
+    "gtfintechlab_european_central_bank",
+    "gtfintechlab_bank_of_japan",
+    "gtfintechlab_bank_of_england",
+    "gtfintechlab_bank_of_canada",
+    "gtfintechlab_reserve_bank_of_australia",
+)
+
+
+@dataclass(frozen=True)
+class CrossBankResult:
+    bank: str
+    checkpoint: str
+    support: int
+    macro_f1: float
+    weighted_f1: float
+    accuracy: float
+    per_class: dict[str, dict[str, float]]
+    latency_ms_p50: float
+    latency_ms_p95: float
+    per_axis: dict[str, dict[str, Any]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "bank": self.bank,
+            "checkpoint": self.checkpoint,
+            "support": self.support,
+            "macro_f1": self.macro_f1,
+            "weighted_f1": self.weighted_f1,
+            "accuracy": self.accuracy,
+            "per_class": self.per_class,
+            "latency_ms": {"p50": self.latency_ms_p50, "p95": self.latency_ms_p95},
+            "per_axis": self.per_axis,
+        }
+
+
+def load_cross_bank_rows(package_dir: Path, bank_source: str) -> list[EvalRow]:
+    """Read cross-bank labeled rows for ``bank_source`` from the package registry."""
+
+    all_rows = _load_registry_rows(package_dir, include_zero_weight=True)
+    return [row for row in all_rows if row.source == bank_source]
+
+
+def _read_raw_registry_extras(package_dir: Path, bank_source: str) -> dict[str, dict[str, Any]]:
+    """Return {record_id: multi_axis_extras} for the bank's rows.
+
+    Used by ``_compute_per_axis_metrics`` to surface stance + time + certainty
+    breakdowns where the gtfintechlab schema carries them.
+    """
+
+    out: dict[str, dict[str, Any]] = {}
+    path = package_dir / "registry_normalized.jsonl"
+    if not path.exists():
+        return out
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if str(payload.get("source", "")) != bank_source:
+            continue
+        rid = str(payload.get("record_id", ""))
+        if rid:
+            extras = payload.get("multi_axis_extras") or {}
+            if isinstance(extras, dict):
+                out[rid] = extras
+    return out
+
+
+def _slice_by_axis_value(
+    rows: Iterable[EvalRow],
+    extras_by_id: dict[str, dict[str, Any]],
+    *,
+    axis_field: str,
+) -> dict[str, list[EvalRow]]:
+    buckets: dict[str, list[EvalRow]] = {}
+    for row in rows:
+        extras = extras_by_id.get(row.record_id, {})
+        value = str(extras.get(axis_field, "") or "").strip()
+        if not value:
+            continue
+        buckets.setdefault(value, []).append(row)
+    return buckets
+
+
+def _compute_per_axis_metrics(
+    rows: list[EvalRow],
+    y_true: list[str],
+    y_pred: list[str],
+    extras_by_id: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Compute macro-F1 sliced by each multi-axis extras field, when present."""
+
+    axis_fields = (
+        ("time", "gtfintechlab_time_label"),
+        ("certainty", "gtfintechlab_certain_label"),
+    )
+    per_axis: dict[str, dict[str, Any]] = {}
+    for axis_name, axis_field in axis_fields:
+        buckets = _slice_by_axis_value(rows, extras_by_id, axis_field=axis_field)
+        if not buckets:
+            continue
+        slice_metrics: dict[str, dict[str, Any]] = {}
+        for bucket_value, bucket_rows in buckets.items():
+            ids = {row.record_id for row in bucket_rows}
+            sub_true = [t for row, t in zip(rows, y_true) if row.record_id in ids]
+            sub_pred = [p for row, p in zip(rows, y_pred) if row.record_id in ids]
+            if not sub_true:
+                continue
+            cls = _compute_classification_metrics(sub_true, sub_pred)
+            slice_metrics[bucket_value] = {
+                "support": len(sub_true),
+                "macro_f1": cls["macro_f1"],
+                "accuracy": cls["accuracy"],
+            }
+        if slice_metrics:
+            per_axis[axis_name] = slice_metrics
+    return per_axis
+
+
+def _label_support(rows: list[EvalRow]) -> Counter[str]:
+    return Counter(row.label for row in rows)
+
+
+def _predict_with_model(
+    rows: list[EvalRow],
+    *,
+    checkpoint: str,
+    max_length: int = 256,
+    batch_size: int = 32,
+) -> tuple[list[str], list[str], list[float]]:
+    """Run inference using a HuggingFace classification checkpoint."""
+
+    import torch
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+    model = AutoModelForSequenceClassification.from_pretrained(checkpoint)
+    model.eval()
+    device = next(model.parameters()).device
+
+    # Honour LABEL2ID order, not the loaded checkpoint's id2label, because some
+    # legacy checkpoints had inverted classes. The canonical TDW order is
+    # (dovish, hawkish, neutral).
+    id2label = ID2LABEL
+
+    y_true: list[str] = []
+    y_pred: list[str] = []
+    latencies: list[float] = []
+
+    with torch.no_grad():
+        for start in range(0, len(rows), batch_size):
+            batch_rows = rows[start : start + batch_size]
+            batch_texts = [r.text for r in batch_rows]
+            enc = tokenizer(
+                batch_texts,
+                truncation=True,
+                max_length=max_length,
+                padding=True,
+                return_tensors="pt",
+            ).to(device)
+            t0 = time.perf_counter()
+            logits = model(**enc).logits
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            per_item_ms = elapsed_ms / max(len(batch_rows), 1)
+            latencies.extend([per_item_ms] * len(batch_rows))
+            preds = logits.argmax(dim=-1).tolist()
+            for row, pred_idx in zip(batch_rows, preds):
+                y_true.append(row.label)
+                y_pred.append(id2label[int(pred_idx)])
+
+    return y_true, y_pred, latencies
+
+
+def evaluate_cross_bank(
+    *,
+    package_dir: Path,
+    bank_source: str,
+    checkpoint: str,
+    max_length: int = 256,
+    batch_size: int = 32,
+    predict_fn=None,
+) -> CrossBankResult:
+    """Evaluate ``checkpoint`` zero-shot on the bank's cross-bank rows.
+
+    ``predict_fn`` is injected by tests with a deterministic stub; production
+    code passes ``None`` to use the HF inference path.
+    """
+
+    if bank_source not in CROSS_BANK_SOURCES:
+        raise ValueError(
+            f"Unknown bank_source {bank_source!r}. Allowed: {CROSS_BANK_SOURCES}"
+        )
+    rows = load_cross_bank_rows(package_dir, bank_source)
+    if not rows:
+        raise ValueError(
+            f"No labeled rows for {bank_source!r} in registry. Re-run ingest_sources to fetch."
+        )
+
+    if predict_fn is None:
+        y_true, y_pred, latencies = _predict_with_model(
+            rows, checkpoint=checkpoint, max_length=max_length, batch_size=batch_size
+        )
+    else:
+        y_true, y_pred, latencies = predict_fn(rows)
+
+    cls = _compute_classification_metrics(y_true, y_pred)
+    latency = _latency_summary(latencies)
+    extras = _read_raw_registry_extras(package_dir, bank_source)
+    per_axis = _compute_per_axis_metrics(rows, y_true, y_pred, extras)
+
+    return CrossBankResult(
+        bank=bank_source,
+        checkpoint=checkpoint,
+        support=len(rows),
+        macro_f1=cls["macro_f1"],
+        weighted_f1=cls["weighted_f1"],
+        accuracy=cls["accuracy"],
+        per_class=cls["per_class"],
+        latency_ms_p50=latency["p50_ms"],
+        latency_ms_p95=latency["p95_ms"],
+        per_axis=per_axis,
+    )
+
+
+__all__ = [
+    "CROSS_BANK_SOURCES",
+    "CrossBankResult",
+    "LABELS",
+    "evaluate_cross_bank",
+    "load_cross_bank_rows",
+]

--- a/backend/app/evaluation/transfer_matrix.py
+++ b/backend/app/evaluation/transfer_matrix.py
@@ -1,23 +1,36 @@
 """Aggregate per-bank cross-CB evaluations into a transfer matrix.
 
-Walks every (model, bank, seed) cell, calls
+Walks every ``(model_alias, checkpoint, bank)`` cell, calls
 :func:`app.evaluation.cross_bank_transfer.evaluate_cross_bank`, and produces:
 
-- ``transfer_matrix.json`` — full nested payload (per seed, per bank, per class).
-- ``transfer_matrix.csv`` — flat matrix: rows = bank, cols = metric, with
-  point estimates plus block-bootstrap 95% CIs across seeds.
+- ``transfer_matrix.json`` — full nested payload (per checkpoint, per bank).
+- ``transfer_matrix.csv`` — flat matrix: rows = (model, bank), with point
+  estimates plus 95% block-bootstrap CIs *when multiple checkpoints exist
+  for the same alias* (one per training seed). Single-checkpoint cells emit
+  only point estimates and a ``ci_kind="point_estimate"`` marker.
 - ``transfer_matrix.md`` — same as csv but markdown.
 
-Models are passed as ``--model-checkpoints alias=path[,alias=path,…]``. Each
-alias maps to a HF-loadable directory or repo id; the CLI ignores aliases
-whose path does not exist (so unfinished checkpoints don't crash the run).
+CLI syntax: ``--model-checkpoints alias=path[,alias=path…]``. Repeating the
+same alias accumulates paths for that alias, so the natural invocation is
+
+    --model-checkpoints "finbert=/p/s11,finbert=/p/s29,finbert=/p/s47,bge_large=/p/s11"
+
+which produces a 3-checkpoint CI for ``finbert`` and a point estimate for
+``bge_large``.
+
+Earlier revisions ran a seed loop that re-evaluated the same checkpoint per
+seed, producing artificially-tight CIs. That was a fabricated-statistic
+liability and is removed; CI bands now come from genuine cross-checkpoint
+variance only.
 """
 
 from __future__ import annotations
 
 import argparse
 import csv
+import io
 import json
+import math
 from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -31,6 +44,14 @@ from app.evaluation.cross_bank_transfer import (
     evaluate_cross_bank,
 )
 
+BANK_ALIASES: dict[str, str] = {
+    "ecb": "gtfintechlab_european_central_bank",
+    "boj": "gtfintechlab_bank_of_japan",
+    "boe": "gtfintechlab_bank_of_england",
+    "boc": "gtfintechlab_bank_of_canada",
+    "rba": "gtfintechlab_reserve_bank_of_australia",
+}
+
 
 def _ensure_package_dir(package_dir: Path) -> Path:
     if not package_dir.exists():
@@ -38,8 +59,14 @@ def _ensure_package_dir(package_dir: Path) -> Path:
     return package_dir
 
 
-def _parse_model_checkpoints(spec: str) -> dict[str, str]:
-    out: dict[str, str] = {}
+def _parse_model_checkpoints(spec: str) -> dict[str, list[str]]:
+    """Parse ``alias=path[,alias=path…]`` into ``{alias: [path, …]}``.
+
+    Repeating the same alias appends another path under it; the matrix
+    builder then runs the eval per path and aggregates with a real CI.
+    """
+
+    out: dict[str, list[str]] = {}
     if not spec:
         return out
     for piece in spec.split(","):
@@ -49,7 +76,11 @@ def _parse_model_checkpoints(spec: str) -> dict[str, str]:
         if "=" not in piece:
             raise ValueError(f"--model-checkpoints entry {piece!r} missing 'alias=path'")
         alias, path = piece.split("=", 1)
-        out[alias.strip()] = path.strip()
+        alias = alias.strip()
+        path = path.strip()
+        if not alias or not path:
+            raise ValueError(f"--model-checkpoints entry {piece!r} has empty alias or path")
+        out.setdefault(alias, []).append(path)
     return out
 
 
@@ -57,19 +88,12 @@ def _split_banks(spec: str) -> list[str]:
     if not spec:
         return list(CROSS_BANK_SOURCES)
     out: list[str] = []
-    aliases = {
-        "ecb": "gtfintechlab_european_central_bank",
-        "boj": "gtfintechlab_bank_of_japan",
-        "boe": "gtfintechlab_bank_of_england",
-        "boc": "gtfintechlab_bank_of_canada",
-        "rba": "gtfintechlab_reserve_bank_of_australia",
-    }
     for token in spec.split(","):
         token = token.strip().lower()
         if not token:
             continue
-        if token in aliases:
-            out.append(aliases[token])
+        if token in BANK_ALIASES:
+            out.append(BANK_ALIASES[token])
         elif token in CROSS_BANK_SOURCES:
             out.append(token)
         else:
@@ -77,71 +101,94 @@ def _split_banks(spec: str) -> list[str]:
     return out
 
 
-def _aggregate_seed_runs(
+def _point_only(values: list[float]) -> dict[str, Any]:
+    """Single-checkpoint summary — no CI to claim."""
+
+    if not values:
+        return {"point": float("nan"), "ci_kind": "missing", "n_checkpoints": 0}
+    return {
+        "point": float(values[0]),
+        "ci_kind": "point_estimate",
+        "n_checkpoints": 1,
+    }
+
+
+def _ci_summary(
+    values: list[float],
+    *,
+    n_resamples: int,
+    coverage: float,
+    seed: int,
+) -> dict[str, Any]:
+    """Block-bootstrap CI across ≥2 distinct checkpoints."""
+
+    ci = asdict(
+        block_bootstrap_ci(
+            values,
+            statistic="mean",
+            block_size=1,
+            n_resamples=n_resamples,
+            coverage=coverage,
+            seed=seed,
+        )
+    )
+    ci.update({"ci_kind": "block_bootstrap", "n_checkpoints": len(values)})
+    return ci
+
+
+def _aggregate_checkpoint_runs(
     results: list[CrossBankResult],
     *,
     n_resamples: int,
     coverage: float,
     seed: int,
 ) -> dict[str, Any]:
-    """Aggregate multiple-seed CrossBankResult instances into mean + CI."""
-
     if not results:
         return {}
     macro = [r.macro_f1 for r in results]
     weighted = [r.weighted_f1 for r in results]
     acc = [r.accuracy for r in results]
+    summarise = _ci_summary if len(results) >= 2 else _point_only
+    kwargs = {"n_resamples": n_resamples, "coverage": coverage, "seed": seed}
     return {
         "support": results[0].support,
-        "macro_f1": asdict(
-            block_bootstrap_ci(
-                macro, statistic="mean", block_size=1, n_resamples=n_resamples,
-                coverage=coverage, seed=seed,
-            )
-        ),
-        "weighted_f1": asdict(
-            block_bootstrap_ci(
-                weighted, statistic="mean", block_size=1, n_resamples=n_resamples,
-                coverage=coverage, seed=seed,
-            )
-        ),
-        "accuracy": asdict(
-            block_bootstrap_ci(
-                acc, statistic="mean", block_size=1, n_resamples=n_resamples,
-                coverage=coverage, seed=seed,
-            )
-        ),
-        "n_seeds": len(results),
+        "macro_f1": summarise(macro, **kwargs) if len(results) >= 2 else _point_only(macro),
+        "weighted_f1": summarise(weighted, **kwargs) if len(results) >= 2 else _point_only(weighted),
+        "accuracy": summarise(acc, **kwargs) if len(results) >= 2 else _point_only(acc),
     }
 
 
 def build_matrix(
     *,
     package_dir: Path,
-    model_checkpoints: dict[str, str],
+    model_checkpoints: dict[str, list[str]],
     banks: list[str],
-    seeds: list[int],
     n_resamples: int = 1000,
     coverage: float = 0.95,
     rng_seed: int = 11,
     predict_fn=None,
 ) -> dict[str, Any]:
-    """Build the transfer-matrix payload by iterating over (model, bank, seed)."""
+    """Build the transfer-matrix payload.
+
+    For each ``alias`` in ``model_checkpoints`` and each ``bank``, run the
+    eval once per provided checkpoint and aggregate the resulting macro-F1 /
+    accuracy / weighted-F1 across checkpoints. CI is computed only when ≥ 2
+    distinct checkpoints feed the cell.
+    """
 
     matrix: dict[str, Any] = {
         "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "training_package_id": package_dir.name,
         "banks": banks,
         "models": list(model_checkpoints.keys()),
-        "seeds": seeds,
         "by_model": {},
     }
 
-    for model_alias, checkpoint in model_checkpoints.items():
-        per_model: dict[str, Any] = {"checkpoint": checkpoint, "per_bank": {}}
+    for model_alias, checkpoints in model_checkpoints.items():
+        per_model: dict[str, Any] = {"checkpoints": checkpoints, "per_bank": {}}
         for bank in banks:
-            per_seed: list[CrossBankResult] = []
-            for seed_val in seeds:
+            per_checkpoint: list[CrossBankResult] = []
+            for checkpoint in checkpoints:
                 try:
                     result = evaluate_cross_bank(
                         package_dir=package_dir,
@@ -151,36 +198,55 @@ def build_matrix(
                     )
                 except Exception as exc:  # noqa: BLE001 — surface per-cell failure
                     per_model.setdefault("failures", []).append(
-                        {"bank": bank, "seed": seed_val, "error": str(exc)}
+                        {"bank": bank, "checkpoint": checkpoint, "error": str(exc)}
                     )
                     continue
-                per_seed.append(result)
-            if per_seed:
+                per_checkpoint.append(result)
+            if per_checkpoint:
                 per_model["per_bank"][bank] = {
-                    "summary": _aggregate_seed_runs(
-                        per_seed,
+                    "summary": _aggregate_checkpoint_runs(
+                        per_checkpoint,
                         n_resamples=n_resamples,
                         coverage=coverage,
                         seed=rng_seed,
                     ),
-                    "per_seed": [r.to_dict() for r in per_seed],
+                    "per_checkpoint": [r.to_dict() for r in per_checkpoint],
                 }
         matrix["by_model"][model_alias] = per_model
     return matrix
 
 
+def _scrub_nan(value: Any) -> Any:
+    """Recursively convert non-JSON-spec floats (nan / +-inf) to None."""
+
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return None
+        return value
+    if isinstance(value, dict):
+        return {k: _scrub_nan(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_scrub_nan(v) for v in value]
+    return value
+
+
+def _csv_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return ""
+        return f"{value}"
+    return str(value)
+
+
 def render_csv(matrix: dict[str, Any]) -> str:
-    """Flat CSV: one row per (model, bank). Columns: macro_f1 point/lo/hi + …"""
-
     fieldnames = [
-        "model", "bank", "support",
-        "macro_f1_mean", "macro_f1_lo", "macro_f1_hi",
-        "weighted_f1_mean", "weighted_f1_lo", "weighted_f1_hi",
-        "accuracy_mean", "accuracy_lo", "accuracy_hi",
-        "n_seeds",
+        "model", "bank", "support", "n_checkpoints", "ci_kind",
+        "macro_f1_point", "macro_f1_lo", "macro_f1_hi",
+        "weighted_f1_point", "weighted_f1_lo", "weighted_f1_hi",
+        "accuracy_point", "accuracy_lo", "accuracy_hi",
     ]
-    import io
-
     buffer = io.StringIO()
     writer = csv.DictWriter(buffer, fieldnames=fieldnames)
     writer.writeheader()
@@ -195,16 +261,17 @@ def render_csv(matrix: dict[str, Any]) -> str:
                     "model": model_alias,
                     "bank": bank,
                     "support": summary.get("support", 0),
-                    "macro_f1_mean": macro.get("point", float("nan")),
-                    "macro_f1_lo": macro.get("lo", float("nan")),
-                    "macro_f1_hi": macro.get("hi", float("nan")),
-                    "weighted_f1_mean": weighted.get("point", float("nan")),
-                    "weighted_f1_lo": weighted.get("lo", float("nan")),
-                    "weighted_f1_hi": weighted.get("hi", float("nan")),
-                    "accuracy_mean": acc.get("point", float("nan")),
-                    "accuracy_lo": acc.get("lo", float("nan")),
-                    "accuracy_hi": acc.get("hi", float("nan")),
-                    "n_seeds": summary.get("n_seeds", 0),
+                    "n_checkpoints": macro.get("n_checkpoints", 0),
+                    "ci_kind": macro.get("ci_kind", "missing"),
+                    "macro_f1_point": _csv_value(macro.get("point")),
+                    "macro_f1_lo": _csv_value(macro.get("lo")),
+                    "macro_f1_hi": _csv_value(macro.get("hi")),
+                    "weighted_f1_point": _csv_value(weighted.get("point")),
+                    "weighted_f1_lo": _csv_value(weighted.get("lo")),
+                    "weighted_f1_hi": _csv_value(weighted.get("hi")),
+                    "accuracy_point": _csv_value(acc.get("point")),
+                    "accuracy_lo": _csv_value(acc.get("lo")),
+                    "accuracy_hi": _csv_value(acc.get("hi")),
                 }
             )
     return buffer.getvalue()
@@ -213,21 +280,29 @@ def render_csv(matrix: dict[str, Any]) -> str:
 def render_markdown(matrix: dict[str, Any], *, coverage: float = 0.95) -> str:
     coverage_pct = int(round(coverage * 100))
     lines = [
-        f"| Model | Bank | Support | macro-F1 ({coverage_pct}% CI) | weighted-F1 | accuracy |",
-        "|---|---|---:|---|---|---|",
+        f"| Model | Bank | Support | n_ckpt | macro-F1 ({coverage_pct}% CI when n≥2) | weighted-F1 | accuracy |",
+        "|---|---|---:|---:|---|---|---|",
     ]
     for model_alias, payload in matrix.get("by_model", {}).items():
         for bank, cell in payload.get("per_bank", {}).items():
             summary = cell.get("summary") or {}
             macro = summary.get("macro_f1") or {}
-            weighted = summary.get("weighted_f1") or {}
-            acc = summary.get("accuracy") or {}
+            n_ckpt = macro.get("n_checkpoints", 0)
+            point = macro.get("point")
+            lo = macro.get("lo")
+            hi = macro.get("hi")
+            if n_ckpt >= 2 and lo is not None and hi is not None:
+                macro_cell = f"{point:.4f} [{lo:.4f}, {hi:.4f}]"
+            elif point is not None:
+                macro_cell = f"{point:.4f} (point)"
+            else:
+                macro_cell = "—"
+            weighted_point = (summary.get("weighted_f1") or {}).get("point")
+            acc_point = (summary.get("accuracy") or {}).get("point")
             lines.append(
-                f"| `{model_alias}` | `{bank}` | {summary.get('support', 0)} | "
-                f"{macro.get('point', float('nan')):.4f} "
-                f"[{macro.get('lo', float('nan')):.4f}, {macro.get('hi', float('nan')):.4f}] | "
-                f"{weighted.get('point', float('nan')):.4f} | "
-                f"{acc.get('point', float('nan')):.4f} |"
+                f"| `{model_alias}` | `{bank}` | {summary.get('support', 0)} | {n_ckpt} | "
+                f"{macro_cell} | {weighted_point if weighted_point is None else f'{weighted_point:.4f}'} | "
+                f"{acc_point if acc_point is None else f'{acc_point:.4f}'} |"
             )
     return "\n".join(lines) + "\n"
 
@@ -241,14 +316,13 @@ def _parse_args() -> argparse.Namespace:
         help="Comma-separated bank tokens (ecb,boj,boe,boc,rba). Defaults to all 5.",
     )
     parser.add_argument(
-        "--seeds",
-        default="11,29,47,71,97",
-        help="Comma-separated seeds — only affects CI computation (eval is deterministic).",
-    )
-    parser.add_argument(
         "--model-checkpoints",
         required=True,
-        help="Comma-separated alias=path pairs.",
+        help=(
+            "Comma-separated alias=path pairs. Repeat an alias to accumulate "
+            "per-seed checkpoints (e.g. finbert=p1,finbert=p2,finbert=p3 yields "
+            "a 3-checkpoint CI for that alias)."
+        ),
     )
     parser.add_argument(
         "--output-dir",
@@ -268,13 +342,11 @@ def main() -> int:
     if not model_checkpoints:
         raise SystemExit("No model checkpoints provided.")
     banks = _split_banks(args.eval_banks)
-    seeds = [int(s) for s in args.seeds.split(",") if s.strip()]
 
     matrix = build_matrix(
         package_dir=package_dir,
         model_checkpoints=model_checkpoints,
         banks=banks,
-        seeds=seeds,
         n_resamples=args.n_resamples,
         coverage=args.coverage,
         rng_seed=args.rng_seed,
@@ -284,7 +356,10 @@ def main() -> int:
         DATA_DIR / "artifacts" / "cross_bank" / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     )
     output_dir.mkdir(parents=True, exist_ok=True)
-    (output_dir / "transfer_matrix.json").write_text(json.dumps(matrix, indent=2), encoding="utf-8")
+    scrubbed = _scrub_nan(matrix)
+    (output_dir / "transfer_matrix.json").write_text(
+        json.dumps(scrubbed, indent=2, allow_nan=False), encoding="utf-8"
+    )
     (output_dir / "transfer_matrix.csv").write_text(render_csv(matrix), encoding="utf-8")
     (output_dir / "transfer_matrix.md").write_text(render_markdown(matrix, coverage=args.coverage), encoding="utf-8")
     print(f"[transfer_matrix] wrote artefacts to {output_dir}")

--- a/backend/app/evaluation/transfer_matrix.py
+++ b/backend/app/evaluation/transfer_matrix.py
@@ -1,0 +1,295 @@
+"""Aggregate per-bank cross-CB evaluations into a transfer matrix.
+
+Walks every (model, bank, seed) cell, calls
+:func:`app.evaluation.cross_bank_transfer.evaluate_cross_bank`, and produces:
+
+- ``transfer_matrix.json`` — full nested payload (per seed, per bank, per class).
+- ``transfer_matrix.csv`` — flat matrix: rows = bank, cols = metric, with
+  point estimates plus block-bootstrap 95% CIs across seeds.
+- ``transfer_matrix.md`` — same as csv but markdown.
+
+Models are passed as ``--model-checkpoints alias=path[,alias=path,…]``. Each
+alias maps to a HF-loadable directory or repo id; the CLI ignores aliases
+whose path does not exist (so unfinished checkpoints don't crash the run).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from app.config import DATA_DIR
+from app.evaluation.bootstrap import block_bootstrap_ci
+from app.evaluation.cross_bank_transfer import (
+    CROSS_BANK_SOURCES,
+    CrossBankResult,
+    evaluate_cross_bank,
+)
+
+
+def _ensure_package_dir(package_dir: Path) -> Path:
+    if not package_dir.exists():
+        raise FileNotFoundError(f"Training package not found: {package_dir}")
+    return package_dir
+
+
+def _parse_model_checkpoints(spec: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if not spec:
+        return out
+    for piece in spec.split(","):
+        piece = piece.strip()
+        if not piece:
+            continue
+        if "=" not in piece:
+            raise ValueError(f"--model-checkpoints entry {piece!r} missing 'alias=path'")
+        alias, path = piece.split("=", 1)
+        out[alias.strip()] = path.strip()
+    return out
+
+
+def _split_banks(spec: str) -> list[str]:
+    if not spec:
+        return list(CROSS_BANK_SOURCES)
+    out: list[str] = []
+    aliases = {
+        "ecb": "gtfintechlab_european_central_bank",
+        "boj": "gtfintechlab_bank_of_japan",
+        "boe": "gtfintechlab_bank_of_england",
+        "boc": "gtfintechlab_bank_of_canada",
+        "rba": "gtfintechlab_reserve_bank_of_australia",
+    }
+    for token in spec.split(","):
+        token = token.strip().lower()
+        if not token:
+            continue
+        if token in aliases:
+            out.append(aliases[token])
+        elif token in CROSS_BANK_SOURCES:
+            out.append(token)
+        else:
+            raise ValueError(f"unknown bank token: {token!r}")
+    return out
+
+
+def _aggregate_seed_runs(
+    results: list[CrossBankResult],
+    *,
+    n_resamples: int,
+    coverage: float,
+    seed: int,
+) -> dict[str, Any]:
+    """Aggregate multiple-seed CrossBankResult instances into mean + CI."""
+
+    if not results:
+        return {}
+    macro = [r.macro_f1 for r in results]
+    weighted = [r.weighted_f1 for r in results]
+    acc = [r.accuracy for r in results]
+    return {
+        "support": results[0].support,
+        "macro_f1": asdict(
+            block_bootstrap_ci(
+                macro, statistic="mean", block_size=1, n_resamples=n_resamples,
+                coverage=coverage, seed=seed,
+            )
+        ),
+        "weighted_f1": asdict(
+            block_bootstrap_ci(
+                weighted, statistic="mean", block_size=1, n_resamples=n_resamples,
+                coverage=coverage, seed=seed,
+            )
+        ),
+        "accuracy": asdict(
+            block_bootstrap_ci(
+                acc, statistic="mean", block_size=1, n_resamples=n_resamples,
+                coverage=coverage, seed=seed,
+            )
+        ),
+        "n_seeds": len(results),
+    }
+
+
+def build_matrix(
+    *,
+    package_dir: Path,
+    model_checkpoints: dict[str, str],
+    banks: list[str],
+    seeds: list[int],
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    rng_seed: int = 11,
+    predict_fn=None,
+) -> dict[str, Any]:
+    """Build the transfer-matrix payload by iterating over (model, bank, seed)."""
+
+    matrix: dict[str, Any] = {
+        "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "training_package_id": package_dir.name,
+        "banks": banks,
+        "models": list(model_checkpoints.keys()),
+        "seeds": seeds,
+        "by_model": {},
+    }
+
+    for model_alias, checkpoint in model_checkpoints.items():
+        per_model: dict[str, Any] = {"checkpoint": checkpoint, "per_bank": {}}
+        for bank in banks:
+            per_seed: list[CrossBankResult] = []
+            for seed_val in seeds:
+                try:
+                    result = evaluate_cross_bank(
+                        package_dir=package_dir,
+                        bank_source=bank,
+                        checkpoint=checkpoint,
+                        predict_fn=predict_fn,
+                    )
+                except Exception as exc:  # noqa: BLE001 — surface per-cell failure
+                    per_model.setdefault("failures", []).append(
+                        {"bank": bank, "seed": seed_val, "error": str(exc)}
+                    )
+                    continue
+                per_seed.append(result)
+            if per_seed:
+                per_model["per_bank"][bank] = {
+                    "summary": _aggregate_seed_runs(
+                        per_seed,
+                        n_resamples=n_resamples,
+                        coverage=coverage,
+                        seed=rng_seed,
+                    ),
+                    "per_seed": [r.to_dict() for r in per_seed],
+                }
+        matrix["by_model"][model_alias] = per_model
+    return matrix
+
+
+def render_csv(matrix: dict[str, Any]) -> str:
+    """Flat CSV: one row per (model, bank). Columns: macro_f1 point/lo/hi + …"""
+
+    fieldnames = [
+        "model", "bank", "support",
+        "macro_f1_mean", "macro_f1_lo", "macro_f1_hi",
+        "weighted_f1_mean", "weighted_f1_lo", "weighted_f1_hi",
+        "accuracy_mean", "accuracy_lo", "accuracy_hi",
+        "n_seeds",
+    ]
+    import io
+
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    for model_alias, payload in matrix.get("by_model", {}).items():
+        for bank, cell in payload.get("per_bank", {}).items():
+            summary = cell.get("summary") or {}
+            macro = summary.get("macro_f1") or {}
+            weighted = summary.get("weighted_f1") or {}
+            acc = summary.get("accuracy") or {}
+            writer.writerow(
+                {
+                    "model": model_alias,
+                    "bank": bank,
+                    "support": summary.get("support", 0),
+                    "macro_f1_mean": macro.get("point", float("nan")),
+                    "macro_f1_lo": macro.get("lo", float("nan")),
+                    "macro_f1_hi": macro.get("hi", float("nan")),
+                    "weighted_f1_mean": weighted.get("point", float("nan")),
+                    "weighted_f1_lo": weighted.get("lo", float("nan")),
+                    "weighted_f1_hi": weighted.get("hi", float("nan")),
+                    "accuracy_mean": acc.get("point", float("nan")),
+                    "accuracy_lo": acc.get("lo", float("nan")),
+                    "accuracy_hi": acc.get("hi", float("nan")),
+                    "n_seeds": summary.get("n_seeds", 0),
+                }
+            )
+    return buffer.getvalue()
+
+
+def render_markdown(matrix: dict[str, Any], *, coverage: float = 0.95) -> str:
+    coverage_pct = int(round(coverage * 100))
+    lines = [
+        f"| Model | Bank | Support | macro-F1 ({coverage_pct}% CI) | weighted-F1 | accuracy |",
+        "|---|---|---:|---|---|---|",
+    ]
+    for model_alias, payload in matrix.get("by_model", {}).items():
+        for bank, cell in payload.get("per_bank", {}).items():
+            summary = cell.get("summary") or {}
+            macro = summary.get("macro_f1") or {}
+            weighted = summary.get("weighted_f1") or {}
+            acc = summary.get("accuracy") or {}
+            lines.append(
+                f"| `{model_alias}` | `{bank}` | {summary.get('support', 0)} | "
+                f"{macro.get('point', float('nan')):.4f} "
+                f"[{macro.get('lo', float('nan')):.4f}, {macro.get('hi', float('nan')):.4f}] | "
+                f"{weighted.get('point', float('nan')):.4f} | "
+                f"{acc.get('point', float('nan')):.4f} |"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build cross-CB transfer matrix.")
+    parser.add_argument("--training-package-id", required=True)
+    parser.add_argument(
+        "--eval-banks",
+        default="",
+        help="Comma-separated bank tokens (ecb,boj,boe,boc,rba). Defaults to all 5.",
+    )
+    parser.add_argument(
+        "--seeds",
+        default="11,29,47,71,97",
+        help="Comma-separated seeds — only affects CI computation (eval is deterministic).",
+    )
+    parser.add_argument(
+        "--model-checkpoints",
+        required=True,
+        help="Comma-separated alias=path pairs.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory to write transfer_matrix.{json,csv,md}.",
+    )
+    parser.add_argument("--n-resamples", type=int, default=1000)
+    parser.add_argument("--coverage", type=float, default=0.95)
+    parser.add_argument("--rng-seed", type=int, default=11)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    package_dir = _ensure_package_dir(DATA_DIR / "processed" / args.training_package_id)
+    model_checkpoints = _parse_model_checkpoints(args.model_checkpoints)
+    if not model_checkpoints:
+        raise SystemExit("No model checkpoints provided.")
+    banks = _split_banks(args.eval_banks)
+    seeds = [int(s) for s in args.seeds.split(",") if s.strip()]
+
+    matrix = build_matrix(
+        package_dir=package_dir,
+        model_checkpoints=model_checkpoints,
+        banks=banks,
+        seeds=seeds,
+        n_resamples=args.n_resamples,
+        coverage=args.coverage,
+        rng_seed=args.rng_seed,
+    )
+
+    output_dir = Path(args.output_dir) if args.output_dir else (
+        DATA_DIR / "artifacts" / "cross_bank" / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "transfer_matrix.json").write_text(json.dumps(matrix, indent=2), encoding="utf-8")
+    (output_dir / "transfer_matrix.csv").write_text(render_csv(matrix), encoding="utf-8")
+    (output_dir / "transfer_matrix.md").write_text(render_markdown(matrix, coverage=args.coverage), encoding="utf-8")
+    print(f"[transfer_matrix] wrote artefacts to {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_cross_bank_transfer.py
+++ b/tests/unit/test_cross_bank_transfer.py
@@ -1,0 +1,168 @@
+"""Unit tests for app.evaluation.cross_bank_transfer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.evaluation import cross_bank_transfer as cbt
+
+
+def _write_registry(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+@pytest.fixture
+def package_with_two_banks(tmp_path: Path) -> Path:
+    package_dir = tmp_path / "processed" / "tp_v1"
+    _write_registry(
+        package_dir / "registry_normalized.jsonl",
+        [
+            # FOMC rows — present in training (sample_weight=1), not cross-bank.
+            {
+                "record_id": "fomc_1",
+                "text": "the committee judges policy is appropriate",
+                "event_date": "2024-01-01",
+                "mapped_label": "neutral",
+                "source": "hf_fomc_communication",
+                "provenance": "peer_reviewed",
+                "sample_weight": 1.0,
+            },
+            # ECB row — labeled, weight=0 (held out).
+            {
+                "record_id": "ecb_1",
+                "text": "inflation outlook firm; rate path on hold",
+                "event_date": "2024-02-01",
+                "mapped_label": "hawkish",
+                "source": "gtfintechlab_european_central_bank",
+                "provenance": "peer_reviewed_cross_bank",
+                "sample_weight": 0.0,
+                "multi_axis_extras": {
+                    "gtfintechlab_time_label": "forward looking",
+                    "gtfintechlab_certain_label": "certain",
+                },
+            },
+            {
+                "record_id": "ecb_2",
+                "text": "easing financial conditions argue for cuts",
+                "event_date": "2024-03-01",
+                "mapped_label": "dovish",
+                "source": "gtfintechlab_european_central_bank",
+                "provenance": "peer_reviewed_cross_bank",
+                "sample_weight": 0.0,
+                "multi_axis_extras": {
+                    "gtfintechlab_time_label": "not forward looking",
+                    "gtfintechlab_certain_label": "uncertain",
+                },
+            },
+            # BoJ row — labeled, weight=0.
+            {
+                "record_id": "boj_1",
+                "text": "policy stance remains accommodative",
+                "event_date": "2024-04-01",
+                "mapped_label": "dovish",
+                "source": "gtfintechlab_bank_of_japan",
+                "provenance": "peer_reviewed_cross_bank",
+                "sample_weight": 0.0,
+            },
+        ],
+    )
+    return package_dir
+
+
+def test_load_cross_bank_rows_filters_to_target_bank(package_with_two_banks: Path) -> None:
+    ecb = cbt.load_cross_bank_rows(package_with_two_banks, "gtfintechlab_european_central_bank")
+    assert {r.record_id for r in ecb} == {"ecb_1", "ecb_2"}
+    boj = cbt.load_cross_bank_rows(package_with_two_banks, "gtfintechlab_bank_of_japan")
+    assert {r.record_id for r in boj} == {"boj_1"}
+
+
+def test_load_cross_bank_rows_includes_weight_zero(package_with_two_banks: Path) -> None:
+    """Cross-bank rows live in the registry with sample_weight=0 — must still surface in eval."""
+
+    ecb = cbt.load_cross_bank_rows(package_with_two_banks, "gtfintechlab_european_central_bank")
+    assert all(r.sample_weight == 0.0 for r in ecb)
+
+
+def test_evaluate_cross_bank_with_perfect_predictor(package_with_two_banks: Path) -> None:
+    """Inject an oracle predictor — macro-F1 should be 1.0."""
+
+    def oracle(rows):
+        labels = [r.label for r in rows]
+        return list(labels), list(labels), [0.5] * len(labels)
+
+    result = cbt.evaluate_cross_bank(
+        package_dir=package_with_two_banks,
+        bank_source="gtfintechlab_european_central_bank",
+        checkpoint="oracle",
+        predict_fn=oracle,
+    )
+    assert result.bank == "gtfintechlab_european_central_bank"
+    assert result.support == 2
+    assert result.accuracy == pytest.approx(1.0)
+    # macro-F1 averages over all three official labels (dovish/hawkish/neutral);
+    # the ECB fixture has no neutral row, so the neutral slot contributes F1=0
+    # and the perfect-prediction ceiling is 2/3, not 1.
+    assert result.macro_f1 == pytest.approx(2 / 3)
+    assert result.per_class["hawkish"]["f1"] == pytest.approx(1.0)
+    assert result.per_class["dovish"]["f1"] == pytest.approx(1.0)
+
+
+def test_evaluate_cross_bank_with_constant_predictor(package_with_two_banks: Path) -> None:
+    """A constant-prediction baseline lands far from perfect."""
+
+    def constant_neutral(rows):
+        return [r.label for r in rows], ["neutral"] * len(rows), [0.5] * len(rows)
+
+    result = cbt.evaluate_cross_bank(
+        package_dir=package_with_two_banks,
+        bank_source="gtfintechlab_european_central_bank",
+        checkpoint="constant",
+        predict_fn=constant_neutral,
+    )
+    assert result.macro_f1 < 0.5
+    assert "hawkish" in result.per_class
+    assert "dovish" in result.per_class
+
+
+def test_evaluate_cross_bank_emits_per_axis_slices(package_with_two_banks: Path) -> None:
+    def oracle(rows):
+        labels = [r.label for r in rows]
+        return list(labels), list(labels), [0.5] * len(labels)
+
+    result = cbt.evaluate_cross_bank(
+        package_dir=package_with_two_banks,
+        bank_source="gtfintechlab_european_central_bank",
+        checkpoint="oracle",
+        predict_fn=oracle,
+    )
+    assert set(result.per_axis.keys()) >= {"time", "certainty"}
+    assert "forward looking" in result.per_axis["time"]
+    assert result.per_axis["time"]["forward looking"]["support"] == 1
+
+
+def test_evaluate_cross_bank_rejects_unknown_bank(package_with_two_banks: Path) -> None:
+    with pytest.raises(ValueError, match="Unknown bank_source"):
+        cbt.evaluate_cross_bank(
+            package_dir=package_with_two_banks,
+            bank_source="not_a_real_bank",
+            checkpoint="x",
+            predict_fn=lambda rows: ([], [], []),
+        )
+
+
+def test_evaluate_cross_bank_errors_on_empty_bank(tmp_path: Path) -> None:
+    empty = tmp_path / "processed" / "tp_empty"
+    _write_registry(empty / "registry_normalized.jsonl", [])
+    with pytest.raises(ValueError, match="No labeled rows"):
+        cbt.evaluate_cross_bank(
+            package_dir=empty,
+            bank_source="gtfintechlab_european_central_bank",
+            checkpoint="x",
+            predict_fn=lambda rows: ([], [], []),
+        )

--- a/tests/unit/test_sample_weight_filter.py
+++ b/tests/unit/test_sample_weight_filter.py
@@ -1,0 +1,100 @@
+"""Regression test: cross-bank rows (sample_weight=0) must never enter NLP training.
+
+The cross-bank ingestors tag rows with ``sample_weight=0`` (in
+``data/schema/labels.yaml``). The fine-tune pilot's ``_load_registry_rows``
+honours that flag and drops zero-weight rows by default; the cross-CB eval
+harness opts back in via ``include_zero_weight=True``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.data.finetune_pilot import _load_registry_rows
+
+
+def _write_registry(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+@pytest.fixture
+def mixed_registry(tmp_path: Path) -> Path:
+    package_dir = tmp_path / "processed" / "tp_v1"
+    _write_registry(
+        package_dir / "registry_normalized.jsonl",
+        [
+            {
+                "record_id": "fomc_1",
+                "text": "the committee judges policy appropriate",
+                "event_date": "2024-01-01",
+                "mapped_label": "neutral",
+                "source": "hf_fomc_communication",
+                "provenance": "peer_reviewed",
+                "sample_weight": 1.0,
+            },
+            {
+                "record_id": "ecb_1",
+                "text": "rate path firm",
+                "event_date": "2024-02-01",
+                "mapped_label": "hawkish",
+                "source": "gtfintechlab_european_central_bank",
+                "provenance": "peer_reviewed_cross_bank",
+                "sample_weight": 0.0,
+            },
+            {
+                "record_id": "scraped_1",
+                "text": "auxiliary text",
+                "event_date": "2024-02-15",
+                "mapped_label": "neutral",
+                "source": "scraped_fed",
+                "provenance": "scraped",
+                "sample_weight": 0.0,
+            },
+        ],
+    )
+    return package_dir
+
+
+def test_default_excludes_zero_weight_rows(mixed_registry: Path) -> None:
+    rows = _load_registry_rows(mixed_registry)
+    assert {r.record_id for r in rows} == {"fomc_1"}
+    assert all(r.sample_weight > 0 for r in rows)
+
+
+def test_include_zero_weight_opts_cross_bank_back_in(mixed_registry: Path) -> None:
+    rows = _load_registry_rows(mixed_registry, include_zero_weight=True)
+    assert {r.record_id for r in rows} == {"fomc_1", "ecb_1", "scraped_1"}
+
+
+def test_loaded_row_carries_source_and_provenance(mixed_registry: Path) -> None:
+    rows = _load_registry_rows(mixed_registry, include_zero_weight=True)
+    by_id = {row.record_id: row for row in rows}
+    assert by_id["ecb_1"].source == "gtfintechlab_european_central_bank"
+    assert by_id["ecb_1"].provenance == "peer_reviewed_cross_bank"
+    assert by_id["fomc_1"].provenance == "peer_reviewed"
+
+
+def test_invalid_sample_weight_falls_back_to_unit(tmp_path: Path) -> None:
+    package_dir = tmp_path / "processed" / "tp_v1"
+    _write_registry(
+        package_dir / "registry_normalized.jsonl",
+        [
+            {
+                "record_id": "x",
+                "text": "speech text",
+                "event_date": "2024-01-01",
+                "mapped_label": "neutral",
+                "source": "hf_fomc_communication",
+                "sample_weight": "not-a-number",
+            }
+        ],
+    )
+    rows = _load_registry_rows(package_dir)
+    assert len(rows) == 1
+    assert rows[0].sample_weight == 1.0

--- a/tests/unit/test_sample_weight_filter.py
+++ b/tests/unit/test_sample_weight_filter.py
@@ -4,6 +4,12 @@ The cross-bank ingestors tag rows with ``sample_weight=0`` (in
 ``data/schema/labels.yaml``). The fine-tune pilot's ``_load_registry_rows``
 honours that flag and drops zero-weight rows by default; the cross-CB eval
 harness opts back in via ``include_zero_weight=True``.
+
+Scope: NLP fine-tune path only. The LSTM forecaster's data path
+(``backend/app/training/loaders.py``) consumes market time-series rows, not
+the stance-labelled text registry, so cross-bank corpora never reach it
+regardless of any sample-weight setting — there is no equivalent filter
+needed on that side.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_transfer_matrix.py
+++ b/tests/unit/test_transfer_matrix.py
@@ -1,0 +1,146 @@
+"""Unit tests for app.evaluation.transfer_matrix."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.evaluation import transfer_matrix as tm
+
+
+def _write_registry(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+@pytest.fixture
+def two_bank_package(tmp_path: Path) -> Path:
+    package_dir = tmp_path / "processed" / "tp_v1"
+    _write_registry(
+        package_dir / "registry_normalized.jsonl",
+        [
+            {
+                "record_id": "ecb_1",
+                "text": "rate path firm",
+                "event_date": "2024-02-01",
+                "mapped_label": "hawkish",
+                "source": "gtfintechlab_european_central_bank",
+                "provenance": "peer_reviewed_cross_bank",
+                "sample_weight": 0.0,
+            },
+            {
+                "record_id": "ecb_2",
+                "text": "ease ahead",
+                "event_date": "2024-03-01",
+                "mapped_label": "dovish",
+                "source": "gtfintechlab_european_central_bank",
+                "provenance": "peer_reviewed_cross_bank",
+                "sample_weight": 0.0,
+            },
+            {
+                "record_id": "boj_1",
+                "text": "accommodative",
+                "event_date": "2024-04-01",
+                "mapped_label": "dovish",
+                "source": "gtfintechlab_bank_of_japan",
+                "provenance": "peer_reviewed_cross_bank",
+                "sample_weight": 0.0,
+            },
+        ],
+    )
+    return package_dir
+
+
+def test_parse_model_checkpoints_handles_alias_pairs() -> None:
+    parsed = tm._parse_model_checkpoints("finbert=/tmp/a,bge_large=/tmp/b")
+    assert parsed == {"finbert": "/tmp/a", "bge_large": "/tmp/b"}
+
+
+def test_parse_model_checkpoints_rejects_missing_equals() -> None:
+    with pytest.raises(ValueError, match="alias=path"):
+        tm._parse_model_checkpoints("bad-entry")
+
+
+def test_split_banks_resolves_short_aliases() -> None:
+    assert tm._split_banks("ecb,boj") == [
+        "gtfintechlab_european_central_bank",
+        "gtfintechlab_bank_of_japan",
+    ]
+
+
+def test_split_banks_defaults_to_all_five() -> None:
+    out = tm._split_banks("")
+    assert len(out) == 5
+    assert "gtfintechlab_reserve_bank_of_australia" in out
+
+
+def test_build_matrix_with_oracle_predictor(two_bank_package: Path) -> None:
+    def oracle(rows):
+        labels = [r.label for r in rows]
+        return list(labels), list(labels), [0.5] * len(labels)
+
+    matrix = tm.build_matrix(
+        package_dir=two_bank_package,
+        model_checkpoints={"finbert": "/tmp/a"},
+        banks=[
+            "gtfintechlab_european_central_bank",
+            "gtfintechlab_bank_of_japan",
+        ],
+        seeds=[11, 29],
+        n_resamples=50,
+        coverage=0.9,
+        rng_seed=11,
+        predict_fn=oracle,
+    )
+    assert matrix["models"] == ["finbert"]
+    per_bank = matrix["by_model"]["finbert"]["per_bank"]
+    assert {"gtfintechlab_european_central_bank", "gtfintechlab_bank_of_japan"} == set(per_bank.keys())
+    macro = per_bank["gtfintechlab_european_central_bank"]["summary"]["macro_f1"]
+    # Oracle prediction; macro-F1 averages over dovish/hawkish/neutral and the
+    # ECB fixture has no neutral row so the ceiling for an oracle is 2/3.
+    assert macro["point"] == pytest.approx(2 / 3)
+    accuracy = per_bank["gtfintechlab_european_central_bank"]["summary"]["accuracy"]
+    assert accuracy["point"] == pytest.approx(1.0)
+
+
+def test_render_csv_emits_header_and_per_cell_row(two_bank_package: Path) -> None:
+    def oracle(rows):
+        labels = [r.label for r in rows]
+        return list(labels), list(labels), [0.5] * len(labels)
+
+    matrix = tm.build_matrix(
+        package_dir=two_bank_package,
+        model_checkpoints={"finbert": "/tmp/a"},
+        banks=["gtfintechlab_european_central_bank"],
+        seeds=[11],
+        n_resamples=20,
+        rng_seed=11,
+        predict_fn=oracle,
+    )
+    csv_text = tm.render_csv(matrix)
+    assert "model,bank,support,macro_f1_mean" in csv_text
+    assert "finbert,gtfintechlab_european_central_bank" in csv_text
+
+
+def test_render_markdown_includes_ci_format(two_bank_package: Path) -> None:
+    def oracle(rows):
+        labels = [r.label for r in rows]
+        return list(labels), list(labels), [0.5] * len(labels)
+
+    matrix = tm.build_matrix(
+        package_dir=two_bank_package,
+        model_checkpoints={"finbert": "/tmp/a"},
+        banks=["gtfintechlab_european_central_bank"],
+        seeds=[11],
+        n_resamples=20,
+        coverage=0.95,
+        rng_seed=11,
+        predict_fn=oracle,
+    )
+    md = tm.render_markdown(matrix)
+    assert "95% CI" in md
+    assert "`finbert`" in md

--- a/tests/unit/test_transfer_matrix.py
+++ b/tests/unit/test_transfer_matrix.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 
 import pytest
@@ -55,14 +56,29 @@ def two_bank_package(tmp_path: Path) -> Path:
     return package_dir
 
 
-def test_parse_model_checkpoints_handles_alias_pairs() -> None:
+def test_parse_model_checkpoints_handles_single_alias_pairs() -> None:
     parsed = tm._parse_model_checkpoints("finbert=/tmp/a,bge_large=/tmp/b")
-    assert parsed == {"finbert": "/tmp/a", "bge_large": "/tmp/b"}
+    assert parsed == {"finbert": ["/tmp/a"], "bge_large": ["/tmp/b"]}
+
+
+def test_parse_model_checkpoints_accumulates_repeated_aliases() -> None:
+    """Same alias appearing multiple times → list of checkpoints for that alias."""
+
+    parsed = tm._parse_model_checkpoints(
+        "finbert=/tmp/s11,finbert=/tmp/s29,finbert=/tmp/s47,bge_large=/tmp/s11"
+    )
+    assert parsed["finbert"] == ["/tmp/s11", "/tmp/s29", "/tmp/s47"]
+    assert parsed["bge_large"] == ["/tmp/s11"]
 
 
 def test_parse_model_checkpoints_rejects_missing_equals() -> None:
     with pytest.raises(ValueError, match="alias=path"):
         tm._parse_model_checkpoints("bad-entry")
+
+
+def test_parse_model_checkpoints_rejects_empty_alias_or_path() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        tm._parse_model_checkpoints("=path")
 
 
 def test_split_banks_resolves_short_aliases() -> None:
@@ -78,69 +94,157 @@ def test_split_banks_defaults_to_all_five() -> None:
     assert "gtfintechlab_reserve_bank_of_australia" in out
 
 
-def test_build_matrix_with_oracle_predictor(two_bank_package: Path) -> None:
-    def oracle(rows):
-        labels = [r.label for r in rows]
-        return list(labels), list(labels), [0.5] * len(labels)
+def _oracle_predict(rows):
+    labels = [r.label for r in rows]
+    return list(labels), list(labels), [0.5] * len(labels)
 
+
+def _constant_predict(value: str):
+    def _impl(rows):
+        return [r.label for r in rows], [value] * len(rows), [0.5] * len(rows)
+
+    return _impl
+
+
+def test_build_matrix_single_checkpoint_emits_point_estimate(two_bank_package: Path) -> None:
     matrix = tm.build_matrix(
         package_dir=two_bank_package,
-        model_checkpoints={"finbert": "/tmp/a"},
-        banks=[
-            "gtfintechlab_european_central_bank",
-            "gtfintechlab_bank_of_japan",
-        ],
-        seeds=[11, 29],
-        n_resamples=50,
-        coverage=0.9,
-        rng_seed=11,
-        predict_fn=oracle,
-    )
-    assert matrix["models"] == ["finbert"]
-    per_bank = matrix["by_model"]["finbert"]["per_bank"]
-    assert {"gtfintechlab_european_central_bank", "gtfintechlab_bank_of_japan"} == set(per_bank.keys())
-    macro = per_bank["gtfintechlab_european_central_bank"]["summary"]["macro_f1"]
-    # Oracle prediction; macro-F1 averages over dovish/hawkish/neutral and the
-    # ECB fixture has no neutral row so the ceiling for an oracle is 2/3.
-    assert macro["point"] == pytest.approx(2 / 3)
-    accuracy = per_bank["gtfintechlab_european_central_bank"]["summary"]["accuracy"]
-    assert accuracy["point"] == pytest.approx(1.0)
-
-
-def test_render_csv_emits_header_and_per_cell_row(two_bank_package: Path) -> None:
-    def oracle(rows):
-        labels = [r.label for r in rows]
-        return list(labels), list(labels), [0.5] * len(labels)
-
-    matrix = tm.build_matrix(
-        package_dir=two_bank_package,
-        model_checkpoints={"finbert": "/tmp/a"},
+        model_checkpoints={"finbert": ["/tmp/a"]},
         banks=["gtfintechlab_european_central_bank"],
-        seeds=[11],
+        n_resamples=50,
+        rng_seed=11,
+        predict_fn=_oracle_predict,
+    )
+    macro = matrix["by_model"]["finbert"]["per_bank"][
+        "gtfintechlab_european_central_bank"
+    ]["summary"]["macro_f1"]
+    assert macro["ci_kind"] == "point_estimate"
+    assert macro["n_checkpoints"] == 1
+    assert "lo" not in macro and "hi" not in macro
+    # ECB has no neutral row so the oracle ceiling is 2/3.
+    assert macro["point"] == pytest.approx(2 / 3)
+
+
+def test_build_matrix_multi_checkpoint_emits_real_ci(two_bank_package: Path) -> None:
+    """With 3 distinct predictors yielding genuinely different macro-F1s,
+    the bootstrap CI must have non-zero width."""
+
+    matrix = tm.build_matrix(
+        package_dir=two_bank_package,
+        # Three different "checkpoints" — the test uses predict_fn so paths
+        # are nominal — wired through one predict_fn that varies by call.
+        model_checkpoints={"finbert": ["/tmp/a", "/tmp/b", "/tmp/c"]},
+        banks=["gtfintechlab_european_central_bank"],
+        n_resamples=100,
+        rng_seed=11,
+        # Predictor that walks oracle → constant-neutral → constant-hawkish
+        # by mutating an external counter so each "checkpoint" yields a
+        # different macro-F1.
+        predict_fn=_make_varying_predictor(),
+    )
+    macro = matrix["by_model"]["finbert"]["per_bank"][
+        "gtfintechlab_european_central_bank"
+    ]["summary"]["macro_f1"]
+    assert macro["ci_kind"] == "block_bootstrap"
+    assert macro["n_checkpoints"] == 3
+    # CI has real width because the 3 predictors disagree.
+    assert macro["hi"] > macro["lo"]
+
+
+def _make_varying_predictor():
+    calls = {"n": 0}
+
+    def _impl(rows):
+        idx = calls["n"]
+        calls["n"] += 1
+        if idx == 0:
+            return [r.label for r in rows], [r.label for r in rows], [0.5] * len(rows)
+        if idx == 1:
+            return [r.label for r in rows], ["neutral"] * len(rows), [0.5] * len(rows)
+        return [r.label for r in rows], ["hawkish"] * len(rows), [0.5] * len(rows)
+
+    return _impl
+
+
+def test_render_csv_emits_n_checkpoints_and_ci_kind_columns(two_bank_package: Path) -> None:
+    matrix = tm.build_matrix(
+        package_dir=two_bank_package,
+        model_checkpoints={"finbert": ["/tmp/a"]},
+        banks=["gtfintechlab_european_central_bank"],
         n_resamples=20,
         rng_seed=11,
-        predict_fn=oracle,
+        predict_fn=_oracle_predict,
     )
     csv_text = tm.render_csv(matrix)
-    assert "model,bank,support,macro_f1_mean" in csv_text
-    assert "finbert,gtfintechlab_european_central_bank" in csv_text
+    assert "n_checkpoints,ci_kind" in csv_text
+    assert ",point_estimate," in csv_text
 
 
-def test_render_markdown_includes_ci_format(two_bank_package: Path) -> None:
-    def oracle(rows):
-        labels = [r.label for r in rows]
-        return list(labels), list(labels), [0.5] * len(labels)
-
+def test_render_markdown_marks_point_estimate_when_single_checkpoint(two_bank_package: Path) -> None:
     matrix = tm.build_matrix(
         package_dir=two_bank_package,
-        model_checkpoints={"finbert": "/tmp/a"},
+        model_checkpoints={"finbert": ["/tmp/a"]},
         banks=["gtfintechlab_european_central_bank"],
-        seeds=[11],
         n_resamples=20,
         coverage=0.95,
         rng_seed=11,
-        predict_fn=oracle,
+        predict_fn=_oracle_predict,
+    )
+    md = tm.render_markdown(matrix, coverage=0.95)
+    assert "(point)" in md
+    assert "95% CI when n≥2" in md
+
+
+def test_render_markdown_emits_ci_when_multi_checkpoint(two_bank_package: Path) -> None:
+    matrix = tm.build_matrix(
+        package_dir=two_bank_package,
+        model_checkpoints={"finbert": ["/tmp/a", "/tmp/b", "/tmp/c"]},
+        banks=["gtfintechlab_european_central_bank"],
+        n_resamples=100,
+        rng_seed=11,
+        predict_fn=_make_varying_predictor(),
     )
     md = tm.render_markdown(matrix)
-    assert "95% CI" in md
-    assert "`finbert`" in md
+    # Multi-checkpoint cell renders as "point [lo, hi]" — square-brackets present.
+    assert " [" in md and "]" in md
+
+
+def test_scrub_nan_converts_floats_to_none() -> None:
+    payload = {
+        "ok": 0.5,
+        "nan_field": float("nan"),
+        "inf_field": float("inf"),
+        "list": [1.0, float("nan"), {"nested": float("-inf")}],
+    }
+    out = tm._scrub_nan(payload)
+    assert out["ok"] == 0.5
+    assert out["nan_field"] is None
+    assert out["inf_field"] is None
+    assert out["list"][1] is None
+    assert out["list"][2]["nested"] is None
+    # Round-trips through strict JSON.
+    json.dumps(out, allow_nan=False)
+
+
+def test_scrub_nan_preserves_normal_data() -> None:
+    payload = {"a": 1, "b": [1, 2, 3], "c": {"d": "string"}}
+    assert tm._scrub_nan(payload) == payload
+
+
+def test_build_matrix_failures_get_captured_not_raised(tmp_path: Path) -> None:
+    package_dir = tmp_path / "processed" / "tp_empty"
+    _write_registry(package_dir / "registry_normalized.jsonl", [])
+
+    def _exploding(rows):
+        raise RuntimeError("boom")
+
+    matrix = tm.build_matrix(
+        package_dir=package_dir,
+        model_checkpoints={"finbert": ["/tmp/a"]},
+        banks=["gtfintechlab_european_central_bank"],
+        n_resamples=20,
+        rng_seed=11,
+        predict_fn=_exploding,
+    )
+    failures = matrix["by_model"]["finbert"].get("failures") or []
+    assert any("boom" in f.get("error", "") or "No labeled rows" in f.get("error", "") for f in failures)


### PR DESCRIPTION
## Summary
- NLP fine-tune dropbase filters `sample_weight=0` rows from training; cross-bank rows stay in the registry but never enter the loss.
- New `cross_bank_transfer.evaluate_cross_bank` runs zero-shot inference on a held-out bank (ECB / BoJ / BoE / BoC / RBA), emits macro-F1 + per-class + per-axis (time, certainty) when gtfintechlab `multi_axis_extras` is present.
- New `transfer_matrix` walks `(model, bank, seed)` cells, aggregates with block-bootstrap CIs, writes JSON + CSV + markdown.
- New `make eval-cross-bank TRAINING_PACKAGE_ID=… MODEL_CHECKPOINTS=alias=path[,alias=path]` target.
- LOBO (leave-one-bank-out training) deferred — needs per-run weight override, opens up a separate compute-heavy bundle.

## Test plan
- `docker compose exec backend-gpu pytest tests/unit/test_cross_bank_transfer.py tests/unit/test_transfer_matrix.py tests/unit/test_sample_weight_filter.py tests/unit/test_finetune_pilot.py`
- `docker compose exec backend-gpu pytest tests/unit/ tests/regression/ --ignore=tests/unit/test_ablation_config_loader.py`