### PR TITLE
Forecaster consumes credibility + linguistic + MP surprise + multi-axis features (rich-feature input)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state next-fomc cross-asset forecaster-sweep forecaster-sweep-aggregate forecaster-credibility-train
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state next-fomc cross-asset forecaster-sweep forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-credibility-train
 
 help:
 	@echo "Targets:"
@@ -54,7 +54,8 @@ help:
 	@echo "  make macro-state      - Build the FRED macro-state parquet (Phase 8 #147)"
 	@echo "  make next-fomc        - Predict next-FOMC decision (Phase 8 headline, #147)"
 	@echo "  make cross-asset      - Cross-asset abnormal-return response head (Phase 8, #148)"
-	@echo "  make forecaster-sweep         - 6-arch x 5-seed forecaster sweep (Phase 8, #70)"
+	@echo "  make forecaster-sweep         - 8-arch x 5-seed forecaster sweep, rich-feature input (35 dim)"
+	@echo "  make forecaster-sweep-baseline - 6-arch x 5-seed forecaster sweep, legacy 6-feature input"
 	@echo "  make forecaster-sweep-aggregate - Aggregate sweep trials into per-arch CIs"
 	@echo "  make forecaster-credibility-train - Single training run with credibility features on"
 
@@ -114,12 +115,24 @@ train-batch:
 		--mode full \
 		--owner "$(OWNER)"
 
-# Forecaster architecture sweep: 6 architectures (lstm, lstm_attn, gru, tcn,
-# transformer, dlinear) x official 5-seed set {11, 29, 47, 71, 97}.
-# Writes forecaster_sweep_results.json + .csv next to the checkpoint.
+# Forecaster architecture sweep. The default target runs the
+# rich-feature path (35-dim per-bar input) across all eight registered
+# architectures (lstm, lstm_attn, gru, tcn, transformer, dlinear,
+# informer, tft) x the official 5-seed set {11, 29, 47, 71, 97}, so the
+# forecaster sees the four feature families the data pipeline already
+# ships (credibility, linguistic, MP-surprise, multi-axis) on every bar.
 #
-# Runs against backend-gpu under the gpu compose profile so the sweep hits
-# the RTX 4080. Override FORECASTER_COMPOSE_SERVICE=backend and
+# The earlier 6-feature path is still available as
+# ``forecaster-sweep-baseline`` for back-compat smoke checks against
+# pre-PR-#173 sweep numbers.
+#
+# Both targets write forecaster_sweep_results.json + .csv under
+# data/artifacts/forecaster_sweep/<TRAINING_PACKAGE_ID>/; the baseline
+# variant lands under a ``baseline_`` filename prefix so the two
+# artefact sets coexist on disk.
+#
+# Runs against backend-gpu under the gpu compose profile so the sweep
+# hits the RTX 4080. Override FORECASTER_COMPOSE_SERVICE=backend and
 # FORECASTER_COMPOSE_PROFILE=default for a CPU-only smoke run. The
 # aggregate target uses the same overrides so artefact paths line up.
 FORECASTER_COMPOSE_SERVICE ?= backend-gpu
@@ -131,9 +144,21 @@ forecaster-sweep:
 		python -m app.train_forecaster \
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
 		--sweep \
-		--architectures lstm lstm_attn gru tcn transformer dlinear \
+		--rich-features \
+		--architectures lstm lstm_attn gru tcn transformer dlinear informer tft \
 		--seeds 11 29 47 71 97 \
 		--report-path "/data/artifacts/forecaster_sweep/$(TRAINING_PACKAGE_ID)/forecaster_sweep_results.json"
+
+forecaster-sweep-baseline:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	docker compose --profile "$(FORECASTER_COMPOSE_PROFILE)" run --rm "$(FORECASTER_COMPOSE_SERVICE)" \
+		python -m app.train_forecaster \
+		--training-package-id "$(TRAINING_PACKAGE_ID)" \
+		--sweep \
+		--no-rich-features \
+		--architectures lstm lstm_attn gru tcn transformer dlinear \
+		--seeds 11 29 47 71 97 \
+		--report-path "/data/artifacts/forecaster_sweep/$(TRAINING_PACKAGE_ID)/baseline_forecaster_sweep_results.json"
 
 # Aggregate per-trial JSONs into a per-architecture headline (block-bootstrap CIs).
 # The aggregator is CPU-bound; the default backend service is fine.

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -14,6 +14,73 @@ SEQUENCE_LENGTH = 20
 FEATURE_SIZE = 6  # [sentiment_score, market_close, market_volatility, close_change_pct, volatility_change, elapsed_time]
 SENTIMENT_FEATURE_INDEX = 0
 ELAPSED_TIME_FEATURE_INDEX = 5
+
+# Rich-feature input space (PR-#173 onward). The training-package loader
+# joins the four feature families produced under Phase 8 onto the
+# per-bar feature vector:
+#
+# - 4 credibility fields (drift_score, realized_vs_stated_gap,
+#   market_implied_gap, months_since_reversal) -- direct off the
+#   events.parquet row.
+# - 15 linguistic features (8 LDA topic shares + 6 hand-crafted
+#   densities + pivot_distance) -- joined on text_hash from
+#   linguistic_features.parquet.
+# - 4 MP-surprise fields (mp_surprise_level, mp_surprise_path_factor,
+#   fed_info_factor, mp_is_intermeeting) -- joined on event_date from
+#   mp_surprises.parquet. ``mp_is_intermeeting`` is the boolean
+#   ``is_intermeeting`` field encoded as 0.0 / 1.0.
+# - 6 multi-axis fields (axis_factor, axis_certainty, axis_time, each
+#   with a paired *_missing flag) -- direct off the events.parquet row.
+#
+# The event-level signal is broadcast to every bar of the 20-day prior
+# window plus the appended event-day target frame, so every bar in a
+# supervised window carries the same rich-feature row.
+#
+# Per-bar slice ordering (deterministic; documented on
+# ``FeatureVector`` below):
+#
+#   [0:6]    market features (existing FEATURE_SIZE slice)
+#   [6:10]   credibility 4-vector
+#   [10:25]  linguistic 15-vector
+#   [25:29]  MP-surprise 4-vector
+#   [29:35]  multi-axis 6-vector (3 values + 3 missing flags)
+#
+# ``RICH_FEATURE_SIZE`` is the constant downstream model factories /
+# CLI use to widen the input projection when ``rich_features=True``.
+RICH_CREDIBILITY_DIM = 4
+RICH_LINGUISTIC_DIM = 15
+RICH_MP_SURPRISE_DIM = 4
+RICH_MULTI_AXIS_DIM = 6
+RICH_EXTRA_FEATURE_SIZE = (
+    RICH_CREDIBILITY_DIM
+    + RICH_LINGUISTIC_DIM
+    + RICH_MP_SURPRISE_DIM
+    + RICH_MULTI_AXIS_DIM
+)
+RICH_FEATURE_SIZE = FEATURE_SIZE + RICH_EXTRA_FEATURE_SIZE
+
+# Slice offsets inside the rich vector. Used by the per-family
+# ablation path on the loader to zero an individual family without
+# changing the per-bar feature size; a downstream sweep can then
+# measure per-family lift while keeping the model input shape
+# constant.
+RICH_MARKET_SLICE = slice(0, FEATURE_SIZE)
+RICH_CREDIBILITY_SLICE = slice(
+    FEATURE_SIZE, FEATURE_SIZE + RICH_CREDIBILITY_DIM
+)
+RICH_LINGUISTIC_SLICE = slice(
+    RICH_CREDIBILITY_SLICE.stop,
+    RICH_CREDIBILITY_SLICE.stop + RICH_LINGUISTIC_DIM,
+)
+RICH_MP_SURPRISE_SLICE = slice(
+    RICH_LINGUISTIC_SLICE.stop,
+    RICH_LINGUISTIC_SLICE.stop + RICH_MP_SURPRISE_DIM,
+)
+RICH_MULTI_AXIS_SLICE = slice(
+    RICH_MP_SURPRISE_SLICE.stop,
+    RICH_MP_SURPRISE_SLICE.stop + RICH_MULTI_AXIS_DIM,
+)
+
 FORECAST_CONFIDENCE_LEVEL = 0.8
 CONFIDENCE_Z_SCORE = 1.2816  # Approximate central 80% interval
 DEFAULT_CLOSE_SCALE = 10000.0
@@ -86,6 +153,42 @@ class ModelConfig:
 
 @dataclass
 class FeatureVector:
+    """Per-bar feature row consumed by the forecaster.
+
+    The 6 market fields (``sentiment_score`` through ``elapsed_time``)
+    are the legacy ``FEATURE_SIZE`` input; ``as_list`` emits exactly
+    that slice and is back-compat with every pre-PR-#173 inference and
+    training path.
+
+    The trailing fields carry the rich-feature input (``RICH_FEATURE_SIZE
+    = 35``) added in PR #173. They are populated by
+    ``app.training.loaders.load_training_sequences_from_package`` when
+    ``rich_features=True``; on the legacy path they stay at their
+    documented defaults so ``as_list`` and ``as_rich_list`` agree on
+    the 6 market positions. ``as_rich_list`` emits the full 35-dim
+    layout in the order documented at the module-level slice
+    constants:
+
+    - positions ``[0:6]`` -- market features.
+    - positions ``[6:10]`` -- credibility 4-vector
+      (``credibility_drift_score`` / ``credibility_realized_vs_stated_gap``
+      / ``credibility_market_implied_gap`` /
+      ``credibility_months_since_reversal``).
+    - positions ``[10:25]`` -- 15-dim linguistic vector
+      (8 LDA topic shares + 6 hand-crafted densities +
+      ``pivot_distance``), in the same field order as
+      ``app.features.linguistic.LinguisticVector``.
+    - positions ``[25:29]`` -- MP-surprise 4-vector
+      (``mp_surprise_level`` / ``mp_surprise_path_factor`` /
+      ``fed_info_factor`` / ``mp_is_intermeeting``).
+    - positions ``[29:35]`` -- 6-dim multi-axis vector
+      (``axis_factor`` / ``axis_factor_missing`` /
+      ``axis_certainty`` / ``axis_certainty_missing`` /
+      ``axis_time`` / ``axis_time_missing``). NaN inputs collapse to
+      ``0.0`` and the paired ``*_missing`` flag flips to ``1.0`` so
+      the model can tell "no signal" apart from "neutral signal".
+    """
+
     date: str
     sentiment_score: float
     market_close: float
@@ -94,6 +197,28 @@ class FeatureVector:
     volatility_change: float = 0.0
     elapsed_time: float = 0.0
     text_embedding: list[float] | None = None
+    # Rich-feature payload (PR #173). Default values match
+    # "all-zero / no-signal" so a FeatureVector built via the legacy
+    # constructors round-trips ``as_rich_list`` to the existing
+    # ``as_list`` plus zero-padding. The loader sets ``rich_payload``
+    # to ``True`` after populating the trailing fields; the tensor
+    # builder dispatches on that flag.
+    credibility_drift_score: float = 0.0
+    credibility_realized_vs_stated_gap: float = 0.0
+    credibility_market_implied_gap: float = 0.0
+    credibility_months_since_reversal: float = 0.0
+    linguistic_features: list[float] | None = None
+    mp_surprise_level: float = 0.0
+    mp_surprise_path_factor: float = 0.0
+    fed_info_factor: float = 0.0
+    mp_is_intermeeting: float = 0.0
+    axis_factor: float = 0.0
+    axis_factor_missing: float = 1.0
+    axis_certainty: float = 0.0
+    axis_certainty_missing: float = 1.0
+    axis_time: float = 0.0
+    axis_time_missing: float = 1.0
+    rich_payload: bool = False
 
     @classmethod
     def from_market_state(
@@ -136,6 +261,43 @@ class FeatureVector:
             max(min(float(self.volatility_change), 1.0), -1.0),
             float(self.elapsed_time) / 30.0,
         ]
+
+    def as_rich_list(self, close_scale: float = DEFAULT_CLOSE_SCALE) -> list[float]:
+        """Emit the full 35-dim per-bar feature vector.
+
+        Layout matches the slice constants at the top of this module
+        and the docstring on :class:`FeatureVector`. The first six
+        positions are byte-identical to :meth:`as_list` so models
+        widened to ``RICH_FEATURE_SIZE`` still see the legacy market
+        signal in positions ``[0:6]``.
+        """
+
+        market = self.as_list(close_scale=close_scale)
+        credibility = [
+            float(self.credibility_drift_score),
+            float(self.credibility_realized_vs_stated_gap),
+            float(self.credibility_market_implied_gap),
+            float(self.credibility_months_since_reversal),
+        ]
+        linguistic_source = self.linguistic_features or []
+        linguistic = [float(v) for v in linguistic_source[:RICH_LINGUISTIC_DIM]]
+        if len(linguistic) < RICH_LINGUISTIC_DIM:
+            linguistic = linguistic + [0.0] * (RICH_LINGUISTIC_DIM - len(linguistic))
+        mp_surprise = [
+            float(self.mp_surprise_level),
+            float(self.mp_surprise_path_factor),
+            float(self.fed_info_factor),
+            float(self.mp_is_intermeeting),
+        ]
+        multi_axis = [
+            float(self.axis_factor),
+            float(self.axis_factor_missing),
+            float(self.axis_certainty),
+            float(self.axis_certainty_missing),
+            float(self.axis_time),
+            float(self.axis_time_missing),
+        ]
+        return market + credibility + linguistic + mp_surprise + multi_axis
 
 
 def build_lookback_sequence(vectors: Iterable[FeatureVector], length: int = SEQUENCE_LENGTH) -> list[FeatureVector]:

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -12,6 +12,7 @@ from typing import Any, Sequence
 import torch
 
 from app.models import FORECASTER_ARCHITECTURES
+from app.models.config import FEATURE_SIZE, RICH_FEATURE_SIZE
 from app.services.forecaster import (
     BEST_MODEL_PATH,
     DEFAULT_BATCH_SIZE,
@@ -160,6 +161,80 @@ def _parse_args() -> argparse.Namespace:
         help="Enable the 4-axis credibility feature path on the forecaster. Default off "
         "preserves the byte-identical regression-test contract for architecture=lstm.",
     )
+    # Rich-feature input space. Default on so a make forecaster-sweep
+    # against a training package consumes the four-family per-bar
+    # vector. Explicit --no-rich-features reproduces the pre-PR-#173
+    # 6-dim path for back-compat smoke checks.
+    rich_group = parser.add_mutually_exclusive_group()
+    rich_group.add_argument(
+        "--rich-features",
+        dest="rich_features",
+        action="store_true",
+        help=(
+            "Enable the 35-dim rich-feature input space on the "
+            "training-package loader. The credibility / linguistic / "
+            "mp-surprise / multi-axis families are joined onto each "
+            "event and broadcast to every bar of the 20-day prior "
+            "window. Default on; ignored when --training-package-id "
+            "is unset."
+        ),
+    )
+    rich_group.add_argument(
+        "--no-rich-features",
+        dest="rich_features",
+        action="store_false",
+        help=(
+            "Disable the rich-feature input space. Reproduces the "
+            "pre-PR-#173 6-feature path for back-compat smoke runs."
+        ),
+    )
+    parser.set_defaults(rich_features=True)
+    # Per-family ablation flags. When a family is off, its slice in
+    # the per-bar feature vector is zeroed but the feature size stays
+    # at RICH_FEATURE_SIZE, so a single sweep can measure per-family
+    # lift without retraining the model architecture.
+    parser.add_argument(
+        "--no-credibility",
+        dest="use_credibility",
+        action="store_false",
+        help=(
+            "Zero the credibility 4-vector slice in the rich-feature "
+            "input. Default on. Ignored when --no-rich-features is set."
+        ),
+    )
+    parser.add_argument(
+        "--no-linguistic",
+        dest="use_linguistic",
+        action="store_false",
+        help=(
+            "Zero the 15-dim linguistic slice in the rich-feature "
+            "input. Default on. Ignored when --no-rich-features is set."
+        ),
+    )
+    parser.add_argument(
+        "--no-mp-surprise",
+        dest="use_mp_surprise",
+        action="store_false",
+        help=(
+            "Zero the MP-surprise 4-vector slice in the rich-feature "
+            "input. Default on. Ignored when --no-rich-features is set."
+        ),
+    )
+    parser.add_argument(
+        "--no-multi-axis",
+        dest="use_multi_axis",
+        action="store_false",
+        help=(
+            "Zero the 6-dim multi-axis slice in the rich-feature "
+            "input. Default on. Ignored when --no-rich-features is set."
+        ),
+    )
+    parser.set_defaults(
+        use_credibility=True,
+        use_linguistic=True,
+        use_mp_surprise=True,
+        use_multi_axis=True,
+    )
     parser.add_argument(
         "--sweep",
         action="store_true",
@@ -235,8 +310,27 @@ def _parse_args() -> argparse.Namespace:
     return args
 
 
+def _resolved_input_size(args: argparse.Namespace) -> int:
+    """Return the per-bar input size implied by the rich-feature flag.
+
+    The rich-feature input only takes effect when the loader actually
+    populates the rich payload (``--training-package-id`` set AND
+    ``--rich-features`` on). On the legacy ``--data-dir`` JSON / JSONL
+    path the per-bar size stays at ``FEATURE_SIZE`` regardless of the
+    flag, so the regression-test contract on the
+    ``--data-dir`` code path is unaffected.
+    """
+
+    rich_on = bool(getattr(args, "rich_features", False))
+    use_package_path = bool(getattr(args, "training_package_id", None))
+    if rich_on and use_package_path:
+        return RICH_FEATURE_SIZE
+    return FEATURE_SIZE
+
+
 def _build_model_config(args: argparse.Namespace) -> ModelConfig:
     return ModelConfig(
+        input_size=_resolved_input_size(args),
         hidden_size=args.hidden_size,
         num_layers=args.num_layers,
         dropout=args.dropout,
@@ -319,6 +413,7 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
         candidates.append(
             {
                 "model_config": ModelConfig(
+                    input_size=_resolved_input_size(args),
                     hidden_size=hidden_size,
                     num_layers=num_layers,
                     dropout=dropout,
@@ -577,6 +672,13 @@ def _run_sweep(
         "training_package_id": training_package_id,
         "checkpoint_path": str(checkpoint_path),
         "credibility_features": bool(args.credibility_features),
+        "rich_features": bool(args.rich_features) and bool(training_package_id),
+        "rich_feature_families": {
+            "credibility": bool(args.use_credibility),
+            "linguistic": bool(args.use_linguistic),
+            "mp_surprise": bool(args.use_mp_surprise),
+            "multi_axis": bool(args.use_multi_axis),
+        },
         "architectures": sorted({trial["architecture"] for trial in trial_records}),
         "seeds": sorted({trial["seed"] for trial in trial_records if trial["seed"] is not None}),
         "trial_count": len(trial_records),
@@ -617,9 +719,19 @@ def main() -> int:
     if use_package_path:
         print(f"Training-package id: {args.training_package_id}")
         print(f"Target mode: {args.target_mode}")
+        print(
+            f"Rich features: {'on' if args.rich_features else 'off'} "
+            f"(credibility={args.use_credibility}, linguistic={args.use_linguistic}, "
+            f"mp_surprise={args.use_mp_surprise}, multi_axis={args.use_multi_axis})"
+        )
         package_sequences = load_training_sequences_from_package(
             args.training_package_id,
             target_mode=args.target_mode,
+            rich_features=bool(args.rich_features),
+            use_credibility=bool(args.use_credibility),
+            use_linguistic=bool(args.use_linguistic),
+            use_mp_surprise=bool(args.use_mp_surprise),
+            use_multi_axis=bool(args.use_multi_axis),
         )
         sequence_count = len(package_sequences)
         observation_count = sum(len(sequence) for sequence in package_sequences)

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -14,8 +14,32 @@ from app.evaluation.metrics import TrainingDataSourceSummary
 from app.models.config import (
     DEFAULT_CLOSE_SCALE,
     DEFAULT_DATA_DIR,
+    RICH_LINGUISTIC_DIM,
     SEQUENCE_LENGTH,
     FeatureVector,
+)
+
+# Ordered linguistic-feature columns expected on
+# ``linguistic_features.parquet``. The order mirrors the
+# :class:`app.features.linguistic.LinguisticVector` dataclass so the
+# 15-dim slice the forecaster sees lines up byte-for-byte with the
+# emitting module's documented layout.
+_LINGUISTIC_FEATURE_COLUMNS: tuple[str, ...] = (
+    "topic_share_inflation",
+    "topic_share_employment",
+    "topic_share_financial_stability",
+    "topic_share_growth",
+    "topic_share_balance_sheet",
+    "topic_share_misc_1",
+    "topic_share_misc_2",
+    "topic_share_misc_3",
+    "hedge_density",
+    "comparison_density",
+    "forward_density",
+    "concrete_ratio",
+    "hawk_dove_asymmetry",
+    "log_token_count",
+    "pivot_distance",
 )
 
 # Numeric encoding of ``axis_stance`` used as the sentiment proxy on the
@@ -489,6 +513,218 @@ def _resolve_training_package_dir(training_package_id: str) -> Path:
     return package_dir
 
 
+def _read_linguistic_lookup(package_dir: Path) -> dict[str, list[float]]:
+    """Return ``text_hash -> 15-dim linguistic feature list``.
+
+    Reads ``linguistic_features.parquet`` from the training-package
+    directory when present. The parquet's column order is documented
+    on :class:`app.features.linguistic.LinguisticVector`; this loader
+    pins the slice to ``_LINGUISTIC_FEATURE_COLUMNS`` so a reordered
+    upstream emission would surface as a missing-column error rather
+    than a silently-misaligned input. NaN cells (e.g. ``pivot_distance``
+    on the first statement) collapse to ``0.0`` here -- the absence
+    flag is set at the row level by ``load_training_sequences_from_package``
+    when the parquet is missing entirely; a per-cell NaN is treated
+    as zero topic / density signal rather than "row missing".
+
+    Returns an empty dict when the parquet is absent or unjoinable on
+    ``text_hash``; callers then emit zeros and set the linguistic
+    missing flag for every row.
+    """
+
+    import pandas as pd
+
+    parquet_path = package_dir / "linguistic_features.parquet"
+    if not parquet_path.exists():
+        return {}
+    frame = pd.read_parquet(parquet_path)
+    if "text_hash" not in frame.columns:
+        return {}
+    # Older packages predate ``pivot_distance`` (PR #166) and so only
+    # ship the first 14 linguistic columns. Missing columns are
+    # tolerated and treated as ``0.0`` on every row so a sweep against
+    # a pre-#166 package degrades cleanly rather than crashing; the
+    # column-name match is exact so silent reorderings still surface
+    # as the wrong-column-in-the-slot failure mode caught by the
+    # downstream unit test.
+    lookup: dict[str, list[float]] = {}
+    for record in frame.to_dict("records"):
+        text_hash = str(record.get("text_hash", "")).strip()
+        if not text_hash:
+            continue
+        row: list[float] = []
+        for column in _LINGUISTIC_FEATURE_COLUMNS:
+            value = record.get(column) if column in frame.columns else None
+            coerced = _coerce_finite_float(value)
+            row.append(0.0 if coerced is None else coerced)
+        lookup[text_hash] = row
+    return lookup
+
+
+def _read_mp_surprise_lookup(
+    package_dir: Path,
+) -> dict[str, dict[str, float]]:
+    """Return ``event_date -> {mp_surprise_level, ..., is_intermeeting}``.
+
+    Looks first inside the training package and then under the canonical
+    location ``data/external/fred/mp_surprises.parquet``. Date keys are
+    ``YYYY-MM-DD`` strings to match the event-row ``event_date`` column
+    formatting. The lookup carries the four scalar columns the loader
+    forwards into the rich-feature vector; the boolean
+    ``is_intermeeting`` flag is left as a Python bool so the broadcaster
+    can encode it as 0.0 / 1.0 at the bar level.
+
+    Returns an empty dict when no parquet is found. Callers then emit
+    zeros + a missing flag for every row.
+    """
+
+    import pandas as pd
+
+    candidates = (
+        package_dir / "mp_surprises.parquet",
+        DATA_DIR / "external" / "fred" / "mp_surprises.parquet",
+    )
+    parquet_path: Path | None = None
+    for candidate in candidates:
+        if candidate.exists():
+            parquet_path = candidate
+            break
+    if parquet_path is None:
+        return {}
+    frame = pd.read_parquet(parquet_path)
+    if "event_date" not in frame.columns:
+        return {}
+    lookup: dict[str, dict[str, float]] = {}
+    for record in frame.to_dict("records"):
+        event_date_raw = record.get("event_date")
+        if event_date_raw is None:
+            continue
+        event_date_str = str(event_date_raw)[:10]
+        if not event_date_str:
+            continue
+        level = _coerce_finite_float(record.get("mp_surprise_level"))
+        path_factor = _coerce_finite_float(record.get("mp_surprise_path_factor"))
+        fed_info = _coerce_finite_float(record.get("fed_info_factor"))
+        is_intermeeting_raw = record.get("is_intermeeting")
+        if isinstance(is_intermeeting_raw, bool):
+            is_intermeeting = 1.0 if is_intermeeting_raw else 0.0
+        else:
+            try:
+                is_intermeeting = 1.0 if bool(int(is_intermeeting_raw)) else 0.0
+            except (TypeError, ValueError):
+                is_intermeeting = 0.0
+        lookup[event_date_str] = {
+            "mp_surprise_level": 0.0 if level is None else level,
+            "mp_surprise_path_factor": 0.0 if path_factor is None else path_factor,
+            "fed_info_factor": 0.0 if fed_info is None else fed_info,
+            "mp_is_intermeeting": is_intermeeting,
+        }
+    return lookup
+
+
+def _attach_rich_features(
+    vectors: list[FeatureVector],
+    *,
+    event_row: dict[str, Any],
+    linguistic_lookup: dict[str, list[float]],
+    mp_surprise_lookup: dict[str, dict[str, float]],
+    text_hash: str,
+    event_date_str: str,
+    use_credibility: bool,
+    use_linguistic: bool,
+    use_mp_surprise: bool,
+    use_multi_axis: bool,
+) -> None:
+    """Broadcast event-level rich features onto every bar in a sequence.
+
+    Per-family ablation flags zero the relevant slice (the per-bar
+    feature size stays at ``RICH_FEATURE_SIZE``) so a downstream sweep
+    can measure per-family lift without changing the model input
+    shape. NaN inputs on the multi-axis fields collapse to ``0.0`` and
+    flip the paired missing flag to ``1.0``.
+    """
+
+    # Credibility 4-vector is sourced directly off the event row.
+    if use_credibility:
+        cred_drift = _coerce_finite_float(event_row.get("credibility_drift_score"))
+        cred_realized = _coerce_finite_float(
+            event_row.get("credibility_realized_vs_stated_gap")
+        )
+        cred_market = _coerce_finite_float(
+            event_row.get("credibility_market_implied_gap")
+        )
+        cred_months = _coerce_finite_float(
+            event_row.get("credibility_months_since_reversal")
+        )
+    else:
+        cred_drift = cred_realized = cred_market = cred_months = 0.0
+    cred_drift = 0.0 if cred_drift is None else cred_drift
+    cred_realized = 0.0 if cred_realized is None else cred_realized
+    cred_market = 0.0 if cred_market is None else cred_market
+    cred_months = 0.0 if cred_months is None else cred_months
+
+    # Linguistic 15-vector. Zeros when the parquet is absent or the
+    # text_hash is not joined; the row-level missing semantics are
+    # captured by the linguistic-features ablation flag (no separate
+    # per-row missing flag because every linguistic field already has
+    # a well-defined zero baseline on the parquet).
+    if use_linguistic:
+        linguistic_row = linguistic_lookup.get(text_hash)
+        if linguistic_row is None:
+            linguistic_features = [0.0] * RICH_LINGUISTIC_DIM
+        else:
+            linguistic_features = list(linguistic_row)
+    else:
+        linguistic_features = [0.0] * RICH_LINGUISTIC_DIM
+
+    # MP-surprise 4-vector. Joined on event_date. Missing parquet or
+    # missing date both emit zeros.
+    if use_mp_surprise:
+        mp_row = mp_surprise_lookup.get(event_date_str, {})
+        mp_level = float(mp_row.get("mp_surprise_level", 0.0))
+        mp_path = float(mp_row.get("mp_surprise_path_factor", 0.0))
+        fed_info = float(mp_row.get("fed_info_factor", 0.0))
+        mp_intermeeting = float(mp_row.get("mp_is_intermeeting", 0.0))
+    else:
+        mp_level = mp_path = fed_info = mp_intermeeting = 0.0
+
+    # Multi-axis 6-vector (3 values + 3 missing flags). NaN flips the
+    # missing flag for that axis but the value still collapses to
+    # zero, so the model sees "no signal" rather than "neutral
+    # numeric value".
+    if use_multi_axis:
+        factor_raw = _coerce_finite_float(event_row.get("axis_factor"))
+        certainty_raw = _coerce_finite_float(event_row.get("axis_certainty"))
+        time_raw = _coerce_finite_float(event_row.get("axis_time"))
+        axis_factor = factor_raw if factor_raw is not None else 0.0
+        axis_factor_missing = 0.0 if factor_raw is not None else 1.0
+        axis_certainty = certainty_raw if certainty_raw is not None else 0.0
+        axis_certainty_missing = 0.0 if certainty_raw is not None else 1.0
+        axis_time = time_raw if time_raw is not None else 0.0
+        axis_time_missing = 0.0 if time_raw is not None else 1.0
+    else:
+        axis_factor = axis_certainty = axis_time = 0.0
+        axis_factor_missing = axis_certainty_missing = axis_time_missing = 0.0
+
+    for vector in vectors:
+        vector.credibility_drift_score = cred_drift
+        vector.credibility_realized_vs_stated_gap = cred_realized
+        vector.credibility_market_implied_gap = cred_market
+        vector.credibility_months_since_reversal = cred_months
+        vector.linguistic_features = list(linguistic_features)
+        vector.mp_surprise_level = mp_level
+        vector.mp_surprise_path_factor = mp_path
+        vector.fed_info_factor = fed_info
+        vector.mp_is_intermeeting = mp_intermeeting
+        vector.axis_factor = axis_factor
+        vector.axis_factor_missing = axis_factor_missing
+        vector.axis_certainty = axis_certainty
+        vector.axis_certainty_missing = axis_certainty_missing
+        vector.axis_time = axis_time
+        vector.axis_time_missing = axis_time_missing
+        vector.rich_payload = True
+
+
 def _read_events_frame(package_dir: Path) -> "Any":
     import pandas as pd
 
@@ -545,6 +781,11 @@ def load_training_sequences_from_package(
     training_package_id: str,
     *,
     target_mode: TargetMode = DEFAULT_TARGET_MODE,
+    rich_features: bool = True,
+    use_credibility: bool = True,
+    use_linguistic: bool = True,
+    use_mp_surprise: bool = True,
+    use_multi_axis: bool = True,
 ) -> list[list[FeatureVector]]:
     """Load one prior-window sequence per FOMC event in a training package.
 
@@ -598,6 +839,24 @@ def load_training_sequences_from_package(
     Returns a ``list[list[FeatureVector]]`` where each inner list holds
     20 prior bars followed by 1 event-day target row (21 vectors
     total). Events with fewer than 20 prior bars are skipped.
+
+    When ``rich_features=True`` (the default) the loader joins
+    ``linguistic_features.parquet`` on ``text_hash`` and
+    ``mp_surprises.parquet`` on ``event_date``, reads the credibility
+    and multi-axis columns straight off the event row, and broadcasts
+    those event-level signals onto every bar of the prior window plus
+    the appended event-day target frame. The resulting ``FeatureVector``
+    rows emit 35 dims through ``as_rich_list``; the 6-dim ``as_list``
+    output stays byte-identical. The per-family ablation flags
+    (``use_credibility`` / ``use_linguistic`` / ``use_mp_surprise`` /
+    ``use_multi_axis``) zero a family's slice while keeping the per-bar
+    feature size constant, so a downstream sweep can measure per-family
+    lift without retraining the model with a different input shape.
+
+    Setting ``rich_features=False`` reproduces the pre-PR-#173 output:
+    ``as_rich_list`` falls back to ``as_list`` plus zero-padding (no
+    rich payload attached), and the per-family ablation flags are
+    ignored.
     """
 
     if target_mode not in _VALID_TARGET_MODES:
@@ -619,6 +878,20 @@ def load_training_sequences_from_package(
         )
 
     excluded_text_hashes = _read_excluded_text_hashes(package_dir)
+
+    # Side-tables for the rich-feature join. Both lookups are read
+    # once per package so the per-event broadcast does not re-open the
+    # parquet on every iteration; the lookups are tiny in absolute
+    # terms (one row per event for MP-surprise, one row per text_hash
+    # for linguistic) so the memory footprint is negligible. When the
+    # caller opted out via ``rich_features=False`` the lookups are
+    # left empty -- ``_attach_rich_features`` is skipped entirely so
+    # the legacy 6-dim path is undisturbed.
+    linguistic_lookup: dict[str, list[float]] = {}
+    mp_surprise_lookup: dict[str, dict[str, float]] = {}
+    if rich_features:
+        linguistic_lookup = _read_linguistic_lookup(package_dir)
+        mp_surprise_lookup = _read_mp_surprise_lookup(package_dir)
 
     # Deduplicate to one row per text_hash. Prefer horizon=1 so the
     # appended target frame is the next trading day's close. Within a
@@ -665,6 +938,7 @@ def load_training_sequences_from_package(
         bars = _parse_prior_bars(row.get("prior_bars_json"))
         if len(bars) < SEQUENCE_LENGTH:
             continue
+        row_text_hash = str(row.get("text_hash", ""))
         sentiment_score = _stance_to_sentiment(row.get("axis_stance"))
         vectors = _bars_to_feature_vectors(
             bars,
@@ -695,6 +969,19 @@ def load_training_sequences_from_package(
             volatility_shift=volatility_shift,
             target_mode=target_mode,
         )
+        if rich_features:
+            _attach_rich_features(
+                vectors,
+                event_row=row,
+                linguistic_lookup=linguistic_lookup,
+                mp_surprise_lookup=mp_surprise_lookup,
+                text_hash=row_text_hash,
+                event_date_str=event_date_str[:10],
+                use_credibility=use_credibility,
+                use_linguistic=use_linguistic,
+                use_mp_surprise=use_mp_surprise,
+                use_multi_axis=use_multi_axis,
+            )
         sequences.append(vectors)
     return sequences
 
@@ -739,7 +1026,7 @@ def _build_training_tensors(
     sequence_groups: Sequence[Sequence[FeatureVector]],
     close_scale: float | None = None,
 ) -> tuple[torch.Tensor | None, torch.Tensor | None, float]:
-    """Materialise the (x, y, close_scale) triple for the legacy training path.
+    """Materialise the (x, y, close_scale) triple for the training path.
 
     The third return value is the close-scale that was used for
     normalisation. Callers that need to persist the scaler (training
@@ -748,9 +1035,27 @@ def _build_training_tensors(
     is supplied, the caller has already fitted it (e.g. on a strict
     train-only window for walk-forward); when ``None`` we fit it on
     the fly from the same sequences.
+
+    Per-bar feature size is chosen by inspecting the first feature
+    vector in the input: rows whose ``rich_payload`` flag is True
+    emit through :meth:`FeatureVector.as_rich_list` (35 dims),
+    everything else stays on the legacy :meth:`FeatureVector.as_list`
+    (6 dims). The dispatch keeps the pre-PR-#173 byte-identical
+    contract for any sequence group built from the legacy
+    ``data_dir`` JSON scan (rich_payload defaults to False on every
+    ``FeatureVector`` constructed without the rich-feature loader).
     """
 
     fitted_scale = float(close_scale) if close_scale is not None else fit_close_scale(sequence_groups)
+
+    use_rich = False
+    for sequence_group in sequence_groups:
+        for item in sequence_group:
+            if getattr(item, "rich_payload", False):
+                use_rich = True
+                break
+        if use_rich:
+            break
 
     sequences: list[list[list[float]]] = []
     targets: list[list[float]] = []
@@ -761,7 +1066,11 @@ def _build_training_tensors(
         for idx in range(SEQUENCE_LENGTH, len(sequence_group)):
             window = sequence_group[idx - SEQUENCE_LENGTH : idx]
             target = sequence_group[idx]
-            sequences.append([item.as_list() for item in window])
+            if use_rich:
+                row_list = [item.as_rich_list() for item in window]
+            else:
+                row_list = [item.as_list() for item in window]
+            sequences.append(row_list)
             targets.append(
                 [
                     target.market_close / fitted_scale,

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -788,6 +788,77 @@ path is bit-identical to prior versions. The
 trainer directly with synthesised vectors and never crosses the
 training-package code path.
 
+### Forecaster rich-feature input space
+
+The training-package loader joins four feature families onto every
+event and broadcasts the event-level signal onto every bar of the
+20-day prior window plus the appended event-day target frame. Per-bar
+feature size grows from `FEATURE_SIZE = 6` to `RICH_FEATURE_SIZE = 35`.
+
+Per-bar slice layout (positions inside `FeatureVector.as_rich_list()`):
+
+| Slice    | Width | Source / fields |
+| -------- | ----- | --------------- |
+| `[0:6]`  | 6     | Existing market features (`sentiment_score`, `market_close`, `market_volatility`, `close_change_pct`, `volatility_change`, `elapsed_time`). Byte-identical to `as_list()`. |
+| `[6:10]` | 4     | Credibility — `credibility_drift_score`, `credibility_realized_vs_stated_gap`, `credibility_market_implied_gap`, `credibility_months_since_reversal`. Off the event row directly. |
+| `[10:25]` | 15   | Linguistic — full `LinguisticVector` (8 LDA topic shares + `hedge_density` / `comparison_density` / `forward_density` / `concrete_ratio` / `hawk_dove_asymmetry` / `log_token_count` + `pivot_distance`). Joined on `text_hash` from `linguistic_features.parquet`. |
+| `[25:29]` | 4    | MP-surprise — `mp_surprise_level`, `mp_surprise_path_factor`, `fed_info_factor`, `mp_is_intermeeting` (boolean encoded as 0.0 / 1.0). Joined on `event_date` from `mp_surprises.parquet`. |
+| `[29:35]` | 6    | Multi-axis — `axis_factor` / `axis_factor_missing`, `axis_certainty` / `axis_certainty_missing`, `axis_time` / `axis_time_missing`. NaN inputs collapse to `0.0` and flip the paired missing flag to `1.0`. |
+
+The 6-dim `as_list()` output stays unchanged. The legacy
+`--data-dir` JSON / JSONL / CSV path emits `FeatureVector` rows whose
+`rich_payload` flag is `False`, so `_build_training_tensors`
+auto-routes them through `as_list()` and the pre-PR-#173 6-feature
+input contract is preserved.
+
+#### Loader flag and per-family ablation
+
+`load_training_sequences_from_package` accepts a `rich_features: bool
+= True` kwarg plus four per-family ablation flags
+(`use_credibility`, `use_linguistic`, `use_mp_surprise`,
+`use_multi_axis`, all `True` by default). When `rich_features=False`
+the loader bypasses the side-table joins entirely and the resulting
+sequences emit 6-dim feature rows. When a per-family flag is `False`
+the relevant slice is zeroed on every bar but the per-bar feature
+size stays at 35, so a single sweep can measure per-family lift
+without changing the model input shape.
+
+The `train_forecaster.py` CLI exposes the same flags:
+
+```
+--rich-features / --no-rich-features
+--no-credibility
+--no-linguistic
+--no-mp-surprise
+--no-multi-axis
+```
+
+`--rich-features` is the default; `--no-rich-features` reproduces the
+pre-PR-#173 6-feature input. The per-family flags are no-ops when
+`--no-rich-features` is set.
+
+#### Missing side-table semantics
+
+- `linguistic_features.parquet` absent or unjoined on `text_hash` →
+  the linguistic slice is all zeros for that event.
+- `mp_surprises.parquet` absent or unjoined on `event_date` → the
+  MP-surprise slice is all zeros for that event.
+- `axis_factor` / `axis_certainty` / `axis_time` NaN → the value
+  collapses to `0.0` AND the paired `*_missing` flag flips to `1.0`,
+  so the model can tell "no signal" apart from "neutral signal".
+- Credibility fields are required on `events.parquet` (the
+  event-row builder guarantees them) and so do not carry a missing
+  flag; absent fields are coerced to `0.0` defensively.
+
+#### Make targets
+
+- `make forecaster-sweep TRAINING_PACKAGE_ID=<id>` — 8-architecture
+  rich-feature sweep (lstm, lstm_attn, gru, tcn, transformer, dlinear,
+  informer, tft) across the official five-seed set.
+- `make forecaster-sweep-baseline TRAINING_PACKAGE_ID=<id>` — the
+  pre-PR-#173 6-feature path against the original six architectures,
+  preserved for back-compat smoke checks against earlier sweep numbers.
+
 ## Pipeline schema validation
 
 `backend/app/data/schemas.py` defines one `pandera.DataFrameSchema` per

--- a/tests/unit/test_training_package_loader.py
+++ b/tests/unit/test_training_package_loader.py
@@ -19,7 +19,19 @@ import pytest
 pd = pytest.importorskip("pandas")
 pytest.importorskip("pyarrow")
 
-from app.models.config import SEQUENCE_LENGTH
+from app.models.config import (
+    FEATURE_SIZE,
+    RICH_CREDIBILITY_DIM,
+    RICH_CREDIBILITY_SLICE,
+    RICH_FEATURE_SIZE,
+    RICH_LINGUISTIC_DIM,
+    RICH_LINGUISTIC_SLICE,
+    RICH_MP_SURPRISE_DIM,
+    RICH_MP_SURPRISE_SLICE,
+    RICH_MULTI_AXIS_DIM,
+    RICH_MULTI_AXIS_SLICE,
+    SEQUENCE_LENGTH,
+)
 from app.training import loaders
 
 
@@ -445,3 +457,326 @@ def test_target_mode_invalid_raises(tmp_path: Path, monkeypatch) -> None:
         loaders.load_training_sequences_from_package(
             "any_id", target_mode="not_a_mode"  # type: ignore[arg-type]
         )
+
+
+# ---------------------------------------------------------------------------
+# Rich-feature loader tests (PR #173)
+#
+# The training-package loader joins linguistic_features.parquet on
+# text_hash, mp_surprises.parquet on event_date, reads the credibility +
+# multi-axis fields straight off the events parquet, and broadcasts the
+# event-level signal onto every bar in the 20-day prior window plus the
+# appended event-day target frame. Per-bar feature size grows from
+# FEATURE_SIZE (6) to RICH_FEATURE_SIZE (35) and is emitted through
+# ``FeatureVector.as_rich_list``.
+# ---------------------------------------------------------------------------
+
+
+_RICH_PACKAGE_ID = "tp_unit_rich_features_v0"
+
+
+def _linguistic_row(text_hash: str, base: float) -> dict:
+    """Build a synthetic linguistic-feature row with the full 15 columns.
+
+    Values are chosen to be unique per-text_hash so the broadcaster's
+    join-on-text_hash contract is observable: each surviving sequence
+    should carry exactly the row keyed by its event's text_hash.
+    """
+
+    return {
+        "text_hash": text_hash,
+        "topic_share_inflation": base + 0.01,
+        "topic_share_employment": base + 0.02,
+        "topic_share_financial_stability": base + 0.03,
+        "topic_share_growth": base + 0.04,
+        "topic_share_balance_sheet": base + 0.05,
+        "topic_share_misc_1": base + 0.06,
+        "topic_share_misc_2": base + 0.07,
+        "topic_share_misc_3": base + 0.08,
+        "hedge_density": base + 0.10,
+        "comparison_density": base + 0.11,
+        "forward_density": base + 0.12,
+        "concrete_ratio": base + 0.13,
+        "hawk_dove_asymmetry": base + 0.14,
+        "log_token_count": base + 0.15,
+        "pivot_distance": base + 0.16,
+    }
+
+
+def _mp_surprise_row(event_date: str, base: float) -> dict:
+    """Build a synthetic mp_surprises row keyed by ``event_date``."""
+
+    return {
+        "event_date": event_date,
+        "mp_surprise_level": base + 0.001,
+        "mp_surprise_path_factor": base + 0.002,
+        "fed_info_factor": base + 0.003,
+        "is_intermeeting": bool(base > 0.5),
+    }
+
+
+@pytest.fixture
+def rich_feature_package_dir(tmp_path: Path, monkeypatch) -> Path:
+    """Materialise a small package with linguistic + mp-surprise parquets.
+
+    Two train-tagged events with known credibility / multi-axis /
+    linguistic / mp-surprise values let the rich-feature tests pin
+    each slice against an arithmetically reconstructible expectation.
+    A third event drops its linguistic row so the missing-join
+    fallback test has a candidate to validate against.
+    """
+
+    package_dir = tmp_path / "processed" / _RICH_PACKAGE_ID
+    package_dir.mkdir(parents=True)
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+
+    events = []
+    for text_hash, event_date, realized_date, base_close, base, factor, certainty in (
+        ("hash_a", "2024-01-31", "2024-02-01", 4400.0, 0.10, 0.25, 0.5),
+        ("hash_b", "2024-02-15", "2024-02-16", 4500.0, 0.20, -0.40, 0.8),
+        ("hash_no_ling", "2024-03-15", "2024-03-16", 4600.0, 0.30, 0.10, 0.2),
+    ):
+        row = _event_row(
+            event_date=event_date,
+            text_hash=text_hash,
+            axis_stance="hawkish",
+            realized_return=0.001,
+            realized_date=realized_date,
+            base_close=base_close,
+        )
+        # Pin credibility + multi-axis to distinguishable, non-zero
+        # values so the per-bar slice assertions are observable.
+        row["credibility_drift_score"] = base + 0.001
+        row["credibility_realized_vs_stated_gap"] = base + 0.002
+        row["credibility_market_implied_gap"] = base + 0.003
+        row["credibility_months_since_reversal"] = int(base * 10)
+        row["axis_factor"] = factor
+        row["axis_certainty"] = certainty
+        row["axis_time"] = base + 0.5
+        events.append(row)
+    pd.DataFrame(events).to_parquet(package_dir / "events.parquet", index=False)
+    pd.DataFrame(
+        [
+            {"text_hash": "hash_a", "split_tag": "train"},
+            {"text_hash": "hash_b", "split_tag": "train"},
+            {"text_hash": "hash_no_ling", "split_tag": "train"},
+        ]
+    ).to_parquet(package_dir / "splits_train_val_test.parquet", index=False)
+
+    # Linguistic parquet covers hash_a and hash_b but NOT hash_no_ling,
+    # so the join-fallback test can assert that the third event's
+    # linguistic slice is all zeros.
+    pd.DataFrame(
+        [
+            _linguistic_row("hash_a", 0.10),
+            _linguistic_row("hash_b", 0.20),
+        ]
+    ).to_parquet(package_dir / "linguistic_features.parquet", index=False)
+
+    # MP-surprise parquet keyed on event_date. Covers all three events.
+    pd.DataFrame(
+        [
+            _mp_surprise_row("2024-01-31", 0.10),
+            _mp_surprise_row("2024-02-15", 0.20),
+            _mp_surprise_row("2024-03-15", 0.30),
+        ]
+    ).to_parquet(package_dir / "mp_surprises.parquet", index=False)
+
+    return package_dir
+
+
+def test_rich_features_emit_35_per_bar(rich_feature_package_dir: Path) -> None:
+    sequences = loaders.load_training_sequences_from_package(
+        _RICH_PACKAGE_ID, rich_features=True
+    )
+    assert len(sequences) == 3
+    # Per-bar size on the rich emitter is the documented constant; the
+    # legacy emitter stays at FEATURE_SIZE for any non-rich vector.
+    for sequence in sequences:
+        for vector in sequence:
+            assert vector.rich_payload is True
+            assert len(vector.as_rich_list()) == RICH_FEATURE_SIZE
+            # Back-compat: the 6-dim slice is still emitted.
+            assert len(vector.as_list()) == FEATURE_SIZE
+            # Positions [0:6] of as_rich_list match as_list bit-for-bit
+            # so models built on the legacy slice keep seeing the same
+            # values when widened to RICH_FEATURE_SIZE.
+            assert vector.as_rich_list()[:FEATURE_SIZE] == vector.as_list()
+
+    # Pin one full slice composition against the synthetic fixture so
+    # the per-family broadcast and the column-ordering contract are
+    # locked together. hash_a: base = 0.10, factor = 0.25, certainty
+    # = 0.5, axis_time = 0.60.
+    by_target_date = {seq[-1].date[:10]: seq for seq in sequences}
+    hash_a_target = by_target_date["2024-02-01"][-1]
+    rich = hash_a_target.as_rich_list()
+    cred_slice = rich[RICH_CREDIBILITY_SLICE]
+    assert cred_slice == pytest.approx([0.101, 0.102, 0.103, 1.0])
+    ling_slice = rich[RICH_LINGUISTIC_SLICE]
+    expected_ling = [
+        0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18,
+        0.20, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26,
+    ]
+    assert ling_slice == pytest.approx(expected_ling)
+    mp_slice = rich[RICH_MP_SURPRISE_SLICE]
+    # hash_a has base=0.10 in the mp parquet (is_intermeeting=False).
+    assert mp_slice == pytest.approx([0.101, 0.102, 0.103, 0.0])
+    multi_axis_slice = rich[RICH_MULTI_AXIS_SLICE]
+    # All three axes present -> missing flags zero.
+    assert multi_axis_slice == pytest.approx([0.25, 0.0, 0.5, 0.0, 0.6, 0.0])
+
+
+def test_rich_features_missing_linguistic_row_zeros_and_flags(
+    rich_feature_package_dir: Path,
+) -> None:
+    sequences = loaders.load_training_sequences_from_package(
+        _RICH_PACKAGE_ID, rich_features=True
+    )
+    # hash_no_ling has no linguistic-parquet row -- its linguistic
+    # slice must be all zeros on every bar of the sequence. The
+    # ablation flag is *not* set (the family is still on); the row's
+    # absence is what zeros the slice.
+    by_target_date = {seq[-1].date[:10]: seq for seq in sequences}
+    no_ling_sequence = by_target_date["2024-03-16"]
+    for vector in no_ling_sequence:
+        ling_slice = vector.as_rich_list()[RICH_LINGUISTIC_SLICE]
+        assert ling_slice == [0.0] * RICH_LINGUISTIC_DIM
+
+    # Sanity: the credibility + mp-surprise + multi-axis slices are
+    # still populated (only the missing family zeros out), so the
+    # broadcaster did not also drop unrelated families.
+    target = no_ling_sequence[-1].as_rich_list()
+    assert target[RICH_CREDIBILITY_SLICE][0] == pytest.approx(0.301)
+    assert target[RICH_MP_SURPRISE_SLICE][0] == pytest.approx(0.301)
+    assert target[RICH_MULTI_AXIS_SLICE][2] == pytest.approx(0.2)
+
+
+def test_rich_features_per_family_ablation_zeros_correct_slice(
+    rich_feature_package_dir: Path,
+) -> None:
+    sequences = loaders.load_training_sequences_from_package(
+        _RICH_PACKAGE_ID,
+        rich_features=True,
+        use_credibility=False,
+    )
+    assert len(sequences) == 3
+    # Credibility slice on every bar must be zero. The per-bar
+    # feature size stays at RICH_FEATURE_SIZE so the model input
+    # shape is unchanged -- the ablation measures lift by zeroing
+    # the slice rather than shrinking the input.
+    for sequence in sequences:
+        for vector in sequence:
+            rich = vector.as_rich_list()
+            assert len(rich) == RICH_FEATURE_SIZE
+            assert rich[RICH_CREDIBILITY_SLICE] == [0.0] * RICH_CREDIBILITY_DIM
+
+    # Other families stay populated: pick hash_a and verify the
+    # linguistic + mp-surprise + multi-axis slices match the
+    # all-on baseline above.
+    by_target_date = {seq[-1].date[:10]: seq for seq in sequences}
+    hash_a_target = by_target_date["2024-02-01"][-1].as_rich_list()
+    assert hash_a_target[RICH_LINGUISTIC_SLICE][0] == pytest.approx(0.11)
+    assert hash_a_target[RICH_MP_SURPRISE_SLICE][0] == pytest.approx(0.101)
+    assert hash_a_target[RICH_MULTI_AXIS_SLICE][0] == pytest.approx(0.25)
+
+
+def test_rich_features_multi_axis_missing_flips_missing_flag(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """NaN multi-axis fields collapse to zero and flip the missing flag."""
+
+    package_id = "tp_unit_multi_axis_missing_v0"
+    package_dir = tmp_path / "processed" / package_id
+    package_dir.mkdir(parents=True)
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+
+    row = _event_row(
+        event_date="2024-04-30",
+        text_hash="hash_nan_axes",
+        axis_stance="neutral",
+        realized_return=0.0,
+        realized_date="2024-05-01",
+        base_close=4700.0,
+    )
+    # axis_factor / axis_certainty / axis_time stay None (default
+    # from ``_event_row``); the loader must collapse them to 0.0 and
+    # flip each *_missing flag to 1.0.
+    pd.DataFrame([row]).to_parquet(package_dir / "events.parquet", index=False)
+    pd.DataFrame(
+        [{"text_hash": "hash_nan_axes", "split_tag": "train"}]
+    ).to_parquet(package_dir / "splits_train_val_test.parquet", index=False)
+
+    sequences = loaders.load_training_sequences_from_package(
+        package_id, rich_features=True
+    )
+    assert len(sequences) == 1
+    target = sequences[0][-1].as_rich_list()
+    multi_axis = target[RICH_MULTI_AXIS_SLICE]
+    # axis_factor, axis_factor_missing, axis_certainty,
+    # axis_certainty_missing, axis_time, axis_time_missing
+    assert multi_axis == pytest.approx([0.0, 1.0, 0.0, 1.0, 0.0, 1.0])
+
+
+def test_no_rich_features_reproduces_legacy_6dim_path(
+    rich_feature_package_dir: Path,
+) -> None:
+    """``rich_features=False`` is byte-identical to the pre-PR-#173 output."""
+
+    legacy = loaders.load_training_sequences_from_package(
+        _RICH_PACKAGE_ID, rich_features=False
+    )
+    assert len(legacy) == 3
+    for sequence in legacy:
+        for vector in sequence:
+            # Rich payload flag stays at the dataclass default.
+            assert vector.rich_payload is False
+            assert len(vector.as_list()) == FEATURE_SIZE
+            # ``as_rich_list`` on a non-rich vector falls back to
+            # ``as_list`` plus zero-padding, so its 6-dim prefix is
+            # unchanged. The remaining 29 dims are zeros plus the
+            # default multi-axis missing flags (1.0 each).
+            rich = vector.as_rich_list()
+            assert len(rich) == RICH_FEATURE_SIZE
+            assert rich[:FEATURE_SIZE] == vector.as_list()
+            assert rich[RICH_CREDIBILITY_SLICE] == [0.0] * RICH_CREDIBILITY_DIM
+            assert rich[RICH_LINGUISTIC_SLICE] == [0.0] * RICH_LINGUISTIC_DIM
+            assert rich[RICH_MP_SURPRISE_SLICE] == [0.0] * RICH_MP_SURPRISE_DIM
+
+
+def test_rich_features_ignored_when_mp_parquet_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """No mp_surprises.parquet -> mp-surprise slice is zero, other
+    families still flow. Confirms the loader degrades cleanly when one
+    of the optional side-tables is absent."""
+
+    package_id = "tp_unit_no_mp_v0"
+    package_dir = tmp_path / "processed" / package_id
+    package_dir.mkdir(parents=True)
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+
+    row = _event_row(
+        event_date="2024-06-15",
+        text_hash="hash_no_mp",
+        axis_stance="hawkish",
+        realized_return=0.001,
+        realized_date="2024-06-16",
+        base_close=4800.0,
+    )
+    row["credibility_drift_score"] = 0.5
+    pd.DataFrame([row]).to_parquet(package_dir / "events.parquet", index=False)
+    pd.DataFrame(
+        [{"text_hash": "hash_no_mp", "split_tag": "train"}]
+    ).to_parquet(package_dir / "splits_train_val_test.parquet", index=False)
+    # NO linguistic_features.parquet, NO mp_surprises.parquet.
+
+    sequences = loaders.load_training_sequences_from_package(
+        package_id, rich_features=True
+    )
+    assert len(sequences) == 1
+    target = sequences[0][-1].as_rich_list()
+    # Credibility still populated from the events row.
+    assert target[RICH_CREDIBILITY_SLICE][0] == pytest.approx(0.5)
+    # Linguistic + mp-surprise slices zero (parquet missing).
+    assert target[RICH_LINGUISTIC_SLICE] == [0.0] * RICH_LINGUISTIC_DIM
+    assert target[RICH_MP_SURPRISE_SLICE] == [0.0] * RICH_MP_SURPRISE_DIM


### PR DESCRIPTION
## Summary

- FeatureVector gains 29 rich-feature dims (credibility 4 + linguistic 15 + mp_surprise 4 + multi-axis 6 incl missing flags) plus the existing 6 market features = 35 per bar.
- load_training_sequences_from_package joins linguistic_features.parquet on text_hash, mp_surprises.parquet on event_date, reads credibility + multi-axis off the event row, broadcasts to every bar of the 20-day window + the event-day target.
- Per-family ablation flags (--no-credibility / --no-linguistic / --no-mp-surprise / --no-multi-axis) zero the corresponding slice while keeping the input shape constant -- lets a single sweep measure per-family lift without retraining the model architecture.
- New default --rich-features flag on train_forecaster (legacy --no-rich-features path stays for back-compat).
- Makefile forecaster-sweep now fires the rich-features path with all 8 architectures (lstm, lstm_attn, gru, tcn, transformer, dlinear, informer, tft); forecaster-sweep-baseline preserves the 6-feature variant.
- 6 new tests pin the 35-dim emission, the missing-linguistic-row fallback, the per-family ablation slice, the multi-axis missing-flag flip, the missing-mp-parquet fallback, and the legacy 6-dim back-compat.
- docs/data-and-training-contracts.md documents the 35-dim per-bar layout, the per-family ablation flags, and the missing-flag semantics.

Real-package smoke (CPU, tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0): 895 sequences loaded, per-bar dim 35, loading time 0.754s.

## Test plan

- [ ] `docker compose run --rm --no-deps backend pytest tests/unit/test_training_package_loader.py tests/regression/ tests/unit/test_forecaster.py -q`
- [ ] `make forecaster-sweep TRAINING_PACKAGE_ID=tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0` runs end-to-end on the rich-features path.

Follows #170 + #172.