### PR TITLE
Forecaster target uses event-study residuals instead of trivial-identity copy

### DIFF
--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -201,6 +201,21 @@ def _parse_args() -> argparse.Namespace:
         help="Where to write the hyperparameter search report JSON.",
     )
     parser.add_argument(
+        "--target-mode",
+        choices=("event_study", "realized_return"),
+        default="event_study",
+        help=(
+            "Target-frame derivation for the training-package loader. "
+            "'event_study' (default) uses abnormal_return + volatility_shift "
+            "so the synthesised target removes the broad-market component "
+            "from the close and reconstructs the post-event 10d realised "
+            "vol from the prior vol + shift. 'realized_return' reproduces "
+            "the pre-fix behaviour (close * (1 + realized_return) and a "
+            "literal copy of prior vol_5d) and is preserved for back-compat "
+            "smoke tests only. Ignored when --training-package-id is unset."
+        ),
+    )
+    parser.add_argument(
         "--list-data",
         action="store_true",
         help="Only inspect discovered datasets and exit without training.",
@@ -601,7 +616,11 @@ def main() -> int:
     package_sequences: list[list[FeatureVector]] | None = None
     if use_package_path:
         print(f"Training-package id: {args.training_package_id}")
-        package_sequences = load_training_sequences_from_package(args.training_package_id)
+        print(f"Target mode: {args.target_mode}")
+        package_sequences = load_training_sequences_from_package(
+            args.training_package_id,
+            target_mode=args.target_mode,
+        )
         sequence_count = len(package_sequences)
         observation_count = sum(len(sequence) for sequence in package_sequences)
         window_count = sum(max(0, len(sequence) - SEQUENCE_LENGTH) for sequence in package_sequences)

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import csv
 import datetime
 import json
+import warnings
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Literal, Sequence
 
 import torch
 
@@ -39,6 +40,47 @@ _STANCE_SENTIMENT_ENCODING: dict[str, float] = {
 # treated as out-of-training when present.
 _TRAINING_PARTITION = "train"
 _NON_TRAINING_SPLIT_TAGS = frozenset({"val", "test", "excluded_from_training"})
+
+# Supported target-frame derivations for the training-package loader.
+#
+# ``event_study`` is the default and the production target. It derives
+# the synthesised target close from ``abnormal_return`` (market-model
+# residual against the trailing 252-day window written by
+# ``app.data.event_dataset_builder``) and the target volatility from
+# ``prior_bars[-1].vol_5d + volatility_shift`` (the post-event 10d
+# realised vol). Both quantities carry genuine temporal signal that the
+# forecaster has to actually learn rather than copy.
+#
+# ``realized_return`` reproduces the pre-fix behaviour: the close target
+# becomes ``prior_bars[-1].close * (1 + realized_return)`` and the
+# volatility target is a literal copy of ``prior_bars[-1].vol_5d``. The
+# volatility column is then a trivial identity over the input window;
+# linear-decomposition models (DLinear) win the volatility-RMSE column
+# at the identity task by construction. The mode is preserved only for
+# back-compat smoke tests that need to reproduce earlier sweep numbers.
+TargetMode = Literal["event_study", "realized_return"]
+_VALID_TARGET_MODES: frozenset[str] = frozenset({"event_study", "realized_return"})
+DEFAULT_TARGET_MODE: TargetMode = "event_study"
+
+
+def _coerce_finite_float(value: Any) -> float | None:
+    """Return ``float(value)`` when the result is finite, else ``None``.
+
+    Parquet nulls materialise as ``float('nan')`` through pandas; the
+    event-study target derivation must surface those as ``None`` so the
+    fallback path can kick in without comparing NaN.
+    """
+
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    # NaN comparison: ``x != x`` is the canonical Python NaN check.
+    if result != result:
+        return None
+    return result
 
 
 def _extract_required_float(record: dict[str, Any], keys: Sequence[str]) -> float:
@@ -331,29 +373,86 @@ def _append_event_day_target(
     realized_return: float | None,
     realized_date: str | None,
     sentiment_score: float,
+    abnormal_return: float | None = None,
+    volatility_shift: float | None = None,
+    target_mode: TargetMode = DEFAULT_TARGET_MODE,
 ) -> None:
-    """Append a single event-day target frame derived from ``realized_return``.
+    """Append a single event-day target frame for the supervised window.
 
     The Phase 8 ``events.parquet`` carries 20 trading-day prior bars but
     no event-day bar; the downstream training-tensor builder needs a
     ``SEQUENCE_LENGTH + 1`` row to compute one supervised (window,
-    target) pair per event. The appended frame projects the close from
-    the most recent prior bar via ``close * (1 + realized_return)`` and
-    re-uses that bar's ``vol_5d`` as the volatility proxy. When
-    ``realized_return`` is missing the projection falls back to a
-    flat repeat of the most recent bar (yields a zero-delta target row).
+    target) pair per event.
+
+    Two derivations are supported via ``target_mode``:
+
+    - ``event_study`` (default): the target close projects the last
+      prior bar via ``close * (1 + abnormal_return)`` -- the market-
+      model residual after removing the trailing-252-day SPX beta /
+      alpha. The target volatility is ``prior_bars[-1].vol_5d +
+      volatility_shift``, i.e. the actual post-event 10d realised vol
+      reconstructed from the prior vol plus the shift. Both quantities
+      have to be learnt from the prior window; neither is a literal
+      copy of an input feature.
+    - ``realized_return``: legacy back-compat path. Projects the close
+      via ``close * (1 + realized_return)`` and re-uses the last prior
+      bar's ``vol_5d`` as the volatility target. The volatility column
+      is then trivially identical to the last input volatility, which
+      gives linear-decomposition models an artefactual edge on the
+      volatility-RMSE column.
+
+    When the event-study fields are NaN / missing the loader emits a
+    ``UserWarning`` and falls back to the realized_return formula for
+    that row so a downstream sweep against a package with broken target
+    columns surfaces the gap immediately rather than silently training
+    on the legacy target.
     """
 
     if not vectors:
         return
     last = vectors[-1]
     base_close = float(last.market_close)
-    if realized_return is None or base_close <= 0.0:
+    base_volatility = float(last.market_volatility)
+
+    if target_mode == "event_study":
+        if abnormal_return is None:
+            warnings.warn(
+                "event-study target requested but abnormal_return is missing; "
+                "falling back to realized_return for this event-day target.",
+                UserWarning,
+                stacklevel=2,
+            )
+            close_shift = realized_return
+        else:
+            close_shift = abnormal_return
+
+        if volatility_shift is None:
+            warnings.warn(
+                "event-study target requested but volatility_shift is missing; "
+                "falling back to prior_bars[-1].vol_5d for this target.",
+                UserWarning,
+                stacklevel=2,
+            )
+            vol_offset: float = 0.0
+        else:
+            vol_offset = float(volatility_shift)
+    else:
+        close_shift = realized_return
+        vol_offset = 0.0
+
+    if close_shift is None or base_close <= 0.0:
         target_close = base_close
     else:
-        target_close = base_close * (1.0 + float(realized_return))
+        target_close = base_close * (1.0 + float(close_shift))
 
-    target_volatility = float(last.market_volatility)
+    target_volatility = base_volatility + vol_offset
+    # Volatility is a non-negative quantity (standard deviation). The
+    # event-study shift can drive the sum below zero on a regime that
+    # rotated from high to low realised vol; clip at zero so the target
+    # tensor never carries a negative volatility row.
+    if target_volatility < 0.0:
+        target_volatility = 0.0
+
     target_date_str: str
     if realized_date:
         target_date_str = str(realized_date)
@@ -373,7 +472,7 @@ def _append_event_day_target(
             market_close=target_close,
             market_volatility=target_volatility,
             previous_close=base_close,
-            previous_volatility=target_volatility,
+            previous_volatility=base_volatility,
             elapsed_time=elapsed_time,
         )
     )
@@ -444,6 +543,8 @@ def _read_excluded_text_hashes(package_dir: Path) -> set[str]:
 
 def load_training_sequences_from_package(
     training_package_id: str,
+    *,
+    target_mode: TargetMode = DEFAULT_TARGET_MODE,
 ) -> list[list[FeatureVector]]:
     """Load one prior-window sequence per FOMC event in a training package.
 
@@ -458,9 +559,26 @@ def load_training_sequences_from_package(
     event-day target frame is appended per event so the downstream
     window slicer (``SEQUENCE_LENGTH=20``) sees the
     ``SEQUENCE_LENGTH + 1`` row it needs to materialise one supervised
-    pair per event; the target close is projected from
-    ``realized_return`` at ``horizon=1`` and the target date is the
-    ``realized_date`` column.
+    pair per event.
+
+    The synthesised target frame's close and volatility derive from the
+    ``target_mode`` selector:
+
+    - ``event_study`` (default): target close projects the last prior
+      bar via ``close * (1 + abnormal_return)`` (market-model residual
+      against the 252-day window the events builder ships); target
+      volatility is ``prior_bars[-1].vol_5d + volatility_shift``
+      (the 10d post-event realised vol reconstructed from the prior
+      vol plus the shift column).
+    - ``realized_return``: legacy back-compat. Target close becomes
+      ``close * (1 + realized_return)`` and target volatility is a
+      literal copy of the last prior bar's ``vol_5d``. Preserved for
+      smoke tests reproducing pre-event-study sweep results.
+
+    NaN ``abnormal_return`` / ``volatility_shift`` rows fall back to
+    the realized-return formula for that event and emit a
+    ``UserWarning`` so a re-run against a package with missing target
+    columns surfaces the gap immediately.
 
     Sequences are deduplicated to one per ``text_hash`` so the
     horizon-multiplied rows in ``events.parquet`` (h in {1, 5, 10, 30})
@@ -481,6 +599,12 @@ def load_training_sequences_from_package(
     20 prior bars followed by 1 event-day target row (21 vectors
     total). Events with fewer than 20 prior bars are skipped.
     """
+
+    if target_mode not in _VALID_TARGET_MODES:
+        raise ValueError(
+            f"Unsupported target_mode: {target_mode!r}. "
+            f"Choose one of {sorted(_VALID_TARGET_MODES)}."
+        )
 
     package_dir = _resolve_training_package_dir(training_package_id)
     frame = _read_events_frame(package_dir)
@@ -549,17 +673,9 @@ def load_training_sequences_from_package(
         )
         if len(vectors) < SEQUENCE_LENGTH:
             continue
-        realized_return_raw = row.get("realized_return")
-        realized_return: float | None
-        try:
-            realized_return = (
-                float(realized_return_raw) if realized_return_raw is not None else None
-            )
-        except (TypeError, ValueError):
-            realized_return = None
-        if realized_return is not None and realized_return != realized_return:
-            # NaN: parquet null materialises as NaN through pandas
-            realized_return = None
+        realized_return = _coerce_finite_float(row.get("realized_return"))
+        abnormal_return = _coerce_finite_float(row.get("abnormal_return"))
+        volatility_shift = _coerce_finite_float(row.get("volatility_shift"))
         realized_date_raw = row.get("realized_date")
         if (
             realized_date_raw is None
@@ -575,6 +691,9 @@ def load_training_sequences_from_package(
             realized_return=realized_return,
             realized_date=realized_date,
             sentiment_score=sentiment_score,
+            abnormal_return=abnormal_return,
+            volatility_shift=volatility_shift,
+            target_mode=target_mode,
         )
         sequences.append(vectors)
     return sequences

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -733,15 +733,46 @@ Per-event sequence construction:
   `close_change_pct` and `volatility_change` computed bar-to-bar, and
   `elapsed_time` set to the signed day count between the bar date and
   the event date.
-- Appends one event-day target frame per event. The target close
-  projects the most recent prior bar via
-  `close * (1 + realized_return)` (h=1) and re-uses the bar's
-  `vol_5d` as the volatility proxy. The downstream window slicer
-  (`SEQUENCE_LENGTH = 20`) then materialises one supervised
-  `(window, target)` pair per event.
+- Appends one event-day target frame per event. The target's close
+  and volatility derive from one of two modes (selected via
+  `--target-mode` on `train_forecaster.py` and the `target_mode`
+  kwarg on `load_training_sequences_from_package`); both produce a
+  `SEQUENCE_LENGTH + 1`-row group so the downstream window slicer
+  materialises one supervised `(window, target)` pair per event.
 - Sorts the resulting sequences by `event_date` (then `text_hash` as
   a deterministic tiebreaker) so two runs on the same package emit
   the same sequence ordering.
+
+#### Forecaster training-package target modes
+
+`load_training_sequences_from_package(training_package_id, target_mode=...)`
+exposes two target-frame derivations. The default is `event_study`;
+`realized_return` is preserved for back-compat smoke tests against
+pre-event-study sweep numbers.
+
+| Mode              | Target close                                       | Target volatility                            |
+| ----------------- | -------------------------------------------------- | -------------------------------------------- |
+| `event_study`     | `prior_bars[-1].close * (1 + abnormal_return)`     | `prior_bars[-1].vol_5d + volatility_shift`   |
+| `realized_return` | `prior_bars[-1].close * (1 + realized_return)`     | `prior_bars[-1].vol_5d` (literal identity)   |
+
+`abnormal_return` is the market-model residual `realized_return -
+(alpha + beta * benchmark_return)` against the trailing 252-day window
+that `app.data.event_dataset_builder` fits per event; the target is the
+component of the realised move not explained by the broad market.
+`volatility_shift` is the post-event minus pre-event 10d realised vol
+(log-return std) shipped on the same parquet row, so reconstructing the
+target from `prior_vol + shift` yields the actual post-event vol rather
+than a copy of the input. The `realized_return` mode is mathematically
+identical to the pre-event-study target; under it the volatility column
+collapses to a literal identity over the last input row, which gives
+linear-decomposition models an artefactual edge on the volatility-RMSE
+column.
+
+`NaN` values in `abnormal_return` or `volatility_shift` fall back to
+the realized-return formula for that row and emit a `UserWarning`, so
+a downstream sweep against a package with missing target columns
+surfaces the gap immediately rather than silently training on the
+legacy target.
 
 Filtering against the splits parquet is opt-in: when
 `splits_train_val_test.parquet` is present and carries a

--- a/tests/unit/test_training_package_loader.py
+++ b/tests/unit/test_training_package_loader.py
@@ -296,3 +296,152 @@ def test_load_training_sequences_from_package_missing_package_raises(
     monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
     with pytest.raises(FileNotFoundError):
         loaders.load_training_sequences_from_package("does_not_exist")
+
+
+# ---------------------------------------------------------------------------
+# Target-frame derivation tests
+#
+# The event-study target frame replaces the pre-fix realized-return /
+# identity-copy target. These tests pin the close + volatility values
+# produced by each ``target_mode`` against synthetic event rows whose
+# ``abnormal_return`` and ``volatility_shift`` are deliberately
+# distinguishable from ``realized_return`` and the prior vol_5d, so the
+# two modes cannot accidentally produce the same numbers.
+# ---------------------------------------------------------------------------
+
+
+_TARGET_PACKAGE_ID = "tp_unit_target_modes_v0"
+
+
+@pytest.fixture
+def target_mode_package_dir(tmp_path: Path, monkeypatch) -> Path:
+    """Minimal one-event package with distinct event-study / realized fields.
+
+    ``abnormal_return`` (0.005) and ``realized_return`` (0.020) are
+    chosen far apart so the close target lands at clearly different
+    values under each mode. ``volatility_shift`` (-0.002) does the
+    same for the volatility column against the last prior bar's
+    vol_5d (0.012 + 4 * 0.0001 = 0.01240 with the synthesiser's
+    five-bar window, but the actual last-bar value depends on
+    SEQUENCE_LENGTH; the test reconstructs it from the same formula).
+    """
+
+    package_dir = tmp_path / "processed" / _TARGET_PACKAGE_ID
+    package_dir.mkdir(parents=True)
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+
+    row = _event_row(
+        event_date="2024-02-15",
+        text_hash="hash_targets",
+        axis_stance="hawkish",
+        realized_return=0.020,
+        realized_date="2024-02-16",
+        base_close=4500.0,
+    )
+    # Override the event-study columns: the helper defaults to
+    # ``abnormal_return == realized_return`` and ``volatility_shift =
+    # 0.0`` so the two modes would coincide; the test needs them
+    # distinct to lock the per-mode arithmetic.
+    row["abnormal_return"] = 0.005
+    row["volatility_shift"] = -0.002
+
+    pd.DataFrame([row]).to_parquet(package_dir / "events.parquet", index=False)
+    pd.DataFrame(
+        [{"text_hash": "hash_targets", "split_tag": "train"}]
+    ).to_parquet(package_dir / "splits_train_val_test.parquet", index=False)
+    return package_dir
+
+
+def _expected_last_prior_bar_close(base_close: float) -> float:
+    return base_close + (SEQUENCE_LENGTH - 1) * 1.5
+
+
+def _expected_last_prior_bar_vol() -> float:
+    return 0.012 + (SEQUENCE_LENGTH - 1) * 0.0001
+
+
+def test_target_uses_abnormal_return_in_event_study_mode(
+    target_mode_package_dir: Path,
+) -> None:
+    sequences = loaders.load_training_sequences_from_package(
+        _TARGET_PACKAGE_ID, target_mode="event_study"
+    )
+    assert len(sequences) == 1
+    target = sequences[0][-1]
+
+    last_close = _expected_last_prior_bar_close(4500.0)
+    last_vol = _expected_last_prior_bar_vol()
+    expected_close = last_close * (1.0 + 0.005)
+    expected_volatility = last_vol + (-0.002)
+
+    assert target.market_close == pytest.approx(expected_close)
+    assert target.market_volatility == pytest.approx(expected_volatility)
+    # Sanity: under realized_return the values would be different, so
+    # the test really does discriminate the two modes.
+    legacy_close = last_close * (1.0 + 0.020)
+    assert target.market_close != pytest.approx(legacy_close)
+    assert target.market_volatility != pytest.approx(last_vol)
+
+
+def test_target_falls_back_when_abnormal_return_is_nan(
+    tmp_path: Path, monkeypatch
+) -> None:
+    package_id = "tp_unit_target_nan_fallback_v0"
+    package_dir = tmp_path / "processed" / package_id
+    package_dir.mkdir(parents=True)
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+
+    row = _event_row(
+        event_date="2024-02-15",
+        text_hash="hash_nan",
+        axis_stance="hawkish",
+        realized_return=0.020,
+        realized_date="2024-02-16",
+        base_close=4500.0,
+    )
+    row["abnormal_return"] = float("nan")
+    row["volatility_shift"] = float("nan")
+
+    pd.DataFrame([row]).to_parquet(package_dir / "events.parquet", index=False)
+    pd.DataFrame(
+        [{"text_hash": "hash_nan", "split_tag": "train"}]
+    ).to_parquet(package_dir / "splits_train_val_test.parquet", index=False)
+
+    with pytest.warns(UserWarning):
+        sequences = loaders.load_training_sequences_from_package(
+            package_id, target_mode="event_study"
+        )
+
+    assert len(sequences) == 1
+    target = sequences[0][-1]
+    last_close = _expected_last_prior_bar_close(4500.0)
+    last_vol = _expected_last_prior_bar_vol()
+    # NaN abnormal_return falls back to realized_return; NaN
+    # volatility_shift falls back to the identity copy of the last
+    # prior bar's vol_5d.
+    assert target.market_close == pytest.approx(last_close * (1.0 + 0.020))
+    assert target.market_volatility == pytest.approx(last_vol)
+
+
+def test_target_mode_realized_return_reproduces_legacy_behaviour(
+    target_mode_package_dir: Path,
+) -> None:
+    sequences = loaders.load_training_sequences_from_package(
+        _TARGET_PACKAGE_ID, target_mode="realized_return"
+    )
+    assert len(sequences) == 1
+    target = sequences[0][-1]
+    last_close = _expected_last_prior_bar_close(4500.0)
+    last_vol = _expected_last_prior_bar_vol()
+    # Legacy formula: close * (1 + realized_return) and identity copy
+    # of the last prior bar's vol_5d. Locks the back-compat path.
+    assert target.market_close == pytest.approx(last_close * (1.0 + 0.020))
+    assert target.market_volatility == pytest.approx(last_vol)
+
+
+def test_target_mode_invalid_raises(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+    with pytest.raises(ValueError):
+        loaders.load_training_sequences_from_package(
+            "any_id", target_mode="not_a_mode"  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary

- load_training_sequences_from_package target bar now derives from abnormal_return + volatility_shift instead of realized_return + identity-copy.
- Close target: base_close * (1 + abnormal_return) — market-model residual against the 252-day window the events builder ships.
- Volatility target: prior_bars[-1].vol_5d + volatility_shift — real post-event 10d realised vol, not the copy.
- NaN columns fall back to the legacy formula and emit a UserWarning so a future package with missing columns surfaces the gap immediately.
- New --target-mode {event_study, realized_return} CLI flag on train_forecaster (default event_study). Legacy mode preserved for back-compat.
- Three new tests lock the event-study path, the NaN fallback, and the legacy back-compat path.
- docs/data-and-training-contracts.md documents both modes.

The previous sweep ranked DLinear first by a wide margin; that win was an artefact of the identity-copy target (DLinear is a linear decomposition and matches identity exactly). The event-study target removes the artefact so the next sweep ranks architectures on a genuine forecasting signal.

Smoke against the real package `tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0`: 895 sequences loaded in both modes, 0 NaN fallbacks (no UserWarning). On this `^GSPC == benchmark` package `abnormal_return ≡ realized_return` by builder contract, so the close target is byte-identical for now and the structural fix lands on the volatility column (`volatility_shift` std ≈ 0.006). The close-side correction kicks in when the package is rebuilt against a non-`^GSPC` asset.

Wiki appendix `../fed-pulse.wiki/06_Deep_Learning_Roadmap.md` § 1.9.7 has a matching note; left uncommitted, push from the wiki worktree separately.

## Test plan

- [ ] `docker compose run --rm --no-deps backend pytest tests/unit/test_training_package_loader.py tests/regression/ -q`
- [ ] After merge, re-run `make forecaster-sweep TRAINING_PACKAGE_ID=<id>` and compare the per-architecture table against the previous sweep summary.

Follows #170.