### PR TITLE
Phase 8 (#157 + #158): pivot_distance + intra-meeting tone shift

### DIFF
--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -200,9 +200,11 @@ _STANCE_ENCODING: dict[str, float] = {
     "neutral": 0.0,
 }
 _CERTAINTY_ENCODING: dict[str, float] = {
-    "certain": 1.0,
-    "neutral": 0.0,
-    "uncertain": -1.0,
+    # ``axis_certainty`` is regression-typed in ``data/schema/labels.yaml``
+    # (range [0.0, 1.0]), so there is no canonical categorical label
+    # vocabulary to encode. The dict is kept for symmetry with
+    # ``_STANCE_ENCODING`` and ``_FACTOR_ENCODING``; numeric passthrough
+    # via ``_axis_to_numeric`` is the only supported path.
 }
 _FACTOR_ENCODING: dict[str, float] = {
     # ``axis_factor`` is regression-only in the schema, so the fallback
@@ -844,7 +846,7 @@ def _axis_to_numeric(value: Any, encoding: dict[str, float]) -> float:
     if isinstance(value, bool):
         # bool is a subclass of int; treat as NaN to avoid surprising True->1.0
         return math.nan
-    if isinstance(value, (int, float)):
+    if isinstance(value, int | float):
         if isinstance(value, float) and math.isnan(value):
             return math.nan
         return float(value)

--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -71,6 +71,38 @@ Schema (one row per event x kind x horizon x asset):
                                  (CPI, NFP, ISM) falls within +/-2 trading
                                  days. Heuristic dates only; we flag, never
                                  drop.
+- ``intra_meeting_stance_shift``    Signed shift in ``axis_stance`` between
+                                     the same-date press_conference and
+                                     statement rows. Numeric encoding
+                                     ``hawkish=+1, dovish=-1, neutral=0``
+                                     applies to categorical stance values;
+                                     ``shift = press - statement``. NaN
+                                     when either kind is missing for the
+                                     event_date, or when an axis value is
+                                     unencodable.
+- ``intra_meeting_certainty_shift`` Signed shift in ``axis_certainty``
+                                     between same-date press_conference
+                                     and statement. ``axis_certainty`` is
+                                     a regression score in ``[0, 1]`` per
+                                     ``data/schema/labels.yaml``; numeric
+                                     values are subtracted directly. If a
+                                     label-encoded variant is ever
+                                     introduced upstream, the encoder
+                                     applies ``uncertain=-1, neutral=0,
+                                     certain=+1`` as a fallback.
+- ``intra_meeting_factor_shift``    Signed shift in ``axis_factor``
+                                     (Gürkaynak-Sack-Swanson forward-
+                                     guidance loading, regression in
+                                     ``[-1, 1]``) between the same-date
+                                     press_conference and statement.
+                                     Numeric subtraction.
+
+The three ``intra_meeting_*_shift`` columns are a property of the FOMC
+date, not of the source. On the collapsed view the value comes from the
+preferred statement and the preferred press_conference. On the full view
+the same value is replicated to every (source x asset x horizon) row
+sharing the event_date, so cross-source analyses see a consistent
+intra-meeting tone shift regardless of which row they read.
 
 Methodological constraints, enforced by assertions in the builder:
 
@@ -98,6 +130,7 @@ import argparse
 import datetime as _dt
 import hashlib
 import json
+import math
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -153,6 +186,37 @@ _EVENT_KIND_MAP: dict[str, str] = {
 # Speech-like kinds use the speech time placeholder; everything else uses
 # the FOMC 2pm ET placeholder.
 _SPEECH_KINDS = frozenset({"speech", "testimony"})
+
+# Categorical encodings used by ``_axis_to_numeric`` when computing the
+# ``intra_meeting_*_shift`` columns. ``axis_stance`` is the only axis
+# that arrives as a categorical label in the bundled registry; the other
+# two axes are regression-typed per ``data/schema/labels.yaml`` and pass
+# their numeric values through unchanged. The ``certainty`` map is a
+# best-effort fallback for any future upstream that emits label strings
+# instead of a regression score.
+_STANCE_ENCODING: dict[str, float] = {
+    "hawkish": 1.0,
+    "dovish": -1.0,
+    "neutral": 0.0,
+}
+_CERTAINTY_ENCODING: dict[str, float] = {
+    "certain": 1.0,
+    "neutral": 0.0,
+    "uncertain": -1.0,
+}
+_FACTOR_ENCODING: dict[str, float] = {
+    # ``axis_factor`` is regression-only in the schema, so the fallback
+    # label map is intentionally empty; numeric passthrough is the only
+    # supported path. The dict is kept for symmetry with stance/certainty.
+}
+
+# Map ``axis_*`` column name to its categorical encoding. Numeric inputs
+# are accepted on every axis via the ``_axis_to_numeric`` fallback.
+_INTRA_MEETING_AXIS_ENCODING: dict[str, dict[str, float]] = {
+    "axis_stance": _STANCE_ENCODING,
+    "axis_certainty": _CERTAINTY_ENCODING,
+    "axis_factor": _FACTOR_ENCODING,
+}
 
 # When multiple registry sources cover the same (event_date, event_kind),
 # pick the row with the highest preference rank. This avoids near-duplicate
@@ -295,13 +359,19 @@ def _aggregate_events(rows: Iterable[_RegistryRow]) -> list[_EventDoc]:
         }
         # Use the first row whose mapped_label or axes carry a value as the
         # document-level label. Deterministic because bucket is sorted.
+        # ``val is not None`` (not truthy) preserves legitimate zeros for
+        # the regression-typed axes (``certainty``, ``factor`` per
+        # ``data/schema/labels.yaml``) -- otherwise a 0.0 factor would
+        # silently be dropped to None and downstream consumers (the
+        # ``intra_meeting_*_shift`` columns in particular) would lose
+        # the signal.
         for r in bucket_sorted:
             if multi_axis["stance"] is None and r.mapped_label:
                 multi_axis["stance"] = r.mapped_label
             for axis_name in ("time", "certainty", "factor", "topic"):
                 if multi_axis[axis_name] is None:
                     val = r.axes.get(axis_name)
-                    if val:
+                    if val is not None:
                         multi_axis[axis_name] = str(val)
             # multi_axis_extras (Op-Fed opinion etc.) is recorded only via
             # axes; the raw extras dict is not lifted into event rows.
@@ -751,6 +821,94 @@ def _has_concurrent_macro_release(
 
 
 # ---------------------------------------------------------------------------
+# Intra-meeting tone shift (statement vs same-day press conference)
+# ---------------------------------------------------------------------------
+
+
+def _axis_to_numeric(value: Any, encoding: dict[str, float]) -> float:
+    """Best-effort encode an axis value to a numeric scalar.
+
+    Returns ``math.nan`` when the value is missing or unencodable so the
+    downstream shift propagates NaN honestly instead of coercing to 0.
+    Order of preference:
+
+    1. ``None`` / empty -> NaN.
+    2. ``int`` / ``float`` (not NaN itself) -> passthrough.
+    3. ``str`` looked up case-insensitively in ``encoding``.
+    4. ``str`` parseable as ``float`` (e.g. "0.42") -> the float.
+    5. Otherwise NaN.
+    """
+
+    if value is None:
+        return math.nan
+    if isinstance(value, bool):
+        # bool is a subclass of int; treat as NaN to avoid surprising True->1.0
+        return math.nan
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and math.isnan(value):
+            return math.nan
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return math.nan
+        encoded = encoding.get(stripped.lower())
+        if encoded is not None:
+            return float(encoded)
+        try:
+            return float(stripped)
+        except ValueError:
+            return math.nan
+    return math.nan
+
+
+def _compute_intra_meeting_shifts(
+    docs: Sequence[_EventDoc],
+) -> dict[str, dict[str, float]]:
+    """Return ``{event_date: {axis_name: shift_value}}`` for every date.
+
+    The shift is ``press_conference_axis - statement_axis`` after
+    encoding each side through ``_axis_to_numeric``. When either side
+    is missing for the date, all three shift values are NaN -- never
+    coerced to zero. Multi-source duplicates are collapsed via
+    ``_choose_preferred`` so the shift is computed on the *preferred*
+    statement and the *preferred* press_conference per date.
+
+    The result is keyed by ``event_date`` (string, ISO date) so callers
+    can join the per-date shifts onto every row regardless of source,
+    asset, or horizon -- the shift is a property of the date.
+    """
+
+    nan_payload = {
+        "intra_meeting_stance_shift": math.nan,
+        "intra_meeting_certainty_shift": math.nan,
+        "intra_meeting_factor_shift": math.nan,
+    }
+    preferred = _choose_preferred(list(docs))
+    by_date: dict[str, dict[str, _EventDoc]] = defaultdict(dict)
+    for doc in preferred:
+        by_date[doc.event_date][doc.event_kind] = doc
+
+    shifts: dict[str, dict[str, float]] = {}
+    for event_date, kinds in by_date.items():
+        stmt = kinds.get("statement")
+        pc = kinds.get("press_conference")
+        if stmt is None or pc is None:
+            shifts[event_date] = dict(nan_payload)
+            continue
+        payload: dict[str, float] = {}
+        for axis_name, encoding in _INTRA_MEETING_AXIS_ENCODING.items():
+            stmt_val = _axis_to_numeric(stmt.multi_axis.get(axis_name[5:]), encoding)
+            pc_val = _axis_to_numeric(pc.multi_axis.get(axis_name[5:]), encoding)
+            if math.isnan(stmt_val) or math.isnan(pc_val):
+                payload[f"intra_meeting_{axis_name[5:]}_shift"] = math.nan
+            else:
+                payload[f"intra_meeting_{axis_name[5:]}_shift"] = pc_val - stmt_val
+        shifts[event_date] = payload
+    return shifts
+
+
+# ---------------------------------------------------------------------------
 # Per-event row construction
 # ---------------------------------------------------------------------------
 
@@ -830,6 +988,7 @@ def _build_event_rows(
     credibility_kwargs: dict[str, Any],
     macro_release_calendar: MacroReleaseCalendar,
     concurrent_macro_window_days: int = CONCURRENT_MACRO_TRADING_DAY_RADIUS,
+    intra_meeting_shift: dict[str, float] | None = None,
 ) -> list[dict[str, Any]]:
     event_date = _date(doc.event_date)
     as_of_ts = _as_of_for_event(doc.event_date, doc.event_kind)
@@ -883,6 +1042,13 @@ def _build_event_rows(
     document_id = _document_id(doc.source, doc.event_date, doc.event_kind)
     token_count = len(doc.text.split())
 
+    if intra_meeting_shift is None:
+        intra_meeting_shift = {
+            "intra_meeting_stance_shift": math.nan,
+            "intra_meeting_certainty_shift": math.nan,
+            "intra_meeting_factor_shift": math.nan,
+        }
+
     rows: list[dict[str, Any]] = []
     for h in horizons:
         tgt = targets.get(h)
@@ -928,6 +1094,15 @@ def _build_event_rows(
                 "direction_t1d": int(direction_t1d),
                 "volatility_shift": float(vol_shift) if vol_shift is not None else None,
                 "concurrent_macro_release": bool(concurrent_macro),
+                "intra_meeting_stance_shift": float(
+                    intra_meeting_shift["intra_meeting_stance_shift"]
+                ),
+                "intra_meeting_certainty_shift": float(
+                    intra_meeting_shift["intra_meeting_certainty_shift"]
+                ),
+                "intra_meeting_factor_shift": float(
+                    intra_meeting_shift["intra_meeting_factor_shift"]
+                ),
                 "realized_date": realized_date.isoformat() if realized_date else None,
             }
         )
@@ -984,6 +1159,9 @@ COLUMN_ORDER = (
     "direction_t1d",
     "volatility_shift",
     "concurrent_macro_release",
+    "intra_meeting_stance_shift",
+    "intra_meeting_certainty_shift",
+    "intra_meeting_factor_shift",
     "realized_date",
 )
 
@@ -1036,6 +1214,13 @@ def build_event_rows(
     if not docs:
         return _empty_frame()
 
+    # Pre-compute intra_meeting_*_shift on the preferred-source pair per
+    # event_date. The shift is a property of the date and is replicated
+    # to every (source x asset x horizon) row sharing that date, so the
+    # full and collapsed views report identical shifts even when the
+    # full view holds multiple source-level rows per kind.
+    intra_meeting_shifts = _compute_intra_meeting_shifts(docs_all)
+
     # Decide the window we need to fetch.
     event_dates = sorted({_date(d.event_date) for d in docs})
     earliest = event_dates[0] - _dt.timedelta(days=MARKET_MODEL_WINDOW_DAYS * 2 + 60)
@@ -1072,6 +1257,7 @@ def build_event_rows(
             credibility_kwargs=credibility_kwargs,
             macro_release_calendar=macro_release_calendar,
             concurrent_macro_window_days=concurrent_macro_window_days,
+            intra_meeting_shift=intra_meeting_shifts.get(doc.event_date),
         )
         if not rows:
             summary.dropped_no_prior_window += 1

--- a/backend/app/features/linguistic.py
+++ b/backend/app/features/linguistic.py
@@ -14,7 +14,7 @@ The design follows three strands of Fed-NLP literature:
   communication." (forward-looking phrasing and comparison-to-prior
   signal the policy vs. growth-news split.)
 
-The output is a 14-dim numeric vector keyed by ``text_hash`` (see
+The output is a 15-dim numeric vector keyed by ``text_hash`` (see
 :class:`LinguisticVector` for the exact field order):
 
 1   ``topic_share_inflation``            -- LDA share for the inflation-aligned topic.
@@ -31,6 +31,11 @@ The output is a 14-dim numeric vector keyed by ``text_hash`` (see
 12  ``concrete_ratio``                   -- unique (numbers ∪ dates ∪ currency) spans / total words.
 13  ``hawk_dove_asymmetry``              -- (#hawk - #dove) / (#hawk + #dove + 1).
 14  ``log_token_count``                  -- log1p(whitespace token count).
+15  ``pivot_distance``                   -- token-set Jaccard distance vs the prior
+                                            same-kind statement (Hansen-McMahon 2016).
+                                            Only defined for ``event_kind = "statement"``;
+                                            other kinds and the first statement
+                                            in the corpus emit ``NaN``.
 
 When a named slot fails the seed-overlap floor (see
 :func:`_assign_named_topics`) the slot is emitted with value ``0.0``
@@ -277,7 +282,7 @@ _TOKEN_RE = re.compile(r"[a-zA-Z0-9]+")
 
 @dataclass(frozen=True)
 class LinguisticVector:
-    """The 14-dim structured linguistic feature row for a single document.
+    """The 15-dim structured linguistic feature row for a single document.
 
     Fields, in emission order:
 
@@ -295,11 +300,16 @@ class LinguisticVector:
     12. ``concrete_ratio``
     13. ``hawk_dove_asymmetry``
     14. ``log_token_count``
+    15. ``pivot_distance``
 
     A named slot that fails the seed-overlap floor in
     :func:`_assign_named_topics` is emitted with ``0.0`` and its
     would-be topic falls through into the next ``misc_*`` slot, so the
-    14 fields are always present regardless of LDA fit quality.
+    15 fields are always present regardless of LDA fit quality.
+
+    ``pivot_distance`` is ``NaN`` for documents whose event kind is not
+    ``statement``, and for the first statement in the corpus. The first
+    14 axes are always finite.
     """
 
     topic_share_inflation: float
@@ -316,6 +326,7 @@ class LinguisticVector:
     concrete_ratio: float
     hawk_dove_asymmetry: float
     log_token_count: float
+    pivot_distance: float = math.nan
 
     def as_dict(self) -> dict[str, float]:
         return {
@@ -333,6 +344,7 @@ class LinguisticVector:
             "concrete_ratio": self.concrete_ratio,
             "hawk_dove_asymmetry": self.hawk_dove_asymmetry,
             "log_token_count": self.log_token_count,
+            "pivot_distance": self.pivot_distance,
         }
 
 
@@ -680,14 +692,66 @@ def _topic_shares(text: str, artifact: LdaArtifact) -> np.ndarray:
 
 
 # ---------------------------------------------------------------------------
+# Pivot distance (token-set Jaccard vs prior same-kind statement)
+# ---------------------------------------------------------------------------
+
+# The kind for which ``pivot_distance`` is defined. Minutes, press
+# conferences, speeches and testimonies follow different stylistic
+# conventions (Q&A transcripts vs. a curated written paragraph), so the
+# vocabulary diff against a prior statement would not be interpretable.
+PIVOT_DISTANCE_KIND: str = "statement"
+
+
+def pivot_distance_tokens(text: str) -> set[str]:
+    """Return the normalised token set used by :func:`pivot_distance`.
+
+    Reuses ``_TOKEN_RE`` -- the same tokeniser that backs ``_word_tokens``
+    -- so the Jaccard distance shares a tokenisation convention with the
+    rest of the module (case-folded alphanumeric runs of length >= 1).
+    """
+
+    return {m.group(0).lower() for m in _TOKEN_RE.finditer(text)}
+
+
+def pivot_distance(text: str, prior_tokens: set[str] | None) -> float:
+    """Token-set Jaccard distance between ``text`` and ``prior_tokens``.
+
+    ``1 - |A ∩ B| / |A ∪ B|`` over the normalised tokens of each
+    document. The result lies in ``[0, 1]``:
+
+    - 0.0 when ``text`` shares its full vocabulary with the prior;
+    - 1.0 when the two vocabularies are disjoint.
+
+    Returns ``NaN`` when ``prior_tokens`` is ``None`` -- there is no
+    prior statement to diff against (first statement in the corpus).
+    Also returns ``NaN`` when both token sets are empty, because the
+    Jaccard distance is undefined on an empty union.
+    """
+
+    if prior_tokens is None:
+        return math.nan
+    current = pivot_distance_tokens(text)
+    if not current and not prior_tokens:
+        return math.nan
+    intersection = len(current & prior_tokens)
+    union = len(current | prior_tokens)
+    if union == 0:
+        return math.nan
+    return 1.0 - (intersection / union)
+
+
+# ---------------------------------------------------------------------------
 # Per-document feature assembly
 # ---------------------------------------------------------------------------
 
 
 def compute_linguistic_features(
-    text: str, lda_artifact: LdaArtifact | None = None
+    text: str,
+    lda_artifact: LdaArtifact | None = None,
+    *,
+    prior_statement_tokens: set[str] | None = None,
 ) -> LinguisticVector:
-    """Compute the 14-dim linguistic feature vector for one document.
+    """Compute the 15-dim linguistic feature vector for one document.
 
     See :class:`LinguisticVector` for the full field list and the
     seed-overlap floor that decides which named slot is emitted.
@@ -696,10 +760,16 @@ def compute_linguistic_features(
     three misc slots all return 0.0 -- the hand-crafted densities are
     still emitted. Pass a fitted artifact (from :func:`fit_lda`) to get
     the full vector.
+
+    ``prior_statement_tokens`` is the normalised token set of the
+    previous statement (chronological order) used to compute
+    ``pivot_distance``. Pass ``None`` when the caller is processing a
+    non-statement document or the first statement in the corpus; the
+    pivot field then emits ``NaN``.
     """
 
     if lda_artifact is None:
-        topic_named = {slot: 0.0 for slot in NAMED_TOPIC_KEYS}
+        topic_named = dict.fromkeys(NAMED_TOPIC_KEYS, 0.0)
         misc_shares = (0.0, 0.0, 0.0)
     else:
         shares = _topic_shares(text, lda_artifact)
@@ -729,6 +799,7 @@ def compute_linguistic_features(
         concrete_ratio=concrete_ratio(text),
         hawk_dove_asymmetry=hawk_dove_asymmetry(text),
         log_token_count=log_token_count(text),
+        pivot_distance=pivot_distance(text, prior_statement_tokens),
     )
 
 
@@ -737,10 +808,27 @@ def compute_linguistic_features(
 # ---------------------------------------------------------------------------
 
 
+# ``document_type`` strings vary by source casing. The map mirrors the
+# event-row builder so the two share the same kind taxonomy.
+_DOCUMENT_TYPE_TO_KIND: dict[str, str] = {
+    "statement": "statement",
+    "Statement": "statement",
+    "minutes": "minutes",
+    "Minutes": "minutes",
+    "meeting_transcript": "minutes",
+    "press_conference": "press_conference",
+    "congressional_testimony": "testimony",
+    "chair_speech": "speech",
+    "governor_speech": "speech",
+}
+
+
 @dataclass
 class _CorpusDoc:
     text_hash: str
     text: str
+    event_date: str = ""
+    event_kind: str = ""
 
 
 def _aggregate_corpus(package_dir: Path) -> list[_CorpusDoc]:
@@ -750,6 +838,13 @@ def _aggregate_corpus(package_dir: Path) -> list[_CorpusDoc]:
     text_hash to give the LDA fit document-level granularity rather
     than per-sentence chatter. Sorted by ``text_hash`` so the corpus
     order is deterministic.
+
+    ``event_date`` and ``event_kind`` are lifted from the first
+    registry row contributing to each ``text_hash`` -- they are
+    properties of the document, not of any single sentence shard.
+    The kind is mapped via ``_DOCUMENT_TYPE_TO_KIND``; rows whose
+    ``document_type`` is unknown contribute an empty kind string and
+    will be skipped by the ``pivot_distance`` walker downstream.
     """
 
     registry = package_dir / "registry_normalized.jsonl"
@@ -757,6 +852,8 @@ def _aggregate_corpus(package_dir: Path) -> list[_CorpusDoc]:
         raise FileNotFoundError(f"Missing registry: {registry}")
     by_hash: dict[str, list[str]] = {}
     seen_order: list[str] = []
+    event_date_by_hash: dict[str, str] = {}
+    event_kind_by_hash: dict[str, str] = {}
     for line in registry.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if not line:
@@ -771,9 +868,18 @@ def _aggregate_corpus(package_dir: Path) -> list[_CorpusDoc]:
         if thash not in by_hash:
             by_hash[thash] = []
             seen_order.append(thash)
+            event_date_by_hash[thash] = str(payload.get("event_date", "") or "").strip()
+            doc_type = str(payload.get("document_type", "") or "").strip()
+            event_kind_by_hash[thash] = _DOCUMENT_TYPE_TO_KIND.get(doc_type, "")
         by_hash[thash].append(text)
     docs = [
-        _CorpusDoc(text_hash=h, text="\n".join(by_hash[h])) for h in seen_order
+        _CorpusDoc(
+            text_hash=h,
+            text="\n".join(by_hash[h]),
+            event_date=event_date_by_hash.get(h, ""),
+            event_kind=event_kind_by_hash.get(h, ""),
+        )
+        for h in seen_order
     ]
     docs.sort(key=lambda d: d.text_hash)
     return docs
@@ -789,15 +895,61 @@ def build_linguistic_feature_frame(
 
     The frame is sorted by ``text_hash`` so re-runs yield identical
     parquet bytes when paired with snappy compression. Columns:
-    ``text_hash`` followed by all 14 numeric feature axes.
+    ``text_hash`` followed by all 15 numeric feature axes.
+
+    ``pivot_distance`` is computed in chronological order over the
+    statement rows only. The walk picks the latest preceding statement
+    whose ``event_date`` is strictly less than the current one and
+    diffs its token set against the current document. The first
+    statement in the corpus (no strictly-prior peer) gets ``NaN``;
+    non-statement documents always get ``NaN``. Ties on ``event_date``
+    are broken by ``text_hash`` ascending, but a tied prior is treated
+    as concurrent and not used -- the prior must be strictly earlier.
     """
 
     docs = _aggregate_corpus(package_dir)
     if artifact is None:
         artifact = fit_lda(d.text for d in docs)
+
+    # Walk statement rows in chronological order and build a map from
+    # text_hash to the token set of the strictly-earlier prior statement
+    # (or None when there is no such peer). Non-statement rows are
+    # absent from the map and pass ``None`` to
+    # ``compute_linguistic_features`` so the pivot field emits NaN.
+    # Same-date statements share a prior (the latest strictly-earlier
+    # date); none of them become the prior for any other same-date peer
+    # because the contract requires ``as_of_ts < current.as_of_ts``.
+    prior_tokens_by_hash: dict[str, set[str] | None] = {}
+    statement_docs = [d for d in docs if d.event_kind == PIVOT_DISTANCE_KIND]
+    statement_docs.sort(key=lambda d: (d.event_date, d.text_hash))
+    by_date: dict[str, list[_CorpusDoc]] = {}
+    date_order: list[str] = []
+    for doc in statement_docs:
+        if doc.event_date not in by_date:
+            by_date[doc.event_date] = []
+            date_order.append(doc.event_date)
+        by_date[doc.event_date].append(doc)
+    prev_tokens: set[str] | None = None
+    for date in date_order:
+        bucket = by_date[date]
+        # All docs sharing this event_date see the same strictly-earlier prior.
+        for doc in bucket:
+            prior_tokens_by_hash[doc.text_hash] = (
+                set(prev_tokens) if prev_tokens is not None else None
+            )
+        # Promote this bucket to "prior" for any later date. When multiple
+        # statements share the same date, the first one in (event_date,
+        # text_hash) order is the canonical prior representative -- a
+        # deterministic, documented tie-break that matches the rest of
+        # the module's ordering convention.
+        prev_tokens = pivot_distance_tokens(bucket[0].text)
+
     rows: list[dict[str, Any]] = []
     for doc in docs:
-        vec = compute_linguistic_features(doc.text, artifact)
+        prior_tokens = prior_tokens_by_hash.get(doc.text_hash)
+        vec = compute_linguistic_features(
+            doc.text, artifact, prior_statement_tokens=prior_tokens
+        )
         row = {"text_hash": doc.text_hash}
         row.update(vec.as_dict())
         rows.append(row)

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -166,6 +166,23 @@ Required columns (full schema in module docstring):
   even though it flags more events. Tightening the ±2-trading-day
   radius is an option if the higher rate proves too noisy for the
   downstream confounder analysis.
+- `intra_meeting_stance_shift`,
+  `intra_meeting_certainty_shift`,
+  `intra_meeting_factor_shift` — signed within-meeting tone shift
+  between the press-conference and statement rows that share an
+  `event_date`. The shift is computed as `press_conference_axis -
+  statement_axis` after encoding each side through
+  `_INTRA_MEETING_AXIS_ENCODING`. Categorical stance values are
+  encoded `hawkish=+1, dovish=-1, neutral=0`; categorical certainty
+  values, when present, are encoded `certain=+1, neutral=0,
+  uncertain=-1`. Numeric values (regression-typed `axis_certainty` /
+  `axis_factor` per `data/schema/labels.yaml`) pass through and are
+  subtracted directly. When either kind is missing for the date, all
+  three shifts are `NaN` — never coerced to zero. Multi-source
+  duplicates are collapsed via `_SOURCE_PREFERENCE` so the shift uses
+  the preferred statement / press-conference pair only; the same
+  per-date shift value is replicated to every row sharing that date
+  on both the collapsed and full views.
 - `asset_symbol` — default `^GSPC`. Per-asset rows are supported: a
   future sweep can rebuild with `--asset NDX` etc. without touching the
   schema.
@@ -278,18 +295,18 @@ been wired (out of scope for #146).
 
 ## Structured linguistic features (Phase 8)
 
-`backend/app/features/linguistic.py` emits a 14-dim interpretable
+`backend/app/features/linguistic.py` emits a 15-dim interpretable
 linguistic feature vector per document, keyed by `text_hash` so it joins
 directly onto event rows or any other registry-derived table.
 
 Output artifacts under `data/processed/<training_package_id>/`:
 
-- `linguistic_features.parquet` — one row per unique `text_hash`. 14
+- `linguistic_features.parquet` — one row per unique `text_hash`. 15
   numeric columns: 5 named LDA topic shares (`inflation`, `employment`,
   `financial_stability`, `growth`, `balance_sheet`), 3 misc topic shares
   (`misc_1..3`), `hedge_density`, `comparison_density`,
   `forward_density`, `concrete_ratio`, `hawk_dove_asymmetry`,
-  `log_token_count`.
+  `log_token_count`, `pivot_distance`.
 - `linguistic_lda_model.pkl` — pickled `(CountVectorizer, LatentDirichletAllocation)`
   bundle plus the slot→topic-index assignment map. Sufficient to score
   any new document without re-fitting.
@@ -359,6 +376,35 @@ Open follow-up: raising `num_topics` to 10-12 and widening the
 inflation seed list are out of scope for this correctness fix and
 will be separate PRs after the bake-off / forecaster sweep produce
 results.
+
+### `pivot_distance` — token diff vs prior FOMC statement
+
+The 15th column captures how much a given FOMC statement deviates in
+vocabulary from the previous statement. It is the token-set Jaccard
+distance `1 - |A ∩ B| / |A ∪ B|` between the normalised token sets of
+the current document and the latest preceding row whose `event_kind`
+is `statement` and whose `event_date` is strictly earlier. The
+tokeniser is the same `_TOKEN_RE` that backs the hand-crafted
+densities (case-folded alphanumeric runs).
+
+NaN semantics:
+
+- `pivot_distance = NaN` when `event_kind != "statement"` — minutes,
+  press conferences, speeches and testimonies follow different
+  stylistic conventions, so the diff is undefined.
+- `pivot_distance = NaN` for the first statement in the corpus (no
+  strictly-earlier peer).
+- Same-date duplicates share the same earlier prior; none of them
+  becomes the prior for any other same-date peer because the
+  contract requires `as_of_ts < current.as_of_ts` strictly.
+
+On the Sprint 1 fit the distribution audit is reproduced by re-running
+`make data-prep`. Placeholder ranges (fill in after the next pipeline
+run): `pivot_distance` ranges roughly `[<min>, <max>]` with mean
+`<mean>` across the statement rows of
+`tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0`. The
+non-statement rows are NaN by construction and excluded from the
+summary.
 
 ## Next-FOMC decision dataset (Phase 8)
 

--- a/tests/unit/test_event_dataset_builder.py
+++ b/tests/unit/test_event_dataset_builder.py
@@ -632,6 +632,333 @@ def test_real_release_calendar_changes_rate_on_smoke_package() -> None:
     assert 0.0 < real_rate < 1.0
 
 
+# ---------------------------------------------------------------------------
+# intra_meeting_{stance,certainty,factor}_shift -- statement vs same-day PC
+# ---------------------------------------------------------------------------
+
+
+def _intra_meeting_entry(
+    *,
+    event_date: str,
+    document_type: str,
+    source_record_id: str,
+    text: str,
+    stance: str | None = None,
+    certainty: float | str | None = None,
+    factor: float | str | None = None,
+    source: str = "scraped_fed",
+) -> dict:
+    """Synthetic registry row with a fixed multi-axis payload.
+
+    Stance is the mapped_label (categorical), certainty and factor land
+    in the ``axes`` payload so the builder lifts them onto the
+    ``_EventDoc.multi_axis`` map.
+    """
+
+    return {
+        "record_id": hashlib.sha256(
+            f"{event_date}|{document_type}|{source_record_id}".encode()
+        ).hexdigest()[:16],
+        "source": source,
+        "source_record_id": source_record_id,
+        "document_type": document_type,
+        "source_type": "fomc_press_conference"
+        if document_type == "press_conference"
+        else "fomc_statement",
+        "event_date": event_date,
+        "text": text,
+        "mapped_label": stance,
+        "axes": {
+            "stance": stance,
+            "time": None,
+            "certainty": certainty,
+            "factor": factor,
+            "topic": None,
+        },
+        "multi_axis_extras": {},
+        "sample_weight": 1.0,
+    }
+
+
+def test_intra_meeting_shift_both_kinds_present(tmp_path: Path) -> None:
+    """When the statement is hawkish and the press conference is dovish on
+    the same event_date, stance_shift = encode(dovish) - encode(hawkish)
+    = -1 - 1 = -2. Certainty and factor are regression-typed numerics
+    here; their shifts are direct subtractions."""
+
+    package = tmp_path / "package"
+    package.mkdir()
+    event_date = "2023-06-14"
+    _write_registry(
+        package / "registry_normalized.jsonl",
+        [
+            _intra_meeting_entry(
+                event_date=event_date,
+                document_type="Statement",
+                source_record_id="fomc_statements.json:1",
+                text="Statement: hawkish baseline.",
+                stance="hawkish",
+                certainty=0.7,
+                factor=0.4,
+            ),
+            _intra_meeting_entry(
+                event_date=event_date,
+                document_type="press_conference",
+                source_record_id="press_conference.json:1",
+                text="Press conference: chair softens on Q&A.",
+                stance="dovish",
+                certainty=0.3,
+                factor=-0.1,
+            ),
+        ],
+    )
+    dates = _make_trading_dates(_dt.date(2021, 1, 4), 800)
+    series = _series_from_closes(dates, [100.0] * 800)
+
+    df = edb.build_event_rows(
+        package_dir=package,
+        asset_series=series,
+        bench_series=series,
+    )
+    assert not df.empty
+    # Every row on the event_date carries the same shift values.
+    for v in df["intra_meeting_stance_shift"].tolist():
+        assert float(v) == pytest.approx(-2.0, abs=1e-9)
+    for v in df["intra_meeting_certainty_shift"].tolist():
+        # Numeric passthrough: 0.3 - 0.7 = -0.4
+        assert float(v) == pytest.approx(-0.4, abs=1e-9)
+    for v in df["intra_meeting_factor_shift"].tolist():
+        # Numeric passthrough: -0.1 - 0.4 = -0.5
+        assert float(v) == pytest.approx(-0.5, abs=1e-9)
+
+
+def test_intra_meeting_shift_missing_press_conference(tmp_path: Path) -> None:
+    """No press conference for the date -> all three shifts NaN."""
+
+    import math as _math
+
+    package = tmp_path / "package"
+    package.mkdir()
+    _write_registry(
+        package / "registry_normalized.jsonl",
+        [
+            _intra_meeting_entry(
+                event_date="2023-06-14",
+                document_type="Statement",
+                source_record_id="fomc_statements.json:1",
+                text="Statement only.",
+                stance="hawkish",
+                certainty=0.7,
+                factor=0.2,
+            ),
+        ],
+    )
+    dates = _make_trading_dates(_dt.date(2021, 1, 4), 800)
+    series = _series_from_closes(dates, [100.0] * 800)
+    df = edb.build_event_rows(
+        package_dir=package,
+        asset_series=series,
+        bench_series=series,
+    )
+    assert not df.empty
+    for col in (
+        "intra_meeting_stance_shift",
+        "intra_meeting_certainty_shift",
+        "intra_meeting_factor_shift",
+    ):
+        for v in df[col].tolist():
+            assert _math.isnan(float(v)), f"{col} expected NaN, got {v}"
+
+
+def test_intra_meeting_shift_missing_statement(tmp_path: Path) -> None:
+    """No statement for the date -> all three shifts NaN."""
+
+    import math as _math
+
+    package = tmp_path / "package"
+    package.mkdir()
+    _write_registry(
+        package / "registry_normalized.jsonl",
+        [
+            _intra_meeting_entry(
+                event_date="2023-06-14",
+                document_type="press_conference",
+                source_record_id="press_conference.json:1",
+                text="Press conference orphan.",
+                stance="dovish",
+                certainty=0.3,
+                factor=-0.4,
+            ),
+        ],
+    )
+    dates = _make_trading_dates(_dt.date(2021, 1, 4), 800)
+    series = _series_from_closes(dates, [100.0] * 800)
+    df = edb.build_event_rows(
+        package_dir=package,
+        asset_series=series,
+        bench_series=series,
+    )
+    assert not df.empty
+    for col in (
+        "intra_meeting_stance_shift",
+        "intra_meeting_certainty_shift",
+        "intra_meeting_factor_shift",
+    ):
+        for v in df[col].tolist():
+            assert _math.isnan(float(v)), f"{col} expected NaN, got {v}"
+
+
+def test_intra_meeting_shift_replicated_on_full_view(tmp_path: Path) -> None:
+    """On the full view (keep_all_sources=True), every (source, asset,
+    horizon) row sharing an event_date must carry the same shift values
+    because the shift is a property of the date, not of the source."""
+
+    package = tmp_path / "package"
+    package.mkdir()
+    event_date = "2023-06-14"
+    _write_registry(
+        package / "registry_normalized.jsonl",
+        [
+            # Two sources of the same statement; preferred = scraped_fed.
+            _intra_meeting_entry(
+                event_date=event_date,
+                document_type="Statement",
+                source_record_id="fomc_statements.json:5",
+                text="Scraped statement.",
+                stance="hawkish",
+                certainty=0.6,
+                factor=0.3,
+                source="scraped_fed",
+            ),
+            _intra_meeting_entry(
+                event_date=event_date,
+                document_type="statement",
+                source_record_id="kaggle:1",
+                text="Kaggle statement variant.",
+                stance="neutral",
+                certainty=0.5,
+                factor=0.0,
+                source="kaggle_fed_statements_minutes",
+            ),
+            _intra_meeting_entry(
+                event_date=event_date,
+                document_type="press_conference",
+                source_record_id="press_conference.json:1",
+                text="Press conference.",
+                stance="dovish",
+                certainty=0.2,
+                factor=-0.2,
+                source="scraped_fed",
+            ),
+        ],
+    )
+    dates = _make_trading_dates(_dt.date(2021, 1, 4), 800)
+    series = _series_from_closes(dates, [100.0] * 800)
+    df_full = edb.build_event_rows(
+        package_dir=package,
+        asset_series=series,
+        bench_series=series,
+        keep_all_sources=True,
+    )
+    # Filter to rows on the event_date and confirm uniform shift values.
+    same_date = df_full[df_full["event_date"] == event_date]
+    assert not same_date.empty
+    # The preferred-pair shift uses scraped_fed (hawkish) statement + dovish PC
+    # -> stance_shift = -1 - 1 = -2. Certainty = 0.2 - 0.6 = -0.4.
+    # Factor = -0.2 - 0.3 = -0.5.
+    for v in same_date["intra_meeting_stance_shift"].tolist():
+        assert float(v) == pytest.approx(-2.0, abs=1e-9)
+    for v in same_date["intra_meeting_certainty_shift"].tolist():
+        assert float(v) == pytest.approx(-0.4, abs=1e-9)
+    for v in same_date["intra_meeting_factor_shift"].tolist():
+        assert float(v) == pytest.approx(-0.5, abs=1e-9)
+    # And on the collapsed view the same value lands on the single
+    # preferred row per kind.
+    df_collapsed = edb.build_event_rows(
+        package_dir=package,
+        asset_series=series,
+        bench_series=series,
+        keep_all_sources=False,
+    )
+    same_date_c = df_collapsed[df_collapsed["event_date"] == event_date]
+    for v in same_date_c["intra_meeting_stance_shift"].tolist():
+        assert float(v) == pytest.approx(-2.0, abs=1e-9)
+
+
+def test_intra_meeting_shift_neutral_axes(tmp_path: Path) -> None:
+    """When both kinds carry the neutral stance and zeroed regression
+    axes, every shift is exactly 0.0 -- not NaN, not coerced."""
+
+    package = tmp_path / "package"
+    package.mkdir()
+    event_date = "2023-06-14"
+    _write_registry(
+        package / "registry_normalized.jsonl",
+        [
+            _intra_meeting_entry(
+                event_date=event_date,
+                document_type="Statement",
+                source_record_id="fomc_statements.json:1",
+                text="Statement neutral.",
+                stance="neutral",
+                certainty=0.5,
+                factor=0.0,
+            ),
+            _intra_meeting_entry(
+                event_date=event_date,
+                document_type="press_conference",
+                source_record_id="press_conference.json:1",
+                text="Press conference neutral.",
+                stance="neutral",
+                certainty=0.5,
+                factor=0.0,
+            ),
+        ],
+    )
+    dates = _make_trading_dates(_dt.date(2021, 1, 4), 800)
+    series = _series_from_closes(dates, [100.0] * 800)
+    df = edb.build_event_rows(
+        package_dir=package,
+        asset_series=series,
+        bench_series=series,
+    )
+    assert not df.empty
+    for col in (
+        "intra_meeting_stance_shift",
+        "intra_meeting_certainty_shift",
+        "intra_meeting_factor_shift",
+    ):
+        for v in df[col].tolist():
+            assert float(v) == pytest.approx(0.0, abs=1e-12), (
+                f"{col} expected 0.0, got {v}"
+            )
+
+
+def test_intra_meeting_shift_columns_in_schema(tmp_path: Path) -> None:
+    """The three shift columns must land on the events.parquet schema
+    even when no event_date carries both kinds."""
+
+    package = tmp_path / "package"
+    package.mkdir()
+    _write_registry(
+        package / "registry_normalized.jsonl",
+        [_registry_entry_for_statement("2023-06-14")],
+    )
+    dates = _make_trading_dates(_dt.date(2021, 1, 4), 800)
+    series = _series_from_closes(dates, [100.0] * 800)
+    df = edb.build_event_rows(
+        package_dir=package,
+        asset_series=series,
+        bench_series=series,
+    )
+    for col in (
+        "intra_meeting_stance_shift",
+        "intra_meeting_certainty_shift",
+        "intra_meeting_factor_shift",
+    ):
+        assert col in df.columns
+
+
 def test_real_release_calendar_contains_landmark_dates() -> None:
     """The shipped calendar must include the canonical landmark dates so
     downstream consumers (and reviewers) can sanity-check the flag.

--- a/tests/unit/test_linguistic_features.py
+++ b/tests/unit/test_linguistic_features.py
@@ -9,12 +9,12 @@ import pandas as pd
 import pytest
 
 from app.features.linguistic import (
-    HAWK_TOKENS,
     HEDGE_TOKENS,
     LinguisticVector,
     MIN_SEED_OVERLAP,
     NAMED_TOPIC_KEYS,
     NUM_TOPICS,
+    PIVOT_DISTANCE_KIND,
     RANDOM_STATE,
     SEED_OVERLAP_TOP_N,
     VOCAB_MIN_DF,
@@ -27,6 +27,8 @@ from app.features.linguistic import (
     hawk_dove_asymmetry,
     hedge_density,
     log_token_count,
+    pivot_distance,
+    pivot_distance_tokens,
 )
 
 
@@ -352,9 +354,12 @@ def test_build_linguistic_feature_frame_is_byte_deterministic(tmp_path):
     pd.testing.assert_frame_equal(frame_a, frame_b)
     assert list(frame_a["text_hash"]) == sorted(h for h, _ in docs)
     assert artifact_a.lda.n_components == NUM_TOPICS
-    # Every numeric column is populated for every row.
+    # Every numeric column other than ``pivot_distance`` is populated
+    # for every row. ``pivot_distance`` is NaN by design for the first
+    # statement in chronological order and for non-statement kinds; the
+    # dedicated ``test_pivot_distance_*`` suite covers its semantics.
     for col in frame_a.columns:
-        if col == "text_hash":
+        if col in ("text_hash", "pivot_distance"):
             continue
         assert frame_a[col].notna().all(), f"column {col} has NaNs"
 
@@ -589,3 +594,223 @@ def test_min_seed_overlap_constants_pinned():
 
     assert MIN_SEED_OVERLAP == 2
     assert SEED_OVERLAP_TOP_N == 10
+
+
+# ---------------------------------------------------------------------------
+# pivot_distance: token-set Jaccard vs prior same-kind statement
+# ---------------------------------------------------------------------------
+
+
+def test_pivot_distance_pure_function_returns_nan_when_prior_is_none():
+    """No prior token set -> NaN. This is the unit-level guarantee that
+    backs the "first statement in the corpus" frame-level rule."""
+
+    result = pivot_distance("inflation remains elevated", None)
+    assert math.isnan(result)
+
+
+def test_pivot_distance_pure_function_zero_on_identical_tokens():
+    """Same vocabulary -> distance 0."""
+
+    text = "inflation has remained elevated reflecting broad price pressures"
+    result = pivot_distance(text, pivot_distance_tokens(text))
+    assert result == pytest.approx(0.0, abs=1e-12)
+
+
+def test_pivot_distance_pure_function_one_on_disjoint_tokens():
+    """Fully disjoint vocab -> distance 1."""
+
+    a = "alpha beta gamma delta"
+    b = "lorem ipsum dolor sit amet"
+    result = pivot_distance(a, pivot_distance_tokens(b))
+    assert result == pytest.approx(1.0, abs=1e-12)
+
+
+def _statement_entry(text_hash: str, event_date: str, text: str) -> dict:
+    return {
+        "text_hash": text_hash,
+        "text": text,
+        "event_date": event_date,
+        "source": "scraped_fed",
+        "source_record_id": text_hash,
+        "document_type": "statement",
+    }
+
+
+def _minutes_entry(text_hash: str, event_date: str, text: str) -> dict:
+    return {
+        "text_hash": text_hash,
+        "text": text,
+        "event_date": event_date,
+        "source": "scraped_fed",
+        "source_record_id": text_hash,
+        "document_type": "minutes",
+    }
+
+
+def _press_conference_entry(text_hash: str, event_date: str, text: str) -> dict:
+    return {
+        "text_hash": text_hash,
+        "text": text,
+        "event_date": event_date,
+        "source": "scraped_fed",
+        "source_record_id": text_hash,
+        "document_type": "press_conference",
+    }
+
+
+def _write_typed_registry(package_dir: Path, entries: list[dict]) -> None:
+    package_dir.mkdir(parents=True, exist_ok=True)
+    with (package_dir / "registry_normalized.jsonl").open(
+        "w", encoding="utf-8"
+    ) as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+
+
+def test_pivot_distance_first_statement_is_nan(tmp_path):
+    """The chronologically first statement has no prior -> NaN."""
+
+    package = tmp_path / "tp_pivot_first"
+    entries = [
+        _statement_entry("a_first", "2023-01-31", _INFLATION_DOC),
+        _statement_entry("b_second", "2023-03-22", _EMPLOYMENT_DOC),
+        _statement_entry("c_third", "2023-05-03", _FINANCIAL_DOC),
+    ]
+    _write_typed_registry(package, entries)
+    artifact = fit_lda(_toy_corpus())
+    frame, _ = build_linguistic_feature_frame(package_dir=package, artifact=artifact)
+    by_hash = {row["text_hash"]: row for row in frame.to_dict(orient="records")}
+    # First statement -> NaN
+    assert math.isnan(by_hash["a_first"]["pivot_distance"])
+    # Subsequent statements have finite distances
+    assert not math.isnan(by_hash["b_second"]["pivot_distance"])
+    assert not math.isnan(by_hash["c_third"]["pivot_distance"])
+
+
+def test_pivot_distance_identical_text_is_zero(tmp_path):
+    """When a statement's text equals the previous statement's text the
+    Jaccard distance must be exactly 0."""
+
+    package = tmp_path / "tp_pivot_zero"
+    entries = [
+        _statement_entry("a_prior", "2023-01-31", _INFLATION_DOC),
+        _statement_entry("b_clone", "2023-03-22", _INFLATION_DOC),
+    ]
+    _write_typed_registry(package, entries)
+    artifact = fit_lda(_toy_corpus())
+    frame, _ = build_linguistic_feature_frame(package_dir=package, artifact=artifact)
+    by_hash = {row["text_hash"]: row for row in frame.to_dict(orient="records")}
+    assert math.isnan(by_hash["a_prior"]["pivot_distance"])
+    assert by_hash["b_clone"]["pivot_distance"] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_pivot_distance_disjoint_vocab_is_one(tmp_path):
+    """Two statements with fully disjoint vocabularies produce distance 1."""
+
+    package = tmp_path / "tp_pivot_one"
+    entries = [
+        _statement_entry(
+            "a_prior", "2023-01-31", "alpha beta gamma delta epsilon zeta"
+        ),
+        _statement_entry(
+            "b_disjoint", "2023-03-22", "lorem ipsum dolor sit amet consectetur"
+        ),
+    ]
+    _write_typed_registry(package, entries)
+    artifact = fit_lda(_toy_corpus())
+    frame, _ = build_linguistic_feature_frame(package_dir=package, artifact=artifact)
+    by_hash = {row["text_hash"]: row for row in frame.to_dict(orient="records")}
+    assert by_hash["b_disjoint"]["pivot_distance"] == pytest.approx(1.0, abs=1e-12)
+
+
+def test_pivot_distance_nan_on_non_statement_kinds(tmp_path):
+    """Minutes / press conferences emit NaN regardless of prior history."""
+
+    package = tmp_path / "tp_pivot_nonstmt"
+    entries = [
+        _statement_entry("a_stmt", "2023-01-31", _INFLATION_DOC),
+        _minutes_entry("b_min", "2023-02-21", _INFLATION_DOC),
+        _press_conference_entry("c_pc", "2023-03-22", _INFLATION_DOC),
+        _statement_entry("d_stmt", "2023-03-22", _INFLATION_DOC),
+    ]
+    _write_typed_registry(package, entries)
+    artifact = fit_lda(_toy_corpus())
+    frame, _ = build_linguistic_feature_frame(package_dir=package, artifact=artifact)
+    by_hash = {row["text_hash"]: row for row in frame.to_dict(orient="records")}
+    # Minutes + press conference -> NaN regardless of prior availability.
+    assert math.isnan(by_hash["b_min"]["pivot_distance"])
+    assert math.isnan(by_hash["c_pc"]["pivot_distance"])
+    # The trailing statement has a prior (a_stmt) and emits a finite value.
+    assert not math.isnan(by_hash["d_stmt"]["pivot_distance"])
+    # That trailing statement is identical text to a_stmt -> distance 0.
+    assert by_hash["d_stmt"]["pivot_distance"] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_pivot_distance_uses_strict_chronological_prior(tmp_path):
+    """When several priors exist, the LATEST one strictly before the current
+    date is used. We make the most-recent prior identical to the current
+    text (distance 0) and an earlier prior fully disjoint (would yield
+    distance 1). The result must be 0, proving the walker picked the
+    strict-less-than most-recent prior."""
+
+    package = tmp_path / "tp_pivot_strict"
+    entries = [
+        # Earliest prior: fully disjoint vocabulary.
+        _statement_entry(
+            "a_oldest", "2023-01-31", "alpha beta gamma delta epsilon"
+        ),
+        # Most-recent strictly-prior statement: identical text to current.
+        _statement_entry(
+            "b_recent_prior", "2023-03-22", _INFLATION_DOC
+        ),
+        # Current statement.
+        _statement_entry("c_current", "2023-05-03", _INFLATION_DOC),
+    ]
+    _write_typed_registry(package, entries)
+    artifact = fit_lda(_toy_corpus())
+    frame, _ = build_linguistic_feature_frame(package_dir=package, artifact=artifact)
+    by_hash = {row["text_hash"]: row for row in frame.to_dict(orient="records")}
+    # Must use the most-recent strict prior (b_recent_prior) -> distance 0.
+    assert by_hash["c_current"]["pivot_distance"] == pytest.approx(
+        0.0, abs=1e-12
+    )
+
+
+def test_pivot_distance_kind_constant_pinned():
+    """Spec guardrail: pivot_distance is only defined for the statement kind."""
+
+    assert PIVOT_DISTANCE_KIND == "statement"
+
+
+def test_linguistic_vector_has_pivot_distance_field():
+    """The 15-dim contract requires ``pivot_distance`` on every row."""
+
+    fields = list(LinguisticVector.__dataclass_fields__.keys())
+    assert "pivot_distance" in fields
+    assert len(fields) == 15
+
+
+def test_compute_linguistic_features_default_pivot_is_nan():
+    """When the caller does not pass ``prior_statement_tokens`` the
+    pivot field emits NaN (matches the non-statement / first-statement
+    semantics)."""
+
+    vec = compute_linguistic_features(_INFLATION_DOC)
+    assert math.isnan(vec.pivot_distance)
+
+
+def test_build_linguistic_feature_frame_pivot_column_present(tmp_path):
+    """The Sprint-1-style builder must emit a ``pivot_distance`` column."""
+
+    package = tmp_path / "tp_pivot_col"
+    entries = [
+        _statement_entry("a_stmt", "2023-01-31", _INFLATION_DOC),
+        _statement_entry("b_stmt", "2023-03-22", _EMPLOYMENT_DOC),
+    ]
+    _write_typed_registry(package, entries)
+    artifact = fit_lda(_toy_corpus())
+    frame, _ = build_linguistic_feature_frame(package_dir=package, artifact=artifact)
+    assert "pivot_distance" in frame.columns
+    # Non-NaN count = #statements with a strict prior = N - 1 here.
+    assert frame["pivot_distance"].notna().sum() == 1


### PR DESCRIPTION
## Summary
- pivot_distance: 15th linguistic feature, token Jaccard vs prior statement
- NaN on first statement and on non-statement event kinds
- intra_meeting_{stance,certainty,factor}_shift: derived columns on events.parquet
- Shift = press_conference axis minus statement axis on same event_date
- NaN when either kind is missing; no coercion
- Schema docstrings + data-and-training-contracts.md updated
- Wiki entry queued locally at ../fed-pulse.wiki/06_Deep_Learning_Roadmap.md for separate push

## Test plan
- [ ] `docker compose run --rm --no-deps backend pytest tests/unit/test_linguistic_features.py tests/unit/test_event_dataset_builder.py -q`
- [ ] `docker compose run --rm --no-deps backend pytest tests/regression/ tests/unit/test_forecaster.py -q`
- [ ] `make verify` end-to-end on the toy snapshot

Closes #157, #158.