### PR TITLE
Phase 8 (#148): cross-asset cross-section response head

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state next-fomc
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state next-fomc cross-asset
 
 help:
 	@echo "Targets:"
@@ -52,6 +52,7 @@ help:
 	@echo "  make pseudo-labels-audit-metrics-judge - Compute teacher precision against the LLM judge gold"
 	@echo "  make macro-state      - Build the FRED macro-state parquet (Phase 8 #147)"
 	@echo "  make next-fomc        - Predict next-FOMC decision (Phase 8 headline, #147)"
+	@echo "  make cross-asset      - Cross-asset abnormal-return response head (Phase 8, #148)"
 
 dev: dev-cpu
 
@@ -280,5 +281,18 @@ next-fomc:
 	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
 	docker compose run --rm backend \
 		python -m app.forecasting.next_fomc_decision \
+		--training-package-id "$(TRAINING_PACKAGE_ID)" \
+		--seed "$(SEED)"
+
+# Predict the cross-section of asset abnormal returns to FOMC events using
+# text + macro + OIS + credibility + linguistic features (Phase 8, #148).
+# Required: TRAINING_PACKAGE_ID pointing at a package under
+# data/processed/<id>/ that contains events.parquet (with per-asset rows)
+# and linguistic_features.parquet. Reads mp_surprises.parquet and
+# macro_state.parquet from data/external/fred/.
+cross-asset:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	docker compose run --rm backend \
+		python -m app.forecasting.cross_asset_response \
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
 		--seed "$(SEED)"

--- a/backend/app/forecasting/cross_asset_response.py
+++ b/backend/app/forecasting/cross_asset_response.py
@@ -1099,7 +1099,7 @@ def write_artifacts(
 def _stringify_summary(summary: Mapping[str, Any]) -> dict[str, Any]:
     out: dict[str, Any] = {}
     for k, v in summary.items():
-        if isinstance(v, (list, tuple)):
+        if isinstance(v, list | tuple):
             out[k] = list(v)
         else:
             out[k] = v

--- a/backend/app/forecasting/cross_asset_response.py
+++ b/backend/app/forecasting/cross_asset_response.py
@@ -73,12 +73,13 @@ Baselines
   tenor (``post_event_curve_1m - ff_target_after``) * 100. Same
   information cutoff as the model (PR #156's fix): both the model's
   features and the baseline read off meeting ``N``'s post-event
-  curve, so the comparison is fair. The bp signal is fed as a raw
-  per-row prediction in basis-points-of-abnormal-return; we report
-  the comparison as a sanity check (the OIS path is in rate space,
-  abnormal returns are in price space, so RMSE comparability
-  depends on the asset -- DGS2 returns scale with bp moves, equity
-  returns less so). See the module docstring caveat below.
+  curve, so the comparison is fair. The bp signal is converted to
+  fractional return space (``bp / 10000``) before scoring so the
+  units match ``abnormal_return`` (1 bp = 0.0001, a 1% move = 100
+  bp). The OIS path is rate-direction, abnormal returns are price
+  responses, so RMSE comparability depends on the asset --
+  rate-sensitive cells (^TNX, DGS2) scale with bp moves;
+  equity cells do not.
 
 Caveat on baseline comparability: zero-prediction is a strict
 RMSE-comparable null. ``ois_bp`` is a signed *direction* baseline
@@ -562,14 +563,14 @@ def walk_forward_predict_cell(
         if include_zero_baseline:
             per_model["zero_baseline"] = 0.0
         if include_ois_bp_baseline:
-            # bp signal in "basis points"; rate-sensitive assets read
-            # this as a per-event direction prediction. Returned as
-            # the raw bp number divided by 100 so the units are
-            # comparable to percentage abnormal returns on equities
-            # (a 1% move == 100 bp). The reader is expected to read
-            # the docstring caveat before interpreting this.
+            # bp signal -> fractional return space. abnormal_return is a
+            # fractional close-to-close return (0.01 == 1%) so 1 bp =
+            # 0.0001. We divide the raw bp by 10000. The signal is
+            # rate-direction, not a calibrated return prediction;
+            # docstring caveat below covers the asymmetry between
+            # rate-sensitive cells (^TNX) and equity cells (XLE).
             if row.ois_baseline_bp is not None:
-                per_model["ois_bp_baseline"] = float(row.ois_baseline_bp) / 100.0
+                per_model["ois_bp_baseline"] = float(row.ois_baseline_bp) / 10000.0
             else:
                 per_model["ois_bp_baseline"] = 0.0
 

--- a/backend/app/forecasting/cross_asset_response.py
+++ b/backend/app/forecasting/cross_asset_response.py
@@ -1,0 +1,1297 @@
+"""Predict the cross-section of asset abnormal returns after an FOMC event (closes #148).
+
+Companion to :mod:`app.forecasting.next_fomc_decision`. Where the
+next-FOMC head asks "what will the Fed do next?", this module asks
+"how does the basket move when the Fed speaks?". Each FOMC event
+fans out into a vector of abnormal-return responses across an asset
+universe (equities, rates, dollar, gold, crude, sector ETFs) at
+multiple trading-day horizons; the joint pattern of those responses
+is what disambiguates a tightening shock ("DGS2 up, SPX down, DXY
+up") from a dovish reset ("DGS2 down, SPX up, gold up") from a
+risk-off panic ("everything down, VIX up").
+
+Target
+------
+
+For each row in :file:`events.parquet` we already carry
+``abnormal_return`` -- the market-model residual at horizon ``h``
+relative to the trailing 252-day window. The cross-asset response
+head reshapes that column into one supervised row per
+``(event_date, asset, horizon)``: features known at meeting ``N``
+predict the post-event abnormal return ``h`` trading days later.
+
+Asset universe
+--------------
+
+Taken from the union of ``asset_symbol`` values present in
+``events.parquet``. The schema already supports per-asset rebuilds.
+For 2024-era packages this typically covers some subset of::
+
+    ^GSPC ^IXIC ^DJI ^TNX DX-Y.NYB GC=F CL=F XLF XLK XLE
+
+Whatever subset is actually in the parquet is what we model; missing
+assets fall out of the metrics table rather than being faked. The
+``asset_universe`` field on :class:`RunArtifacts` records the
+actually-modelled symbols.
+
+Horizons
+--------
+
+``1, 5, 10, 30`` trading days (already produced by the event-row
+dataset builder). Each ``(asset, horizon)`` pair is one cell.
+
+Models
+------
+
+Per-cell models (one regression per ``(asset, horizon)``):
+
+- **ridge**     -- :class:`sklearn.linear_model.Ridge` (alpha=1.0).
+  The headline. Linear in the joint feature matrix; deterministic;
+  L2-regularised so the cell-level fit does not blow up on the ~150
+  meetings we have.
+- **hist_gbt**  -- :class:`sklearn.ensemble.HistGradientBoostingRegressor`
+  seeded with ``random_state=11``. Non-linear comparator.
+
+Optional pooled-panel exploration:
+
+- **pooled_ridge** -- A single :class:`Ridge` on the stacked frame
+  with per-asset and per-horizon dummies appended to the feature
+  matrix. Marked exploratory because the panel structure assumes
+  asset/horizon effects are additive over a shared coefficient
+  vector, which they are not in practice; we report it so the
+  reader sees how a pooled fit compares against per-cell fits with
+  the same hyperparameter.
+
+Baselines
+---------
+
+- **zero**     -- predict ``0`` abnormal return. The natural null
+  for a residual that is supposed to be mean-zero by construction.
+  Any per-cell model that fails to beat zero on RMSE is providing
+  no lift.
+- **ois_bp**   -- OIS-implied basis-point change at the 1-month
+  tenor (``post_event_curve_1m - ff_target_after``) * 100. Same
+  information cutoff as the model (PR #156's fix): both the model's
+  features and the baseline read off meeting ``N``'s post-event
+  curve, so the comparison is fair. The bp signal is fed as a raw
+  per-row prediction in basis-points-of-abnormal-return; we report
+  the comparison as a sanity check (the OIS path is in rate space,
+  abnormal returns are in price space, so RMSE comparability
+  depends on the asset -- DGS2 returns scale with bp moves, equity
+  returns less so). See the module docstring caveat below.
+
+Caveat on baseline comparability: zero-prediction is a strict
+RMSE-comparable null. ``ois_bp`` is a signed *direction* baseline
+that may dominate on rate-sensitive cells (^TNX) but lose to zero on
+sector-equity cells (XLE). We report both rather than picking one.
+
+Walk-forward CV
+---------------
+
+Leave-one-meeting-out per cell, mirroring
+``next_fomc_decision.walk_forward_predict``: for held-out meeting
+``M`` the train set is every supervised row in that cell whose
+``feature_event_date < M``. The fitter asserts the strict inequality
+on every fold. Train folds with fewer rows than the feature
+dimension fall back to baselines only.
+
+Feature families
+----------------
+
+Same five families as :mod:`next_fomc_decision`:
+
+- ``ois``        -- 10-dim OIS curve + level/path/info factors
+- ``text``       -- 15-dim multi-axis one-hot
+- ``linguistic`` -- 14-dim structured features (from #149)
+- ``credibility``-- 4-dim credibility vector
+- ``macro``      -- 6-dim FRED macro-state snapshot at feature time
+
+Ablation subsets reported in ``feature_attribution.md``::
+
+    ois_only / ois_text / ois_text_linguistic / ois_text_credibility
+    ois_text_macro / full
+
+Plus the two model-free rows (``zero_baseline``, ``ois_bp``).
+
+Pandemic-era ablation
+---------------------
+
+The window ``2020-04-01..2021-06-30`` is excluded in the
+ex-pandemic metrics block, same constant convention as
+``next_fomc_decision``. The break is large enough that the
+regime-conditioned numbers are worth seeing side-by-side.
+
+Determinism
+-----------
+
+* All sklearn estimators seeded with ``random_state=11``.
+* Rows are sorted by ``(event_date, asset_symbol, horizon)`` before
+  any consumption.
+* JSON dumps use ``sort_keys=True, indent=2``.
+* Predictions are rounded to 8 decimal places before serialisation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import logging
+import math
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from app.config import DATA_DIR
+from app.forecasting.next_fomc_decision import (
+    PANDEMIC_END,
+    PANDEMIC_START,
+    _credibility_feature_names,
+    _curve_value_at,
+    _extract_credibility_features,
+    _extract_linguistic_features,
+    _extract_macro_features,
+    _extract_ois_features,
+    _extract_text_features,
+    _linguistic_feature_names,
+    _macro_feature_names,
+    _ois_feature_names,
+    _text_feature_names,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+FEATURE_FAMILIES: tuple[str, ...] = ("ois", "text", "linguistic", "credibility", "macro")
+
+# Ablation subsets reported in feature_attribution.md. Order matters:
+# each entry produces one row in the markdown table.
+ABLATION_SUBSETS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("ois_only", ("ois",)),
+    ("ois_text", ("ois", "text")),
+    ("ois_text_linguistic", ("ois", "text", "linguistic")),
+    ("ois_text_credibility", ("ois", "text", "credibility")),
+    ("ois_text_macro", ("ois", "text", "macro")),
+    ("full", FEATURE_FAMILIES),
+)
+
+# Asset symbols the issue (#148) lists as the canonical cross-section.
+# The actual modelled universe is the intersection of this with whatever
+# ``asset_symbol`` values are present in ``events.parquet``.
+CANONICAL_ASSETS: tuple[str, ...] = (
+    "^GSPC",
+    "^IXIC",
+    "^DJI",
+    "^TNX",
+    "DX-Y.NYB",
+    "GC=F",
+    "CL=F",
+    "XLF",
+    "XLK",
+    "XLE",
+)
+
+# Canonical horizons (trading days) the event-row builder emits.
+CANONICAL_HORIZONS: tuple[int, ...] = (1, 5, 10, 30)
+
+# Headline cells highlighted in feature_attribution.md.
+HEADLINE_CELLS: tuple[tuple[str, int], ...] = (("^GSPC", 1), ("^GSPC", 5))
+
+
+# ---------------------------------------------------------------------------
+# Supervised-row data class
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CrossAssetRow:
+    """One supervised row.
+
+    The row is keyed by ``(feature_event_date, asset_symbol, horizon)``.
+    Features are extracted at meeting ``N`` (feature_event_date) and
+    predict the abnormal return at horizon ``h`` trading days later.
+    """
+
+    feature_event_date: _dt.date
+    asset_symbol: str
+    horizon: int
+    abnormal_return: float
+    # Per-family feature vectors.
+    ois: list[float]
+    text: list[float]
+    linguistic: list[float]
+    credibility: list[float]
+    macro: list[float]
+    # OIS-implied basis-point signal for the bp baseline. Same
+    # information cutoff as the model: read from meeting N's
+    # post-event curve at 1m tenor minus meeting N's ff_target_after.
+    ois_baseline_bp: float | None
+    feature_names: dict[str, tuple[str, ...]] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Dataset assembly
+# ---------------------------------------------------------------------------
+
+
+def _collapse_events_to_meeting_axis(events: pd.DataFrame) -> pd.DataFrame:
+    """Pick one event_kind row per ``(event_date, asset_symbol, horizon)``.
+
+    Multi-source duplicates are already collapsed upstream in
+    ``events.parquet``; what remains is potentially multiple
+    ``event_kind`` rows per meeting (statement + minutes + press
+    conference). Same preference as :mod:`next_fomc_decision`:
+    statement > press_conference > minutes > first available.
+    """
+
+    if events.empty:
+        return events
+    kind_pref = {"statement": 0, "press_conference": 1, "minutes": 2}
+    e = events.copy()
+    e["_kind_rank"] = e["event_kind"].map(lambda k: kind_pref.get(str(k), 99))
+    e = e.sort_values(
+        ["event_date", "asset_symbol", "horizon", "_kind_rank", "event_kind"],
+        kind="mergesort",
+    )
+    e = e.drop_duplicates(
+        subset=["event_date", "asset_symbol", "horizon"], keep="first"
+    )
+    return e.drop(columns=["_kind_rank"]).reset_index(drop=True)
+
+
+def _safe_abnormal_return(value: Any) -> float | None:
+    """Pull a float abnormal return; ``None`` if missing/NaN."""
+
+    if value is None:
+        return None
+    try:
+        fv = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(fv):
+        return None
+    return fv
+
+
+def _ois_baseline_bp_from_mp_row(mp_row: pd.Series | None) -> float | None:
+    """Compute the OIS-implied basis-point signal at meeting ``N``.
+
+    Same information cutoff as the model: reads meeting ``N``'s
+    post-event curve at the 1-month tenor and subtracts the
+    ``ff_target_after`` set at meeting ``N``. The 1-month tenor is the
+    closest free OIS-proxy tenor to the ~6-week inter-meeting window.
+    Returns ``None`` when the curve or base rate is missing.
+    """
+
+    if mp_row is None:
+        return None
+    implied_rate = _curve_value_at(mp_row.get("post_event_curve"), 1)
+    base = mp_row.get("ff_target_after")
+    if isinstance(base, float) and math.isnan(base):
+        base = None
+    if implied_rate is None or base is None:
+        return None
+    return (float(implied_rate) - float(base)) * 100.0
+
+
+def build_supervised_rows(
+    *,
+    events: pd.DataFrame,
+    mp_surprises: pd.DataFrame,
+    linguistic_features: pd.DataFrame,
+    macro_state: pd.DataFrame,
+    asset_universe: Sequence[str] | None = None,
+    horizons: Sequence[int] | None = None,
+) -> tuple[list[CrossAssetRow], dict[str, Any]]:
+    """Join the four parquets into per-(meeting, asset, horizon) supervised rows.
+
+    Returns ``(rows, summary)``. ``summary`` records dropped-row
+    counts, the meeting span, and the realised asset/horizon
+    universe. Rows are sorted by
+    ``(feature_event_date, asset_symbol, horizon)``.
+    """
+
+    summary: dict[str, Any] = {
+        "rows_in_events": int(len(events)),
+        "rows_in_mp_surprises": int(len(mp_surprises)),
+        "rows_in_linguistic": int(len(linguistic_features)),
+        "rows_in_macro_state": int(len(macro_state)),
+        "dropped_missing_target": 0,
+        "dropped_unknown_asset": 0,
+        "dropped_unknown_horizon": 0,
+        "rows_emitted": 0,
+        "asset_universe": [],
+        "horizons": [],
+    }
+
+    if events.empty:
+        return [], summary
+
+    asset_filter: set[str] | None
+    if asset_universe is None:
+        asset_filter = None
+    else:
+        asset_filter = {str(a) for a in asset_universe}
+
+    horizon_filter: set[int] | None
+    if horizons is None:
+        horizon_filter = None
+    else:
+        horizon_filter = {int(h) for h in horizons}
+
+    events_per_cell = _collapse_events_to_meeting_axis(events)
+
+    ling_cols = (
+        _linguistic_feature_names(linguistic_features.columns)
+        if not linguistic_features.empty
+        else ()
+    )
+
+    # Index mp_surprises by event_date once.
+    mp_by_date: dict[str, pd.Series] = {}
+    if not mp_surprises.empty:
+        for _, row in mp_surprises.iterrows():
+            mp_by_date[str(row["event_date"])] = row
+
+    feature_names = {
+        "ois": _ois_feature_names(),
+        "text": _text_feature_names(),
+        "linguistic": ling_cols,
+        "credibility": _credibility_feature_names(),
+        "macro": _macro_feature_names(),
+    }
+
+    out_rows: list[CrossAssetRow] = []
+    seen_assets: set[str] = set()
+    seen_horizons: set[int] = set()
+
+    for _, event_row in events_per_cell.iterrows():
+        asset = str(event_row.get("asset_symbol", ""))
+        if not asset:
+            summary["dropped_unknown_asset"] += 1
+            continue
+        if asset_filter is not None and asset not in asset_filter:
+            summary["dropped_unknown_asset"] += 1
+            continue
+
+        try:
+            horizon = int(event_row["horizon"])
+        except (KeyError, TypeError, ValueError):
+            summary["dropped_unknown_horizon"] += 1
+            continue
+        if horizon_filter is not None and horizon not in horizon_filter:
+            summary["dropped_unknown_horizon"] += 1
+            continue
+
+        abnormal = _safe_abnormal_return(event_row.get("abnormal_return"))
+        if abnormal is None:
+            summary["dropped_missing_target"] += 1
+            continue
+
+        try:
+            feature_event_date = _dt.date.fromisoformat(str(event_row["event_date"]))
+        except (KeyError, ValueError):
+            summary["dropped_missing_target"] += 1
+            continue
+
+        mp_row = mp_by_date.get(feature_event_date.isoformat())
+        # When mp_surprises is missing for this meeting, synthesize a
+        # zero-valued series so the OIS feature vector has consistent
+        # length. The baseline_bp will land at ``None``.
+        if mp_row is None and not mp_surprises.empty:
+            mp_row = pd.Series(dict.fromkeys(mp_surprises.columns))
+
+        ois_vec = _extract_ois_features(mp_row) if mp_row is not None else [0.0] * len(_ois_feature_names())
+        text_vec = _extract_text_features(event_row)
+        cred_vec = _extract_credibility_features(event_row)
+        macro_vec = _extract_macro_features(macro_state, feature_event_date)
+        ling_vec = _extract_linguistic_features(
+            event_row.get("text_hash"), linguistic_features, ling_cols
+        )
+
+        ois_bp = _ois_baseline_bp_from_mp_row(mp_row) if mp_row is not None else None
+
+        out_rows.append(
+            CrossAssetRow(
+                feature_event_date=feature_event_date,
+                asset_symbol=asset,
+                horizon=horizon,
+                abnormal_return=float(abnormal),
+                ois=ois_vec,
+                text=text_vec,
+                linguistic=ling_vec,
+                credibility=cred_vec,
+                macro=macro_vec,
+                ois_baseline_bp=ois_bp,
+                feature_names=feature_names,
+            )
+        )
+        seen_assets.add(asset)
+        seen_horizons.add(horizon)
+
+    out_rows.sort(
+        key=lambda r: (r.feature_event_date, r.asset_symbol, r.horizon)
+    )
+    summary["rows_emitted"] = len(out_rows)
+    summary["asset_universe"] = sorted(seen_assets)
+    summary["horizons"] = sorted(seen_horizons)
+    return out_rows, summary
+
+
+# ---------------------------------------------------------------------------
+# Feature matrix
+# ---------------------------------------------------------------------------
+
+
+def _build_feature_matrix(
+    rows: Sequence[CrossAssetRow], families: Sequence[str]
+) -> tuple[np.ndarray, tuple[str, ...]]:
+    """Stack the requested family vectors row-wise; returns ``(X, col_names)``."""
+
+    if not rows:
+        return np.zeros((0, 0), dtype=np.float64), ()
+    col_names: list[str] = []
+    for fam in families:
+        col_names.extend(rows[0].feature_names.get(fam, ()))
+    matrix = np.zeros((len(rows), len(col_names)), dtype=np.float64)
+    for i, row in enumerate(rows):
+        cursor = 0
+        for fam in families:
+            vec = getattr(row, fam)
+            n = len(vec)
+            matrix[i, cursor : cursor + n] = vec
+            cursor += n
+    return matrix, tuple(col_names)
+
+
+def _standardise(
+    X_train: np.ndarray, X_test: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Fit per-column ``(mean, std)`` on train; apply to both.
+
+    Train-only fit honours the leakage rules in CLAUDE.md. Zero-variance
+    columns are passed through unchanged.
+    """
+
+    if X_train.size == 0:
+        return X_train, X_test
+    mean = X_train.mean(axis=0)
+    std = X_train.std(axis=0)
+    std_safe = np.where(std < 1e-8, 1.0, std)
+    return (X_train - mean) / std_safe, (X_test - mean) / std_safe
+
+
+# ---------------------------------------------------------------------------
+# Per-cell walk-forward CV
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CellPrediction:
+    """One held-out meeting in one ``(asset, horizon)`` cell."""
+
+    feature_event_date: str
+    asset_symbol: str
+    horizon: int
+    target: float
+    n_train_rows: int
+    predictions: dict[str, float] = field(default_factory=dict)
+
+
+def _rows_for_cell(
+    rows: Sequence[CrossAssetRow], *, asset: str, horizon: int
+) -> list[CrossAssetRow]:
+    """Subset by ``(asset, horizon)``; preserves time ordering."""
+
+    return [
+        r for r in rows if r.asset_symbol == asset and r.horizon == horizon
+    ]
+
+
+def walk_forward_predict_cell(
+    cell_rows: Sequence[CrossAssetRow],
+    *,
+    families: Sequence[str] = FEATURE_FAMILIES,
+    include_ridge: bool = True,
+    include_gbt: bool = True,
+    include_zero_baseline: bool = True,
+    include_ois_bp_baseline: bool = True,
+    ridge_alpha: float = 1.0,
+    random_state: int = 11,
+) -> list[CellPrediction]:
+    """Leave-one-meeting-out walk-forward CV inside a single cell.
+
+    Mirrors :func:`next_fomc_decision.walk_forward_predict` but the
+    target is a float (abnormal return) so we use regressors and
+    report regression metrics. Train folds with fewer rows than the
+    feature dimension fall back to baselines only -- ridge with
+    ``alpha=1`` can technically fit underdetermined systems but the
+    answer is dominated by the prior, so we skip it.
+    """
+
+    X_all, _ = _build_feature_matrix(cell_rows, families)
+    y_all = np.asarray([r.abnormal_return for r in cell_rows], dtype=np.float64)
+
+    preds: list[CellPrediction] = []
+    for i, row in enumerate(cell_rows):
+        X_train = X_all[:i]
+        y_train = y_all[:i]
+        X_test = X_all[i : i + 1]
+
+        # No-look-ahead assertion. Every train row's feature_event_date
+        # must be strictly older than the held-out row's.
+        for j in range(i):
+            assert cell_rows[j].feature_event_date < row.feature_event_date, (
+                "walk-forward leak: cell row "
+                f"{j} feature_date={cell_rows[j].feature_event_date} "
+                "not strictly before held-out feature_date="
+                f"{row.feature_event_date}"
+            )
+
+        per_model: dict[str, float] = {}
+
+        if include_zero_baseline:
+            per_model["zero_baseline"] = 0.0
+        if include_ois_bp_baseline:
+            # bp signal in "basis points"; rate-sensitive assets read
+            # this as a per-event direction prediction. Returned as
+            # the raw bp number divided by 100 so the units are
+            # comparable to percentage abnormal returns on equities
+            # (a 1% move == 100 bp). The reader is expected to read
+            # the docstring caveat before interpreting this.
+            if row.ois_baseline_bp is not None:
+                per_model["ois_bp_baseline"] = float(row.ois_baseline_bp) / 100.0
+            else:
+                per_model["ois_bp_baseline"] = 0.0
+
+        feature_dim = X_train.shape[1] if X_train.size else 0
+        if i > feature_dim and feature_dim > 0:
+            X_tr_s, X_te_s = _standardise(X_train, X_test)
+            if include_ridge:
+                try:
+                    from sklearn.linear_model import Ridge
+
+                    model = Ridge(alpha=ridge_alpha, random_state=random_state)
+                    model.fit(X_tr_s, y_train)
+                    per_model["ridge"] = float(model.predict(X_te_s)[0])
+                except Exception as exc:  # noqa: BLE001 -- log + fall through
+                    LOGGER.warning("Ridge fit failed at row %d: %s", i, exc)
+
+            if include_gbt:
+                try:
+                    from sklearn.ensemble import HistGradientBoostingRegressor
+
+                    gbt = HistGradientBoostingRegressor(
+                        random_state=random_state, max_iter=200
+                    )
+                    gbt.fit(X_tr_s, y_train)
+                    per_model["hist_gbt"] = float(gbt.predict(X_te_s)[0])
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.warning(
+                        "HistGradientBoostingRegressor failed at row %d: %s", i, exc
+                    )
+
+        per_model = {k: round(v, 8) for k, v in per_model.items()}
+
+        preds.append(
+            CellPrediction(
+                feature_event_date=row.feature_event_date.isoformat(),
+                asset_symbol=row.asset_symbol,
+                horizon=row.horizon,
+                target=round(float(row.abnormal_return), 8),
+                n_train_rows=i,
+                predictions=per_model,
+            )
+        )
+
+    return preds
+
+
+# ---------------------------------------------------------------------------
+# Pooled-panel exploration
+# ---------------------------------------------------------------------------
+
+
+def walk_forward_predict_pooled(
+    rows: Sequence[CrossAssetRow],
+    *,
+    families: Sequence[str] = FEATURE_FAMILIES,
+    ridge_alpha: float = 1.0,
+    random_state: int = 11,
+) -> list[CellPrediction]:
+    """Optional pooled-panel ridge with asset / horizon dummies.
+
+    Exploratory comparator: one regression for the whole panel,
+    asset and horizon enter as one-hot dummies. Walk-forward time
+    boundary is the held-out row's ``feature_event_date``: train on
+    every panel row whose date is strictly earlier. Marked
+    exploratory because the additivity assumption (asset and horizon
+    effects share the same coefficient vector across all features)
+    is implausible -- DGS yields and equity sectors do not share a
+    sentiment-to-return slope.
+
+    Predictions land under model name ``pooled_ridge`` in the
+    returned ``CellPrediction`` payloads.
+    """
+
+    if not rows:
+        return []
+    X_feat, _ = _build_feature_matrix(rows, families)
+    assets = sorted({r.asset_symbol for r in rows})
+    horizons = sorted({r.horizon for r in rows})
+    asset_to_idx = {a: i for i, a in enumerate(assets)}
+    horizon_to_idx = {h: i for i, h in enumerate(horizons)}
+
+    n = len(rows)
+    asset_dum = np.zeros((n, len(assets)), dtype=np.float64)
+    horizon_dum = np.zeros((n, len(horizons)), dtype=np.float64)
+    for i, row in enumerate(rows):
+        asset_dum[i, asset_to_idx[row.asset_symbol]] = 1.0
+        horizon_dum[i, horizon_to_idx[row.horizon]] = 1.0
+
+    X_full = np.hstack([X_feat, asset_dum, horizon_dum])
+    y_all = np.asarray([r.abnormal_return for r in rows], dtype=np.float64)
+
+    # We need a row index ordered by date so the walk-forward time
+    # boundary is well-defined across the panel.
+    order = sorted(
+        range(n),
+        key=lambda i: (rows[i].feature_event_date, rows[i].asset_symbol, rows[i].horizon),
+    )
+    rows_sorted = [rows[i] for i in order]
+    X_sorted = X_full[order]
+    y_sorted = y_all[order]
+
+    preds: list[CellPrediction] = []
+    for i, row in enumerate(rows_sorted):
+        # Train rows: every sorted row whose date is strictly earlier
+        # than the held-out row's date. Equal-date rows in other
+        # cells are excluded to avoid leaking same-event information
+        # across assets.
+        train_mask = np.asarray(
+            [
+                rows_sorted[j].feature_event_date < row.feature_event_date
+                for j in range(n)
+            ],
+            dtype=bool,
+        )
+        X_train = X_sorted[train_mask]
+        y_train = y_sorted[train_mask]
+        X_test = X_sorted[i : i + 1]
+        per_model: dict[str, float] = {}
+        if X_train.shape[0] > X_full.shape[1]:
+            try:
+                from sklearn.linear_model import Ridge
+
+                X_tr_s, X_te_s = _standardise(X_train, X_test)
+                model = Ridge(alpha=ridge_alpha, random_state=random_state)
+                model.fit(X_tr_s, y_train)
+                per_model["pooled_ridge"] = round(
+                    float(model.predict(X_te_s)[0]), 8
+                )
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning("Pooled ridge fit failed at row %d: %s", i, exc)
+        preds.append(
+            CellPrediction(
+                feature_event_date=row.feature_event_date.isoformat(),
+                asset_symbol=row.asset_symbol,
+                horizon=row.horizon,
+                target=round(float(row.abnormal_return), 8),
+                n_train_rows=int(train_mask.sum()),
+                predictions=per_model,
+            )
+        )
+    return preds
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+def compute_cell_metrics(
+    preds: Sequence[CellPrediction], model_name: str
+) -> dict[str, Any]:
+    """RMSE / MAE / R^2 / directional-hit-rate for one model in one cell.
+
+    The directional hit rate is ``mean(sign(pred) == sign(truth))``
+    excluding rows where either side is exactly zero (those land in
+    the "ties" bucket). When no rows have a prediction, all metrics
+    return ``None``.
+    """
+
+    y_true: list[float] = []
+    y_pred: list[float] = []
+    for p in preds:
+        v = p.predictions.get(model_name)
+        if v is None:
+            continue
+        y_true.append(float(p.target))
+        y_pred.append(float(v))
+    n = len(y_true)
+    if n == 0:
+        return {
+            "n": 0,
+            "rmse": None,
+            "mae": None,
+            "r2": None,
+            "directional_hit_rate": None,
+            "directional_n": 0,
+        }
+    yt = np.asarray(y_true, dtype=np.float64)
+    yp = np.asarray(y_pred, dtype=np.float64)
+    err = yp - yt
+    rmse = float(math.sqrt(float((err ** 2).mean())))
+    mae = float(np.abs(err).mean())
+    var_truth = float(((yt - yt.mean()) ** 2).sum())
+    if var_truth <= 1e-18:
+        r2: float | None = None
+    else:
+        ss_res = float((err ** 2).sum())
+        r2 = float(1.0 - ss_res / var_truth)
+
+    truth_sign = np.sign(yt)
+    pred_sign = np.sign(yp)
+    nonzero = (truth_sign != 0) & (pred_sign != 0)
+    dir_n = int(nonzero.sum())
+    if dir_n == 0:
+        hit_rate: float | None = None
+    else:
+        hit_rate = float((truth_sign[nonzero] == pred_sign[nonzero]).mean())
+    return {
+        "n": int(n),
+        "rmse": round(rmse, 8),
+        "mae": round(mae, 8),
+        "r2": None if r2 is None else round(r2, 8),
+        "directional_hit_rate": None if hit_rate is None else round(hit_rate, 8),
+        "directional_n": dir_n,
+    }
+
+
+def filter_predictions_excluding_window(
+    preds: Sequence[CellPrediction], *, start: _dt.date, end: _dt.date
+) -> list[CellPrediction]:
+    """Drop predictions whose ``feature_event_date`` falls inside ``[start, end]``."""
+
+    keep: list[CellPrediction] = []
+    for pred in preds:
+        try:
+            d = _dt.date.fromisoformat(pred.feature_event_date)
+        except ValueError:
+            keep.append(pred)
+            continue
+        if start <= d <= end:
+            continue
+        keep.append(pred)
+    return keep
+
+
+# ---------------------------------------------------------------------------
+# Top-level run
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunArtifacts:
+    """Returned by :func:`run`."""
+
+    rows: list[CrossAssetRow]
+    predictions: list[CellPrediction]
+    metrics: dict[str, Any]
+    summary: dict[str, Any]
+    ablation_metrics: dict[str, dict[str, Any]]
+    asset_universe: list[str]
+    horizons: list[int]
+
+
+def _per_cell_metrics(
+    preds: Sequence[CellPrediction],
+    *,
+    assets: Sequence[str],
+    horizons: Sequence[int],
+    model_names: Sequence[str],
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Nested dict: ``cell_id -> model -> metrics``."""
+
+    by_cell: dict[tuple[str, int], list[CellPrediction]] = {
+        (a, h): [] for a in assets for h in horizons
+    }
+    for p in preds:
+        key = (p.asset_symbol, int(p.horizon))
+        if key in by_cell:
+            by_cell[key].append(p)
+    out: dict[str, dict[str, dict[str, Any]]] = {}
+    for (asset, horizon), cell_preds in by_cell.items():
+        cell_id = f"{asset}|h{horizon}"
+        out[cell_id] = {
+            m: compute_cell_metrics(cell_preds, m) for m in model_names
+        }
+    return out
+
+
+def _aggregate_model_names(preds: Sequence[CellPrediction]) -> list[str]:
+    names: set[str] = set()
+    for p in preds:
+        for k in p.predictions:
+            names.add(k)
+    return sorted(names)
+
+
+def run(
+    *,
+    events: pd.DataFrame,
+    mp_surprises: pd.DataFrame,
+    linguistic_features: pd.DataFrame,
+    macro_state: pd.DataFrame,
+    output_dir: Path | None = None,
+    asset_universe: Sequence[str] | None = None,
+    horizons: Sequence[int] | None = None,
+    include_pooled: bool = True,
+    random_state: int = 11,
+) -> RunArtifacts:
+    """End-to-end run: assemble, per-cell walk-forward, score, optionally write."""
+
+    rows, summary = build_supervised_rows(
+        events=events,
+        mp_surprises=mp_surprises,
+        linguistic_features=linguistic_features,
+        macro_state=macro_state,
+        asset_universe=asset_universe,
+        horizons=horizons,
+    )
+
+    realised_assets: list[str] = list(summary["asset_universe"])
+    realised_horizons: list[int] = list(summary["horizons"])
+
+    per_cell_preds: list[CellPrediction] = []
+    for asset in realised_assets:
+        for horizon in realised_horizons:
+            cell_rows = _rows_for_cell(rows, asset=asset, horizon=horizon)
+            if not cell_rows:
+                continue
+            preds = walk_forward_predict_cell(
+                cell_rows,
+                families=FEATURE_FAMILIES,
+                random_state=random_state,
+            )
+            per_cell_preds.extend(preds)
+
+    if include_pooled and rows:
+        pooled_preds = walk_forward_predict_pooled(
+            rows,
+            families=FEATURE_FAMILIES,
+            random_state=random_state,
+        )
+        # Merge ``pooled_ridge`` predictions onto matching per-cell
+        # CellPrediction entries keyed by (date, asset, horizon).
+        index = {
+            (p.feature_event_date, p.asset_symbol, p.horizon): p for p in per_cell_preds
+        }
+        for pp in pooled_preds:
+            key = (pp.feature_event_date, pp.asset_symbol, pp.horizon)
+            target = index.get(key)
+            if target is not None:
+                target.predictions.update(pp.predictions)
+            else:
+                per_cell_preds.append(pp)
+        per_cell_preds.sort(
+            key=lambda p: (p.feature_event_date, p.asset_symbol, p.horizon)
+        )
+
+    model_names = _aggregate_model_names(per_cell_preds)
+
+    metrics_full = _per_cell_metrics(
+        per_cell_preds,
+        assets=realised_assets,
+        horizons=realised_horizons,
+        model_names=model_names,
+    )
+    ex_pandemic_preds = filter_predictions_excluding_window(
+        per_cell_preds, start=PANDEMIC_START, end=PANDEMIC_END
+    )
+    metrics_ex_pandemic = _per_cell_metrics(
+        ex_pandemic_preds,
+        assets=realised_assets,
+        horizons=realised_horizons,
+        model_names=model_names,
+    )
+
+    metrics: dict[str, Any] = {
+        "full_window": metrics_full,
+        "ex_pandemic_window": metrics_ex_pandemic,
+        "pandemic_window": {
+            "start": PANDEMIC_START.isoformat(),
+            "end": PANDEMIC_END.isoformat(),
+        },
+        "model_names": model_names,
+        "asset_universe": realised_assets,
+        "horizons": realised_horizons,
+        "n_predictions": len(per_cell_preds),
+        "methodology_source": "cross_asset_event_response_v1",
+    }
+
+    ablation_metrics = _run_ablations(
+        rows,
+        random_state=random_state,
+    )
+
+    if output_dir is not None:
+        write_artifacts(
+            output_dir=Path(output_dir),
+            predictions=per_cell_preds,
+            metrics=metrics,
+            summary=summary,
+            ablations=ablation_metrics,
+        )
+
+    return RunArtifacts(
+        rows=rows,
+        predictions=per_cell_preds,
+        metrics=metrics,
+        summary=summary,
+        ablation_metrics=ablation_metrics,
+        asset_universe=realised_assets,
+        horizons=realised_horizons,
+    )
+
+
+def _count_features(rows: Sequence[CrossAssetRow], families: Sequence[str]) -> int:
+    if not rows:
+        return 0
+    return sum(len(rows[0].feature_names.get(fam, ())) for fam in families)
+
+
+def _run_ablations(
+    rows: Sequence[CrossAssetRow],
+    *,
+    random_state: int,
+) -> dict[str, dict[str, Any]]:
+    """Per-feature-family ablation on the ridge model only.
+
+    Runs once per :data:`ABLATION_SUBSETS` entry, recording the metric
+    bundle on each headline cell so the ``feature_attribution.md``
+    table can compare what each family adds. The ridge model is the
+    one we ablate; the gradient-boosted model is left at its full
+    feature set to keep run time bounded.
+    """
+
+    out: dict[str, dict[str, Any]] = {}
+    for name, fams in ABLATION_SUBSETS:
+        cell_preds: list[CellPrediction] = []
+        for asset, horizon in HEADLINE_CELLS:
+            cell_rows = _rows_for_cell(rows, asset=asset, horizon=horizon)
+            if not cell_rows:
+                continue
+            preds = walk_forward_predict_cell(
+                cell_rows,
+                families=fams,
+                include_ridge=True,
+                include_gbt=False,
+                include_zero_baseline=False,
+                include_ois_bp_baseline=False,
+                random_state=random_state,
+            )
+            cell_preds.extend(preds)
+        per_cell: dict[str, dict[str, Any]] = {}
+        for asset, horizon in HEADLINE_CELLS:
+            this_cell = [
+                p for p in cell_preds if p.asset_symbol == asset and p.horizon == horizon
+            ]
+            per_cell[f"{asset}|h{horizon}"] = compute_cell_metrics(this_cell, "ridge")
+        out[name] = {
+            "families": list(fams),
+            "n_features": _count_features(rows, fams),
+            "headline_cells": per_cell,
+        }
+
+    # Two model-free reference rows. We run them once each with the
+    # full feature pipeline (so the baselines have rows to report)
+    # but only collect the baseline columns.
+    base_preds: list[CellPrediction] = []
+    for asset, horizon in HEADLINE_CELLS:
+        cell_rows = _rows_for_cell(rows, asset=asset, horizon=horizon)
+        if not cell_rows:
+            continue
+        preds = walk_forward_predict_cell(
+            cell_rows,
+            families=("ois",),
+            include_ridge=False,
+            include_gbt=False,
+            include_zero_baseline=True,
+            include_ois_bp_baseline=True,
+            random_state=random_state,
+        )
+        base_preds.extend(preds)
+    for model_name, label in (
+        ("zero_baseline", "zero_baseline"),
+        ("ois_bp_baseline", "ois_bp_baseline"),
+    ):
+        baseline_per_cell: dict[str, dict[str, Any]] = {}
+        for asset, horizon in HEADLINE_CELLS:
+            this_cell = [
+                p for p in base_preds if p.asset_symbol == asset and p.horizon == horizon
+            ]
+            baseline_per_cell[f"{asset}|h{horizon}"] = compute_cell_metrics(
+                this_cell, model_name
+            )
+        out[label] = {
+            "families": [label],
+            "n_features": 0,
+            "headline_cells": baseline_per_cell,
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Artifact writers
+# ---------------------------------------------------------------------------
+
+
+def write_artifacts(
+    *,
+    output_dir: Path,
+    predictions: Sequence[CellPrediction],
+    metrics: Mapping[str, Any],
+    summary: Mapping[str, Any],
+    ablations: Mapping[str, Any],
+) -> None:
+    """Persist predictions.json, metrics.json, feature_attribution.md."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "predictions.json").write_text(
+        json.dumps(
+            {
+                "predictions": [
+                    {
+                        "feature_event_date": p.feature_event_date,
+                        "asset_symbol": p.asset_symbol,
+                        "horizon": p.horizon,
+                        "target": p.target,
+                        "n_train_rows": p.n_train_rows,
+                        "predictions": p.predictions,
+                    }
+                    for p in predictions
+                ],
+                "summary": _stringify_summary(summary),
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "metrics.json").write_text(
+        json.dumps(dict(metrics), indent=2, sort_keys=True), encoding="utf-8"
+    )
+    (output_dir / "feature_attribution.md").write_text(
+        _format_attribution_md(ablations), encoding="utf-8"
+    )
+
+
+def _stringify_summary(summary: Mapping[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for k, v in summary.items():
+        if isinstance(v, (list, tuple)):
+            out[k] = list(v)
+        else:
+            out[k] = v
+    return out
+
+
+def _format_attribution_md(ablations: Mapping[str, Any]) -> str:
+    """Format the per-family ablation table for headline cells.
+
+    Two tables -- one per headline cell -- so the reader can see how
+    each subset moves the RMSE / MAE / directional-hit-rate.
+    """
+
+    lines = [
+        "# Cross-asset response head -- feature-family attribution",
+        "",
+        "Each row is a per-cell leave-one-meeting-out walk-forward run on",
+        "the ridge model trained on the listed feature subset. Two cells",
+        "are highlighted: SPX (^GSPC) at h=1d and h=5d. Model-free rows",
+        "(zero_baseline, ois_bp_baseline) sit at the bottom for reference.",
+        "",
+    ]
+    for asset, horizon in HEADLINE_CELLS:
+        cell_id = f"{asset}|h{horizon}"
+        lines.append(f"## Headline cell: {cell_id}")
+        lines.append("")
+        lines.append(
+            "| Subset | Families | #features | n | RMSE | MAE | R^2 | DirHitRate |"
+        )
+        lines.append("| --- | --- | --- | --- | --- | --- | --- | --- |")
+        for name, payload in ablations.items():
+            cells = payload.get("headline_cells", {})
+            m = cells.get(cell_id, {})
+            lines.append(
+                "| {name} | {fams} | {nf} | {n} | {rmse} | {mae} | {r2} | {dh} |".format(
+                    name=name,
+                    fams=", ".join(payload.get("families", [])),
+                    nf=payload.get("n_features", 0),
+                    n=m.get("n"),
+                    rmse=m.get("rmse"),
+                    mae=m.get("mae"),
+                    r2=m.get("r2"),
+                    dh=m.get("directional_hit_rate"),
+                )
+            )
+        lines.append("")
+    lines.append(
+        "Notes: ``zero_baseline`` is the mean-zero null (any model below it on "
+        "RMSE is providing no lift); ``ois_bp_baseline`` is the OIS-implied "
+        "bp signal at meeting N's post-event 1m tenor divided by 100, so its "
+        "RMSE is comparable on rate-sensitive cells but inflated on equity "
+        "cells -- read the module docstring caveat before drawing inference."
+    )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _load_parquet_safely(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise SystemExit(f"required parquet missing: {path}")
+    return pd.read_parquet(path)
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Predict cross-asset abnormal-return responses to FOMC events "
+            "using text + macro + OIS + credibility + linguistic features "
+            "(Phase 8 #148)."
+        ),
+    )
+    parser.add_argument("--training-package-id", required=True)
+    parser.add_argument(
+        "--data-dir",
+        default=str(DATA_DIR),
+        help="Root data dir (default: app.config.DATA_DIR).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help=(
+            "Override for the artifact output dir. Default: "
+            "data/artifacts/cross_asset/."
+        ),
+    )
+    parser.add_argument(
+        "--events-name",
+        default="events.parquet",
+        help="Filename of the events parquet under data/processed/<pkg>/.",
+    )
+    parser.add_argument(
+        "--mp-surprises-name",
+        default="mp_surprises.parquet",
+        help="Filename of the MP surprises parquet under data/external/fred/.",
+    )
+    parser.add_argument(
+        "--linguistic-name",
+        default="linguistic_features.parquet",
+        help="Filename of the linguistic features parquet under data/processed/<pkg>/.",
+    )
+    parser.add_argument(
+        "--macro-state-name",
+        default="macro_state.parquet",
+        help="Filename of the macro-state parquet under data/external/fred/.",
+    )
+    parser.add_argument(
+        "--asset",
+        action="append",
+        default=None,
+        help=(
+            "Restrict the asset universe. Pass multiple --asset flags to "
+            "model a subset. Default: every ``asset_symbol`` in the events "
+            "parquet."
+        ),
+    )
+    parser.add_argument(
+        "--horizon",
+        action="append",
+        type=int,
+        default=None,
+        help=(
+            "Restrict the modelled horizons. Pass multiple --horizon flags. "
+            "Default: every horizon in the events parquet."
+        ),
+    )
+    parser.add_argument(
+        "--no-pooled",
+        action="store_true",
+        help="Disable the exploratory pooled-panel ridge model.",
+    )
+    parser.add_argument("--seed", type=int, default=11)
+    return parser.parse_args(argv)
+
+
+def _resolve_iterable(
+    flag: Iterable[Any] | None, default: tuple[Any, ...]
+) -> tuple[Any, ...]:
+    if not flag:
+        return default
+    return tuple(flag)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    data_dir = Path(args.data_dir)
+    package_dir = data_dir / "processed" / args.training_package_id
+    fred_dir = data_dir / "external" / "fred"
+
+    events = _load_parquet_safely(package_dir / args.events_name)
+    mp = _load_parquet_safely(fred_dir / args.mp_surprises_name)
+    ling_path = package_dir / args.linguistic_name
+    linguistic = (
+        _load_parquet_safely(ling_path) if ling_path.exists() else pd.DataFrame()
+    )
+    macro_path = fred_dir / args.macro_state_name
+    macro = (
+        _load_parquet_safely(macro_path) if macro_path.exists() else pd.DataFrame()
+    )
+
+    output_dir = (
+        Path(args.output_dir)
+        if args.output_dir
+        else data_dir / "artifacts" / "cross_asset"
+    )
+
+    artifacts = run(
+        events=events,
+        mp_surprises=mp,
+        linguistic_features=linguistic,
+        macro_state=macro,
+        output_dir=output_dir,
+        asset_universe=args.asset,
+        horizons=args.horizon,
+        include_pooled=not args.no_pooled,
+        random_state=args.seed,
+    )
+
+    print(f"[cross-asset] rows emitted: {artifacts.summary['rows_emitted']}")
+    print(
+        f"[cross-asset] asset universe: {', '.join(artifacts.asset_universe) or '<none>'}"
+    )
+    print(
+        f"[cross-asset] horizons: {', '.join(str(h) for h in artifacts.horizons) or '<none>'}"
+    )
+    print(f"[cross-asset] models: {', '.join(artifacts.metrics['model_names'])}")
+    print(f"[cross-asset] output dir: {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -438,3 +438,99 @@ Outputs land under `data/artifacts/next_fomc/`:
   `ois_only`, `ois_text`, `ois_text_linguistic`, `ois_text_credibility`,
   `ois_text_macro`, `full`, plus the model-free `ois_baseline_only`
   and `naive_carry_only` rows for reference.
+
+## Cross-asset response (Phase 8)
+
+The cross-asset response head
+(`backend/app/forecasting/cross_asset_response.py`, closes #148) reuses
+the same per-meeting feature joins as the next-FOMC head and predicts
+the cross-section of asset abnormal returns rather than a single Fed
+decision class. Where the next-FOMC head asks "what will the Fed
+do next?", this head asks "how does the basket move when the Fed
+speaks?".
+
+### Target
+
+Per-row regression target is the `abnormal_return` column on
+`events.parquet`. The event-row dataset builder (#145) already
+produces one row per `(event_date, event_kind, asset_symbol, horizon)`
+with the market-model residual at horizon `h` computed against a
+trailing 252-day window strictly before `as_of_ts`. The cross-asset
+head reshapes that to one supervised row per
+`(meeting, asset, horizon)`.
+
+### Asset universe
+
+Read from `events.parquet`'s `asset_symbol` column. The canonical
+issue-#148 universe is:
+
+    ^GSPC ^IXIC ^DJI ^TNX DX-Y.NYB GC=F CL=F XLF XLK XLE
+
+Whatever subset is actually present in the parquet is what we model;
+the realised list is recorded under `metrics.json[asset_universe]`.
+`--asset` flags on the CLI can restrict the universe further.
+
+### Horizons
+
+`1, 5, 10, 30` trading days (the canonical set the event-row builder
+emits). `--horizon` flags restrict the modelled subset.
+
+### Feature families
+
+Same five families as the next-FOMC head (`ois`, `text`,
+`linguistic`, `credibility`, `macro`); the helpers are imported
+directly from `next_fomc_decision` so the feature-name contracts stay
+in lock-step.
+
+### Models
+
+Per-cell (one regression per `(asset, horizon)`):
+
+- **ridge** -- `sklearn.linear_model.Ridge(alpha=1.0)`. Headline
+  model; L2-regularised linear fit on the joint feature matrix.
+- **hist_gbt** -- `sklearn.ensemble.HistGradientBoostingRegressor`
+  seeded with `random_state=11`. Non-linear comparator.
+
+Optional pooled-panel exploration:
+
+- **pooled_ridge** -- single `Ridge` on the stacked frame with
+  per-asset and per-horizon one-hot dummies. Marked exploratory;
+  documented in the module docstring.
+
+### Baselines
+
+- **zero_baseline** -- predicts `0` abnormal return. The strict
+  null for a mean-zero residual.
+- **ois_bp_baseline** -- OIS-implied basis-point signal from
+  meeting `N`'s `post_event_curve` at the 1-month tenor minus
+  `ff_target_after`, divided by 100 so the units roughly align with
+  percentage abnormal returns. Same information cutoff as the
+  model. Rate-sensitive cells (e.g. ^TNX) make this baseline
+  competitive; sector-equity cells make it inflated. Documented in
+  the module docstring caveat -- read it before drawing inference.
+
+### Walk-forward CV
+
+Leave-one-meeting-out *per cell*. For held-out meeting `M` in cell
+`(asset, horizon)`, the train set is every supervised row in that
+cell whose `feature_event_date < M`. The fitter asserts the strict
+inequality on every fold. Train folds with fewer rows than the
+feature dimension fall back to the baselines.
+
+The pooled-panel variant walks the time boundary over the whole
+panel: equal-date rows in other cells are excluded so same-event
+information cannot leak across assets.
+
+### Artifact layout
+
+Outputs land under `data/artifacts/cross_asset/`:
+
+- `predictions.json` -- per `(meeting, asset, horizon, model)`
+  prediction with the realised target and train-row count.
+- `metrics.json` -- per-cell RMSE, MAE, R^2, directional hit rate
+  for every model. Reports both the full window and the
+  pandemic-excluded window (`2020-04-01..2021-06-30`).
+- `feature_attribution.md` -- ablation table for the headline cells
+  `^GSPC|h1` and `^GSPC|h5`. Same subset list as the next-FOMC
+  attribution table, plus the model-free `zero_baseline` and
+  `ois_bp_baseline` reference rows.

--- a/tests/unit/test_cross_asset_response.py
+++ b/tests/unit/test_cross_asset_response.py
@@ -1,0 +1,642 @@
+"""Tests for the cross-asset response head (Phase 8 #148).
+
+Covers the acceptance criteria from #148:
+
+* walk-forward construction yields ``N-1`` train rows for the N-th
+  meeting *within a single cell*, with strict no-look-ahead asserted,
+* per-cell ridge recovers a synthetic linear target,
+* feature-family ablation produces strictly fewer columns when a
+  family is dropped,
+* target reconstruction reads ``abnormal_return`` from
+  ``events.parquet`` and silently ignores rows where the asset's
+  target is missing,
+* the pandemic-window filter excludes the documented date range.
+
+Synthetic data is intentionally small; the tests pin behavioural
+contracts, not real-world model quality.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.forecasting import cross_asset_response as car
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-data builders
+# ---------------------------------------------------------------------------
+
+
+def _make_pre_event_curve(rate_pct: float) -> str:
+    points = [
+        {"months_ahead": tenor, "implied_rate": rate_pct}
+        for tenor in (1, 3, 6, 12, 24)
+    ]
+    return json.dumps(points)
+
+
+def _make_mp_surprises_df(
+    meetings: list[tuple[str, float, float]],
+) -> pd.DataFrame:
+    """``(event_date_iso, ff_target_prior, ff_target_after)`` rows."""
+
+    rows = []
+    for idx, (event_date, prior, after) in enumerate(meetings, start=1):
+        rows.append(
+            {
+                "event_date": event_date,
+                "meeting_id": idx,
+                "ff_target_prior": float(prior),
+                "ff_target_after": float(after),
+                "mp_surprise_level": 0.0,
+                "mp_surprise_path_factor": 0.0,
+                "pre_event_curve": _make_pre_event_curve(float(prior)),
+                "post_event_curve": _make_pre_event_curve(float(after)),
+                "fed_info_factor": 0.0,
+                "is_intermeeting": False,
+                "methodology": "ois_proxy",
+                "fed_info_factor_source": "daily_window_proxy",
+                "target_source": "band|after:band",
+                "data_version": "test_version_v1",
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _make_events_df(
+    *,
+    event_dates: list[str],
+    assets: list[str],
+    horizons: list[int],
+    abnormal_overrides: dict[tuple[str, str, int], float] | None = None,
+) -> pd.DataFrame:
+    """Build a minimal events frame with one row per ``(date, asset, horizon)``."""
+
+    overrides = abnormal_overrides or {}
+    rows: list[dict] = []
+    for idx, ed in enumerate(event_dates, start=1):
+        for asset in assets:
+            for h in horizons:
+                key = (ed, asset, h)
+                rows.append(
+                    {
+                        "event_date": ed,
+                        "event_kind": "statement",
+                        "document_id": f"doc_{idx}_{asset}_{h}",
+                        "text_hash": f"hash_{idx}",
+                        "source": "scraped_fed",
+                        "source_record_id": f"rec_{idx}_{asset}_{h}",
+                        "as_of_ts": f"{ed}T19:00:00Z",
+                        "text": f"placeholder text for {ed}",
+                        "token_count": 100,
+                        "axis_stance": "neutral",
+                        "axis_time": "neutral",
+                        "axis_certainty": "neutral",
+                        "axis_factor": "neutral",
+                        "axis_topic": "neutral",
+                        "credibility_drift_score": 0.0,
+                        "credibility_realized_vs_stated_gap": 0.0,
+                        "credibility_market_implied_gap": 0.0,
+                        "credibility_months_since_reversal": 6,
+                        "prior_window_sha256": "abc",
+                        "prior_bars_json": "[]",
+                        "asset_symbol": asset,
+                        "horizon": h,
+                        "realized_return": 0.0,
+                        "abnormal_return": overrides.get(key, 0.0),
+                        "alpha": 0.0,
+                        "beta": 1.0,
+                        "direction_t1d": 0,
+                        "volatility_shift": 0.0,
+                        "concurrent_macro_release": False,
+                        "realized_date": ed,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def _make_linguistic_df(event_count: int) -> pd.DataFrame:
+    rows = []
+    for idx in range(1, event_count + 1):
+        row: dict = {"text_hash": f"hash_{idx}"}
+        for axis in (
+            "topic_share_inflation",
+            "topic_share_employment",
+            "topic_share_financial_stability",
+            "topic_share_growth",
+            "topic_share_balance_sheet",
+            "topic_share_misc_1",
+            "topic_share_misc_2",
+            "topic_share_misc_3",
+            "hedge_density",
+            "comparison_density",
+            "forward_density",
+            "concrete_ratio",
+            "hawk_dove_asymmetry",
+            "log_token_count",
+        ):
+            row[axis] = 0.1 * idx
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def _make_macro_df(event_dates: list[str]) -> pd.DataFrame:
+    rows = []
+    for ed in event_dates:
+        d = _dt.date.fromisoformat(ed) - _dt.timedelta(days=1)
+        rows.append(
+            {
+                "as_of_date": d.isoformat(),
+                "unrate": 4.0,
+                "cpi_yoy": 2.0,
+                "core_pce_yoy": 1.8,
+                "ism_proxy": 0.5,
+                "payems_mom": 200.0,
+                "rsafs_mom": 0.3,
+                "ism_proxy_source": "MANEMP_3m_pct",
+                "publication_delay_days": 30,
+                "data_version": "test_v1",
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _make_canonical_meetings() -> list[tuple[str, float, float]]:
+    """Twelve meetings stepping through the 2022-2023 hiking cycle."""
+
+    return [
+        ("2022-01-26", 0.125, 0.125),
+        ("2022-03-16", 0.125, 0.375),
+        ("2022-05-04", 0.375, 0.875),
+        ("2022-06-15", 0.875, 1.625),
+        ("2022-07-27", 1.625, 2.375),
+        ("2022-09-21", 2.375, 3.125),
+        ("2022-11-02", 3.125, 3.875),
+        ("2022-12-14", 3.875, 4.375),
+        ("2023-02-01", 4.375, 4.625),
+        ("2023-03-22", 4.625, 4.875),
+        ("2023-05-03", 4.875, 5.125),
+        ("2023-06-14", 5.125, 5.125),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Supervised row construction
+# ---------------------------------------------------------------------------
+
+
+def test_build_supervised_rows_fans_out_per_asset_per_horizon() -> None:
+    meetings = _make_canonical_meetings()
+    event_dates = [m[0] for m in meetings]
+    assets = ["^GSPC", "^TNX", "XLF"]
+    horizons = [1, 5]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(
+        event_dates=event_dates, assets=assets, horizons=horizons
+    )
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+
+    rows, summary = car.build_supervised_rows(
+        events=events,
+        mp_surprises=mp,
+        linguistic_features=ling,
+        macro_state=macro,
+    )
+
+    # 12 meetings * 3 assets * 2 horizons = 72 supervised rows.
+    expected = len(meetings) * len(assets) * len(horizons)
+    assert summary["rows_emitted"] == expected
+    assert summary["asset_universe"] == sorted(assets)
+    assert summary["horizons"] == sorted(horizons)
+    # Rows arrive sorted by (date, asset, horizon).
+    keys = [(r.feature_event_date, r.asset_symbol, r.horizon) for r in rows]
+    assert keys == sorted(keys)
+
+
+def test_build_supervised_rows_drops_missing_abnormal_return() -> None:
+    """A row whose abnormal_return is NaN must drop, leaving the rest intact."""
+
+    meetings = _make_canonical_meetings()[:3]
+    event_dates = [m[0] for m in meetings]
+    assets = ["^GSPC", "GC=F"]
+    horizons = [1]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(
+        event_dates=event_dates, assets=assets, horizons=horizons
+    )
+    # Corrupt one cell's abnormal_return.
+    mask = (
+        (events["event_date"] == event_dates[1])
+        & (events["asset_symbol"] == "GC=F")
+    )
+    events.loc[mask, "abnormal_return"] = float("nan")
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+
+    rows, summary = car.build_supervised_rows(
+        events=events,
+        mp_surprises=mp,
+        linguistic_features=ling,
+        macro_state=macro,
+    )
+    # 6 - 1 = 5 rows survive.
+    assert summary["rows_emitted"] == 5
+    assert summary["dropped_missing_target"] == 1
+    # The dropped row's (date, asset) pair is absent.
+    missing_keys = {(r.feature_event_date, r.asset_symbol) for r in rows}
+    assert (_dt.date.fromisoformat(event_dates[1]), "GC=F") not in missing_keys
+
+
+def test_build_supervised_rows_honours_asset_filter() -> None:
+    meetings = _make_canonical_meetings()[:4]
+    event_dates = [m[0] for m in meetings]
+    assets = ["^GSPC", "^TNX", "GC=F", "CL=F"]
+    horizons = [1, 5]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(
+        event_dates=event_dates, assets=assets, horizons=horizons
+    )
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+
+    rows, summary = car.build_supervised_rows(
+        events=events,
+        mp_surprises=mp,
+        linguistic_features=ling,
+        macro_state=macro,
+        asset_universe=["^GSPC", "GC=F"],
+        horizons=[1],
+    )
+
+    expected = len(meetings) * 2 * 1
+    assert summary["rows_emitted"] == expected
+    assert set(r.asset_symbol for r in rows) == {"^GSPC", "GC=F"}
+    assert set(r.horizon for r in rows) == {1}
+    # The filter logs dropped counts.
+    assert summary["dropped_unknown_asset"] > 0
+    assert summary["dropped_unknown_horizon"] > 0
+
+
+def test_collapse_events_picks_statement_over_minutes() -> None:
+    """When both kinds exist for a meeting, statement wins."""
+
+    df = pd.DataFrame(
+        [
+            {
+                "event_date": "2022-01-26",
+                "event_kind": "minutes",
+                "asset_symbol": "^GSPC",
+                "horizon": 1,
+                "axis_stance": "neutral",
+                "abnormal_return": 0.1,
+            },
+            {
+                "event_date": "2022-01-26",
+                "event_kind": "statement",
+                "asset_symbol": "^GSPC",
+                "horizon": 1,
+                "axis_stance": "hawkish",
+                "abnormal_return": 0.2,
+            },
+        ]
+    )
+    out = car._collapse_events_to_meeting_axis(df)
+    assert len(out) == 1
+    assert out.iloc[0]["event_kind"] == "statement"
+    assert out.iloc[0]["axis_stance"] == "hawkish"
+
+
+# ---------------------------------------------------------------------------
+# Feature ablation
+# ---------------------------------------------------------------------------
+
+
+def test_feature_ablation_drops_columns() -> None:
+    meetings = _make_canonical_meetings()
+    event_dates = [m[0] for m in meetings]
+    assets = ["^GSPC"]
+    horizons = [1]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(
+        event_dates=event_dates, assets=assets, horizons=horizons
+    )
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+    rows, _ = car.build_supervised_rows(
+        events=events,
+        mp_surprises=mp,
+        linguistic_features=ling,
+        macro_state=macro,
+    )
+
+    X_full, names_full = car._build_feature_matrix(rows, car.FEATURE_FAMILIES)
+    X_ois, names_ois = car._build_feature_matrix(rows, ("ois",))
+    X_no_macro, names_no_macro = car._build_feature_matrix(
+        rows, ("ois", "text", "linguistic", "credibility")
+    )
+
+    # Each ablation removes columns; nothing is silently retained.
+    assert X_ois.shape[1] < X_full.shape[1]
+    assert X_no_macro.shape[1] < X_full.shape[1]
+    assert set(names_ois).issubset(set(names_full))
+    assert set(names_no_macro).issubset(set(names_full))
+    # Dropping macro removes exactly the macro feature columns -- the
+    # set difference matches the documented macro family schema.
+    macro_cols = set(rows[0].feature_names["macro"])
+    assert set(names_full) - set(names_no_macro) == macro_cols
+    # OIS-only keeps exactly the OIS family.
+    assert set(names_ois) == set(rows[0].feature_names["ois"])
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward CV
+# ---------------------------------------------------------------------------
+
+
+def test_walk_forward_cell_produces_n_minus_1_train_rows() -> None:
+    meetings = _make_canonical_meetings()
+    event_dates = [m[0] for m in meetings]
+    assets = ["^GSPC"]
+    horizons = [1]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(
+        event_dates=event_dates, assets=assets, horizons=horizons
+    )
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+    rows, _ = car.build_supervised_rows(
+        events=events,
+        mp_surprises=mp,
+        linguistic_features=ling,
+        macro_state=macro,
+    )
+
+    cell_rows = car._rows_for_cell(rows, asset="^GSPC", horizon=1)
+    preds = car.walk_forward_predict_cell(
+        cell_rows, families=("ois",), include_gbt=False
+    )
+    assert len(preds) == len(cell_rows)
+    assert [p.n_train_rows for p in preds] == list(range(len(cell_rows)))
+    # Every prediction has the two model-free baselines.
+    for p in preds:
+        assert "zero_baseline" in p.predictions
+        assert "ois_bp_baseline" in p.predictions
+
+
+def test_walk_forward_cell_no_look_ahead_assertion() -> None:
+    """The walk-forward routine asserts no-look-ahead internally."""
+
+    meetings = _make_canonical_meetings()
+    event_dates = [m[0] for m in meetings]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(
+        event_dates=event_dates, assets=["^GSPC"], horizons=[1]
+    )
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+    rows, _ = car.build_supervised_rows(
+        events=events,
+        mp_surprises=mp,
+        linguistic_features=ling,
+        macro_state=macro,
+    )
+    cell_rows = car._rows_for_cell(rows, asset="^GSPC", horizon=1)
+    # Confirm: the internal assertion does not fire on well-formed data.
+    car.walk_forward_predict_cell(cell_rows, families=("ois",), include_gbt=False)
+
+    # External cross-check: rebuild a deliberately mis-ordered cell and
+    # verify the internal AssertionError fires.
+    bad = list(cell_rows)
+    bad[0], bad[-1] = bad[-1], bad[0]  # swap first and last
+    with pytest.raises(AssertionError, match="walk-forward leak"):
+        car.walk_forward_predict_cell(bad, families=("ois",), include_gbt=False)
+
+
+def test_walk_forward_cell_ridge_fits_synthetic_linear_target() -> None:
+    """A pure-linear target in the feature subspace lets ridge approximate it.
+
+    We synthesise the abnormal return for ^GSPC as a linear function of
+    the mp_surprise_level + path factor, then check that ridge's
+    out-of-fold MAE is much lower than the zero baseline's MAE on the
+    held-out tail.
+    """
+
+    rng = np.random.default_rng(seed=11)
+    n_meetings = 40
+    base = _dt.date(2018, 1, 1)
+    meetings = []
+    for i in range(n_meetings):
+        d = base + _dt.timedelta(days=42 * i)
+        prior = round(0.25 * (i // 5), 3)
+        after = prior  # no rate move; surprises live in MP-surprise columns
+        meetings.append((d.isoformat(), prior, after))
+
+    mp_df = _make_mp_surprises_df(meetings)
+    # Make mp_surprise_level vary so the linear target has something to
+    # learn against.
+    levels = rng.normal(size=n_meetings)
+    mp_df["mp_surprise_level"] = levels
+
+    event_dates = [m[0] for m in meetings]
+    events = _make_events_df(
+        event_dates=event_dates, assets=["^GSPC"], horizons=[1]
+    )
+    # Target: 0.7 * surprise_level + small noise.
+    noise = rng.normal(scale=0.05, size=n_meetings)
+    abnormals = 0.7 * levels + noise
+    for i, ed in enumerate(event_dates):
+        mask = events["event_date"] == ed
+        events.loc[mask, "abnormal_return"] = float(abnormals[i])
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+
+    rows, _ = car.build_supervised_rows(
+        events=events,
+        mp_surprises=mp_df,
+        linguistic_features=ling,
+        macro_state=macro,
+    )
+    cell_rows = car._rows_for_cell(rows, asset="^GSPC", horizon=1)
+    preds = car.walk_forward_predict_cell(
+        cell_rows, families=("ois",), include_gbt=False
+    )
+
+    # Restrict to the tail half where ridge has enough train rows.
+    tail = preds[len(preds) // 2 :]
+    ridge_mae = np.mean(
+        [
+            abs(p.target - p.predictions["ridge"])
+            for p in tail
+            if "ridge" in p.predictions
+        ]
+    )
+    zero_mae = np.mean([abs(p.target) for p in tail])
+    # Ridge should comfortably beat the zero baseline on the tail half;
+    # 0.7 of the target is in-subspace so a < 0.7 ratio is sufficient.
+    assert ridge_mae < 0.7 * zero_mae
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+def test_compute_cell_metrics_zero_baseline_against_zero_truth() -> None:
+    """Zero predictions vs zero truth -> RMSE 0, R^2 None (zero var)."""
+
+    preds = [
+        car.CellPrediction(
+            feature_event_date="2022-01-26",
+            asset_symbol="^GSPC",
+            horizon=1,
+            target=0.0,
+            n_train_rows=0,
+            predictions={"zero_baseline": 0.0},
+        )
+        for _ in range(5)
+    ]
+    m = car.compute_cell_metrics(preds, "zero_baseline")
+    assert m["n"] == 5
+    assert m["rmse"] == 0.0
+    assert m["mae"] == 0.0
+    assert m["r2"] is None  # zero-variance truth
+
+
+def test_compute_cell_metrics_directional_hit_rate() -> None:
+    """All-positive predictions vs alternating-sign truth -> 50% hit rate."""
+
+    preds = []
+    for i, truth in enumerate([0.1, -0.2, 0.3, -0.4]):
+        preds.append(
+            car.CellPrediction(
+                feature_event_date=f"2022-01-{20 + i:02d}",
+                asset_symbol="^GSPC",
+                horizon=1,
+                target=truth,
+                n_train_rows=i,
+                predictions={"ridge": 0.05},
+            )
+        )
+    m = car.compute_cell_metrics(preds, "ridge")
+    assert m["directional_hit_rate"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Pandemic-window filter
+# ---------------------------------------------------------------------------
+
+
+def test_pandemic_window_filter_excludes_documented_range() -> None:
+    in_window = car.CellPrediction(
+        feature_event_date="2020-05-15",
+        asset_symbol="^GSPC",
+        horizon=1,
+        target=0.0,
+        n_train_rows=10,
+        predictions={"zero_baseline": 0.0},
+    )
+    out_window = car.CellPrediction(
+        feature_event_date="2023-09-20",
+        asset_symbol="^GSPC",
+        horizon=1,
+        target=0.0,
+        n_train_rows=20,
+        predictions={"zero_baseline": 0.0},
+    )
+    # Right at the boundary: PANDEMIC_END (2021-06-30) inclusive.
+    on_boundary = car.CellPrediction(
+        feature_event_date=car.PANDEMIC_END.isoformat(),
+        asset_symbol="^GSPC",
+        horizon=1,
+        target=0.0,
+        n_train_rows=15,
+        predictions={"zero_baseline": 0.0},
+    )
+    filtered = car.filter_predictions_excluding_window(
+        [in_window, out_window, on_boundary],
+        start=car.PANDEMIC_START,
+        end=car.PANDEMIC_END,
+    )
+    assert len(filtered) == 1
+    assert filtered[0].feature_event_date == "2023-09-20"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end run + artifact serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_run_writes_artifacts(tmp_path: Path) -> None:
+    meetings = _make_canonical_meetings()
+    event_dates = [m[0] for m in meetings]
+    assets = ["^GSPC", "^TNX"]
+    horizons = [1, 5]
+    mp = _make_mp_surprises_df(meetings)
+    events = _make_events_df(
+        event_dates=event_dates, assets=assets, horizons=horizons
+    )
+    ling = _make_linguistic_df(len(event_dates))
+    macro = _make_macro_df(event_dates)
+
+    artifacts = car.run(
+        events=events,
+        mp_surprises=mp,
+        linguistic_features=ling,
+        macro_state=macro,
+        output_dir=tmp_path,
+        # The synthetic frame's targets are flat; disable pooled to keep
+        # the run fast and deterministic.
+        include_pooled=False,
+    )
+
+    predictions_path = tmp_path / "predictions.json"
+    metrics_path = tmp_path / "metrics.json"
+    attribution_path = tmp_path / "feature_attribution.md"
+    assert predictions_path.exists()
+    assert metrics_path.exists()
+    assert attribution_path.exists()
+
+    metrics = json.loads(metrics_path.read_text())
+    assert "full_window" in metrics
+    assert "ex_pandemic_window" in metrics
+    assert metrics["asset_universe"] == sorted(assets)
+    assert metrics["horizons"] == sorted(horizons)
+    assert metrics["methodology_source"] == "cross_asset_event_response_v1"
+
+    attribution_text = attribution_path.read_text()
+    assert "ois_only" in attribution_text
+    assert "full" in attribution_text
+    # The headline cell appears in the markdown.
+    assert "^GSPC|h1" in attribution_text
+    assert artifacts.summary["rows_emitted"] > 0
+
+
+def test_ois_baseline_bp_from_mp_row_handles_missing_curve() -> None:
+    """No curve, no signal -- the baseline bp is ``None``."""
+
+    s = pd.Series(
+        {
+            "post_event_curve": None,
+            "ff_target_after": 5.0,
+        }
+    )
+    assert car._ois_baseline_bp_from_mp_row(s) is None
+    # Valid curve and base rate -> a numeric bp signal.
+    s2 = pd.Series(
+        {
+            "post_event_curve": _make_pre_event_curve(5.25),
+            "ff_target_after": 5.0,
+        }
+    )
+    bp = car._ois_baseline_bp_from_mp_row(s2)
+    assert bp is not None
+    assert math.isclose(bp, 25.0, abs_tol=1e-6)


### PR DESCRIPTION
## Summary

- Per-cell ridge + HistGradientBoostingRegressor on `(asset, horizon)` cells; pooled-panel ridge as exploratory comparator
- Reuses next-FOMC feature joins (OIS, text, linguistic, credibility, macro) so cross-asset lift is directly attributable
- Zero-prediction and OIS bp baselines with documented unit caveat for rate-sensitive vs equity cells
- Leave-one-meeting-out walk-forward per cell with strict no-look-ahead assertion
- Pandemic-window ablation excludes 2020-04-01..2021-06-30, same convention as next-FOMC
- Artefacts: predictions.json, metrics.json, feature_attribution.md under data/artifacts/cross_asset/
- CLI `python -m app.forecasting.cross_asset_response` and `make cross-asset` target
- Wiki entry in `06_Deep_Learning_Roadmap.md` Cross-asset response section (separate direct push)

## Test plan

- [ ] `ruff check backend/app/forecasting/cross_asset_response.py tests/unit/test_cross_asset_response.py`
- [ ] `docker compose run --rm backend pytest tests/unit/test_cross_asset_response.py -q`
- [ ] `make cross-asset TRAINING_PACKAGE_ID=<id>` produces the three artefacts and the headline-cell attribution table