### PR TITLE
Layer 2 thickening: lstm_attn pool, DLinear, 20-day lookback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,8 @@ PRETRAIN_BLOCK_SIZE ?= 256
 PRETRAIN_LR ?= 2e-5
 PRETRAIN_MAX_ROWS ?= 0
 PRETRAIN_OBJECTIVE ?= mlm_nsp
+PRETRAIN_BASE_CHECKPOINT ?= ProsusAI/finbert
+PRETRAIN_OUT_NAME ?= finbert_fed_adjacent
 finbert-fed-adjacent-pretrain:
 	docker compose run --rm backend \
 		python -m app.data.continued_pretraining \
@@ -198,7 +200,18 @@ finbert-fed-adjacent-pretrain:
 		--block-size "$(PRETRAIN_BLOCK_SIZE)" \
 		--learning-rate "$(PRETRAIN_LR)" \
 		--max-rows "$(PRETRAIN_MAX_ROWS)" \
-		--objective "$(PRETRAIN_OBJECTIVE)"
+		--objective "$(PRETRAIN_OBJECTIVE)" \
+		--base-checkpoint "$(PRETRAIN_BASE_CHECKPOINT)" \
+		--checkpoint-name "$(PRETRAIN_OUT_NAME)"
+
+# Control ablation: same substrate + recipe, but starting from bert-base-uncased
+# instead of ProsusAI/finbert. Pair the resulting checkpoint with the FinBERT-
+# based one in the bake-off to isolate the contribution of the finance prior.
+finbert-fed-adjacent-pretrain-bert-control:
+	$(MAKE) finbert-fed-adjacent-pretrain \
+		PRETRAIN_BASE_CHECKPOINT=bert-base-uncased \
+		PRETRAIN_OUT_NAME=bert_base_fed_adjacent \
+		$(if $(SUBSTRATE),SUBSTRATE=$(SUBSTRATE),)
 
 finbert-fed-adjacent-pretrain-smoke:
 	docker compose run --rm backend \

--- a/backend/app/data/attention_ablation.py
+++ b/backend/app/data/attention_ablation.py
@@ -63,7 +63,7 @@ from app.services.forecaster import (
     SEQUENCE_LENGTH,
     FeatureVector,
     ForecasterModel,
-    build_last5_sequence,
+    build_lookback_sequence,
 )
 
 # All valid variant cells for the 8-way grid (B and C are mutually exclusive).
@@ -141,7 +141,7 @@ def _build_feature_seq(
                 elapsed_time=elapsed,
             )
         )
-    feature_vectors = build_last5_sequence(feature_vectors)
+    feature_vectors = build_lookback_sequence(feature_vectors)
     seq = [v.as_list() for v in feature_vectors]
     target_close_norm = float(target_row["close"]) / DEFAULT_CLOSE_SCALE
     target_volatility = float(target_row["volatility_5d"])

--- a/backend/app/data/finetune_batch.py
+++ b/backend/app/data/finetune_batch.py
@@ -34,8 +34,10 @@ ENCODERS: dict[str, str] = {
     "finbert": "ProsusAI/finbert",
     "fomc_roberta": "ZiweiChen/FinBERT-FOMC",
     "gtfintechlab_fomc_roberta": "gtfintechlab/FOMC-RoBERTa",
+    "gtfintechlab_fomc_roberta_any_exp": "gtfintechlab/fomc-roberta-any-exp",
     "deberta_v3_base": "microsoft/deberta-v3-base",
     "finbert_fed_adjacent": "local/finbert-fed-adjacent",
+    "bert_base_fed_adjacent": "local/bert-base-fed-adjacent",
     "bge_large_en_v15": "BAAI/bge-large-en-v1.5",
     "nomic_embed_text_v15": "nomic-ai/nomic-embed-text-v1.5",
 }

--- a/backend/app/models/attention.py
+++ b/backend/app/models/attention.py
@@ -42,6 +42,46 @@ class TimeDecayAttention(nn.Module):
         return x * scale
 
 
+class RecurrentSequenceAttention(nn.Module):
+    """Learned additive attention over a recurrent layer's output sequence.
+
+    Replaces the ``output[:, -1, :]`` "take only the last step" pool used in
+    the v1 LSTM with a content-aware weighted sum across all timesteps. For
+    sequences of length 20+ this lets the head focus on the relevant slice
+    of history (e.g. an FOMC-day cluster) rather than the last business day.
+
+    Additive (Bahdanau-style) scoring: ``score = v · tanh(W · h_t)``, softmax
+    over time. Optional ``mask`` zeros out padded timesteps if the caller
+    pads variable-length sequences.
+    """
+
+    def __init__(self, hidden_size: int, attn_dim: int | None = None):
+        super().__init__()
+        self.hidden_size = int(hidden_size)
+        attn_dim = int(attn_dim) if attn_dim is not None else self.hidden_size
+        self.proj = nn.Linear(self.hidden_size, attn_dim, bias=True)
+        self.v = nn.Linear(attn_dim, 1, bias=False)
+
+    def forward(
+        self,
+        sequence: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """sequence: (B, T, H) → pooled: (B, H), weights: (B, T)."""
+
+        if sequence.dim() != 3:
+            raise ValueError(
+                f"RecurrentSequenceAttention expects (B, T, H); got shape {tuple(sequence.shape)}"
+            )
+        scores = self.v(torch.tanh(self.proj(sequence))).squeeze(-1)  # (B, T)
+        if mask is not None:
+            scores = scores.masked_fill(mask == 0, float("-inf"))
+        weights = F.softmax(scores, dim=-1)
+        weights = torch.nan_to_num(weights, nan=0.0)
+        pooled = torch.einsum("bt,bth->bh", weights, sequence)
+        return pooled, weights
+
+
 class ChunkAttentionPooler(nn.Module):
     """Variant B from the Phase 4 attention plan: attention over chunk embeddings
     with values multiplicatively damped by exp(-lambda * |elapsed_days|).

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -6,7 +6,11 @@ from typing import Any, Iterable
 
 from app.config import DATA_DIR, MODEL_CHECKPOINT_DIR
 
-SEQUENCE_LENGTH = 5
+# v2 reference: 20-day lookback over daily bars. v1 used 5 (sub-week)
+# which was too short for the recurrent core to learn temporal structure.
+# Tests/regression callers reference this constant; on-disk checkpoints
+# persist their training-time value via training/checkpoint.py.
+SEQUENCE_LENGTH = 20
 FEATURE_SIZE = 6  # [sentiment_score, market_close, market_volatility, close_change_pct, volatility_change, elapsed_time]
 SENTIMENT_FEATURE_INDEX = 0
 ELAPSED_TIME_FEATURE_INDEX = 5
@@ -117,7 +121,9 @@ class FeatureVector:
         ]
 
 
-def build_last5_sequence(vectors: Iterable[FeatureVector], length: int = SEQUENCE_LENGTH) -> list[FeatureVector]:
+def build_lookback_sequence(vectors: Iterable[FeatureVector], length: int = SEQUENCE_LENGTH) -> list[FeatureVector]:
+    """Pad-front (with the oldest vector) or truncate to a fixed lookback window."""
+
     items = list(vectors)
     if not items:
         items = [FeatureVector(date="", sentiment_score=0.0, market_close=0.0, market_volatility=0.0)]

--- a/backend/app/models/dlinear.py
+++ b/backend/app/models/dlinear.py
@@ -1,0 +1,106 @@
+"""DLinear baseline (Zeng et al. 2023, "Are Transformers Effective for Time
+Series Forecasting?").
+
+Decomposes the input into a moving-average trend and a residual seasonal
+component, projects each through its own Linear layer, then sums. Despite
+the simplicity, DLinear consistently matches or beats Transformer-style
+architectures on financial time series in recent benchmarks; including it
+gives the bake-off a strong non-recurrent control.
+
+Input contract matches LSTM/TCN: ``(B, T, F)``. Output: ``(B, T, hidden)``
+plus a ``None`` placeholder so the forecaster's ``output, _ = core(x)``
+destructuring keeps working unchanged. Pooling to the head uses the same
+``output[:, -1, :]`` step as the recurrent cores.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class _SeriesDecomposition(nn.Module):
+    """Trend = moving average over a centred window; seasonal = input − trend."""
+
+    def __init__(self, kernel_size: int = 5):
+        super().__init__()
+        if kernel_size < 1:
+            raise ValueError("kernel_size must be >= 1")
+        self.kernel_size = int(kernel_size)
+        # AvgPool1d with stride=1 and replicate padding: trend has the same
+        # length as input. Use F.pad with mode="replicate" for boundary
+        # handling so DLinear matches the published recipe.
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        # x: (B, T, F) — pool along T
+        x_t = x.transpose(1, 2)  # (B, F, T)
+        pad = (self.kernel_size - 1) // 2
+        # Symmetric replicate padding so the trend keeps the original length.
+        padded = nn.functional.pad(x_t, (pad, pad), mode="replicate")
+        trend = nn.functional.avg_pool1d(
+            padded, kernel_size=self.kernel_size, stride=1, padding=0
+        )
+        trend = trend.transpose(1, 2)  # (B, T, F)
+        seasonal = x - trend
+        return trend, seasonal
+
+
+class DLinear(nn.Module):
+    """DLinear core. Two per-feature linear maps, one for trend, one for seasonal.
+
+    The published DLinear uses ``Linear(T, H)`` per channel (i.e., shared
+    weights across features). We mirror that by stacking the input as
+    ``(B*F, T)`` for each linear application, then reshaping back.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        sequence_length: int,
+        decomposition_kernel: int = 5,
+    ):
+        super().__init__()
+        self.input_size = int(input_size)
+        self.hidden_size = int(hidden_size)
+        self.sequence_length = int(sequence_length)
+        self.decomposition = _SeriesDecomposition(kernel_size=decomposition_kernel)
+        # DLinear's two heads operate on the time dimension. Output H lets us
+        # plug into the existing forecaster head which expects (B, T, H).
+        self.trend_linear = nn.Linear(self.sequence_length, self.sequence_length)
+        self.seasonal_linear = nn.Linear(self.sequence_length, self.sequence_length)
+        # Project the F input channels into hidden_size on the final pool step
+        # so the downstream head sees the same dim as the recurrent variants.
+        self.feature_proj = nn.Linear(self.input_size, self.hidden_size)
+        # Zero-init like the chunk projection elsewhere — keeps DLinear close
+        # to a no-op at step 0 so the cross-arch comparison starts from a
+        # neutral baseline rather than a different random init.
+        nn.init.zeros_(self.trend_linear.weight)
+        nn.init.zeros_(self.trend_linear.bias)
+        nn.init.zeros_(self.seasonal_linear.weight)
+        nn.init.zeros_(self.seasonal_linear.bias)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
+        if x.dim() != 3:
+            raise ValueError(f"DLinear expects (B, T, F); got {tuple(x.shape)}")
+        batch_size, seq_len, feat = x.shape
+        if seq_len != self.sequence_length:
+            raise ValueError(
+                f"DLinear was built for seq_len={self.sequence_length}, got {seq_len}"
+            )
+        trend, seasonal = self.decomposition(x)  # both (B, T, F)
+        # Per-feature linear over the time axis: reshape to (B*F, T), apply
+        # linear, reshape back. The shared weights across features mirror the
+        # published DLinear recipe.
+        def _apply(linear: nn.Linear, tensor: torch.Tensor) -> torch.Tensor:
+            return (
+                linear(tensor.transpose(1, 2).reshape(batch_size * feat, seq_len))
+                .reshape(batch_size, feat, seq_len)
+                .transpose(1, 2)
+            )
+
+        trend_out = _apply(self.trend_linear, trend)
+        seasonal_out = _apply(self.seasonal_linear, seasonal)
+        summed = trend_out + seasonal_out  # (B, T, F)
+        projected = self.feature_proj(summed)  # (B, T, hidden)
+        return projected, None

--- a/backend/app/models/lstm.py
+++ b/backend/app/models/lstm.py
@@ -4,7 +4,11 @@ import torch
 from torch import nn
 from torch.nn import functional as F
 
-from app.models.attention import ChunkAttentionPooler, TimeDecayAttention
+from app.models.attention import (
+    ChunkAttentionPooler,
+    RecurrentSequenceAttention,
+    TimeDecayAttention,
+)
 from app.models.config import (
     CREDIBILITY_FEATURE_DIM,
     DEFAULT_CHUNK_DECAY_RATE,
@@ -16,9 +20,14 @@ from app.models.config import (
     DEFAULT_INITIAL_DECAY_RATE,
     DEFAULT_NUM_LAYERS,
     FEATURE_SIZE,
+    SEQUENCE_LENGTH,
 )
+from app.models.dlinear import DLinear
 from app.models.tcn import TemporalConvNet
 from app.models.transformer import SmallTransformer
+
+_ATTENTION_POOL_MODELS = frozenset({"lstm_attn"})
+_DLINEAR_MODELS = frozenset({"dlinear"})
 
 
 class ForecasterModel(nn.Module):
@@ -65,10 +74,10 @@ class ForecasterModel(nn.Module):
         eight-way ablation sweeps them as separate cells.
         """
         super().__init__()
-        _allowed_model_types = {"lstm", "gru", "tcn", "transformer"}
+        _allowed_model_types = {"lstm", "lstm_attn", "gru", "tcn", "transformer", "dlinear"}
         if model_type not in _allowed_model_types:
             raise ValueError(
-                f"Unknown model_type: {model_type!r}. Allowed: lstm, gru, tcn, transformer"
+                f"Unknown model_type: {model_type!r}. Allowed: {sorted(_allowed_model_types)}"
             )
         if use_chunk_attention and use_llm_embeddings:
             raise ValueError(
@@ -136,6 +145,13 @@ class ForecasterModel(nn.Module):
             dropout=lstm_dropout,
         )
         self.lstm = self.recurrent_core  # alias for backward compatibility
+        self.uses_attention_pool = self.model_type in _ATTENTION_POOL_MODELS
+        if self.uses_attention_pool:
+            self.recurrent_attention: RecurrentSequenceAttention | None = (
+                RecurrentSequenceAttention(hidden_size=hidden_size)
+            )
+        else:
+            self.recurrent_attention = None
         self.head = nn.Sequential(
             nn.LayerNorm(hidden_size),
             nn.Linear(hidden_size, head_hidden_size),
@@ -185,8 +201,15 @@ class ForecasterModel(nn.Module):
             broadcast = credibility.unsqueeze(1).expand(-1, seq_len, -1)
             x = torch.cat([x, broadcast], dim=-1)
         output, _ = self.lstm(x)
-        last_step = output[:, -1, :]
-        raw = self.head(last_step)
+        if self.uses_attention_pool:
+            if self.recurrent_attention is None:
+                raise RuntimeError(
+                    "recurrent_attention not initialised but lstm_attn variant is active"
+                )
+            pooled_step, _attn_weights = self.recurrent_attention(output)
+        else:
+            pooled_step = output[:, -1, :]
+        raw = self.head(pooled_step)
         close = raw[:, 0:1]
         # Volatility must stay non-negative, while close remains unconstrained.
         volatility = F.softplus(raw[:, 1:2])
@@ -223,7 +246,7 @@ class ForecasterModel(nn.Module):
         num_layers: int,
         dropout: float,
     ) -> nn.Module:
-        if model_type == "lstm":
+        if model_type in {"lstm", "lstm_attn"}:
             return nn.LSTM(
                 input_size=input_size,
                 hidden_size=hidden_size,
@@ -252,6 +275,12 @@ class ForecasterModel(nn.Module):
                 num_layers=num_layers,
                 dropout=dropout,
             )
+        if model_type == "dlinear":
+            return DLinear(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                sequence_length=SEQUENCE_LENGTH,
+            )
         raise ValueError(
-            f"Unknown model_type: {model_type!r}. Allowed: lstm, gru, tcn, transformer"
+            f"Unknown model_type: {model_type!r}. Allowed: lstm, lstm_attn, gru, tcn, transformer, dlinear"
         )

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -95,3 +95,15 @@ encoders:
       ``revision`` is filled in with the local checkpoint directory or its sha256
       after the GPU run completes. Empty revision means "not yet trained" — the
       bake-off CLI skips this encoder until a revision is pinned.
+
+  bert_base_fed_adjacent:
+    repo: local/bert-base-fed-adjacent
+    revision: ""
+    gated: false
+    task: masked_lm
+    description: |
+      Control ablation for finbert_fed_adjacent — same BIS+local continued-
+      pretrain recipe applied on top of bert-base-uncased instead of ProsusAI/
+      finbert. Run via ``make finbert-fed-adjacent-pretrain-bert-control``; the
+      bake-off pairs the two checkpoints so we can isolate the contribution of
+      the FinBERT prior versus the BIS substrate alone.

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -50,7 +50,7 @@ from app.models.config import (
     SEQUENCE_LENGTH,
     FeatureVector,
     ModelConfig,
-    build_last5_sequence,
+    build_lookback_sequence,
 )
 from app.models.lstm import ForecasterModel
 from app.models.tcn import TemporalConvNet
@@ -326,7 +326,7 @@ def forecast_quantitative_series(
 
     last_date = history_timestamps[-1] if history_timestamps else ""
     for step in range(steps):
-        fixed_sequence = build_last5_sequence(rolling)
+        fixed_sequence = build_lookback_sequence(rolling)
         next_close, next_vol = _predict_next_point(model, fixed_sequence)
         last_vector = fixed_sequence[-1]
         if forecast_dates and step < len(forecast_dates):

--- a/tests/unit/test_forecaster.py
+++ b/tests/unit/test_forecaster.py
@@ -16,7 +16,7 @@ from app.services.forecaster import (  # noqa: E402
     SENTIMENT_FEATURE_INDEX,
     TimeDecayAttention,
     build_feature_vectors,
-    build_last5_sequence,
+    build_lookback_sequence,
     forecast_quantitative_series,
     get_model_artifact_metadata,
     inspect_training_data_sources,
@@ -43,8 +43,8 @@ def test_parse_horizon_steps():
     assert parse_horizon_steps("invalid") == 3
 
 
-def test_build_last5_sequence_padding():
-    seq = build_last5_sequence(_sample_vectors(2), length=5)
+def test_build_lookback_sequence_padding():
+    seq = build_lookback_sequence(_sample_vectors(2), length=5)
     assert len(seq) == 5
     assert seq[0].date == "2026-01-01"
 
@@ -98,10 +98,16 @@ def test_build_feature_vectors_threads_text_embedding_to_each_row():
 
 
 def test_inspect_training_data_sources_reports_usable_and_insufficient_files(tmp_path):
+    # SEQUENCE_LENGTH=20 → usable series needs ≥ 21 records (one full window).
+    # Pick day-of-month safely (max 28) so the synthetic dates remain valid.
     usable = {
         "records": [
-            {"date": f"2026-01-{idx + 1:02d}", "close": 5000 + idx * 10, "volatility_5d": 0.01 + idx * 0.0001}
-            for idx in range(7)
+            {
+                "date": f"2026-{1 + idx // 28:02d}-{(idx % 28) + 1:02d}",
+                "close": 5000 + idx * 10,
+                "volatility_5d": 0.01 + idx * 0.0001,
+            }
+            for idx in range(24)
         ]
     }
     insufficient = {
@@ -123,7 +129,7 @@ def test_inspect_training_data_sources_reports_usable_and_insufficient_files(tmp
 
 
 def test_forecast_quantitative_series_fast_shape():
-    out = forecast_quantitative_series(_sample_vectors(10), forecast_mode="fast", horizon="3d")
+    out = forecast_quantitative_series(_sample_vectors(32), forecast_mode="fast", horizon="3d")
     assert "prediction" in out and "series" in out and "model" in out
     assert out["prediction"]["horizon"] == "3d"
     assert out["model"]["runtime_mode"] == "fast"
@@ -134,7 +140,9 @@ def test_forecast_quantitative_series_fast_shape():
     assert len(out["series"]["forecast_volatility"]) == 3
     assert len(out["series"]["forecast_volatility_lower"]) == 3
     assert len(out["series"]["forecast_volatility_upper"]) == 3
-    assert len(out["series"]["timestamps"]) == 10
+    # forecast_quantitative_series clips history to the last 30 entries
+    # regardless of input length — see services/forecaster.py history_vectors slice.
+    assert len(out["series"]["timestamps"]) == 30
     assert out["series"]["forecast_confidence_level"] == 0.8
     assert all(
         lower <= point <= upper
@@ -148,7 +156,7 @@ def test_forecast_quantitative_series_fast_shape():
 
 
 def test_forecast_quantitative_series_quick_train_shape():
-    out = forecast_quantitative_series(_sample_vectors(12), forecast_mode="quick_train", horizon="5d")
+    out = forecast_quantitative_series(_sample_vectors(32), forecast_mode="quick_train", horizon="5d")
     assert out["prediction"]["horizon"] == "5d"
     assert out["model"]["runtime_mode"] == "quick_train"
     assert out["model"]["adaptation_epochs_completed"] is not None
@@ -162,7 +170,7 @@ def test_forecast_quantitative_series_quick_train_shape():
 
 def test_train_model_reports_model_config_and_metrics():
     result = train_model(
-        vectors=_sample_vectors(10),
+        vectors=_sample_vectors(32),
         model_config=ModelConfig(hidden_size=24, num_layers=1, dropout=0.05, head_hidden_size=12),
         epochs=3,
         batch_size=4,
@@ -181,7 +189,7 @@ def test_train_model_reports_model_config_and_metrics():
 def test_train_model_checkpoint_contains_training_metadata(tmp_path):
     checkpoint_path = tmp_path / "forecaster.pt"
     result = train_model(
-        vectors=_sample_vectors(10),
+        vectors=_sample_vectors(32),
         model_config=ModelConfig(hidden_size=20, num_layers=2, dropout=0.10, head_hidden_size=10),
         epochs=2,
         batch_size=4,

--- a/tests/unit/test_lstm_attn_and_dlinear.py
+++ b/tests/unit/test_lstm_attn_and_dlinear.py
@@ -1,0 +1,136 @@
+"""Tests for the Layer-2 architecture upgrades: lstm_attn pool and DLinear core."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.models.attention import RecurrentSequenceAttention
+from app.models.config import SEQUENCE_LENGTH
+from app.models.dlinear import DLinear
+from app.models.lstm import ForecasterModel
+
+
+def _seed() -> None:
+    torch.manual_seed(11)
+
+
+# ---- RecurrentSequenceAttention ----------------------------------------------
+
+
+def test_recurrent_attention_pool_output_shape() -> None:
+    attn = RecurrentSequenceAttention(hidden_size=16)
+    seq = torch.randn(3, 20, 16)
+    pooled, weights = attn(seq)
+    assert pooled.shape == (3, 16)
+    assert weights.shape == (3, 20)
+    # Weights sum to 1 along the time axis.
+    assert torch.allclose(weights.sum(dim=-1), torch.ones(3), atol=1e-5)
+
+
+def test_recurrent_attention_pool_rejects_non_3d_input() -> None:
+    attn = RecurrentSequenceAttention(hidden_size=8)
+    with pytest.raises(ValueError, match="expects \\(B, T, H\\)"):
+        attn(torch.randn(8, 16))
+
+
+def test_recurrent_attention_pool_honours_mask() -> None:
+    """Fully-masked sequences must not produce NaN pooled outputs."""
+
+    attn = RecurrentSequenceAttention(hidden_size=8)
+    seq = torch.randn(2, 5, 8)
+    mask = torch.tensor([[1, 1, 0, 0, 0], [1, 1, 1, 0, 0]], dtype=torch.float32)
+    pooled, weights = attn(seq, mask=mask)
+    assert not torch.isnan(pooled).any()
+    # Masked positions must have ~zero weight.
+    assert weights[0, 2:].abs().sum() < 1e-5
+    assert weights[1, 3:].abs().sum() < 1e-5
+
+
+# ---- LSTM-with-attention forecaster ------------------------------------------
+
+
+def test_lstm_attn_constructs_with_attention_pool() -> None:
+    model = ForecasterModel(model_type="lstm_attn")
+    assert model.uses_attention_pool is True
+    assert isinstance(model.recurrent_attention, RecurrentSequenceAttention)
+
+
+def test_lstm_attn_forward_uses_attention_not_last_step() -> None:
+    """The whole-sequence attention pool should give a different output than
+    the last-step pool for the same inputs and weights."""
+
+    _seed()
+    last_step_model = ForecasterModel(model_type="lstm", hidden_size=16)
+    attn_model = ForecasterModel(model_type="lstm_attn", hidden_size=16)
+
+    # Force identical LSTM weights so the only difference is the pool.
+    attn_model.lstm.load_state_dict(last_step_model.lstm.state_dict())
+    attn_model.head.load_state_dict(last_step_model.head.state_dict())
+
+    x = torch.randn(2, SEQUENCE_LENGTH, last_step_model.input_size)
+    out_last = last_step_model(x)
+    out_attn = attn_model(x)
+    assert out_last.shape == out_attn.shape
+    # With the same weights and a non-trivial attention layer the outputs
+    # should differ — confirms the pool actually fires.
+    assert not torch.allclose(out_last, out_attn, atol=1e-5)
+
+
+def test_lstm_attn_with_credibility_features_concats_correctly() -> None:
+    model = ForecasterModel(model_type="lstm_attn", credibility_features=True, hidden_size=8)
+    x = torch.randn(2, SEQUENCE_LENGTH, model.input_size)
+    credibility = torch.zeros(2, 4)
+    out = model(x, credibility=credibility)
+    assert out.shape == (2, 2)
+
+
+# ---- DLinear -----------------------------------------------------------------
+
+
+def test_dlinear_returns_padding_compatible_shape() -> None:
+    core = DLinear(input_size=6, hidden_size=12, sequence_length=SEQUENCE_LENGTH)
+    x = torch.randn(4, SEQUENCE_LENGTH, 6)
+    out, hidden = core(x)
+    assert out.shape == (4, SEQUENCE_LENGTH, 12)
+    assert hidden is None
+
+
+def test_dlinear_rejects_wrong_sequence_length() -> None:
+    core = DLinear(input_size=4, hidden_size=8, sequence_length=20)
+    with pytest.raises(ValueError, match="seq_len="):
+        core(torch.randn(1, 7, 4))
+
+
+def test_dlinear_initial_output_close_to_feature_projection() -> None:
+    """Trend and seasonal linears are zero-initialised so DLinear at step 0
+    should just emit the projected feature average — a clean baseline."""
+
+    _seed()
+    core = DLinear(input_size=4, hidden_size=8, sequence_length=10)
+    x = torch.randn(2, 10, 4)
+    out, _ = core(x)
+    # Trend = AvgPool of x; seasonal = x − trend. Both linears zero ⇒
+    # `summed = bias_t + bias_s = 0`. So projected = feature_proj(0) = bias.
+    bias = core.feature_proj.bias
+    assert torch.allclose(out, bias.expand_as(out), atol=1e-6)
+
+
+def test_dlinear_forecaster_end_to_end() -> None:
+    model = ForecasterModel(model_type="dlinear", hidden_size=12)
+    x = torch.randn(3, SEQUENCE_LENGTH, model.input_size)
+    out = model(x)
+    assert out.shape == (3, 2)
+    # softplus on the volatility column → non-negative.
+    assert (out[:, 1] >= 0).all()
+
+
+# ---- Rejected combos ---------------------------------------------------------
+
+
+def test_unknown_model_type_lists_full_allowed_set() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        ForecasterModel(model_type="not_a_model")
+    msg = str(excinfo.value)
+    for name in ("lstm", "lstm_attn", "gru", "tcn", "transformer", "dlinear"):
+        assert name in msg

--- a/tests/unit/test_prepare_training_data.py
+++ b/tests/unit/test_prepare_training_data.py
@@ -49,14 +49,16 @@ def test_prepare_training_dataset_creates_grouped_records(tmp_path, monkeypatch)
 
 
 def test_prepare_training_dataset_output_is_trainer_compatible(tmp_path, monkeypatch):
+    # SEQUENCE_LENGTH=20 → a "usable" sequence needs ≥ 21 records.
+    # Generate 22 documents across Feb–Mar so day-of-month stays valid.
     documents = [
         {
-            "date": f"2026-02-{idx + 1:02d}",
+            "date": f"2026-{2 + idx // 22:02d}-{(idx % 22) + 1:02d}",
             "text": f"Statement text {idx}",
             "title": f"Statement {idx}",
             "document_type": "Statement",
         }
-        for idx in range(7)
+        for idx in range(22)
     ]
     (tmp_path / "fomc_statements.json").write_text(json.dumps(documents), encoding="utf-8")
     (tmp_path / "fomc_minutes.json").write_text(json.dumps([]), encoding="utf-8")
@@ -81,5 +83,5 @@ def test_prepare_training_dataset_output_is_trainer_compatible(tmp_path, monkeyp
     sequences, summaries = inspect_training_data_sources(tmp_path)
 
     assert len(sequences) == 1
-    assert len(sequences[0]) == 7
+    assert len(sequences[0]) == 22
     assert any(summary.path.name == "train_dataset.json" and summary.status == "usable" for summary in summaries)


### PR DESCRIPTION
## Summary
- New `model_type=lstm_attn` adds a Bahdanau additive-attention pool over the full LSTM output sequence — head sees the relevant slice of history, not just the last bar.
- New `backend/app/models/dlinear.py` adds a Zeng et al. 2023 DLinear core as a strong non-recurrent bake-off baseline. Same `(B, T, hidden)` contract as the recurrent variants.
- `SEQUENCE_LENGTH` 5 → 20 trading days. `build_last5_sequence` → `build_lookback_sequence` everywhere.
- New `make finbert-fed-adjacent-pretrain-bert-control` runs the same BIS substrate recipe on `bert-base-uncased` instead of `ProsusAI/finbert` — isolates the FinBERT-prior contribution.
- `registry.yaml` adds `bert_base_fed_adjacent` placeholder; `finetune_batch.ENCODERS` adds it + the now-accessible `gtfintechlab/fomc-roberta-any-exp`.

## Test plan
- `docker compose exec backend-gpu pytest tests/unit/test_lstm_attn_and_dlinear.py tests/unit/test_forecaster.py tests/regression/test_forecaster_determinism.py`
- `docker compose exec backend-gpu pytest tests/unit/ tests/regression/ --ignore=tests/unit/test_ablation_config_loader.py`