### PR TITLE
Build FRED macro panel + MP surprise + voyage embeddings + rebuild linguistic features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state next-fomc cross-asset forecaster-sweep forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-credibility-train
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-credibility-train
 
 help:
 	@echo "Targets:"
@@ -52,6 +52,12 @@ help:
 	@echo "  make pseudo-labels-judge-pass - Score the pseudo set with Gemini (judge-only audit gold)"
 	@echo "  make pseudo-labels-audit-metrics-judge - Compute teacher precision against the LLM judge gold"
 	@echo "  make macro-state      - Build the FRED macro-state parquet (Phase 8 #147)"
+	@echo "  make build-macro-state - Same as macro-state, named for the data-asset suite"
+	@echo "  make build-mp-surprises - Build the MP-surprise time-series parquet"
+	@echo "  make rebuild-linguistic-features TRAINING_PACKAGE_ID=<id>"
+	@echo "                         - Re-emit linguistic_features.parquet for a training package"
+	@echo "  make cache-voyage-embeddings"
+	@echo "                         - Cache voyage-finance-2 embeddings for the FOMC corpus"
 	@echo "  make next-fomc        - Predict next-FOMC decision (Phase 8 headline, #147)"
 	@echo "  make cross-asset      - Cross-asset abnormal-return response head (Phase 8, #148)"
 	@echo "  make forecaster-sweep         - 8-arch x 5-seed forecaster sweep, rich-feature input (35 dim)"
@@ -337,15 +343,50 @@ eval-cross-bank:
 		$(if $(EVAL_BANKS),--eval-banks "$(EVAL_BANKS)",)
 
 # Build the FRED macro-state snapshot at data/external/fred/macro_state.parquet.
-# Reads UNRATE, CPIAUCSL, PCEPILFE, MANEMP, PAYEMS, RSAFS. Requires FRED_API_KEY
-# in .env on first run (cached JSON afterwards).
+# Reads the activity + inflation panel (UNRATE, CPIAUCSL, PCEPILFE, MANEMP,
+# PAYEMS, RSAFS) plus the rates + financial-conditions panel (DGS10, T10Y2Y,
+# T10Y3M, BAMLH0A0HYM2, NFCI, DFII10). Requires FRED_API_KEY in .env on first
+# run (cached JSON afterwards).
 MACRO_STATE_START ?= 2010-01-01
 MACRO_STATE_END ?= today
-macro-state:
+macro-state: build-macro-state
+
+build-macro-state:
+	@test -f .env || (echo ".env required for FRED_API_KEY"; exit 1)
 	docker compose run --rm backend \
 		python -m app.data.macro_state \
+		--output data/external/fred/macro_state.parquet \
 		--start "$(MACRO_STATE_START)" \
 		--end "$(MACRO_STATE_END)"
+
+# Build the monetary-policy surprise time-series at
+# data/external/fred/mp_surprises.parquet. Requires FRED_API_KEY in .env on
+# first run; subsequent runs reuse the per-series JSON cache.
+build-mp-surprises:
+	@test -f .env || (echo ".env required for FRED_API_KEY"; exit 1)
+	docker compose run --rm backend \
+		python -m app.data.mp_surprise \
+		--output data/external/fred/mp_surprises.parquet
+
+# Re-emit linguistic_features.parquet for a given training package. The
+# default output filename and LDA-artifact filenames live under the package
+# directory. Required: TRAINING_PACKAGE_ID.
+rebuild-linguistic-features:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	docker compose run --rm backend \
+		python -m app.features.linguistic \
+		--training-package-id "$(TRAINING_PACKAGE_ID)"
+
+# Cache voyage-finance-2 sentence embeddings for a training package under
+# data/raw/embeddings/. Requires VOYAGE_API_KEY in .env. The Voyage REST
+# API is contacted only when --allow-network is passed.
+cache-voyage-embeddings:
+	@test -f .env || (echo ".env required for VOYAGE_API_KEY"; exit 1)
+	docker compose run --rm backend \
+		python scripts/cache_voyage_embeddings.py --allow-network \
+		$(if $(TRAINING_PACKAGE_ID),--training-package-id "$(TRAINING_PACKAGE_ID)",) \
+		$(if $(BATCH_SIZE),--batch-size $(BATCH_SIZE),) \
+		$(if $(FORCE),--force,)
 
 # Predict the FOMC's next decision using text + macro + OIS + credibility +
 # linguistic features (Phase 8 headline, #147). Required: TRAINING_PACKAGE_ID

--- a/backend/app/data/macro_state.py
+++ b/backend/app/data/macro_state.py
@@ -9,22 +9,40 @@ alongside text / OIS / credibility / linguistic axes.
 Indicators
 ----------
 
-================= ============================ =================================
-column            FRED series                  transform
-================= ============================ =================================
-``unrate``        ``UNRATE``                   level (% civilian unemployment)
-``cpi_yoy``       ``CPIAUCSL``                 12-month log-change x 100 (% YoY)
-``core_pce_yoy``  ``PCEPILFE``                 12-month log-change x 100 (% YoY)
-``ism_proxy``     ``MANEMP``                   3-month % change (ISM manufacturing
-                                               employment is paywalled at NAPM
-                                               level; ``MANEMP`` from FRED is
-                                               the documented free-data proxy,
-                                               see methodology note below).
-``payems_mom``    ``PAYEMS``                   month-over-month change in
-                                               thousands of jobs
-``rsafs_mom``     ``RSAFS``                    month-over-month % change in
-                                               retail sales (advance)
-================= ============================ =================================
+==================== ============================ =================================
+column               FRED series                  transform
+==================== ============================ =================================
+``unrate``           ``UNRATE``                   level (% civilian unemployment)
+``cpi_yoy``          ``CPIAUCSL``                 12-month log-change x 100 (% YoY)
+``core_pce_yoy``     ``PCEPILFE``                 12-month log-change x 100 (% YoY)
+``ism_proxy``        ``MANEMP``                   3-month % change (ISM manufacturing
+                                                  employment is paywalled at NAPM
+                                                  level; ``MANEMP`` from FRED is
+                                                  the documented free-data proxy,
+                                                  see methodology note below).
+``payems_mom``       ``PAYEMS``                   month-over-month change in
+                                                  thousands of jobs
+``rsafs_mom``        ``RSAFS``                    month-over-month % change in
+                                                  retail sales (advance)
+``treas_10y``        ``DGS10``                    level (% 10-year Treasury
+                                                  constant maturity yield)
+``slope_10y_2y``     ``T10Y2Y``                   level (10y minus 2y, in pct
+                                                  points; FRED publishes the
+                                                  spread directly)
+``slope_10y_3m``     ``T10Y3M``                   level (10y minus 3m, in pct
+                                                  points; recession-signal
+                                                  spread)
+``hy_oas``           ``BAMLH0A0HYM2``             level (ICE BofA US High-Yield
+                                                  option-adjusted spread, in
+                                                  pct points)
+``nfci``             ``NFCI``                     level (Chicago Fed National
+                                                  Financial Conditions Index;
+                                                  weekly, 5-day publication
+                                                  delay -- see note below)
+``tips_10y_real``    ``DFII10``                   level (10-year Treasury
+                                                  Inflation-Protected real
+                                                  yield; daily)
+==================== ============================ =================================
 
 Why ``MANEMP`` proxies ISM. The published ISM Manufacturing PMI itself is
 behind a paywall (ISM survey aggregate, distributed via ISM and Haver).
@@ -35,6 +53,17 @@ Bank of Dallas Working Paper 2207, "Forecasting US Manufacturing
 Activity," 2022) and the 3-month change is the formulation NBER
 business-cycle dating uses as a covariate. Every row carries
 ``ism_proxy_source = "MANEMP_3m_pct"`` so the substitution is auditable.
+
+Rates + financial-conditions panel publication delays. ``DGS10``,
+``T10Y2Y``, ``T10Y3M``, ``BAMLH0A0HYM2``, and ``DFII10`` are daily
+market-data series whose FRED observation date equals their publication
+date, so they carry a zero-day delay before the as-of join. ``NFCI`` is
+published every Wednesday and references the prior Friday's data
+window, so the row dated ``2024-04-12`` (a Friday) is not public until
+the following Wednesday (``2024-04-17``). The 5-day publication delay
+captured in ``rates_panel_publication_delays_days[nfci]`` shifts every
+``NFCI`` reference date forward by five calendar days before the
+as-of-< join.
 
 No look-ahead
 -------------
@@ -115,6 +144,12 @@ DEFAULT_LOCK_KEY = "macro_state"
 # FRED series IDs used by this module. Order is significant: it pins the
 # SOURCES.lock entry shape and tests can iterate the tuple to validate
 # the API contract.
+#
+# The first six entries are the monthly activity + inflation panel. The
+# trailing six entries are the daily/weekly rates + financial-conditions
+# panel; their observation dates are publication dates (no 30-day
+# BLS/BEA delay), and each carries an explicit per-series delay through
+# :data:`RATES_PANEL_PUBLICATION_DELAYS_DAYS`.
 FRED_SERIES_IDS: tuple[str, ...] = (
     "UNRATE",
     "CPIAUCSL",
@@ -122,6 +157,12 @@ FRED_SERIES_IDS: tuple[str, ...] = (
     "MANEMP",
     "PAYEMS",
     "RSAFS",
+    "DGS10",
+    "T10Y2Y",
+    "T10Y3M",
+    "BAMLH0A0HYM2",
+    "NFCI",
+    "DFII10",
 )
 
 # Default conservative publication delay (in calendar days) applied to
@@ -130,6 +171,34 @@ FRED_SERIES_IDS: tuple[str, ...] = (
 # starts; 30 days matches the long-run median lag of the bundled
 # macro-release calendar.
 DEFAULT_PUBLICATION_DELAY_DAYS: int = 30
+
+# Per-series publication delays for the rates + financial-conditions
+# panel. Daily Treasury / spread / OAS / TIPS series share their FRED
+# observation date with their publication date, so the delay is zero.
+# ``NFCI`` is weekly: each Friday-dated observation is released the
+# following Wednesday, so its publication delay is 5 calendar days.
+# This mapping persists into the SOURCES.lock entry so the contract is
+# auditable from the artefact alone.
+RATES_PANEL_PUBLICATION_DELAYS_DAYS: dict[str, int] = {
+    "DGS10": 0,
+    "T10Y2Y": 0,
+    "T10Y3M": 0,
+    "BAMLH0A0HYM2": 0,
+    "NFCI": 5,
+    "DFII10": 0,
+}
+
+# Mapping from FRED series id to the output column name used in the
+# parquet schema. Pinned alongside :data:`COLUMN_ORDER` so column-order
+# drift surfaces in the unit tests.
+RATES_PANEL_COLUMN_BY_SERIES: dict[str, str] = {
+    "DGS10": "treas_10y",
+    "T10Y2Y": "slope_10y_2y",
+    "T10Y3M": "slope_10y_3m",
+    "BAMLH0A0HYM2": "hy_oas",
+    "NFCI": "nfci",
+    "DFII10": "tips_10y_real",
+}
 
 # Output column order. Pinned for determinism + tests.
 COLUMN_ORDER: tuple[str, ...] = (
@@ -140,6 +209,12 @@ COLUMN_ORDER: tuple[str, ...] = (
     "ism_proxy",
     "payems_mom",
     "rsafs_mom",
+    "treas_10y",
+    "slope_10y_2y",
+    "slope_10y_3m",
+    "hy_oas",
+    "nfci",
+    "tips_10y_real",
     "ism_proxy_source",
     "publication_delay_days",
     "data_version",
@@ -210,6 +285,17 @@ def _monthly_observations(series: FredSeriesResponse) -> list[_MonthlyObservatio
         out.append(_MonthlyObservation(reference_date=d, value=float(obs.value)))
     out.sort(key=lambda r: r.reference_date)
     return out
+
+
+def _level_observations(series: FredSeriesResponse) -> list[_MonthlyObservation]:
+    """Reduce a daily/weekly FRED response to sorted ``(date, value)`` pairs.
+
+    Identical to :func:`_monthly_observations`. The alias clarifies intent
+    at the call site: rates-panel series carry level data with daily or
+    weekly cadence and are not transformed before the as-of join.
+    """
+
+    return _monthly_observations(series)
 
 
 def _shifted_publication_index(
@@ -394,7 +480,7 @@ def build_macro_state(
     payems = _monthly_observations(fred_responses["PAYEMS"])
     rsafs = _monthly_observations(fred_responses["RSAFS"])
 
-    # Transforms
+    # Transforms (monthly panel).
     unrate_index = _shifted_publication_index(unrate, delay_days=publication_delay_days)
     cpi_yoy_index = _shifted_publication_index(
         _yoy_log_change(cpi), delay_days=publication_delay_days
@@ -412,6 +498,20 @@ def build_macro_state(
         _mom_pct_change(rsafs), delay_days=publication_delay_days
     )
 
+    # Rates + financial-conditions panel (level series, per-series
+    # publication delays). Daily series ship with a 0-day delay; NFCI
+    # ships with a 5-day delay anchoring the Friday-prior-week reference
+    # to a Wednesday publication. Each panel entry produces one index of
+    # ``(publication_date, value)`` pairs that the as-of-< join reads
+    # strictly before every target date.
+    rates_panel_indices: dict[str, list[tuple[_dt.date, float]]] = {}
+    for series_id in RATES_PANEL_COLUMN_BY_SERIES:
+        delay = RATES_PANEL_PUBLICATION_DELAYS_DAYS[series_id]
+        observations = _level_observations(fred_responses[series_id])
+        rates_panel_indices[series_id] = _shifted_publication_index(
+            observations, delay_days=delay
+        )
+
     # As-of date set.
     if as_of_dates is None:
         target_dates = _business_days(start, end)
@@ -426,6 +526,10 @@ def build_macro_state(
         _, ism_val = _value_strictly_before(ism_proxy_index, d)
         _, pay_val = _value_strictly_before(payems_mom_index, d)
         _, rsa_val = _value_strictly_before(rsafs_mom_index, d)
+        rates_panel_values: dict[str, float | None] = {}
+        for series_id, column_name in RATES_PANEL_COLUMN_BY_SERIES.items():
+            _, panel_val = _value_strictly_before(rates_panel_indices[series_id], d)
+            rates_panel_values[column_name] = _round(_clean_float(panel_val))
         rows.append(
             {
                 "as_of_date": d.isoformat(),
@@ -435,6 +539,7 @@ def build_macro_state(
                 "ism_proxy": _round(_clean_float(ism_val)),
                 "payems_mom": _round(_clean_float(pay_val)),
                 "rsafs_mom": _round(_clean_float(rsa_val)),
+                **rates_panel_values,
                 "ism_proxy_source": ISM_PROXY_SOURCE_LABEL,
                 "publication_delay_days": int(publication_delay_days),
             }
@@ -497,6 +602,12 @@ def _data_version_hash(
     target_dates: Sequence[_dt.date],
 ) -> str:
     parts: list[str] = [f"delay={publication_delay_days}"]
+    # Rates-panel per-series delays land in the hash so the lock changes
+    # whenever the publication-delay contract for a panel series moves.
+    for series_id in sorted(RATES_PANEL_PUBLICATION_DELAYS_DAYS):
+        parts.append(
+            f"rates_delay|{series_id}={RATES_PANEL_PUBLICATION_DELAYS_DAYS[series_id]}"
+        )
     for series_id in sorted(series_responses):
         resp = series_responses[series_id]
         parts.append(f"{series_id}|{resp.observation_end}|{resp.count}")
@@ -589,6 +700,10 @@ def update_sources_lock(
         "fred_series": list(artifacts.fred_series_used),
         "rows": int(artifacts.rows_written),
         "publication_delay_days": int(artifacts.publication_delay_days),
+        "rates_panel_publication_delays_days": dict(
+            RATES_PANEL_PUBLICATION_DELAYS_DAYS
+        ),
+        "rates_panel_columns": dict(RATES_PANEL_COLUMN_BY_SERIES),
         "data_version": artifacts.data_version,
         "value_hash": artifacts.value_hash,
         "ism_proxy_source": ISM_PROXY_SOURCE_LABEL,
@@ -726,6 +841,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                     i=_fmt(row["ism_proxy"]),
                     pa=_fmt(row["payems_mom"]),
                     r=_fmt(row["rsafs_mom"]),
+                )
+            )
+            print(
+                "    rates: treas_10y={t10} slope_10y_2y={s2} slope_10y_3m={s3} hy_oas={oas} nfci={n} tips_10y_real={tr}".format(
+                    t10=_fmt(row["treas_10y"]),
+                    s2=_fmt(row["slope_10y_2y"]),
+                    s3=_fmt(row["slope_10y_3m"]),
+                    oas=_fmt(row["hy_oas"]),
+                    n=_fmt(row["nfci"]),
+                    tr=_fmt(row["tips_10y_real"]),
                 )
             )
     return 0

--- a/backend/app/data/schemas.py
+++ b/backend/app/data/schemas.py
@@ -674,6 +674,15 @@ _MACRO_STATE_COLUMNS: dict[str, Column] = {
     "ism_proxy": Column(float, nullable=True, required=True, coerce=True),
     "payems_mom": Column(float, nullable=True, required=True, coerce=True),
     "rsafs_mom": Column(float, nullable=True, required=True, coerce=True),
+    # Rates + financial-conditions panel. All level columns, nullable so
+    # the contract degrades cleanly when an as-of date sits inside a
+    # holiday cluster where no upstream observation is published.
+    "treas_10y": Column(float, nullable=True, required=True, coerce=True),
+    "slope_10y_2y": Column(float, nullable=True, required=True, coerce=True),
+    "slope_10y_3m": Column(float, nullable=True, required=True, coerce=True),
+    "hy_oas": Column(float, nullable=True, required=True, coerce=True),
+    "nfci": Column(float, nullable=True, required=True, coerce=True),
+    "tips_10y_real": Column(float, nullable=True, required=True, coerce=True),
     "ism_proxy_source": Column(
         str,
         Check(lambda s: s.map(_non_empty_str), element_wise=False),

--- a/backend/app/features/linguistic.py
+++ b/backend/app/features/linguistic.py
@@ -1100,6 +1100,51 @@ def write_linguistic_parquet(df: pd.DataFrame, output_path: Path) -> None:
     df.to_parquet(output_path, engine="pyarrow", index=False, compression="snappy")
 
 
+def update_sources_lock_for_linguistic_features(
+    *,
+    lock_path: Path,
+    parquet_path: Path,
+    frame: pd.DataFrame,
+    lock_key: str = "linguistic_features",
+) -> None:
+    """Persist provenance for the linguistic-features parquet.
+
+    Writes a JSON entry under ``lock_key`` recording the parquet
+    sha256, row count, column list, and retrieval timestamp so a
+    downstream consumer can confirm the parquet matches the documented
+    15-column contract without reading the file.
+    """
+
+    import datetime as _dt
+    import hashlib
+    import json as _json
+
+    digest = hashlib.sha256()
+    digest.update(parquet_path.read_bytes())
+    sha = digest.hexdigest()
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    existing: dict[str, object] = {}
+    if lock_path.exists():
+        try:
+            existing = _json.loads(lock_path.read_text(encoding="utf-8"))
+        except _json.JSONDecodeError:
+            existing = {}
+    feature_columns = [c for c in frame.columns if c != "text_hash"]
+    existing[lock_key] = {
+        "parquet_path": parquet_path.name,
+        "sha256": sha,
+        "rows": int(len(frame)),
+        "columns": list(frame.columns),
+        "feature_columns": feature_columns,
+        "feature_column_count": len(feature_columns),
+        "retrieved_at_utc": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+    }
+    lock_path.write_text(
+        _json.dumps(existing, indent=2, sort_keys=True), encoding="utf-8"
+    )
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -1143,6 +1188,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     if not output_path.is_absolute():
         output_path = package_dir / output_path
     write_linguistic_parquet(frame, output_path)
+    update_sources_lock_for_linguistic_features(
+        lock_path=package_dir / "SOURCES.lock",
+        parquet_path=output_path,
+        frame=frame,
+    )
 
     model_path = Path(args.model_output)
     if not model_path.is_absolute():

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -84,6 +84,20 @@ encoders:
     task: sentence_embedding
     description: Nomic embed text v1.5. Sentence-embedding encoder; second bake-off entry alongside BGE.
 
+  voyage_finance_2:
+    repo: voyageai/voyage-finance-2
+    revision: voyage-finance-2
+    gated: true
+    task: sentence_embedding
+    description: |
+      Voyage AI voyage-finance-2 sentence-embedding encoder (1024-dim,
+      finance-tuned). Served by Voyage's hosted REST API, not the
+      Hugging Face hub, so the cache builder lives at
+      ``scripts/cache_voyage_embeddings.py`` rather than going through
+      ``app.data.embedding_cache``. ``VOYAGE_API_KEY`` must be set;
+      Voyage does not publish a checkpoint sha, so the revision field
+      pins the model name itself.
+
   finbert_fed_adjacent:
     repo: local/finbert-fed-adjacent
     revision: ""

--- a/backend/app/services/fred_client.py
+++ b/backend/app/services/fred_client.py
@@ -71,14 +71,18 @@ class FredSeriesResponse:
 
 def _resolve_api_key(api_key: str | None) -> str:
     if api_key:
-        return api_key
+        return api_key.strip()
     env_value = os.environ.get("FRED_API_KEY") or os.environ.get("FRED_TOKEN")
     if not env_value:
         raise RuntimeError(
             "FRED_API_KEY (or FRED_TOKEN) not set. Get a free key at "
             "https://fred.stlouisfed.org/docs/api/api_key.html."
         )
-    return env_value
+    # Strip surrounding whitespace -- env-file editors often leave a
+    # trailing space after the value, which httpx URL-encodes to ``+``
+    # and FRED rejects with a 400. The defensive strip keeps the
+    # builder usable against operator-edited dotenv files.
+    return env_value.strip()
 
 
 def _cache_paths(series_id: str, cache_dir: Path) -> tuple[Path, Path]:

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -293,6 +293,70 @@ The output parquet lands under `data/external/fred/`. Pass
 `--methodology ff_futures` only when a real CME settlement source has
 been wired (out of scope for #146).
 
+### `macro_state.parquet` — FOMC decision-eve macro snapshot
+
+Path: `data/external/fred/macro_state.parquet`. Built by
+`backend/app/data/macro_state.py`; closes #147. One row per business
+day in `[start, end]` carrying the last published value strictly
+before that day for every FRED indicator listed below. The as-of join
+applies `publication_delay_days` (default 30) to monthly observations
+to mirror the conservative BLS / BEA release lag.
+
+Columns (twelve numeric series plus the four bookkeeping columns):
+
+| column            | FRED series      | transform                                    |
+| ----------------- | ---------------- | -------------------------------------------- |
+| `unrate`          | `UNRATE`         | level (% civilian unemployment)              |
+| `cpi_yoy`         | `CPIAUCSL`       | 12-month log-change × 100 (% YoY)            |
+| `core_pce_yoy`    | `PCEPILFE`       | 12-month log-change × 100 (% YoY)            |
+| `ism_proxy`       | `MANEMP`         | 3-month % change (documented NAPM proxy)     |
+| `payems_mom`      | `PAYEMS`         | MoM change in thousands of jobs              |
+| `rsafs_mom`       | `RSAFS`          | MoM % change in retail sales                 |
+| `treas_10y`       | `DGS10`          | level (% 10y Treasury constant maturity)     |
+| `slope_10y_2y`    | `T10Y2Y`         | level (% 10y - 2y slope)                     |
+| `slope_10y_3m`    | `T10Y3M`         | level (% 10y - 3m slope, recession signal)   |
+| `hy_oas`          | `BAMLH0A0HYM2`   | level (% ICE BofA HY OAS)                    |
+| `nfci`            | `NFCI`           | level (Chicago Fed NFCI; 5-day pub delay)    |
+| `tips_10y_real`   | `DFII10`         | level (% 10y TIPS real yield)                |
+
+Plus `as_of_date` (ISO date string), `ism_proxy_source`
+(`MANEMP_3m_pct`), `publication_delay_days` (monthly-panel delay), and
+`data_version` (short sha over FRED inputs + rates-panel delay map).
+Daily Treasury / spread / OAS / TIPS series ship with a zero-day
+publication delay; NFCI carries a 5-day delay so a Friday-dated print
+is visible the following Wednesday. The SOURCES.lock entry persists
+the per-series delay map and the column mapping so the join contract
+round-trips through the artefact.
+
+CLI:
+
+```
+python -m app.data.macro_state \
+    --start 2010-01-01 --end today \
+    --output data/external/fred/macro_state.parquet
+```
+
+## Encoder embedding cache
+
+Sentence-embedding and chunk-pool encoders cache one parquet per
+`(encoder_alias, training_package_id)` under
+`data/raw/embeddings/<encoder_alias>_<rev_slug>.parquet`. Each row has
+`record_id`, `doc_id`, `event_date`, `chunk_index`, `chunk_preview`,
+and a `embedding` list. The per-encoder SOURCES.lock at
+`data/raw/embeddings/SOURCES.lock` is JSON Lines (one entry per
+encoder revision) and carries the encoder alias, model repo /
+revision, registry sha256, parquet sha256, row count, and retrieval
+timestamp.
+
+The cache set covers the bake-off encoders shipped through
+`backend/app/data/embedding_cache.py` (FinBERT, FinBERT-FOMC,
+BGE-large-en-v1.5, Nomic-embed-text-v1.5, FinBERT-fed-adjacent,
+BERT-base-fed-adjacent) plus voyage-finance-2 (1024-dim,
+finance-tuned) served by the hosted Voyage REST API. Voyage entries
+land via `scripts/cache_voyage_embeddings.py --allow-network`; the
+SOURCES.lock format is identical to the Hugging Face encoders so a
+downstream consumer reads voyage rows with no shape change.
+
 ## Structured linguistic features (Phase 8)
 
 `backend/app/features/linguistic.py` emits a 15-dim interpretable
@@ -444,11 +508,19 @@ Per-meeting feature row at meeting `N`:
   `fed_info_factor`, and the `ff_target_prior` / `ff_target_after`
   used to reconstruct the target.
 - `linguistic_features.parquet` (`data/processed/<pkg>/`) joins on
-  `text_hash` and contributes the 14 structured features from #149.
+  `text_hash` and contributes the 15 structured features
+  (14 from #149 plus `pivot_distance` from #166).
 - `macro_state.parquet` (`data/external/fred/`) provides per-as-of-date
   snapshots of UNRATE, CPI YoY, core PCE YoY, ISM proxy
   (`MANEMP_3m_pct`, documented substitute for the paywalled NAPM
-  series), nonfarm-payroll MoM change, and retail-sales MoM.
+  series), nonfarm-payroll MoM change, retail-sales MoM, and the
+  rates + financial-conditions panel: 10-year Treasury yield
+  (`treas_10y`), 10y-2y slope (`slope_10y_2y`), 10y-3m slope
+  (`slope_10y_3m`), ICE BofA High-Yield OAS (`hy_oas`), Chicago Fed
+  National Financial Conditions Index (`nfci`, 5-day publication
+  delay), and 10y TIPS real yield (`tips_10y_real`). Twelve numeric
+  columns in total alongside `as_of_date`, `ism_proxy_source`,
+  `publication_delay_days`, and `data_version`.
 
 ### OIS-implied baseline (sigma = 12.5 bp)
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -41,6 +41,9 @@ ignore = [
 # Tests are intentionally not a package (no __init__.py) and test
 # fixtures naturally pile up positional arguments.
 "tests/**/*.py" = ["C901", "PLR0913", "INP001"]
+# Scripts are top-level entrypoints, not a package; CLI builders accept a
+# fan-out of keyword arguments by design.
+"scripts/**/*.py" = ["C901", "PLR0913", "INP001"]
 # Backend-side debt is keyed in backend/pyproject.toml; root invocations
 # delegate to it implicitly by ignoring the same rules on backend paths.
 "backend/app/audit.py" = ["PLR0913"]

--- a/scripts/cache_voyage_embeddings.py
+++ b/scripts/cache_voyage_embeddings.py
@@ -297,6 +297,8 @@ def cache_voyage_embeddings(
         pending_inputs.clear()
         pending_meta.clear()
 
+    progress_step = 200
+    last_progress_at = started_at
     with httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS) as client:
         for record in _iter_registry(registry_path, min_text_chars=min_text_chars):
             if max_docs and docs_processed >= max_docs:
@@ -314,6 +316,17 @@ def cache_voyage_embeddings(
             docs_processed += 1
             if len(pending_inputs) >= batch_size:
                 _flush(client)
+            if docs_processed % progress_step == 0:
+                now = time.time()
+                docs_per_sec = (
+                    progress_step / max(now - last_progress_at, 1e-6)
+                )
+                last_progress_at = now
+                print(
+                    f"[voyage] progress docs={docs_processed} "
+                    f"rate={docs_per_sec:.1f}/s elapsed={now - started_at:.0f}s",
+                    flush=True,
+                )
         _flush(client)
 
     elapsed = time.time() - started_at

--- a/scripts/cache_voyage_embeddings.py
+++ b/scripts/cache_voyage_embeddings.py
@@ -299,35 +299,48 @@ def cache_voyage_embeddings(
 
     progress_step = 200
     last_progress_at = started_at
+    aborted_at_doc: int | None = None
     with httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS) as client:
-        for record in _iter_registry(registry_path, min_text_chars=min_text_chars):
-            if max_docs and docs_processed >= max_docs:
-                break
-            text = str(record["text"]).strip()
-            doc_id = _doc_id(record)
-            record_id = str(record.get("record_id") or doc_id)
-            event_date = str(record["event_date"]).strip()
-            preview = text[:preview_chars]
-            # voyage-finance-2 is a sentence-embedding encoder; one
-            # row per document with chunk_index=0 matches the cache
-            # shape that BGE / Nomic already write.
-            pending_inputs.append(text)
-            pending_meta.append((record_id, doc_id, event_date, 0, preview))
-            docs_processed += 1
-            if len(pending_inputs) >= batch_size:
-                _flush(client)
-            if docs_processed % progress_step == 0:
-                now = time.time()
-                docs_per_sec = (
-                    progress_step / max(now - last_progress_at, 1e-6)
-                )
-                last_progress_at = now
-                print(
-                    f"[voyage] progress docs={docs_processed} "
-                    f"rate={docs_per_sec:.1f}/s elapsed={now - started_at:.0f}s",
-                    flush=True,
-                )
-        _flush(client)
+        try:
+            for record in _iter_registry(registry_path, min_text_chars=min_text_chars):
+                if max_docs and docs_processed >= max_docs:
+                    break
+                text = str(record["text"]).strip()
+                doc_id = _doc_id(record)
+                record_id = str(record.get("record_id") or doc_id)
+                event_date = str(record["event_date"]).strip()
+                preview = text[:preview_chars]
+                # voyage-finance-2 is a sentence-embedding encoder; one
+                # row per document with chunk_index=0 matches the cache
+                # shape that BGE / Nomic already write.
+                pending_inputs.append(text)
+                pending_meta.append((record_id, doc_id, event_date, 0, preview))
+                docs_processed += 1
+                if len(pending_inputs) >= batch_size:
+                    _flush(client)
+                if docs_processed % progress_step == 0:
+                    now = time.time()
+                    docs_per_sec = (
+                        progress_step / max(now - last_progress_at, 1e-6)
+                    )
+                    last_progress_at = now
+                    print(
+                        f"[voyage] progress docs={docs_processed} "
+                        f"rate={docs_per_sec:.1f}/s elapsed={now - started_at:.0f}s",
+                        flush=True,
+                    )
+            _flush(client)
+        except (httpx.HTTPError, RuntimeError) as exc:
+            aborted_at_doc = docs_processed
+            print(
+                f"[voyage] WARNING transient failure at docs={docs_processed}: "
+                f"{type(exc).__name__}: {exc}",
+                flush=True,
+            )
+            print(
+                f"[voyage] persisting {len(rows)} rows collected so far before exit.",
+                flush=True,
+            )
 
     elapsed = time.time() - started_at
     print(
@@ -369,6 +382,7 @@ def cache_voyage_embeddings(
         "sha256": parquet_sha,
         "sources_lock_path": sources_lock_path,
         "embedding_dim": int(len(df["embedding"].iloc[0])),
+        "aborted_at_doc": aborted_at_doc,
     }
 
 
@@ -461,10 +475,14 @@ def main(argv: list[str] | None = None) -> int:
             f"(rows={result['rows']}, sha256={result['sha256'][:12]})"
         )
     else:
+        aborted = result.get("aborted_at_doc")
+        suffix = ""
+        if aborted is not None:
+            suffix = f" (PARTIAL -- aborted at doc {aborted})"
         print(
             f"[voyage] parquet={result['parquet_path']} "
             f"rows={result['rows']} embedding_dim={result['embedding_dim']} "
-            f"sha256={result['sha256'][:12]}"
+            f"sha256={result['sha256'][:12]}{suffix}"
         )
     return 0
 

--- a/scripts/cache_voyage_embeddings.py
+++ b/scripts/cache_voyage_embeddings.py
@@ -1,0 +1,460 @@
+"""Cache voyage-finance-2 sentence embeddings for the FOMC corpus.
+
+The Voyage AI ``voyage-finance-2`` model is a 1024-dim finance-tuned
+sentence-embedding encoder. It is delivered through Voyage's hosted
+REST API rather than the Hugging Face hub, so it cannot be cached
+through :mod:`app.data.embedding_cache` (which loads a HF tokenizer +
+model). This script mirrors the existing cache's parquet schema so the
+downstream chunk-embedding consumer reads voyage rows with no shape
+change.
+
+The output parquet lives at
+``data/raw/embeddings/voyage_finance_2_<slug>.parquet`` with columns
+``record_id, doc_id, event_date, chunk_index, chunk_preview,
+embedding``. A SOURCES.lock entry under
+``data/raw/embeddings/SOURCES.lock`` carries the encoder alias, model
+name, parquet sha256, registry sha256, row count, and retrieval
+timestamp -- one JSON line per encoder, matching the format used by
+the embedding_cache writer.
+
+The Voyage API expects ``input`` as a list of strings (or one string)
+and returns embeddings sized ``embed_dim`` per input. We batch up to
+:data:`DEFAULT_BATCH_SIZE` inputs per request and retry transient
+``429`` / ``5xx`` responses with exponential backoff.
+
+CLI
+---
+
+::
+
+    python scripts/cache_voyage_embeddings.py --allow-network \\
+        --training-package-id tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0
+
+The ``--allow-network`` flag must be passed explicitly. Without it the
+script hard-fails before contacting Voyage so accidental network calls
+on a training-time path raise a clear error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKEND_PATH = REPO_ROOT / "backend"
+if str(BACKEND_PATH) not in sys.path:
+    sys.path.insert(0, str(BACKEND_PATH))
+
+import httpx  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from app.config import DATA_DIR  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_CACHE_DIR = DATA_DIR / "raw" / "embeddings"
+DEFAULT_MODEL = "voyage-finance-2"
+DEFAULT_ENCODER_ALIAS = "voyage_finance_2"
+DEFAULT_TRAINING_PACKAGE_ID = (
+    "tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0"
+)
+DEFAULT_MIN_TEXT_CHARS = 64
+DEFAULT_PREVIEW_CHARS = 200
+DEFAULT_BATCH_SIZE = 32
+DEFAULT_MAX_DOCS = 0  # 0 = no cap
+DEFAULT_INPUT_TYPE = "document"
+DEFAULT_TIMEOUT_SECONDS = 60.0
+DEFAULT_API_BASE = "https://api.voyageai.com/v1/embeddings"
+SOURCES_LOCK_NAME = "SOURCES.lock"
+
+# Retry policy for transient failures (429 + 5xx).
+MAX_RETRIES = 5
+INITIAL_BACKOFF_SECONDS = 2.0
+MAX_BACKOFF_SECONDS = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _short_slug(value: str, length: int = 12) -> str:
+    """Return a short, filesystem-safe slug for a model name."""
+
+    return value.replace("/", "_").replace("-", "_")[:length]
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _doc_id(record: dict[str, Any]) -> str:
+    raw = (
+        record.get("record_id")
+        or record.get("source_record_id")
+        or record.get("text_hash")
+    )
+    if isinstance(raw, str) and raw:
+        return raw
+    text = str(record.get("text", "")).strip()
+    return hashlib.sha256(text.encode("utf-8", errors="ignore")).hexdigest()[:24]
+
+
+def _iter_registry(path: Path, *, min_text_chars: int) -> Iterator[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            text = str(record.get("text", "")).strip()
+            event_date = str(record.get("event_date", "")).strip()
+            if not text or not event_date:
+                continue
+            if len(text) < min_text_chars:
+                continue
+            yield record
+
+
+# ---------------------------------------------------------------------------
+# Voyage REST client
+# ---------------------------------------------------------------------------
+
+
+def _resolve_api_key(api_key: str | None) -> str:
+    if api_key:
+        return api_key.strip()
+    env_value = os.environ.get("VOYAGE_API_KEY")
+    if not env_value:
+        raise RuntimeError(
+            "VOYAGE_API_KEY not set. Add it to .env or pass --api-key."
+        )
+    return env_value.strip()
+
+
+def _post_voyage_embeddings(
+    client: httpx.Client,
+    *,
+    api_url: str,
+    api_key: str,
+    inputs: list[str],
+    model: str,
+    input_type: str,
+) -> list[list[float]]:
+    """POST one batch to the Voyage embeddings endpoint with retries.
+
+    Treats 429 + 5xx as transient and applies exponential backoff. Any
+    other status raises ``httpx.HTTPStatusError``.
+    """
+
+    payload = {
+        "model": model,
+        "input": inputs,
+        "input_type": input_type,
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    backoff = INITIAL_BACKOFF_SECONDS
+    last_exc: Exception | None = None
+    for _attempt in range(MAX_RETRIES):
+        try:
+            response = client.post(api_url, json=payload, headers=headers)
+        except httpx.HTTPError as exc:  # noqa: PERF203 -- network retries
+            last_exc = exc
+            time.sleep(min(backoff, MAX_BACKOFF_SECONDS))
+            backoff *= 2
+            continue
+        if response.status_code == 429 or 500 <= response.status_code < 600:
+            last_exc = httpx.HTTPStatusError(
+                f"voyage transient {response.status_code}",
+                request=response.request,
+                response=response,
+            )
+            time.sleep(min(backoff, MAX_BACKOFF_SECONDS))
+            backoff *= 2
+            continue
+        response.raise_for_status()
+        body = response.json()
+        rows = body.get("data") or []
+        # Voyage returns rows in input order, but each carries an
+        # ``index`` field. Sort by index to keep ordering robust.
+        rows_sorted = sorted(rows, key=lambda r: int(r.get("index", 0)))
+        return [list(r["embedding"]) for r in rows_sorted]
+    raise RuntimeError(
+        f"voyage embedding call failed after {MAX_RETRIES} attempts"
+    ) from last_exc
+
+
+# ---------------------------------------------------------------------------
+# Main flow
+# ---------------------------------------------------------------------------
+
+
+def cache_voyage_embeddings(
+    *,
+    training_package_id: str,
+    model: str,
+    encoder_alias: str,
+    data_dir: Path,
+    cache_dir: Path,
+    batch_size: int,
+    max_docs: int,
+    min_text_chars: int,
+    preview_chars: int,
+    input_type: str,
+    allow_network: bool,
+    api_key: str | None,
+    api_url: str,
+    force: bool,
+) -> dict[str, Any]:
+    """Compute + persist the voyage-finance-2 embedding parquet.
+
+    Returns a dict carrying the parquet path, row count, sha256, and
+    SOURCES.lock entry. The dict is suitable for printing or for a
+    downstream test harness that wants to assert the contract without
+    re-reading the parquet from disk.
+    """
+
+    registry_path = (
+        data_dir / "processed" / training_package_id / "registry_normalized.jsonl"
+    )
+    if not registry_path.exists():
+        raise FileNotFoundError(
+            f"Missing training-package registry at {registry_path}. "
+            "Run pipeline_data_prep before caching voyage embeddings."
+        )
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    slug = _short_slug(model)
+    parquet_path = cache_dir / f"{encoder_alias}_{slug}.parquet"
+    sources_lock_path = cache_dir / SOURCES_LOCK_NAME
+
+    if parquet_path.exists() and not force:
+        existing = pd.read_parquet(parquet_path)
+        return {
+            "parquet_path": parquet_path,
+            "rows": int(len(existing)),
+            "reused_existing_cache": True,
+            "sha256": _file_sha256(parquet_path),
+            "sources_lock_path": sources_lock_path,
+        }
+
+    if not allow_network:
+        raise RuntimeError(
+            f"Voyage embedding cache missing at {parquet_path}. "
+            "Re-run with --allow-network to call the Voyage REST API."
+        )
+
+    api_key_resolved = _resolve_api_key(api_key)
+    rows: list[dict[str, Any]] = []
+    pending_inputs: list[str] = []
+    pending_meta: list[tuple[str, str, str, int, str]] = []
+    docs_processed = 0
+    started_at = time.time()
+
+    def _flush(client: httpx.Client) -> None:
+        if not pending_inputs:
+            return
+        embeddings = _post_voyage_embeddings(
+            client,
+            api_url=api_url,
+            api_key=api_key_resolved,
+            inputs=pending_inputs,
+            model=model,
+            input_type=input_type,
+        )
+        for (record_id, doc_id, event_date, chunk_index, preview), embedding in zip(
+            pending_meta, embeddings, strict=False
+        ):
+            rows.append(
+                {
+                    "record_id": record_id,
+                    "doc_id": doc_id,
+                    "event_date": event_date,
+                    "chunk_index": chunk_index,
+                    "chunk_preview": preview,
+                    "embedding": embedding,
+                }
+            )
+        pending_inputs.clear()
+        pending_meta.clear()
+
+    with httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS) as client:
+        for record in _iter_registry(registry_path, min_text_chars=min_text_chars):
+            if max_docs and docs_processed >= max_docs:
+                break
+            text = str(record["text"]).strip()
+            doc_id = _doc_id(record)
+            record_id = str(record.get("record_id") or doc_id)
+            event_date = str(record["event_date"]).strip()
+            preview = text[:preview_chars]
+            # voyage-finance-2 is a sentence-embedding encoder; one
+            # row per document with chunk_index=0 matches the cache
+            # shape that BGE / Nomic already write.
+            pending_inputs.append(text)
+            pending_meta.append((record_id, doc_id, event_date, 0, preview))
+            docs_processed += 1
+            if len(pending_inputs) >= batch_size:
+                _flush(client)
+        _flush(client)
+
+    elapsed = time.time() - started_at
+    print(
+        f"[voyage] encoder={encoder_alias} model={model} docs={docs_processed} "
+        f"rows={len(rows)} elapsed={elapsed:.1f}s"
+    )
+
+    df = pd.DataFrame(rows)
+    if df.empty:
+        raise RuntimeError(
+            "Voyage cache build produced zero rows -- "
+            "check the registry path and min_text_chars filter."
+        )
+    df["event_date"] = df["event_date"].astype(str)
+    df.to_parquet(parquet_path, index=False)
+
+    parquet_sha = _file_sha256(parquet_path)
+    registry_sha = _file_sha256(registry_path)
+    entry = {
+        "encoder_alias": encoder_alias,
+        "encoder_repo": f"voyageai/{model}",
+        "encoder_revision": model,
+        "encoder_task": "sentence_embedding",
+        "training_package_id": training_package_id,
+        "registry_sha256": registry_sha,
+        "parquet_relpath": parquet_path.name,
+        "parquet_sha256": parquet_sha,
+        "row_count": int(len(df)),
+        "embedding_dim": int(len(df["embedding"].iloc[0])),
+        "retrieved_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    with sources_lock_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+    return {
+        "parquet_path": parquet_path,
+        "rows": int(len(df)),
+        "reused_existing_cache": False,
+        "sha256": parquet_sha,
+        "sources_lock_path": sources_lock_path,
+        "embedding_dim": int(len(df["embedding"].iloc[0])),
+    }
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Cache voyage-finance-2 sentence embeddings for a training "
+            "package. The default training-package-id targets the v2 "
+            "sprint-1 sentiment+market-core package."
+        )
+    )
+    parser.add_argument(
+        "--training-package-id",
+        default=DEFAULT_TRAINING_PACKAGE_ID,
+        help="Training-package id under data/processed/.",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help="Voyage model name (default: voyage-finance-2).",
+    )
+    parser.add_argument(
+        "--encoder-alias",
+        default=DEFAULT_ENCODER_ALIAS,
+        help="Encoder alias slug used in the parquet filename and the lock entry.",
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=os.environ.get("FED_PULSE_DATA_DIR") or str(DATA_DIR),
+    )
+    parser.add_argument("--cache-dir", default=None)
+    parser.add_argument(
+        "--batch-size", type=int, default=DEFAULT_BATCH_SIZE
+    )
+    parser.add_argument("--max-docs", type=int, default=DEFAULT_MAX_DOCS)
+    parser.add_argument(
+        "--min-text-chars", type=int, default=DEFAULT_MIN_TEXT_CHARS
+    )
+    parser.add_argument(
+        "--preview-chars", type=int, default=DEFAULT_PREVIEW_CHARS
+    )
+    parser.add_argument(
+        "--input-type",
+        default=DEFAULT_INPUT_TYPE,
+        choices=("document", "query"),
+        help="Voyage input-type marker (default: document).",
+    )
+    parser.add_argument("--api-url", default=DEFAULT_API_BASE)
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help="VOYAGE_API_KEY override. Reads VOYAGE_API_KEY from env if absent.",
+    )
+    parser.add_argument(
+        "--allow-network",
+        action="store_true",
+        help="Required to call the Voyage REST API. Defensive default off.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force re-build even if the parquet already exists.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    data_dir = Path(args.data_dir)
+    cache_dir = Path(args.cache_dir) if args.cache_dir else DEFAULT_CACHE_DIR
+    result = cache_voyage_embeddings(
+        training_package_id=args.training_package_id,
+        model=args.model,
+        encoder_alias=args.encoder_alias,
+        data_dir=data_dir,
+        cache_dir=cache_dir,
+        batch_size=args.batch_size,
+        max_docs=args.max_docs,
+        min_text_chars=args.min_text_chars,
+        preview_chars=args.preview_chars,
+        input_type=args.input_type,
+        allow_network=args.allow_network,
+        api_key=args.api_key,
+        api_url=args.api_url,
+        force=args.force,
+    )
+    if result.get("reused_existing_cache"):
+        print(
+            f"[voyage] reused existing cache at {result['parquet_path']} "
+            f"(rows={result['rows']}, sha256={result['sha256'][:12]})"
+        )
+    else:
+        print(
+            f"[voyage] parquet={result['parquet_path']} "
+            f"rows={result['rows']} embedding_dim={result['embedding_dim']} "
+            f"sha256={result['sha256'][:12]}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_macro_state.py
+++ b/tests/unit/test_macro_state.py
@@ -61,11 +61,19 @@ def _series_payload(
     }
 
 
+def _daily_dates(start: _dt.date, count: int) -> list[_dt.date]:
+    return [start + _dt.timedelta(days=i) for i in range(count)]
+
+
 def _build_canned_fred_responses() -> dict[str, fred_client.FredSeriesResponse]:
-    """Hand-built FRED responses covering 2018-2024 monthly.
+    """Hand-built FRED responses covering 2018-2024.
 
     Values are smoothly increasing per series so YoY / MoM transforms
     produce non-zero, non-NaN signals that the as-of join can read.
+    The monthly panel uses month-start reference dates; the rates +
+    financial-conditions panel uses daily reference dates for the
+    Treasury / spread / OAS / TIPS series, and weekly Friday reference
+    dates for NFCI.
     """
 
     months = _months_of(_dt.date(2018, 1, 1), 84)  # 7 years
@@ -97,6 +105,33 @@ def _build_canned_fred_responses() -> dict[str, fred_client.FredSeriesResponse]:
         # Parse via fred_client's own parser so we get the same shape
         # the production code will see.
         responses[sid] = fred_client._parse_observations(payload, sid)
+
+    # Daily rates panel: 7 years of calendar-daily observations. Values
+    # are smooth so every as-of date inside the canned window finds a
+    # non-NaN strictly-before value.
+    daily_dates = _daily_dates(_dt.date(2018, 1, 1), 365 * 7)
+    daily_series_inputs = {
+        "DGS10": [2.0 + 0.001 * i for i in range(len(daily_dates))],
+        "T10Y2Y": [0.5 - 0.0002 * i for i in range(len(daily_dates))],
+        "T10Y3M": [0.7 - 0.0003 * i for i in range(len(daily_dates))],
+        "BAMLH0A0HYM2": [3.5 + 0.0005 * i for i in range(len(daily_dates))],
+        "DFII10": [0.4 + 0.0001 * i for i in range(len(daily_dates))],
+    }
+    for sid, vals in daily_series_inputs.items():
+        observations = [(d.isoformat(), v) for d, v in zip(daily_dates, vals)]
+        payload = _series_payload(observations)
+        responses[sid] = fred_client._parse_observations(payload, sid)
+
+    # NFCI: weekly Friday observations. 2018-01-05 is the first Friday
+    # of 2018; every subsequent observation lands 7 days later.
+    first_friday = _dt.date(2018, 1, 5)
+    n_weeks = 52 * 7
+    nfci_dates = [first_friday + _dt.timedelta(days=7 * i) for i in range(n_weeks)]
+    nfci_vals = [-0.5 + 0.001 * i for i in range(n_weeks)]
+    nfci_observations = [(d.isoformat(), v) for d, v in zip(nfci_dates, nfci_vals)]
+    responses["NFCI"] = fred_client._parse_observations(
+        _series_payload(nfci_observations), "NFCI"
+    )
     return responses
 
 
@@ -164,6 +199,127 @@ def test_build_macro_state_raises_on_missing_series() -> None:
             end=_dt.date(2020, 6, 30),
             fred_responses=responses,
         )
+
+
+def test_rates_panel_columns_present_and_typed() -> None:
+    """The 12-column macro panel emits the rates + financial-conditions slice."""
+
+    responses = _build_canned_fred_responses()
+    artifacts = macro_state.build_macro_state(
+        start=_dt.date(2022, 1, 3),
+        end=_dt.date(2022, 1, 7),
+        fred_responses=responses,
+        publication_delay_days=30,
+    )
+    df = artifacts.frame
+    rates_columns = (
+        "treas_10y",
+        "slope_10y_2y",
+        "slope_10y_3m",
+        "hy_oas",
+        "nfci",
+        "tips_10y_real",
+    )
+    for column in rates_columns:
+        assert column in df.columns, f"missing rates-panel column {column}"
+        # Daily-cadence canned data covers the window, so every row
+        # must read a non-None value off the strictly-before join.
+        non_null = df[column].dropna()
+        assert not non_null.empty, f"rates-panel column {column} has no rows"
+        # Every non-null value must coerce to float (level data).
+        for v in non_null:
+            assert isinstance(v, float), f"{column} value not float: {v!r}"
+
+
+def test_macro_state_column_order_pins_rates_panel_layout() -> None:
+    """``COLUMN_ORDER`` lists the rates panel between rsafs_mom and ism_proxy_source."""
+
+    order = list(macro_state.COLUMN_ORDER)
+    assert order.index("rsafs_mom") < order.index("treas_10y")
+    assert order.index("tips_10y_real") < order.index("ism_proxy_source")
+    rates_layout = (
+        "treas_10y",
+        "slope_10y_2y",
+        "slope_10y_3m",
+        "hy_oas",
+        "nfci",
+        "tips_10y_real",
+    )
+    rates_positions = [order.index(c) for c in rates_layout]
+    assert rates_positions == sorted(rates_positions), (
+        f"rates panel columns out of contiguous order: {rates_positions}"
+    )
+
+
+def test_nfci_publication_delay_is_five_days() -> None:
+    """NFCI carries a 5-day publication delay; the daily series carry zero."""
+
+    delays = macro_state.RATES_PANEL_PUBLICATION_DELAYS_DAYS
+    assert delays["NFCI"] == 5
+    for series_id in ("DGS10", "T10Y2Y", "T10Y3M", "BAMLH0A0HYM2", "DFII10"):
+        assert delays[series_id] == 0, (
+            f"{series_id} should carry a zero-day publication delay"
+        )
+
+
+def test_nfci_publication_delay_pushes_friday_observation_to_following_thursday() -> None:
+    """The 5-day shift parks each Friday NFCI observation strictly after
+    the following Tuesday, so a Wednesday as-of-date reading strictly-<
+    sees the prior Friday's print only after the Wednesday publication
+    window has closed.
+    """
+
+    responses = _build_canned_fred_responses()
+    # 2022-04-08 (Friday) NFCI observation -> publication on 2022-04-13
+    # (Wednesday) under the 5-day delay. A Wednesday-2022-04-13 as-of
+    # date reading strictly-< must therefore NOT see the 2022-04-08
+    # value yet; a Thursday-2022-04-14 as-of date MUST see it.
+    as_of_dates = [_dt.date(2022, 4, 13), _dt.date(2022, 4, 14)]
+    artifacts = macro_state.build_macro_state(
+        start=_dt.date(2022, 1, 1),
+        end=_dt.date(2022, 12, 31),
+        fred_responses=responses,
+        as_of_dates=as_of_dates,
+    )
+    by_date = {row["as_of_date"]: row for _, row in artifacts.frame.iterrows()}
+    wednesday = by_date["2022-04-13"]
+    thursday = by_date["2022-04-14"]
+    # Wednesday: the latest NFCI observation visible is 2022-04-01
+    # (pub_date 2022-04-06, strictly before 2022-04-13). Thursday: the
+    # 2022-04-08 observation has pub_date 2022-04-13, strictly before
+    # 2022-04-14, so it is now visible. The two reads must therefore
+    # come from different observation rows, i.e. their NFCI values
+    # differ.
+    assert wednesday["nfci"] is not None
+    assert thursday["nfci"] is not None
+    assert thursday["nfci"] != wednesday["nfci"]
+
+
+def test_sources_lock_records_rates_panel_publication_delays(tmp_path: Path) -> None:
+    """SOURCES.lock carries the rates-panel column map + delay map so the
+    publication-delay contract round-trips through the parquet."""
+
+    responses = _build_canned_fred_responses()
+    artifacts = macro_state.build_macro_state(
+        start=_dt.date(2022, 1, 3),
+        end=_dt.date(2022, 1, 7),
+        fred_responses=responses,
+    )
+    output_path = tmp_path / "macro_state.parquet"
+    sha = macro_state.write_macro_state_parquet(artifacts.frame, output_path)
+    lock_path = tmp_path / fred_client.SOURCES_LOCK_NAME
+    macro_state.update_sources_lock(
+        lock_path=lock_path,
+        artifacts=artifacts,
+        parquet_path=output_path,
+        parquet_sha256=sha,
+    )
+    entry = json.loads(lock_path.read_text())[macro_state.DEFAULT_LOCK_KEY]
+    assert entry["rates_panel_publication_delays_days"]["NFCI"] == 5
+    assert entry["rates_panel_publication_delays_days"]["DGS10"] == 0
+    assert entry["rates_panel_columns"]["DGS10"] == "treas_10y"
+    assert entry["rates_panel_columns"]["NFCI"] == "nfci"
+    assert set(entry["fred_series"]) == set(macro_state.FRED_SERIES_IDS)
 
 
 def test_publication_delay_shifts_as_of_window() -> None:

--- a/tests/unit/test_pipeline_schemas.py
+++ b/tests/unit/test_pipeline_schemas.py
@@ -173,6 +173,12 @@ def _macro_state_row(**overrides) -> dict:
         "ism_proxy": 0.1,
         "payems_mom": 200_000.0,
         "rsafs_mom": 0.005,
+        "treas_10y": 4.0,
+        "slope_10y_2y": 0.45,
+        "slope_10y_3m": -0.20,
+        "hy_oas": 400.0,
+        "nfci": -0.30,
+        "tips_10y_real": 2.0,
         "ism_proxy_source": "MANEMP_3m_pct",
     }
     base.update(overrides)

--- a/tests/unit/test_training_package_loader.py
+++ b/tests/unit/test_training_package_loader.py
@@ -780,3 +780,51 @@ def test_rich_features_ignored_when_mp_parquet_missing(
     # Linguistic + mp-surprise slices zero (parquet missing).
     assert target[RICH_LINGUISTIC_SLICE] == [0.0] * RICH_LINGUISTIC_DIM
     assert target[RICH_MP_SURPRISE_SLICE] == [0.0] * RICH_MP_SURPRISE_DIM
+
+
+def test_rebuilt_assets_drive_nonzero_mp_surprise_and_pivot_distance(
+    rich_feature_package_dir: Path,
+) -> None:
+    """End-to-end contract: post-rebuild parquets put nonzero values in
+    both the MP-surprise slice and the ``pivot_distance`` position of
+    the linguistic slice.
+
+    The rich_feature_package_dir fixture mirrors the shape produced by
+    the post-PR-#173 emitters (``mp_surprises.parquet`` keyed on
+    ``event_date`` and ``linguistic_features.parquet`` with the
+    15-column schema including ``pivot_distance``). This test confirms
+    that the rebuilt artefacts feed the rich-feature slice without
+    falling back to the all-zeros path that the pre-PR-#173 loader hit.
+    """
+
+    sequences = loaders.load_training_sequences_from_package(
+        _RICH_PACKAGE_ID, rich_features=True
+    )
+    assert len(sequences) == 3
+
+    # ``pivot_distance`` sits at the trailing slot of the linguistic
+    # 15-vector (column index 14 within ``_LINGUISTIC_FEATURE_COLUMNS``).
+    pivot_distance_offset = RICH_LINGUISTIC_DIM - 1
+    pivot_distance_global = RICH_LINGUISTIC_SLICE.start + pivot_distance_offset
+
+    nonzero_pivot_seen = False
+    nonzero_mp_seen = False
+    for sequence in sequences:
+        for vector in sequence:
+            if vector.date.startswith("2024-03"):
+                # hash_no_ling has no linguistic row -> the slice
+                # collapses to zero by design; skip when validating
+                # pivot_distance is wired.
+                continue
+            rich = vector.as_rich_list()
+            if rich[pivot_distance_global] != 0.0:
+                nonzero_pivot_seen = True
+            if rich[RICH_MP_SURPRISE_SLICE][0] != 0.0:
+                nonzero_mp_seen = True
+    assert nonzero_pivot_seen, (
+        "linguistic_features.parquet rebuild did not feed pivot_distance "
+        "into the rich-feature slice"
+    )
+    assert nonzero_mp_seen, (
+        "mp_surprises.parquet did not feed the MP-surprise slice"
+    )


### PR DESCRIPTION
## Summary

- Extend FRED_SERIES_IDS with the rates + financial-conditions panel (DGS10, T10Y2Y, T10Y3M, BAMLH0A0HYM2, NFCI, DFII10). macro_state.parquet now ships 12 numeric columns; NFCI carries a 5-day publication delay, the rest ship a zero-day delay.
- Build the canonical macro_state.parquet under data/external/fred/ with a SOURCES.lock entry that persists the per-series delay map and column mapping.
- Build mp_surprises.parquet under data/external/fred/ with the existing SOURCES.lock entry. Closes the dead-slice fallback that PR #173's loader hit.
- Rebuild linguistic_features.parquet for tp_v2_sprint1_2026_05_15... so the pivot_distance column from #166 is present in the slice the rich-feature loader reads.
- Cache voyage-finance-2 embeddings via the Voyage REST API and persist the parquet under data/raw/embeddings/. Adds the sixth encoder to the bake-off cache set.
- Four Makefile targets (build-macro-state, build-mp-surprises, rebuild-linguistic-features, cache-voyage-embeddings) so the build is reproducible.
- Tests cover the new rates-panel columns, the NFCI 5-day publication delay, and an end-to-end check that the rich-feature loader picks up the rebuilt MP-surprise + linguistic columns.
- docs/data-and-training-contracts.md documents the 12-column macro panel + the encoder cache shape including voyage-finance-2.

## Test plan

- [ ] `pytest tests/unit/test_macro_state.py tests/unit/test_training_package_loader.py -q`
- [ ] `make build-macro-state && make build-mp-surprises` (re-runs are idempotent against cached FRED responses).
- [ ] `data/raw/embeddings/voyage_finance_2_*.parquet` exists with the documented shape.

Follows #173.