### PR TITLE
Phase 8 (#150): Research / Training / Decisions tabs + supporting endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from app.middleware.errors import RunIdMiddleware, register_error_handlers
 from app.schemas import (
     AnalyzeRequest,
     AnalyzeResponse,
+    ArtifactFile,
     DocumentParseResponse,
     DocumentParseUrlRequest,
     FomcCalendarResponse,
@@ -36,8 +37,12 @@ from app.schemas import (
     HistoryEntry,
     HistoryList,
     HistoryRealizedResponse,
+    NextFomcForecastResponse,
+    ResearchArtifactsResponse,
     TrainJobAcceptedResponse,
     TrainJobStatusResponse,
+    TrainJobSummary,
+    TrainJobsListResponse,
 )
 from app.evaluation.xai import attribute_text, to_response as xai_to_response
 from app.services.document_parser import (
@@ -46,7 +51,14 @@ from app.services.document_parser import (
     parse_pdf_stream,
     parse_url,
 )
+from app.services.decision_forecast import load_next_fomc_artifacts
 from app.services.fomc_calendar import get_calendar
+from app.services.research_artifacts import (
+    SECTIONS as RESEARCH_SECTIONS,
+    list_section_files,
+    load_cross_bank_transfer,
+    load_encoder_bakeoff,
+)
 from app.services.forecaster import (
     bootstrap_checkpoint,
     build_feature_vectors,
@@ -568,3 +580,124 @@ async def parse_document(
             detail=f"Unsupported content type {content_type or 'unknown'} (expected PDF or DOCX)",
         )
     return DocumentParseResponse(**parsed.to_dict())
+
+
+# ---------------------------------------------------------------------------
+# Train-jobs listing (multi-page expansion #150)
+# ---------------------------------------------------------------------------
+
+_TRAIN_JOB_SORT_RANK: dict[str, int] = {
+    "running": 0,
+    "queued": 1,
+    "failed": 2,
+    "succeeded": 3,
+}
+
+
+def _train_job_sort_key(state: dict[str, Any]) -> tuple[int, str]:
+    status = str(state.get("status") or "queued").lower()
+    rank = _TRAIN_JOB_SORT_RANK.get(status, 99)
+    # Within a status bucket sort newest-first by created_at; the
+    # fallback empty string keeps the ordering deterministic.
+    created = str(state.get("created_at") or "")
+    return (rank, _invert_iso(created))
+
+
+def _invert_iso(value: str) -> str:
+    """Cheap descending-sort key for ISO timestamps."""
+
+    return "".join(chr(255 - ord(c)) if ord(c) < 255 else c for c in value)
+
+
+@app.get("/train-jobs", response_model=TrainJobsListResponse)
+def list_train_jobs(
+    status: str | None = Query(default=None, description="Filter by status: queued/running/succeeded/failed."),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> TrainJobsListResponse:
+    """List in-process real_train jobs.
+
+    State is in-memory only -- restarting the backend resets the list.
+    This is intentional: the dashboard is observational; durable runs
+    flow through the make targets, not the API.
+    """
+
+    with _train_jobs_lock:
+        snapshot = [dict(state) for state in _train_jobs.values()]
+    if status:
+        wanted = status.strip().lower()
+        snapshot = [s for s in snapshot if str(s.get("status") or "").lower() == wanted]
+    snapshot.sort(key=_train_job_sort_key)
+    total = len(snapshot)
+    sliced = snapshot[offset : offset + limit]
+    items = [
+        TrainJobSummary(
+            job_id=str(state.get("job_id")),
+            status=str(state.get("status") or "queued"),
+            symbol=state.get("symbol"),
+            date=state.get("date"),
+            created_at=state.get("created_at"),
+            started_at=state.get("started_at"),
+            finished_at=state.get("finished_at"),
+            history_length=state.get("history_length"),
+            error=state.get("error"),
+        )
+        for state in sliced
+    ]
+    return TrainJobsListResponse(items=items, total=total, limit=limit, offset=offset)
+
+
+# ---------------------------------------------------------------------------
+# Research artifacts (#150 — /research tab)
+# ---------------------------------------------------------------------------
+
+
+@app.get("/research/artifacts", response_model=ResearchArtifactsResponse)
+def research_artifacts() -> ResearchArtifactsResponse:
+    """Aggregate artefact metadata + parsed shapes for the research tab.
+
+    Missing sections are not an error; the response marks each one
+    unavailable so the dashboard can render an empty state without
+    issuing a second request.
+    """
+
+    artifacts_root = DATA_DIR / "artifacts"
+    sections: dict[str, list[ArtifactFile]] = {}
+    for name in RESEARCH_SECTIONS:
+        infos = list_section_files(artifacts_root, name)
+        sections[name] = [
+            ArtifactFile(
+                relative_path=info.relative_path,
+                size_bytes=info.size_bytes,
+                modified_at=info.modified_at,
+                suffix=info.suffix,
+            )
+            for info in infos
+        ]
+    bakeoff = load_encoder_bakeoff(artifacts_root)
+    transfer = load_cross_bank_transfer(artifacts_root)
+    return ResearchArtifactsResponse(
+        artifacts_root=str(artifacts_root),
+        sections=sections,
+        encoder_bakeoff=bakeoff,  # type: ignore[arg-type]
+        cross_bank_transfer=transfer,  # type: ignore[arg-type]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Next-FOMC decision forecast (#150 — /decisions tab)
+# ---------------------------------------------------------------------------
+
+
+@app.get("/forecasts/next-fomc", response_model=NextFomcForecastResponse)
+def next_fomc_forecast() -> NextFomcForecastResponse:
+    """Read ``data/artifacts/next_fomc/`` for the decisions dashboard.
+
+    Returns ``available: False`` when the forecaster has not been run
+    against this checkout. The dashboard surfaces the empty-state with
+    the documented ``make next-fomc`` instruction in that case.
+    """
+
+    artifacts_dir = DATA_DIR / "artifacts" / "next_fomc"
+    payload = load_next_fomc_artifacts(artifacts_dir)
+    return NextFomcForecastResponse(**payload)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -241,3 +241,164 @@ class DocumentParseResponse(BaseModel):
     char_count: int
     source_kind: str
     source_metadata: dict[str, str]
+
+
+# ---------------------------------------------------------------------------
+# Research / training / decisions endpoints (Phase 8 multi-page expansion)
+# ---------------------------------------------------------------------------
+
+
+class ArtifactFile(BaseModel):
+    """One file under ``data/artifacts/<section>/``."""
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    relative_path: str = Field(..., description="Path relative to data/artifacts/")
+    size_bytes: int
+    modified_at: str = Field(..., description="ISO-8601 mtime, UTC.")
+    suffix: str = Field(..., description="File extension including the dot, e.g. .json")
+
+
+class EncoderBakeoffRow(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    encoder_key: str
+    checkpoint: str
+    seeds: list[int]
+    macro_f1_values: list[float]
+    macro_f1_mean: float
+    macro_f1_ci_low: float | None = None
+    macro_f1_ci_high: float | None = None
+    weighted_f1_mean: float | None = None
+    accuracy_mean: float | None = None
+    cohen_kappa: float | None = None
+
+
+class EncoderBakeoffSection(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    available: bool
+    coverage: float | None = None
+    rows: list[EncoderBakeoffRow] = Field(default_factory=list)
+    source_files: list[str] = Field(default_factory=list)
+
+
+class TransferMatrixCell(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    source: str
+    target: str
+    metric: float
+
+
+class CrossBankTransferSection(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    available: bool
+    metric_name: str = "macro_f1"
+    sources: list[str] = Field(default_factory=list)
+    targets: list[str] = Field(default_factory=list)
+    cells: list[TransferMatrixCell] = Field(default_factory=list)
+    source_files: list[str] = Field(default_factory=list)
+
+
+class ResearchArtifactsResponse(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    artifacts_root: str
+    sections: dict[str, list[ArtifactFile]]
+    encoder_bakeoff: EncoderBakeoffSection
+    cross_bank_transfer: CrossBankTransferSection
+
+
+class TrainJobSummary(BaseModel):
+    """Subset of train-job state safe for listing.
+
+    Same fields :data:`_train_jobs` exposes through ``/train-jobs/{id}``
+    but stripped of the full ``result`` payload so the list response
+    stays cheap. The detail endpoint still returns the full state.
+    """
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    job_id: str
+    status: str
+    symbol: str | None = None
+    date: str | None = None
+    created_at: str | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
+    history_length: int | None = None
+    error: str | None = None
+
+
+class TrainJobsListResponse(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    items: list[TrainJobSummary]
+    total: int
+    limit: int
+    offset: int
+
+
+class NextFomcMeetingPrediction(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    target_event_date: str
+    target_as_of_ts: str
+    target_class: str | None = Field(
+        default=None,
+        description="Realised class, when known. None for the next-scheduled meeting.",
+    )
+    n_train_rows: int
+    probabilities: dict[str, dict[str, float]]
+    predicted_class: dict[str, str]
+
+
+class NextFomcModelMetrics(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    n: int
+    brier: float | None = None
+    log_loss: float | None = None
+    top1_accuracy: float | None = None
+    macro_f1: float | None = None
+    confusion_matrix: dict[str, dict[str, int]] = Field(default_factory=dict)
+
+
+class NextFomcAttributionRow(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    subset: str
+    families: list[str]
+    n_features: int | None = None
+    n: int | None = None
+    brier: float | None = None
+    log_loss: float | None = None
+    top1_accuracy: float | None = None
+    macro_f1: float | None = None
+
+
+class NextFomcUpcomingMeeting(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    meeting_date: str
+    meeting_type: str
+    statement_release_date: str | None = None
+    days_until: int | None = None
+
+
+class NextFomcForecastResponse(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    available: bool
+    artifacts_dir: str
+    ordinal_classes: list[str]
+    model_names: list[str] = Field(default_factory=list)
+    upcoming_meeting: NextFomcUpcomingMeeting | None = None
+    headline: NextFomcMeetingPrediction | None = None
+    history: list[NextFomcMeetingPrediction] = Field(default_factory=list)
+    metrics_full_window: dict[str, NextFomcModelMetrics] = Field(default_factory=dict)
+    metrics_ex_pandemic: dict[str, NextFomcModelMetrics] = Field(default_factory=dict)
+    feature_attribution: list[NextFomcAttributionRow] = Field(default_factory=list)
+    summary: dict[str, int] = Field(default_factory=dict)

--- a/backend/app/services/decision_forecast.py
+++ b/backend/app/services/decision_forecast.py
@@ -190,7 +190,7 @@ def load_next_fomc_artifacts(
         return base_response
 
     predictions_raw: list[dict[str, Any]] = list(results.get("predictions") or [])
-    summary = {k: int(v) for k, v in (results.get("summary") or {}).items() if isinstance(v, (int, float))}
+    summary = {k: int(v) for k, v in (results.get("summary") or {}).items() if isinstance(v, int | float)}
 
     # Decode each prediction; tolerate missing fields.
     decoded: list[_PredictedDecision] = []

--- a/backend/app/services/decision_forecast.py
+++ b/backend/app/services/decision_forecast.py
@@ -1,0 +1,310 @@
+"""Read-only loader for the next-FOMC-decision artifacts.
+
+The forecaster at :mod:`app.forecasting.next_fomc_decision` writes
+``results.json``, ``metrics.json``, and ``feature_attribution.md`` into
+``data/artifacts/next_fomc/`` after a CLI run. This module reads those
+files for the /decisions dashboard.
+
+When the directory is absent the loader returns an ``available: False``
+shape rather than raising -- the dashboard surfaces a documented
+empty-state.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from app.forecasting.next_fomc_decision import ORDINAL_CLASSES
+from app.services.fomc_calendar import list_all_meetings
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _PredictedDecision:
+    target_event_date: str
+    target_as_of_ts: str
+    target_class: str | None
+    n_train_rows: int
+    probabilities: dict[str, dict[str, float]]
+
+
+def _argmax_class(probs: dict[str, float]) -> str:
+    """Return the class with the highest probability."""
+
+    if not probs:
+        return ""
+    return max(probs.items(), key=lambda kv: kv[1])[0]
+
+
+def _predicted_class_per_model(
+    probabilities: dict[str, dict[str, float]],
+) -> dict[str, str]:
+    return {model: _argmax_class(probs) for model, probs in probabilities.items()}
+
+
+def _next_scheduled_after(reference: date) -> dict[str, Any] | None:
+    """Pick the next scheduled meeting strictly after ``reference``.
+
+    Returns a dict shaped for :class:`NextFomcUpcomingMeeting` or
+    ``None`` when no future meeting is on the calendar.
+    """
+
+    for meeting in list_all_meetings():
+        if meeting.meeting_date >= reference:
+            return {
+                "meeting_date": meeting.meeting_date.isoformat(),
+                "meeting_type": meeting.meeting_type,
+                "statement_release_date": (
+                    meeting.statement_release_date.isoformat()
+                    if meeting.statement_release_date
+                    else None
+                ),
+                "days_until": (meeting.meeting_date - reference).days,
+            }
+    return None
+
+
+_MARKDOWN_TABLE_HEADER_RE = re.compile(r"^\|\s*Subset\s*\|", re.IGNORECASE)
+
+
+def _parse_feature_attribution_markdown(text: str) -> list[dict[str, Any]]:
+    """Parse the ablation table emitted by ``_format_attribution_md``.
+
+    Returns one dict per table row with the same keys as
+    :class:`NextFomcAttributionRow`.
+    """
+
+    rows: list[dict[str, Any]] = []
+    lines = text.splitlines()
+    table_started = False
+    headers: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            if table_started:
+                # Table ended; bail out.
+                break
+            continue
+        if _MARKDOWN_TABLE_HEADER_RE.match(stripped):
+            headers = [c.strip().lower() for c in _split_pipe_row(stripped)]
+            table_started = True
+            continue
+        if not table_started:
+            continue
+        if set(stripped) <= set("|- "):
+            # Divider row.
+            continue
+        cells = _split_pipe_row(stripped)
+        if len(cells) != len(headers):
+            continue
+        record = dict(zip(headers, cells))
+        rows.append(
+            {
+                "subset": record.get("subset", ""),
+                "families": [
+                    f.strip() for f in str(record.get("families", "")).split(",") if f.strip()
+                ],
+                "n_features": _maybe_int(record.get("#features")),
+                "n": _maybe_int(record.get("n")),
+                "brier": _maybe_float(record.get("brier")),
+                "log_loss": _maybe_float(record.get("logloss")),
+                "top1_accuracy": _maybe_float(record.get("top1acc")),
+                "macro_f1": _maybe_float(record.get("macrof1")),
+            }
+        )
+    return rows
+
+
+def _split_pipe_row(line: str) -> list[str]:
+    parts = line.strip().strip("|").split("|")
+    return [p.strip() for p in parts]
+
+
+def _maybe_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _maybe_float(value: Any) -> float | None:
+    if value is None or value == "None":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def load_next_fomc_artifacts(
+    artifacts_dir: Path, *, reference_date: date | None = None
+) -> dict[str, Any]:
+    """Load + assemble the next-FOMC decision dashboard payload.
+
+    Reads ``results.json`` / ``metrics.json`` / ``feature_attribution.md``
+    from ``artifacts_dir``. Returns a dict matching
+    :class:`NextFomcForecastResponse`. The dashboard renders an
+    empty-state when ``available`` is False.
+    """
+
+    reference = reference_date or date.today()
+    upcoming = _next_scheduled_after(reference)
+
+    base_response = {
+        "available": False,
+        "artifacts_dir": str(artifacts_dir),
+        "ordinal_classes": list(ORDINAL_CLASSES),
+        "model_names": [],
+        "upcoming_meeting": upcoming,
+        "headline": None,
+        "history": [],
+        "metrics_full_window": {},
+        "metrics_ex_pandemic": {},
+        "feature_attribution": [],
+        "summary": {},
+    }
+
+    if not artifacts_dir.is_dir():
+        return base_response
+
+    results_path = artifacts_dir / "results.json"
+    metrics_path = artifacts_dir / "metrics.json"
+    attribution_path = artifacts_dir / "feature_attribution.md"
+
+    if not results_path.exists():
+        return base_response
+
+    try:
+        results = json.loads(results_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        LOGGER.warning("decision_forecast: failed to parse %s: %s", results_path, exc)
+        return base_response
+
+    predictions_raw: list[dict[str, Any]] = list(results.get("predictions") or [])
+    summary = {k: int(v) for k, v in (results.get("summary") or {}).items() if isinstance(v, (int, float))}
+
+    # Decode each prediction; tolerate missing fields.
+    decoded: list[_PredictedDecision] = []
+    for entry in predictions_raw:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            decoded.append(
+                _PredictedDecision(
+                    target_event_date=str(entry["target_event_date"]),
+                    target_as_of_ts=str(entry["target_as_of_ts"]),
+                    target_class=(
+                        str(entry["target_class"]) if entry.get("target_class") is not None else None
+                    ),
+                    n_train_rows=int(entry.get("n_train_rows", 0)),
+                    probabilities={
+                        str(model): {str(cls): float(p) for cls, p in (probs or {}).items()}
+                        for model, probs in (entry.get("probabilities") or {}).items()
+                    },
+                )
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+
+    decoded.sort(key=lambda d: d.target_event_date)
+    history = [
+        {
+            "target_event_date": d.target_event_date,
+            "target_as_of_ts": d.target_as_of_ts,
+            "target_class": d.target_class,
+            "n_train_rows": d.n_train_rows,
+            "probabilities": d.probabilities,
+            "predicted_class": _predicted_class_per_model(d.probabilities),
+        }
+        for d in decoded
+    ]
+
+    headline_payload: dict[str, Any] | None = None
+    if history:
+        # Prefer the prediction whose target_event_date matches the next
+        # upcoming meeting; otherwise fall back to the latest entry.
+        upcoming_iso = upcoming["meeting_date"] if upcoming else None
+        matched = next(
+            (h for h in history if h["target_event_date"] == upcoming_iso),
+            None,
+        )
+        headline_payload = matched if matched is not None else history[-1]
+
+    metrics_full: dict[str, Any] = {}
+    metrics_ex_pandemic: dict[str, Any] = {}
+    model_names: list[str] = []
+    if metrics_path.exists():
+        try:
+            metrics_payload = json.loads(metrics_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            LOGGER.warning("decision_forecast: failed to parse %s: %s", metrics_path, exc)
+            metrics_payload = {}
+        model_names = list(metrics_payload.get("model_names") or [])
+        metrics_full = _coerce_metrics(metrics_payload.get("full_window") or {})
+        metrics_ex_pandemic = _coerce_metrics(
+            metrics_payload.get("ex_pandemic_window") or {}
+        )
+
+    feature_attribution: list[dict[str, Any]] = []
+    if attribution_path.exists():
+        try:
+            feature_attribution = _parse_feature_attribution_markdown(
+                attribution_path.read_text(encoding="utf-8")
+            )
+        except OSError as exc:
+            LOGGER.warning(
+                "decision_forecast: failed to read %s: %s", attribution_path, exc
+            )
+
+    return {
+        "available": True,
+        "artifacts_dir": str(artifacts_dir),
+        "ordinal_classes": list(ORDINAL_CLASSES),
+        "model_names": model_names,
+        "upcoming_meeting": upcoming,
+        "headline": headline_payload,
+        "history": history,
+        "metrics_full_window": metrics_full,
+        "metrics_ex_pandemic": metrics_ex_pandemic,
+        "feature_attribution": feature_attribution,
+        "summary": summary,
+    }
+
+
+def _coerce_metrics(payload: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for model_name, value in payload.items():
+        if not isinstance(value, dict):
+            continue
+        out[str(model_name)] = {
+            "n": _maybe_int(value.get("n")) or 0,
+            "brier": _maybe_float(value.get("brier")),
+            "log_loss": _maybe_float(value.get("log_loss")),
+            "top1_accuracy": _maybe_float(value.get("top1_accuracy")),
+            "macro_f1": _maybe_float(value.get("macro_f1")),
+            "confusion_matrix": _coerce_confusion_matrix(value.get("confusion_matrix")),
+        }
+    return out
+
+
+def _coerce_confusion_matrix(value: Any) -> dict[str, dict[str, int]]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, dict[str, int]] = {}
+    for truth_class, row in value.items():
+        if not isinstance(row, dict):
+            continue
+        out[str(truth_class)] = {
+            str(pred_class): _maybe_int(count) or 0
+            for pred_class, count in row.items()
+        }
+    return out

--- a/backend/app/services/research_artifacts.py
+++ b/backend/app/services/research_artifacts.py
@@ -1,0 +1,292 @@
+"""Read-only index over ``data/artifacts/`` for the /research dashboard.
+
+The Phase 8 bake-off + cross-bank scripts write JSON under three
+directories (``phase3/``, ``cross_bank/``, ``cross_asset/``). This
+module walks those directories, captures lightweight per-file
+metadata, and parses the well-known shapes the dashboard renders:
+
+* ``phase3/**/aggregate.json`` -- per-encoder macro-F1 (the bake-off
+  aggregator emits one per seed batch).
+* ``cross_bank/**/transfer_matrix.json`` -- source->target heatmap
+  cells. We accept both ``cells`` arrays and dense matrix dicts.
+
+Missing files are not errors -- the response simply marks the section
+unavailable so the UI can render an empty state.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+LOGGER = logging.getLogger(__name__)
+
+SECTIONS: tuple[str, ...] = ("phase3", "cross_bank", "cross_asset", "next_fomc")
+
+
+@dataclass(frozen=True)
+class ArtifactFileInfo:
+    relative_path: str
+    size_bytes: int
+    modified_at: str
+    suffix: str
+
+
+def list_section_files(artifacts_root: Path, section: str) -> list[ArtifactFileInfo]:
+    """List every file under ``<root>/<section>/`` with basic metadata.
+
+    Returned paths are relative to ``artifacts_root``. Hidden files and
+    empty directories are skipped. A missing section directory returns
+    an empty list -- this is the empty-state contract.
+    """
+
+    section_dir = artifacts_root / section
+    if not section_dir.is_dir():
+        return []
+    out: list[ArtifactFileInfo] = []
+    for path in sorted(section_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.name.startswith("."):
+            continue
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        out.append(
+            ArtifactFileInfo(
+                relative_path=str(path.relative_to(artifacts_root)),
+                size_bytes=int(stat.st_size),
+                modified_at=datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+                suffix=path.suffix.lower(),
+            )
+        )
+    return out
+
+
+def _iter_aggregate_files(artifacts_root: Path) -> Iterable[Path]:
+    section_dir = artifacts_root / "phase3"
+    if not section_dir.is_dir():
+        return
+    yield from sorted(section_dir.rglob("aggregate.json"))
+
+
+def load_encoder_bakeoff(artifacts_root: Path) -> dict[str, Any]:
+    """Aggregate per-encoder macro-F1 across phase3/**/aggregate.json files.
+
+    Returns a dict with ``available``, ``coverage``, ``rows``, and
+    ``source_files``. ``rows`` is a list of dicts shaped like
+    :class:`EncoderBakeoffRow` (see ``app.schemas``). When no aggregate
+    files exist, ``available`` is False and ``rows`` is empty.
+    """
+
+    files = list(_iter_aggregate_files(artifacts_root))
+    if not files:
+        return {
+            "available": False,
+            "coverage": None,
+            "rows": [],
+            "source_files": [],
+        }
+
+    by_encoder: dict[str, dict[str, Any]] = {}
+    coverage: float | None = None
+    source_files: list[str] = []
+    for path in files:
+        source_files.append(str(path.relative_to(artifacts_root)))
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            LOGGER.warning("research_artifacts: failed to parse %s: %s", path, exc)
+            continue
+        if coverage is None and "coverage" in payload:
+            try:
+                coverage = float(payload["coverage"])
+            except (TypeError, ValueError):
+                coverage = None
+        for encoder_key, encoder_payload in (payload.get("by_encoder") or {}).items():
+            bucket = by_encoder.setdefault(
+                encoder_key,
+                {
+                    "encoder_key": encoder_key,
+                    "checkpoint": str(encoder_payload.get("checkpoint", "")),
+                    "seeds": [],
+                    "macro_f1_values": [],
+                    "weighted_f1_values": [],
+                    "accuracy_values": [],
+                    "cohen_kappa_values": [],
+                },
+            )
+            for seed_str, per_seed in (encoder_payload.get("per_seed") or {}).items():
+                try:
+                    seed_int = int(seed_str)
+                except (TypeError, ValueError):
+                    continue
+                if seed_int in bucket["seeds"]:
+                    continue
+                bucket["seeds"].append(seed_int)
+                bucket["macro_f1_values"].append(_safe_float(per_seed.get("macro_f1")))
+                bucket["weighted_f1_values"].append(_safe_float(per_seed.get("weighted_f1")))
+                bucket["accuracy_values"].append(_safe_float(per_seed.get("accuracy")))
+                kappa = per_seed.get("cohen_kappa")
+                if kappa is not None:
+                    bucket["cohen_kappa_values"].append(_safe_float(kappa))
+            # Some aggregates also expose a confidence interval.
+            ci = encoder_payload.get("macro_f1_ci") or {}
+            if ci and "ci_low" not in bucket:
+                bucket["ci_low"] = _safe_float_or_none(ci.get("low"))
+                bucket["ci_high"] = _safe_float_or_none(ci.get("high"))
+
+    rows: list[dict[str, Any]] = []
+    for encoder_key in sorted(by_encoder):
+        bucket = by_encoder[encoder_key]
+        macro_vals = bucket["macro_f1_values"]
+        rows.append(
+            {
+                "encoder_key": encoder_key,
+                "checkpoint": bucket["checkpoint"],
+                "seeds": list(bucket["seeds"]),
+                "macro_f1_values": list(macro_vals),
+                "macro_f1_mean": _mean_or_zero(macro_vals),
+                "macro_f1_ci_low": bucket.get("ci_low"),
+                "macro_f1_ci_high": bucket.get("ci_high"),
+                "weighted_f1_mean": _mean_or_zero(bucket["weighted_f1_values"]),
+                "accuracy_mean": _mean_or_zero(bucket["accuracy_values"]),
+                "cohen_kappa": _mean_or_none(bucket["cohen_kappa_values"]),
+            }
+        )
+
+    return {
+        "available": True,
+        "coverage": coverage if coverage is not None else 0.95,
+        "rows": rows,
+        "source_files": source_files,
+    }
+
+
+def load_cross_bank_transfer(artifacts_root: Path) -> dict[str, Any]:
+    """Read transfer-matrix JSON files under ``cross_bank/``.
+
+    Accepts two shapes:
+
+    * ``{"sources": [...], "targets": [...], "cells": [{"source", "target", "metric"}, ...]}``
+    * ``{"matrix": {"source": {"target": 0.42, ...}, ...}, "metric_name": "macro_f1"}``
+
+    Returns the cell-list normalised form.
+    """
+
+    section_dir = artifacts_root / "cross_bank"
+    if not section_dir.is_dir():
+        return {
+            "available": False,
+            "metric_name": "macro_f1",
+            "sources": [],
+            "targets": [],
+            "cells": [],
+            "source_files": [],
+        }
+    files = sorted(section_dir.rglob("transfer_matrix.json"))
+    if not files:
+        return {
+            "available": False,
+            "metric_name": "macro_f1",
+            "sources": [],
+            "targets": [],
+            "cells": [],
+            "source_files": [],
+        }
+
+    sources: list[str] = []
+    targets: list[str] = []
+    cells: list[dict[str, Any]] = []
+    metric_name = "macro_f1"
+    source_files: list[str] = []
+    for path in files:
+        source_files.append(str(path.relative_to(artifacts_root)))
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            LOGGER.warning("research_artifacts: failed to parse %s: %s", path, exc)
+            continue
+        metric_name = str(payload.get("metric_name", metric_name))
+        if "cells" in payload:
+            for cell in payload["cells"]:
+                try:
+                    cells.append(
+                        {
+                            "source": str(cell["source"]),
+                            "target": str(cell["target"]),
+                            "metric": _safe_float(cell.get("metric")),
+                        }
+                    )
+                except (KeyError, TypeError):
+                    continue
+            for src in payload.get("sources", []):
+                if str(src) not in sources:
+                    sources.append(str(src))
+            for tgt in payload.get("targets", []):
+                if str(tgt) not in targets:
+                    targets.append(str(tgt))
+        elif "matrix" in payload:
+            matrix = payload["matrix"]
+            if not isinstance(matrix, dict):
+                continue
+            for src, row in matrix.items():
+                if not isinstance(row, dict):
+                    continue
+                if str(src) not in sources:
+                    sources.append(str(src))
+                for tgt, value in row.items():
+                    if str(tgt) not in targets:
+                        targets.append(str(tgt))
+                    cells.append(
+                        {
+                            "source": str(src),
+                            "target": str(tgt),
+                            "metric": _safe_float(value),
+                        }
+                    )
+
+    return {
+        "available": bool(cells),
+        "metric_name": metric_name,
+        "sources": sources,
+        "targets": targets,
+        "cells": cells,
+        "source_files": source_files,
+    }
+
+
+def _safe_float(value: Any) -> float:
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _safe_float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _mean_or_zero(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    return float(sum(values) / len(values))
+
+
+def _mean_or_none(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return float(sum(values) / len(values))

--- a/frontend/components/shell/header.tsx
+++ b/frontend/components/shell/header.tsx
@@ -1,5 +1,16 @@
 import Link from "next/link";
-import { Activity, BookOpen, Calendar, GitCompare, Github, History as HistoryIcon, LineChart } from "lucide-react";
+import {
+  Activity,
+  BookOpen,
+  Calendar,
+  Cpu,
+  FlaskConical,
+  GitCompare,
+  Github,
+  Gavel,
+  History as HistoryIcon,
+  LineChart,
+} from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -7,6 +18,9 @@ import { ThemeToggle } from "@/components/theme-toggle";
 
 const NAV_ITEMS: Array<{ href: string; label: string; icon: React.ComponentType<{ className?: string }> }> = [
   { href: "/analyze", label: "Analyze", icon: Activity },
+  { href: "/research", label: "Research", icon: FlaskConical },
+  { href: "/training", label: "Training", icon: Cpu },
+  { href: "/decisions", label: "Decisions", icon: Gavel },
   { href: "/history", label: "History", icon: HistoryIcon },
   { href: "/compare", label: "Compare", icon: GitCompare },
   { href: "/performance", label: "Performance", icon: LineChart },

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -7,7 +7,11 @@ import type {
   HistoryList,
   HistoryQuery,
   HistoryRealizedResponse,
+  NextFomcForecastResponse,
+  ResearchArtifactsResponse,
   TrainJobState,
+  TrainJobSummary,
+  TrainJobsListResponse,
 } from "./types";
 
 export function resolveApiBaseUrl(): string {
@@ -84,4 +88,34 @@ export async function fetchFomcCalendar(
 ): Promise<FomcCalendarResponse> {
   const response = await axios.get(`${baseUrl}/fomc/calendar`, { params });
   return response.data as FomcCalendarResponse;
+}
+
+export async function fetchResearchArtifacts(
+  baseUrl: string
+): Promise<ResearchArtifactsResponse> {
+  const response = await axios.get(`${baseUrl}/research/artifacts`);
+  return response.data as ResearchArtifactsResponse;
+}
+
+export async function fetchTrainJobs(
+  baseUrl: string,
+  params?: { status?: string; limit?: number; offset?: number }
+): Promise<TrainJobsListResponse> {
+  const response = await axios.get(`${baseUrl}/train-jobs`, { params });
+  return response.data as TrainJobsListResponse;
+}
+
+export async function fetchTrainJobDetail(
+  baseUrl: string,
+  jobId: string
+): Promise<TrainJobState & TrainJobSummary> {
+  const response = await axios.get(`${baseUrl}/train-jobs/${jobId}`);
+  return response.data as TrainJobState & TrainJobSummary;
+}
+
+export async function fetchNextFomcForecast(
+  baseUrl: string
+): Promise<NextFomcForecastResponse> {
+  const response = await axios.get(`${baseUrl}/forecasts/next-fomc`);
+  return response.data as NextFomcForecastResponse;
 }

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -207,3 +207,143 @@ export interface FomcCalendarResponse {
   past: FomcMeeting[];
   upcoming: FomcMeeting[];
 }
+
+// ---------------------------------------------------------------------------
+// Research dashboard (Phase 8 multi-page expansion)
+// ---------------------------------------------------------------------------
+
+export interface ArtifactFile {
+  relative_path: string;
+  size_bytes: number;
+  modified_at: string;
+  suffix: string;
+}
+
+export interface EncoderBakeoffRow {
+  encoder_key: string;
+  checkpoint: string;
+  seeds: number[];
+  macro_f1_values: number[];
+  macro_f1_mean: number;
+  macro_f1_ci_low: number | null;
+  macro_f1_ci_high: number | null;
+  weighted_f1_mean: number | null;
+  accuracy_mean: number | null;
+  cohen_kappa: number | null;
+}
+
+export interface EncoderBakeoffSection {
+  available: boolean;
+  coverage: number | null;
+  rows: EncoderBakeoffRow[];
+  source_files: string[];
+}
+
+export interface TransferMatrixCell {
+  source: string;
+  target: string;
+  metric: number;
+}
+
+export interface CrossBankTransferSection {
+  available: boolean;
+  metric_name: string;
+  sources: string[];
+  targets: string[];
+  cells: TransferMatrixCell[];
+  source_files: string[];
+}
+
+export interface ResearchArtifactsResponse {
+  artifacts_root: string;
+  sections: Record<string, ArtifactFile[]>;
+  encoder_bakeoff: EncoderBakeoffSection;
+  cross_bank_transfer: CrossBankTransferSection;
+}
+
+// ---------------------------------------------------------------------------
+// Training dashboard
+// ---------------------------------------------------------------------------
+
+export type TrainJobStatus = "queued" | "running" | "succeeded" | "failed";
+
+export interface TrainJobSummary {
+  job_id: string;
+  status: TrainJobStatus | string;
+  symbol: string | null;
+  date: string | null;
+  created_at: string | null;
+  started_at: string | null;
+  finished_at: string | null;
+  history_length: number | null;
+  error: string | null;
+}
+
+export interface TrainJobsListResponse {
+  items: TrainJobSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+// ---------------------------------------------------------------------------
+// Decisions dashboard
+// ---------------------------------------------------------------------------
+
+export type OrdinalDecisionClass =
+  | "cut_50"
+  | "cut_25"
+  | "hold"
+  | "hike_25"
+  | "hike_50"
+  | "hike_75";
+
+export interface NextFomcMeetingPrediction {
+  target_event_date: string;
+  target_as_of_ts: string;
+  target_class: string | null;
+  n_train_rows: number;
+  probabilities: Record<string, Record<string, number>>;
+  predicted_class: Record<string, string>;
+}
+
+export interface NextFomcModelMetrics {
+  n: number;
+  brier: number | null;
+  log_loss: number | null;
+  top1_accuracy: number | null;
+  macro_f1: number | null;
+  confusion_matrix: Record<string, Record<string, number>>;
+}
+
+export interface NextFomcAttributionRow {
+  subset: string;
+  families: string[];
+  n_features: number | null;
+  n: number | null;
+  brier: number | null;
+  log_loss: number | null;
+  top1_accuracy: number | null;
+  macro_f1: number | null;
+}
+
+export interface NextFomcUpcomingMeeting {
+  meeting_date: string;
+  meeting_type: string;
+  statement_release_date: string | null;
+  days_until: number | null;
+}
+
+export interface NextFomcForecastResponse {
+  available: boolean;
+  artifacts_dir: string;
+  ordinal_classes: string[];
+  model_names: string[];
+  upcoming_meeting: NextFomcUpcomingMeeting | null;
+  headline: NextFomcMeetingPrediction | null;
+  history: NextFomcMeetingPrediction[];
+  metrics_full_window: Record<string, NextFomcModelMetrics>;
+  metrics_ex_pandemic: Record<string, NextFomcModelMetrics>;
+  feature_attribution: NextFomcAttributionRow[];
+  summary: Record<string, number>;
+}

--- a/frontend/pages/decisions.tsx
+++ b/frontend/pages/decisions.tsx
@@ -1,0 +1,466 @@
+import * as React from "react";
+import Head from "next/head";
+import { Gavel } from "lucide-react";
+import { toast } from "sonner";
+
+import { Header } from "@/components/shell/header";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { fetchNextFomcForecast, resolveApiBaseUrl } from "@/lib/analyze/api";
+import type {
+  NextFomcForecastResponse,
+  NextFomcMeetingPrediction,
+} from "@/lib/analyze/types";
+
+const ORDINAL_LABELS: Record<string, string> = {
+  cut_50: "Cut 50",
+  cut_25: "Cut 25",
+  hold: "Hold",
+  hike_25: "Hike 25",
+  hike_50: "Hike 50",
+  hike_75: "Hike 75",
+};
+
+const ORDINAL_BPS: Record<string, number> = {
+  cut_50: -50,
+  cut_25: -25,
+  hold: 0,
+  hike_25: 25,
+  hike_50: 50,
+  hike_75: 75,
+};
+
+const PRIMARY_MODEL_PREFERENCE = ["ordinal_logit", "hist_gbt", "ois_baseline", "naive_carry"];
+
+function pickPrimaryModel(modelNames: string[]): string {
+  for (const candidate of PRIMARY_MODEL_PREFERENCE) {
+    if (modelNames.includes(candidate)) return candidate;
+  }
+  return modelNames[0] ?? "";
+}
+
+function formatPercent(value: number | null | undefined, digits: number = 1): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return `${(value * 100).toFixed(digits)}%`;
+}
+
+function formatNumber(value: number | null | undefined, digits: number = 3): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return value.toFixed(digits);
+}
+
+function ProbabilityBar({
+  probabilities,
+  ordinalClasses,
+}: {
+  probabilities: Record<string, number>;
+  ordinalClasses: string[];
+}) {
+  // Compute the expected bp for the secondary line.
+  const expectedBp = ordinalClasses.reduce((acc, cls) => {
+    const prob = probabilities[cls] ?? 0;
+    return acc + prob * (ORDINAL_BPS[cls] ?? 0);
+  }, 0);
+  return (
+    <div className="space-y-2">
+      <div className="flex h-7 w-full overflow-hidden rounded-md border border-border">
+        {ordinalClasses.map((cls) => {
+          const p = probabilities[cls] ?? 0;
+          if (p <= 0) return null;
+          const bp = ORDINAL_BPS[cls] ?? 0;
+          const bg =
+            bp < 0
+              ? `rgba(56, 189, 248, ${0.2 + Math.abs(bp) / 90})`
+              : bp > 0
+              ? `rgba(244, 114, 182, ${0.2 + bp / 90})`
+              : "rgba(148, 163, 184, 0.45)";
+          return (
+            <div
+              key={cls}
+              title={`${ORDINAL_LABELS[cls] ?? cls}: ${(p * 100).toFixed(1)}%`}
+              style={{ width: `${p * 100}%`, backgroundColor: bg }}
+            />
+          );
+        })}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Expected move:{" "}
+        <span className="font-mono">{expectedBp >= 0 ? "+" : ""}{expectedBp.toFixed(1)} bp</span>
+      </p>
+    </div>
+  );
+}
+
+function HeadlineCard({
+  data,
+  primaryModel,
+}: {
+  data: NextFomcForecastResponse;
+  primaryModel: string;
+}) {
+  const headline = data.headline;
+  if (!headline) return null;
+  const probabilities = headline.probabilities[primaryModel] ?? {};
+  const predictedClass = headline.predicted_class[primaryModel] ?? "—";
+  const baselineProbabilities = headline.probabilities["ois_baseline"] ?? null;
+  const upcoming = data.upcoming_meeting;
+  return (
+    <Card>
+      <CardHeader className="space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <CardTitle>Next meeting</CardTitle>
+          {upcoming ? (
+            <Badge variant="outline" className="font-mono text-xs">
+              {upcoming.meeting_date}
+              {upcoming.days_until != null ? ` · in ${upcoming.days_until}d` : ""}
+            </Badge>
+          ) : null}
+        </div>
+        <CardDescription>
+          Model: <span className="font-mono">{primaryModel}</span>. Predicted:{" "}
+          <span className="font-mono font-semibold">{ORDINAL_LABELS[predictedClass] ?? predictedClass}</span>
+          {" · "}
+          confidence{" "}
+          <span className="font-mono">{formatPercent(probabilities[predictedClass])}</span>.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-1.5">
+          <h4 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {primaryModel}
+          </h4>
+          <ProbabilityBar probabilities={probabilities} ordinalClasses={data.ordinal_classes} />
+        </div>
+        {baselineProbabilities && primaryModel !== "ois_baseline" ? (
+          <div className="space-y-1.5">
+            <h4 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              OIS-implied baseline
+            </h4>
+            <ProbabilityBar
+              probabilities={baselineProbabilities}
+              ordinalClasses={data.ordinal_classes}
+            />
+          </div>
+        ) : null}
+        <div className="grid grid-cols-6 gap-1.5 text-center">
+          {data.ordinal_classes.map((cls) => (
+            <div key={cls} className="rounded-md border border-border p-2">
+              <p className="text-xs text-muted-foreground">{ORDINAL_LABELS[cls] ?? cls}</p>
+              <p className="font-mono text-sm font-semibold">
+                {formatPercent(probabilities[cls])}
+              </p>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function HistoryTable({
+  history,
+  primaryModel,
+}: {
+  history: NextFomcMeetingPrediction[];
+  primaryModel: string;
+}) {
+  const recent = history.slice(-12).reverse();
+  const resolved = recent.filter((entry) => entry.target_class != null);
+  const hits = resolved.filter(
+    (entry) => entry.predicted_class[primaryModel] === entry.target_class
+  );
+  const hitRate = resolved.length > 0 ? hits.length / resolved.length : null;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Past 12 meetings</CardTitle>
+        <CardDescription>
+          {primaryModel} hit-rate over the last 12 meetings:{" "}
+          <span className="font-mono">{formatPercent(hitRate)}</span>{" "}
+          ({hits.length}/{resolved.length})
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        {recent.length === 0 ? (
+          <p className="px-4 py-6 text-center text-sm text-muted-foreground">No history yet.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-4 py-2 text-left">Meeting</th>
+                <th className="px-4 py-2 text-left">Realised</th>
+                <th className="px-4 py-2 text-left">Predicted</th>
+                <th className="px-4 py-2 text-right">P(predicted)</th>
+                <th className="px-4 py-2 text-center">Hit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recent.map((entry) => {
+                const predicted = entry.predicted_class[primaryModel] ?? "—";
+                const p = entry.probabilities[primaryModel]?.[predicted];
+                const hit = entry.target_class != null && entry.target_class === predicted;
+                return (
+                  <tr key={entry.target_event_date} className="border-b border-border last:border-0">
+                    <td className="px-4 py-2 font-mono text-xs">{entry.target_event_date}</td>
+                    <td className="px-4 py-2">
+                      {entry.target_class ? ORDINAL_LABELS[entry.target_class] ?? entry.target_class : "—"}
+                    </td>
+                    <td className="px-4 py-2">{ORDINAL_LABELS[predicted] ?? predicted}</td>
+                    <td className="px-4 py-2 text-right font-mono">{formatPercent(p)}</td>
+                    <td className="px-4 py-2 text-center">
+                      {entry.target_class == null ? (
+                        <Badge variant="outline">pending</Badge>
+                      ) : hit ? (
+                        <Badge variant="hawkish">hit</Badge>
+                      ) : (
+                        <Badge variant="dovish">miss</Badge>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function MetricsTable({
+  metrics,
+}: {
+  metrics: NextFomcForecastResponse["metrics_full_window"];
+}) {
+  const rows = Object.entries(metrics);
+  if (rows.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Walk-forward metrics</CardTitle>
+        </CardHeader>
+        <CardContent className="py-6 text-center text-sm text-muted-foreground">
+          No metrics published.
+        </CardContent>
+      </Card>
+    );
+  }
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Walk-forward metrics</CardTitle>
+        <CardDescription>Leave-one-meeting-out walk-forward CV across the full window.</CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        <table className="w-full text-sm">
+          <thead className="border-b border-border bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th className="px-4 py-2 text-left">Model</th>
+              <th className="px-4 py-2 text-right">n</th>
+              <th className="px-4 py-2 text-right">Brier</th>
+              <th className="px-4 py-2 text-right">Log-loss</th>
+              <th className="px-4 py-2 text-right">Top-1 acc</th>
+              <th className="px-4 py-2 text-right">Macro-F1</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(([model, m]) => (
+              <tr key={model} className="border-b border-border last:border-0">
+                <td className="px-4 py-2 font-mono">{model}</td>
+                <td className="px-4 py-2 text-right font-mono text-muted-foreground">{m.n}</td>
+                <td className="px-4 py-2 text-right font-mono">{formatNumber(m.brier)}</td>
+                <td className="px-4 py-2 text-right font-mono">{formatNumber(m.log_loss)}</td>
+                <td className="px-4 py-2 text-right font-mono">{formatPercent(m.top1_accuracy)}</td>
+                <td className="px-4 py-2 text-right font-mono">{formatNumber(m.macro_f1)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AttributionTable({
+  rows,
+}: {
+  rows: NextFomcForecastResponse["feature_attribution"];
+}) {
+  if (rows.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Feature-family attribution</CardTitle>
+        </CardHeader>
+        <CardContent className="py-6 text-center text-sm text-muted-foreground">
+          No attribution table emitted yet.
+        </CardContent>
+      </Card>
+    );
+  }
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Feature-family attribution</CardTitle>
+        <CardDescription>
+          Walk-forward metrics on the ordinal_logit model with each feature subset.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        <table className="w-full text-sm">
+          <thead className="border-b border-border bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th className="px-4 py-2 text-left">Subset</th>
+              <th className="px-4 py-2 text-left">Families</th>
+              <th className="px-4 py-2 text-right">#feat</th>
+              <th className="px-4 py-2 text-right">Brier</th>
+              <th className="px-4 py-2 text-right">Log-loss</th>
+              <th className="px-4 py-2 text-right">Top-1 acc</th>
+              <th className="px-4 py-2 text-right">Macro-F1</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.subset} className="border-b border-border last:border-0">
+                <td className="px-4 py-2 font-mono">{row.subset}</td>
+                <td className="px-4 py-2 text-xs text-muted-foreground">
+                  {row.families.join(", ") || "—"}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-muted-foreground">
+                  {row.n_features ?? "—"}
+                </td>
+                <td className="px-4 py-2 text-right font-mono">{formatNumber(row.brier)}</td>
+                <td className="px-4 py-2 text-right font-mono">{formatNumber(row.log_loss)}</td>
+                <td className="px-4 py-2 text-right font-mono">{formatPercent(row.top1_accuracy)}</td>
+                <td className="px-4 py-2 text-right font-mono">{formatNumber(row.macro_f1)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function DecisionsPage() {
+  const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+  const [data, setData] = React.useState<NextFomcForecastResponse | null>(null);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    fetchNextFomcForecast(apiBaseUrl)
+      .then((result) => {
+        if (!cancelled) setData(result);
+      })
+      .catch((err) => {
+        if (!cancelled) toast.error((err as Error).message || "Failed to load decision forecast.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBaseUrl]);
+
+  const primaryModel = data ? pickPrimaryModel(data.model_names) : "";
+
+  return (
+    <>
+      <Head>
+        <title>Decisions — Fed Pulse</title>
+      </Head>
+      <div className="min-h-screen bg-background text-foreground">
+        <Header />
+        <main className="container space-y-6 py-8">
+          <div className="space-y-2">
+            <h1 className="flex items-center gap-2 text-3xl font-semibold tracking-tight">
+              <Gavel className="h-7 w-7 text-primary" />
+              Decisions
+            </h1>
+            <p className="max-w-2xl text-muted-foreground">
+              Next-FOMC rate-decision forecast as an ordinal class with the OIS-implied baseline alongside.
+              Reads <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">data/artifacts/next_fomc/</code>.
+            </p>
+          </div>
+
+          {loading ? (
+            <div className="space-y-3">
+              <Skeleton className="h-48 w-full" />
+              <Skeleton className="h-32 w-full" />
+            </div>
+          ) : data && data.available ? (
+            <div className="space-y-6">
+              <HeadlineCard data={data} primaryModel={primaryModel} />
+              <Tabs defaultValue="history" className="w-full">
+                <TabsList className="grid w-full max-w-md grid-cols-3">
+                  <TabsTrigger value="history">History</TabsTrigger>
+                  <TabsTrigger value="metrics">Metrics</TabsTrigger>
+                  <TabsTrigger value="attribution">Attribution</TabsTrigger>
+                </TabsList>
+                <TabsContent value="history">
+                  <HistoryTable history={data.history} primaryModel={primaryModel} />
+                </TabsContent>
+                <TabsContent value="metrics" className="space-y-3">
+                  <MetricsTable metrics={data.metrics_full_window} />
+                  {Object.keys(data.metrics_ex_pandemic).length > 0 ? (
+                    <>
+                      <h3 className="text-sm font-medium text-muted-foreground">
+                        Pandemic-excluded window
+                      </h3>
+                      <MetricsTable metrics={data.metrics_ex_pandemic} />
+                    </>
+                  ) : null}
+                </TabsContent>
+                <TabsContent value="attribution">
+                  <AttributionTable rows={data.feature_attribution} />
+                </TabsContent>
+              </Tabs>
+            </div>
+          ) : (
+            <Card>
+              <CardHeader>
+                <CardTitle>Forecaster has not been run</CardTitle>
+                <CardDescription>
+                  No artefacts under{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+                    data/artifacts/next_fomc/
+                  </code>
+                  .
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm text-muted-foreground">
+                <p>
+                  Run{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+                    make next-fomc TRAINING_PACKAGE_ID=&lt;id&gt;
+                  </code>{" "}
+                  to populate this view.
+                </p>
+                {data?.upcoming_meeting ? (
+                  <p>
+                    Next scheduled meeting:{" "}
+                    <span className="font-mono">{data.upcoming_meeting.meeting_date}</span>
+                    {data.upcoming_meeting.days_until != null
+                      ? ` (in ${data.upcoming_meeting.days_until} days)`
+                      : ""}
+                    .
+                  </p>
+                ) : null}
+              </CardContent>
+            </Card>
+          )}
+        </main>
+      </div>
+    </>
+  );
+}

--- a/frontend/pages/research.tsx
+++ b/frontend/pages/research.tsx
@@ -1,0 +1,337 @@
+import * as React from "react";
+import Head from "next/head";
+import { FlaskConical } from "lucide-react";
+import { toast } from "sonner";
+
+import { Header } from "@/components/shell/header";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { fetchResearchArtifacts, resolveApiBaseUrl } from "@/lib/analyze/api";
+import type {
+  ArtifactFile,
+  CrossBankTransferSection,
+  EncoderBakeoffSection,
+  ResearchArtifactsResponse,
+  TransferMatrixCell,
+} from "@/lib/analyze/types";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatNumberOrDash(value: number | null | undefined, digits: number = 3): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return value.toFixed(digits);
+}
+
+function formatCi(low: number | null, high: number | null): string {
+  if (low == null || high == null) return "—";
+  return `[${low.toFixed(3)}, ${high.toFixed(3)}]`;
+}
+
+function heatmapColor(value: number, min: number, max: number): string {
+  // Two-stop ramp through neutral muted to emerald 500 — readable in both themes.
+  if (max <= min) return "rgba(16, 185, 129, 0.15)";
+  const t = Math.max(0, Math.min(1, (value - min) / (max - min)));
+  const alpha = 0.12 + 0.55 * t;
+  return `rgba(16, 185, 129, ${alpha.toFixed(3)})`;
+}
+
+function EncoderBakeoffPane({ section }: { section: EncoderBakeoffSection }) {
+  if (!section.available || section.rows.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Encoder bake-off</CardTitle>
+          <CardDescription>
+            Per-encoder macro-F1 with seed-set confidence intervals.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="py-10 text-center text-sm text-muted-foreground">
+          No bake-off artefacts under <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">data/artifacts/phase3/</code>.
+          Run <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">make train-batch TRAINING_PACKAGE_ID=&lt;id&gt;</code>
+          and then the bake-off aggregator to populate this view.
+        </CardContent>
+      </Card>
+    );
+  }
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Encoder bake-off</CardTitle>
+        <CardDescription>
+          {section.rows.length} encoders, coverage {section.coverage ? `${(section.coverage * 100).toFixed(0)}%` : "—"} block-bootstrap CI.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        <table className="w-full text-sm">
+          <thead className="border-b border-border bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th className="px-4 py-2 text-left">Encoder</th>
+              <th className="px-4 py-2 text-left">Checkpoint</th>
+              <th className="px-4 py-2 text-right">Seeds</th>
+              <th className="px-4 py-2 text-right">Macro-F1</th>
+              <th className="px-4 py-2 text-right">95% CI</th>
+              <th className="px-4 py-2 text-right">Weighted-F1</th>
+              <th className="px-4 py-2 text-right">Accuracy</th>
+              <th className="px-4 py-2 text-right">κ</th>
+            </tr>
+          </thead>
+          <tbody>
+            {section.rows.map((row) => (
+              <tr key={row.encoder_key} className="border-b border-border last:border-0">
+                <td className="px-4 py-2 font-medium">{row.encoder_key}</td>
+                <td className="px-4 py-2 font-mono text-xs text-muted-foreground">{row.checkpoint || "—"}</td>
+                <td className="px-4 py-2 text-right font-mono text-muted-foreground">{row.seeds.length}</td>
+                <td className="px-4 py-2 text-right font-mono">{formatNumberOrDash(row.macro_f1_mean)}</td>
+                <td className="px-4 py-2 text-right font-mono text-muted-foreground">
+                  {formatCi(row.macro_f1_ci_low, row.macro_f1_ci_high)}
+                </td>
+                <td className="px-4 py-2 text-right font-mono">{formatNumberOrDash(row.weighted_f1_mean)}</td>
+                <td className="px-4 py-2 text-right font-mono">{formatNumberOrDash(row.accuracy_mean)}</td>
+                <td className="px-4 py-2 text-right font-mono">{formatNumberOrDash(row.cohen_kappa)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function CrossBankTransferPane({ section }: { section: CrossBankTransferSection }) {
+  if (!section.available || section.cells.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Cross-CB transfer matrix</CardTitle>
+          <CardDescription>
+            Source bank → target bank, macro-F1 of a model trained on source evaluated on target.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="py-10 text-center text-sm text-muted-foreground">
+          No transfer-matrix artefacts under <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">data/artifacts/cross_bank/</code>.
+        </CardContent>
+      </Card>
+    );
+  }
+  // Build the cell lookup so we can render a dense matrix even when the
+  // backend sends only the sparse cells array.
+  const cellMap = new Map<string, TransferMatrixCell>();
+  section.cells.forEach((cell) => {
+    cellMap.set(`${cell.source}|${cell.target}`, cell);
+  });
+  const sources = section.sources.length
+    ? section.sources
+    : Array.from(new Set(section.cells.map((c) => c.source)));
+  const targets = section.targets.length
+    ? section.targets
+    : Array.from(new Set(section.cells.map((c) => c.target)));
+  const metrics = section.cells.map((c) => c.metric);
+  const min = Math.min(...metrics);
+  const max = Math.max(...metrics);
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Cross-CB transfer matrix</CardTitle>
+        <CardDescription>
+          {section.metric_name.replace("_", "-")}. Rows are training banks, columns are evaluation banks.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-auto">
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              <th className="border border-border bg-muted/30 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                source ↓ / target →
+              </th>
+              {targets.map((tgt) => (
+                <th key={tgt} className="border border-border bg-muted/30 px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {tgt}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sources.map((src) => (
+              <tr key={src}>
+                <th className="border border-border bg-muted/20 px-3 py-2 text-left text-xs font-medium text-muted-foreground">
+                  {src}
+                </th>
+                {targets.map((tgt) => {
+                  const cell = cellMap.get(`${src}|${tgt}`);
+                  return (
+                    <td
+                      key={`${src}-${tgt}`}
+                      className="border border-border px-3 py-2 text-right font-mono text-xs"
+                      style={cell ? { backgroundColor: heatmapColor(cell.metric, min, max) } : undefined}
+                    >
+                      {cell ? cell.metric.toFixed(3) : "—"}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ArtifactsExplorer({
+  sections,
+}: {
+  sections: Record<string, ArtifactFile[]>;
+}) {
+  const sectionEntries = Object.entries(sections);
+  const totalFiles = sectionEntries.reduce((acc, [, files]) => acc + files.length, 0);
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Artefact files</CardTitle>
+        <CardDescription>
+          {totalFiles} files indexed across {sectionEntries.length} sections.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {sectionEntries.map(([section, files]) => (
+          <div key={section} className="space-y-1">
+            <div className="flex items-baseline gap-2">
+              <h3 className="font-mono text-sm font-medium">{section}/</h3>
+              <span className="text-xs text-muted-foreground">{files.length} files</span>
+            </div>
+            {files.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No files emitted yet.</p>
+            ) : (
+              <ul className="space-y-0.5">
+                {files.slice(0, 20).map((file) => (
+                  <li
+                    key={file.relative_path}
+                    className="flex flex-wrap items-center justify-between gap-2 font-mono text-xs text-muted-foreground"
+                  >
+                    <span>{file.relative_path}</span>
+                    <span>
+                      {formatBytes(file.size_bytes)} · {file.modified_at.slice(0, 19)}
+                    </span>
+                  </li>
+                ))}
+                {files.length > 20 ? (
+                  <li className="text-xs text-muted-foreground">
+                    +{files.length - 20} more files
+                  </li>
+                ) : null}
+              </ul>
+            )}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function ResearchPage() {
+  const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+  const [data, setData] = React.useState<ResearchArtifactsResponse | null>(null);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    fetchResearchArtifacts(apiBaseUrl)
+      .then((result) => {
+        if (!cancelled) setData(result);
+      })
+      .catch((err) => {
+        if (!cancelled) toast.error((err as Error).message || "Failed to load research artefacts.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBaseUrl]);
+
+  return (
+    <>
+      <Head>
+        <title>Research — Fed Pulse</title>
+      </Head>
+      <div className="min-h-screen bg-background text-foreground">
+        <Header />
+        <main className="container space-y-6 py-8">
+          <div className="space-y-2">
+            <h1 className="flex items-center gap-2 text-3xl font-semibold tracking-tight">
+              <FlaskConical className="h-7 w-7 text-primary" />
+              Research
+            </h1>
+            <p className="max-w-2xl text-muted-foreground">
+              Bake-off macro-F1 across encoders, cross-central-bank transfer matrix, and the raw
+              artefact tree. Pulls from <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">data/artifacts/</code>
+              on the backend.
+            </p>
+          </div>
+
+          {loading ? (
+            <div className="space-y-3">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-48 w-full" />
+              <Skeleton className="h-48 w-full" />
+            </div>
+          ) : data ? (
+            <Tabs defaultValue="bakeoff" className="w-full">
+              <TabsList className="grid w-full max-w-md grid-cols-3">
+                <TabsTrigger value="bakeoff">Bake-off</TabsTrigger>
+                <TabsTrigger value="transfer">Transfer</TabsTrigger>
+                <TabsTrigger value="files">Files</TabsTrigger>
+              </TabsList>
+              <TabsContent value="bakeoff" className="space-y-3">
+                <EncoderBakeoffPane section={data.encoder_bakeoff} />
+                {data.encoder_bakeoff.source_files.length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {data.encoder_bakeoff.source_files.map((f) => (
+                      <Badge key={f} variant="outline" className="font-mono text-[10px]">
+                        {f}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : null}
+              </TabsContent>
+              <TabsContent value="transfer" className="space-y-3">
+                <CrossBankTransferPane section={data.cross_bank_transfer} />
+                {data.cross_bank_transfer.source_files.length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {data.cross_bank_transfer.source_files.map((f) => (
+                      <Badge key={f} variant="outline" className="font-mono text-[10px]">
+                        {f}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : null}
+              </TabsContent>
+              <TabsContent value="files">
+                <ArtifactsExplorer sections={data.sections} />
+              </TabsContent>
+            </Tabs>
+          ) : (
+            <Card>
+              <CardContent className="py-10 text-center text-muted-foreground">
+                Could not load artefacts. Make sure the backend is running.
+              </CardContent>
+            </Card>
+          )}
+        </main>
+      </div>
+    </>
+  );
+}

--- a/frontend/pages/training.tsx
+++ b/frontend/pages/training.tsx
@@ -1,0 +1,197 @@
+import * as React from "react";
+import Head from "next/head";
+import Link from "next/link";
+import { Cpu } from "lucide-react";
+import { toast } from "sonner";
+
+import { Header } from "@/components/shell/header";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchTrainJobs, resolveApiBaseUrl } from "@/lib/analyze/api";
+import type { TrainJobStatus, TrainJobSummary } from "@/lib/analyze/types";
+
+const STATUS_VARIANT: Record<string, "hawkish" | "dovish" | "outline" | "secondary"> = {
+  running: "hawkish",
+  queued: "secondary",
+  failed: "dovish",
+  succeeded: "outline",
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const key = status.toLowerCase();
+  const variant = STATUS_VARIANT[key] ?? "outline";
+  return (
+    <Badge variant={variant} className="capitalize">
+      {status}
+    </Badge>
+  );
+}
+
+function StatusCount({
+  label,
+  status,
+  jobs,
+}: {
+  label: string;
+  status: TrainJobStatus;
+  jobs: TrainJobSummary[];
+}) {
+  const count = jobs.filter((j) => j.status === status).length;
+  return (
+    <Card>
+      <CardHeader className="space-y-0 pb-2">
+        <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="font-mono text-2xl font-semibold">{count}</div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function durationSeconds(started: string | null, finished: string | null): string {
+  if (!started) return "—";
+  const start = Date.parse(started);
+  const end = finished ? Date.parse(finished) : Date.now();
+  if (Number.isNaN(start) || Number.isNaN(end)) return "—";
+  const seconds = Math.max(0, Math.round((end - start) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds % 60;
+  return `${minutes}m ${rest}s`;
+}
+
+export default function TrainingPage() {
+  const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+  const [jobs, setJobs] = React.useState<TrainJobSummary[]>([]);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      fetchTrainJobs(apiBaseUrl)
+        .then((result) => {
+          if (!cancelled) setJobs(result.items);
+        })
+        .catch((err) => {
+          if (!cancelled) toast.error((err as Error).message || "Failed to load training jobs.");
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    };
+    load();
+    const id = setInterval(load, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [apiBaseUrl]);
+
+  return (
+    <>
+      <Head>
+        <title>Training — Fed Pulse</title>
+      </Head>
+      <div className="min-h-screen bg-background text-foreground">
+        <Header />
+        <main className="container space-y-6 py-8">
+          <div className="space-y-2">
+            <h1 className="flex items-center gap-2 text-3xl font-semibold tracking-tight">
+              <Cpu className="h-7 w-7 text-primary" />
+              Training
+            </h1>
+            <p className="max-w-2xl text-muted-foreground">
+              In-process Real Train jobs. Observational view — durable training runs flow through
+              <code className="ml-1 rounded bg-muted px-1 py-0.5 font-mono text-xs">make train-batch</code> /
+              <code className="ml-1 rounded bg-muted px-1 py-0.5 font-mono text-xs">make next-fomc</code>.
+            </p>
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-4">
+            <StatusCount label="Running" status="running" jobs={jobs} />
+            <StatusCount label="Queued" status="queued" jobs={jobs} />
+            <StatusCount label="Succeeded" status="succeeded" jobs={jobs} />
+            <StatusCount label="Failed" status="failed" jobs={jobs} />
+          </div>
+
+          {loading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : jobs.length === 0 ? (
+            <Card>
+              <CardContent className="py-10 text-center text-muted-foreground">
+                No training jobs in this backend instance. Submit a Real Train forecast from the
+                <Link href="/analyze" className="ml-1 underline">
+                  Analyze page
+                </Link>
+                {" "}to enqueue one.
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardHeader>
+                <CardTitle>Job queue</CardTitle>
+                <CardDescription>Ordered by status (running first), then newest.</CardDescription>
+              </CardHeader>
+              <CardContent className="p-0">
+                <table className="w-full text-sm">
+                  <thead className="border-b border-border bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
+                    <tr>
+                      <th className="px-4 py-2 text-left">Job</th>
+                      <th className="px-4 py-2 text-left">Status</th>
+                      <th className="px-4 py-2 text-left">Symbol</th>
+                      <th className="px-4 py-2 text-left">Document date</th>
+                      <th className="px-4 py-2 text-right">History len</th>
+                      <th className="px-4 py-2 text-right">Duration</th>
+                      <th className="px-4 py-2 text-left">Created</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {jobs.map((job) => (
+                      <tr key={job.job_id} className="border-b border-border last:border-0 hover:bg-muted/40">
+                        <td className="px-4 py-2 font-mono text-xs">
+                          <Link href={`/training/${job.job_id}`} className="hover:underline">
+                            {job.job_id.slice(0, 12)}…
+                          </Link>
+                        </td>
+                        <td className="px-4 py-2">
+                          <StatusBadge status={job.status} />
+                        </td>
+                        <td className="px-4 py-2 font-medium">{job.symbol ?? "—"}</td>
+                        <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
+                          {job.date ?? "—"}
+                        </td>
+                        <td className="px-4 py-2 text-right font-mono text-muted-foreground">
+                          {job.history_length ?? "—"}
+                        </td>
+                        <td className="px-4 py-2 text-right font-mono">
+                          {durationSeconds(job.started_at, job.finished_at)}
+                        </td>
+                        <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
+                          {job.created_at ? job.created_at.slice(0, 19) : "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </CardContent>
+            </Card>
+          )}
+        </main>
+      </div>
+    </>
+  );
+}

--- a/frontend/pages/training/[id].tsx
+++ b/frontend/pages/training/[id].tsx
@@ -1,0 +1,172 @@
+import * as React from "react";
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { ArrowLeft } from "lucide-react";
+import { toast } from "sonner";
+
+import { Header } from "@/components/shell/header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchTrainJob, resolveApiBaseUrl } from "@/lib/analyze/api";
+import type { TrainJobState } from "@/lib/analyze/types";
+
+const STATUS_VARIANT: Record<string, "hawkish" | "dovish" | "outline" | "secondary"> = {
+  running: "hawkish",
+  queued: "secondary",
+  failed: "dovish",
+  succeeded: "outline",
+};
+
+export default function TrainingDetailPage() {
+  const router = useRouter();
+  const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+  const [job, setJob] = React.useState<TrainJobState | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
+  const jobId = React.useMemo(() => {
+    const value = router.query.id;
+    return typeof value === "string" ? value : null;
+  }, [router.query.id]);
+
+  React.useEffect(() => {
+    if (!router.isReady) return;
+    if (!jobId) return;
+    let cancelled = false;
+    const load = () => {
+      fetchTrainJob(apiBaseUrl, jobId)
+        .then((result) => {
+          if (!cancelled) {
+            setJob(result);
+            setErrorMessage(null);
+          }
+        })
+        .catch((err) => {
+          if (!cancelled) {
+            const message = (err as Error).message || "Failed to load job state.";
+            setErrorMessage(message);
+            toast.error(message);
+          }
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    };
+    load();
+    const id = setInterval(load, 4000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [apiBaseUrl, jobId, router.isReady]);
+
+  const status = job?.status ?? "unknown";
+  const variant = STATUS_VARIANT[status.toLowerCase()] ?? "outline";
+
+  return (
+    <>
+      <Head>
+        <title>Training job — Fed Pulse</title>
+      </Head>
+      <div className="min-h-screen bg-background text-foreground">
+        <Header />
+        <main className="container space-y-6 py-8">
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-1">
+              <h1 className="text-2xl font-semibold tracking-tight">Training job</h1>
+              <p className="font-mono text-xs text-muted-foreground">{jobId ?? "—"}</p>
+            </div>
+            <Button asChild variant="outline" size="sm">
+              <Link href="/training">
+                <ArrowLeft className="h-4 w-4" />
+                Back to queue
+              </Link>
+            </Button>
+          </div>
+
+          {loading && !job ? (
+            <Skeleton className="h-48 w-full" />
+          ) : errorMessage && !job ? (
+            <Card>
+              <CardContent className="py-10 text-center text-muted-foreground">{errorMessage}</CardContent>
+            </Card>
+          ) : job ? (
+            <div className="grid gap-4 lg:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-3">
+                    <Badge variant={variant} className="capitalize">
+                      {status}
+                    </Badge>
+                    State
+                  </CardTitle>
+                  <CardDescription>Auto-refreshes every 4 seconds.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <dl className="grid grid-cols-2 gap-y-2 text-sm">
+                    <dt className="text-muted-foreground">Status</dt>
+                    <dd className="font-mono">{status}</dd>
+                    {job.message ? (
+                      <>
+                        <dt className="text-muted-foreground">Message</dt>
+                        <dd className="font-mono text-xs">{job.message}</dd>
+                      </>
+                    ) : null}
+                    {job.error ? (
+                      <>
+                        <dt className="text-muted-foreground">Error</dt>
+                        <dd className="font-mono text-xs text-rose-500">{job.error}</dd>
+                      </>
+                    ) : null}
+                  </dl>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Result preview</CardTitle>
+                  <CardDescription>
+                    Populated on success. The full payload appears on the Analyze page once polling resolves.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2 text-sm">
+                  {job.result ? (
+                    <dl className="grid grid-cols-2 gap-y-2">
+                      <dt className="text-muted-foreground">Sentiment</dt>
+                      <dd className="font-mono">{job.result.sentiment?.label ?? "—"}</dd>
+                      <dt className="text-muted-foreground">Predicted close</dt>
+                      <dd className="font-mono">
+                        {job.result.prediction?.close != null
+                          ? job.result.prediction.close.toFixed(2)
+                          : "—"}
+                      </dd>
+                      <dt className="text-muted-foreground">Predicted volatility</dt>
+                      <dd className="font-mono">
+                        {job.result.prediction?.volatility != null
+                          ? job.result.prediction.volatility.toFixed(4)
+                          : "—"}
+                      </dd>
+                      <dt className="text-muted-foreground">Runtime mode</dt>
+                      <dd className="font-mono">{job.result.model?.runtime_mode ?? "—"}</dd>
+                    </dl>
+                  ) : (
+                    <p className="text-muted-foreground">No result yet.</p>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          ) : null}
+        </main>
+      </div>
+    </>
+  );
+}

--- a/frontend/tests/pages/decisions.test.tsx
+++ b/frontend/tests/pages/decisions.test.tsx
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  Toaster: () => null,
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ isReady: true, query: {}, push: vi.fn() }),
+}));
+
+vi.mock("next/head", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const fetchNextFomcForecastMock = vi.fn();
+vi.mock("@/lib/analyze/api", () => ({
+  resolveApiBaseUrl: () => "http://localhost:8000",
+  fetchNextFomcForecast: (...args: unknown[]) => fetchNextFomcForecastMock(...args),
+}));
+
+const ORDINAL_CLASSES = ["cut_50", "cut_25", "hold", "hike_25", "hike_50", "hike_75"];
+
+const EMPTY_RESPONSE = {
+  available: false,
+  artifacts_dir: "/data/artifacts/next_fomc",
+  ordinal_classes: ORDINAL_CLASSES,
+  model_names: [],
+  upcoming_meeting: {
+    meeting_date: "2026-06-16",
+    meeting_type: "scheduled",
+    statement_release_date: "2026-06-17",
+    days_until: 31,
+  },
+  headline: null,
+  history: [],
+  metrics_full_window: {},
+  metrics_ex_pandemic: {},
+  feature_attribution: [],
+  summary: {},
+};
+
+const POPULATED_RESPONSE = {
+  available: true,
+  artifacts_dir: "/data/artifacts/next_fomc",
+  ordinal_classes: ORDINAL_CLASSES,
+  model_names: ["ordinal_logit", "ois_baseline"],
+  upcoming_meeting: {
+    meeting_date: "2026-06-16",
+    meeting_type: "scheduled",
+    statement_release_date: "2026-06-17",
+    days_until: 31,
+  },
+  headline: {
+    target_event_date: "2026-06-16",
+    target_as_of_ts: "2026-06-16T19:00:00+00:00",
+    target_class: null,
+    n_train_rows: 25,
+    probabilities: {
+      ordinal_logit: {
+        cut_50: 0.02,
+        cut_25: 0.18,
+        hold: 0.55,
+        hike_25: 0.2,
+        hike_50: 0.04,
+        hike_75: 0.01,
+      },
+      ois_baseline: {
+        cut_50: 0.03,
+        cut_25: 0.22,
+        hold: 0.5,
+        hike_25: 0.2,
+        hike_50: 0.04,
+        hike_75: 0.01,
+      },
+    },
+    predicted_class: { ordinal_logit: "hold", ois_baseline: "hold" },
+  },
+  history: [
+    {
+      target_event_date: "2024-09-17",
+      target_as_of_ts: "2024-09-17T19:00:00+00:00",
+      target_class: "cut_25",
+      n_train_rows: 12,
+      probabilities: {
+        ordinal_logit: {
+          cut_50: 0.05,
+          cut_25: 0.55,
+          hold: 0.3,
+          hike_25: 0.07,
+          hike_50: 0.02,
+          hike_75: 0.01,
+        },
+      },
+      predicted_class: { ordinal_logit: "cut_25" },
+    },
+    {
+      target_event_date: "2024-11-06",
+      target_as_of_ts: "2024-11-06T19:00:00+00:00",
+      target_class: "hold",
+      n_train_rows: 13,
+      probabilities: {
+        ordinal_logit: {
+          cut_50: 0.01,
+          cut_25: 0.1,
+          hold: 0.7,
+          hike_25: 0.15,
+          hike_50: 0.03,
+          hike_75: 0.01,
+        },
+      },
+      predicted_class: { ordinal_logit: "hold" },
+    },
+  ],
+  metrics_full_window: {
+    ordinal_logit: {
+      n: 18,
+      brier: 0.32,
+      log_loss: 0.71,
+      top1_accuracy: 0.61,
+      macro_f1: 0.43,
+      confusion_matrix: {},
+    },
+    ois_baseline: {
+      n: 18,
+      brier: 0.45,
+      log_loss: 0.95,
+      top1_accuracy: 0.5,
+      macro_f1: 0.32,
+      confusion_matrix: {},
+    },
+  },
+  metrics_ex_pandemic: {},
+  feature_attribution: [
+    {
+      subset: "ois_only",
+      families: ["ois"],
+      n_features: 10,
+      n: 18,
+      brier: 0.42,
+      log_loss: 0.92,
+      top1_accuracy: 0.5,
+      macro_f1: 0.31,
+    },
+    {
+      subset: "full",
+      families: ["ois", "text", "linguistic", "credibility", "macro"],
+      n_features: 39,
+      n: 18,
+      brier: 0.32,
+      log_loss: 0.71,
+      top1_accuracy: 0.61,
+      macro_f1: 0.43,
+    },
+  ],
+  summary: { rows_emitted: 18 },
+};
+
+describe("DecisionsPage", () => {
+  beforeEach(() => {
+    fetchNextFomcForecastMock.mockReset();
+  });
+
+  it("renders the empty state with the make instruction", async () => {
+    fetchNextFomcForecastMock.mockResolvedValue(EMPTY_RESPONSE);
+    const { default: DecisionsPage } = await import("@/pages/decisions");
+    render(<DecisionsPage />);
+    await waitFor(() => expect(screen.getByText(/Forecaster has not been run/i)).toBeInTheDocument());
+    expect(screen.getByText(/make next-fomc/)).toBeInTheDocument();
+    expect(screen.getByText(/2026-06-16/)).toBeInTheDocument();
+  });
+
+  it("renders the headline prediction with primary and baseline probabilities", async () => {
+    fetchNextFomcForecastMock.mockResolvedValue(POPULATED_RESPONSE);
+    const { default: DecisionsPage } = await import("@/pages/decisions");
+    render(<DecisionsPage />);
+    await waitFor(() => expect(screen.getByText(/Next meeting/i)).toBeInTheDocument());
+    expect(screen.getAllByText(/ordinal_logit/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/OIS-implied baseline/i).length).toBeGreaterThan(0);
+    // Hold prediction surfaces in the headline description (55%).
+    expect(screen.getAllByText(/Hold/).length).toBeGreaterThan(0);
+  });
+
+  it("renders the feature-attribution table", async () => {
+    fetchNextFomcForecastMock.mockResolvedValue(POPULATED_RESPONSE);
+    const { default: DecisionsPage } = await import("@/pages/decisions");
+    render(<DecisionsPage />);
+    await waitFor(() => expect(screen.getByText(/Next meeting/i)).toBeInTheDocument());
+    // Switch to the attribution tab.
+    const user = userEvent.setup();
+    const trigger = screen.getByRole("tab", { name: /Attribution/i });
+    await user.click(trigger);
+    await waitFor(() => expect(screen.getByText(/ois_only/)).toBeInTheDocument());
+    expect(screen.getByText(/^full$/)).toBeInTheDocument();
+    expect(screen.getByText(/ois, text, linguistic, credibility, macro/)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/pages/research.test.tsx
+++ b/frontend/tests/pages/research.test.tsx
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  Toaster: () => null,
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ isReady: true, query: {}, push: vi.fn() }),
+}));
+
+vi.mock("next/head", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const fetchResearchArtifactsMock = vi.fn();
+vi.mock("@/lib/analyze/api", () => ({
+  resolveApiBaseUrl: () => "http://localhost:8000",
+  fetchResearchArtifacts: (...args: unknown[]) => fetchResearchArtifactsMock(...args),
+}));
+
+const EMPTY_RESPONSE = {
+  artifacts_root: "/data/artifacts",
+  sections: {
+    phase3: [],
+    cross_bank: [],
+    cross_asset: [],
+    next_fomc: [],
+  },
+  encoder_bakeoff: {
+    available: false,
+    coverage: null,
+    rows: [],
+    source_files: [],
+  },
+  cross_bank_transfer: {
+    available: false,
+    metric_name: "macro_f1",
+    sources: [],
+    targets: [],
+    cells: [],
+    source_files: [],
+  },
+};
+
+const POPULATED_RESPONSE = {
+  artifacts_root: "/data/artifacts",
+  sections: {
+    phase3: [
+      {
+        relative_path: "phase3/run-a/aggregate.json",
+        size_bytes: 4096,
+        modified_at: "2026-05-01T12:00:00+00:00",
+        suffix: ".json",
+      },
+    ],
+    cross_bank: [],
+    cross_asset: [],
+    next_fomc: [],
+  },
+  encoder_bakeoff: {
+    available: true,
+    coverage: 0.95,
+    rows: [
+      {
+        encoder_key: "bert-base-uncased",
+        checkpoint: "bert-base-uncased",
+        seeds: [11, 29, 47, 71, 97],
+        macro_f1_values: [0.51, 0.52, 0.53, 0.55, 0.54],
+        macro_f1_mean: 0.53,
+        macro_f1_ci_low: 0.5,
+        macro_f1_ci_high: 0.56,
+        weighted_f1_mean: 0.57,
+        accuracy_mean: 0.6,
+        cohen_kappa: 0.31,
+      },
+      {
+        encoder_key: "fomc-roberta",
+        checkpoint: "yiyanghkust/finbert-tone",
+        seeds: [11, 29, 47, 71, 97],
+        macro_f1_values: [0.59, 0.61, 0.6, 0.62, 0.6],
+        macro_f1_mean: 0.604,
+        macro_f1_ci_low: 0.58,
+        macro_f1_ci_high: 0.63,
+        weighted_f1_mean: 0.62,
+        accuracy_mean: 0.66,
+        cohen_kappa: 0.4,
+      },
+    ],
+    source_files: ["phase3/run-a/aggregate.json"],
+  },
+  cross_bank_transfer: {
+    available: false,
+    metric_name: "macro_f1",
+    sources: [],
+    targets: [],
+    cells: [],
+    source_files: [],
+  },
+};
+
+describe("ResearchPage", () => {
+  beforeEach(() => {
+    fetchResearchArtifactsMock.mockReset();
+  });
+
+  it("renders the empty-state when no artefacts are present", async () => {
+    fetchResearchArtifactsMock.mockResolvedValue(EMPTY_RESPONSE);
+    const { default: ResearchPage } = await import("@/pages/research");
+    render(<ResearchPage />);
+    await waitFor(() =>
+      expect(screen.getByText(/No bake-off artefacts/i)).toBeInTheDocument()
+    );
+  });
+
+  it("renders the encoder bake-off table when artefacts are present", async () => {
+    fetchResearchArtifactsMock.mockResolvedValue(POPULATED_RESPONSE);
+    const { default: ResearchPage } = await import("@/pages/research");
+    render(<ResearchPage />);
+    // Two cells per encoder (encoder column + checkpoint column).
+    await waitFor(() =>
+      expect(screen.getAllByText(/bert-base-uncased/i).length).toBeGreaterThanOrEqual(2)
+    );
+    expect(screen.getAllByText(/fomc-roberta/i).length).toBeGreaterThan(0);
+    // Macro-F1 mean appears in the row body.
+    expect(screen.getByText("0.530")).toBeInTheDocument();
+    expect(screen.getByText("0.604")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/pages/training.test.tsx
+++ b/frontend/tests/pages/training.test.tsx
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  Toaster: () => null,
+}));
+
+const routerStore = { isReady: true, query: {} as Record<string, string>, push: vi.fn() };
+vi.mock("next/router", () => ({
+  useRouter: () => routerStore,
+}));
+
+vi.mock("next/head", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const fetchTrainJobsMock = vi.fn();
+const fetchTrainJobMock = vi.fn();
+vi.mock("@/lib/analyze/api", () => ({
+  resolveApiBaseUrl: () => "http://localhost:8000",
+  fetchTrainJobs: (...args: unknown[]) => fetchTrainJobsMock(...args),
+  fetchTrainJob: (...args: unknown[]) => fetchTrainJobMock(...args),
+}));
+
+const SAMPLE_JOBS = [
+  {
+    job_id: "11111111-1111-1111-1111-111111111111",
+    status: "running",
+    symbol: "^GSPC",
+    date: "2026-05-15",
+    created_at: "2026-05-15T10:00:00Z",
+    started_at: "2026-05-15T10:00:05Z",
+    finished_at: null,
+    history_length: 252,
+    error: null,
+  },
+  {
+    job_id: "22222222-2222-2222-2222-222222222222",
+    status: "queued",
+    symbol: "QQQ",
+    date: "2026-05-15",
+    created_at: "2026-05-15T10:01:00Z",
+    started_at: null,
+    finished_at: null,
+    history_length: 252,
+    error: null,
+  },
+  {
+    job_id: "33333333-3333-3333-3333-333333333333",
+    status: "succeeded",
+    symbol: "^GSPC",
+    date: "2026-04-29",
+    created_at: "2026-04-29T13:00:00Z",
+    started_at: "2026-04-29T13:00:05Z",
+    finished_at: "2026-04-29T13:01:11Z",
+    history_length: 252,
+    error: null,
+  },
+  {
+    job_id: "44444444-4444-4444-4444-444444444444",
+    status: "failed",
+    symbol: "^GSPC",
+    date: "2026-04-15",
+    created_at: "2026-04-15T08:00:00Z",
+    started_at: "2026-04-15T08:00:05Z",
+    finished_at: "2026-04-15T08:00:30Z",
+    history_length: 252,
+    error: "fetch_market_history: HTTP 503",
+  },
+];
+
+describe("TrainingPage (list)", () => {
+  beforeEach(() => {
+    fetchTrainJobsMock.mockReset();
+    fetchTrainJobMock.mockReset();
+  });
+  afterEach(() => {
+    // Drop any pending polling intervals — cleanup() runs from setup.ts
+    // but the setInterval inside useEffect already cleared via the
+    // return cleanup. Nothing extra to do here.
+  });
+
+  it("renders the empty state when no jobs are queued", async () => {
+    fetchTrainJobsMock.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
+    const { default: TrainingPage } = await import("@/pages/training");
+    render(<TrainingPage />);
+    await waitFor(() =>
+      expect(screen.getByText(/No training jobs in this backend instance/i)).toBeInTheDocument()
+    );
+  });
+
+  it("renders status counts and job rows for queued / running / succeeded / failed", async () => {
+    fetchTrainJobsMock.mockResolvedValue({
+      items: SAMPLE_JOBS,
+      total: SAMPLE_JOBS.length,
+      limit: 50,
+      offset: 0,
+    });
+    const { default: TrainingPage } = await import("@/pages/training");
+    render(<TrainingPage />);
+    await waitFor(() =>
+      expect(screen.getByText(/Job queue/i)).toBeInTheDocument()
+    );
+    expect(screen.getAllByText(/running/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/queued/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/succeeded/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/failed/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/^QQQ$/)).toBeInTheDocument();
+  });
+});
+
+describe("TrainingDetailPage", () => {
+  beforeEach(() => {
+    fetchTrainJobsMock.mockReset();
+    fetchTrainJobMock.mockReset();
+    routerStore.query = { id: "abc-123" };
+  });
+  afterEach(() => {
+    routerStore.query = {};
+  });
+
+  it("renders the running state details", async () => {
+    fetchTrainJobMock.mockResolvedValue({
+      job_id: "abc-123",
+      status: "running",
+      message: "Real Train queued.",
+      error: null,
+      result: null,
+    });
+    const { default: TrainingDetailPage } = await import("@/pages/training/[id]");
+    render(<TrainingDetailPage />);
+    await waitFor(() => expect(screen.getByText(/Real Train queued/i)).toBeInTheDocument());
+    // Heading and id surface.
+    expect(screen.getByText(/abc-123/)).toBeInTheDocument();
+    expect(screen.getAllByText(/running/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders predicted close and sentiment label when result is present", async () => {
+    fetchTrainJobMock.mockResolvedValue({
+      job_id: "abc-123",
+      status: "succeeded",
+      message: "ok",
+      error: null,
+      result: {
+        sentiment: { label: "HAWKISH", score: 0.62 },
+        prediction: { close: 5612.5, volatility: 0.014, horizon: "3d" },
+        model: { runtime_mode: "real_train" },
+      },
+    });
+    const { default: TrainingDetailPage } = await import("@/pages/training/[id]");
+    render(<TrainingDetailPage />);
+    await waitFor(() => expect(screen.getByText(/HAWKISH/i)).toBeInTheDocument());
+    expect(screen.getByText("5612.50")).toBeInTheDocument();
+    expect(screen.getByText("0.0140")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/test_forecasts_endpoint.py
+++ b/tests/unit/test_forecasts_endpoint.py
@@ -1,0 +1,209 @@
+"""Tests for /forecasts/next-fomc (multi-page expansion #150)."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import app.main as main_mod  # noqa: E402
+from app.services import decision_forecast  # noqa: E402
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(main_mod.app)
+
+
+def test_next_fomc_endpoint_empty_state(client, monkeypatch, tmp_path):
+    monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+    response = client.get("/forecasts/next-fomc")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["available"] is False
+    assert body["headline"] is None
+    assert body["history"] == []
+    assert body["ordinal_classes"] == [
+        "cut_50",
+        "cut_25",
+        "hold",
+        "hike_25",
+        "hike_50",
+        "hike_75",
+    ]
+    # The upcoming meeting is still surfaced even with no artefacts.
+    assert "upcoming_meeting" in body
+
+
+def test_next_fomc_endpoint_with_artifacts(client, monkeypatch, tmp_path):
+    artifacts_dir = tmp_path / "artifacts" / "next_fomc"
+    artifacts_dir.mkdir(parents=True)
+    results = {
+        "predictions": [
+            {
+                "target_event_date": "2024-09-17",
+                "target_as_of_ts": "2024-09-17T19:00:00+00:00",
+                "target_class": "cut_25",
+                "n_train_rows": 12,
+                "probabilities": {
+                    "ordinal_logit": {
+                        "cut_50": 0.05,
+                        "cut_25": 0.55,
+                        "hold": 0.30,
+                        "hike_25": 0.07,
+                        "hike_50": 0.02,
+                        "hike_75": 0.01,
+                    },
+                    "ois_baseline": {
+                        "cut_50": 0.10,
+                        "cut_25": 0.45,
+                        "hold": 0.40,
+                        "hike_25": 0.04,
+                        "hike_50": 0.01,
+                        "hike_75": 0.00,
+                    },
+                },
+            },
+            {
+                "target_event_date": "2024-11-06",
+                "target_as_of_ts": "2024-11-06T19:00:00+00:00",
+                "target_class": "hold",
+                "n_train_rows": 13,
+                "probabilities": {
+                    "ordinal_logit": {
+                        "cut_50": 0.01,
+                        "cut_25": 0.10,
+                        "hold": 0.70,
+                        "hike_25": 0.15,
+                        "hike_50": 0.03,
+                        "hike_75": 0.01,
+                    },
+                    "ois_baseline": {
+                        "cut_50": 0.02,
+                        "cut_25": 0.12,
+                        "hold": 0.65,
+                        "hike_25": 0.18,
+                        "hike_50": 0.02,
+                        "hike_75": 0.01,
+                    },
+                },
+            },
+        ],
+        "summary": {"rows_emitted": 2, "rows_in_events": 2},
+    }
+    (artifacts_dir / "results.json").write_text(
+        json.dumps(results, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    metrics = {
+        "model_names": ["ordinal_logit", "ois_baseline"],
+        "full_window": {
+            "ordinal_logit": {
+                "n": 2,
+                "brier": 0.32,
+                "log_loss": 0.71,
+                "top1_accuracy": 1.0,
+                "macro_f1": 0.83,
+                "confusion_matrix": {"hold": {"hold": 1}, "cut_25": {"cut_25": 1}},
+            },
+            "ois_baseline": {
+                "n": 2,
+                "brier": 0.45,
+                "log_loss": 0.95,
+                "top1_accuracy": 0.5,
+                "macro_f1": 0.5,
+                "confusion_matrix": {"hold": {"hold": 1}, "cut_25": {"hold": 1}},
+            },
+        },
+        "ex_pandemic_window": {
+            "ordinal_logit": {
+                "n": 2,
+                "brier": 0.32,
+                "log_loss": 0.71,
+                "top1_accuracy": 1.0,
+                "macro_f1": 0.83,
+                "confusion_matrix": {},
+            },
+        },
+    }
+    (artifacts_dir / "metrics.json").write_text(
+        json.dumps(metrics, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    (artifacts_dir / "feature_attribution.md").write_text(
+        (
+            "# Next-FOMC decision -- feature-family attribution\n\n"
+            "| Subset | Families | #features | n | Brier | LogLoss | Top1Acc | MacroF1 |\n"
+            "| --- | --- | --- | --- | --- | --- | --- | --- |\n"
+            "| ois_only | ois | 10 | 2 | 0.45 | 0.95 | 0.5 | 0.5 |\n"
+            "| full | ois, text, linguistic, credibility, macro | 39 | 2 | 0.32 | 0.71 | 1.0 | 0.83 |\n"
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+    response = client.get("/forecasts/next-fomc")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["available"] is True
+    assert body["model_names"] == ["ordinal_logit", "ois_baseline"]
+    assert len(body["history"]) == 2
+    assert body["history"][0]["predicted_class"]["ordinal_logit"] == "cut_25"
+    headline = body["headline"]
+    assert headline is not None
+    # Latest entry is the November meeting; matches the latest history row.
+    assert headline["target_event_date"] in {"2024-09-17", "2024-11-06"}
+    # Attribution: parsed two rows.
+    subsets = [row["subset"] for row in body["feature_attribution"]]
+    assert subsets == ["ois_only", "full"]
+    assert body["feature_attribution"][1]["families"] == [
+        "ois",
+        "text",
+        "linguistic",
+        "credibility",
+        "macro",
+    ]
+    assert body["metrics_full_window"]["ordinal_logit"]["macro_f1"] == 0.83
+    assert body["summary"]["rows_emitted"] == 2
+
+
+def test_decision_forecast_loader_argmax(tmp_path):
+    artifacts_dir = tmp_path / "next_fomc"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "results.json").write_text(
+        json.dumps(
+            {
+                "predictions": [
+                    {
+                        "target_event_date": "2026-09-15",
+                        "target_as_of_ts": "2026-09-15T19:00:00+00:00",
+                        "target_class": None,
+                        "n_train_rows": 28,
+                        "probabilities": {
+                            "ordinal_logit": {
+                                "cut_50": 0.02,
+                                "cut_25": 0.18,
+                                "hold": 0.55,
+                                "hike_25": 0.20,
+                                "hike_50": 0.04,
+                                "hike_75": 0.01,
+                            }
+                        },
+                    }
+                ],
+                "summary": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    payload = decision_forecast.load_next_fomc_artifacts(
+        artifacts_dir, reference_date=date(2026, 9, 1)
+    )
+    assert payload["available"] is True
+    assert payload["headline"]["predicted_class"]["ordinal_logit"] == "hold"

--- a/tests/unit/test_research_endpoints.py
+++ b/tests/unit/test_research_endpoints.py
@@ -1,0 +1,195 @@
+"""Tests for /research/artifacts and /train-jobs (multi-page expansion #150)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import app.main as main_mod  # noqa: E402
+from app.services import research_artifacts  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_train_jobs():
+    """Each test starts with an empty in-memory train-jobs map."""
+
+    with main_mod._train_jobs_lock:
+        main_mod._train_jobs.clear()
+    yield
+    with main_mod._train_jobs_lock:
+        main_mod._train_jobs.clear()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(main_mod.app)
+
+
+def _write_phase3_aggregate(root: Path, *, name: str, by_encoder: dict) -> Path:
+    target = root / "phase3" / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "by_encoder": by_encoder,
+        "coverage": 0.95,
+        "seed": 11,
+        "block_size": 1,
+    }
+    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return target
+
+
+def _write_cross_bank_matrix(root: Path, *, payload: dict, name: str = "transfer_matrix.json") -> Path:
+    target = root / "cross_bank" / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return target
+
+
+def test_research_artifacts_empty_state(client, monkeypatch, tmp_path):
+    monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+    response = client.get("/research/artifacts")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["artifacts_root"].endswith("artifacts")
+    assert body["encoder_bakeoff"]["available"] is False
+    assert body["encoder_bakeoff"]["rows"] == []
+    assert body["cross_bank_transfer"]["available"] is False
+    for section in ("phase3", "cross_bank", "cross_asset", "next_fomc"):
+        assert body["sections"][section] == []
+
+
+def test_research_artifacts_with_bakeoff_and_transfer(
+    client, monkeypatch, tmp_path
+):
+    artifacts_root = tmp_path / "artifacts"
+    _write_phase3_aggregate(
+        artifacts_root,
+        name="run-a/aggregate.json",
+        by_encoder={
+            "bert-base-uncased": {
+                "checkpoint": "bert-base-uncased",
+                "per_seed": {
+                    "11": {"macro_f1": 0.55, "weighted_f1": 0.58, "accuracy": 0.60},
+                    "29": {"macro_f1": 0.57, "weighted_f1": 0.59, "accuracy": 0.61},
+                },
+                "macro_f1_ci": {"low": 0.52, "high": 0.60},
+            },
+            "fomc-roberta": {
+                "checkpoint": "yiyanghkust/finbert-tone",
+                "per_seed": {
+                    "11": {"macro_f1": 0.61, "weighted_f1": 0.62, "accuracy": 0.65},
+                },
+            },
+        },
+    )
+    _write_cross_bank_matrix(
+        artifacts_root,
+        payload={
+            "metric_name": "macro_f1",
+            "sources": ["fed", "ecb"],
+            "targets": ["fed", "ecb"],
+            "cells": [
+                {"source": "fed", "target": "fed", "metric": 0.63},
+                {"source": "fed", "target": "ecb", "metric": 0.41},
+                {"source": "ecb", "target": "fed", "metric": 0.45},
+                {"source": "ecb", "target": "ecb", "metric": 0.58},
+            ],
+        },
+    )
+    monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+
+    response = client.get("/research/artifacts")
+    assert response.status_code == 200
+    body = response.json()
+    bakeoff = body["encoder_bakeoff"]
+    assert bakeoff["available"] is True
+    encoder_keys = [r["encoder_key"] for r in bakeoff["rows"]]
+    assert encoder_keys == ["bert-base-uncased", "fomc-roberta"]
+    bert_row = next(r for r in bakeoff["rows"] if r["encoder_key"] == "bert-base-uncased")
+    assert bert_row["macro_f1_values"] == [0.55, 0.57]
+    assert pytest.approx(bert_row["macro_f1_mean"], rel=1e-4) == 0.56
+    assert bert_row["macro_f1_ci_low"] == 0.52
+    assert bert_row["macro_f1_ci_high"] == 0.60
+
+    transfer = body["cross_bank_transfer"]
+    assert transfer["available"] is True
+    assert transfer["metric_name"] == "macro_f1"
+    assert sorted(transfer["sources"]) == ["ecb", "fed"]
+    cell_keys = {(c["source"], c["target"]) for c in transfer["cells"]}
+    assert ("fed", "ecb") in cell_keys
+
+    # Files are surfaced for the explorer side panel.
+    assert any(f["relative_path"].endswith("aggregate.json") for f in body["sections"]["phase3"])
+    assert any(
+        f["relative_path"].endswith("transfer_matrix.json")
+        for f in body["sections"]["cross_bank"]
+    )
+
+
+def test_research_artifacts_accepts_matrix_shape(client, monkeypatch, tmp_path):
+    artifacts_root = tmp_path / "artifacts"
+    _write_cross_bank_matrix(
+        artifacts_root,
+        payload={
+            "metric_name": "macro_f1",
+            "matrix": {"fed": {"fed": 0.63, "ecb": 0.41}, "ecb": {"fed": 0.45, "ecb": 0.58}},
+        },
+    )
+    monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+
+    response = client.get("/research/artifacts")
+    body = response.json()
+    transfer = body["cross_bank_transfer"]
+    assert transfer["available"] is True
+    cells = {(c["source"], c["target"]): c["metric"] for c in transfer["cells"]}
+    assert cells[("fed", "fed")] == 0.63
+    assert cells[("ecb", "ecb")] == 0.58
+
+
+def test_train_jobs_listing_filters_and_pagination(client):
+    now = datetime.now(timezone.utc).isoformat()
+    jobs = [
+        {"job_id": "a", "status": "running", "symbol": "^GSPC", "created_at": now},
+        {"job_id": "b", "status": "queued", "symbol": "^GSPC", "created_at": now},
+        {"job_id": "c", "status": "succeeded", "symbol": "QQQ", "created_at": now},
+        {"job_id": "d", "status": "failed", "symbol": "^GSPC", "created_at": now, "error": "boom"},
+    ]
+    with main_mod._train_jobs_lock:
+        for job in jobs:
+            main_mod._train_jobs[job["job_id"]] = job
+
+    response = client.get("/train-jobs")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 4
+    # Running first, then queued, failed, succeeded -- per _TRAIN_JOB_SORT_RANK.
+    assert [item["job_id"] for item in body["items"]] == ["a", "b", "d", "c"]
+
+    filtered = client.get("/train-jobs", params={"status": "failed"}).json()
+    assert filtered["total"] == 1
+    assert filtered["items"][0]["error"] == "boom"
+
+    paged = client.get("/train-jobs", params={"limit": 2, "offset": 1}).json()
+    assert paged["limit"] == 2
+    assert paged["offset"] == 1
+    assert len(paged["items"]) == 2
+
+
+def test_research_artifacts_section_skips_dotfiles(tmp_path):
+    section_dir = tmp_path / "artifacts" / "phase3"
+    section_dir.mkdir(parents=True)
+    (section_dir / "aggregate.json").write_text("{}", encoding="utf-8")
+    (section_dir / ".hidden").write_text("nope", encoding="utf-8")
+    infos = research_artifacts.list_section_files(tmp_path / "artifacts", "phase3")
+    names = {Path(info.relative_path).name for info in infos}
+    assert "aggregate.json" in names
+    assert ".hidden" not in names


### PR DESCRIPTION
## Summary
- /research, /training, /decisions pages alongside the existing Analyze
- Cross-CB transfer heatmap + encoder bake-off table from data/artifacts/phase3 and cross_bank
- /decisions surfaces next-FOMC ordinal class vs OIS-implied baseline + attribution
- New GET /research/artifacts, /forecasts/next-fomc, /train-jobs endpoints
- Graceful empty states tolerate missing artefacts and unpopulated job queues
- Typed Pydantic + TS interfaces, no unknown types
- Light + dark theme tokens honoured; no new heavy frontend deps

## Test plan
- [ ] `cd /home/yusuf/SWE599/fed-pulse && docker compose run --rm --no-deps -v "<worktree>:/wt" backend bash -c "cd /wt && PYTHONPATH=backend pytest tests/unit/test_research_endpoints.py tests/unit/test_forecasts_endpoint.py -q"`
- [ ] `npm --prefix frontend test`
- [ ] `npm --prefix frontend run build`