### PR TITLE
Phase 8 (#70): multi-architecture forecaster sweep + credibility flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ FEATURE_VERSION ?=
 TRAINING_PACKAGE_ID ?=
 OWNER ?= unknown
 SEED ?= 11
+ARCHITECTURE ?= lstm
 
 TEACHER_CHECKPOINT ?= /data/artifacts/phase3/pilot_finetune_20260505T142652Z/hf_checkpoints
 PSEUDO_STRATEGY ?= chunk_vote
@@ -27,7 +28,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state next-fomc cross-asset
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state next-fomc cross-asset forecaster-sweep forecaster-sweep-aggregate forecaster-credibility-train
 
 help:
 	@echo "Targets:"
@@ -53,6 +54,9 @@ help:
 	@echo "  make macro-state      - Build the FRED macro-state parquet (Phase 8 #147)"
 	@echo "  make next-fomc        - Predict next-FOMC decision (Phase 8 headline, #147)"
 	@echo "  make cross-asset      - Cross-asset abnormal-return response head (Phase 8, #148)"
+	@echo "  make forecaster-sweep         - 6-arch x 5-seed forecaster sweep (Phase 8, #70)"
+	@echo "  make forecaster-sweep-aggregate - Aggregate sweep trials into per-arch CIs"
+	@echo "  make forecaster-credibility-train - Single training run with credibility features on"
 
 dev: dev-cpu
 
@@ -106,6 +110,37 @@ train-batch:
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
 		--mode full \
 		--owner "$(OWNER)"
+
+# Forecaster architecture sweep: 6 architectures (lstm, lstm_attn, gru, tcn,
+# transformer, dlinear) x official 5-seed set {11, 29, 47, 71, 97}.
+# Writes forecaster_sweep_results.json + .csv next to the checkpoint.
+forecaster-sweep:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	docker compose run --rm backend \
+		python -m app.train_forecaster \
+		--sweep \
+		--architectures lstm lstm_attn gru tcn transformer dlinear \
+		--seeds 11 29 47 71 97 \
+		--report-path "/data/artifacts/forecaster_sweep/$(TRAINING_PACKAGE_ID)/forecaster_sweep_results.json"
+
+# Aggregate per-trial JSONs into a per-architecture headline (block-bootstrap CIs).
+forecaster-sweep-aggregate:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	docker compose run --rm backend \
+		python -m app.evaluation.forecaster_sweep_aggregator \
+		--artifact-dir "/data/artifacts/forecaster_sweep/$(TRAINING_PACKAGE_ID)"
+
+# Single-architecture training with --credibility-features ON. Used for
+# isolated credibility-vs-baseline comparisons; defaults to ARCHITECTURE=lstm
+# and SEED=11. Override either as needed.
+forecaster-credibility-train:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	docker compose run --rm backend \
+		python -m app.train_forecaster \
+		--architecture "$(ARCHITECTURE)" \
+		--seed "$(SEED)" \
+		--credibility-features \
+		--checkpoint-path "/data/artifacts/forecaster_sweep/$(TRAINING_PACKAGE_ID)/credibility_$(ARCHITECTURE)_seed$(SEED).pt"
 
 changelog:
 	@command -v git-cliff >/dev/null 2>&1 || { \

--- a/backend/app/evaluation/forecaster_sweep_aggregator.py
+++ b/backend/app/evaluation/forecaster_sweep_aggregator.py
@@ -1,0 +1,303 @@
+"""Aggregate forecaster sweep trials into a per-architecture headline table.
+
+Consumes one or more ``forecaster_sweep_results.json`` payloads produced by
+``backend/app/train_forecaster.py`` (see :func:`_run_sweep`), groups trials by
+architecture, and emits
+
+- a JSON summary with block-bootstrap CIs per architecture
+- a markdown headline table sortable by combined-RMSE (lower is better)
+
+The bootstrap CIs are computed via :func:`app.evaluation.bootstrap.block_bootstrap_ci`
+to keep the protocol identical to the NLP bake-off aggregator.
+
+Usage::
+
+    python -m app.evaluation.forecaster_sweep_aggregator \\
+        --artifact-dir backend/models/forecaster_sweep_results.json \\
+        --output-dir   data/artifacts/forecaster_sweep
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from app.evaluation.bootstrap import BootstrapCI, block_bootstrap_ci
+
+
+@dataclass(frozen=True)
+class ArchitectureRow:
+    architecture: str
+    seeds: list[int]
+    credibility_features: bool
+    combined_rmse_values: list[float]
+    close_rmse_values: list[float]
+    volatility_rmse_values: list[float]
+    combined_rmse_ci: BootstrapCI
+    close_rmse_ci: BootstrapCI
+    volatility_rmse_ci: BootstrapCI
+
+
+def _load_report(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _iter_report_files(artifact_dir: Path) -> Iterable[Path]:
+    """Yield every sweep-result JSON under ``artifact_dir``.
+
+    Accepts either a single file (matching ``*sweep_results.json``) or a
+    directory. When given a directory the iteration is recursive and sorted
+    so output is deterministic.
+    """
+
+    if artifact_dir.is_file():
+        yield artifact_dir
+        return
+    if not artifact_dir.is_dir():
+        raise FileNotFoundError(f"artifact_dir does not exist: {artifact_dir}")
+    yield from sorted(artifact_dir.glob("**/*sweep_results.json"))
+
+
+def _trial_seed(trial: dict) -> int | None:
+    seed = trial.get("seed")
+    if seed is None:
+        return None
+    try:
+        return int(seed)
+    except (TypeError, ValueError):
+        return None
+
+
+def _trial_architecture(trial: dict) -> str:
+    architecture = trial.get("architecture")
+    if architecture:
+        return str(architecture)
+    summary = trial.get("summary") or {}
+    model_config = summary.get("model_config") or {}
+    return str(model_config.get("architecture", "lstm"))
+
+
+def _trial_metric(trial: dict, key: str) -> float | None:
+    summary = trial.get("summary") or {}
+    metrics = summary.get("metrics") or {}
+    value = metrics.get(key)
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _trial_credibility(trial: dict) -> bool:
+    summary = trial.get("summary") or {}
+    model_config = summary.get("model_config") or {}
+    return bool(model_config.get("credibility_features", False))
+
+
+def _collect_per_architecture(reports: list[dict]) -> dict[str, dict]:
+    by_arch: dict[str, dict] = {}
+    for report in reports:
+        for trial in report.get("trials") or []:
+            architecture = _trial_architecture(trial)
+            bucket = by_arch.setdefault(
+                architecture,
+                {
+                    "seeds": [],
+                    "combined_rmse": [],
+                    "close_rmse": [],
+                    "volatility_rmse": [],
+                    "credibility_features": _trial_credibility(trial),
+                },
+            )
+            combined = _trial_metric(trial, "combined_rmse")
+            if combined is None:
+                continue
+            seed = _trial_seed(trial)
+            if seed is not None:
+                bucket["seeds"].append(seed)
+            bucket["combined_rmse"].append(combined)
+            close = _trial_metric(trial, "close_rmse")
+            if close is not None:
+                bucket["close_rmse"].append(close)
+            vol = _trial_metric(trial, "volatility_rmse")
+            if vol is not None:
+                bucket["volatility_rmse"].append(vol)
+            # Once any credibility-on trial lands for an architecture the
+            # bucket flips on so the headline label stays honest.
+            bucket["credibility_features"] = bucket["credibility_features"] or _trial_credibility(trial)
+    return by_arch
+
+
+def _build_rows(
+    by_arch: dict[str, dict],
+    *,
+    block_size: int,
+    n_resamples: int,
+    coverage: float,
+    seed: int,
+) -> list[ArchitectureRow]:
+    rows: list[ArchitectureRow] = []
+    for architecture, payload in by_arch.items():
+        if not payload["combined_rmse"]:
+            continue
+        rows.append(
+            ArchitectureRow(
+                architecture=architecture,
+                seeds=sorted(set(payload["seeds"])),
+                credibility_features=bool(payload["credibility_features"]),
+                combined_rmse_values=list(payload["combined_rmse"]),
+                close_rmse_values=list(payload["close_rmse"]),
+                volatility_rmse_values=list(payload["volatility_rmse"]),
+                combined_rmse_ci=block_bootstrap_ci(
+                    payload["combined_rmse"],
+                    statistic="mean",
+                    block_size=block_size,
+                    n_resamples=n_resamples,
+                    coverage=coverage,
+                    seed=seed,
+                ),
+                close_rmse_ci=block_bootstrap_ci(
+                    payload["close_rmse"] or [0.0],
+                    statistic="mean",
+                    block_size=block_size,
+                    n_resamples=n_resamples,
+                    coverage=coverage,
+                    seed=seed,
+                ),
+                volatility_rmse_ci=block_bootstrap_ci(
+                    payload["volatility_rmse"] or [0.0],
+                    statistic="mean",
+                    block_size=block_size,
+                    n_resamples=n_resamples,
+                    coverage=coverage,
+                    seed=seed,
+                ),
+            )
+        )
+    # Lower combined-RMSE is better, so ascending sort gives rank order.
+    rows.sort(key=lambda r: r.combined_rmse_ci.point)
+    return rows
+
+
+def render_markdown(rows: list[ArchitectureRow], *, coverage: float) -> str:
+    if not rows:
+        return "_no forecaster sweep rows found_\n"
+    coverage_pct = int(round(coverage * 100))
+    lines = [
+        f"| Rank | Architecture | Credibility | n | combined-RMSE (mean, {coverage_pct}% CI) | close-RMSE | volatility-RMSE |",
+        "|---:|---|:-:|---:|---|---|---|",
+    ]
+    for rank, row in enumerate(rows, start=1):
+        n = len(row.combined_rmse_values)
+        cr = row.combined_rmse_ci
+        c = row.close_rmse_ci
+        v = row.volatility_rmse_ci
+        lines.append(
+            f"| {rank} | `{row.architecture}` | {'on' if row.credibility_features else 'off'} | {n} | "
+            f"{cr.point:.4f} [{cr.lo:.4f}, {cr.hi:.4f}] | "
+            f"{c.point:.4f} [{c.lo:.4f}, {c.hi:.4f}] | "
+            f"{v.point:.4f} [{v.lo:.4f}, {v.hi:.4f}] |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _row_to_json(row: ArchitectureRow) -> dict:
+    return {
+        "architecture": row.architecture,
+        "seeds": row.seeds,
+        "credibility_features": row.credibility_features,
+        "combined_rmse": {
+            "values": row.combined_rmse_values,
+            "ci": asdict(row.combined_rmse_ci),
+        },
+        "close_rmse": {
+            "values": row.close_rmse_values,
+            "ci": asdict(row.close_rmse_ci),
+        },
+        "volatility_rmse": {
+            "values": row.volatility_rmse_values,
+            "ci": asdict(row.volatility_rmse_ci),
+        },
+    }
+
+
+def aggregate(
+    artifact_dir: Path,
+    *,
+    block_size: int = 1,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    seed: int = 11,
+) -> tuple[list[ArchitectureRow], str, dict]:
+    """Read sweep reports under ``artifact_dir`` and emit (rows, md, json_payload)."""
+
+    report_paths = list(_iter_report_files(artifact_dir))
+    if not report_paths:
+        raise FileNotFoundError(f"no sweep report files found under {artifact_dir}")
+    reports = [_load_report(p) for p in report_paths]
+    by_arch = _collect_per_architecture(reports)
+    rows = _build_rows(
+        by_arch,
+        block_size=block_size,
+        n_resamples=n_resamples,
+        coverage=coverage,
+        seed=seed,
+    )
+    markdown = render_markdown(rows, coverage=coverage)
+    payload = {
+        "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "artifact_dir": str(artifact_dir),
+        "source_reports": [str(p) for p in report_paths],
+        "block_size": block_size,
+        "n_resamples": n_resamples,
+        "coverage": coverage,
+        "bootstrap_seed": seed,
+        "architectures": [_row_to_json(row) for row in rows],
+    }
+    return rows, markdown, payload
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Aggregate forecaster sweep trials into a per-architecture headline table."
+    )
+    parser.add_argument("--artifact-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--block-size", type=int, default=1)
+    parser.add_argument("--n-resamples", type=int, default=1000)
+    parser.add_argument("--coverage", type=float, default=0.95)
+    parser.add_argument("--seed", type=int, default=11)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    rows, markdown, payload = aggregate(
+        args.artifact_dir,
+        block_size=args.block_size,
+        n_resamples=args.n_resamples,
+        coverage=args.coverage,
+        seed=args.seed,
+    )
+
+    output_dir = args.output_dir or (
+        args.artifact_dir.parent if args.artifact_dir.is_file() else args.artifact_dir
+    ) / "forecaster_sweep_summary"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    json_path = output_dir / f"forecaster_sweep_summary_{timestamp}.json"
+    md_path = output_dir / f"forecaster_sweep_summary_{timestamp}.md"
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    md_path.write_text(markdown, encoding="utf-8")
+    print(f"[forecaster_sweep_aggregator] {len(rows)} architectures -> {json_path}")
+    print(f"[forecaster_sweep_aggregator] markdown -> {md_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.config import FORECASTER_ARCHITECTURES
 from app.models.registry import (
     MODEL_REGISTRY_PATH,
     EncoderRef,
@@ -7,6 +8,7 @@ from app.models.registry import (
 
 __all__ = [
     "EncoderRef",
+    "FORECASTER_ARCHITECTURES",
     "MODEL_REGISTRY_PATH",
     "load_registry",
     "revision_for",

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -37,6 +37,16 @@ MODELS_DIR = MODEL_CHECKPOINT_DIR
 BEST_MODEL_PATH = MODELS_DIR / "forecaster_best.pt"
 
 
+FORECASTER_ARCHITECTURES: tuple[str, ...] = (
+    "lstm",
+    "lstm_attn",
+    "gru",
+    "tcn",
+    "transformer",
+    "dlinear",
+)
+
+
 @dataclass(frozen=True)
 class ModelConfig:
     input_size: int = FEATURE_SIZE
@@ -48,9 +58,13 @@ class ModelConfig:
     text_channel: str = "scalar"
     embedding_adapter_dim: int = 128
     credibility_features: bool = False
+    architecture: str = "lstm"
 
     @classmethod
     def from_model(cls, model: "Any") -> "ModelConfig":
+        architecture = getattr(model, "model_type", None) or "lstm"
+        if architecture not in FORECASTER_ARCHITECTURES:
+            architecture = "lstm"
         return cls(
             input_size=model.input_size,
             hidden_size=model.hidden_size,
@@ -61,6 +75,7 @@ class ModelConfig:
             text_channel=getattr(model, "text_channel", "scalar"),
             embedding_adapter_dim=getattr(model, "chunk_projection_dim", 128) or 128,
             credibility_features=bool(getattr(model, "credibility_features", False)),
+            architecture=str(architecture),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -20,13 +20,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from torch import nn
-
 from app.models.config import FORECASTER_ARCHITECTURES, ModelConfig
 from app.models.lstm import ForecasterModel
 
 
-def build_forecaster(config: ModelConfig | dict[str, Any]) -> nn.Module:
+def build_forecaster(config: ModelConfig | dict[str, Any]) -> ForecasterModel:
     """Build a forecaster module for ``config.architecture``.
 
     All architectures share the same input contract ``(batch, seq_len, 6)``

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -1,0 +1,53 @@
+"""Forecaster architecture factory.
+
+The six architectures (``lstm``, ``lstm_attn``, ``gru``, ``tcn``,
+``transformer``, ``dlinear``) are all wired through the same
+:class:`app.models.lstm.ForecasterModel` wrapper via its ``model_type``
+constructor argument — the wrapper handles per-architecture core selection
+plus the shared optional ``TimeDecayAttention`` /
+``RecurrentSequenceAttention`` / ``ChunkAttentionPooler`` /
+credibility-features paths. The factory exists so callers (sweep harness,
+training loop, tests) get a single dispatch entry point that does not have
+to know the wrapper's internal kwarg layout, and so the public
+``ModelConfig.architecture`` field is the only thing they have to set.
+
+The default ``architecture="lstm"`` path is byte-identical to the previous
+``ForecasterModel()`` construction so the determinism regression at
+``tests/regression/test_forecaster_determinism.py`` stays green.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from torch import nn
+
+from app.models.config import FORECASTER_ARCHITECTURES, ModelConfig
+from app.models.lstm import ForecasterModel
+
+
+def build_forecaster(config: ModelConfig | dict[str, Any]) -> nn.Module:
+    """Build a forecaster module for ``config.architecture``.
+
+    All architectures share the same input contract ``(batch, seq_len, 6)``
+    and output contract ``(batch, 2)`` (close, volatility).  The wrapper
+    dispatches the recurrent core internally via ``model_type``; this
+    function exists to translate the public ``architecture`` field to the
+    wrapper's internal ``model_type`` argument and to raise a clear error
+    when the architecture string is unknown.
+    """
+
+    resolved = config if isinstance(config, ModelConfig) else ModelConfig(**config)
+    architecture = resolved.architecture
+    if architecture not in FORECASTER_ARCHITECTURES:
+        raise ValueError(
+            f"Unknown architecture: {architecture!r}. "
+            f"Allowed: {sorted(FORECASTER_ARCHITECTURES)}"
+        )
+
+    kwargs = resolved.to_dict()
+    kwargs.pop("architecture", None)
+    return ForecasterModel(model_type=architecture, **kwargs)
+
+
+__all__ = ["build_forecaster"]

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -9,6 +9,7 @@ from typing import Any, Sequence
 
 import torch
 
+from app.models import FORECASTER_ARCHITECTURES
 from app.services.forecaster import (
     BEST_MODEL_PATH,
     DEFAULT_BATCH_SIZE,
@@ -28,6 +29,9 @@ from app.services.forecaster import (
     train_model,
 )
 
+# Official seed set for the multi-architecture sweep (mirrors the NLP bake-off
+# protocol in ``docs/benchmark-policy.md``).
+DEFAULT_SWEEP_SEEDS: tuple[int, ...] = (11, 29, 47, 71, 97)
 
 DEFAULT_REPORT_PATH = BEST_MODEL_PATH.parent / "forecaster_sweep_results.json"
 
@@ -101,6 +105,37 @@ def _parse_args() -> argparse.Namespace:
         help="Explicit device override, e.g. 'cuda', 'cuda:0', or 'cpu'.",
     )
     parser.add_argument(
+        "--architecture",
+        choices=list(FORECASTER_ARCHITECTURES),
+        default="lstm",
+        help="Forecaster architecture for a single training run.",
+    )
+    parser.add_argument(
+        "--architectures",
+        nargs="+",
+        choices=list(FORECASTER_ARCHITECTURES),
+        help="Sweep over the listed architectures (combine with --sweep).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Deterministic seed for a single training run.",
+    )
+    parser.add_argument(
+        "--seeds",
+        nargs="+",
+        type=int,
+        help="Sweep over the listed seeds. Defaults to the official seed set when "
+        "combined with --architectures.",
+    )
+    parser.add_argument(
+        "--credibility-features",
+        action="store_true",
+        help="Enable the 4-axis credibility feature path on the forecaster. Default off "
+        "preserves the byte-identical regression-test contract for architecture=lstm.",
+    )
+    parser.add_argument(
         "--sweep",
         action="store_true",
         help="Run a grid search and select the best checkpoint by validation RMSE.",
@@ -154,6 +189,8 @@ def _build_model_config(args: argparse.Namespace) -> ModelConfig:
         num_layers=args.num_layers,
         dropout=args.dropout,
         head_hidden_size=args.head_hidden_size,
+        architecture=args.architecture,
+        credibility_features=bool(args.credibility_features),
     )
 
 
@@ -206,14 +243,26 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
     dropouts = args.dropouts or [args.dropout]
     learning_rates = args.learning_rates or [args.learning_rate]
     epochs_options = args.epochs_grid or [args.epochs]
+    architectures = args.architectures or [args.architecture]
+    # When the caller asks for an architecture sweep but doesn't list seeds we
+    # fall back to the official five-seed set; this matches the bake-off
+    # aggregator and avoids accidentally publishing a single-seed table.
+    if args.seeds:
+        seeds: list[int | None] = [int(s) for s in args.seeds]
+    elif args.architectures:
+        seeds = list(DEFAULT_SWEEP_SEEDS)
+    else:
+        seeds = [args.seed]
 
     candidates: list[dict[str, Any]] = []
-    for hidden_size, num_layers, dropout, learning_rate, epochs in itertools.product(
+    for architecture, hidden_size, num_layers, dropout, learning_rate, epochs, seed in itertools.product(
+        architectures,
         hidden_sizes,
         num_layers_options,
         dropouts,
         learning_rates,
         epochs_options,
+        seeds,
     ):
         candidates.append(
             {
@@ -222,9 +271,12 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                     num_layers=num_layers,
                     dropout=dropout,
                     head_hidden_size=args.head_hidden_size,
+                    architecture=str(architecture),
+                    credibility_features=bool(args.credibility_features),
                 ),
                 "learning_rate": float(learning_rate),
                 "epochs": int(epochs),
+                "seed": int(seed) if seed is not None else None,
             }
         )
     return candidates
@@ -237,6 +289,9 @@ def _flatten_trial_record(record: dict[str, Any]) -> dict[str, Any]:
     return {
         "trial_index": record["trial_index"],
         "selected": record.get("selected", False),
+        "architecture": model_config.get("architecture") or record.get("architecture"),
+        "seed": record.get("seed"),
+        "credibility_features": model_config.get("credibility_features"),
         "hidden_size": model_config.get("hidden_size"),
         "num_layers": model_config.get("num_layers"),
         "dropout": model_config.get("dropout"),
@@ -258,7 +313,7 @@ def _flatten_trial_record(record: dict[str, Any]) -> dict[str, Any]:
 
 def _write_sweep_report(report_path: Path, payload: dict[str, Any]) -> None:
     report_path.parent.mkdir(parents=True, exist_ok=True)
-    report_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    report_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
     csv_path = report_path.with_suffix(".csv")
     trial_rows = [_flatten_trial_record(trial) for trial in payload.get("trials", [])]
@@ -282,6 +337,7 @@ def _run_single_training(
     early_stopping_patience: int,
     model_config: ModelConfig,
     save_checkpoint: bool,
+    seed: int | None = None,
 ) -> TrainingRunSummary:
     result = train_model(
         data_dir=data_dir,
@@ -294,6 +350,7 @@ def _run_single_training(
         save_checkpoint=save_checkpoint,
         device=device,
         model_config=model_config,
+        seed=seed,
     )
     return result.summary
 
@@ -318,6 +375,7 @@ def _run_sweep(
         model_config = candidate["model_config"]
         learning_rate = candidate["learning_rate"]
         epochs = candidate["epochs"]
+        seed = candidate.get("seed")
         summary = _run_single_training(
             data_dir=data_dir,
             checkpoint_path=checkpoint_path,
@@ -329,9 +387,17 @@ def _run_sweep(
             early_stopping_patience=args.early_stopping_patience,
             model_config=model_config,
             save_checkpoint=False,
+            seed=seed,
         )
         summaries.append(summary)
-        trial_records.append({"trial_index": index, "summary": summary.to_dict()})
+        trial_records.append(
+            {
+                "trial_index": index,
+                "architecture": model_config.architecture,
+                "seed": seed,
+                "summary": summary.to_dict(),
+            }
+        )
         metrics = summary.metrics
         metrics_label = (
             f"combined_rmse={metrics.combined_rmse:.6f}, loss={metrics.loss:.6f}"
@@ -340,6 +406,7 @@ def _run_sweep(
         )
         print(
             f"[trial {index}/{len(candidates)}] "
+            f"arch={model_config.architecture}, seed={seed}, "
             f"hidden={model_config.hidden_size}, layers={model_config.num_layers}, "
             f"dropout={model_config.dropout:.3f}, lr={learning_rate:.6g}, epochs={epochs} -> {metrics_label}"
         )
@@ -355,8 +422,10 @@ def _run_sweep(
         if summary == best_summary
     )
     best_model_config = best_summary.model_config
+    best_seed = candidates[best_trial_index - 1].get("seed")
     print(
         "Re-training best configuration for final checkpoint: "
+        f"arch={best_model_config.architecture}, seed={best_seed}, "
         f"hidden={best_model_config.hidden_size}, layers={best_model_config.num_layers}, "
         f"dropout={best_model_config.dropout:.3f}, lr={best_summary.learning_rate:.6g}, "
         f"epochs={best_summary.epochs_requested}"
@@ -372,6 +441,7 @@ def _run_sweep(
         early_stopping_patience=best_summary.early_stopping_patience,
         model_config=best_model_config,
         save_checkpoint=True,
+        seed=best_seed,
     )
     for trial in trial_records:
         trial["selected"] = trial["trial_index"] == best_trial_index
@@ -382,6 +452,9 @@ def _run_sweep(
         "device": str(device),
         "data_dir": str(data_dir),
         "checkpoint_path": str(checkpoint_path),
+        "credibility_features": bool(args.credibility_features),
+        "architectures": sorted({trial["architecture"] for trial in trial_records}),
+        "seeds": sorted({trial["seed"] for trial in trial_records if trial["seed"] is not None}),
         "trial_count": len(trial_records),
         "best_trial_index": best_trial_index,
         "best_trial": trial_records[best_trial_index - 1],
@@ -430,10 +503,19 @@ def main() -> int:
         )
         return 1
 
-    if args.sweep or any(
+    sweep_mode = args.sweep or any(
         option is not None
-        for option in (args.hidden_sizes, args.num_layers_grid, args.dropouts, args.learning_rates, args.epochs_grid)
-    ):
+        for option in (
+            args.hidden_sizes,
+            args.num_layers_grid,
+            args.dropouts,
+            args.learning_rates,
+            args.epochs_grid,
+            args.architectures,
+            args.seeds,
+        )
+    )
+    if sweep_mode:
         return _run_sweep(
             args=args,
             data_dir=data_dir,
@@ -442,7 +524,10 @@ def main() -> int:
             device=device,
         )
 
-    print("Starting professional forecaster training...")
+    print(
+        "Starting professional forecaster training "
+        f"(architecture={args.architecture}, credibility_features={bool(args.credibility_features)})..."
+    )
     summary = _run_single_training(
         data_dir=data_dir,
         checkpoint_path=checkpoint_path,
@@ -454,6 +539,7 @@ def main() -> int:
         early_stopping_patience=args.early_stopping_patience,
         model_config=_build_model_config(args),
         save_checkpoint=True,
+        seed=args.seed,
     )
     metrics = summary.metrics
     if metrics is not None:

--- a/backend/app/training/checkpoint.py
+++ b/backend/app/training/checkpoint.py
@@ -89,6 +89,7 @@ def _coerce_payload_config(payload: dict[str, Any] | None) -> ModelConfig:
             text_channel=str(raw.get("text_channel", "scalar")),
             embedding_adapter_dim=int(raw.get("embedding_adapter_dim", 128)),
             credibility_features=bool(raw.get("credibility_features", False)),
+            architecture=str(raw.get("architecture", "lstm")),
         )
     return ModelConfig()
 

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -55,6 +55,7 @@ def _coerce_model_config(model_config: ModelConfig | dict[str, Any] | None = Non
             text_channel=str(model_config.get("text_channel", "scalar")),
             embedding_adapter_dim=int(model_config.get("embedding_adapter_dim", 128)),
             credibility_features=bool(model_config.get("credibility_features", False)),
+            architecture=str(model_config.get("architecture", "lstm")),
         )
     return ModelConfig()
 
@@ -64,8 +65,12 @@ def _build_model(
     *,
     device: torch.device | None = None,
 ) -> ForecasterModel:
+    # Local import keeps ``app.models.factory`` cold until training fires,
+    # which keeps the FastAPI singleton import path narrow.
+    from app.models.factory import build_forecaster
+
     resolved_config = _coerce_model_config(model_config)
-    model = ForecasterModel(**resolved_config.to_dict())
+    model = build_forecaster(resolved_config)
     if device is not None:
         model = model.to(device)
     return model

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -534,3 +534,102 @@ Outputs land under `data/artifacts/cross_asset/`:
   `^GSPC|h1` and `^GSPC|h5`. Same subset list as the next-FOMC
   attribution table, plus the model-free `zero_baseline` and
   `ois_bp_baseline` reference rows.
+
+## Forecaster architecture sweep (Phase 8)
+
+The quantitative-forecaster CLI under `backend/app/train_forecaster.py`
+ships a six-architecture sweep harness with an optional credibility
+features flag. All six architectures share the same input contract
+(`(batch, 20, 6)`) and the same output contract (`(batch, 2)` for
+close/volatility) so the sweep harness, evaluation loop, and downstream
+inference path treat them interchangeably.
+
+### Architecture roster
+
+| Arch         | Core                                             | Notes |
+|--------------|--------------------------------------------------|-------|
+| `lstm`       | `nn.LSTM` (default)                              | The v2 default; byte-identical to pre-#70 behaviour when `credibility_features=False`. |
+| `lstm_attn`  | `nn.LSTM` + `RecurrentSequenceAttention` pool    | Additive-attention pool over LSTM outputs replaces `output[:, -1, :]`. |
+| `gru`        | `nn.GRU`                                         | Same hyperparameter shape as the LSTM core. |
+| `tcn`        | Two dilated-conv `TemporalConvNet` blocks        | Causal padding; residual identity. |
+| `transformer`| `SmallTransformer` (2 layers, 4 heads)           | `hidden_size` must be divisible by 4 (default 64 satisfies). |
+| `dlinear`    | DLinear (trend + seasonal decomposition)         | Pinned to `SEQUENCE_LENGTH=20`. |
+
+The official registry constant lives at `app.models.FORECASTER_ARCHITECTURES`.
+
+### Credibility-features flag
+
+`--credibility-features` activates the four-axis credibility vector
+(`drift_score`, `realized_vs_stated_gap`, `market_implied_gap`,
+`months_since_reversal`) on the forecaster input. Default off preserves
+the byte-identical training contract — the determinism regression at
+`tests/regression/test_forecaster_determinism.py` plus the lock test at
+`tests/unit/test_forecaster_credibility_flag.py` enforce that
+`architecture="lstm"` + `credibility_features=False` is bit-identical
+across runs at the same seed (within `1e-7` for the in-test contract;
+the published `1e-4` contract covers cross-platform drift).
+
+### Sweep output schema
+
+`forecaster_sweep_results.json` (JSON, sorted keys) carries:
+
+```
+{
+  "mode": "sweep",
+  "selection_metric": "combined_rmse",
+  "architectures": ["dlinear", "gru", "lstm", "lstm_attn", "tcn", "transformer"],
+  "seeds": [11, 29, 47, 71, 97],
+  "credibility_features": false,
+  "trial_count": 30,
+  "best_trial_index": <int>,
+  "best_trial": {...},
+  "selected_checkpoint": {...},
+  "trials": [
+    {
+      "trial_index": <int>,
+      "architecture": "<arch>",
+      "seed": <int>,
+      "selected": <bool>,
+      "summary": <TrainingRunSummary.to_dict()>
+    },
+    ...
+  ]
+}
+```
+
+A sibling `.csv` with one row per trial is written next to the JSON.
+The companion aggregator `app.evaluation.forecaster_sweep_aggregator`
+reads one or more sweep result files and emits a markdown headline
+table plus per-architecture block-bootstrap CIs (95% by default,
+`block_size=1`, `n_resamples=1000`, deterministic at `seed=11`). The
+aggregator output schema is:
+
+```
+{
+  "generated_at_utc": "<ISO 8601>",
+  "block_size": 1,
+  "n_resamples": 1000,
+  "coverage": 0.95,
+  "bootstrap_seed": 11,
+  "architectures": [
+    {
+      "architecture": "<arch>",
+      "seeds": [...],
+      "credibility_features": <bool>,
+      "combined_rmse": {"values": [...], "ci": {...}},
+      "close_rmse":    {"values": [...], "ci": {...}},
+      "volatility_rmse": {"values": [...], "ci": {...}}
+    },
+    ...
+  ]
+}
+```
+
+### Make targets
+
+- `make forecaster-sweep TRAINING_PACKAGE_ID=<id>` — the full
+  6-arch x 5-seed sweep.
+- `make forecaster-sweep-aggregate TRAINING_PACKAGE_ID=<id>` —
+  per-architecture headline (block-bootstrap CIs).
+- `make forecaster-credibility-train TRAINING_PACKAGE_ID=<id> ARCHITECTURE=lstm SEED=11`
+  — single-architecture run with `--credibility-features` on.

--- a/tests/unit/test_forecaster_credibility_features.py
+++ b/tests/unit/test_forecaster_credibility_features.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import torch
 
 from app.models.config import CREDIBILITY_FEATURE_DIM, ModelConfig
+from app.models.factory import build_forecaster
 from app.models.lstm import ForecasterModel
 
 
@@ -21,7 +22,8 @@ def _seed(seed: int = 11) -> None:
 def test_credibility_off_is_default() -> None:
     config = ModelConfig()
     assert config.credibility_features is False
-    model = ForecasterModel(**config.to_dict())
+    model = build_forecaster(config)
+    assert isinstance(model, ForecasterModel)
     assert model.credibility_features is False
     assert model.credibility_dim == 0
 

--- a/tests/unit/test_forecaster_credibility_flag.py
+++ b/tests/unit/test_forecaster_credibility_flag.py
@@ -1,0 +1,168 @@
+"""Lock the credibility-features default-off contract for the training loop.
+
+The forecaster sweep harness must keep ``credibility_features=False`` as the
+default so the determinism regression and every published checkpoint behind
+v1/v2 keep loading.  These tests verify two slices of that contract:
+
+1. The default ``ModelConfig().credibility_features`` is ``False``.
+2. ``train_model`` with ``credibility_features=False`` is bit-identical to
+   itself across two runs at the same seed -- the same byte-for-byte
+   protocol the regression test enforces at the canonical seed 11.
+
+The default-off invariant is more important than the default-on numbers
+because every consumer of the v1/v2 forecaster checkpoint assumes the
+6-feature input shape.  Flipping the default would silently change the
+LSTM input layer and break every on-disk checkpoint without warning.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.config import ModelConfig  # noqa: E402
+from app.services.forecaster import FeatureVector, train_model  # noqa: E402
+
+
+def _synthetic_vectors(n: int) -> list[FeatureVector]:
+    out: list[FeatureVector] = []
+    for i in range(n):
+        sentiment = math.sin(i * 0.41) * 0.6 + 0.1
+        close = 4000.0 + 12.0 * i + 5.0 * math.sin(i * 0.3)
+        vol = 0.012 + 0.003 * math.sin(i * 0.7 + 1.1)
+        prev_close = (
+            4000.0 + 12.0 * (i - 1) + 5.0 * math.sin((i - 1) * 0.3) if i else close
+        )
+        prev_vol = 0.012 + 0.003 * math.sin((i - 1) * 0.7 + 1.1) if i else vol
+        out.append(
+            FeatureVector.from_market_state(
+                date=f"2024-01-{i + 1:02d}",
+                sentiment_score=sentiment,
+                market_close=close,
+                market_volatility=vol,
+                previous_close=prev_close,
+                previous_volatility=prev_vol,
+                elapsed_time=float(i % 30),
+            )
+        )
+    return out
+
+
+def _train_rmse(
+    *,
+    seed: int,
+    vectors: list[FeatureVector],
+    checkpoint: Path,
+    credibility_features: bool,
+    architecture: str = "lstm",
+) -> float:
+    result = train_model(
+        vectors=vectors,
+        epochs=4,
+        batch_size=8,
+        learning_rate=1e-3,
+        validation_split=0.25,
+        early_stopping_patience=2,
+        save_checkpoint=False,
+        checkpoint_path=checkpoint,
+        device="cpu",
+        seed=seed,
+        model_config=ModelConfig(
+            input_size=6,
+            hidden_size=8,
+            num_layers=1,
+            dropout=0.0,
+            head_hidden_size=8,
+            architecture=architecture,
+            credibility_features=credibility_features,
+        ),
+    )
+    metrics = result.summary.metrics
+    assert metrics is not None
+    return float(metrics.combined_rmse)
+
+
+def test_default_modelconfig_has_credibility_off() -> None:
+    assert ModelConfig().credibility_features is False
+    assert ModelConfig().architecture == "lstm"
+
+
+def test_credibility_off_is_byte_identical_under_same_seed(tmp_path: Path) -> None:
+    """Two runs of ``train_model`` at seed=11 with credibility_features=False
+    must produce identical combined-RMSE.  Locks the byte-identical contract
+    declared in ``docs/data-and-training-contracts.md`` for the default
+    forecaster path.
+    """
+
+    vectors = _synthetic_vectors(28)
+    first = _train_rmse(
+        seed=11,
+        vectors=vectors,
+        checkpoint=tmp_path / "first.pt",
+        credibility_features=False,
+    )
+    second = _train_rmse(
+        seed=11,
+        vectors=vectors,
+        checkpoint=tmp_path / "second.pt",
+        credibility_features=False,
+    )
+    assert first == pytest.approx(second, abs=1e-7), (
+        f"credibility-off byte-identity regression: seed=11 produced "
+        f"{first} vs {second}; the default training path leaks randomness"
+    )
+
+
+def test_credibility_off_lstm_matches_default_architecture(tmp_path: Path) -> None:
+    """``architecture="lstm"`` + ``credibility_features=False`` is the default
+    path; switching to the explicit lstm choice must be byte-identical so the
+    factory dispatch does not silently change the v2 LSTM result.
+    """
+
+    vectors = _synthetic_vectors(28)
+    default_path = _train_rmse(
+        seed=11,
+        vectors=vectors,
+        checkpoint=tmp_path / "default.pt",
+        credibility_features=False,
+        architecture="lstm",
+    )
+    explicit_lstm = _train_rmse(
+        seed=11,
+        vectors=vectors,
+        checkpoint=tmp_path / "explicit.pt",
+        credibility_features=False,
+        architecture="lstm",
+    )
+    # Within the ±1e-4 contract for default-LSTM stability documented in
+    # docs/data-and-training-contracts.md, the two paths must agree.
+    assert default_path == pytest.approx(explicit_lstm, abs=1e-4)
+
+
+def test_credibility_on_diverges_from_credibility_off(tmp_path: Path) -> None:
+    """Flipping the credibility flag must change the model graph, so the
+    trained RMSE should not coincidentally equal the credibility-off run.
+    This guards against the flag being accidentally a no-op.
+    """
+
+    vectors = _synthetic_vectors(28)
+    off = _train_rmse(
+        seed=11,
+        vectors=vectors,
+        checkpoint=tmp_path / "off.pt",
+        credibility_features=False,
+    )
+    on = _train_rmse(
+        seed=11,
+        vectors=vectors,
+        checkpoint=tmp_path / "on.pt",
+        credibility_features=True,
+    )
+    assert off != pytest.approx(on, abs=1e-6), (
+        "credibility-on produced the same RMSE as credibility-off; "
+        "the flag is silently a no-op somewhere in the loop"
+    )

--- a/tests/unit/test_forecaster_factory.py
+++ b/tests/unit/test_forecaster_factory.py
@@ -1,0 +1,98 @@
+"""Cover the multi-architecture forecaster factory.
+
+Locks the dispatch surface used by both the sweep harness and the training
+loop: each of the six architectures must return a runnable module that
+accepts ``(batch, 20, 6)`` input and emits ``(batch, 2)`` output, and the
+default ``architecture="lstm"`` must return an instance of the canonical
+``ForecasterModel`` wrapper so on-disk checkpoints keep loading.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models import FORECASTER_ARCHITECTURES  # noqa: E402
+from app.models.config import FEATURE_SIZE, SEQUENCE_LENGTH, ModelConfig  # noqa: E402
+from app.models.factory import build_forecaster  # noqa: E402
+from app.models.lstm import ForecasterModel  # noqa: E402
+
+
+def _fresh(seed: int = 11) -> None:
+    torch.manual_seed(seed)
+
+
+def test_registry_lists_six_architectures() -> None:
+    assert set(FORECASTER_ARCHITECTURES) == {
+        "lstm",
+        "lstm_attn",
+        "gru",
+        "tcn",
+        "transformer",
+        "dlinear",
+    }
+
+
+def test_default_config_returns_lstm_forecaster_model() -> None:
+    _fresh()
+    model = build_forecaster(ModelConfig())
+    assert isinstance(model, ForecasterModel)
+    assert model.model_type == "lstm"
+
+
+def test_factory_rejects_unknown_architecture() -> None:
+    with pytest.raises(ValueError) as exc:
+        build_forecaster(ModelConfig(architecture="not_a_thing"))
+    message = str(exc.value).lower()
+    assert "architecture" in message or "unknown" in message
+
+
+@pytest.mark.parametrize("architecture", list(FORECASTER_ARCHITECTURES))
+def test_each_architecture_emits_two_outputs(architecture: str) -> None:
+    """Every architecture must respect the shared (batch, 20, 6) -> (batch, 2) shape."""
+
+    _fresh()
+    # ``transformer`` requires hidden_size divisible by 4 (num_heads=4); the
+    # default 64 satisfies this. ``dlinear`` is pinned to SEQUENCE_LENGTH=20.
+    config = ModelConfig(architecture=architecture)
+    model = build_forecaster(config)
+    model.eval()
+    assert isinstance(model, ForecasterModel)
+    assert model.model_type == architecture
+
+    batch = 4
+    x = torch.randn(batch, SEQUENCE_LENGTH, FEATURE_SIZE)
+    with torch.no_grad():
+        out = model(x)
+    assert out.shape == (batch, 2), (
+        f"architecture={architecture}: expected (batch, 2); got {tuple(out.shape)}"
+    )
+    # Volatility (column 1) must stay non-negative; the wrapper softpluses it
+    # before returning so this invariant should hold across all architectures.
+    assert torch.all(out[:, 1] >= 0.0), (
+        f"architecture={architecture}: volatility output went negative"
+    )
+
+
+def test_credibility_features_flow_through_factory() -> None:
+    _fresh()
+    config = ModelConfig(architecture="lstm", credibility_features=True)
+    model = build_forecaster(config)
+    assert isinstance(model, ForecasterModel)
+    assert model.credibility_features is True
+
+    x = torch.randn(2, SEQUENCE_LENGTH, FEATURE_SIZE)
+    credibility = torch.zeros(2, model.credibility_dim, dtype=torch.float32)
+    with torch.no_grad():
+        out = model(x, credibility=credibility)
+    assert out.shape == (2, 2)
+
+
+def test_factory_accepts_plain_dict_config() -> None:
+    """Callers that round-trip ModelConfig via JSON pass dicts; the factory must accept them."""
+
+    _fresh()
+    model = build_forecaster(ModelConfig(architecture="gru").to_dict())
+    assert isinstance(model, ForecasterModel)
+    assert model.model_type == "gru"

--- a/tests/unit/test_forecaster_sweep_aggregator.py
+++ b/tests/unit/test_forecaster_sweep_aggregator.py
@@ -1,0 +1,184 @@
+"""Cover ``app.evaluation.forecaster_sweep_aggregator``.
+
+Three slices:
+
+- CI bands at synthetic inputs match the block-bootstrap protocol (lo <= point <= hi).
+- Rank ordering follows ascending combined-RMSE.
+- The aggregator is deterministic at a fixed bootstrap seed -- the same
+  input deck produces a byte-stable markdown table on repeat calls.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.evaluation.forecaster_sweep_aggregator import (
+    ArchitectureRow,
+    aggregate,
+    render_markdown,
+)
+
+
+def _trial(
+    *,
+    architecture: str,
+    seed: int,
+    combined_rmse: float,
+    close_rmse: float | None = None,
+    volatility_rmse: float | None = None,
+    credibility_features: bool = False,
+) -> dict:
+    if close_rmse is None:
+        close_rmse = combined_rmse * 0.8
+    if volatility_rmse is None:
+        volatility_rmse = combined_rmse * 0.2
+    return {
+        "trial_index": 0,
+        "architecture": architecture,
+        "seed": seed,
+        "summary": {
+            "model_config": {
+                "architecture": architecture,
+                "credibility_features": credibility_features,
+            },
+            "metrics": {
+                "combined_rmse": combined_rmse,
+                "close_rmse": close_rmse,
+                "volatility_rmse": volatility_rmse,
+                "loss": combined_rmse,
+            },
+        },
+    }
+
+
+def _write_report(path: Path, trials: list[dict]) -> Path:
+    payload = {"mode": "sweep", "trials": trials}
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def test_ci_bands_bracket_the_point_estimate(tmp_path: Path) -> None:
+    trials = [
+        _trial(architecture="lstm", seed=11, combined_rmse=0.10),
+        _trial(architecture="lstm", seed=29, combined_rmse=0.12),
+        _trial(architecture="lstm", seed=47, combined_rmse=0.11),
+        _trial(architecture="lstm", seed=71, combined_rmse=0.13),
+        _trial(architecture="lstm", seed=97, combined_rmse=0.115),
+        _trial(architecture="gru", seed=11, combined_rmse=0.20),
+        _trial(architecture="gru", seed=29, combined_rmse=0.21),
+        _trial(architecture="gru", seed=47, combined_rmse=0.19),
+        _trial(architecture="gru", seed=71, combined_rmse=0.22),
+        _trial(architecture="gru", seed=97, combined_rmse=0.205),
+    ]
+    _write_report(tmp_path / "sweep_results.json", trials)
+
+    rows, _, payload = aggregate(tmp_path, seed=11)
+    # Two architectures, five seeds each
+    assert {row.architecture for row in rows} == {"lstm", "gru"}
+    for row in rows:
+        assert len(row.combined_rmse_values) == 5
+        assert row.combined_rmse_ci.lo <= row.combined_rmse_ci.point <= row.combined_rmse_ci.hi
+        assert row.combined_rmse_ci.coverage == 0.95
+    # LSTM should be ranked first (lower combined-RMSE).
+    assert rows[0].architecture == "lstm"
+    assert rows[1].architecture == "gru"
+    # JSON payload mirrors the rows in order.
+    assert [arch["architecture"] for arch in payload["architectures"]] == [
+        "lstm",
+        "gru",
+    ]
+
+
+def test_aggregator_handles_multiple_reports(tmp_path: Path) -> None:
+    """Two separate sweep files in the same directory must be merged per architecture."""
+
+    _write_report(
+        tmp_path / "a_sweep_results.json",
+        [_trial(architecture="lstm", seed=11, combined_rmse=0.10)],
+    )
+    _write_report(
+        tmp_path / "b_sweep_results.json",
+        [
+            _trial(architecture="lstm", seed=29, combined_rmse=0.12),
+            _trial(architecture="tcn", seed=11, combined_rmse=0.18),
+        ],
+    )
+
+    rows, _, _ = aggregate(tmp_path, seed=11)
+    by_arch = {row.architecture: row for row in rows}
+    assert sorted(by_arch["lstm"].seeds) == [11, 29]
+    assert by_arch["tcn"].seeds == [11]
+
+
+def test_markdown_table_is_deterministic(tmp_path: Path) -> None:
+    """Same inputs + same bootstrap seed must yield the same markdown."""
+
+    trials = [
+        _trial(architecture="lstm", seed=11, combined_rmse=0.10),
+        _trial(architecture="lstm", seed=29, combined_rmse=0.11),
+        _trial(architecture="gru", seed=11, combined_rmse=0.20),
+        _trial(architecture="gru", seed=29, combined_rmse=0.205),
+    ]
+    _write_report(tmp_path / "sweep_results.json", trials)
+
+    _, md_first, _ = aggregate(tmp_path, seed=11)
+    _, md_second, _ = aggregate(tmp_path, seed=11)
+    assert md_first == md_second
+
+
+def test_render_markdown_handles_empty_rows() -> None:
+    assert "no forecaster sweep rows" in render_markdown([], coverage=0.95)
+
+
+def test_credibility_flag_surfaces_in_markdown(tmp_path: Path) -> None:
+    """When the trials are credibility-on the headline must reflect that label."""
+
+    trials = [
+        _trial(
+            architecture="lstm",
+            seed=11,
+            combined_rmse=0.10,
+            credibility_features=True,
+        ),
+        _trial(
+            architecture="lstm",
+            seed=29,
+            combined_rmse=0.11,
+            credibility_features=True,
+        ),
+    ]
+    _write_report(tmp_path / "sweep_results.json", trials)
+
+    rows, markdown, _ = aggregate(tmp_path, seed=11)
+    assert rows[0].credibility_features is True
+    assert "| on |" in markdown
+
+
+def test_missing_artifact_dir_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        aggregate(tmp_path / "does_not_exist", seed=11)
+
+
+def test_directory_without_reports_raises(tmp_path: Path) -> None:
+    (tmp_path / "unrelated.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(FileNotFoundError):
+        aggregate(tmp_path, seed=11)
+
+
+def test_row_dataclass_is_frozen() -> None:
+    row = ArchitectureRow(
+        architecture="lstm",
+        seeds=[11],
+        credibility_features=False,
+        combined_rmse_values=[0.1],
+        close_rmse_values=[0.08],
+        volatility_rmse_values=[0.02],
+        combined_rmse_ci=None,  # type: ignore[arg-type]
+        close_rmse_ci=None,  # type: ignore[arg-type]
+        volatility_rmse_ci=None,  # type: ignore[arg-type]
+    )
+    with pytest.raises(Exception):
+        row.architecture = "gru"  # type: ignore[misc]

--- a/tests/unit/test_train_forecaster.py
+++ b/tests/unit/test_train_forecaster.py
@@ -69,6 +69,11 @@ def test_build_sweep_candidates_creates_cartesian_product():
         dropouts=[0.10],
         learning_rates=[1e-3, 5e-4],
         epochs_grid=[20],
+        architecture="lstm",
+        architectures=None,
+        seed=None,
+        seeds=None,
+        credibility_features=False,
     )
 
     candidates = build_sweep_candidates(args)
@@ -77,3 +82,7 @@ def test_build_sweep_candidates_creates_cartesian_product():
     assert {candidate["model_config"].hidden_size for candidate in candidates} == {32, 64}
     assert {candidate["model_config"].num_layers for candidate in candidates} == {1, 2}
     assert {candidate["learning_rate"] for candidate in candidates} == {1e-3, 5e-4}
+    # When the caller doesn't pass `--architectures`, the sweep stays on the
+    # single architecture so default behaviour (LSTM-only) is preserved.
+    assert {candidate["model_config"].architecture for candidate in candidates} == {"lstm"}
+    assert {candidate["seed"] for candidate in candidates} == {None}


### PR DESCRIPTION
## Summary
- `ModelConfig.architecture` + `app.models.FORECASTER_ARCHITECTURES` registry
- `app.models.factory.build_forecaster` dispatches all 6 architectures
- CLI gains `--architecture`, `--architectures`, `--seed`, `--seeds`, `--credibility-features`
- Sweep report records architecture + seed per trial (sorted-keys JSON + CSV)
- `app.evaluation.forecaster_sweep_aggregator` emits per-arch block-bootstrap headline
- Make targets: `forecaster-sweep`, `forecaster-sweep-aggregate`, `forecaster-credibility-train`
- `architecture="lstm"` + `credibility_features=False` byte-identical (locked by tests)
- Wiki + `docs/data-and-training-contracts.md` document the sweep contract

## Test plan
- [ ] `docker compose run --rm --no-deps backend pytest tests/unit/test_forecaster_factory.py tests/unit/test_forecaster_credibility_flag.py tests/unit/test_forecaster_sweep_aggregator.py -q`
- [ ] `docker compose run --rm --no-deps backend pytest tests/regression/ tests/unit/test_forecaster.py -q`
- [ ] `ruff check backend/app/train_forecaster.py backend/app/models/factory.py backend/app/evaluation/forecaster_sweep_aggregator.py`