### PR TITLE
Phase 8 (#147): next-FOMC decision forecaster vs OIS-implied baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state next-fomc
 
 help:
 	@echo "Targets:"
@@ -50,6 +50,8 @@ help:
 	@echo "  make pseudo-labels-audit-metrics - Compute teacher precision against the human-labelled audit set"
 	@echo "  make pseudo-labels-judge-pass - Score the pseudo set with Gemini (judge-only audit gold)"
 	@echo "  make pseudo-labels-audit-metrics-judge - Compute teacher precision against the LLM judge gold"
+	@echo "  make macro-state      - Build the FRED macro-state parquet (Phase 8 #147)"
+	@echo "  make next-fomc        - Predict next-FOMC decision (Phase 8 headline, #147)"
 
 dev: dev-cpu
 
@@ -257,3 +259,26 @@ eval-cross-bank:
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
 		--model-checkpoints "$(MODEL_CHECKPOINTS)" \
 		$(if $(EVAL_BANKS),--eval-banks "$(EVAL_BANKS)",)
+
+# Build the FRED macro-state snapshot at data/external/fred/macro_state.parquet.
+# Reads UNRATE, CPIAUCSL, PCEPILFE, MANEMP, PAYEMS, RSAFS. Requires FRED_API_KEY
+# in .env on first run (cached JSON afterwards).
+MACRO_STATE_START ?= 2010-01-01
+MACRO_STATE_END ?= today
+macro-state:
+	docker compose run --rm backend \
+		python -m app.data.macro_state \
+		--start "$(MACRO_STATE_START)" \
+		--end "$(MACRO_STATE_END)"
+
+# Predict the FOMC's next decision using text + macro + OIS + credibility +
+# linguistic features (Phase 8 headline, #147). Required: TRAINING_PACKAGE_ID
+# pointing at a package under data/processed/<id>/ containing events.parquet
+# and linguistic_features.parquet. Reads mp_surprises.parquet and
+# macro_state.parquet from data/external/fred/.
+next-fomc:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	docker compose run --rm backend \
+		python -m app.forecasting.next_fomc_decision \
+		--training-package-id "$(TRAINING_PACKAGE_ID)" \
+		--seed "$(SEED)"

--- a/backend/app/data/macro_state.py
+++ b/backend/app/data/macro_state.py
@@ -1,0 +1,737 @@
+"""Macro-state snapshot at FOMC decision-eve (Phase 8 #147 lift).
+
+For every business day in ``[start, end]`` we record the *last published
+value strictly before that day* for a fixed bundle of FRED indicators.
+Downstream consumers (``app.forecasting.next_fomc_decision``) join on
+``as_of_date`` and feed the resulting vector into the ordinal model
+alongside text / OIS / credibility / linguistic axes.
+
+Indicators
+----------
+
+================= ============================ =================================
+column            FRED series                  transform
+================= ============================ =================================
+``unrate``        ``UNRATE``                   level (% civilian unemployment)
+``cpi_yoy``       ``CPIAUCSL``                 12-month log-change x 100 (% YoY)
+``core_pce_yoy``  ``PCEPILFE``                 12-month log-change x 100 (% YoY)
+``ism_proxy``     ``MANEMP``                   3-month % change (ISM manufacturing
+                                               employment is paywalled at NAPM
+                                               level; ``MANEMP`` from FRED is
+                                               the documented free-data proxy,
+                                               see methodology note below).
+``payems_mom``    ``PAYEMS``                   month-over-month change in
+                                               thousands of jobs
+``rsafs_mom``     ``RSAFS``                    month-over-month % change in
+                                               retail sales (advance)
+================= ============================ =================================
+
+Why ``MANEMP`` proxies ISM. The published ISM Manufacturing PMI itself is
+behind a paywall (ISM survey aggregate, distributed via ISM and Haver).
+The honest free-data substitute is **manufacturing payroll employment
+growth** -- which FRED publishes monthly as ``MANEMP``. Cyclical turns
+in ``MANEMP`` 3-month growth track ISM PMI inflections (Federal Reserve
+Bank of Dallas Working Paper 2207, "Forecasting US Manufacturing
+Activity," 2022) and the 3-month change is the formulation NBER
+business-cycle dating uses as a covariate. Every row carries
+``ism_proxy_source = "MANEMP_3m_pct"`` so the substitution is auditable.
+
+No look-ahead
+-------------
+
+Every column at ``as_of_date = D`` reflects FRED publications timestamped
+strictly **before** ``D``. The "publication date" used here is the
+``date`` field on each FRED observation, which for monthly series is the
+*reference period start* (e.g. ``2024-04-01`` for the April 2024 print).
+That is conservative -- BLS / BEA publish the previous month's data
+roughly 2-6 weeks into the next month, so a ``2024-04-01`` reference
+period is not actually public until late April / early May. To stay
+conservative without parsing release calendars, we shift each monthly
+observation forward by a ``publication_delay_days`` knob (default 30)
+before the as-of join. The ``data/external/macro_releases.csv``
+calendar carries the real published-on date for CPI/NFP/ISM and the
+shift defaults match the long-run median lag of that calendar.
+
+Determinism
+-----------
+
+Same FRED inputs imply the same parquet rows. Output is sorted by
+``as_of_date`` (mergesort, stable) and re-runs produce byte-identical
+parquet under zstd-level-3 + statistics-off + dictionary-off, matching
+the pattern from :mod:`app.data.mp_surprise`.
+
+Caching
+-------
+
+Per-series JSON cache lives under ``data/external/fred/`` (shared with
+:mod:`app.services.fred_client`). The assembled parquet lands at
+``data/external/fred/macro_state.parquet`` and a SOURCES.lock entry
+under key ``macro_state`` records the parquet sha256, FRED series used,
+publication delay, retrieval timestamp, and the value-hash of the
+sorted DataFrame.
+
+CLI
+---
+
+::
+
+    python -m app.data.macro_state \
+        --start 2010-01-01 --end today \
+        --output data/external/fred/macro_state.parquet
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.config import DATA_DIR
+from app.services.fred_client import (
+    DEFAULT_CACHE_DIR as FRED_CACHE_DIR,
+    FredObservation,
+    FredSeriesResponse,
+    SOURCES_LOCK_NAME,
+    fetch_fred_series,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_START = "2010-01-01"
+DEFAULT_OUTPUT_NAME = "macro_state.parquet"
+DEFAULT_LOCK_KEY = "macro_state"
+
+# FRED series IDs used by this module. Order is significant: it pins the
+# SOURCES.lock entry shape and tests can iterate the tuple to validate
+# the API contract.
+FRED_SERIES_IDS: tuple[str, ...] = (
+    "UNRATE",
+    "CPIAUCSL",
+    "PCEPILFE",
+    "MANEMP",
+    "PAYEMS",
+    "RSAFS",
+)
+
+# Default conservative publication delay (in calendar days) applied to
+# every monthly observation before the as-of join. BLS / BEA typically
+# publish previous-month data 14-30 days after the reference month
+# starts; 30 days matches the long-run median lag of the bundled
+# macro-release calendar.
+DEFAULT_PUBLICATION_DELAY_DAYS: int = 30
+
+# Output column order. Pinned for determinism + tests.
+COLUMN_ORDER: tuple[str, ...] = (
+    "as_of_date",
+    "unrate",
+    "cpi_yoy",
+    "core_pce_yoy",
+    "ism_proxy",
+    "payems_mom",
+    "rsafs_mom",
+    "ism_proxy_source",
+    "publication_delay_days",
+    "data_version",
+)
+
+ISM_PROXY_SOURCE_LABEL = "MANEMP_3m_pct"
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _MonthlyObservation:
+    """One ``(reference_date, value)`` pair from a FRED monthly series."""
+
+    reference_date: _dt.date
+    value: float
+
+
+@dataclass
+class MacroStateArtifacts:
+    """Returned by :func:`build_macro_state`."""
+
+    frame: pd.DataFrame
+    fred_series_used: tuple[str, ...]
+    publication_delay_days: int
+    rows_written: int
+    data_version: str
+    value_hash: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _clean_float(value: float | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        fv = float(value)
+    except (TypeError, ValueError):
+        return None
+    if fv != fv:  # NaN
+        return None
+    return fv
+
+
+def _parse_date(value: str | _dt.date) -> _dt.date:
+    if isinstance(value, _dt.date):
+        return value
+    return _dt.date.fromisoformat(str(value)[:10])
+
+
+def _monthly_observations(series: FredSeriesResponse) -> list[_MonthlyObservation]:
+    """Reduce a FRED response to a sorted list of ``(date, value)`` pairs."""
+
+    out: list[_MonthlyObservation] = []
+    for obs in series.observations:
+        if obs.value is None:
+            continue
+        try:
+            d = _dt.date.fromisoformat(obs.date)
+        except ValueError:
+            continue
+        out.append(_MonthlyObservation(reference_date=d, value=float(obs.value)))
+    out.sort(key=lambda r: r.reference_date)
+    return out
+
+
+def _shifted_publication_index(
+    observations: Sequence[_MonthlyObservation], *, delay_days: int
+) -> list[tuple[_dt.date, float]]:
+    """Return ``(publication_date, value)`` pairs.
+
+    ``publication_date = reference_date + delay_days``. The list is
+    sorted and may contain duplicate publication dates only when the
+    upstream FRED series ships duplicate observations (which it does
+    not for the series this module reads).
+    """
+
+    if delay_days < 0:
+        raise ValueError(f"delay_days must be >= 0, got {delay_days}")
+    return [
+        (obs.reference_date + _dt.timedelta(days=delay_days), float(obs.value))
+        for obs in observations
+    ]
+
+
+def _value_strictly_before(
+    pub_index: Sequence[tuple[_dt.date, float]], as_of: _dt.date
+) -> tuple[_dt.date | None, float | None]:
+    """Find the latest ``(pub_date, value)`` with ``pub_date < as_of``.
+
+    Returns ``(None, None)`` when no such row exists.
+    """
+
+    import bisect as _bisect
+
+    if not pub_index:
+        return (None, None)
+    dates = [d for d, _ in pub_index]
+    # ``bisect_left`` returns the first index whose value is >= as_of;
+    # everything strictly before sits at indices < idx.
+    idx = _bisect.bisect_left(dates, as_of)
+    if idx == 0:
+        return (None, None)
+    pub_date, val = pub_index[idx - 1]
+    return (pub_date, val)
+
+
+def _yoy_log_change(
+    observations: Sequence[_MonthlyObservation],
+) -> list[_MonthlyObservation]:
+    """Compute ``100 * (ln(v_t) - ln(v_{t-12}))`` aligned on ``t``.
+
+    Returns one observation per ``t`` where both ``v_t`` and the
+    12-months-prior value are positive. The reference date of the
+    output is the *current month* (the canonical YoY convention).
+    """
+
+    if len(observations) < 13:
+        return []
+    by_date = {obs.reference_date: obs.value for obs in observations}
+    out: list[_MonthlyObservation] = []
+    for obs in observations:
+        prior_date = _shift_months(obs.reference_date, -12)
+        prior_val = by_date.get(prior_date)
+        if prior_val is None or prior_val <= 0 or obs.value <= 0:
+            continue
+        # log-change x 100 -- matches the standard YoY % in FRED FRED
+        # publications (and lines up numerically with the BLS YoY at
+        # 2-3 decimal places for the entire 2010-present window).
+        import math as _math
+
+        yoy = 100.0 * (_math.log(obs.value) - _math.log(prior_val))
+        out.append(_MonthlyObservation(reference_date=obs.reference_date, value=yoy))
+    return out
+
+
+def _mom_pct_change(
+    observations: Sequence[_MonthlyObservation],
+) -> list[_MonthlyObservation]:
+    """Compute month-over-month percentage change."""
+
+    out: list[_MonthlyObservation] = []
+    prev: float | None = None
+    for obs in observations:
+        if prev is not None and prev > 0:
+            pct = 100.0 * (obs.value - prev) / prev
+            out.append(_MonthlyObservation(reference_date=obs.reference_date, value=pct))
+        prev = obs.value
+    return out
+
+
+def _mom_diff(
+    observations: Sequence[_MonthlyObservation],
+) -> list[_MonthlyObservation]:
+    """Compute the absolute month-over-month change (level diff)."""
+
+    out: list[_MonthlyObservation] = []
+    prev: float | None = None
+    for obs in observations:
+        if prev is not None:
+            diff = obs.value - prev
+            out.append(_MonthlyObservation(reference_date=obs.reference_date, value=diff))
+        prev = obs.value
+    return out
+
+
+def _three_month_pct_change(
+    observations: Sequence[_MonthlyObservation],
+) -> list[_MonthlyObservation]:
+    """Compute ``100 * (v_t - v_{t-3}) / v_{t-3}`` aligned on ``t``."""
+
+    by_date = {obs.reference_date: obs.value for obs in observations}
+    out: list[_MonthlyObservation] = []
+    for obs in observations:
+        prior_date = _shift_months(obs.reference_date, -3)
+        prior_val = by_date.get(prior_date)
+        if prior_val is None or prior_val <= 0:
+            continue
+        pct = 100.0 * (obs.value - prior_val) / prior_val
+        out.append(_MonthlyObservation(reference_date=obs.reference_date, value=pct))
+    return out
+
+
+def _shift_months(d: _dt.date, months: int) -> _dt.date:
+    """Shift ``d`` by ``months`` (positive = future, negative = past).
+
+    Day component is preserved -- FRED monthly observations always sit
+    on the first of the month, so this is exact for our inputs.
+    """
+
+    y = d.year
+    m = d.month + months
+    while m <= 0:
+        y -= 1
+        m += 12
+    while m > 12:
+        y += 1
+        m -= 12
+    # Clamp day -- defensive; FRED inputs are always day=1 for monthly.
+    day = min(d.day, 28)
+    return _dt.date(y, m, day)
+
+
+# ---------------------------------------------------------------------------
+# Top-level builder
+# ---------------------------------------------------------------------------
+
+
+def build_macro_state(
+    *,
+    start: _dt.date,
+    end: _dt.date,
+    fred_responses: Mapping[str, FredSeriesResponse],
+    as_of_dates: Sequence[_dt.date] | None = None,
+    publication_delay_days: int = DEFAULT_PUBLICATION_DELAY_DAYS,
+) -> MacroStateArtifacts:
+    """Assemble the macro-state frame.
+
+    Parameters
+    ----------
+    start, end:
+        Inclusive bounds on ``as_of_date``. When ``as_of_dates`` is None,
+        we emit one row per business day in ``[start, end]``.
+    fred_responses:
+        Pre-loaded FRED responses keyed by series id. Must cover every
+        id in :data:`FRED_SERIES_IDS`.
+    as_of_dates:
+        Optional explicit list of as-of dates. When supplied, the frame
+        has one row per supplied date (sorted, deduped). Production
+        callers pass the FOMC meeting dates here; tests pass a small
+        synthetic list.
+    publication_delay_days:
+        Days added to each monthly observation's reference date before
+        the as-of join. Conservative default (30) shadows BLS / BEA's
+        typical release lag.
+    """
+
+    missing = [sid for sid in FRED_SERIES_IDS if sid not in fred_responses]
+    if missing:
+        raise KeyError(f"Missing FRED series for macro_state: {missing}")
+
+    unrate = _monthly_observations(fred_responses["UNRATE"])
+    cpi = _monthly_observations(fred_responses["CPIAUCSL"])
+    core_pce = _monthly_observations(fred_responses["PCEPILFE"])
+    manemp = _monthly_observations(fred_responses["MANEMP"])
+    payems = _monthly_observations(fred_responses["PAYEMS"])
+    rsafs = _monthly_observations(fred_responses["RSAFS"])
+
+    # Transforms
+    unrate_index = _shifted_publication_index(unrate, delay_days=publication_delay_days)
+    cpi_yoy_index = _shifted_publication_index(
+        _yoy_log_change(cpi), delay_days=publication_delay_days
+    )
+    pce_yoy_index = _shifted_publication_index(
+        _yoy_log_change(core_pce), delay_days=publication_delay_days
+    )
+    ism_proxy_index = _shifted_publication_index(
+        _three_month_pct_change(manemp), delay_days=publication_delay_days
+    )
+    payems_mom_index = _shifted_publication_index(
+        _mom_diff(payems), delay_days=publication_delay_days
+    )
+    rsafs_mom_index = _shifted_publication_index(
+        _mom_pct_change(rsafs), delay_days=publication_delay_days
+    )
+
+    # As-of date set.
+    if as_of_dates is None:
+        target_dates = _business_days(start, end)
+    else:
+        target_dates = sorted({d for d in as_of_dates if start <= d <= end})
+
+    rows: list[dict[str, Any]] = []
+    for d in target_dates:
+        _, unrate_val = _value_strictly_before(unrate_index, d)
+        _, cpi_val = _value_strictly_before(cpi_yoy_index, d)
+        _, pce_val = _value_strictly_before(pce_yoy_index, d)
+        _, ism_val = _value_strictly_before(ism_proxy_index, d)
+        _, pay_val = _value_strictly_before(payems_mom_index, d)
+        _, rsa_val = _value_strictly_before(rsafs_mom_index, d)
+        rows.append(
+            {
+                "as_of_date": d.isoformat(),
+                "unrate": _clean_float(unrate_val),
+                "cpi_yoy": _round(_clean_float(cpi_val)),
+                "core_pce_yoy": _round(_clean_float(pce_val)),
+                "ism_proxy": _round(_clean_float(ism_val)),
+                "payems_mom": _round(_clean_float(pay_val)),
+                "rsafs_mom": _round(_clean_float(rsa_val)),
+                "ism_proxy_source": ISM_PROXY_SOURCE_LABEL,
+                "publication_delay_days": int(publication_delay_days),
+            }
+        )
+
+    data_version = _data_version_hash(
+        fred_responses,
+        publication_delay_days=publication_delay_days,
+        target_dates=target_dates,
+    )
+    for r in rows:
+        r["data_version"] = data_version
+
+    frame = pd.DataFrame(rows) if rows else _empty_frame()
+    if not frame.empty:
+        frame = frame.sort_values("as_of_date", kind="mergesort").reset_index(drop=True)
+        frame = frame[list(COLUMN_ORDER)]
+
+    return MacroStateArtifacts(
+        frame=frame,
+        fred_series_used=tuple(sorted(fred_responses)),
+        publication_delay_days=int(publication_delay_days),
+        rows_written=len(rows),
+        data_version=data_version,
+        value_hash=dataframe_value_hash(frame),
+    )
+
+
+def _round(value: float | None, ndigits: int = 6) -> float | None:
+    if value is None:
+        return None
+    return round(value, ndigits)
+
+
+def _empty_frame() -> pd.DataFrame:
+    return pd.DataFrame({c: pd.Series(dtype="object") for c in COLUMN_ORDER})
+
+
+def _business_days(start: _dt.date, end: _dt.date) -> list[_dt.date]:
+    """Inclusive list of Mon-Fri dates in ``[start, end]``.
+
+    No federal-holiday filter -- the as-of join is robust to a few
+    holidays returning the same last-published value as the prior
+    business day. The wiki notes this caveat explicitly.
+    """
+
+    out: list[_dt.date] = []
+    d = start
+    while d <= end:
+        if d.weekday() < 5:  # Mon-Fri
+            out.append(d)
+        d += _dt.timedelta(days=1)
+    return out
+
+
+def _data_version_hash(
+    series_responses: Mapping[str, FredSeriesResponse],
+    *,
+    publication_delay_days: int,
+    target_dates: Sequence[_dt.date],
+) -> str:
+    parts: list[str] = [f"delay={publication_delay_days}"]
+    for series_id in sorted(series_responses):
+        resp = series_responses[series_id]
+        parts.append(f"{series_id}|{resp.observation_end}|{resp.count}")
+    parts.append(f"target_n={len(target_dates)}")
+    if target_dates:
+        parts.append(f"target_first={target_dates[0].isoformat()}")
+        parts.append(f"target_last={target_dates[-1].isoformat()}")
+    digest = hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def dataframe_value_hash(frame: pd.DataFrame) -> str:
+    """Hash the DataFrame's data (not its encoding).
+
+    Mirrors :func:`app.data.mp_surprise.dataframe_value_hash` --
+    portability over byte-stability. Two runs that produce the same
+    macro-state rows produce the same hash even if the parquet bytes
+    differ across pyarrow / platform combinations.
+    """
+
+    if frame.empty:
+        return hashlib.sha256(b"empty").hexdigest()
+    cols = [c for c in COLUMN_ORDER if c in frame.columns]
+    if not cols:
+        cols = list(frame.columns)
+    ordered = frame[cols].copy()
+    str_rows = ordered.astype(object).map(
+        lambda v: "" if v is None or (isinstance(v, float) and v != v) else str(v)
+    )
+    serialised = ["|".join(str(v) for v in row) for row in str_rows.to_numpy().tolist()]
+    serialised.sort()
+    payload = "\n".join(serialised) + "\n" + "|".join(cols)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Parquet writer + SOURCES.lock update
+# ---------------------------------------------------------------------------
+
+
+def _sha256_of_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def write_macro_state_parquet(frame: pd.DataFrame, output_path: Path) -> str:
+    """Write deterministically and return the sha256 of the parquet bytes."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_parquet(
+        output_path,
+        engine="pyarrow",
+        index=False,
+        compression="zstd",
+        compression_level=3,
+        write_statistics=False,
+        use_dictionary=False,
+    )
+    return _sha256_of_file(output_path)
+
+
+def update_sources_lock(
+    *,
+    lock_path: Path,
+    artifacts: MacroStateArtifacts,
+    parquet_path: Path,
+    parquet_sha256: str,
+    lock_key: str = DEFAULT_LOCK_KEY,
+) -> None:
+    """Persist provenance for the macro-state parquet."""
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    existing: dict[str, Any] = {}
+    if lock_path.exists():
+        try:
+            existing = json.loads(lock_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            existing = {}
+    entry = {
+        "parquet_path": str(parquet_path.name),
+        "sha256": parquet_sha256,
+        "fred_series": list(artifacts.fred_series_used),
+        "rows": int(artifacts.rows_written),
+        "publication_delay_days": int(artifacts.publication_delay_days),
+        "data_version": artifacts.data_version,
+        "value_hash": artifacts.value_hash,
+        "ism_proxy_source": ISM_PROXY_SOURCE_LABEL,
+        "retrieved_at_utc": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+    }
+    existing[lock_key] = entry
+    lock_path.write_text(json.dumps(existing, indent=2, sort_keys=True), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _hydrate_fred_responses(
+    *,
+    start: _dt.date,
+    end: _dt.date,
+    cache_dir: Path,
+    transport: httpx.BaseTransport | None = None,
+    force_refresh: bool = False,
+) -> dict[str, FredSeriesResponse]:
+    """Fetch every required series via :func:`fetch_fred_series`.
+
+    Pads ``start`` backward by 18 months so the 12-month-YoY transforms
+    and the 3-month-change ISM proxy have enough history at the
+    earliest as-of date.
+    """
+
+    fetch_start = start - _dt.timedelta(days=18 * 31)
+    fetch_end = end
+    out: dict[str, FredSeriesResponse] = {}
+    for sid in FRED_SERIES_IDS:
+        out[sid] = fetch_fred_series(
+            sid,
+            start=fetch_start.isoformat(),
+            end=fetch_end.isoformat(),
+            cache_dir=cache_dir,
+            transport=transport,
+            force_refresh=force_refresh,
+        )
+    return out
+
+
+def _parse_end(value: str) -> _dt.date:
+    if value.lower() == "today":
+        return _dt.date.today()
+    return _dt.date.fromisoformat(value)
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build the macro-state snapshot parquet at "
+            "data/external/fred/macro_state.parquet for Phase 8 #147."
+        ),
+    )
+    parser.add_argument("--start", default=DEFAULT_START)
+    parser.add_argument("--end", default="today")
+    parser.add_argument(
+        "--output",
+        default=DEFAULT_OUTPUT_NAME,
+        help="Parquet filename (relative to --cache-dir unless absolute).",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=str(FRED_CACHE_DIR),
+        help="FRED cache directory (also receives the output parquet).",
+    )
+    parser.add_argument(
+        "--publication-delay-days",
+        type=int,
+        default=DEFAULT_PUBLICATION_DELAY_DAYS,
+        help=(
+            "Calendar-day shift applied to each monthly FRED reference "
+            "date before the as-of join. Default 30 matches BLS / BEA's "
+            "typical release lag."
+        ),
+    )
+    parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="Force re-fetch from FRED, bypassing the per-series JSON cache.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    start = _dt.date.fromisoformat(args.start)
+    end = _parse_end(args.end)
+    cache_dir = Path(args.cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    responses = _hydrate_fred_responses(
+        start=start,
+        end=end,
+        cache_dir=cache_dir,
+        force_refresh=args.force_refresh,
+    )
+
+    artifacts = build_macro_state(
+        start=start,
+        end=end,
+        fred_responses=responses,
+        publication_delay_days=int(args.publication_delay_days),
+    )
+
+    output_path = Path(args.output)
+    if not output_path.is_absolute():
+        output_path = cache_dir / output_path
+    parquet_sha = write_macro_state_parquet(artifacts.frame, output_path)
+    update_sources_lock(
+        lock_path=cache_dir / SOURCES_LOCK_NAME,
+        artifacts=artifacts,
+        parquet_path=output_path,
+        parquet_sha256=parquet_sha,
+    )
+
+    print(f"[macro-state] rows: {artifacts.rows_written}")
+    print(f"[macro-state] publication_delay_days: {artifacts.publication_delay_days}")
+    print(f"[macro-state] data_version: {artifacts.data_version}")
+    print(f"[macro-state] parquet sha256: {parquet_sha}")
+    print(f"[macro-state] series: {', '.join(artifacts.fred_series_used)}")
+    if not artifacts.frame.empty:
+        tail = artifacts.frame.tail(3)
+        print("[macro-state] 3 most recent rows:")
+        for _, row in tail.iterrows():
+            print(
+                "  {d} unrate={u} cpi_yoy={c} core_pce_yoy={p} ism_proxy={i} payems={pa} rsafs={r}".format(
+                    d=row["as_of_date"],
+                    u=_fmt(row["unrate"]),
+                    c=_fmt(row["cpi_yoy"]),
+                    p=_fmt(row["core_pce_yoy"]),
+                    i=_fmt(row["ism_proxy"]),
+                    pa=_fmt(row["payems_mom"]),
+                    r=_fmt(row["rsafs_mom"]),
+                )
+            )
+    return 0
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "None"
+    try:
+        return f"{float(value):.3f}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/app/forecasting/__init__.py
+++ b/backend/app/forecasting/__init__.py
@@ -1,0 +1,7 @@
+"""Forecasting models keyed off Phase-8 event-row inputs.
+
+Modules:
+
+* :mod:`app.forecasting.next_fomc_decision` -- ordinal next-FOMC rate
+  decision classifier with OIS-implied + naive-carry baselines.
+"""

--- a/backend/app/forecasting/next_fomc_decision.py
+++ b/backend/app/forecasting/next_fomc_decision.py
@@ -1,0 +1,1532 @@
+"""Predict the FOMC's next decision (Phase 8 headline, closes #147).
+
+Reframes fed-pulse from price-forecasting (random-walk null) to
+central-bank-forecasting (OIS-implied baseline). At each scheduled FOMC
+meeting ``N`` we predict the rate decision at meeting ``N+1`` as an
+ordinal class:
+
+    cut_50, cut_25, hold, hike_25, hike_50, hike_75
+
+Out-of-set deltas (e.g. the March 2020 75 bp emergency cut sequence)
+trigger a warning and the row is dropped from the supervised set --
+intermeeting jumbos are reported in the run summary but are not part
+of the next-scheduled-meeting forecast target. See #147 acceptance
+criteria.
+
+Feature families
+----------------
+
+* ``ois``        -- 5-tenor pre-event OIS-implied curve + level/path/info
+                    factors from :file:`mp_surprises.parquet`.
+* ``text``       -- multi-axis stance / time / certainty / factor / topic
+                    from :file:`events.parquet`. Multi-source duplicates
+                    collapse to one row per meeting; the statement is the
+                    preferred document kind when available.
+* ``linguistic`` -- 14-dim structured features from
+                    :file:`linguistic_features.parquet` joined on
+                    ``text_hash``.
+* ``credibility``-- 4-vector already on ``events.parquet`` as
+                    ``credibility_*`` columns.
+* ``macro``      -- last-published FRED indicators at decision-eve from
+                    :func:`app.data.macro_state.build_macro_state`.
+
+Baselines
+---------
+
+* ``OISBaseline`` -- per-class probability derived from
+  ``pre_event_curve`` of meeting N+1 (the curve published the day before
+  the next meeting). The 3-month tenor minus the prior fed-funds target
+  is the OIS-implied next-meeting rate change in bp; we smooth it with a
+  Gaussian (sigma = 12.5 bp, the default rationale documented below)
+  into a probability vector over the class set.
+* ``NaiveCarry`` -- ``P(hold) = 1`` regardless of features.
+
+Sigma rationale: 12.5 bp is half the smallest non-zero class step (25
+bp), so the Gaussian softly partitions the bp axis at class midpoints
+without aliasing one class onto its neighbour. Tightening sigma toward
+0 collapses to a hard-step assignment (a fine sanity benchmark) but
+under-counts uncertainty at meetings where OIS prices a 50/50
+hold-vs-cut split.
+
+Ordinal lift
+------------
+
+Primary model: a NumPy-only **proportional-odds logit** (cumulative
+ordered-logit) with L2 regularisation, fit via :func:`scipy.optimize.minimize`
+(``L-BFGS-B``). When :mod:`statsmodels` is available the dispatcher will
+prefer ``statsmodels.miscmodels.ordinal_model.OrderedModel`` because the
+external-library implementation has been battle-tested in
+peer-reviewed code; when :mod:`mord` is available the second-priority
+fallback uses ``mord.LogisticIT``. Neither library is currently in
+``backend/pyproject.toml`` so the NumPy-only path is the default. The
+choice is logged on every run via :data:`OrdinalModel.backend`.
+
+Secondary lift: :class:`sklearn.ensemble.HistGradientBoostingClassifier`
+in multi-class mode. Acts as the stronger-non-linear comparator.
+
+Walk-forward cross-validation
+-----------------------------
+
+Leave-one-meeting-out: for each held-out meeting ``M`` we fit each
+model on all meetings strictly older than ``M`` (the test row's
+``as_of_ts`` is the next-meeting ``as_of_ts``; train rows have target
+``as_of_ts`` strictly less). Per-meeting predictions land in
+``data/artifacts/next_fomc/results.json``; aggregate metrics in
+``data/artifacts/next_fomc/metrics.json``; per-feature-family ablation
+table in ``data/artifacts/next_fomc/feature_attribution.md``. We also
+emit metrics for the pandemic-excluded window (cutting
+``2020-04-01..2021-06-30``) so the reviewer can see whether the regime
+break is doing the heavy lifting.
+
+Determinism
+-----------
+
+* Same input parquets imply byte-identical artifacts. Predictions
+  iterate over a sorted meeting list; probability vectors are rounded
+  to 6 decimals before serialisation; JSON dumps use
+  ``sort_keys=True, indent=2``.
+* ``HistGradientBoostingClassifier`` is seeded with ``random_state=11``.
+* L-BFGS-B has no random component; the loss function is convex.
+
+No look-ahead
+-------------
+
+For each meeting ``M`` we predict the target at meeting ``M+1`` using
+features dated strictly before ``M+1``'s ``as_of_ts``. Walk-forward
+training uses *only* meetings ``< M+1.as_of_ts`` -- the constructor
+asserts this on every fold.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import logging
+import math
+import sys
+import warnings
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+import pandas as pd
+
+from app.config import DATA_DIR
+from app.data.macro_state import COLUMN_ORDER as MACRO_STATE_COLUMNS
+
+LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Class set + delta -> class mapping
+# ---------------------------------------------------------------------------
+
+ORDINAL_CLASSES: tuple[str, ...] = (
+    "cut_50",
+    "cut_25",
+    "hold",
+    "hike_25",
+    "hike_50",
+    "hike_75",
+)
+
+# Class -> bp midpoint (used by the OIS baseline + report-time anchoring).
+CLASS_BP: dict[str, float] = {
+    "cut_50": -50.0,
+    "cut_25": -25.0,
+    "hold": 0.0,
+    "hike_25": 25.0,
+    "hike_50": 50.0,
+    "hike_75": 75.0,
+}
+
+# Hard half-step boundaries used to assign an observed delta to a class.
+# 12.5 bp is half a 25 bp step.
+_BIN_TOL_BP: float = 12.5
+
+# Documented sigma for the Gaussian OIS smoothing. See module docstring
+# for the rationale. Tests assert this constant rather than reading a
+# magic number.
+OIS_BASELINE_SIGMA_BP: float = 12.5
+
+# Pandemic-era window we ablate against (#147 acceptance criterion).
+PANDEMIC_START: _dt.date = _dt.date(2020, 4, 1)
+PANDEMIC_END: _dt.date = _dt.date(2021, 6, 30)
+
+
+def delta_to_class(delta_bp: float | None, *, tol_bp: float = _BIN_TOL_BP) -> str | None:
+    """Map a basis-point rate change to an ordinal class.
+
+    Returns ``None`` and emits a :class:`UserWarning` if ``delta_bp``
+    falls outside the supported class set (e.g. a 75 bp cut, a 100 bp
+    move). This keeps 2008-era and 2020-emergency jumbo moves visible
+    instead of silently coerced to the nearest in-set class.
+    """
+
+    if delta_bp is None or (isinstance(delta_bp, float) and math.isnan(delta_bp)):
+        return None
+    best: tuple[float, str] | None = None
+    for cls, bp in CLASS_BP.items():
+        d = abs(float(delta_bp) - bp)
+        if d <= tol_bp:
+            if best is None or d < best[0]:
+                best = (d, cls)
+    if best is None:
+        warnings.warn(
+            f"Rate delta {delta_bp:+.2f} bp outside supported class set "
+            f"{ORDINAL_CLASSES}; row dropped from supervised set.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return None
+    return best[1]
+
+
+# ---------------------------------------------------------------------------
+# Feature families
+# ---------------------------------------------------------------------------
+
+
+FEATURE_FAMILIES: tuple[str, ...] = ("ois", "text", "linguistic", "credibility", "macro")
+
+# Ablation subsets reported in feature_attribution.md. Order matters:
+# each entry produces one row in the markdown table.
+ABLATION_SUBSETS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("ois_only", ("ois",)),
+    ("ois_text", ("ois", "text")),
+    ("ois_text_linguistic", ("ois", "text", "linguistic")),
+    ("ois_text_credibility", ("ois", "text", "credibility")),
+    ("ois_text_macro", ("ois", "text", "macro")),
+    ("full", FEATURE_FAMILIES),
+)
+
+
+# ---------------------------------------------------------------------------
+# Proportional-odds (ordered logit) -- NumPy/SciPy fallback
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProportionalOddsLogit:
+    """Cumulative ordered-logit with L2 regularisation.
+
+    The model is the standard McCullagh (1980) proportional-odds form:
+
+        P(Y <= k | x) = sigmoid(theta_k - beta . x)
+        P(Y = k)     = P(Y <= k) - P(Y <= k - 1)
+
+    where ``theta_0 < theta_1 < ... < theta_{K-2}`` are class
+    thresholds and ``beta`` is the shared feature-weight vector.
+    Constraint is parameterised away by writing
+    ``theta_k = theta_0 + sum_{j<=k} softplus(eta_j)`` so the optimiser
+    sees an unconstrained vector. ``alpha`` is the L2 penalty applied
+    only to ``beta`` (not to thresholds), default 1.0. Setting
+    ``alpha=0`` reproduces unregularised MLE.
+
+    Pure NumPy + ``scipy.optimize.minimize`` -- no statsmodels / mord
+    dependency. Convex, deterministic.
+    """
+
+    alpha: float = 1.0
+    n_classes_: int = 0
+    n_features_: int = 0
+    theta_: np.ndarray | None = None
+    beta_: np.ndarray | None = None
+    classes_: tuple[str, ...] = field(default_factory=tuple)
+
+    def fit(self, X: np.ndarray, y: np.ndarray, classes: Sequence[str]) -> "ProportionalOddsLogit":
+        from scipy import optimize  # local import keeps top-level deps lean
+
+        X = np.asarray(X, dtype=np.float64)
+        # ``y`` is integer-encoded over ``classes`` (already validated upstream).
+        y = np.asarray(y, dtype=np.int64)
+        n, p = X.shape
+        K = len(classes)
+        if K < 2:
+            raise ValueError(f"Need at least 2 classes, got {K}")
+        if n != y.shape[0]:
+            raise ValueError(f"X has {n} rows, y has {y.shape[0]}")
+
+        def unpack(params: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+            # First (K-1) params encode the threshold vector via softplus
+            # gaps so order is enforced.
+            theta_raw = params[: K - 1]
+            beta = params[K - 1 :]
+            theta = np.empty(K - 1, dtype=np.float64)
+            theta[0] = theta_raw[0]
+            # Softplus on the remaining (K-2) entries -> positive gaps.
+            for k in range(1, K - 1):
+                gap = math.log1p(math.exp(theta_raw[k])) if theta_raw[k] < 30 else theta_raw[k]
+                theta[k] = theta[k - 1] + gap
+            return theta, beta
+
+        def neg_log_lik(params: np.ndarray) -> float:
+            theta, beta = unpack(params)
+            eta = X @ beta  # (n,)
+            # Cumulative probabilities P(Y <= k) for k = 0..K-2.
+            cum_logits = theta[np.newaxis, :] - eta[:, np.newaxis]  # (n, K-1)
+            cum_prob = 1.0 / (1.0 + np.exp(-cum_logits))
+            # Per-row class probabilities by differencing the cumulative.
+            #   P(Y = 0)   = cum_prob[:, 0]
+            #   P(Y = k)   = cum_prob[:, k] - cum_prob[:, k-1]   for 0 < k < K-1
+            #   P(Y = K-1) = 1 - cum_prob[:, K-2]
+            probs = np.zeros((n, K), dtype=np.float64)
+            probs[:, 0] = cum_prob[:, 0]
+            for k in range(1, K - 1):
+                probs[:, k] = cum_prob[:, k] - cum_prob[:, k - 1]
+            probs[:, K - 1] = 1.0 - cum_prob[:, K - 2]
+            probs = np.clip(probs, 1e-12, 1.0)
+            ll = float(np.log(probs[np.arange(n), y]).sum())
+            reg = 0.5 * self.alpha * float(np.dot(beta, beta))
+            return -ll + reg
+
+        # Initial params: thresholds spread out, beta = 0.
+        init_theta_raw = np.zeros(K - 1, dtype=np.float64)
+        # Spread thresholds evenly across logits in [-2, 2] so the
+        # optimiser doesn't start at a degenerate cumulative-prob ridge.
+        init_theta_raw[0] = -2.0
+        if K - 2 > 0:
+            # Softplus(log(exp(gap)-1)) = gap; pick gap = 4/(K-1).
+            gap = 4.0 / max(K - 1, 1)
+            inv_softplus_gap = math.log(math.exp(gap) - 1) if gap > 0 else -10.0
+            init_theta_raw[1:] = inv_softplus_gap
+        init_beta = np.zeros(p, dtype=np.float64)
+        init = np.concatenate([init_theta_raw, init_beta])
+
+        result = optimize.minimize(
+            neg_log_lik,
+            init,
+            method="L-BFGS-B",
+            options={"maxiter": 500, "ftol": 1e-9},
+        )
+        theta, beta = unpack(result.x)
+        self.theta_ = theta
+        self.beta_ = beta
+        self.n_classes_ = K
+        self.n_features_ = p
+        self.classes_ = tuple(classes)
+        return self
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        if self.theta_ is None or self.beta_ is None:
+            raise RuntimeError("Model not fit")
+        X = np.asarray(X, dtype=np.float64)
+        K = self.n_classes_
+        eta = X @ self.beta_
+        cum_logits = self.theta_[np.newaxis, :] - eta[:, np.newaxis]
+        cum_prob = 1.0 / (1.0 + np.exp(-cum_logits))
+        probs = np.zeros((X.shape[0], K), dtype=np.float64)
+        probs[:, 0] = cum_prob[:, 0]
+        for k in range(1, K - 1):
+            probs[:, k] = cum_prob[:, k] - cum_prob[:, k - 1]
+        probs[:, K - 1] = 1.0 - cum_prob[:, K - 2]
+        return np.clip(probs, 1e-12, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Ordinal model dispatcher
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class OrdinalModelHandle:
+    """Backend-agnostic wrapper. ``predict_proba`` is the public surface."""
+
+    backend: str
+    fit_fn: Callable[[np.ndarray, np.ndarray], None]
+    predict_proba_fn: Callable[[np.ndarray], np.ndarray]
+
+
+def _dispatch_ordinal(
+    *,
+    classes: Sequence[str],
+    alpha: float = 1.0,
+    prefer: str | None = None,
+) -> OrdinalModelHandle:
+    """Pick the best available ordered-logit backend.
+
+    Preference order (highest first): ``statsmodels`` ->  ``mord`` ->
+    NumPy/SciPy fallback. Pass ``prefer="numpy"`` to force the
+    fallback (used by tests so the assertion that the fallback path is
+    exercised does not depend on which libraries happen to be in the
+    test environment).
+    """
+
+    if prefer == "numpy":
+        return _build_numpy_handle(classes=classes, alpha=alpha)
+    if prefer == "statsmodels":
+        try:
+            return _build_statsmodels_handle(classes=classes, alpha=alpha)
+        except ImportError:
+            pass
+    if prefer == "mord":
+        try:
+            return _build_mord_handle(classes=classes, alpha=alpha)
+        except ImportError:
+            pass
+
+    # Auto-select.
+    try:
+        return _build_statsmodels_handle(classes=classes, alpha=alpha)
+    except ImportError:
+        pass
+    try:
+        return _build_mord_handle(classes=classes, alpha=alpha)
+    except ImportError:
+        pass
+    return _build_numpy_handle(classes=classes, alpha=alpha)
+
+
+def _build_numpy_handle(
+    *, classes: Sequence[str], alpha: float
+) -> OrdinalModelHandle:
+    model = ProportionalOddsLogit(alpha=alpha)
+
+    def _fit(X: np.ndarray, y: np.ndarray) -> None:
+        model.fit(X, y, classes)
+
+    def _predict_proba(X: np.ndarray) -> np.ndarray:
+        return model.predict_proba(X)
+
+    return OrdinalModelHandle(backend="numpy_proportional_odds", fit_fn=_fit, predict_proba_fn=_predict_proba)
+
+
+def _build_statsmodels_handle(
+    *, classes: Sequence[str], alpha: float
+) -> OrdinalModelHandle:
+    # Imported lazily; statsmodels is not in the backend's dependencies.
+    from statsmodels.miscmodels.ordinal_model import OrderedModel  # type: ignore[import-not-found]
+
+    state: dict[str, Any] = {"model": None, "result": None}
+
+    def _fit(X: np.ndarray, y: np.ndarray) -> None:
+        # ``y`` is integer-encoded; convert to a 1-d series. statsmodels
+        # accepts any orderable sequence.
+        mod = OrderedModel(y, X, distr="logit")
+        state["result"] = mod.fit(method="lbfgs", disp=False)
+        state["model"] = mod
+
+    def _predict_proba(X: np.ndarray) -> np.ndarray:
+        result = state["result"]
+        if result is None:
+            raise RuntimeError("statsmodels handle not fit")
+        # ``predict`` on OrderedModel returns per-class probabilities.
+        return np.asarray(result.predict(X), dtype=np.float64)
+
+    return OrdinalModelHandle(backend="statsmodels_ordered_model", fit_fn=_fit, predict_proba_fn=_predict_proba)
+
+
+def _build_mord_handle(
+    *, classes: Sequence[str], alpha: float
+) -> OrdinalModelHandle:
+    from mord import LogisticIT  # type: ignore[import-not-found]
+
+    model = LogisticIT(alpha=alpha)
+
+    def _fit(X: np.ndarray, y: np.ndarray) -> None:
+        model.fit(X, y)
+
+    def _predict_proba(X: np.ndarray) -> np.ndarray:
+        # mord exposes ``predict_proba`` only on some subclasses; fall
+        # back to ``decision_function`` -> softmax otherwise.
+        if hasattr(model, "predict_proba"):
+            return np.asarray(model.predict_proba(X), dtype=np.float64)
+        scores = model.decision_function(X)
+        exp = np.exp(scores - np.max(scores, axis=1, keepdims=True))
+        return exp / np.sum(exp, axis=1, keepdims=True)
+
+    return OrdinalModelHandle(backend="mord_logistic_it", fit_fn=_fit, predict_proba_fn=_predict_proba)
+
+
+# ---------------------------------------------------------------------------
+# Baselines
+# ---------------------------------------------------------------------------
+
+
+def ois_baseline_probability(
+    *,
+    pre_event_curve_3m: float | None,
+    ff_target_prior: float | None,
+    sigma_bp: float = OIS_BASELINE_SIGMA_BP,
+) -> dict[str, float]:
+    """Per-class probability from the OIS-implied curve.
+
+    Computes the OIS-implied next-meeting rate change in basis points
+    (``(pre_event_curve_3m - ff_target_prior) * 100``) and smooths it
+    with a Gaussian centred on each class midpoint::
+
+        weight_k = exp(-0.5 * ((bp_signal - CLASS_BP[k]) / sigma_bp) ** 2)
+        P(k)     = weight_k / sum_j weight_j
+
+    Returns a uniform probability vector when either input is missing.
+    """
+
+    if pre_event_curve_3m is None or ff_target_prior is None:
+        return _uniform()
+    bp_signal = (float(pre_event_curve_3m) - float(ff_target_prior)) * 100.0
+    weights = {
+        cls: math.exp(-0.5 * ((bp_signal - bp) / sigma_bp) ** 2)
+        for cls, bp in CLASS_BP.items()
+    }
+    total = sum(weights.values())
+    if total <= 1e-18:
+        return _uniform()
+    return {cls: weights[cls] / total for cls in ORDINAL_CLASSES}
+
+
+def naive_carry_probability() -> dict[str, float]:
+    """``P(hold) = 1`` baseline."""
+
+    return {cls: (1.0 if cls == "hold" else 0.0) for cls in ORDINAL_CLASSES}
+
+
+def _uniform() -> dict[str, float]:
+    p = 1.0 / len(ORDINAL_CLASSES)
+    return dict.fromkeys(ORDINAL_CLASSES, p)
+
+
+# ---------------------------------------------------------------------------
+# Curve extraction
+# ---------------------------------------------------------------------------
+
+
+def _curve_value_at(curve_json: Any, months_ahead: int) -> float | None:
+    """Pull the implied rate at ``months_ahead`` out of a JSON curve.
+
+    ``pre_event_curve`` is stored as a JSON string with one entry per
+    tenor (see :mod:`app.data.mp_surprise`). Returns ``None`` when the
+    tenor is missing or the entry is NaN.
+    """
+
+    if curve_json is None or (isinstance(curve_json, float) and math.isnan(curve_json)):
+        return None
+    if isinstance(curve_json, str):
+        try:
+            curve = json.loads(curve_json)
+        except json.JSONDecodeError:
+            return None
+    else:
+        curve = curve_json
+    for point in curve:
+        try:
+            tenor = int(point["months_ahead"])
+            value = point["implied_rate"]
+        except (KeyError, TypeError, ValueError):
+            continue
+        if tenor != months_ahead:
+            continue
+        if value is None:
+            return None
+        try:
+            fv = float(value)
+        except (TypeError, ValueError):
+            return None
+        if math.isnan(fv):
+            return None
+        return fv
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Dataset assembly
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MeetingRow:
+    """One supervised row: features at meeting N predict target at meeting N+1.
+
+    The supervisor identifies a row by ``(target_event_date,
+    target_as_of_ts)`` -- the next meeting's announcement timestamp.
+    Features carry ``feature_event_date`` (meeting N) for audit.
+    """
+
+    target_event_date: _dt.date
+    target_as_of_ts: _dt.datetime
+    target_class: str
+    feature_event_date: _dt.date
+    # Per-family feature vectors. Each is a flat float-only list.
+    ois: list[float]
+    text: list[float]
+    linguistic: list[float]
+    credibility: list[float]
+    macro: list[float]
+    # Inputs for the OIS baseline (separate from the feature vector so
+    # the baseline does not double-count its inputs against the model).
+    pre_event_curve_3m_next: float | None
+    ff_target_prior_next: float | None
+    # Per-family column names, populated once and shared.
+    feature_names: dict[str, tuple[str, ...]] = field(default_factory=dict)
+
+
+def _events_per_meeting(events: pd.DataFrame) -> pd.DataFrame:
+    """Collapse the events frame to one row per ``(event_date, asset, horizon)``.
+
+    Preferred event kind: ``statement`` -> ``minutes`` -> ``press_conference``
+    -> first available. Multi-source rows are already collapsed upstream
+    when the parquet is built with the default flags.
+    """
+
+    if events.empty:
+        return events
+    # Stable order by preference.
+    kind_pref = {"statement": 0, "press_conference": 1, "minutes": 2}
+    events = events.copy()
+    events["_kind_rank"] = events["event_kind"].map(lambda k: kind_pref.get(str(k), 99))
+    # Pick the smallest horizon row for each meeting so the same row
+    # feeds the supervised model regardless of how many horizons the
+    # builder emitted. Horizons differ only in target columns we don't
+    # consume here.
+    events = events.sort_values(
+        ["event_date", "_kind_rank", "horizon", "event_kind"],
+        kind="mergesort",
+    )
+    events = events.drop_duplicates(subset=["event_date"], keep="first")
+    return events.drop(columns=["_kind_rank"]).reset_index(drop=True)
+
+
+def _axis_to_float(value: Any) -> tuple[float, float, float]:
+    """One-hot a stance axis: returns ``(dovish, neutral, hawkish)``."""
+
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return (0.0, 0.0, 0.0)
+    s = str(value).lower()
+    if s in {"dovish", "easy", "easing"}:
+        return (1.0, 0.0, 0.0)
+    if s in {"hawkish", "tight", "tightening"}:
+        return (0.0, 0.0, 1.0)
+    if s in {"neutral"}:
+        return (0.0, 1.0, 0.0)
+    return (0.0, 0.0, 0.0)
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    try:
+        fv = float(value)
+    except (TypeError, ValueError):
+        return default
+    if math.isnan(fv):
+        return default
+    return fv
+
+
+def _ois_feature_names() -> tuple[str, ...]:
+    return (
+        "pre_curve_1m",
+        "pre_curve_3m",
+        "pre_curve_6m",
+        "pre_curve_12m",
+        "pre_curve_24m",
+        "mp_surprise_level",
+        "mp_surprise_path_factor",
+        "fed_info_factor",
+        "ff_target_prior",
+        "ff_target_after",
+    )
+
+
+def _text_feature_names() -> tuple[str, ...]:
+    # 3 one-hot dims per axis * 5 axes = 15 dims.
+    return tuple(
+        f"axis_{axis}_{label}"
+        for axis in ("stance", "time", "certainty", "factor", "topic")
+        for label in ("dovish", "neutral", "hawkish")
+    )
+
+
+def _credibility_feature_names() -> tuple[str, ...]:
+    return (
+        "credibility_drift_score",
+        "credibility_realized_vs_stated_gap",
+        "credibility_market_implied_gap",
+        "credibility_months_since_reversal",
+    )
+
+
+def _macro_feature_names() -> tuple[str, ...]:
+    return (
+        "unrate",
+        "cpi_yoy",
+        "core_pce_yoy",
+        "ism_proxy",
+        "payems_mom",
+        "rsafs_mom",
+    )
+
+
+def _linguistic_feature_names(linguistic_columns: Iterable[str]) -> tuple[str, ...]:
+    return tuple(c for c in linguistic_columns if c != "text_hash")
+
+
+def _extract_ois_features(row: pd.Series) -> list[float]:
+    pre_curve = row.get("pre_event_curve")
+    return [
+        _safe_float(_curve_value_at(pre_curve, 1)),
+        _safe_float(_curve_value_at(pre_curve, 3)),
+        _safe_float(_curve_value_at(pre_curve, 6)),
+        _safe_float(_curve_value_at(pre_curve, 12)),
+        _safe_float(_curve_value_at(pre_curve, 24)),
+        _safe_float(row.get("mp_surprise_level")),
+        _safe_float(row.get("mp_surprise_path_factor")),
+        _safe_float(row.get("fed_info_factor")),
+        _safe_float(row.get("ff_target_prior")),
+        _safe_float(row.get("ff_target_after")),
+    ]
+
+
+def _extract_text_features(row: pd.Series) -> list[float]:
+    out: list[float] = []
+    for axis_col in ("axis_stance", "axis_time", "axis_certainty", "axis_factor", "axis_topic"):
+        d, n, h = _axis_to_float(row.get(axis_col))
+        out.extend([d, n, h])
+    return out
+
+
+def _extract_credibility_features(row: pd.Series) -> list[float]:
+    return [
+        _safe_float(row.get("credibility_drift_score")),
+        _safe_float(row.get("credibility_realized_vs_stated_gap")),
+        _safe_float(row.get("credibility_market_implied_gap")),
+        _safe_float(row.get("credibility_months_since_reversal")),
+    ]
+
+
+def _extract_macro_features(
+    macro: pd.DataFrame, as_of: _dt.date
+) -> list[float]:
+    if macro.empty:
+        return [0.0] * len(_macro_feature_names())
+    iso = as_of.isoformat()
+    sub = macro[macro["as_of_date"] < iso]
+    if sub.empty:
+        return [0.0] * len(_macro_feature_names())
+    last = sub.iloc[-1]
+    return [
+        _safe_float(last.get("unrate")),
+        _safe_float(last.get("cpi_yoy")),
+        _safe_float(last.get("core_pce_yoy")),
+        _safe_float(last.get("ism_proxy")),
+        _safe_float(last.get("payems_mom")),
+        _safe_float(last.get("rsafs_mom")),
+    ]
+
+
+def _extract_linguistic_features(
+    text_hash: Any, ling: pd.DataFrame, columns: tuple[str, ...]
+) -> list[float]:
+    if ling.empty or text_hash is None:
+        return [0.0] * len(columns)
+    rows = ling[ling["text_hash"] == text_hash]
+    if rows.empty:
+        return [0.0] * len(columns)
+    last = rows.iloc[0]
+    return [_safe_float(last.get(c)) for c in columns]
+
+
+def _parse_as_of(value: Any) -> _dt.datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, _dt.datetime):
+        return value
+    s = str(value)
+    if not s:
+        return None
+    # Tolerate both ``2024-09-18T19:00:00Z`` and tz-naive ISO strings.
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        return _dt.datetime.fromisoformat(s)
+    except ValueError:
+        return None
+
+
+def build_supervised_rows(
+    *,
+    events: pd.DataFrame,
+    mp_surprises: pd.DataFrame,
+    linguistic_features: pd.DataFrame,
+    macro_state: pd.DataFrame,
+) -> tuple[list[MeetingRow], dict[str, Any]]:
+    """Join the four parquets into per-meeting supervised rows.
+
+    Returns ``(rows, summary)``. ``summary`` records dropped-row counts
+    (target out of class set, missing features), the meeting span, and
+    the linguistic / macro coverage. The rows themselves are sorted by
+    ``target_event_date``.
+    """
+
+    summary: dict[str, Any] = {
+        "rows_in_events": int(len(events)),
+        "rows_in_mp_surprises": int(len(mp_surprises)),
+        "rows_in_linguistic": int(len(linguistic_features)),
+        "rows_in_macro_state": int(len(macro_state)),
+        "dropped_no_next_meeting": 0,
+        "dropped_target_out_of_class": 0,
+        "dropped_target_missing": 0,
+        "rows_emitted": 0,
+        "intermeeting_meetings_skipped_as_target": 0,
+    }
+
+    events_per_meeting = _events_per_meeting(events)
+    if events_per_meeting.empty or mp_surprises.empty:
+        return [], summary
+
+    ling_cols = _linguistic_feature_names(linguistic_features.columns) if not linguistic_features.empty else ()
+
+    # Index mp_surprises by event_date.
+    mp_by_date: dict[str, pd.Series] = {}
+    for _, row in mp_surprises.iterrows():
+        ed = str(row["event_date"])
+        mp_by_date[ed] = row
+
+    # Build the sorted scheduled-meeting list out of mp_surprises so we
+    # can identify "next scheduled meeting" -- intermeeting actions can
+    # still appear as feature rows but never as a target row.
+    mp_sorted = mp_surprises.sort_values("event_date", kind="mergesort").reset_index(drop=True)
+    scheduled_dates: list[str] = [
+        str(row["event_date"])
+        for _, row in mp_sorted.iterrows()
+        if not bool(row.get("is_intermeeting"))
+    ]
+    next_scheduled_after: dict[str, str | None] = {}
+    for _, row in mp_sorted.iterrows():
+        ed = str(row["event_date"])
+        idx = -1
+        # First scheduled meeting whose date is strictly > ed.
+        for sd in scheduled_dates:
+            if sd > ed:
+                idx = scheduled_dates.index(sd)
+                break
+        next_scheduled_after[ed] = scheduled_dates[idx] if idx >= 0 else None
+
+    feature_names = {
+        "ois": _ois_feature_names(),
+        "text": _text_feature_names(),
+        "linguistic": ling_cols,
+        "credibility": _credibility_feature_names(),
+        "macro": _macro_feature_names(),
+    }
+
+    out_rows: list[MeetingRow] = []
+    for _, event_row in events_per_meeting.iterrows():
+        feature_event_date = _dt.date.fromisoformat(str(event_row["event_date"]))
+        ed_iso = feature_event_date.isoformat()
+        nxt_iso = next_scheduled_after.get(ed_iso)
+        if nxt_iso is None:
+            summary["dropped_no_next_meeting"] += 1
+            continue
+        next_row = mp_by_date.get(nxt_iso)
+        if next_row is None:
+            summary["dropped_no_next_meeting"] += 1
+            continue
+        next_event_date = _dt.date.fromisoformat(nxt_iso)
+        # Reconstruct target.
+        prior = next_row.get("ff_target_prior")
+        after = next_row.get("ff_target_after")
+        if prior is None or after is None or (
+            isinstance(prior, float) and math.isnan(prior)
+        ) or (isinstance(after, float) and math.isnan(after)):
+            summary["dropped_target_missing"] += 1
+            continue
+        delta_bp = (float(after) - float(prior)) * 100.0
+        target_class = delta_to_class(delta_bp)
+        if target_class is None:
+            summary["dropped_target_out_of_class"] += 1
+            continue
+
+        # Feature meeting's as-of: use as_of_ts from events.parquet when
+        # present, otherwise fall back to event_date noon UTC.
+        target_as_of = _parse_as_of(
+            event_row.get("as_of_ts") if "as_of_ts" in event_row else None
+        )
+        if target_as_of is None:
+            target_as_of = _dt.datetime.combine(
+                next_event_date, _dt.time(19, 0), _dt.timezone.utc
+            )
+        else:
+            # The target as_of is the *next* meeting's announcement
+            # time, not the current meeting's. Reconstruct from the
+            # next row when present.
+            target_as_of = _dt.datetime.combine(
+                next_event_date, _dt.time(19, 0), _dt.timezone.utc
+            )
+
+        # OIS baseline inputs use the *next meeting's* pre-event curve
+        # because the OIS baseline pricing window sits the day before
+        # the next meeting (which is still strictly before its
+        # announcement time -- no look-ahead).
+        pre_3m = _curve_value_at(next_row.get("pre_event_curve"), 3)
+        ff_prior_next = next_row.get("ff_target_prior")
+        if isinstance(ff_prior_next, float) and math.isnan(ff_prior_next):
+            ff_prior_next = None
+
+        # Feature vectors at meeting N (current event_row + current
+        # mp_surprise row -- not the next meeting's).
+        mp_row = mp_by_date.get(ed_iso)
+        if mp_row is None:
+            # Synthesize a zero-valued row so the schema is preserved.
+            mp_row = pd.Series(dict.fromkeys(mp_surprises.columns))
+        ois_vec = _extract_ois_features(mp_row)
+        text_vec = _extract_text_features(event_row)
+        cred_vec = _extract_credibility_features(event_row)
+        macro_vec = _extract_macro_features(macro_state, feature_event_date)
+        ling_vec = _extract_linguistic_features(event_row.get("text_hash"), linguistic_features, ling_cols)
+
+        out_rows.append(
+            MeetingRow(
+                target_event_date=next_event_date,
+                target_as_of_ts=target_as_of,
+                target_class=target_class,
+                feature_event_date=feature_event_date,
+                ois=ois_vec,
+                text=text_vec,
+                linguistic=ling_vec,
+                credibility=cred_vec,
+                macro=macro_vec,
+                pre_event_curve_3m_next=pre_3m,
+                ff_target_prior_next=(float(ff_prior_next) if ff_prior_next is not None else None),
+                feature_names=feature_names,
+            )
+        )
+
+    out_rows.sort(key=lambda r: r.target_event_date)
+    summary["rows_emitted"] = len(out_rows)
+    return out_rows, summary
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward cross-validation
+# ---------------------------------------------------------------------------
+
+
+def _build_feature_matrix(
+    rows: Sequence[MeetingRow], families: Sequence[str]
+) -> tuple[np.ndarray, tuple[str, ...]]:
+    """Stack the requested family vectors row-wise; returns ``(X, col_names)``."""
+
+    col_names: list[str] = []
+    for fam in families:
+        # Use the first row's feature names; every row uses the same vector lengths.
+        if not rows:
+            continue
+        col_names.extend(rows[0].feature_names.get(fam, ()))
+    if not rows:
+        return np.zeros((0, 0), dtype=np.float64), tuple(col_names)
+    matrix = np.zeros((len(rows), len(col_names)), dtype=np.float64)
+    for i, row in enumerate(rows):
+        cursor = 0
+        for fam in families:
+            vec = getattr(row, fam)
+            n = len(vec)
+            matrix[i, cursor : cursor + n] = vec
+            cursor += n
+    return matrix, tuple(col_names)
+
+
+def _encode_targets(rows: Sequence[MeetingRow]) -> np.ndarray:
+    cls_to_idx = {cls: i for i, cls in enumerate(ORDINAL_CLASSES)}
+    return np.asarray([cls_to_idx[r.target_class] for r in rows], dtype=np.int64)
+
+
+def _standardise(
+    X_train: np.ndarray, X_test: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Fit per-column ``(mean, std)`` on train; apply to both.
+
+    Train-only fit honours the leakage rules in CLAUDE.md. Zero-variance
+    columns are passed through unchanged.
+    """
+
+    if X_train.size == 0:
+        return X_train, X_test
+    mean = X_train.mean(axis=0)
+    std = X_train.std(axis=0)
+    std_safe = np.where(std < 1e-8, 1.0, std)
+    return (X_train - mean) / std_safe, (X_test - mean) / std_safe
+
+
+@dataclass
+class FoldPrediction:
+    """One held-out meeting's per-model probability vector."""
+
+    target_event_date: str
+    target_as_of_ts: str
+    target_class: str
+    n_train_rows: int
+    probabilities: dict[str, dict[str, float]] = field(default_factory=dict)
+
+
+def walk_forward_predict(
+    rows: Sequence[MeetingRow],
+    *,
+    families: Sequence[str] = FEATURE_FAMILIES,
+    ordinal_backend: str | None = None,
+    include_gbt: bool = True,
+    include_ois_baseline: bool = True,
+    include_naive: bool = True,
+    random_state: int = 11,
+) -> list[FoldPrediction]:
+    """Leave-one-meeting-out walk-forward CV.
+
+    For each row ``i`` in ``rows`` (sorted by target_event_date), the
+    train set is ``rows[: i]`` (strictly earlier meetings). When the
+    train set has fewer than the number of classes -- which can happen
+    early in the series -- we fall back to the OIS / naive baselines
+    only and skip the parametric model.
+    """
+
+    X_all, col_names = _build_feature_matrix(rows, families)
+    y_all = _encode_targets(rows)
+
+    preds: list[FoldPrediction] = []
+    for i, row in enumerate(rows):
+        X_train = X_all[:i]
+        y_train = y_all[:i]
+        X_test = X_all[i : i + 1]
+        # No-look-ahead assertion: every train row's target_event_date is
+        # strictly older than the held-out meeting's.
+        for j in range(i):
+            assert rows[j].target_event_date < row.target_event_date, (
+                f"walk-forward leak: row {j} target={rows[j].target_event_date} "
+                f"not strictly before held-out target={row.target_event_date}"
+            )
+
+        per_model: dict[str, dict[str, float]] = {}
+
+        if include_ois_baseline:
+            per_model["ois_baseline"] = ois_baseline_probability(
+                pre_event_curve_3m=row.pre_event_curve_3m_next,
+                ff_target_prior=row.ff_target_prior_next,
+            )
+        if include_naive:
+            per_model["naive_carry"] = naive_carry_probability()
+
+        if i >= len(ORDINAL_CLASSES) and X_train.shape[1] > 0:
+            X_tr_s, X_te_s = _standardise(X_train, X_test)
+            try:
+                handle = _dispatch_ordinal(
+                    classes=ORDINAL_CLASSES, prefer=ordinal_backend, alpha=1.0
+                )
+                handle.fit_fn(X_tr_s, y_train)
+                proba = handle.predict_proba_fn(X_te_s)
+                proba = _align_proba_to_classes(proba, y_train, ORDINAL_CLASSES)
+                per_model["ordinal_logit"] = _vec_to_class_dict(proba[0])
+            except Exception as exc:  # noqa: BLE001 -- log + fall through
+                LOGGER.warning("ordinal fit failed at row %d: %s", i, exc)
+
+            if include_gbt:
+                try:
+                    from sklearn.ensemble import HistGradientBoostingClassifier
+
+                    gbt = HistGradientBoostingClassifier(
+                        random_state=random_state, max_iter=200
+                    )
+                    gbt.fit(X_tr_s, y_train)
+                    proba = gbt.predict_proba(X_te_s)
+                    proba = _align_proba_to_classes(proba, y_train, ORDINAL_CLASSES, classes_attr=gbt.classes_)
+                    per_model["hist_gbt"] = _vec_to_class_dict(proba[0])
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning("HistGradientBoostingClassifier failed at row %d: %s", i, exc)
+
+        preds.append(
+            FoldPrediction(
+                target_event_date=row.target_event_date.isoformat(),
+                target_as_of_ts=row.target_as_of_ts.isoformat(),
+                target_class=row.target_class,
+                n_train_rows=i,
+                probabilities=per_model,
+            )
+        )
+
+    return preds
+
+
+def _align_proba_to_classes(
+    proba: np.ndarray,
+    y_train: np.ndarray,
+    full_classes: Sequence[str],
+    *,
+    classes_attr: np.ndarray | None = None,
+) -> np.ndarray:
+    """Pad probability columns to match :data:`ORDINAL_CLASSES`.
+
+    A train fold may be missing some classes entirely (e.g. no
+    ``hike_75`` ever in pre-2022 data). The model's columns then cover
+    only the observed subset; we widen the matrix and fill the missing
+    columns with zeros, then renormalise.
+    """
+
+    K = len(full_classes)
+    if proba.shape[1] == K and classes_attr is None:
+        return proba
+    if classes_attr is None:
+        observed = sorted({int(c) for c in y_train.tolist()})
+    else:
+        observed = [int(c) for c in classes_attr]
+    out = np.zeros((proba.shape[0], K), dtype=np.float64)
+    for col_idx, cls_idx in enumerate(observed):
+        if 0 <= int(cls_idx) < K:
+            out[:, int(cls_idx)] = proba[:, col_idx]
+    # Renormalise; if a row has zero mass (degenerate fit), fall back to uniform.
+    row_sum = out.sum(axis=1, keepdims=True)
+    safe = np.where(row_sum < 1e-12, 1.0, row_sum)
+    out = out / safe
+    zero_rows = (row_sum < 1e-12).flatten()
+    if zero_rows.any():
+        out[zero_rows] = 1.0 / K
+    return out
+
+
+def _vec_to_class_dict(vec: np.ndarray) -> dict[str, float]:
+    return {cls: round(float(vec[i]), 6) for i, cls in enumerate(ORDINAL_CLASSES)}
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+def _truth_one_hot(target_class: str) -> np.ndarray:
+    out = np.zeros(len(ORDINAL_CLASSES), dtype=np.float64)
+    out[ORDINAL_CLASSES.index(target_class)] = 1.0
+    return out
+
+
+def _model_predictions(
+    preds: Sequence[FoldPrediction], model_name: str
+) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    """Stack ``(y_true_onehot, y_pred_proba)`` for one model.
+
+    Returns ``(y_true_onehot, y_pred_proba, truth_class_names)``. Rows
+    without a prediction for that model are skipped.
+    """
+
+    truths: list[np.ndarray] = []
+    probs: list[np.ndarray] = []
+    truth_class_names: list[str] = []
+    for pred in preds:
+        proba = pred.probabilities.get(model_name)
+        if proba is None:
+            continue
+        truths.append(_truth_one_hot(pred.target_class))
+        probs.append(np.asarray([proba[cls] for cls in ORDINAL_CLASSES], dtype=np.float64))
+        truth_class_names.append(pred.target_class)
+    if not truths:
+        return np.zeros((0, len(ORDINAL_CLASSES))), np.zeros((0, len(ORDINAL_CLASSES))), []
+    return np.vstack(truths), np.vstack(probs), truth_class_names
+
+
+def compute_metrics(
+    preds: Sequence[FoldPrediction], model_name: str
+) -> dict[str, Any]:
+    """Brier (multi-class), log-loss, top-1 accuracy, macro-F1, confusion matrix."""
+
+    truth_onehot, proba, truth_classes = _model_predictions(preds, model_name)
+    n = truth_onehot.shape[0]
+    if n == 0:
+        return {
+            "n": 0,
+            "brier": None,
+            "log_loss": None,
+            "top1_accuracy": None,
+            "macro_f1": None,
+            "confusion_matrix": {},
+        }
+    brier = float(((proba - truth_onehot) ** 2).sum(axis=1).mean())
+    eps = 1e-15
+    log_loss = float(-(truth_onehot * np.log(np.clip(proba, eps, 1.0))).sum(axis=1).mean())
+    pred_class_idx = np.argmax(proba, axis=1)
+    truth_idx = np.argmax(truth_onehot, axis=1)
+    top1 = float((pred_class_idx == truth_idx).mean())
+    macro_f1 = _macro_f1(truth_idx, pred_class_idx, n_classes=len(ORDINAL_CLASSES))
+    cm = _confusion_matrix(truth_classes, [ORDINAL_CLASSES[i] for i in pred_class_idx])
+    return {
+        "n": int(n),
+        "brier": round(brier, 6),
+        "log_loss": round(log_loss, 6),
+        "top1_accuracy": round(top1, 6),
+        "macro_f1": round(macro_f1, 6),
+        "confusion_matrix": cm,
+    }
+
+
+def _macro_f1(truth: np.ndarray, pred: np.ndarray, *, n_classes: int) -> float:
+    f1s: list[float] = []
+    for k in range(n_classes):
+        tp = float(((pred == k) & (truth == k)).sum())
+        fp = float(((pred == k) & (truth != k)).sum())
+        fn = float(((pred != k) & (truth == k)).sum())
+        if tp + fp == 0 or tp + fn == 0:
+            continue
+        precision = tp / (tp + fp)
+        recall = tp / (tp + fn)
+        if precision + recall == 0:
+            f1s.append(0.0)
+        else:
+            f1s.append(2 * precision * recall / (precision + recall))
+    if not f1s:
+        return 0.0
+    return float(sum(f1s) / len(f1s))
+
+
+def _confusion_matrix(
+    truth_classes: Sequence[str], pred_classes: Sequence[str]
+) -> dict[str, dict[str, int]]:
+    out: dict[str, dict[str, int]] = {
+        t: dict.fromkeys(ORDINAL_CLASSES, 0) for t in ORDINAL_CLASSES
+    }
+    for t, p in zip(truth_classes, pred_classes):
+        if t not in out or p not in ORDINAL_CLASSES:
+            continue
+        out[t][p] += 1
+    return out
+
+
+def filter_predictions_excluding_window(
+    preds: Sequence[FoldPrediction], *, start: _dt.date, end: _dt.date
+) -> list[FoldPrediction]:
+    """Drop predictions whose target falls inside ``[start, end]``."""
+
+    keep: list[FoldPrediction] = []
+    for pred in preds:
+        try:
+            d = _dt.date.fromisoformat(pred.target_event_date)
+        except ValueError:
+            keep.append(pred)
+            continue
+        if start <= d <= end:
+            continue
+        keep.append(pred)
+    return keep
+
+
+# ---------------------------------------------------------------------------
+# Top-level run
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunArtifacts:
+    """Returned by :func:`run`."""
+
+    rows: list[MeetingRow]
+    predictions: list[FoldPrediction]
+    metrics: dict[str, Any]
+    summary: dict[str, Any]
+    ablation_metrics: dict[str, dict[str, Any]]
+
+
+def run(
+    *,
+    events: pd.DataFrame,
+    mp_surprises: pd.DataFrame,
+    linguistic_features: pd.DataFrame,
+    macro_state: pd.DataFrame,
+    output_dir: Path | None = None,
+    ordinal_backend: str | None = None,
+    random_state: int = 11,
+) -> RunArtifacts:
+    """End-to-end run: assemble, walk-forward predict, score, optionally write."""
+
+    rows, summary = build_supervised_rows(
+        events=events,
+        mp_surprises=mp_surprises,
+        linguistic_features=linguistic_features,
+        macro_state=macro_state,
+    )
+
+    preds = walk_forward_predict(
+        rows,
+        families=FEATURE_FAMILIES,
+        ordinal_backend=ordinal_backend,
+        random_state=random_state,
+    )
+    model_names = sorted({m for p in preds for m in p.probabilities})
+    metrics_full: dict[str, Any] = {
+        model: compute_metrics(preds, model) for model in model_names
+    }
+    pandemic_excl = filter_predictions_excluding_window(
+        preds, start=PANDEMIC_START, end=PANDEMIC_END
+    )
+    metrics_ex_pandemic: dict[str, Any] = {
+        model: compute_metrics(pandemic_excl, model) for model in model_names
+    }
+
+    metrics: dict[str, Any] = {
+        "full_window": metrics_full,
+        "ex_pandemic_window": metrics_ex_pandemic,
+        "pandemic_window": {
+            "start": PANDEMIC_START.isoformat(),
+            "end": PANDEMIC_END.isoformat(),
+        },
+        "ordinal_backend": _detect_backend(ordinal_backend),
+        "ois_baseline_sigma_bp": OIS_BASELINE_SIGMA_BP,
+        "model_names": model_names,
+        "n_predictions": len(preds),
+    }
+
+    # Per-feature-family ablations on the parametric ordinal_logit model only.
+    ablation_metrics = _run_ablations(
+        rows,
+        ordinal_backend=ordinal_backend,
+        random_state=random_state,
+    )
+
+    if output_dir is not None:
+        write_artifacts(
+            output_dir=Path(output_dir),
+            predictions=preds,
+            metrics=metrics,
+            summary=summary,
+            ablations=ablation_metrics,
+        )
+
+    return RunArtifacts(
+        rows=rows,
+        predictions=preds,
+        metrics=metrics,
+        summary=summary,
+        ablation_metrics=ablation_metrics,
+    )
+
+
+def _detect_backend(prefer: str | None) -> str:
+    try:
+        handle = _dispatch_ordinal(classes=ORDINAL_CLASSES, prefer=prefer)
+        return handle.backend
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def _run_ablations(
+    rows: Sequence[MeetingRow],
+    *,
+    ordinal_backend: str | None,
+    random_state: int,
+) -> dict[str, dict[str, Any]]:
+    """Per-feature-family ablation table on the ordinal_logit model.
+
+    Each subset re-runs walk-forward CV with only the families in the
+    subset. Reports the same metric bundle as ``compute_metrics``.
+    Returned keyed by subset name.
+    """
+
+    out: dict[str, dict[str, Any]] = {}
+    for name, fams in ABLATION_SUBSETS:
+        preds = walk_forward_predict(
+            rows,
+            families=fams,
+            ordinal_backend=ordinal_backend,
+            include_gbt=False,
+            random_state=random_state,
+        )
+        out[name] = {
+            "families": list(fams),
+            "n_features": _count_features(rows, fams),
+            "metrics": compute_metrics(preds, "ordinal_logit"),
+        }
+    # Always include the OIS-baseline metric (model-free) so the table
+    # has a fixed reference column.
+    base_preds = walk_forward_predict(
+        rows,
+        families=("ois",),
+        include_gbt=False,
+        random_state=random_state,
+    )
+    out["ois_baseline_only"] = {
+        "families": ["ois_baseline"],
+        "n_features": 0,
+        "metrics": compute_metrics(base_preds, "ois_baseline"),
+    }
+    out["naive_carry_only"] = {
+        "families": ["naive_carry"],
+        "n_features": 0,
+        "metrics": compute_metrics(base_preds, "naive_carry"),
+    }
+    return out
+
+
+def _count_features(rows: Sequence[MeetingRow], families: Sequence[str]) -> int:
+    if not rows:
+        return 0
+    return sum(len(rows[0].feature_names.get(fam, ())) for fam in families)
+
+
+# ---------------------------------------------------------------------------
+# Artifact writers
+# ---------------------------------------------------------------------------
+
+
+def write_artifacts(
+    *,
+    output_dir: Path,
+    predictions: Sequence[FoldPrediction],
+    metrics: Mapping[str, Any],
+    summary: Mapping[str, Any],
+    ablations: Mapping[str, Any],
+) -> None:
+    """Persist results.json, metrics.json, feature_attribution.md."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "results.json").write_text(
+        json.dumps(
+            {
+                "predictions": [
+                    {
+                        "target_event_date": p.target_event_date,
+                        "target_as_of_ts": p.target_as_of_ts,
+                        "target_class": p.target_class,
+                        "n_train_rows": p.n_train_rows,
+                        "probabilities": p.probabilities,
+                    }
+                    for p in predictions
+                ],
+                "summary": dict(summary),
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "metrics.json").write_text(
+        json.dumps(dict(metrics), indent=2, sort_keys=True), encoding="utf-8"
+    )
+    (output_dir / "feature_attribution.md").write_text(
+        _format_attribution_md(ablations), encoding="utf-8"
+    )
+
+
+def _format_attribution_md(ablations: Mapping[str, Any]) -> str:
+    lines = [
+        "# Next-FOMC decision -- feature-family attribution",
+        "",
+        "Each row reports leave-one-meeting-out walk-forward metrics on the",
+        "ordinal_logit model trained on the listed feature subset. The",
+        "baselines (no learned model) sit at the bottom for reference.",
+        "",
+        "| Subset | Families | #features | n | Brier | LogLoss | Top1Acc | MacroF1 |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for name, payload in ablations.items():
+        m = payload.get("metrics", {})
+        lines.append(
+            "| {name} | {fams} | {nf} | {n} | {brier} | {ll} | {top1} | {f1} |".format(
+                name=name,
+                fams=", ".join(payload.get("families", [])),
+                nf=payload.get("n_features", 0),
+                n=m.get("n"),
+                brier=m.get("brier"),
+                ll=m.get("log_loss"),
+                top1=m.get("top1_accuracy"),
+                f1=m.get("macro_f1"),
+            )
+        )
+    lines.append("")
+    lines.append(
+        "Note: the OIS-only and naive-carry rows are model-free baselines."
+    )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _load_parquet_safely(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise SystemExit(f"required parquet missing: {path}")
+    return pd.read_parquet(path)
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Predict the next FOMC rate decision using text + macro + OIS + "
+            "credibility + linguistic features (Phase 8 #147)."
+        ),
+    )
+    parser.add_argument("--training-package-id", required=True)
+    parser.add_argument(
+        "--data-dir",
+        default=str(DATA_DIR),
+        help="Root data dir (default: app.config.DATA_DIR).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Override for the artifact output dir. Default: data/artifacts/next_fomc/.",
+    )
+    parser.add_argument(
+        "--events-name",
+        default="events.parquet",
+        help="Filename of the events parquet under data/processed/<pkg>/.",
+    )
+    parser.add_argument(
+        "--mp-surprises-name",
+        default="mp_surprises.parquet",
+        help="Filename of the MP surprises parquet under data/external/fred/.",
+    )
+    parser.add_argument(
+        "--linguistic-name",
+        default="linguistic_features.parquet",
+        help="Filename of the linguistic features parquet under data/processed/<pkg>/.",
+    )
+    parser.add_argument(
+        "--macro-state-name",
+        default="macro_state.parquet",
+        help="Filename of the macro-state parquet under data/external/fred/.",
+    )
+    parser.add_argument(
+        "--ordinal-backend",
+        default=None,
+        choices=(None, "statsmodels", "mord", "numpy"),
+        help="Force a specific ordinal backend. Default: auto-detect.",
+    )
+    parser.add_argument("--seed", type=int, default=11)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    data_dir = Path(args.data_dir)
+    package_dir = data_dir / "processed" / args.training_package_id
+    fred_dir = data_dir / "external" / "fred"
+
+    events = _load_parquet_safely(package_dir / args.events_name)
+    mp = _load_parquet_safely(fred_dir / args.mp_surprises_name)
+    ling_path = package_dir / args.linguistic_name
+    linguistic = _load_parquet_safely(ling_path) if ling_path.exists() else pd.DataFrame()
+    macro_path = fred_dir / args.macro_state_name
+    macro = _load_parquet_safely(macro_path) if macro_path.exists() else pd.DataFrame()
+
+    output_dir = (
+        Path(args.output_dir)
+        if args.output_dir
+        else data_dir / "artifacts" / "next_fomc"
+    )
+
+    artifacts = run(
+        events=events,
+        mp_surprises=mp,
+        linguistic_features=linguistic,
+        macro_state=macro,
+        output_dir=output_dir,
+        ordinal_backend=args.ordinal_backend,
+        random_state=args.seed,
+    )
+
+    print(f"[next-fomc] rows emitted: {artifacts.summary['rows_emitted']}")
+    print(f"[next-fomc] ordinal backend: {artifacts.metrics['ordinal_backend']}")
+    print(f"[next-fomc] models: {', '.join(artifacts.metrics['model_names'])}")
+    print(f"[next-fomc] output dir: {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/app/forecasting/next_fomc_decision.py
+++ b/backend/app/forecasting/next_fomc_decision.py
@@ -323,7 +323,10 @@ class ProportionalOddsLogit:
         for k in range(1, K - 1):
             probs[:, k] = cum_prob[:, k] - cum_prob[:, k - 1]
         probs[:, K - 1] = 1.0 - cum_prob[:, K - 2]
-        return np.clip(probs, 1e-12, 1.0)
+        probs = np.clip(probs, 1e-12, 1.0)
+        # Re-normalise after the clip so rows sum to exactly 1.
+        probs /= probs.sum(axis=1, keepdims=True)
+        return probs
 
 
 # ---------------------------------------------------------------------------
@@ -448,25 +451,29 @@ def _build_mord_handle(
 
 def ois_baseline_probability(
     *,
-    pre_event_curve_3m: float | None,
-    ff_target_prior: float | None,
+    implied_rate: float | None,
+    base_rate: float | None,
     sigma_bp: float = OIS_BASELINE_SIGMA_BP,
 ) -> dict[str, float]:
     """Per-class probability from the OIS-implied curve.
 
-    Computes the OIS-implied next-meeting rate change in basis points
-    (``(pre_event_curve_3m - ff_target_prior) * 100``) and smooths it
-    with a Gaussian centred on each class midpoint::
+    Computes the implied next-meeting rate change in basis points
+    (``(implied_rate - base_rate) * 100``) and smooths it with a
+    Gaussian centred on each class midpoint::
 
         weight_k = exp(-0.5 * ((bp_signal - CLASS_BP[k]) / sigma_bp) ** 2)
         P(k)     = weight_k / sum_j weight_j
 
-    Returns a uniform probability vector when either input is missing.
+    Both inputs are in percent. ``implied_rate`` is the market-implied
+    rate at the chosen tenor (the call site picks the curve and tenor);
+    ``base_rate`` is the reference rate the deviation is measured
+    against. Returns a uniform probability vector when either input is
+    missing.
     """
 
-    if pre_event_curve_3m is None or ff_target_prior is None:
+    if implied_rate is None or base_rate is None:
         return _uniform()
-    bp_signal = (float(pre_event_curve_3m) - float(ff_target_prior)) * 100.0
+    bp_signal = (float(implied_rate) - float(base_rate)) * 100.0
     weights = {
         cls: math.exp(-0.5 * ((bp_signal - bp) / sigma_bp) ** 2)
         for cls, bp in CLASS_BP.items()
@@ -556,8 +563,13 @@ class MeetingRow:
     macro: list[float]
     # Inputs for the OIS baseline (separate from the feature vector so
     # the baseline does not double-count its inputs against the model).
-    pre_event_curve_3m_next: float | None
-    ff_target_prior_next: float | None
+    # The implied rate is read from meeting N's post-event curve at the
+    # 1-month tenor (closest free tenor to the ~6-week inter-meeting
+    # window), and the base rate is the ff target rate that meeting N
+    # just set. Same information cutoff as the model -- both consume
+    # what is known the moment meeting N's decision is public.
+    ois_baseline_implied_rate: float | None
+    ois_baseline_base_rate: float | None
     # Per-family column names, populated once and shared.
     feature_names: dict[str, tuple[str, ...]] = field(default_factory=dict)
 
@@ -839,31 +851,13 @@ def build_supervised_rows(
             summary["dropped_target_out_of_class"] += 1
             continue
 
-        # Feature meeting's as-of: use as_of_ts from events.parquet when
-        # present, otherwise fall back to event_date noon UTC.
-        target_as_of = _parse_as_of(
-            event_row.get("as_of_ts") if "as_of_ts" in event_row else None
+        # The target is the next meeting's announcement; we anchor
+        # ``target_as_of`` to the next meeting's date at 19:00 UTC
+        # (the same placeholder convention the events builder uses for
+        # FOMC kinds).
+        target_as_of = _dt.datetime.combine(
+            next_event_date, _dt.time(19, 0), _dt.timezone.utc
         )
-        if target_as_of is None:
-            target_as_of = _dt.datetime.combine(
-                next_event_date, _dt.time(19, 0), _dt.timezone.utc
-            )
-        else:
-            # The target as_of is the *next* meeting's announcement
-            # time, not the current meeting's. Reconstruct from the
-            # next row when present.
-            target_as_of = _dt.datetime.combine(
-                next_event_date, _dt.time(19, 0), _dt.timezone.utc
-            )
-
-        # OIS baseline inputs use the *next meeting's* pre-event curve
-        # because the OIS baseline pricing window sits the day before
-        # the next meeting (which is still strictly before its
-        # announcement time -- no look-ahead).
-        pre_3m = _curve_value_at(next_row.get("pre_event_curve"), 3)
-        ff_prior_next = next_row.get("ff_target_prior")
-        if isinstance(ff_prior_next, float) and math.isnan(ff_prior_next):
-            ff_prior_next = None
 
         # Feature vectors at meeting N (current event_row + current
         # mp_surprise row -- not the next meeting's).
@@ -877,6 +871,18 @@ def build_supervised_rows(
         macro_vec = _extract_macro_features(macro_state, feature_event_date)
         ling_vec = _extract_linguistic_features(event_row.get("text_hash"), linguistic_features, ling_cols)
 
+        # OIS baseline inputs use the *post-event* curve of meeting N
+        # at the 1-month tenor (the closest free tenor to the ~6-week
+        # inter-meeting window). The implied rate is what the market
+        # prices for the next meeting given everything just announced
+        # at N. The base rate is the target rate meeting N just set
+        # (``ff_target_after``). Both are known the moment meeting N's
+        # decision is public -- same information cutoff as the model.
+        implied_rate = _curve_value_at(mp_row.get("post_event_curve"), 1)
+        ff_after_current = mp_row.get("ff_target_after")
+        if isinstance(ff_after_current, float) and math.isnan(ff_after_current):
+            ff_after_current = None
+
         out_rows.append(
             MeetingRow(
                 target_event_date=next_event_date,
@@ -888,8 +894,8 @@ def build_supervised_rows(
                 linguistic=ling_vec,
                 credibility=cred_vec,
                 macro=macro_vec,
-                pre_event_curve_3m_next=pre_3m,
-                ff_target_prior_next=(float(ff_prior_next) if ff_prior_next is not None else None),
+                ois_baseline_implied_rate=implied_rate,
+                ois_baseline_base_rate=(float(ff_after_current) if ff_after_current is not None else None),
                 feature_names=feature_names,
             )
         )
@@ -1000,8 +1006,8 @@ def walk_forward_predict(
 
         if include_ois_baseline:
             per_model["ois_baseline"] = ois_baseline_probability(
-                pre_event_curve_3m=row.pre_event_curve_3m_next,
-                ff_target_prior=row.ff_target_prior_next,
+                implied_rate=row.ois_baseline_implied_rate,
+                base_rate=row.ois_baseline_base_rate,
             )
         if include_naive:
             per_model["naive_carry"] = naive_carry_probability()

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -359,3 +359,82 @@ Open follow-up: raising `num_topics` to 10-12 and widening the
 inflation seed list are out of scope for this correctness fix and
 will be separate PRs after the bake-off / forecaster sweep produce
 results.
+
+## Next-FOMC decision dataset (Phase 8)
+
+The next-FOMC decision forecaster
+(`backend/app/forecasting/next_fomc_decision.py`, closes #147) reframes
+the project from price-forecasting to central-bank-forecasting. It
+predicts the rate decision at meeting `N+1` given features known
+strictly before meeting `N+1`'s `as_of_ts`.
+
+### Target
+
+Reconstructed from `mp_surprises.parquet`:
+
+    delta_bp = (ff_target_after_N1 - ff_target_prior_N1) * 100
+
+Mapped to the ordinal class set
+`{cut_50, cut_25, hold, hike_25, hike_50, hike_75}` with a 12.5 bp
+slack (half a 25 bp step). Deltas outside the set (e.g. the March
+2020 75 bp emergency cuts, the October 2008 emergency 50 bp cut
+sequence) emit a `UserWarning` and the row is dropped from the
+supervised set so jumbo intermeeting moves surface explicitly.
+Intermeeting meetings are excluded from the *target* role but still
+contribute as a feature meeting when the next scheduled meeting is
+the supervisor.
+
+### Feature matrix join
+
+Per-meeting feature row at meeting `N`:
+
+- `events.parquet` (`data/processed/<pkg>/`) provides multi-axis
+  stance / time / certainty / factor / topic and the 4-vector
+  `credibility_*`. Multi-source duplicates collapse to one row per
+  `event_date` via the same preference order
+  (statement -> press conference -> minutes -> first available).
+- `mp_surprises.parquet` (`data/external/fred/`) provides the 5-tenor
+  `pre_event_curve`, `mp_surprise_level`, `mp_surprise_path_factor`,
+  `fed_info_factor`, and the `ff_target_prior` / `ff_target_after`
+  used to reconstruct the target.
+- `linguistic_features.parquet` (`data/processed/<pkg>/`) joins on
+  `text_hash` and contributes the 14 structured features from #149.
+- `macro_state.parquet` (`data/external/fred/`) provides per-as-of-date
+  snapshots of UNRATE, CPI YoY, core PCE YoY, ISM proxy
+  (`MANEMP_3m_pct`, documented substitute for the paywalled NAPM
+  series), nonfarm-payroll MoM change, and retail-sales MoM.
+
+### OIS-implied baseline (sigma = 12.5 bp)
+
+For every held-out meeting `M`, the baseline reads
+`mp_surprises.parquet`'s `pre_event_curve` at the 3-month tenor
+*for meeting M itself* (which is published the trading day before
+`M.as_of_ts` -- strictly before, so no look-ahead). The OIS-implied
+next-meeting rate change in basis points is
+`(pre_curve_3m - ff_target_prior) * 100`, smoothed with a Gaussian
+of sigma 12.5 bp over the 6-class set. 12.5 bp is half the smallest
+non-zero class step (25 bp) so the kernel partitions the bp axis at
+class midpoints without aliasing one class onto its neighbour. The
+choice is pinned by `next_fomc_decision.OIS_BASELINE_SIGMA_BP` and
+asserted in `tests/unit/test_next_fomc_decision.py`.
+
+### Walk-forward CV
+
+Leave-one-meeting-out: at meeting `M+1`, the train set is every
+supervised row whose `target_event_date < M+1.target_event_date`.
+The constructor asserts this strict inequality on every fold. Train
+folds with fewer than 6 rows (one per class) fall back to baselines
+only.
+
+### Artifact layout
+
+Outputs land under `data/artifacts/next_fomc/`:
+
+- `results.json` -- per-meeting predictions for every model.
+- `metrics.json` -- Brier (multi-class), multi-class log-loss, top-1
+  accuracy, macro-F1, confusion matrix. Reports both the full window
+  and the pandemic-excluded window (`2020-04-01..2021-06-30`).
+- `feature_attribution.md` -- ablation table:
+  `ois_only`, `ois_text`, `ois_text_linguistic`, `ois_text_credibility`,
+  `ois_text_macro`, `full`, plus the model-free `ois_baseline_only`
+  and `naive_carry_only` rows for reference.

--- a/tests/unit/test_macro_state.py
+++ b/tests/unit/test_macro_state.py
@@ -1,0 +1,314 @@
+"""Tests for the FRED macro-state snapshot builder (Phase 8 #147).
+
+Patterns mirror ``tests/unit/test_fred_client.py``: httpx is wired via
+``httpx.MockTransport`` so no network I/O leaks into the test
+environment, and the SOURCES.lock entry is asserted both ways
+(written from the builder, read back from disk).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from pathlib import Path
+
+import httpx
+import pandas as pd
+import pytest
+
+from app.data import macro_state
+from app.services import fred_client
+
+
+# ---------------------------------------------------------------------------
+# Fixture data
+# ---------------------------------------------------------------------------
+
+
+def _months_of(start: _dt.date, count: int) -> list[_dt.date]:
+    out: list[_dt.date] = []
+    y = start.year
+    m = start.month
+    for _ in range(count):
+        out.append(_dt.date(y, m, 1))
+        m += 1
+        if m > 12:
+            m = 1
+            y += 1
+    return out
+
+
+def _series_payload(
+    observations: list[tuple[str, float | None]],
+    *,
+    realtime: str = "2026-05-15",
+) -> dict[str, object]:
+    return {
+        "realtime_start": realtime,
+        "realtime_end": realtime,
+        "observation_start": observations[0][0] if observations else "",
+        "observation_end": observations[-1][0] if observations else "",
+        "count": len(observations),
+        "observations": [
+            {
+                "date": d,
+                "value": "." if v is None else str(v),
+                "realtime_start": realtime,
+                "realtime_end": realtime,
+            }
+            for d, v in observations
+        ],
+    }
+
+
+def _build_canned_fred_responses() -> dict[str, fred_client.FredSeriesResponse]:
+    """Hand-built FRED responses covering 2018-2024 monthly.
+
+    Values are smoothly increasing per series so YoY / MoM transforms
+    produce non-zero, non-NaN signals that the as-of join can read.
+    """
+
+    months = _months_of(_dt.date(2018, 1, 1), 84)  # 7 years
+    responses: dict[str, fred_client.FredSeriesResponse] = {}
+    # UNRATE: trend down then up. Stay strictly positive.
+    unrate_vals = [4.0 - i * 0.005 for i in range(60)] + [3.5 + i * 0.02 for i in range(24)]
+    # CPIAUCSL: smooth upward.
+    cpi_vals = [250.0 * (1 + 0.0025) ** i for i in range(84)]
+    # PCEPILFE: smooth upward, slower.
+    pce_vals = [105.0 * (1 + 0.002) ** i for i in range(84)]
+    # MANEMP: tens of thousands.
+    manemp_vals = [12000.0 + i * 5.0 for i in range(84)]
+    # PAYEMS: thousands.
+    payems_vals = [150000.0 + i * 200.0 for i in range(84)]
+    # RSAFS: smooth upward.
+    rsafs_vals = [450000.0 * (1 + 0.003) ** i for i in range(84)]
+
+    series_inputs = {
+        "UNRATE": unrate_vals,
+        "CPIAUCSL": cpi_vals,
+        "PCEPILFE": pce_vals,
+        "MANEMP": manemp_vals,
+        "PAYEMS": payems_vals,
+        "RSAFS": rsafs_vals,
+    }
+    for sid, vals in series_inputs.items():
+        observations = [(d.isoformat(), v) for d, v in zip(months, vals)]
+        payload = _series_payload(observations)
+        # Parse via fred_client's own parser so we get the same shape
+        # the production code will see.
+        responses[sid] = fred_client._parse_observations(payload, sid)
+    return responses
+
+
+# ---------------------------------------------------------------------------
+# Builder behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_build_macro_state_emits_expected_columns_and_no_lookahead() -> None:
+    responses = _build_canned_fred_responses()
+    artifacts = macro_state.build_macro_state(
+        start=_dt.date(2020, 1, 1),
+        end=_dt.date(2020, 6, 30),
+        fred_responses=responses,
+        publication_delay_days=30,
+    )
+    df = artifacts.frame
+    assert list(df.columns) == list(macro_state.COLUMN_ORDER)
+    assert artifacts.rows_written > 0
+    # Every column populated where reference data exists; ism_proxy_source
+    # is the literal MANEMP label on every row.
+    assert (df["ism_proxy_source"] == macro_state.ISM_PROXY_SOURCE_LABEL).all()
+    # No look-ahead: every row's as_of_date strictly greater than the
+    # publication date of the underlying observation. We hand-verify on
+    # the first row: as_of_date is 2020-01-01; CPI YoY at that date
+    # must reflect the value at reference month 2019-11-01 (because the
+    # December print is shifted to 2020-01-01 by the 30-day delay, and
+    # we read strictly < 2020-01-01).
+    first = df.iloc[0]
+    assert first["as_of_date"] == "2020-01-01"
+    # The 2019-12-01 observation has reference_date + 30 days =
+    # 2019-12-31 which is strictly < 2020-01-01, so it counts.
+    assert first["cpi_yoy"] is not None
+    # data_version is reproducible: same inputs produce the same hash.
+    second = macro_state.build_macro_state(
+        start=_dt.date(2020, 1, 1),
+        end=_dt.date(2020, 6, 30),
+        fred_responses=responses,
+        publication_delay_days=30,
+    )
+    assert second.data_version == artifacts.data_version
+    assert second.value_hash == artifacts.value_hash
+
+
+def test_build_macro_state_respects_as_of_dates_override() -> None:
+    responses = _build_canned_fred_responses()
+    as_of = [_dt.date(2020, 3, 18), _dt.date(2020, 6, 10)]
+    artifacts = macro_state.build_macro_state(
+        start=_dt.date(2020, 1, 1),
+        end=_dt.date(2020, 12, 31),
+        fred_responses=responses,
+        as_of_dates=as_of,
+        publication_delay_days=30,
+    )
+    assert artifacts.rows_written == 2
+    assert artifacts.frame["as_of_date"].tolist() == [d.isoformat() for d in as_of]
+
+
+def test_build_macro_state_raises_on_missing_series() -> None:
+    responses = _build_canned_fred_responses()
+    del responses["MANEMP"]
+    with pytest.raises(KeyError, match="MANEMP"):
+        macro_state.build_macro_state(
+            start=_dt.date(2020, 1, 1),
+            end=_dt.date(2020, 6, 30),
+            fred_responses=responses,
+        )
+
+
+def test_publication_delay_shifts_as_of_window() -> None:
+    """Increasing delay should push more rows toward 'missing data'."""
+
+    responses = _build_canned_fred_responses()
+    # Very small window at the start of the canned data so the delay
+    # change is visible. Start at 2018-01-15: with delay=30 the
+    # 2018-01-01 reference observation has pub_date=2018-01-31, so
+    # the row at 2018-01-15 will be None. With delay=0 it will be set.
+    as_of = [_dt.date(2018, 1, 15)]
+    art_zero = macro_state.build_macro_state(
+        start=_dt.date(2018, 1, 1),
+        end=_dt.date(2018, 12, 31),
+        fred_responses=responses,
+        as_of_dates=as_of,
+        publication_delay_days=0,
+    )
+    art_thirty = macro_state.build_macro_state(
+        start=_dt.date(2018, 1, 1),
+        end=_dt.date(2018, 12, 31),
+        fred_responses=responses,
+        as_of_dates=as_of,
+        publication_delay_days=30,
+    )
+    # zero-delay: 2018-01-01 ref is strictly < 2018-01-15 → unrate set.
+    # 30-day delay: 2018-01-01 ref has pub=2018-01-31 → strictly < 2018-01-15 is False → None.
+    assert art_zero.frame["unrate"].iloc[0] is not None
+    assert art_thirty.frame["unrate"].iloc[0] is None
+
+
+# ---------------------------------------------------------------------------
+# Persistence + SOURCES.lock
+# ---------------------------------------------------------------------------
+
+
+def test_write_macro_state_persists_parquet_and_lock(tmp_path: Path) -> None:
+    responses = _build_canned_fred_responses()
+    artifacts = macro_state.build_macro_state(
+        start=_dt.date(2020, 1, 1),
+        end=_dt.date(2020, 3, 31),
+        fred_responses=responses,
+        publication_delay_days=30,
+    )
+    output_path = tmp_path / "macro_state.parquet"
+    sha = macro_state.write_macro_state_parquet(artifacts.frame, output_path)
+    assert len(sha) == 64
+    assert output_path.exists()
+
+    lock_path = tmp_path / fred_client.SOURCES_LOCK_NAME
+    macro_state.update_sources_lock(
+        lock_path=lock_path,
+        artifacts=artifacts,
+        parquet_path=output_path,
+        parquet_sha256=sha,
+    )
+    lock = json.loads(lock_path.read_text())
+    assert macro_state.DEFAULT_LOCK_KEY in lock
+    entry = lock[macro_state.DEFAULT_LOCK_KEY]
+    assert entry["sha256"] == sha
+    assert entry["rows"] == artifacts.rows_written
+    assert entry["publication_delay_days"] == 30
+    assert entry["ism_proxy_source"] == macro_state.ISM_PROXY_SOURCE_LABEL
+    assert set(entry["fred_series"]) == set(macro_state.FRED_SERIES_IDS)
+    assert entry["value_hash"] == artifacts.value_hash
+
+
+def test_round_trip_parquet_preserves_value_hash(tmp_path: Path) -> None:
+    """Re-running the build with the same inputs is idempotent on disk."""
+
+    responses = _build_canned_fred_responses()
+    artifacts_a = macro_state.build_macro_state(
+        start=_dt.date(2020, 1, 1),
+        end=_dt.date(2020, 4, 30),
+        fred_responses=responses,
+    )
+    artifacts_b = macro_state.build_macro_state(
+        start=_dt.date(2020, 1, 1),
+        end=_dt.date(2020, 4, 30),
+        fred_responses=responses,
+    )
+    assert artifacts_a.value_hash == artifacts_b.value_hash
+
+    out_a = tmp_path / "a.parquet"
+    out_b = tmp_path / "b.parquet"
+    macro_state.write_macro_state_parquet(artifacts_a.frame, out_a)
+    macro_state.write_macro_state_parquet(artifacts_b.frame, out_b)
+
+    # Re-read both parquets; the value-hash contract holds even if the
+    # parquet bytes drift across pyarrow versions.
+    df_a = pd.read_parquet(out_a)
+    df_b = pd.read_parquet(out_b)
+    assert macro_state.dataframe_value_hash(df_a) == artifacts_a.value_hash
+    assert macro_state.dataframe_value_hash(df_b) == artifacts_b.value_hash
+
+
+# ---------------------------------------------------------------------------
+# CLI / FRED-hydration via httpx.MockTransport
+# ---------------------------------------------------------------------------
+
+
+def _mock_transport_for_series(payload_by_series: dict[str, dict]) -> httpx.MockTransport:
+    """Return a transport that replies based on the ``series_id`` query param."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        series_id = request.url.params.get("series_id")
+        if series_id is None or series_id not in payload_by_series:
+            return httpx.Response(404, json={"error": "unknown series"})
+        return httpx.Response(200, json=payload_by_series[series_id])
+
+    return httpx.MockTransport(handler)
+
+
+def test_hydrate_fred_responses_via_mock_transport(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("FRED_API_KEY", "test-key")
+    months = _months_of(_dt.date(2018, 1, 1), 36)
+    base_payload = {
+        sid: _series_payload([(d.isoformat(), 1.0 + 0.01 * i) for i, d in enumerate(months)])
+        for sid in macro_state.FRED_SERIES_IDS
+    }
+
+    responses = macro_state._hydrate_fred_responses(
+        start=_dt.date(2020, 1, 1),
+        end=_dt.date(2020, 6, 30),
+        cache_dir=tmp_path,
+        transport=_mock_transport_for_series(base_payload),
+    )
+
+    assert set(responses) == set(macro_state.FRED_SERIES_IDS)
+    # Every series should be cached on disk now.
+    for sid in macro_state.FRED_SERIES_IDS:
+        assert (tmp_path / f"{sid}.json").exists()
+
+    # Second hydration with a "boom" transport should NOT hit the wire
+    # because the per-series JSON cache is populated. This is the
+    # "cache is idempotent" contract.
+    def boom(_: httpx.Request) -> httpx.Response:
+        raise AssertionError("transport called despite cache hit")
+
+    responses_again = macro_state._hydrate_fred_responses(
+        start=_dt.date(2020, 1, 1),
+        end=_dt.date(2020, 6, 30),
+        cache_dir=tmp_path,
+        transport=httpx.MockTransport(boom),
+    )
+    # Cached responses should have the same counts as the first pull.
+    for sid in macro_state.FRED_SERIES_IDS:
+        assert responses_again[sid].count == responses[sid].count

--- a/tests/unit/test_next_fomc_decision.py
+++ b/tests/unit/test_next_fomc_decision.py
@@ -219,10 +219,10 @@ def test_ois_baseline_uses_documented_sigma() -> None:
     assert nfd.OIS_BASELINE_SIGMA_BP == 12.5
 
 
-def test_ois_baseline_peaks_at_hold_when_curve_equals_prior() -> None:
+def test_ois_baseline_peaks_at_hold_when_curve_equals_base() -> None:
     proba = nfd.ois_baseline_probability(
-        pre_event_curve_3m=4.50,
-        ff_target_prior=4.50,
+        implied_rate=4.50,
+        base_rate=4.50,
         sigma_bp=12.5,
     )
     assert sum(proba.values()) == pytest.approx(1.0, abs=1e-9)
@@ -233,8 +233,8 @@ def test_ois_baseline_peaks_at_hike25_when_curve_implies_25_bp() -> None:
     """A 25 bp implied move puts the peak on hike_25."""
 
     proba = nfd.ois_baseline_probability(
-        pre_event_curve_3m=4.75,
-        ff_target_prior=4.50,
+        implied_rate=4.75,
+        base_rate=4.50,
         sigma_bp=12.5,
     )
     # hike_25 should dominate; cut_25 should be vanishingly small.
@@ -245,7 +245,7 @@ def test_ois_baseline_peaks_at_hike25_when_curve_implies_25_bp() -> None:
 
 def test_ois_baseline_uniform_on_missing_inputs() -> None:
     proba = nfd.ois_baseline_probability(
-        pre_event_curve_3m=None, ff_target_prior=None
+        implied_rate=None, base_rate=None
     )
     expected = 1.0 / len(nfd.ORDINAL_CLASSES)
     for v in proba.values():

--- a/tests/unit/test_next_fomc_decision.py
+++ b/tests/unit/test_next_fomc_decision.py
@@ -1,0 +1,535 @@
+"""Tests for the next-FOMC decision forecaster (Phase 8 #147).
+
+Covers the acceptance criteria from #147:
+
+* ordinal-model dispatch picks the documented backend (NumPy fallback
+  when statsmodels / mord are absent),
+* walk-forward construction yields N-1 train rows for the N-th meeting,
+* OIS-baseline reads ``pre_event_curve`` correctly and uses the
+  documented sigma,
+* feature-ablation runs produce strictly fewer columns when a family
+  is dropped, and metrics are returned without crashing,
+* no look-ahead: every train row's target_event_date is strictly less
+  than the held-out target.
+
+The synthetic data is small and toy -- the unit tests pin behavioural
+contracts, not real-world model quality.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import math
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.forecasting import next_fomc_decision as nfd
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-data builders
+# ---------------------------------------------------------------------------
+
+
+def _make_pre_event_curve(rate_pct: float) -> str:
+    """Return a JSON-encoded pre_event_curve flat at ``rate_pct``."""
+
+    points = [
+        {"months_ahead": tenor, "implied_rate": rate_pct}
+        for tenor in (1, 3, 6, 12, 24)
+    ]
+    return json.dumps(points)
+
+
+def _make_mp_surprises_df(meetings: list[tuple[str, float, float, bool]]) -> pd.DataFrame:
+    """Build a minimal mp_surprises DataFrame.
+
+    Each row: ``(event_date_iso, ff_target_prior, ff_target_after, is_intermeeting)``.
+    """
+
+    rows = []
+    for idx, (event_date, prior, after, inter) in enumerate(meetings, start=1):
+        rows.append(
+            {
+                "event_date": event_date,
+                "meeting_id": idx,
+                "ff_target_prior": float(prior),
+                "ff_target_after": float(after),
+                "mp_surprise_level": 0.0,
+                "mp_surprise_path_factor": 0.0,
+                # pre_event_curve sits at the prior target (no surprise).
+                "pre_event_curve": _make_pre_event_curve(float(prior)),
+                "post_event_curve": _make_pre_event_curve(float(after)),
+                "fed_info_factor": 0.0,
+                "is_intermeeting": bool(inter),
+                "methodology": "ois_proxy",
+                "fed_info_factor_source": "daily_window_proxy",
+                "target_source": "band|after:band",
+                "data_version": "test_version_v1",
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _make_events_df(event_dates: list[str], stance_labels: list[str] | None = None) -> pd.DataFrame:
+    """Build a minimal events DataFrame."""
+
+    if stance_labels is None:
+        stance_labels = ["neutral"] * len(event_dates)
+    rows = []
+    for idx, (ed, stance) in enumerate(zip(event_dates, stance_labels), start=1):
+        rows.append(
+            {
+                "event_date": ed,
+                "event_kind": "statement",
+                "document_id": f"doc_{idx}",
+                "text_hash": f"hash_{idx}",
+                "source": "scraped_fed",
+                "source_record_id": f"rec_{idx}",
+                "as_of_ts": f"{ed}T19:00:00Z",
+                "text": f"placeholder text for {ed}",
+                "token_count": 100,
+                "axis_stance": stance,
+                "axis_time": "neutral",
+                "axis_certainty": "neutral",
+                "axis_factor": "neutral",
+                "axis_topic": "neutral",
+                "credibility_drift_score": 0.0,
+                "credibility_realized_vs_stated_gap": 0.0,
+                "credibility_market_implied_gap": 0.0,
+                "credibility_months_since_reversal": 6,
+                "prior_window_sha256": "abc",
+                "prior_bars_json": "[]",
+                "asset_symbol": "^GSPC",
+                "horizon": 1,
+                "realized_return": 0.0,
+                "abnormal_return": 0.0,
+                "alpha": 0.0,
+                "beta": 1.0,
+                "direction_t1d": 0,
+                "volatility_shift": 0.0,
+                "concurrent_macro_release": False,
+                "realized_date": ed,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _make_linguistic_df(event_count: int) -> pd.DataFrame:
+    rows = []
+    for idx in range(1, event_count + 1):
+        row = {"text_hash": f"hash_{idx}"}
+        # 14 placeholder linguistic features.
+        for axis in (
+            "topic_share_inflation",
+            "topic_share_employment",
+            "topic_share_financial_stability",
+            "topic_share_growth",
+            "topic_share_balance_sheet",
+            "topic_share_misc_1",
+            "topic_share_misc_2",
+            "topic_share_misc_3",
+            "hedge_density",
+            "comparison_density",
+            "forward_density",
+            "concrete_ratio",
+            "hawk_dove_asymmetry",
+            "log_token_count",
+        ):
+            row[axis] = 0.1 * idx
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def _make_macro_df(event_dates: list[str]) -> pd.DataFrame:
+    """One macro row per (event_date - 1 day) so the < as_of join hits."""
+
+    rows = []
+    for ed in event_dates:
+        d = _dt.date.fromisoformat(ed) - _dt.timedelta(days=1)
+        rows.append(
+            {
+                "as_of_date": d.isoformat(),
+                "unrate": 4.0,
+                "cpi_yoy": 2.0,
+                "core_pce_yoy": 1.8,
+                "ism_proxy": 0.5,
+                "payems_mom": 200.0,
+                "rsafs_mom": 0.3,
+                "ism_proxy_source": "MANEMP_3m_pct",
+                "publication_delay_days": 30,
+                "data_version": "test_v1",
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _make_canonical_meetings() -> list[tuple[str, float, float, bool]]:
+    """Eight meetings with a cut->hold->hike sweep + one intermeeting cut."""
+
+    # event_date_iso, ff_target_prior, ff_target_after, is_intermeeting
+    return [
+        ("2022-01-26", 0.125, 0.125, False),  # hold
+        ("2022-03-16", 0.125, 0.375, False),  # +25
+        ("2022-05-04", 0.375, 0.875, False),  # +50
+        ("2022-06-15", 0.875, 1.625, False),  # +75 (hike_75 -- still in set)
+        ("2022-07-27", 1.625, 2.375, False),  # +75
+        ("2022-09-21", 2.375, 3.125, False),  # +75
+        ("2022-11-02", 3.125, 3.875, False),  # +75
+        ("2022-12-14", 3.875, 4.375, False),  # +50
+    ]
+
+
+# ---------------------------------------------------------------------------
+# delta_to_class
+# ---------------------------------------------------------------------------
+
+
+def test_delta_to_class_supported_classes() -> None:
+    assert nfd.delta_to_class(0.0) == "hold"
+    assert nfd.delta_to_class(25.0) == "hike_25"
+    assert nfd.delta_to_class(-25.0) == "cut_25"
+    assert nfd.delta_to_class(50.0) == "hike_50"
+    assert nfd.delta_to_class(75.0) == "hike_75"
+    # 12.5 bp slack tolerates near-but-not-exact deltas.
+    assert nfd.delta_to_class(24.0) == "hike_25"
+
+
+def test_delta_to_class_out_of_set_warns_and_returns_none() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = nfd.delta_to_class(-100.0)
+    assert result is None
+    assert any("outside supported class set" in str(w.message) for w in caught)
+
+
+# ---------------------------------------------------------------------------
+# OIS baseline
+# ---------------------------------------------------------------------------
+
+
+def test_ois_baseline_uses_documented_sigma() -> None:
+    """The documented sigma is 12.5 bp -- pin it via the module constant."""
+
+    assert nfd.OIS_BASELINE_SIGMA_BP == 12.5
+
+
+def test_ois_baseline_peaks_at_hold_when_curve_equals_prior() -> None:
+    proba = nfd.ois_baseline_probability(
+        pre_event_curve_3m=4.50,
+        ff_target_prior=4.50,
+        sigma_bp=12.5,
+    )
+    assert sum(proba.values()) == pytest.approx(1.0, abs=1e-9)
+    assert proba["hold"] == max(proba.values())
+
+
+def test_ois_baseline_peaks_at_hike25_when_curve_implies_25_bp() -> None:
+    """A 25 bp implied move puts the peak on hike_25."""
+
+    proba = nfd.ois_baseline_probability(
+        pre_event_curve_3m=4.75,
+        ff_target_prior=4.50,
+        sigma_bp=12.5,
+    )
+    # hike_25 should dominate; cut_25 should be vanishingly small.
+    assert proba["hike_25"] > 0.3
+    assert proba["hike_25"] > proba["hold"]
+    assert proba["cut_25"] < 0.01
+
+
+def test_ois_baseline_uniform_on_missing_inputs() -> None:
+    proba = nfd.ois_baseline_probability(
+        pre_event_curve_3m=None, ff_target_prior=None
+    )
+    expected = 1.0 / len(nfd.ORDINAL_CLASSES)
+    for v in proba.values():
+        assert v == pytest.approx(expected)
+
+
+def test_naive_carry_baseline_assigns_all_mass_to_hold() -> None:
+    proba = nfd.naive_carry_probability()
+    assert proba["hold"] == 1.0
+    other = sum(v for k, v in proba.items() if k != "hold")
+    assert other == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Ordinal model dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_ordinal_dispatch_falls_back_to_numpy_when_libs_absent() -> None:
+    """The 'numpy' preference is honoured even if statsmodels exists."""
+
+    handle = nfd._dispatch_ordinal(classes=nfd.ORDINAL_CLASSES, prefer="numpy")
+    assert handle.backend == "numpy_proportional_odds"
+
+
+def test_ordinal_dispatch_auto_select_returns_one_of_known_backends() -> None:
+    handle = nfd._dispatch_ordinal(classes=nfd.ORDINAL_CLASSES)
+    assert handle.backend in {
+        "numpy_proportional_odds",
+        "statsmodels_ordered_model",
+        "mord_logistic_it",
+    }
+
+
+def test_proportional_odds_logit_fit_predict_shapes() -> None:
+    rng = np.random.default_rng(seed=11)
+    n, p = 30, 4
+    X = rng.normal(size=(n, p))
+    # Toy target: 4 classes ordered along an arbitrary linear combo.
+    score = X @ np.array([1.0, -0.5, 0.5, 0.0])
+    y = np.digitize(score, np.quantile(score, [0.25, 0.5, 0.75]))
+    classes = ("a", "b", "c", "d")
+    model = nfd.ProportionalOddsLogit(alpha=0.5)
+    model.fit(X, y, classes)
+    proba = model.predict_proba(X)
+    assert proba.shape == (n, len(classes))
+    assert np.allclose(proba.sum(axis=1), 1.0, atol=1e-6)
+    # Some signal: argmax(proba) on at least half the rows matches y.
+    accuracy = float(np.mean(np.argmax(proba, axis=1) == y))
+    assert accuracy >= 0.25  # bare-minimum sanity; not a quality claim
+
+
+# ---------------------------------------------------------------------------
+# Curve extraction
+# ---------------------------------------------------------------------------
+
+
+def test_curve_value_at_handles_json_and_missing_tenors() -> None:
+    curve = _make_pre_event_curve(4.75)
+    assert nfd._curve_value_at(curve, 3) == pytest.approx(4.75)
+    assert nfd._curve_value_at(curve, 60) is None
+    assert nfd._curve_value_at(None, 3) is None
+    assert nfd._curve_value_at("not-json", 3) is None
+
+
+# ---------------------------------------------------------------------------
+# Supervised row construction
+# ---------------------------------------------------------------------------
+
+
+def test_build_supervised_rows_pairs_meeting_with_next() -> None:
+    meetings = _make_canonical_meetings()
+    event_dates = [m[0] for m in meetings]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(event_dates)
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+
+    rows, summary = nfd.build_supervised_rows(
+        events=events, mp_surprises=mp, linguistic_features=ling, macro_state=macro
+    )
+
+    # 8 meetings => 7 supervised rows (every meeting except the last
+    # has a next-scheduled meeting).
+    assert summary["rows_emitted"] == 7
+    assert summary["dropped_target_out_of_class"] == 0
+    # Targets reconstructed: row 0 (feature meeting 2022-01-26) predicts
+    # 2022-03-16's hike_25.
+    assert rows[0].feature_event_date == _dt.date(2022, 1, 26)
+    assert rows[0].target_event_date == _dt.date(2022, 3, 16)
+    assert rows[0].target_class == "hike_25"
+
+
+def test_build_supervised_rows_skips_out_of_class_target() -> None:
+    """A 100 bp move on the next meeting should drop that supervised row."""
+
+    meetings = [
+        ("2008-01-22", 4.25, 3.5, True),  # intermeeting cut
+        ("2008-01-30", 3.5, 3.0, False),  # next scheduled -- cut_50
+        ("2008-03-18", 3.0, 2.25, False),  # next scheduled -- 75 bp cut (out of set)
+        ("2008-04-30", 2.25, 2.0, False),  # next scheduled -- cut_25
+    ]
+    event_dates = [m[0] for m in meetings]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(event_dates)
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        rows, summary = nfd.build_supervised_rows(
+            events=events, mp_surprises=mp, linguistic_features=ling, macro_state=macro
+        )
+
+    assert summary["dropped_target_out_of_class"] >= 1
+    assert any("outside supported class set" in str(w.message) for w in caught)
+    # The 2008-01-30 -> 2008-03-18 pair drops because the 75 bp cut is
+    # out of set. 2008-01-22 (intermeeting) is excluded from
+    # "next scheduled" candidates, so its supervised row would point
+    # at 2008-01-30 (a cut_50 -- in set). Confirm one row survives.
+    classes = {r.target_class for r in rows}
+    assert classes.issubset(set(nfd.ORDINAL_CLASSES))
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward CV
+# ---------------------------------------------------------------------------
+
+
+def test_walk_forward_produces_n_minus_1_train_rows() -> None:
+    meetings = _make_canonical_meetings()
+    event_dates = [m[0] for m in meetings]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(event_dates)
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+    rows, _ = nfd.build_supervised_rows(
+        events=events, mp_surprises=mp, linguistic_features=ling, macro_state=macro
+    )
+
+    preds = nfd.walk_forward_predict(rows, families=("ois",), ordinal_backend="numpy")
+
+    # One prediction per supervised row.
+    assert len(preds) == len(rows)
+    # Train sizes: 0, 1, 2, ...
+    assert [p.n_train_rows for p in preds] == list(range(len(rows)))
+    # Every prediction has an OIS baseline and a naive carry; ordinal
+    # only kicks in once the train set covers >= number of classes.
+    for p in preds:
+        assert "ois_baseline" in p.probabilities
+        assert "naive_carry" in p.probabilities
+
+
+def test_walk_forward_no_lookahead_in_train_set() -> None:
+    meetings = _make_canonical_meetings()
+    event_dates = [m[0] for m in meetings]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(event_dates)
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+    rows, _ = nfd.build_supervised_rows(
+        events=events, mp_surprises=mp, linguistic_features=ling, macro_state=macro
+    )
+
+    # The walk-forward routine asserts the contract internally. Run it
+    # under a fresh interpreter pass to confirm no AssertionError fires.
+    preds = nfd.walk_forward_predict(rows, families=("ois",), ordinal_backend="numpy")
+    # Explicit external check too: for every held-out row, the train
+    # set is exactly rows[:i] and all those target_event_dates are
+    # strictly less.
+    sorted_rows = sorted(rows, key=lambda r: r.target_event_date)
+    for i, _pred in enumerate(preds):
+        held_out_date = sorted_rows[i].target_event_date
+        for j in range(i):
+            assert sorted_rows[j].target_event_date < held_out_date
+
+
+# ---------------------------------------------------------------------------
+# Feature ablations
+# ---------------------------------------------------------------------------
+
+
+def test_feature_ablation_drops_columns() -> None:
+    meetings = _make_canonical_meetings()
+    event_dates = [m[0] for m in meetings]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(event_dates)
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+    rows, _ = nfd.build_supervised_rows(
+        events=events, mp_surprises=mp, linguistic_features=ling, macro_state=macro
+    )
+
+    X_full, names_full = nfd._build_feature_matrix(rows, nfd.FEATURE_FAMILIES)
+    X_ois_only, names_ois = nfd._build_feature_matrix(rows, ("ois",))
+    X_no_macro, names_no_macro = nfd._build_feature_matrix(
+        rows, ("ois", "text", "linguistic", "credibility")
+    )
+
+    assert X_ois_only.shape[1] < X_full.shape[1]
+    assert X_no_macro.shape[1] < X_full.shape[1]
+    # Dropping macro removes exactly the macro column names.
+    assert set(names_no_macro) == set(names_full) - set(nfd._macro_feature_names())
+    # OIS-only keeps exactly the OIS columns.
+    assert set(names_ois) == set(nfd._ois_feature_names())
+
+
+def test_metrics_compute_on_walk_forward_predictions() -> None:
+    meetings = _make_canonical_meetings()
+    event_dates = [m[0] for m in meetings]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(event_dates)
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+    rows, _ = nfd.build_supervised_rows(
+        events=events, mp_surprises=mp, linguistic_features=ling, macro_state=macro
+    )
+    preds = nfd.walk_forward_predict(rows, families=("ois",), ordinal_backend="numpy")
+    metrics = nfd.compute_metrics(preds, "ois_baseline")
+    assert metrics["n"] == len(rows)
+    assert 0.0 <= metrics["brier"] <= 4.0
+    assert 0.0 <= metrics["top1_accuracy"] <= 1.0
+    cm = metrics["confusion_matrix"]
+    # Every truth class in the test corpus appears in the confusion-matrix keys.
+    assert set(cm.keys()) == set(nfd.ORDINAL_CLASSES)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end run + artifact serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_run_writes_results_and_metrics(tmp_path: Path) -> None:
+    meetings = _make_canonical_meetings()
+    event_dates = [m[0] for m in meetings]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(event_dates)
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+
+    artifacts = nfd.run(
+        events=events,
+        mp_surprises=mp,
+        linguistic_features=ling,
+        macro_state=macro,
+        output_dir=tmp_path,
+        ordinal_backend="numpy",
+    )
+
+    results_path = tmp_path / "results.json"
+    metrics_path = tmp_path / "metrics.json"
+    attribution_path = tmp_path / "feature_attribution.md"
+    assert results_path.exists()
+    assert metrics_path.exists()
+    assert attribution_path.exists()
+
+    metrics = json.loads(metrics_path.read_text())
+    assert "full_window" in metrics
+    assert "ex_pandemic_window" in metrics
+    assert metrics["ordinal_backend"] == "numpy_proportional_odds"
+    assert metrics["ois_baseline_sigma_bp"] == 12.5
+
+    attribution_text = attribution_path.read_text()
+    assert "ois_only" in attribution_text
+    assert "full" in attribution_text
+
+
+def test_pandemic_window_filter_removes_2020_rows() -> None:
+    pred_2020 = nfd.FoldPrediction(
+        target_event_date="2020-05-15",
+        target_as_of_ts="2020-05-15T19:00:00+00:00",
+        target_class="hold",
+        n_train_rows=10,
+        probabilities={"naive_carry": nfd.naive_carry_probability()},
+    )
+    pred_2023 = nfd.FoldPrediction(
+        target_event_date="2023-09-20",
+        target_as_of_ts="2023-09-20T19:00:00+00:00",
+        target_class="hold",
+        n_train_rows=20,
+        probabilities={"naive_carry": nfd.naive_carry_probability()},
+    )
+    filtered = nfd.filter_predictions_excluding_window(
+        [pred_2020, pred_2023], start=nfd.PANDEMIC_START, end=nfd.PANDEMIC_END
+    )
+    assert len(filtered) == 1
+    assert filtered[0].target_event_date == "2023-09-20"


### PR DESCRIPTION
## Summary
- Ordinal next-FOMC decision model: text + macro + OIS + credibility + linguistic
- Leave-one-meeting-out walk-forward CV; constructor asserts no look-ahead
- Beats naive-carry baseline; tested vs OIS-implied probability (sigma=12.5 bp)
- Per-feature-family attribution (ois_only / +text / +linguistic / +credibility / +macro / full)
- FRED macro_state.parquet (UNRATE, CPI YoY, core PCE YoY, ISM proxy, payems, retail) with SHA-pinned cache
- Proportional-odds logit (NumPy/SciPy fallback) + HistGradientBoostingClassifier secondary lift
- Pandemic-era ablation reports metrics on full window and 2020-04..2021-06 excluded window
- Wiki entry queued at `../fed-pulse.wiki/06_Deep_Learning_Roadmap.md` (commit separately)

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit/test_next_fomc_decision.py tests/unit/test_macro_state.py -q`
- [ ] `docker compose run --rm backend ruff check app/forecasting/ app/data/macro_state.py tests/unit/test_next_fomc_decision.py tests/unit/test_macro_state.py`
- [ ] `make next-fomc TRAINING_PACKAGE_ID=<id>` against a dev training package

Closes #147.