### PR TITLE
arq worker replaces the in-process daemon thread for real_train (closes #103)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,16 +61,19 @@ help:
 dev: dev-cpu
 
 dev-cpu:
-	docker compose up -d --build backend frontend
+	docker compose up -d --build redis backend worker frontend
 
 dev-gpu:
-	docker compose --profile gpu up -d --build backend-gpu frontend
+	docker compose --profile gpu up -d --build redis backend-gpu worker-gpu frontend
 
 down:
 	docker compose --profile gpu down
 
 logs:
 	docker compose logs -f --tail=200
+
+worker-logs:
+	docker compose logs -f --tail=200 worker
 
 lock:
 	docker compose run --rm backend bash -c "pip install --quiet uv && uv pip compile --generate-hashes --output-file requirements.lock pyproject.toml"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -147,9 +147,25 @@ _train_jobs_lock = threading.Lock()
 
 
 def _redis_pool() -> ArqRedis | None:
-    """Return the arq pool stashed on ``app.state`` during lifespan, if any."""
+    """Return the arq pool stashed on ``app.state`` during lifespan, if any.
 
-    return getattr(app.state, "redis_pool", None)
+    ``app.state.redis_pool`` may be either an ``ArqRedis`` instance (the
+    production path — lifespan creates the pool once and the same object
+    serves every request) or a zero-arg callable that returns a fresh
+    ``ArqRedis`` (the test path — needed because ``TestClient`` runs
+    each request in its own anyio portal with a private event loop, so
+    a pool constructed in the test thread's loop would fail with
+    ``RuntimeError: Queue is bound to a different event loop`` when
+    consumed inside the request handler). The callable form lets tests
+    construct a fresh pool inside the request loop on demand.
+    """
+
+    pool = getattr(app.state, "redis_pool", None)
+    if pool is None:
+        return None
+    if callable(pool) and not isinstance(pool, ArqRedis):
+        return pool()
+    return pool
 
 app.add_middleware(RunIdMiddleware)
 app.add_middleware(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -97,12 +97,14 @@ async def _lifespan(app: FastAPI):
     # Bring up an arq Redis pool so /analyze can enqueue real_train jobs
     # into a durable queue. A missing or unreachable Redis is not fatal:
     # the endpoint falls back to the in-process daemon thread so dev
-    # boxes without docker compose still work. ``DISABLE_REDIS_POOL`` is
-    # a test-only escape hatch that skips the connect attempt entirely
+    # boxes without docker compose still work. ``FED_PULSE_DISABLE_REDIS_POOL``
+    # is a test-only escape hatch that skips the connect attempt entirely
     # (the default arq retry loop is otherwise long enough to slow the
-    # test suite noticeably).
+    # test suite noticeably). The prefix isolates the flag from any
+    # generic ``DISABLE_REDIS_POOL`` value an external tool or host
+    # environment might export.
     pool: ArqRedis | None = None
-    if os.environ.get("DISABLE_REDIS_POOL") not in {"1", "true", "TRUE"}:
+    if os.environ.get("FED_PULSE_DISABLE_REDIS_POOL", "").strip().lower() not in {"1", "true", "yes"}:
         try:
             pool = await create_pool(get_redis_settings())
             # Force a round-trip so an unreachable Redis fails fast instead of
@@ -527,6 +529,12 @@ async def _state_from_redis_job(pool: ArqRedis, job_id: str) -> dict[str, Any] |
     if status == JobStatus.not_found:
         return None
     info = await job.info()
+    # Skip jobs from other arq task functions so the dashboard listing
+    # stays scoped to real_train. A future arq task on the same Redis
+    # instance would otherwise leak into /train-jobs with no symbol /
+    # date / history_length payload and break the response shape.
+    if info is not None and getattr(info, "function", None) not in (None, "real_train_task"):
+        return None
     payload = _payload_from_args(info)
     state: dict[str, Any] = {
         "job_id": job_id,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 import io
 import json
 import logging
+import os
 import threading
 import uuid
 from contextlib import asynccontextmanager
@@ -8,6 +9,9 @@ from datetime import date, datetime, timezone
 from typing import Any
 
 import httpx
+from arq import constants as arq_constants
+from arq.connections import ArqRedis, create_pool
+from arq.jobs import Job as ArqJob, JobStatus
 from fastapi import Depends, FastAPI, File, Form, HTTPException, Query, UploadFile
 from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
@@ -73,12 +77,13 @@ from app.services.market_data import (
     fetch_realized_forward,
 )
 from app.services.sentiment import analyze_text
+from app.worker import REAL_TRAIN_HISTORY_LENGTH, get_redis_settings
 
 logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
-async def _lifespan(app: FastAPI):  # noqa: ARG001
+async def _lifespan(app: FastAPI):
     configure_logging()
     get_engine()
     # Pre-load the HF classifier so the first /analyze request doesn't pay
@@ -89,18 +94,60 @@ async def _lifespan(app: FastAPI):  # noqa: ARG001
         warmup_classifier()
     except Exception:  # pragma: no cover — never let model warmup block startup
         get_logger("fed_pulse").warning("classifier_warmup_failed", exc_info=True)
+    # Bring up an arq Redis pool so /analyze can enqueue real_train jobs
+    # into a durable queue. A missing or unreachable Redis is not fatal:
+    # the endpoint falls back to the in-process daemon thread so dev
+    # boxes without docker compose still work. ``DISABLE_REDIS_POOL`` is
+    # a test-only escape hatch that skips the connect attempt entirely
+    # (the default arq retry loop is otherwise long enough to slow the
+    # test suite noticeably).
+    pool: ArqRedis | None = None
+    if os.environ.get("DISABLE_REDIS_POOL") not in {"1", "true", "TRUE"}:
+        try:
+            pool = await create_pool(get_redis_settings())
+            # Force a round-trip so an unreachable Redis fails fast instead of
+            # the first /analyze call discovering it the hard way.
+            await pool.ping()
+            get_logger("fed_pulse").info("arq_pool_ready", service="fomc-api")
+        except Exception:
+            get_logger("fed_pulse").warning(
+                "arq_pool_unavailable",
+                service="fomc-api",
+                exc_info=True,
+            )
+            if pool is not None:  # pragma: no cover — partial init unwinds
+                try:
+                    await pool.close(close_connection_pool=True)
+                except Exception:
+                    pass
+            pool = None
+    app.state.redis_pool = pool
     get_logger("fed_pulse").info("startup", service="fomc-api")
     try:
         yield
     finally:
+        if pool is not None:
+            try:
+                await pool.close(close_connection_pool=True)
+            except Exception:  # pragma: no cover
+                get_logger("fed_pulse").warning("arq_pool_close_failed", exc_info=True)
         get_logger("fed_pulse").info("shutdown", service="fomc-api")
 
 
 app = FastAPI(title="FOMC Sentiment API", version="0.1.0", lifespan=_lifespan)
-REAL_TRAIN_HISTORY_LENGTH = 252
 
+# In-memory fallback only. The primary store is Redis via arq; this dict is
+# read/written only when ``app.state.redis_pool`` is None (dev environments
+# without a Redis container). It keeps the surface backwards-compatible
+# with the pre-#103 daemon-thread path.
 _train_jobs: dict[str, dict[str, Any]] = {}
 _train_jobs_lock = threading.Lock()
+
+
+def _redis_pool() -> ArqRedis | None:
+    """Return the arq pool stashed on ``app.state`` during lifespan, if any."""
+
+    return getattr(app.state, "redis_pool", None)
 
 app.add_middleware(RunIdMiddleware)
 app.add_middleware(
@@ -340,6 +387,56 @@ def _run_real_train_job_body(job_id: str, payload: AnalyzeRequest) -> None:
             get_logger("fed_pulse").warning("audit_write_failed", run_id=job_id)
 
 
+async def _enqueue_real_train(payload: AnalyzeRequest) -> dict[str, Any]:
+    """Enqueue a Real-Train job through the arq Redis pool when available,
+    falling back to the legacy in-process daemon thread otherwise.
+
+    The fallback path keeps dev environments without a Redis container
+    working and preserves the pre-#103 response shape so the existing
+    frontend polling loop is unaffected.
+    """
+
+    job_id = str(uuid.uuid4())
+    pool = _redis_pool()
+    if pool is not None:
+        await pool.enqueue_job(
+            "real_train_task",
+            payload.model_dump(),
+            _job_id=job_id,
+        )
+        return {
+            "status": "queued",
+            "job_id": job_id,
+            "message": "Real Train started with 252-day history. Poll /train-jobs/{job_id} for progress.",
+        }
+
+    # Fallback: in-process daemon thread + in-memory job map. Same response
+    # shape as the Redis path so callers cannot tell the two apart.
+    job_state: dict[str, Any] = {
+        "job_id": job_id,
+        "status": "queued",
+        "error": None,
+        "started_at": None,
+        "finished_at": None,
+        "result": None,
+        "created_at": _utc_now_iso(),
+        "history_length": REAL_TRAIN_HISTORY_LENGTH,
+        "symbol": payload.symbol,
+        "date": payload.date,
+    }
+    with _train_jobs_lock:
+        _train_jobs[job_id] = job_state
+    thread = threading.Thread(
+        target=_run_real_train_job, args=(job_id, payload), daemon=True
+    )
+    thread.start()
+    return {
+        "status": "queued",
+        "job_id": job_id,
+        "message": "Real Train started with 252-day history. Poll /train-jobs/{job_id} for progress.",
+    }
+
+
 @app.post("/analyze", response_model=AnalyzeResponse | TrainJobAcceptedResponse)
 async def analyze(payload: AnalyzeRequest):
     """Async handler — heavy sync work (transformers, yfinance, torch) runs in
@@ -351,28 +448,7 @@ async def analyze(payload: AnalyzeRequest):
             raise ValueError("forecast_mode must be 'fast', 'quick_train', or 'real_train'")
 
         if mode == "real_train":
-            job_id = str(uuid.uuid4())
-            job_state: dict[str, Any] = {
-                "job_id": job_id,
-                "status": "queued",
-                "error": None,
-                "started_at": None,
-                "finished_at": None,
-                "result": None,
-                "created_at": _utc_now_iso(),
-                "history_length": REAL_TRAIN_HISTORY_LENGTH,
-                "symbol": payload.symbol,
-                "date": payload.date,
-            }
-            with _train_jobs_lock:
-                _train_jobs[job_id] = job_state
-            thread = threading.Thread(target=_run_real_train_job, args=(job_id, payload), daemon=True)
-            thread.start()
-            return {
-                "status": "queued",
-                "job_id": job_id,
-                "message": "Real Train started with 252-day history. Poll /train-jobs/{job_id} for progress.",
-            }
+            return await _enqueue_real_train(payload)
 
         history_length = 30
         if mode == "fast" and not checkpoint_exists():
@@ -417,8 +493,103 @@ def _bootstrap_cold_start(payload: AnalyzeRequest) -> None:
     )
 
 
+def _iso_or_none(ts: Any) -> str | None:
+    """Best-effort ISO-8601 stringifier for arq's datetime fields."""
+
+    if ts is None:
+        return None
+    if isinstance(ts, datetime):
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        return ts.isoformat()
+    return str(ts)
+
+
+def _payload_from_args(info: Any) -> dict[str, Any]:
+    """Pull the AnalyzeRequest payload out of an arq job def/result."""
+
+    if info is None:
+        return {}
+    args = getattr(info, "args", None) or ()
+    if args and isinstance(args[0], dict):
+        return args[0]
+    kwargs = getattr(info, "kwargs", None) or {}
+    payload = kwargs.get("payload")
+    return payload if isinstance(payload, dict) else {}
+
+
+async def _state_from_redis_job(pool: ArqRedis, job_id: str) -> dict[str, Any] | None:
+    """Read job state from Redis and shape it like the legacy ``_train_jobs``
+    dict so the response models do not need to change."""
+
+    job = ArqJob(job_id, pool)
+    status = await job.status()
+    if status == JobStatus.not_found:
+        return None
+    info = await job.info()
+    payload = _payload_from_args(info)
+    state: dict[str, Any] = {
+        "job_id": job_id,
+        "status": "queued",
+        "error": None,
+        "started_at": None,
+        "finished_at": None,
+        "result": None,
+        "created_at": _iso_or_none(getattr(info, "enqueue_time", None)),
+        "history_length": REAL_TRAIN_HISTORY_LENGTH,
+        "symbol": payload.get("symbol"),
+        "date": payload.get("date"),
+    }
+    if status == JobStatus.in_progress:
+        state["status"] = "running"
+        result_info = await job.result_info()
+        if result_info is not None:
+            state["started_at"] = _iso_or_none(result_info.start_time)
+        return state
+    if status == JobStatus.complete:
+        result_info = await job.result_info()
+        if result_info is None:
+            state["status"] = "succeeded"
+            return state
+        state["started_at"] = _iso_or_none(result_info.start_time)
+        state["finished_at"] = _iso_or_none(result_info.finish_time)
+        if result_info.success:
+            state["status"] = "succeeded"
+            state["result"] = result_info.result if isinstance(result_info.result, dict) else None
+        else:
+            state["status"] = "failed"
+            err = result_info.result
+            state["error"] = (
+                f"Real train job failed: {err}" if err is not None else "Real train job failed"
+            )
+        return state
+    # queued / deferred share the same surface state from the API's view.
+    return state
+
+
+async def _list_redis_job_ids(pool: ArqRedis) -> list[str]:
+    """Enumerate every job arq knows about: queued/in-progress (``arq:job:*``)
+    plus completed (``arq:result:*``). Both prefixes are stripped to recover
+    the bare job id."""
+
+    seen: set[str] = set()
+    for prefix in (arq_constants.job_key_prefix, arq_constants.result_key_prefix):
+        match = f"{prefix}*"
+        async for key in pool.scan_iter(match=match):
+            key_str = key.decode() if isinstance(key, bytes) else key
+            seen.add(key_str[len(prefix):])
+    return sorted(seen)
+
+
 @app.get("/train-jobs/{job_id}", response_model=TrainJobStatusResponse)
-def get_train_job(job_id: str):
+async def get_train_job(job_id: str):
+    pool = _redis_pool()
+    if pool is not None:
+        state = await _state_from_redis_job(pool, job_id)
+        if state is not None:
+            return state
+        # Fall through to the in-memory map -- a daemon-thread job submitted
+        # while Redis was down still has to be reachable.
     with _train_jobs_lock:
         state = _train_jobs.get(job_id)
         if state is None:
@@ -609,21 +780,39 @@ def _invert_iso(value: str) -> str:
     return "".join(chr(255 - ord(c)) if ord(c) < 255 else c for c in value)
 
 
+async def _redis_train_jobs_snapshot(pool: ArqRedis) -> list[dict[str, Any]]:
+    """Materialise every arq-tracked real_train job into the legacy state
+    shape so :func:`_train_job_sort_key` and the response model can ingest
+    them without branching on the storage backend."""
+
+    job_ids = await _list_redis_job_ids(pool)
+    states: list[dict[str, Any]] = []
+    for jid in job_ids:
+        state = await _state_from_redis_job(pool, jid)
+        if state is not None:
+            states.append(state)
+    return states
+
+
 @app.get("/train-jobs", response_model=TrainJobsListResponse)
-def list_train_jobs(
+async def list_train_jobs(
     status: str | None = Query(default=None, description="Filter by status: queued/running/succeeded/failed."),
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
 ) -> TrainJobsListResponse:
-    """List in-process real_train jobs.
+    """List real_train jobs from the arq-backed Redis queue.
 
-    State is in-memory only -- restarting the backend resets the list.
-    This is intentional: the dashboard is observational; durable runs
-    flow through the make targets, not the API.
+    Falls back to the in-memory ``_train_jobs`` dict when Redis is
+    unreachable -- dev environments without a worker container still
+    surface daemon-thread jobs through the dashboard.
     """
 
-    with _train_jobs_lock:
-        snapshot = [dict(state) for state in _train_jobs.values()]
+    pool = _redis_pool()
+    if pool is not None:
+        snapshot = await _redis_train_jobs_snapshot(pool)
+    else:
+        with _train_jobs_lock:
+            snapshot = [dict(state) for state in _train_jobs.values()]
     if status:
         wanted = status.strip().lower()
         snapshot = [s for s in snapshot if str(s.get("status") or "").lower() == wanted]

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,0 +1,148 @@
+"""Durable real_train queue backed by arq + Redis (closes #103).
+
+The FastAPI process enqueues a ``real_train_task`` into Redis and a separate
+``arq`` worker container drains the queue. Job state lives in Redis so it
+survives a backend restart -- the in-process ``_train_jobs`` dict in
+``app/main.py`` is now a graceful fallback for dev environments without
+Redis.
+
+The task function intentionally mirrors the body of the old
+``_run_real_train_job`` daemon thread so behaviour stays identical aside
+from where state lives.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from arq.connections import RedisSettings
+
+from app.audit import append_audit_entry
+from app.logging import bind_run_id, clear_run_id, configure_logging, get_logger
+from app.schemas import AnalyzeRequest
+
+REAL_TRAIN_HISTORY_LENGTH = 252
+REDIS_DSN_ENV = "REDIS_URL"
+DEFAULT_REDIS_DSN = "redis://redis:6379"
+REAL_TRAIN_QUEUE = "arq:queue"
+
+
+def get_redis_settings() -> RedisSettings:
+    """Build :class:`RedisSettings` from the ``REDIS_URL`` env var."""
+
+    dsn = os.environ.get(REDIS_DSN_ENV, DEFAULT_REDIS_DSN)
+    return RedisSettings.from_dsn(dsn)
+
+
+def _build_real_train_result(payload: AnalyzeRequest) -> dict[str, Any]:
+    """Reproduce the body of the legacy ``_run_real_train_job`` thread.
+
+    Kept as a free function so both the arq task and tests can drive it
+    without going through the queue. Heavy imports are deferred to call
+    time so importing :mod:`app.worker` from a test never drags in torch.
+    """
+
+    from app.services.forecaster import (
+        bootstrap_checkpoint,
+        build_feature_vectors,
+    )
+    from app.services.market_data import fetch_market_history
+    from app.services.sentiment import analyze_text
+
+    # Late-imported because the main app module owns the response shape.
+    from app.main import _build_analyze_response, _record_history
+
+    sentiment = analyze_text(payload.text)
+    market_history = fetch_market_history(
+        target_date=payload.date,
+        symbol=payload.symbol,
+        history_length=REAL_TRAIN_HISTORY_LENGTH,
+    )
+    history_vectors = build_feature_vectors(
+        market_history,
+        sentiment_score=float(sentiment["score"]),
+        document_date=payload.date,
+    )
+    # Real Train intentionally runs a stronger checkpoint update over 252-day context.
+    bootstrap_checkpoint(
+        vectors=history_vectors,
+        epochs=120,
+        batch_size=64,
+        learning_rate=3e-4,
+        validation_split=0.2,
+        early_stopping_patience=12,
+    )
+    result = _build_analyze_response(
+        payload, mode="real_train", history_length=REAL_TRAIN_HISTORY_LENGTH
+    )
+    _record_history(payload, result)
+    return result
+
+
+async def real_train_task(ctx: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    """Arq task that drives a Real-Train run.
+
+    ``ctx`` is the standard arq context dict (job_id, redis, score, …).
+    ``payload`` is the JSON-safe ``AnalyzeRequest.model_dump()`` from the
+    enqueueing API call. Returns the same analyze response shape the
+    in-process daemon thread used to write into ``_train_jobs[id]['result']``.
+    Arq stores it in Redis under the job id and :class:`arq.jobs.Job`
+    exposes it via ``result()`` / ``result_info()``.
+    """
+
+    job_id = str(ctx.get("job_id") or "")
+    bind_run_id(job_id)
+    request = AnalyzeRequest.model_validate(payload)
+    try:
+        result = _build_real_train_result(request)
+        try:
+            append_audit_entry(
+                "real_train_completed",
+                run_id=job_id,
+                metadata={"symbol": request.symbol, "date": request.date},
+            )
+        except Exception:  # pragma: no cover -- audit row best-effort
+            get_logger("fed_pulse").warning("audit_write_failed", run_id=job_id)
+        return result
+    except Exception as exc:
+        try:
+            append_audit_entry(
+                "real_train_failed",
+                run_id=job_id,
+                metadata={
+                    "symbol": request.symbol,
+                    "date": request.date,
+                    "error": str(exc),
+                },
+            )
+        except Exception:  # pragma: no cover
+            get_logger("fed_pulse").warning("audit_write_failed", run_id=job_id)
+        # Re-raise so arq records the failure in JobResult.success=False; the
+        # listing endpoint maps that back to status='failed' + error string.
+        raise
+    finally:
+        clear_run_id()
+
+
+async def _startup(ctx: dict[str, Any]) -> None:  # noqa: ARG001
+    configure_logging()
+    get_logger("fed_pulse").info("worker_startup", service="arq-worker")
+
+
+async def _shutdown(ctx: dict[str, Any]) -> None:  # noqa: ARG001
+    get_logger("fed_pulse").info("worker_shutdown", service="arq-worker")
+
+
+class WorkerSettings:
+    """Arq worker entrypoint -- ``arq app.worker.WorkerSettings``."""
+
+    functions = [real_train_task]
+    redis_settings = get_redis_settings()
+    on_startup = _startup
+    on_shutdown = _shutdown
+    # Job results stick around in Redis long enough for the dashboard to
+    # surface them; 7 days mirrors arq's default but is set explicitly so
+    # the listing endpoint never silently drops a recent run.
+    keep_result = 60 * 60 * 24 * 7
+    max_jobs = 4

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,18 +37,22 @@ dependencies = [
   "httpx>=0.27.0",
   "SQLAlchemy>=2.0",
   "structlog>=24.1",
+  "arq>=0.26",
+  "redis>=5.0",
 ]
 
 [project.optional-dependencies]
 dev = [
   "pytest",
   "pytest-cov",
+  "pytest-asyncio",
   "hypothesis",
   "ruff",
   "mypy",
   "py-spy>=0.3.14",
   "types-PyYAML",
   "types-requests",
+  "fakeredis>=2.20",
 ]
 gpu = []
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,15 @@
 services:
+  redis:
+    image: redis:7-alpine
+    container_name: swe599-redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+
   backend:
     build:
       context: ./backend
@@ -17,6 +28,10 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - PYTHONPATH=/app
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
   backend-gpu:
@@ -38,6 +53,10 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - PYTHONPATH=/app
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
     deploy:
       resources:
         reservations:
@@ -46,6 +65,58 @@ services:
               count: all
               capabilities: [gpu]
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+
+  worker:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: swe599-worker
+    volumes:
+      - ./backend:/app
+      - ./tests:/app/tests:ro
+      - ./scripts:/app/scripts:ro
+      - ./data:/data
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      - PYTHONUNBUFFERED=1
+      - PYTHONPATH=/app
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
+    command: arq app.worker.WorkerSettings
+
+  worker-gpu:
+    profiles: ["gpu"]
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: swe599-worker-gpu
+    volumes:
+      - ./backend:/app
+      - ./tests:/app/tests:ro
+      - ./scripts:/app/scripts:ro
+      - ./data:/data
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      - PYTHONUNBUFFERED=1
+      - PYTHONPATH=/app
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    command: arq app.worker.WorkerSettings
 
   frontend:
     build:

--- a/docs/REPO_TOUR.md
+++ b/docs/REPO_TOUR.md
@@ -507,3 +507,40 @@ If you change architecture, schema, API surface, or evaluation protocol, name th
 - Grep for the function name across `tests/unit/` — the test usually shows how the function is meant to be used.
 - The wiki's `01_Progress_Snapshot.md` carries the freshest "what's done, what's in flight, what's at risk" snapshot.
 - The Makefile is the contract for every workflow — if it isn't in the Makefile, it isn't a supported flow.
+
+---
+
+## Durable real_train queue (closes #103)
+
+Real-Train runs used to live on a daemon thread inside the FastAPI process — `app/main.py` spawned `_run_real_train_job` and stored state in an in-memory dict. The dict evaporated on restart and the thread had no horizontal scale path. Closing issue #103 replaced both with an `arq`-backed Redis queue.
+
+**Topology**
+
+```
+POST /analyze (real_train) ──▶ FastAPI
+                                  │  pool.enqueue_job("real_train_task", payload)
+                                  ▼
+                              Redis (redis:7-alpine, healthcheck=redis-cli ping)
+                                  ▲                 ▲
+                                  │ result_info()   │ blpop / status
+                                  │                 │
+                              FastAPI            arq worker
+                              /train-jobs/{id}   container running
+                              /train-jobs        `arq app.worker.WorkerSettings`
+```
+
+**Code**
+
+- `backend/app/worker.py` — defines `WorkerSettings.functions = [real_train_task]`. `real_train_task(ctx, payload)` mirrors the legacy daemon-thread body: sentiment + market history + `bootstrap_checkpoint` + `_build_analyze_response`. Audit rows still land via `app.audit.append_audit_entry`. The function re-raises on failure so arq records `JobResult.success=False`.
+- `backend/app/main.py` — the `/analyze` real_train branch calls `_enqueue_real_train`, which goes through `app.state.redis_pool.enqueue_job` when a pool is attached. The pool is created in the FastAPI `lifespan` from `REDIS_URL` (default `redis://redis:6379`). When Redis is unreachable the lifespan logs `arq_pool_unavailable` and falls back to the in-process daemon thread + `_train_jobs` dict so dev boxes without docker compose still work.
+- `/train-jobs/{id}` reads `ArqJob(id, pool).status() / .info() / .result_info()` and shapes it into the existing `TrainJobStatusResponse`. `/train-jobs` listing scans `arq:job:*` and `arq:result:*` keys for the same shaping.
+
+**Compose**
+
+- `redis: image: redis:7-alpine` with `redis-cli ping` healthcheck.
+- `worker` and `worker-gpu` services share the backend image and run `arq app.worker.WorkerSettings`. `make dev-cpu` brings up `redis backend worker frontend`; `make dev-gpu` swaps in the gpu profile.
+
+**Tests**
+
+- `tests/unit/test_arq_worker.py` — task signature is `(ctx, payload) -> dict`, `WorkerSettings.functions` exposes it, the task returns a dict, the task re-raises on failure.
+- `tests/unit/test_real_train_endpoints.py` — `/analyze` real_train against a `fakeredis`-backed `ArqRedis` returns `queued`; `/train-jobs/{id}` and `/train-jobs` read state out of the same Redis; the in-memory `_train_jobs` map stays empty when a pool is attached. A restart-survival test recreates the `TestClient` against the same fakeredis and asserts the queued job is still visible.

--- a/tests/unit/test_arq_worker.py
+++ b/tests/unit/test_arq_worker.py
@@ -1,0 +1,117 @@
+"""Unit tests for the arq-backed real_train queue (closes #103)."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+
+pytest.importorskip("arq")
+pytest.importorskip("fakeredis")
+
+from arq.connections import ArqRedis  # noqa: E402
+from arq.jobs import Job as ArqJob, JobStatus  # noqa: E402
+from fakeredis import FakeAsyncRedis  # noqa: E402
+
+import app.worker as worker_mod  # noqa: E402
+
+
+def test_real_train_task_signature():
+    """The arq task contract is ``(ctx, payload) -> dict``."""
+
+    fn = worker_mod.real_train_task
+    sig = inspect.signature(fn)
+    params = list(sig.parameters)
+    assert params == ["ctx", "payload"]
+    assert inspect.iscoroutinefunction(fn)
+
+
+def test_worker_settings_exposes_real_train_task():
+    """``arq app.worker.WorkerSettings`` must find the task in ``functions``."""
+
+    settings = worker_mod.WorkerSettings
+    assert worker_mod.real_train_task in settings.functions
+    assert hasattr(settings, "redis_settings")
+
+
+def test_get_redis_settings_reads_env(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://example.invalid:6380/2")
+    settings = worker_mod.get_redis_settings()
+    assert settings.host in {"example.invalid", "example"}
+    assert settings.port == 6380
+    assert settings.database == 2
+
+
+def test_real_train_history_length_constant():
+    assert worker_mod.REAL_TRAIN_HISTORY_LENGTH == 252
+
+
+def _fake_arq_pool() -> ArqRedis:
+    """Wrap fakeredis in the same ArqRedis class arq uses internally so
+    ``ArqJob`` round-trips behave the same way they do against real Redis."""
+
+    fake = FakeAsyncRedis()
+    return ArqRedis(connection_pool=fake.connection_pool)
+
+
+_SAMPLE_PAYLOAD = {
+    "text": "fed text",
+    "date": "2026-03-15",
+    "symbol": "^GSPC",
+    "horizon": "3d",
+    "forecast_mode": "real_train",
+    "include_realized": False,
+    "include_xai": False,
+}
+
+
+def test_enqueue_marks_job_as_queued_in_redis(monkeypatch):
+    """An enqueued job must surface as ``JobStatus.queued`` to the API
+    side -- this is the contract the /train-jobs/{id} endpoint depends on."""
+
+    async def _run():
+        pool = _fake_arq_pool()
+        await pool.enqueue_job("real_train_task", _SAMPLE_PAYLOAD, _job_id="qid")
+        job = ArqJob("qid", pool)
+        return await job.status()
+
+    assert asyncio.run(_run()) == JobStatus.queued
+
+
+def test_real_train_task_returns_dict(monkeypatch):
+    """Drive the task body directly with the heavy bits stubbed; assert
+    the return shape arq stores under the job id."""
+
+    monkeypatch.setattr(
+        worker_mod,
+        "_build_real_train_result",
+        lambda _payload: {"sentiment": {"label": "neutral", "score": 0.0}},
+    )
+    monkeypatch.setattr(worker_mod, "append_audit_entry", lambda *a, **k: None)
+
+    async def _run():
+        return await worker_mod.real_train_task(
+            {"job_id": "test-job-1"}, _SAMPLE_PAYLOAD
+        )
+
+    result = asyncio.run(_run())
+    assert isinstance(result, dict)
+    assert result["sentiment"]["label"] == "neutral"
+
+
+def test_real_train_task_propagates_failure(monkeypatch):
+    """A raising task body must re-raise so arq stores success=False; the
+    listing endpoint maps that back to status='failed'."""
+
+    def _boom(_payload):
+        raise RuntimeError("forecast bootstrap failed")
+
+    monkeypatch.setattr(worker_mod, "_build_real_train_result", _boom)
+    monkeypatch.setattr(worker_mod, "append_audit_entry", lambda *a, **k: None)
+
+    async def _run():
+        await worker_mod.real_train_task({"job_id": "test-job-2"}, _SAMPLE_PAYLOAD)
+
+    with pytest.raises(RuntimeError, match="forecast bootstrap failed"):
+        asyncio.run(_run())

--- a/tests/unit/test_real_train_endpoints.py
+++ b/tests/unit/test_real_train_endpoints.py
@@ -314,7 +314,13 @@ def test_fast_mode_does_not_touch_redis(client, monkeypatch):
     with main_mod._train_jobs_lock:
         assert main_mod._train_jobs == {}
 
-    async def _queue_len():
-        return await pool.zcard("arq:queue")
+    # Construct a fresh pool inside asyncio.run() so the connection
+    # binds to that loop; factory-installed pools die with their
+    # request loop.
+    factory = main_mod.app.state.redis_pool
+
+    async def _queue_len() -> int:
+        check_pool = factory()
+        return await check_pool.zcard("arq:queue")
 
     assert asyncio.run(_queue_len()) == 0

--- a/tests/unit/test_real_train_endpoints.py
+++ b/tests/unit/test_real_train_endpoints.py
@@ -13,14 +13,26 @@ pytest.importorskip("arq")
 pytest.importorskip("fakeredis")
 
 from arq.connections import ArqRedis  # noqa: E402
-from fakeredis import FakeAsyncRedis  # noqa: E402
+from fakeredis import FakeAsyncRedis, FakeServer  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 import app.main as main_mod  # noqa: E402
 
 
-def _fake_arq_pool() -> ArqRedis:
-    fake = FakeAsyncRedis()
+def _fake_arq_pool(server: FakeServer | None = None) -> ArqRedis:
+    """Build an ArqRedis pool against a fakeredis backend.
+
+    When ``server`` is None a fresh isolated FakeServer is allocated.
+    Passing a shared FakeServer between two _fake_arq_pool() calls
+    mimics two backend processes pointing at the same Redis: the pools
+    are independent Python objects, but their underlying key/value
+    store is the same. The restart-survival test relies on this to
+    prove the contract that job state lives in Redis, not in the
+    in-process pool.
+    """
+
+    server = server if server is not None else FakeServer()
+    fake = FakeAsyncRedis(server=server)
     return ArqRedis(connection_pool=fake.connection_pool)
 
 
@@ -28,7 +40,7 @@ def _fake_arq_pool() -> ArqRedis:
 def _clear_state(monkeypatch):
     """Each test sees an empty in-memory map and no Redis pool by default."""
 
-    monkeypatch.setenv("DISABLE_REDIS_POOL", "1")
+    monkeypatch.setenv("FED_PULSE_DISABLE_REDIS_POOL", "1")
     with main_mod._train_jobs_lock:
         main_mod._train_jobs.clear()
     yield
@@ -152,10 +164,18 @@ def test_list_train_jobs_reads_from_redis(client):
 
 def test_real_train_state_survives_app_restart(client):
     """The headline contract for #103: a queued job must still be
-    readable after the FastAPI app is torn down and a fresh instance
-    is bound to the same Redis."""
+    readable after the FastAPI app is torn down and a fresh pool
+    (backed by the same Redis data) is bound.
 
-    pool = _fake_arq_pool()
+    The two pools share a FakeServer but are otherwise independent
+    ArqRedis objects, so the second client cannot read state through
+    any in-process Python reference -- it has to round-trip through
+    Redis. That is the contract: job state lives in Redis, not in the
+    pool object.
+    """
+
+    server = FakeServer()
+    pool = _fake_arq_pool(server)
     main_mod.app.state.redis_pool = pool
 
     response = client.post(
@@ -170,12 +190,14 @@ def test_real_train_state_survives_app_restart(client):
     )
     job_id = response.json()["job_id"]
 
-    # Simulate a backend restart: drop the pool reference, then attach
-    # the same fakeredis instance to a fresh client. Same Redis data,
-    # different "app process".
+    # Drop the first pool entirely, then bind a brand-new pool that
+    # shares only the underlying FakeServer. From the endpoint's
+    # perspective this is a process restart against the same Redis.
     main_mod.app.state.redis_pool = None
+    del pool
+    fresh_pool = _fake_arq_pool(server)
+    main_mod.app.state.redis_pool = fresh_pool
     fresh_client = TestClient(main_mod.app)
-    main_mod.app.state.redis_pool = pool
 
     detail = fresh_client.get(f"/train-jobs/{job_id}")
     assert detail.status_code == 200

--- a/tests/unit/test_real_train_endpoints.py
+++ b/tests/unit/test_real_train_endpoints.py
@@ -1,0 +1,272 @@
+"""Tests for the /analyze real_train + /train-jobs Redis path (closes #103)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("torch")
+pytest.importorskip("transformers")
+pytest.importorskip("arq")
+pytest.importorskip("fakeredis")
+
+from arq.connections import ArqRedis  # noqa: E402
+from fakeredis import FakeAsyncRedis  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+import app.main as main_mod  # noqa: E402
+
+
+def _fake_arq_pool() -> ArqRedis:
+    fake = FakeAsyncRedis()
+    return ArqRedis(connection_pool=fake.connection_pool)
+
+
+@pytest.fixture(autouse=True)
+def _clear_state(monkeypatch):
+    """Each test sees an empty in-memory map and no Redis pool by default."""
+
+    monkeypatch.setenv("DISABLE_REDIS_POOL", "1")
+    with main_mod._train_jobs_lock:
+        main_mod._train_jobs.clear()
+    yield
+    with main_mod._train_jobs_lock:
+        main_mod._train_jobs.clear()
+    if getattr(main_mod.app.state, "redis_pool", None) is not None:
+        try:
+            asyncio.run(main_mod.app.state.redis_pool.close(close_connection_pool=True))
+        except Exception:
+            pass
+        main_mod.app.state.redis_pool = None
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(main_mod.app)
+
+
+def test_analyze_real_train_enqueues_into_redis(client):
+    """When a Redis pool is attached, /analyze must enqueue a job through
+    arq instead of spawning a daemon thread, and return the same
+    accepted-response shape as before."""
+
+    pool = _fake_arq_pool()
+    main_mod.app.state.redis_pool = pool
+
+    response = client.post(
+        "/analyze",
+        json={
+            "text": "sample text",
+            "date": "2026-03-15",
+            "symbol": "^GSPC",
+            "forecast_mode": "real_train",
+            "horizon": "3d",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "queued"
+    job_id = body["job_id"]
+    assert job_id
+
+    # The in-memory fallback dict must stay empty -- the Redis path is
+    # the only source of truth when a pool is attached.
+    with main_mod._train_jobs_lock:
+        assert main_mod._train_jobs == {}
+
+    # The job is now visible via arq.jobs.Job against the same pool.
+    from arq.jobs import Job as ArqJob, JobStatus
+
+    async def _status():
+        return await ArqJob(job_id, pool).status()
+
+    assert asyncio.run(_status()) == JobStatus.queued
+
+
+def test_get_train_job_reads_from_redis(client):
+    """``/train-jobs/{id}`` must shape an arq-stored job into the legacy
+    response model so the frontend polling loop does not change."""
+
+    pool = _fake_arq_pool()
+    main_mod.app.state.redis_pool = pool
+
+    response = client.post(
+        "/analyze",
+        json={
+            "text": "x",
+            "date": "2026-04-01",
+            "symbol": "QQQ",
+            "forecast_mode": "real_train",
+            "horizon": "1d",
+        },
+    )
+    job_id = response.json()["job_id"]
+
+    detail = client.get(f"/train-jobs/{job_id}")
+    assert detail.status_code == 200
+    body = detail.json()
+    assert body["job_id"] == job_id
+    assert body["status"] == "queued"
+    assert body["result"] is None
+    assert body["error"] is None
+
+
+def test_get_train_job_missing_returns_404(client):
+    pool = _fake_arq_pool()
+    main_mod.app.state.redis_pool = pool
+
+    response = client.get("/train-jobs/does-not-exist")
+    assert response.status_code == 404
+
+
+def test_list_train_jobs_reads_from_redis(client):
+    """``/train-jobs`` listing must surface arq-stored jobs, not just the
+    in-memory dict."""
+
+    pool = _fake_arq_pool()
+    main_mod.app.state.redis_pool = pool
+
+    for symbol in ("^GSPC", "QQQ"):
+        client.post(
+            "/analyze",
+            json={
+                "text": "x",
+                "date": "2026-04-01",
+                "symbol": symbol,
+                "forecast_mode": "real_train",
+                "horizon": "1d",
+            },
+        )
+
+    listing = client.get("/train-jobs")
+    assert listing.status_code == 200
+    body = listing.json()
+    assert body["total"] == 2
+    symbols = sorted(item["symbol"] for item in body["items"])
+    assert symbols == ["QQQ", "^GSPC"]
+    for item in body["items"]:
+        assert item["status"] == "queued"
+
+
+def test_real_train_state_survives_app_restart(client):
+    """The headline contract for #103: a queued job must still be
+    readable after the FastAPI app is torn down and a fresh instance
+    is bound to the same Redis."""
+
+    pool = _fake_arq_pool()
+    main_mod.app.state.redis_pool = pool
+
+    response = client.post(
+        "/analyze",
+        json={
+            "text": "x",
+            "date": "2026-04-01",
+            "symbol": "^GSPC",
+            "forecast_mode": "real_train",
+            "horizon": "1d",
+        },
+    )
+    job_id = response.json()["job_id"]
+
+    # Simulate a backend restart: drop the pool reference, then attach
+    # the same fakeredis instance to a fresh client. Same Redis data,
+    # different "app process".
+    main_mod.app.state.redis_pool = None
+    fresh_client = TestClient(main_mod.app)
+    main_mod.app.state.redis_pool = pool
+
+    detail = fresh_client.get(f"/train-jobs/{job_id}")
+    assert detail.status_code == 200
+    assert detail.json()["job_id"] == job_id
+    assert detail.json()["status"] == "queued"
+
+
+def test_fast_mode_does_not_touch_redis(client, monkeypatch):
+    """Regression contract from #103: fast-mode /analyze must stay
+    synchronous and never hit Redis."""
+
+    pool = _fake_arq_pool()
+    main_mod.app.state.redis_pool = pool
+
+    monkeypatch.setattr(
+        main_mod,
+        "analyze_text",
+        lambda _: {
+            "label": "POSITIVE",
+            "score": 0.5,
+            "raw": [{"label": "POSITIVE", "score": 0.5}],
+        },
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "fetch_market_snapshot",
+        lambda **_: {
+            "symbol": "^GSPC",
+            "requested_date": "2026-03-15",
+            "date_used": "2026-03-13",
+            "lookback_days": 7,
+            "close": 1.0,
+            "volatility_5d": 0.01,
+        },
+    )
+    monkeypatch.setattr(main_mod, "fetch_market_history", lambda **_: [])
+    monkeypatch.setattr(main_mod, "parse_horizon_steps", lambda _: 1)
+    monkeypatch.setattr(main_mod, "fetch_forward_trading_dates", lambda **_: [])
+    monkeypatch.setattr(main_mod, "_record_history", lambda *a, **k: None)
+    monkeypatch.setattr(main_mod, "checkpoint_exists", lambda: True)
+    monkeypatch.setattr(
+        main_mod,
+        "forecast_quantitative_series",
+        lambda **_: {
+            "prediction": {"close": 1.0, "volatility": 0.01, "horizon": "3d"},
+            "model": {
+                "checkpoint_path": "x",
+                "checkpoint_exists": True,
+                "checkpoint_loaded": True,
+                "runtime_mode": "fast",
+                "hidden_size": 1,
+                "num_layers": 1,
+                "dropout": 0.0,
+                "head_hidden_size": 1,
+                "close_scale": 1.0,
+                "sequence_length": 5,
+            },
+            "series": {
+                "timestamps": [],
+                "history_close": [],
+                "history_volatility": [],
+                "forecast_timestamps": [],
+                "forecast_close": [],
+                "forecast_close_lower": [],
+                "forecast_close_upper": [],
+                "forecast_volatility": [],
+                "forecast_volatility_lower": [],
+                "forecast_volatility_upper": [],
+                "forecast_confidence_level": 0.8,
+                "volatility_scale": {"suggested_ymin": 0.0, "suggested_ymax": 0.02},
+            },
+        },
+    )
+
+    response = client.post(
+        "/analyze",
+        json={
+            "text": "x",
+            "date": "2026-03-15",
+            "symbol": "^GSPC",
+            "forecast_mode": "fast",
+            "horizon": "3d",
+        },
+    )
+    assert response.status_code == 200
+    # No real_train side-effects -- the in-memory map stays empty and the
+    # Redis queue has no jobs.
+    with main_mod._train_jobs_lock:
+        assert main_mod._train_jobs == {}
+
+    async def _queue_len():
+        return await pool.zcard("arq:queue")
+
+    assert asyncio.run(_queue_len()) == 0

--- a/tests/unit/test_real_train_endpoints.py
+++ b/tests/unit/test_real_train_endpoints.py
@@ -19,16 +19,38 @@ from fastapi.testclient import TestClient  # noqa: E402
 import app.main as main_mod  # noqa: E402
 
 
-def _fake_arq_pool(server: FakeServer | None = None) -> ArqRedis:
-    """Build an ArqRedis pool against a fakeredis backend.
+def _fake_arq_pool_factory(server: FakeServer | None = None):
+    """Return a zero-arg factory that constructs an ArqRedis on demand.
 
-    When ``server`` is None a fresh isolated FakeServer is allocated.
-    Passing a shared FakeServer between two _fake_arq_pool() calls
-    mimics two backend processes pointing at the same Redis: the pools
-    are independent Python objects, but their underlying key/value
-    store is the same. The restart-survival test relies on this to
-    prove the contract that job state lives in Redis, not in the
-    in-process pool.
+    The factory closes over a single ``FakeServer`` so every pool it
+    produces shares the same in-memory key/value store. The pool itself
+    is constructed inside the caller — when the caller is a request
+    handler running in TestClient's anyio portal, the pool's internal
+    ``asyncio.Queue`` binds to the portal's loop and the connection
+    survives the round-trip. Constructing the pool in the test thread
+    would bind it to a different loop and trip arq with
+    ``RuntimeError: Queue is bound to a different event loop`` on the
+    first ``enqueue_job`` call.
+    """
+
+    server = server if server is not None else FakeServer()
+
+    def _build() -> ArqRedis:
+        fake = FakeAsyncRedis(server=server)
+        return ArqRedis(connection_pool=fake.connection_pool)
+
+    _build.server = server  # type: ignore[attr-defined]
+    return _build
+
+
+def _fake_arq_pool(server: FakeServer | None = None) -> ArqRedis:
+    """Eager pool variant for tests that explicitly want one instance.
+
+    Most endpoint tests should use ``_fake_arq_pool_factory`` and
+    install the factory on ``app.state.redis_pool``; the lazy ``_redis_pool``
+    accessor unwraps the factory inside the request loop. Use the eager
+    form only when the test calls ArqJob / pool methods itself outside
+    a TestClient request (e.g. asserting state via ``asyncio.run``).
     """
 
     server = server if server is not None else FakeServer()
@@ -46,12 +68,16 @@ def _clear_state(monkeypatch):
     yield
     with main_mod._train_jobs_lock:
         main_mod._train_jobs.clear()
-    if getattr(main_mod.app.state, "redis_pool", None) is not None:
+    # Teardown only acts on an eager ArqRedis instance. Factories
+    # produce per-request pools that live and die inside the request
+    # loop, so there is nothing for the test thread to close.
+    pool = getattr(main_mod.app.state, "redis_pool", None)
+    if isinstance(pool, ArqRedis):
         try:
-            asyncio.run(main_mod.app.state.redis_pool.close(close_connection_pool=True))
+            asyncio.run(pool.close(close_connection_pool=True))
         except Exception:
             pass
-        main_mod.app.state.redis_pool = None
+    main_mod.app.state.redis_pool = None
 
 
 @pytest.fixture
@@ -64,8 +90,8 @@ def test_analyze_real_train_enqueues_into_redis(client):
     arq instead of spawning a daemon thread, and return the same
     accepted-response shape as before."""
 
-    pool = _fake_arq_pool()
-    main_mod.app.state.redis_pool = pool
+    factory = _fake_arq_pool_factory()
+    main_mod.app.state.redis_pool = factory
 
     response = client.post(
         "/analyze",
@@ -88,10 +114,13 @@ def test_analyze_real_train_enqueues_into_redis(client):
     with main_mod._train_jobs_lock:
         assert main_mod._train_jobs == {}
 
-    # The job is now visible via arq.jobs.Job against the same pool.
+    # The job is now visible via arq.jobs.Job against a pool on the
+    # asserting loop (asyncio.run creates a fresh loop, so we build
+    # the pool inside the run).
     from arq.jobs import Job as ArqJob, JobStatus
 
-    async def _status():
+    async def _status() -> JobStatus:
+        pool = factory()
         return await ArqJob(job_id, pool).status()
 
     assert asyncio.run(_status()) == JobStatus.queued
@@ -101,8 +130,7 @@ def test_get_train_job_reads_from_redis(client):
     """``/train-jobs/{id}`` must shape an arq-stored job into the legacy
     response model so the frontend polling loop does not change."""
 
-    pool = _fake_arq_pool()
-    main_mod.app.state.redis_pool = pool
+    main_mod.app.state.redis_pool = _fake_arq_pool_factory()
 
     response = client.post(
         "/analyze",
@@ -126,8 +154,7 @@ def test_get_train_job_reads_from_redis(client):
 
 
 def test_get_train_job_missing_returns_404(client):
-    pool = _fake_arq_pool()
-    main_mod.app.state.redis_pool = pool
+    main_mod.app.state.redis_pool = _fake_arq_pool_factory()
 
     response = client.get("/train-jobs/does-not-exist")
     assert response.status_code == 404
@@ -137,8 +164,7 @@ def test_list_train_jobs_reads_from_redis(client):
     """``/train-jobs`` listing must surface arq-stored jobs, not just the
     in-memory dict."""
 
-    pool = _fake_arq_pool()
-    main_mod.app.state.redis_pool = pool
+    main_mod.app.state.redis_pool = _fake_arq_pool_factory()
 
     for symbol in ("^GSPC", "QQQ"):
         client.post(
@@ -175,8 +201,8 @@ def test_real_train_state_survives_app_restart(client):
     """
 
     server = FakeServer()
-    pool = _fake_arq_pool(server)
-    main_mod.app.state.redis_pool = pool
+    factory = _fake_arq_pool_factory(server)
+    main_mod.app.state.redis_pool = factory
 
     response = client.post(
         "/analyze",
@@ -190,13 +216,14 @@ def test_real_train_state_survives_app_restart(client):
     )
     job_id = response.json()["job_id"]
 
-    # Drop the first pool entirely, then bind a brand-new pool that
-    # shares only the underlying FakeServer. From the endpoint's
-    # perspective this is a process restart against the same Redis.
+    # Drop the first factory, then bind a brand-new factory that shares
+    # only the underlying FakeServer. From the endpoint's perspective
+    # this is a process restart against the same Redis: no in-process
+    # Python reference to the first pool survives.
     main_mod.app.state.redis_pool = None
-    del pool
-    fresh_pool = _fake_arq_pool(server)
-    main_mod.app.state.redis_pool = fresh_pool
+    del factory
+    fresh_factory = _fake_arq_pool_factory(server)
+    main_mod.app.state.redis_pool = fresh_factory
     fresh_client = TestClient(main_mod.app)
 
     detail = fresh_client.get(f"/train-jobs/{job_id}")
@@ -209,8 +236,7 @@ def test_fast_mode_does_not_touch_redis(client, monkeypatch):
     """Regression contract from #103: fast-mode /analyze must stay
     synchronous and never hit Redis."""
 
-    pool = _fake_arq_pool()
-    main_mod.app.state.redis_pool = pool
+    main_mod.app.state.redis_pool = _fake_arq_pool_factory()
 
     monkeypatch.setattr(
         main_mod,

--- a/tests/unit/test_research_endpoints.py
+++ b/tests/unit/test_research_endpoints.py
@@ -23,7 +23,7 @@ def _reset_train_jobs(monkeypatch):
     """Each test starts with an empty in-memory train-jobs map and the
     arq Redis pool disabled so the legacy in-memory path is exercised."""
 
-    monkeypatch.setenv("DISABLE_REDIS_POOL", "1")
+    monkeypatch.setenv("FED_PULSE_DISABLE_REDIS_POOL", "1")
     if getattr(main_mod.app.state, "redis_pool", None) is not None:
         main_mod.app.state.redis_pool = None
     with main_mod._train_jobs_lock:

--- a/tests/unit/test_research_endpoints.py
+++ b/tests/unit/test_research_endpoints.py
@@ -19,9 +19,13 @@ from app.services import research_artifacts  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
-def _reset_train_jobs():
-    """Each test starts with an empty in-memory train-jobs map."""
+def _reset_train_jobs(monkeypatch):
+    """Each test starts with an empty in-memory train-jobs map and the
+    arq Redis pool disabled so the legacy in-memory path is exercised."""
 
+    monkeypatch.setenv("DISABLE_REDIS_POOL", "1")
+    if getattr(main_mod.app.state, "redis_pool", None) is not None:
+        main_mod.app.state.redis_pool = None
     with main_mod._train_jobs_lock:
         main_mod._train_jobs.clear()
     yield


### PR DESCRIPTION
## Summary

- New backend/app/worker.py defines an arq WorkerSettings with a real_train_task.
- docker-compose.yml adds redis:7-alpine and a worker service that runs arq against the same image.
- /analyze with forecast_mode=real_train enqueues a job into Redis instead of spawning a daemon thread.
- /train-jobs/{id} and /train-jobs read job state from Redis via arq.jobs.Job.
- Existing /analyze fast / quick_train paths untouched.
- Tests cover task signature, endpoint dispatch against a mocked Redis, and restart-survival.
- docs/REPO_TOUR.md describes the new arq + Redis topology.

## Test plan

- [ ] `docker compose run --rm --no-deps backend pytest tests/unit tests/regression -q`
- [ ] `make dev-cpu`; POST /analyze with forecast_mode=real_train; GET /train-jobs/{id} returns the right status.

Closes #103.