### PR TITLE
Phase 8 (#160): Informer and TFT forecaster architectures

### DIFF
--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -44,6 +44,8 @@ FORECASTER_ARCHITECTURES: tuple[str, ...] = (
     "tcn",
     "transformer",
     "dlinear",
+    "informer",
+    "tft",
 )
 
 

--- a/backend/app/models/informer.py
+++ b/backend/app/models/informer.py
@@ -29,6 +29,7 @@ current default generator.
 from __future__ import annotations
 
 import math
+from typing import cast
 
 import torch
 from torch import nn
@@ -50,7 +51,10 @@ class _SinusoidalPositionalEmbedding(nn.Module):
         self.register_buffer("pe", pe.unsqueeze(0))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return x + self.pe[:, : x.size(1), :]
+        # `register_buffer` returns None; mypy needs the explicit cast
+        # because `nn.Module.__getattr__` is typed as `Tensor | Module`.
+        pe = cast(torch.Tensor, self.pe)
+        return x + pe[:, : x.size(1), :]
 
 
 class _ProbSparseAttention(nn.Module):

--- a/backend/app/models/informer.py
+++ b/backend/app/models/informer.py
@@ -1,0 +1,286 @@
+"""Informer encoder core (Zhou et al., AAAI 2021).
+
+A compact, dependency-free implementation of the encoder side of Informer:
+ProbSparse self-attention plus the standard transformer-style feed-forward
+block, stacked across ``e_layers`` encoder layers and wrapped in a fixed
+sinusoidal positional embedding. Mirrors the public-good Informer reference
+(``zhouhaoyi/Informer2020``) without pulling that repository or
+``pytorch-forecasting`` as a dependency — pure PyTorch only.
+
+Input shape: ``(batch, seq_len, input_size)``. Output: ``(batch, seq_len,
+hidden_size)`` plus a ``None`` placeholder so the forecaster's
+``output, _ = core(x)`` destructuring keeps working unchanged. Pooling to
+the head uses the same ``output[:, -1, :]`` step as the recurrent cores.
+
+The ProbSparse attention reduces full self-attention's ``O(L^2)`` cost to
+``O(L log L)`` by sampling a constant number of dot-product probes per
+query and only routing the top-``u`` queries (by KL-vs-uniform score)
+through the full softmax. For ``L=20`` the asymptotic win is small, but the
+implementation is functionally identical to the published one and keeps
+the encoder a drop-in for the longer-horizon sweeps the Phase-8 wiki
+sketches.
+
+Determinism contract: the module owns no global RNG state. Caller-side
+``torch.manual_seed`` is honored because every stochastic choice (the
+sampled probe indices) is derived from ``torch.randint`` against the
+current default generator.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+class _SinusoidalPositionalEmbedding(nn.Module):
+    """Standard sinusoidal positional embedding shared by the encoder layers."""
+
+    def __init__(self, d_model: int, max_len: int = 512) -> None:
+        super().__init__()
+        position = torch.arange(max_len).unsqueeze(1).float()
+        div_term = torch.exp(
+            torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model)
+        )
+        pe = torch.zeros(max_len, d_model)
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        self.register_buffer("pe", pe.unsqueeze(0))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.pe[:, : x.size(1), :]
+
+
+class _ProbSparseAttention(nn.Module):
+    """ProbSparse self-attention from Informer (Zhou et al. 2021).
+
+    For each query the sparsity score is approximated by sampling ``U_part``
+    keys at random and computing the max-vs-mean gap of the partial dot
+    products. The top ``u`` queries by that score are then routed through a
+    real softmax over the full key set; the remaining queries are replaced
+    by the mean of the value sequence, which is the standard "lazy"
+    fallback from the paper.
+    """
+
+    def __init__(self, factor: int = 5, dropout: float = 0.1) -> None:
+        super().__init__()
+        if factor < 1:
+            raise ValueError(f"factor must be >= 1, got {factor}")
+        self.factor = int(factor)
+        self.dropout = nn.Dropout(dropout)
+
+    def _prob_qk(
+        self, queries: torch.Tensor, keys: torch.Tensor, sample_k: int, n_top: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # queries: (B, H, L_Q, D), keys: (B, H, L_K, D)
+        b, h, l_k, d = keys.shape
+        _, _, l_q, _ = queries.shape
+
+        # Sample sample_k key positions per (B, H, L_Q) triple.
+        index_sample = torch.randint(l_k, (l_q, sample_k), device=keys.device)
+        # Index into K: (B, H, L_Q, sample_k, D)
+        k_expand = keys.unsqueeze(-3).expand(b, h, l_q, l_k, d)
+        k_sample = k_expand[:, :, torch.arange(l_q).unsqueeze(1), index_sample, :]
+
+        # Partial dot products against sampled keys: (B, H, L_Q, sample_k)
+        q_k_sample = torch.matmul(queries.unsqueeze(-2), k_sample.transpose(-2, -1)).squeeze(-2)
+
+        # Sparsity score: max - mean across sampled keys. Top n_top queries win.
+        m = q_k_sample.max(dim=-1).values - q_k_sample.mean(dim=-1)
+        m_top = m.topk(n_top, sorted=False).indices  # (B, H, n_top)
+
+        # Real (full) softmax for the winning queries only.
+        q_reduced = queries[
+            torch.arange(b)[:, None, None],
+            torch.arange(h)[None, :, None],
+            m_top,
+            :,
+        ]
+        q_k = torch.matmul(q_reduced, keys.transpose(-2, -1))
+        return q_k, m_top
+
+    def _get_initial_context(
+        self, values: torch.Tensor, l_q: int
+    ) -> torch.Tensor:
+        # Average of V along the key axis, broadcast to query positions.
+        v_mean = values.mean(dim=-2)  # (B, H, D)
+        context = v_mean.unsqueeze(-2).expand(*values.shape[:-2], l_q, values.shape[-1])
+        return context.clone()
+
+    def _update_context(
+        self,
+        context_in: torch.Tensor,
+        values: torch.Tensor,
+        scores: torch.Tensor,
+        index: torch.Tensor,
+    ) -> torch.Tensor:
+        b, h, _, d = values.shape
+        attn = F.softmax(scores, dim=-1)
+        attn = self.dropout(attn)
+        context_top = torch.matmul(attn, values)  # (B, H, n_top, D)
+        context_in[
+            torch.arange(b)[:, None, None],
+            torch.arange(h)[None, :, None],
+            index,
+            :,
+        ] = context_top
+        return context_in
+
+    def forward(
+        self,
+        queries: torch.Tensor,
+        keys: torch.Tensor,
+        values: torch.Tensor,
+    ) -> torch.Tensor:
+        # queries/keys/values: (B, L, H, D) — match the public reference layout.
+        b, l_q, h, d = queries.shape
+        _, l_k, _, _ = keys.shape
+
+        # Move heads forward: (B, H, L, D)
+        queries = queries.transpose(1, 2)
+        keys = keys.transpose(1, 2)
+        values = values.transpose(1, 2)
+
+        # Cap probe / top-k counts to the actual sequence length. For L=20
+        # this typically yields U_part ≈ 15, u ≈ 15 — i.e., almost-dense
+        # attention. The same code degrades gracefully to dense as L grows.
+        u_part = min(self.factor * max(1, int(math.ceil(math.log(max(l_k, 2))))), l_k)
+        u = min(self.factor * max(1, int(math.ceil(math.log(max(l_q, 2))))), l_q)
+
+        scores_top, index = self._prob_qk(queries, keys, sample_k=u_part, n_top=u)
+        scale = 1.0 / math.sqrt(d)
+        scores_top = scores_top * scale
+
+        context = self._get_initial_context(values, l_q)
+        context = self._update_context(context, values, scores_top, index)
+
+        # Restore (B, L, H, D)
+        return context.transpose(1, 2).contiguous()
+
+
+class _AttentionLayer(nn.Module):
+    """Multi-head wrapper around ProbSparse attention."""
+
+    def __init__(
+        self, d_model: int, n_heads: int, factor: int = 5, dropout: float = 0.1
+    ) -> None:
+        super().__init__()
+        if d_model % n_heads != 0:
+            raise ValueError(
+                f"d_model={d_model} must be divisible by n_heads={n_heads}"
+            )
+        self.d_keys = d_model // n_heads
+        self.n_heads = int(n_heads)
+        self.query_proj = nn.Linear(d_model, d_model)
+        self.key_proj = nn.Linear(d_model, d_model)
+        self.value_proj = nn.Linear(d_model, d_model)
+        self.out_proj = nn.Linear(d_model, d_model)
+        self.inner = _ProbSparseAttention(factor=factor, dropout=dropout)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        b, seq_len, _ = x.shape
+        q = self.query_proj(x).view(b, seq_len, self.n_heads, self.d_keys)
+        k = self.key_proj(x).view(b, seq_len, self.n_heads, self.d_keys)
+        v = self.value_proj(x).view(b, seq_len, self.n_heads, self.d_keys)
+        out = self.inner(q, k, v)  # (B, L, H, D)
+        out = out.view(b, seq_len, self.n_heads * self.d_keys)
+        return self.out_proj(out)
+
+
+class _EncoderLayer(nn.Module):
+    """Attention + position-wise feed-forward, with residual + LayerNorm."""
+
+    def __init__(
+        self,
+        d_model: int,
+        n_heads: int,
+        d_ff: int,
+        factor: int = 5,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.attn = _AttentionLayer(d_model, n_heads, factor=factor, dropout=dropout)
+        self.norm1 = nn.LayerNorm(d_model)
+        self.norm2 = nn.LayerNorm(d_model)
+        self.ff = nn.Sequential(
+            nn.Linear(d_model, d_ff),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(d_ff, d_model),
+        )
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = x + self.dropout(self.attn(self.norm1(x)))
+        h = h + self.dropout(self.ff(self.norm2(h)))
+        return h
+
+
+class InformerEncoder(nn.Module):
+    """Informer encoder core matching the project's recurrent-core contract.
+
+    Input ``(B, T, input_size)`` → output ``(B, T, hidden_size)``. Returns
+    ``(output, None)`` so the forecaster's ``output, _ = self.lstm(x)``
+    destructuring keeps working unchanged.
+
+    Defaults follow the AAAI-2021 paper for short-horizon settings:
+    ``d_model=64``, ``n_heads=4``, ``e_layers=2``, ``dropout=0.1``,
+    ``factor=5``. ``d_model`` is taken from the forecaster's
+    ``hidden_size`` so the head can pool the encoder output without an
+    extra projection.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int = 64,
+        n_heads: int = 4,
+        e_layers: int = 2,
+        dropout: float = 0.1,
+        factor: int = 5,
+        d_ff: int | None = None,
+    ) -> None:
+        super().__init__()
+        if hidden_size % n_heads != 0:
+            raise ValueError(
+                f"hidden_size={hidden_size} must be divisible by n_heads={n_heads}"
+            )
+        self.input_size = int(input_size)
+        self.hidden_size = int(hidden_size)
+        self.input_proj = (
+            nn.Linear(input_size, hidden_size)
+            if input_size != hidden_size
+            else nn.Identity()
+        )
+        self.pos = _SinusoidalPositionalEmbedding(hidden_size)
+        self.embed_dropout = nn.Dropout(dropout)
+        d_ff_eff = int(d_ff) if d_ff is not None else hidden_size * 2
+        self.layers = nn.ModuleList(
+            [
+                _EncoderLayer(
+                    d_model=hidden_size,
+                    n_heads=n_heads,
+                    d_ff=d_ff_eff,
+                    factor=factor,
+                    dropout=dropout,
+                )
+                for _ in range(e_layers)
+            ]
+        )
+        self.norm = nn.LayerNorm(hidden_size)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
+        if x.dim() != 3:
+            raise ValueError(f"InformerEncoder expects (B, T, F); got {tuple(x.shape)}")
+        h = self.input_proj(x)
+        h = self.pos(h)
+        h = self.embed_dropout(h)
+        for layer in self.layers:
+            h = layer(h)
+        h = self.norm(h)
+        return h, None
+
+
+__all__ = ["InformerEncoder"]

--- a/backend/app/models/informer.py
+++ b/backend/app/models/informer.py
@@ -64,12 +64,19 @@ class _ProbSparseAttention(nn.Module):
     fallback from the paper.
     """
 
-    def __init__(self, factor: int = 5, dropout: float = 0.1) -> None:
+    def __init__(self, factor: int = 5, dropout: float = 0.1, sample_seed: int = 11) -> None:
         super().__init__()
         if factor < 1:
             raise ValueError(f"factor must be >= 1, got {factor}")
         self.factor = int(factor)
         self.dropout = nn.Dropout(dropout)
+        # Per-instance sampling generator so the ProbSparse sampling
+        # inside forward() does not advance the global RNG. The module
+        # claims to own no global RNG state; the generator is what makes
+        # that claim true and keeps callers' torch.manual_seed unpolluted
+        # across forward passes.
+        self._sample_generator = torch.Generator(device="cpu")
+        self._sample_generator.manual_seed(int(sample_seed))
 
     def _prob_qk(
         self, queries: torch.Tensor, keys: torch.Tensor, sample_k: int, n_top: int
@@ -78,8 +85,12 @@ class _ProbSparseAttention(nn.Module):
         b, h, l_k, d = keys.shape
         _, _, l_q, _ = queries.shape
 
-        # Sample sample_k key positions per (B, H, L_Q) triple.
-        index_sample = torch.randint(l_k, (l_q, sample_k), device=keys.device)
+        # Sample sample_k key positions per (B, H, L_Q) triple. The
+        # generator is per-instance so the global RNG state of the
+        # caller is preserved across forward passes.
+        index_sample = torch.randint(
+            l_k, (l_q, sample_k), generator=self._sample_generator
+        ).to(keys.device)
         # Index into K: (B, H, L_Q, sample_k, D)
         k_expand = keys.unsqueeze(-3).expand(b, h, l_q, l_k, d)
         k_sample = k_expand[:, :, torch.arange(l_q).unsqueeze(1), index_sample, :]

--- a/backend/app/models/lstm.py
+++ b/backend/app/models/lstm.py
@@ -74,7 +74,16 @@ class ForecasterModel(nn.Module):
         eight-way ablation sweeps them as separate cells.
         """
         super().__init__()
-        _allowed_model_types = {"lstm", "lstm_attn", "gru", "tcn", "transformer", "dlinear"}
+        _allowed_model_types = {
+            "lstm",
+            "lstm_attn",
+            "gru",
+            "tcn",
+            "transformer",
+            "dlinear",
+            "informer",
+            "tft",
+        }
         if model_type not in _allowed_model_types:
             raise ValueError(
                 f"Unknown model_type: {model_type!r}. Allowed: {sorted(_allowed_model_types)}"
@@ -281,6 +290,23 @@ class ForecasterModel(nn.Module):
                 hidden_size=hidden_size,
                 sequence_length=SEQUENCE_LENGTH,
             )
+        if model_type == "informer":
+            from app.models.informer import InformerEncoder
+
+            return InformerEncoder(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                dropout=dropout,
+            )
+        if model_type == "tft":
+            from app.models.tft import TFTEncoder
+
+            return TFTEncoder(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                dropout=dropout,
+            )
         raise ValueError(
-            f"Unknown model_type: {model_type!r}. Allowed: lstm, lstm_attn, gru, tcn, transformer, dlinear"
+            f"Unknown model_type: {model_type!r}. "
+            "Allowed: lstm, lstm_attn, gru, tcn, transformer, dlinear, informer, tft"
         )

--- a/backend/app/models/tft.py
+++ b/backend/app/models/tft.py
@@ -1,0 +1,229 @@
+"""Temporal Fusion Transformer encoder (Lim et al., 2021).
+
+A lightweight, dependency-free implementation of the time-series-encoder
+portion of TFT: per-timestep Variable-Selection Network (VSN) over the six
+input features, GRN-gated residual blocks, and a multi-head self-attention
+block over the selected representation. Mirrors the public TFT recipe in
+spirit without pulling ``pytorch-forecasting`` as a dependency — pure
+PyTorch only.
+
+The published TFT has a richer structure (LSTM encoder/decoder, static
+covariate enrichment, multi-horizon quantile heads). We keep only the
+encoder-side pieces that match the project's single-horizon, no-static-
+metadata input contract; the head, time-decay, and credibility paths live
+upstream in ``ForecasterModel``.
+
+Input shape: ``(batch, seq_len, input_size)``. Output: ``(batch, seq_len,
+hidden_size)`` plus a ``None`` placeholder so the forecaster's
+``output, _ = core(x)`` destructuring keeps working unchanged. Pooling to
+the head uses the same ``output[:, -1, :]`` step as the recurrent cores.
+
+Determinism contract: the module owns no global RNG state. Same input +
+same upstream ``torch.manual_seed`` ⇒ bit-identical output.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+class _GatedLinearUnit(nn.Module):
+    """GLU: ``sigmoid(gate(x)) * proj(x)`` — TFT's elementwise gating."""
+
+    def __init__(self, input_size: int, hidden_size: int) -> None:
+        super().__init__()
+        self.proj = nn.Linear(input_size, hidden_size)
+        self.gate = nn.Linear(input_size, hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj(x) * torch.sigmoid(self.gate(x))
+
+
+class _GatedResidualNetwork(nn.Module):
+    """Gated Residual Network (GRN) from TFT Section 3.
+
+    ``GRN(a) = LayerNorm(a' + GLU(dense2(ELU(dense1(a)))))`` where ``a'`` is
+    the input mapped to the GRN's output width via a skip connection (an
+    identity when widths match, a Linear when they do not). Dropout sits
+    between ``dense2`` and the GLU.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        output_size: int | None = None,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        out_size = int(output_size) if output_size is not None else int(hidden_size)
+        self.input_size = int(input_size)
+        self.hidden_size = int(hidden_size)
+        self.output_size = out_size
+        self.skip: nn.Module = (
+            nn.Identity() if self.input_size == self.output_size else nn.Linear(self.input_size, self.output_size)
+        )
+        self.fc1 = nn.Linear(self.input_size, self.hidden_size)
+        self.fc2 = nn.Linear(self.hidden_size, self.hidden_size)
+        self.dropout = nn.Dropout(dropout)
+        self.glu = _GatedLinearUnit(self.hidden_size, self.output_size)
+        self.norm = nn.LayerNorm(self.output_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = self.skip(x)
+        h = F.elu(self.fc1(x))
+        h = self.fc2(h)
+        h = self.dropout(h)
+        h = self.glu(h)
+        return self.norm(residual + h)
+
+
+class _VariableSelectionNetwork(nn.Module):
+    """Per-timestep VSN over scalar features.
+
+    For each of the ``num_inputs`` scalar input features we keep a small
+    per-feature GRN that lifts the scalar into ``hidden_size``. A separate
+    GRN over the concatenated raw inputs then produces softmax weights
+    across the features. The output at every timestep is the weighted sum
+    of the per-feature embeddings.
+    """
+
+    def __init__(
+        self,
+        num_inputs: int,
+        hidden_size: int,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        if num_inputs < 1:
+            raise ValueError(f"num_inputs must be >= 1, got {num_inputs}")
+        self.num_inputs = int(num_inputs)
+        self.hidden_size = int(hidden_size)
+        self.feature_grns = nn.ModuleList(
+            [
+                _GatedResidualNetwork(
+                    input_size=1, hidden_size=hidden_size, output_size=hidden_size, dropout=dropout
+                )
+                for _ in range(self.num_inputs)
+            ]
+        )
+        self.weight_grn = _GatedResidualNetwork(
+            input_size=self.num_inputs,
+            hidden_size=hidden_size,
+            output_size=self.num_inputs,
+            dropout=dropout,
+        )
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        # x: (B, T, F). Per-feature GRN lift -> (B, T, F, H).
+        if x.shape[-1] != self.num_inputs:
+            raise ValueError(
+                f"VSN built for num_inputs={self.num_inputs}, got input feature dim {x.shape[-1]}"
+            )
+        embeds = []
+        for idx, grn in enumerate(self.feature_grns):
+            f_i = x[..., idx : idx + 1]  # (B, T, 1)
+            embeds.append(grn(f_i))  # (B, T, H)
+        stacked = torch.stack(embeds, dim=-2)  # (B, T, F, H)
+        weights_raw = self.weight_grn(x)  # (B, T, F)
+        weights = F.softmax(weights_raw, dim=-1).unsqueeze(-1)  # (B, T, F, 1)
+        combined = (stacked * weights).sum(dim=-2)  # (B, T, H)
+        return combined, weights.squeeze(-1)
+
+
+class _InterpretableMultiHeadAttention(nn.Module):
+    """Multi-head self-attention used by the TFT encoder block.
+
+    Standard scaled dot-product attention with ``n_heads`` and per-head
+    width ``hidden_size // n_heads``. Wrapped here so the encoder stays a
+    single ``nn.Module`` without importing ``nn.MultiheadAttention`` (which
+    is fine but has a different output shape convention).
+    """
+
+    def __init__(self, hidden_size: int, n_heads: int, dropout: float = 0.1) -> None:
+        super().__init__()
+        if hidden_size % n_heads != 0:
+            raise ValueError(
+                f"hidden_size={hidden_size} must be divisible by n_heads={n_heads}"
+            )
+        self.hidden_size = int(hidden_size)
+        self.n_heads = int(n_heads)
+        self.d_head = self.hidden_size // self.n_heads
+        self.query_proj = nn.Linear(hidden_size, hidden_size)
+        self.key_proj = nn.Linear(hidden_size, hidden_size)
+        self.value_proj = nn.Linear(hidden_size, hidden_size)
+        self.out_proj = nn.Linear(hidden_size, hidden_size)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        b, t, _ = x.shape
+        q = self.query_proj(x).view(b, t, self.n_heads, self.d_head).transpose(1, 2)
+        k = self.key_proj(x).view(b, t, self.n_heads, self.d_head).transpose(1, 2)
+        v = self.value_proj(x).view(b, t, self.n_heads, self.d_head).transpose(1, 2)
+        scores = torch.matmul(q, k.transpose(-2, -1)) / (self.d_head**0.5)
+        attn = F.softmax(scores, dim=-1)
+        attn = self.dropout(attn)
+        ctx = torch.matmul(attn, v)  # (B, H, T, d_head)
+        ctx = ctx.transpose(1, 2).contiguous().view(b, t, self.hidden_size)
+        return self.out_proj(ctx)
+
+
+class TFTEncoder(nn.Module):
+    """Lightweight TFT encoder matching the project's recurrent-core contract.
+
+    Pipeline:
+        VSN over the raw scalar features
+        → GRN gated residual block (post-VSN enrichment)
+        → multi-head self-attention with residual + LayerNorm
+        → GRN gated feed-forward with residual + LayerNorm.
+
+    Input ``(B, T, input_size)`` → output ``(B, T, hidden_size)``. Returns
+    ``(output, None)`` so the forecaster's ``output, _ = self.lstm(x)``
+    destructuring keeps working unchanged.
+
+    Defaults follow Lim et al. 2021 for small-budget settings:
+    ``hidden_size=64``, ``n_heads=4``, ``dropout=0.1``. ``hidden_size``
+    must be divisible by ``n_heads``.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int = 64,
+        n_heads: int = 4,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.input_size = int(input_size)
+        self.hidden_size = int(hidden_size)
+        self.vsn = _VariableSelectionNetwork(
+            num_inputs=self.input_size, hidden_size=hidden_size, dropout=dropout
+        )
+        self.post_vsn_grn = _GatedResidualNetwork(
+            input_size=hidden_size, hidden_size=hidden_size, output_size=hidden_size, dropout=dropout
+        )
+        self.attn = _InterpretableMultiHeadAttention(
+            hidden_size=hidden_size, n_heads=n_heads, dropout=dropout
+        )
+        self.attn_norm = nn.LayerNorm(hidden_size)
+        self.attn_dropout = nn.Dropout(dropout)
+        self.ff_grn = _GatedResidualNetwork(
+            input_size=hidden_size, hidden_size=hidden_size, output_size=hidden_size, dropout=dropout
+        )
+        self.ff_norm = nn.LayerNorm(hidden_size)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
+        if x.dim() != 3:
+            raise ValueError(f"TFTEncoder expects (B, T, F); got {tuple(x.shape)}")
+        h, _weights = self.vsn(x)  # (B, T, H)
+        h = self.post_vsn_grn(h)
+        attn_out = self.attn(h)
+        h = self.attn_norm(h + self.attn_dropout(attn_out))
+        ff_out = self.ff_grn(h)
+        h = self.ff_norm(h + ff_out)
+        return h, None
+
+
+__all__ = ["TFTEncoder"]

--- a/backend/app/models/tft.py
+++ b/backend/app/models/tft.py
@@ -72,11 +72,16 @@ class _GatedResidualNetwork(nn.Module):
         self.norm = nn.LayerNorm(self.output_size)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Order follows Lim et al. (2021), Section 3.3, Eq. 3:
+        # ELU(fc1) -> fc2 -> GLU -> dropout -> residual add -> LayerNorm.
+        # Dropout is applied AFTER the gating, not before — the GLU
+        # weights the signal first, then dropout zeroes a fraction of
+        # the gated activations.
         residual = self.skip(x)
         h = F.elu(self.fc1(x))
         h = self.fc2(h)
-        h = self.dropout(h)
         h = self.glu(h)
+        h = self.dropout(h)
         return self.norm(residual + h)
 
 

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -554,8 +554,38 @@ inference path treat them interchangeably.
 | `tcn`        | Two dilated-conv `TemporalConvNet` blocks        | Causal padding; residual identity. |
 | `transformer`| `SmallTransformer` (2 layers, 4 heads)           | `hidden_size` must be divisible by 4 (default 64 satisfies). |
 | `dlinear`    | DLinear (trend + seasonal decomposition)         | Pinned to `SEQUENCE_LENGTH=20`. |
+| `informer`   | Informer encoder (ProbSparse self-attention)     | 2 encoder layers, 4 heads, `factor=5`. Same `(B,T,H)` core output as the recurrent variants. |
+| `tft`        | Temporal Fusion Transformer encoder              | VSN over 6 features + GRN gating + 4-head self-attention. `hidden_size` must be divisible by 4. |
 
 The official registry constant lives at `app.models.FORECASTER_ARCHITECTURES`.
+
+#### Informer
+
+`backend/app/models/informer.py` implements the encoder side of Informer
+(Zhou et al., AAAI 2021) in pure PyTorch — no `pytorch-forecasting` or
+upstream Informer repo dependency. ProbSparse self-attention reduces full
+self-attention's `O(L^2)` cost to `O(L log L)` by sampling probe keys per
+query and routing only the top-`u` queries through a real softmax;
+remaining queries fall back to the mean of the value sequence. Defaults
+match the AAAI-2021 short-horizon recipe: `d_model = hidden_size = 64`,
+`n_heads = 4`, `e_layers = 2`, `dropout = 0.1`, `factor = 5`. Input
+contract `(batch, 20, 6)`; encoder-output contract `(batch, 20,
+hidden_size)` + `None` so the wrapper's `output, _ = core(x)`
+destructuring keeps working unchanged.
+
+#### TFT
+
+`backend/app/models/tft.py` implements a lightweight Temporal Fusion
+Transformer encoder (Lim et al., 2021) in pure PyTorch — no
+`pytorch-forecasting` dependency. Per-timestep Variable Selection Network
+over the six scalar features, GRN-gated residual blocks, and a 4-head
+self-attention block sit between two LayerNorms. Defaults follow the
+small-budget setup from the paper: `hidden_size = 64`, `n_heads = 4`,
+`dropout = 0.1`. Same input/output contract as the rest of the registry.
+The published TFT's LSTM encoder/decoder, static-covariate enrichment, and
+multi-horizon quantile head are intentionally out of scope — the project's
+single-horizon head and time-decay/credibility paths live in
+`ForecasterModel` above the encoder.
 
 ### Credibility-features flag
 
@@ -577,7 +607,7 @@ the published `1e-4` contract covers cross-platform drift).
 {
   "mode": "sweep",
   "selection_metric": "combined_rmse",
-  "architectures": ["dlinear", "gru", "lstm", "lstm_attn", "tcn", "transformer"],
+  "architectures": ["dlinear", "gru", "informer", "lstm", "lstm_attn", "tcn", "tft", "transformer"],
   "seeds": [11, 29, 47, 71, 97],
   "credibility_features": false,
   "trial_count": 30,
@@ -628,7 +658,8 @@ aggregator output schema is:
 ### Make targets
 
 - `make forecaster-sweep TRAINING_PACKAGE_ID=<id>` — the full
-  6-arch x 5-seed sweep.
+  8-arch x 5-seed sweep. Pass `ARCHITECTURES=<csv>` (or
+  `--architectures …`) to restrict.
 - `make forecaster-sweep-aggregate TRAINING_PACKAGE_ID=<id>` —
   per-architecture headline (block-bootstrap CIs).
 - `make forecaster-credibility-train TRAINING_PACKAGE_ID=<id> ARCHITECTURE=lstm SEED=11`

--- a/tests/unit/test_forecaster.py
+++ b/tests/unit/test_forecaster.py
@@ -626,3 +626,65 @@ def test_forecaster_model_transformer_variant_forward_returns_expected_shape() -
             assert a.shape == b.shape
     else:
         assert out.shape == lstm_out.shape
+
+
+def test_forecaster_model_informer_variant_forward_returns_expected_shape() -> None:
+    import torch
+    from app.services.forecaster import ForecasterModel
+
+    model = ForecasterModel(input_size=6, hidden_size=32, model_type="informer")
+    x = torch.zeros(2, 5, 6)
+    out = model(x)
+    lstm_model = ForecasterModel(input_size=6, hidden_size=32, model_type="lstm")
+    lstm_out = lstm_model(x)
+    assert out.shape == lstm_out.shape
+
+
+def test_forecaster_model_informer_variant_backward_runs() -> None:
+    """One backward step must produce gradients on the Informer-backed wrapper."""
+
+    import torch
+    from app.services.forecaster import ForecasterModel
+
+    torch.manual_seed(11)
+    model = ForecasterModel(input_size=6, hidden_size=32, model_type="informer")
+    x = torch.randn(2, 5, 6)
+    out = model(x)
+    out.sum().backward()
+    grad_total = sum(
+        p.grad.abs().sum().item()
+        for p in model.parameters()
+        if p.requires_grad and p.grad is not None
+    )
+    assert grad_total > 0.0
+
+
+def test_forecaster_model_tft_variant_forward_returns_expected_shape() -> None:
+    import torch
+    from app.services.forecaster import ForecasterModel
+
+    model = ForecasterModel(input_size=6, hidden_size=32, model_type="tft")
+    x = torch.zeros(2, 5, 6)
+    out = model(x)
+    lstm_model = ForecasterModel(input_size=6, hidden_size=32, model_type="lstm")
+    lstm_out = lstm_model(x)
+    assert out.shape == lstm_out.shape
+
+
+def test_forecaster_model_tft_variant_backward_runs() -> None:
+    """One backward step must produce gradients on the TFT-backed wrapper."""
+
+    import torch
+    from app.services.forecaster import ForecasterModel
+
+    torch.manual_seed(11)
+    model = ForecasterModel(input_size=6, hidden_size=32, model_type="tft")
+    x = torch.randn(2, 5, 6)
+    out = model(x)
+    out.sum().backward()
+    grad_total = sum(
+        p.grad.abs().sum().item()
+        for p in model.parameters()
+        if p.requires_grad and p.grad is not None
+    )
+    assert grad_total > 0.0

--- a/tests/unit/test_forecaster_factory.py
+++ b/tests/unit/test_forecaster_factory.py
@@ -23,7 +23,7 @@ def _fresh(seed: int = 11) -> None:
     torch.manual_seed(seed)
 
 
-def test_registry_lists_six_architectures() -> None:
+def test_registry_lists_eight_architectures() -> None:
     assert set(FORECASTER_ARCHITECTURES) == {
         "lstm",
         "lstm_attn",
@@ -31,6 +31,8 @@ def test_registry_lists_six_architectures() -> None:
         "tcn",
         "transformer",
         "dlinear",
+        "informer",
+        "tft",
     }
 
 
@@ -96,3 +98,39 @@ def test_factory_accepts_plain_dict_config() -> None:
     model = build_forecaster(ModelConfig(architecture="gru").to_dict())
     assert isinstance(model, ForecasterModel)
     assert model.model_type == "gru"
+
+
+def test_factory_dispatches_informer() -> None:
+    """architecture=\"informer\" returns a ForecasterModel whose core is the Informer encoder."""
+
+    from app.models.informer import InformerEncoder
+
+    _fresh()
+    model = build_forecaster(ModelConfig(architecture="informer"))
+    model.eval()
+    assert isinstance(model, ForecasterModel)
+    assert model.model_type == "informer"
+    assert isinstance(model.recurrent_core, InformerEncoder)
+    x = torch.randn(4, SEQUENCE_LENGTH, FEATURE_SIZE)
+    with torch.no_grad():
+        out = model(x)
+    assert out.shape == (4, 2)
+    assert torch.all(out[:, 1] >= 0.0)
+
+
+def test_factory_dispatches_tft() -> None:
+    """architecture=\"tft\" returns a ForecasterModel whose core is the TFT encoder."""
+
+    from app.models.tft import TFTEncoder
+
+    _fresh()
+    model = build_forecaster(ModelConfig(architecture="tft"))
+    model.eval()
+    assert isinstance(model, ForecasterModel)
+    assert model.model_type == "tft"
+    assert isinstance(model.recurrent_core, TFTEncoder)
+    x = torch.randn(4, SEQUENCE_LENGTH, FEATURE_SIZE)
+    with torch.no_grad():
+        out = model(x)
+    assert out.shape == (4, 2)
+    assert torch.all(out[:, 1] >= 0.0)

--- a/tests/unit/test_informer.py
+++ b/tests/unit/test_informer.py
@@ -81,6 +81,29 @@ def test_informer_is_deterministic_at_fixed_seed() -> None:
     assert torch.equal(first, second), "InformerEncoder is not deterministic at fixed seed"
 
 
+def test_informer_forward_does_not_advance_global_rng() -> None:
+    """ProbSparse sampling must use a per-instance generator, not the global RNG.
+
+    If forward() calls torch.randint without an explicit generator, the
+    global RNG state advances and breaks reproducibility for callers
+    that rely on torch.manual_seed for upstream determinism.
+    """
+
+    torch.manual_seed(11)
+    encoder = InformerEncoder(input_size=FEATURE_SIZE, hidden_size=32)
+    encoder.eval()
+    x = torch.randn(2, SEQUENCE_LENGTH, FEATURE_SIZE)
+
+    rng_before = torch.random.get_rng_state().clone()
+    with torch.no_grad():
+        _ = encoder(x)
+    rng_after = torch.random.get_rng_state().clone()
+    assert torch.equal(rng_before, rng_after), (
+        "InformerEncoder advanced the global RNG state during forward(); "
+        "ProbSparse sampling must use a per-instance generator."
+    )
+
+
 def test_informer_rejects_indivisible_head_count() -> None:
     with pytest.raises(ValueError):
         InformerEncoder(input_size=FEATURE_SIZE, hidden_size=30, n_heads=4)

--- a/tests/unit/test_informer.py
+++ b/tests/unit/test_informer.py
@@ -1,0 +1,104 @@
+"""Unit tests for the Informer encoder core.
+
+The Informer encoder must respect the project's recurrent-core contract:
+input ``(B, T, F)`` → output ``(B, T, H)`` plus a ``None`` placeholder so
+the ``output, _ = core(x)`` destructuring in ``ForecasterModel.forward``
+keeps working. Same-seed determinism is required because the ProbSparse
+attention layer samples key indices through the default RNG; the test
+locks the seed and asserts byte-identical outputs across two passes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.config import FEATURE_SIZE, SEQUENCE_LENGTH  # noqa: E402
+from app.models.informer import InformerEncoder  # noqa: E402
+
+
+def _fresh(seed: int = 11) -> None:
+    torch.manual_seed(seed)
+
+
+def test_informer_forward_returns_expected_shape() -> None:
+    _fresh()
+    encoder = InformerEncoder(input_size=FEATURE_SIZE, hidden_size=64)
+    encoder.eval()
+    x = torch.randn(4, SEQUENCE_LENGTH, FEATURE_SIZE)
+    with torch.no_grad():
+        out, placeholder = encoder(x)
+    assert out.shape == (4, SEQUENCE_LENGTH, 64)
+    assert placeholder is None
+    assert torch.all(torch.isfinite(out))
+
+
+def test_informer_forward_returns_tuple_for_lstm_destructuring() -> None:
+    """``output, _ = core(x)`` is the destructuring used by ForecasterModel."""
+
+    _fresh()
+    encoder = InformerEncoder(input_size=FEATURE_SIZE, hidden_size=32, n_heads=4)
+    x = torch.randn(2, SEQUENCE_LENGTH, FEATURE_SIZE)
+    output, _ = encoder(x)
+    assert output.shape == (2, SEQUENCE_LENGTH, 32)
+
+
+def test_informer_gradient_flows_to_parameters() -> None:
+    _fresh()
+    encoder = InformerEncoder(input_size=FEATURE_SIZE, hidden_size=32)
+    x = torch.randn(3, SEQUENCE_LENGTH, FEATURE_SIZE, requires_grad=True)
+    out, _ = encoder(x)
+    out.sum().backward()
+    # Every learnable parameter must receive a non-zero gradient.
+    grad_norms = [
+        param.grad.abs().sum().item()
+        for param in encoder.parameters()
+        if param.requires_grad and param.grad is not None
+    ]
+    assert grad_norms, "no learnable parameters received gradients"
+    assert all(norm >= 0.0 for norm in grad_norms)
+    # At least one parameter must have a strictly positive gradient norm
+    # (otherwise the encoder is functionally constant w.r.t. input).
+    assert any(norm > 0.0 for norm in grad_norms)
+
+
+def test_informer_is_deterministic_at_fixed_seed() -> None:
+    """Same input + same seed must yield bit-identical outputs."""
+
+    def _run() -> torch.Tensor:
+        torch.manual_seed(11)
+        encoder = InformerEncoder(input_size=FEATURE_SIZE, hidden_size=32)
+        encoder.eval()
+        torch.manual_seed(11)
+        x = torch.randn(2, SEQUENCE_LENGTH, FEATURE_SIZE)
+        with torch.no_grad():
+            out, _ = encoder(x)
+        return out
+
+    first = _run()
+    second = _run()
+    assert torch.equal(first, second), "InformerEncoder is not deterministic at fixed seed"
+
+
+def test_informer_rejects_indivisible_head_count() -> None:
+    with pytest.raises(ValueError):
+        InformerEncoder(input_size=FEATURE_SIZE, hidden_size=30, n_heads=4)
+
+
+def test_informer_rejects_wrong_input_rank() -> None:
+    encoder = InformerEncoder(input_size=FEATURE_SIZE, hidden_size=32)
+    with pytest.raises(ValueError):
+        encoder(torch.randn(SEQUENCE_LENGTH, FEATURE_SIZE))
+
+
+def test_informer_handles_short_sequences() -> None:
+    """ProbSparse u/U_part computation must clamp to seq_len for very short inputs."""
+
+    _fresh()
+    encoder = InformerEncoder(input_size=FEATURE_SIZE, hidden_size=32)
+    encoder.eval()
+    x = torch.randn(2, 3, FEATURE_SIZE)
+    with torch.no_grad():
+        out, _ = encoder(x)
+    assert out.shape == (2, 3, 32)

--- a/tests/unit/test_tft.py
+++ b/tests/unit/test_tft.py
@@ -1,0 +1,95 @@
+"""Unit tests for the Temporal Fusion Transformer encoder.
+
+The TFT encoder must respect the project's recurrent-core contract:
+input ``(B, T, F)`` → output ``(B, T, H)`` plus a ``None`` placeholder so
+the ``output, _ = core(x)`` destructuring in ``ForecasterModel.forward``
+keeps working. Same-seed determinism is required so that the official
+seed set produces reproducible results during the sweep.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.config import FEATURE_SIZE, SEQUENCE_LENGTH  # noqa: E402
+from app.models.tft import TFTEncoder  # noqa: E402
+
+
+def _fresh(seed: int = 11) -> None:
+    torch.manual_seed(seed)
+
+
+def test_tft_forward_returns_expected_shape() -> None:
+    _fresh()
+    encoder = TFTEncoder(input_size=FEATURE_SIZE, hidden_size=64)
+    encoder.eval()
+    x = torch.randn(4, SEQUENCE_LENGTH, FEATURE_SIZE)
+    with torch.no_grad():
+        out, placeholder = encoder(x)
+    assert out.shape == (4, SEQUENCE_LENGTH, 64)
+    assert placeholder is None
+    assert torch.all(torch.isfinite(out))
+
+
+def test_tft_forward_returns_tuple_for_lstm_destructuring() -> None:
+    """``output, _ = core(x)`` is the destructuring used by ForecasterModel."""
+
+    _fresh()
+    encoder = TFTEncoder(input_size=FEATURE_SIZE, hidden_size=32, n_heads=4)
+    x = torch.randn(2, SEQUENCE_LENGTH, FEATURE_SIZE)
+    output, _ = encoder(x)
+    assert output.shape == (2, SEQUENCE_LENGTH, 32)
+
+
+def test_tft_gradient_flows_to_parameters() -> None:
+    _fresh()
+    encoder = TFTEncoder(input_size=FEATURE_SIZE, hidden_size=32)
+    x = torch.randn(3, SEQUENCE_LENGTH, FEATURE_SIZE, requires_grad=True)
+    out, _ = encoder(x)
+    out.sum().backward()
+    grad_norms = [
+        param.grad.abs().sum().item()
+        for param in encoder.parameters()
+        if param.requires_grad and param.grad is not None
+    ]
+    assert grad_norms, "no learnable parameters received gradients"
+    assert any(norm > 0.0 for norm in grad_norms)
+
+
+def test_tft_is_deterministic_at_fixed_seed() -> None:
+    """Same input + same seed must yield bit-identical outputs."""
+
+    def _run() -> torch.Tensor:
+        torch.manual_seed(11)
+        encoder = TFTEncoder(input_size=FEATURE_SIZE, hidden_size=32)
+        encoder.eval()
+        torch.manual_seed(11)
+        x = torch.randn(2, SEQUENCE_LENGTH, FEATURE_SIZE)
+        with torch.no_grad():
+            out, _ = encoder(x)
+        return out
+
+    first = _run()
+    second = _run()
+    assert torch.equal(first, second), "TFTEncoder is not deterministic at fixed seed"
+
+
+def test_tft_rejects_indivisible_head_count() -> None:
+    with pytest.raises(ValueError):
+        TFTEncoder(input_size=FEATURE_SIZE, hidden_size=30, n_heads=4)
+
+
+def test_tft_rejects_wrong_input_rank() -> None:
+    encoder = TFTEncoder(input_size=FEATURE_SIZE, hidden_size=32)
+    with pytest.raises(ValueError):
+        encoder(torch.randn(SEQUENCE_LENGTH, FEATURE_SIZE))
+
+
+def test_tft_rejects_feature_dim_mismatch() -> None:
+    """VSN is built for a specific num_inputs; mismatched feature dim must error."""
+
+    encoder = TFTEncoder(input_size=FEATURE_SIZE, hidden_size=32)
+    with pytest.raises(ValueError):
+        encoder(torch.randn(2, SEQUENCE_LENGTH, FEATURE_SIZE + 1))


### PR DESCRIPTION
## Summary
- Informer (Zhou 2021): ProbSparse self-attention encoder, pure PyTorch, no new deps
- TFT (Lim 2021): variable-selection + GRN gating + multi-head attention, pure PyTorch
- Wired into FORECASTER_ARCHITECTURES + ForecasterModel.model_type dispatch
- Factory dispatches \"informer\" and \"tft\" with same input/output contract as other archs
- Default LSTM path stays byte-identical (regression test enforces)
- Per-arch defaults documented in data-and-training-contracts.md
- Wiki entry queued locally at ../fed-pulse.wiki/06_Deep_Learning_Roadmap.md for separate push

## Test plan
- [ ] \`docker compose run --rm --no-deps backend pytest tests/unit/test_informer.py tests/unit/test_tft.py tests/regression/ -q\`
- [ ] \`make forecaster-sweep TRAINING_PACKAGE_ID=<id> ARCHITECTURES=informer,tft\` once GPU is free

Closes #160.