### PR TITLE
Forecaster consumes pooled text embeddings via encoder-agnostic adapter (time-decay over prior-4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-credibility-train
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train
 
 help:
 	@echo "Targets:"
@@ -60,8 +60,9 @@ help:
 	@echo "                         - Cache voyage-finance-2 embeddings for the FOMC corpus"
 	@echo "  make next-fomc        - Predict next-FOMC decision (Phase 8 headline, #147)"
 	@echo "  make cross-asset      - Cross-asset abnormal-return response head (Phase 8, #148)"
-	@echo "  make forecaster-sweep         - 8-arch x 5-seed forecaster sweep, rich-feature input (35 dim)"
+	@echo "  make forecaster-sweep         - 8-arch x 5-seed forecaster sweep, rich-feature input + text-embedding adapter (TEXT_ENCODER=<alias>)"
 	@echo "  make forecaster-sweep-baseline - 6-arch x 5-seed forecaster sweep, legacy 6-feature input"
+	@echo "  make forecaster-sweep-shuffled-control - Memorisation-control row: same architectures + seeds, median HP, --shuffle-targets-control on"
 	@echo "  make forecaster-sweep-aggregate - Aggregate sweep trials into per-arch CIs"
 	@echo "  make forecaster-credibility-train - Single training run with credibility features on"
 
@@ -146,6 +147,7 @@ FORECASTER_COMPOSE_PROFILE ?= gpu
 
 forecaster-sweep:
 	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	@test -n "$(TEXT_ENCODER)" || (echo "TEXT_ENCODER is required (e.g. finbert, voyage_finance_2, or 'none' for the text-off row)"; exit 1)
 	docker compose --profile "$(FORECASTER_COMPOSE_PROFILE)" run --rm "$(FORECASTER_COMPOSE_SERVICE)" \
 		python -m app.train_forecaster \
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
@@ -153,7 +155,40 @@ forecaster-sweep:
 		--rich-features \
 		--architectures lstm lstm_attn gru tcn transformer dlinear informer tft \
 		--seeds 11 29 47 71 97 \
+		--hidden-sizes 32 64 128 \
+		--num-layers-grid 1 2 3 \
+		--dropouts 0.1 0.2 0.3 0.4 \
+		--learning-rates 1e-3 3e-4 \
+		--weight-decays 0 1e-4 1e-3 \
+		--text-encoder "$(TEXT_ENCODER)" \
+		--text-adapter-dims 32 64 128 \
 		--report-path "/data/artifacts/forecaster_sweep/$(TRAINING_PACKAGE_ID)/forecaster_sweep_results.json"
+
+# Memorisation control: one median-HP combo across all architectures
+# and the five seeds, with --shuffle-targets-control on. A model whose
+# real-targets RMSE is close to its shuffled-targets RMSE is memorising
+# rather than learning the input-target mapping. Output lands beside
+# the main sweep under a distinct filename so the aggregator picks it
+# up as the shuffled-control row.
+forecaster-sweep-shuffled-control:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	@test -n "$(TEXT_ENCODER)" || (echo "TEXT_ENCODER is required"; exit 1)
+	docker compose --profile "$(FORECASTER_COMPOSE_PROFILE)" run --rm "$(FORECASTER_COMPOSE_SERVICE)" \
+		python -m app.train_forecaster \
+		--training-package-id "$(TRAINING_PACKAGE_ID)" \
+		--sweep \
+		--rich-features \
+		--architectures lstm lstm_attn gru tcn transformer dlinear informer tft \
+		--seeds 11 29 47 71 97 \
+		--hidden-sizes 64 \
+		--num-layers-grid 2 \
+		--dropouts 0.2 \
+		--learning-rates 1e-3 \
+		--weight-decays 0 \
+		--text-encoder "$(TEXT_ENCODER)" \
+		--text-adapter-dims 64 \
+		--shuffle-targets-control \
+		--report-path "/data/artifacts/forecaster_sweep/$(TRAINING_PACKAGE_ID)/shuffled_control_forecaster_sweep_results.json"
 
 forecaster-sweep-baseline:
 	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)

--- a/backend/app/data/embedding_cache.py
+++ b/backend/app/data/embedding_cache.py
@@ -54,7 +54,11 @@ class CachePaths:
 def _short_revision(revision: str, length: int = 12) -> str:
     if not revision:
         return "unpinned"
-    return revision[:length]
+    # Cache writers (e.g. ``scripts/cache_voyage_embeddings.py``) normalise
+    # path-unsafe characters in the revision slug so a hyphenated tag like
+    # ``voyage-finance-2`` lands on disk as ``..._voyage_finan.parquet``.
+    # Match that normalisation here so the loader resolves the same name.
+    return revision.replace("-", "_").replace("/", "_")[:length]
 
 
 def resolve_cache_paths(

--- a/backend/app/evaluation/forecaster_sweep_aggregator.py
+++ b/backend/app/evaluation/forecaster_sweep_aggregator.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
@@ -40,6 +40,23 @@ class ArchitectureRow:
     combined_rmse_ci: BootstrapCI
     close_rmse_ci: BootstrapCI
     volatility_rmse_ci: BootstrapCI
+    # Mitigation 4: per-row train + val RMSE and the gap derivative.
+    # ``train_rmse_values`` and ``val_rmse_values`` collect every trial
+    # under the architecture (one per seed x HP combo); the aggregator
+    # bootstraps the mean and emits a ``gap_flag`` when the mean gap
+    # crosses 0.5. The headline "val" label maps to the holdout-side
+    # RMSE the loop reports as ``combined_rmse``; "train" is the
+    # final-state training-set RMSE captured by
+    # ``TrainingRunSummary.train_metrics``. Defaults stay zero-valued
+    # so older callers / unit fixtures that predate the train-metrics
+    # column build a row without naming them.
+    train_rmse_values: list[float] = field(default_factory=list)
+    val_rmse_values: list[float] = field(default_factory=list)
+    train_rmse_ci: BootstrapCI | None = None
+    val_rmse_ci: BootstrapCI | None = None
+    holdout_train_gap: float = 0.0
+    gap_flag: str = "ok"
+    target_mode: str = "real"
 
 
 def _load_report(path: Path) -> dict[str, Any]:
@@ -102,18 +119,57 @@ def _trial_credibility(trial: dict[str, Any]) -> bool:
     return bool(model_config.get("credibility_features", False))
 
 
+def _trial_train_metric(trial: dict[str, Any], key: str) -> float | None:
+    summary = trial.get("summary") or {}
+    train_metrics = summary.get("train_metrics") or {}
+    value = train_metrics.get(key)
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _trial_target_mode(trial: dict[str, Any]) -> str:
+    summary = trial.get("summary") or {}
+    mode = summary.get("target_mode")
+    if isinstance(mode, str) and mode:
+        return mode
+    return "real"
+
+
+def _bucket_key(architecture: str, target_mode: str) -> str:
+    """Compose the dict key the aggregator groups by.
+
+    Shuffled-target trials sit in a separate bucket so the
+    memorisation-control row does not contaminate the headline table.
+    The key is ``"<architecture>"`` for ``target_mode == "real"`` and
+    ``"<architecture>::shuffled"`` otherwise.
+    """
+
+    if target_mode == "real":
+        return architecture
+    return f"{architecture}::{target_mode}"
+
+
 def _collect_per_architecture(reports: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     by_arch: dict[str, dict[str, Any]] = {}
     for report in reports:
         for trial in report.get("trials") or []:
             architecture = _trial_architecture(trial)
+            target_mode = _trial_target_mode(trial)
+            key = _bucket_key(architecture, target_mode)
             bucket = by_arch.setdefault(
-                architecture,
+                key,
                 {
+                    "architecture": architecture,
+                    "target_mode": target_mode,
                     "seeds": [],
                     "combined_rmse": [],
                     "close_rmse": [],
                     "volatility_rmse": [],
+                    "train_combined_rmse": [],
                     "credibility_features": _trial_credibility(trial),
                 },
             )
@@ -130,6 +186,9 @@ def _collect_per_architecture(reports: list[dict[str, Any]]) -> dict[str, dict[s
             vol = _trial_metric(trial, "volatility_rmse")
             if vol is not None:
                 bucket["volatility_rmse"].append(vol)
+            train_combined = _trial_train_metric(trial, "combined_rmse")
+            if train_combined is not None:
+                bucket["train_combined_rmse"].append(train_combined)
             # Once any credibility-on trial lands for an architecture the
             # bucket flips on so the headline label stays honest.
             bucket["credibility_features"] = bucket["credibility_features"] or _trial_credibility(trial)
@@ -145,19 +204,30 @@ def _build_rows(
     seed: int,
 ) -> list[ArchitectureRow]:
     rows: list[ArchitectureRow] = []
-    for architecture, payload in by_arch.items():
+    for _bucket_key_str, payload in by_arch.items():
         if not payload["combined_rmse"]:
             continue
+        architecture = str(payload.get("architecture", _bucket_key_str))
+        target_mode = str(payload.get("target_mode", "real"))
+        train_values = list(payload.get("train_combined_rmse") or [])
+        val_values = list(payload["combined_rmse"])
+        train_mean = (sum(train_values) / len(train_values)) if train_values else 0.0
+        val_mean = sum(val_values) / len(val_values) if val_values else 0.0
+        if train_mean > 0.0:
+            gap = (val_mean - train_mean) / train_mean
+        else:
+            gap = 0.0
+        gap_flag = "high" if gap > 0.5 else "ok"
         rows.append(
             ArchitectureRow(
                 architecture=architecture,
                 seeds=sorted(set(payload["seeds"])),
                 credibility_features=bool(payload["credibility_features"]),
-                combined_rmse_values=list(payload["combined_rmse"]),
+                combined_rmse_values=val_values,
                 close_rmse_values=list(payload["close_rmse"]),
                 volatility_rmse_values=list(payload["volatility_rmse"]),
                 combined_rmse_ci=block_bootstrap_ci(
-                    payload["combined_rmse"],
+                    val_values,
                     statistic="mean",
                     block_size=block_size,
                     n_resamples=n_resamples,
@@ -180,10 +250,34 @@ def _build_rows(
                     coverage=coverage,
                     seed=seed,
                 ),
+                train_rmse_values=train_values,
+                val_rmse_values=val_values,
+                train_rmse_ci=block_bootstrap_ci(
+                    train_values or [0.0],
+                    statistic="mean",
+                    block_size=block_size,
+                    n_resamples=n_resamples,
+                    coverage=coverage,
+                    seed=seed,
+                ),
+                val_rmse_ci=block_bootstrap_ci(
+                    val_values,
+                    statistic="mean",
+                    block_size=block_size,
+                    n_resamples=n_resamples,
+                    coverage=coverage,
+                    seed=seed,
+                ),
+                holdout_train_gap=float(gap),
+                gap_flag=gap_flag,
+                target_mode=target_mode,
             )
         )
     # Lower combined-RMSE is better, so ascending sort gives rank order.
-    rows.sort(key=lambda r: r.combined_rmse_ci.point)
+    # Real-target rows sort first so the headline table is the
+    # production-relevant ranking; shuffled rows trail underneath in
+    # the same ascending order.
+    rows.sort(key=lambda r: (0 if r.target_mode == "real" else 1, r.combined_rmse_ci.point))
     return rows
 
 
@@ -191,41 +285,84 @@ def render_markdown(rows: list[ArchitectureRow], *, coverage: float) -> str:
     if not rows:
         return "_no forecaster sweep rows found_\n"
     coverage_pct = int(round(coverage * 100))
-    lines = [
-        f"| Rank | Architecture | Credibility | n | combined-RMSE (mean, {coverage_pct}% CI) | close-RMSE | volatility-RMSE |",
-        "|---:|---|:-:|---:|---|---|---|",
-    ]
-    for rank, row in enumerate(rows, start=1):
-        n = len(row.combined_rmse_values)
-        cr = row.combined_rmse_ci
-        c = row.close_rmse_ci
-        v = row.volatility_rmse_ci
+
+    real_rows = [row for row in rows if row.target_mode == "real"]
+    shuffled_rows = [row for row in rows if row.target_mode != "real"]
+
+    lines: list[str] = []
+    if real_rows:
         lines.append(
-            f"| {rank} | `{row.architecture}` | {'on' if row.credibility_features else 'off'} | {n} | "
-            f"{cr.point:.4f} [{cr.lo:.4f}, {cr.hi:.4f}] | "
-            f"{c.point:.4f} [{c.lo:.4f}, {c.hi:.4f}] | "
-            f"{v.point:.4f} [{v.lo:.4f}, {v.hi:.4f}] |"
+            f"| Rank | Architecture | Credibility | n | mode | train-RMSE | holdout-RMSE | holdout/train gap | combined-RMSE (mean, {coverage_pct}% CI) | close-RMSE | volatility-RMSE |"
         )
+        lines.append("|---:|---|:-:|---:|:-:|---|---|---:|---|---|---|")
+        for rank, row in enumerate(real_rows, start=1):
+            lines.append(_render_row_line(row, rank, coverage_pct))
+
+    if shuffled_rows:
+        lines.append("")
+        lines.append("### Shuffled-targets control")
+        lines.append("")
+        lines.append(
+            f"| Rank | Architecture | Credibility | n | mode | train-RMSE | holdout-RMSE | holdout/train gap | combined-RMSE (mean, {coverage_pct}% CI) | close-RMSE | volatility-RMSE |"
+        )
+        lines.append("|---:|---|:-:|---:|:-:|---|---|---:|---|---|---|")
+        for rank, row in enumerate(shuffled_rows, start=1):
+            lines.append(_render_row_line(row, rank, coverage_pct))
+
     return "\n".join(lines) + "\n"
+
+
+def _render_row_line(row: ArchitectureRow, rank: int, coverage_pct: int) -> str:
+    n = len(row.combined_rmse_values)
+    cr = row.combined_rmse_ci
+    c = row.close_rmse_ci
+    v = row.volatility_rmse_ci
+    train_ci = row.train_rmse_ci
+    val_ci = row.val_rmse_ci
+    gap_text = f"{row.holdout_train_gap:+.3f}"
+    if row.gap_flag == "high":
+        gap_text = f"{gap_text}!"
+    return (
+        f"| {rank} | `{row.architecture}` | "
+        f"{'on' if row.credibility_features else 'off'} | {n} | "
+        f"{row.target_mode} | "
+        f"{train_ci.point:.4f} [{train_ci.lo:.4f}, {train_ci.hi:.4f}] | "
+        f"{val_ci.point:.4f} [{val_ci.lo:.4f}, {val_ci.hi:.4f}] | "
+        f"{gap_text} | "
+        f"{cr.point:.4f} [{cr.lo:.4f}, {cr.hi:.4f}] | "
+        f"{c.point:.4f} [{c.lo:.4f}, {c.hi:.4f}] | "
+        f"{v.point:.4f} [{v.lo:.4f}, {v.hi:.4f}] |"
+    )
 
 
 def _row_to_json(row: ArchitectureRow) -> dict[str, Any]:
     return {
         "architecture": row.architecture,
+        "target_mode": row.target_mode,
         "seeds": row.seeds,
         "credibility_features": row.credibility_features,
         "combined_rmse": {
             "values": row.combined_rmse_values,
-            "ci": asdict(row.combined_rmse_ci),
+            "ci": asdict(row.combined_rmse_ci) if row.combined_rmse_ci is not None else None,
         },
         "close_rmse": {
             "values": row.close_rmse_values,
-            "ci": asdict(row.close_rmse_ci),
+            "ci": asdict(row.close_rmse_ci) if row.close_rmse_ci is not None else None,
         },
         "volatility_rmse": {
             "values": row.volatility_rmse_values,
-            "ci": asdict(row.volatility_rmse_ci),
+            "ci": asdict(row.volatility_rmse_ci) if row.volatility_rmse_ci is not None else None,
         },
+        "train_rmse": {
+            "values": row.train_rmse_values,
+            "ci": asdict(row.train_rmse_ci) if row.train_rmse_ci is not None else None,
+        },
+        "val_rmse": {
+            "values": row.val_rmse_values,
+            "ci": asdict(row.val_rmse_ci) if row.val_rmse_ci is not None else None,
+        },
+        "holdout_train_gap": row.holdout_train_gap,
+        "gap_flag": row.gap_flag,
     }
 
 

--- a/backend/app/evaluation/metrics.py
+++ b/backend/app/evaluation/metrics.py
@@ -36,6 +36,12 @@ class TrainingRunSummary:
     checkpoint_saved: bool
     best_epoch: int | None = None
     metrics: EvaluationMetrics | None = None
+    train_metrics: EvaluationMetrics | None = None
+    weight_decay: float = 1e-4
+    target_mode: str = "real"
+    text_encoder: str | None = None
+    text_adapter_dim: int = 0
+    text_pool_lambda_inv_days: float = 0.0
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -81,6 +81,37 @@ RICH_MULTI_AXIS_SLICE = slice(
     RICH_MP_SURPRISE_SLICE.stop + RICH_MULTI_AXIS_DIM,
 )
 
+# Text-embedding adapter dim search axis. The forecaster sweep iterates
+# over these values so the diminishing-returns curve across {32, 64, 128}
+# shows up in the aggregator table. The default mirrors the small-data
+# regime: 64 dims is enough capacity to register the encoder signal
+# without overfitting the ~895 training sequences.
+DEFAULT_TEXT_ADAPTER_DIM = 64
+TEXT_ADAPTER_DIM_CHOICES: tuple[int, ...] = (32, 64, 128)
+
+# Default time-decay window for the prior-4 statement pooling
+# (softmax(-Delta t / lambda_inv_days)). 30 days places roughly half the
+# weight on the most recent statement when the prior FOMC release was
+# 45 days ago; the sweep can override this through the CLI.
+DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS = 30.0
+
+
+def rich_feature_size_with_text(text_adapter_dim: int) -> int:
+    """Return the per-bar input size when the text-embedding path is on.
+
+    The scalar slice stays at ``RICH_FEATURE_SIZE`` (35). The adapter
+    projection contributes another ``text_adapter_dim`` dims that the
+    model broadcasts to every bar of the prior window plus the
+    event-day target frame. The trailing ``+1`` is the missing flag the
+    loader emits when fewer than one prior statement is available.
+    """
+
+    if text_adapter_dim <= 0:
+        raise ValueError(
+            f"text_adapter_dim must be a positive integer; got {text_adapter_dim}"
+        )
+    return RICH_FEATURE_SIZE + int(text_adapter_dim) + 1
+
 FORECAST_CONFIDENCE_LEVEL = 0.8
 CONFIDENCE_Z_SCORE = 1.2816  # Approximate central 80% interval
 DEFAULT_CLOSE_SCALE = 10000.0
@@ -128,6 +159,14 @@ class ModelConfig:
     embedding_adapter_dim: int = 128
     credibility_features: bool = False
     architecture: str = "lstm"
+    # Pooled text-embedding path (PR #176 onward). ``text_embedding_dim``
+    # is the encoder-native dim of the pooled vector the loader emits
+    # (FinBERT 768, voyage-finance-2 1024, ...); ``text_adapter_dim``
+    # is the projection target the recurrent core actually sees. Both
+    # default to ``0`` so any pre-existing checkpoint deserialises into
+    # the byte-identical no-text path.
+    text_embedding_dim: int = 0
+    text_adapter_dim: int = 0
 
     @classmethod
     def from_model(cls, model: "Any") -> "ModelConfig":
@@ -145,6 +184,8 @@ class ModelConfig:
             embedding_adapter_dim=getattr(model, "chunk_projection_dim", 128) or 128,
             credibility_features=bool(getattr(model, "credibility_features", False)),
             architecture=str(architecture),
+            text_embedding_dim=int(getattr(model, "text_embedding_dim", 0) or 0),
+            text_adapter_dim=int(getattr(model, "text_adapter_dim", 0) or 0),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -219,6 +260,18 @@ class FeatureVector:
     axis_time: float = 0.0
     axis_time_missing: float = 1.0
     rich_payload: bool = False
+    # Pooled text-embedding payload (PR #176 onward). Carries the
+    # variable-length encoder-output vector (FinBERT 768, voyage-finance-2
+    # 1024, BGE 1024, ...) materialised by the loader's softmax(-Delta t /
+    # lambda) weighted mean over the four most recent prior statements.
+    # The list stays empty (and ``text_embedding_missing`` stays at 1.0)
+    # on the legacy 6-feature path; the model factory only widens the
+    # recurrent input when the loader explicitly attaches a pooled
+    # vector. ``as_rich_list`` does NOT include this field — the
+    # projection happens inside the model's forward pass through the
+    # ``TextEmbeddingAdapter`` so the scalar slice stays at 35 dims.
+    text_embedding_pooled: list[float] = field(default_factory=list)
+    text_embedding_missing: float = 1.0
 
     @classmethod
     def from_market_state(

--- a/backend/app/models/lstm.py
+++ b/backend/app/models/lstm.py
@@ -49,6 +49,8 @@ class ForecasterModel(nn.Module):
         text_channel: str = "scalar",
         embedding_adapter_dim: int = 128,
         credibility_features: bool = False,
+        text_embedding_dim: int = 0,
+        text_adapter_dim: int = 0,
     ):
         """Forecaster LSTM with optional text-feature variants.
 
@@ -143,7 +145,38 @@ class ForecasterModel(nn.Module):
         else:
             self.chunk_pooler = None
             self.chunk_projection = None
-        lstm_input_size = input_size + self.chunk_projection_dim + self.credibility_dim
+        # Pooled-text-embedding path (PR #176 onward). The adapter
+        # projects the encoder-native pooled vector (``text_embedding_dim``)
+        # to a fixed ``text_adapter_dim`` slot that the recurrent core
+        # broadcasts to every bar of the prior window plus the
+        # event-day target frame. Both dims are 0 by default so a
+        # checkpoint trained without the text path forwards
+        # byte-identically. The trailing +1 (when the path is active)
+        # is the missing flag the loader emits when fewer than one
+        # prior statement is available.
+        self.text_embedding_dim = int(text_embedding_dim or 0)
+        self.text_adapter_dim = int(text_adapter_dim or 0)
+        self._text_path_active = self.text_embedding_dim > 0 and self.text_adapter_dim > 0
+        if self._text_path_active:
+            from app.models.text_embedding_adapter import TextEmbeddingAdapter
+
+            self.text_adapter: nn.Module | None = TextEmbeddingAdapter(
+                in_dim=self.text_embedding_dim,
+                out_dim=self.text_adapter_dim,
+                zero_init=True,
+            )
+            text_path_dim = self.text_adapter_dim + 1
+        else:
+            self.text_adapter = None
+            text_path_dim = 0
+        self.text_path_dim = text_path_dim
+
+        lstm_input_size = (
+            input_size
+            + self.chunk_projection_dim
+            + self.credibility_dim
+            + text_path_dim
+        )
         self.lstm_input_size = lstm_input_size
         lstm_dropout = dropout if num_layers > 1 else 0.0
         self.recurrent_core = self._build_recurrent_core(
@@ -176,6 +209,8 @@ class ForecasterModel(nn.Module):
         elapsed_days: torch.Tensor | None = None,
         chunk_mask: torch.Tensor | None = None,
         credibility: torch.Tensor | None = None,
+        text_embedding: torch.Tensor | None = None,
+        text_embedding_missing: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if self.use_time_decay:
             x = self.time_decay(x)
@@ -208,6 +243,43 @@ class ForecasterModel(nn.Module):
                 )
             seq_len = x.shape[1]
             broadcast = credibility.unsqueeze(1).expand(-1, seq_len, -1)
+            x = torch.cat([x, broadcast], dim=-1)
+        if self._text_path_active:
+            if self.text_adapter is None:
+                raise RuntimeError(
+                    "text_adapter not initialised but text-embedding path is active"
+                )
+            if text_embedding is None:
+                raise ValueError(
+                    "ForecasterModel requires `text_embedding` when text_adapter_dim > 0"
+                )
+            if text_embedding.dim() == 1:
+                text_embedding = text_embedding.unsqueeze(0)
+            if text_embedding.shape[-1] != self.text_embedding_dim:
+                raise ValueError(
+                    f"text_embedding tensor must have shape (..., {self.text_embedding_dim}); "
+                    f"got {tuple(text_embedding.shape)}"
+                )
+            projected = self.text_adapter(text_embedding)
+            if text_embedding_missing is None:
+                missing_column = torch.zeros(
+                    (projected.shape[0], 1), dtype=projected.dtype, device=projected.device
+                )
+            else:
+                missing_column = text_embedding_missing
+                if missing_column.dim() == 1:
+                    missing_column = missing_column.unsqueeze(-1)
+                missing_column = missing_column.to(dtype=projected.dtype, device=projected.device)
+            # When the missing flag is on, the pooled embedding is
+            # zeros by construction (the loader emits zeros + flag=1
+            # together). Multiply the adapter output by (1 - missing)
+            # so the recurrent core sees an unambiguous zero slot
+            # even if a future loader path emits non-zero placeholders.
+            keep_mask = (1.0 - missing_column).clamp_(min=0.0, max=1.0)
+            projected = projected * keep_mask
+            text_slot = torch.cat([projected, missing_column], dim=-1)
+            seq_len = x.shape[1]
+            broadcast = text_slot.unsqueeze(1).expand(-1, seq_len, -1)
             x = torch.cat([x, broadcast], dim=-1)
         output, _ = self.lstm(x)
         if self.uses_attention_pool:

--- a/backend/app/models/text_embedding_adapter.py
+++ b/backend/app/models/text_embedding_adapter.py
@@ -1,0 +1,95 @@
+"""Encoder-agnostic adapter for pooled FOMC statement embeddings.
+
+The forecaster consumes pooled text embeddings as a 5th feature family on
+top of the 35-dim rich-feature scalar input. The pooling logic (time-
+decay weighted mean over the prior-4 statement embeddings) lives in
+``app.training.loaders`` and produces a single ``in_dim``-vector per
+event. This module projects that vector to a fixed ``out_dim`` so the
+recurrent core sees the same per-bar feature size regardless of which
+encoder (FinBERT 768, voyage-finance-2 1024, BGE 1024, etc.) emitted
+the pooled embedding.
+
+Layer order is ``Linear -> LayerNorm -> GELU``. The linear stage is
+zero-initialised so a freshly activated text-embedding path forwards to
+the same point in feature space as the rich-features-only baseline; the
+adapter only departs from that subspace if gradients show the text
+signal reduces the loss. On ``in_dim`` mismatch the adapter projects
+zeros (the loader will have set the missing flag to ``1.0``) and the
+recurrent core sees the same zero-broadcast slot it gets when the
+encoder is disabled.
+"""
+
+from __future__ import annotations
+
+from torch import Tensor, nn
+
+
+class TextEmbeddingAdapter(nn.Module):
+    """Project a pooled text embedding from ``in_dim`` to ``out_dim``.
+
+    Parameters
+    ----------
+    in_dim:
+        Source embedding dim. FinBERT / FinBERT-FOMC / FinBERT-Fed-adjacent
+        emit 768; BGE-large / nomic-embed / voyage-finance-2 emit 1024.
+        The loader resolves the source dim from the embedding parquet
+        itself; the model constructor pins ``in_dim`` so a mismatched
+        run fails fast at the linear forward rather than silently
+        truncating.
+    out_dim:
+        Projection target. Default 64. The forecaster sweep iterates over
+        ``{32, 64, 128}`` so the diminishing-returns curve is visible in
+        the aggregator table.
+    zero_init:
+        When ``True`` (default) the linear weight and bias are zeroed
+        so the model starts byte-identical to the no-text-embedding
+        baseline and only departs when gradients lower the loss.
+
+    Forward contract
+    ----------------
+    Input  ``(batch, in_dim)``  -- the pooled embedding per event.
+    Output ``(batch, out_dim)`` -- the projected vector the recurrent
+    core broadcasts to every bar of the prior window + the event-day
+    target frame.
+    """
+
+    def __init__(
+        self,
+        in_dim: int,
+        out_dim: int = 64,
+        *,
+        zero_init: bool = True,
+    ) -> None:
+        super().__init__()
+        if in_dim <= 0:
+            raise ValueError(f"in_dim must be a positive integer; got {in_dim}")
+        if out_dim <= 0:
+            raise ValueError(f"out_dim must be a positive integer; got {out_dim}")
+        self.in_dim = int(in_dim)
+        self.out_dim = int(out_dim)
+        self.linear = nn.Linear(self.in_dim, self.out_dim, bias=True)
+        self.norm = nn.LayerNorm(self.out_dim)
+        self.activation = nn.GELU()
+        if zero_init:
+            nn.init.zeros_(self.linear.weight)
+            nn.init.zeros_(self.linear.bias)
+
+    @property
+    def out_features(self) -> int:
+        return self.out_dim
+
+    def forward(self, pooled: Tensor) -> Tensor:
+        if pooled.dim() == 1:
+            pooled = pooled.unsqueeze(0)
+        if pooled.shape[-1] != self.in_dim:
+            raise ValueError(
+                f"TextEmbeddingAdapter expected input of shape (..., {self.in_dim}); "
+                f"got {tuple(pooled.shape)}"
+            )
+        projected = self.linear(pooled)
+        normalised = self.norm(projected)
+        activated: Tensor = self.activation(normalised)
+        return activated
+
+
+__all__ = ["TextEmbeddingAdapter"]

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -12,7 +12,14 @@ from typing import Any, Sequence
 import torch
 
 from app.models import FORECASTER_ARCHITECTURES
-from app.models.config import FEATURE_SIZE, RICH_FEATURE_SIZE
+from app.models.config import (
+    DEFAULT_TEXT_ADAPTER_DIM,
+    DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS,
+    FEATURE_SIZE,
+    RICH_FEATURE_SIZE,
+    TEXT_ADAPTER_DIM_CHOICES,
+    rich_feature_size_with_text,
+)
 from app.services.forecaster import (
     BEST_MODEL_PATH,
     DEFAULT_BATCH_SIZE,
@@ -235,6 +242,89 @@ def _parse_args() -> argparse.Namespace:
         use_mp_surprise=True,
         use_multi_axis=True,
     )
+    # Text-embedding path. ``--text-encoder=none`` keeps the no-text
+    # path. ``--no-text-embeddings`` is the symmetric per-family flag
+    # that mirrors PR #173's per-family ablation pattern (model input
+    # shape stays constant; the embedding slot zeros out).
+    _TEXT_ENCODER_CHOICES = (
+        "none",
+        "finbert",
+        "finbert_fomc",
+        "finbert_fed_adjacent",
+        "bert_base_fed_adjacent",
+        "bge_large_en_v15",
+        "nomic_embed_text_v15",
+        "voyage_finance_2",
+    )
+    parser.add_argument(
+        "--text-encoder",
+        choices=_TEXT_ENCODER_CHOICES,
+        default="none",
+        help=(
+            "Encoder alias whose pooled FOMC statement embeddings the "
+            "forecaster consumes as a 5th feature family. The loader "
+            "pulls the per-statement embeddings from "
+            "data/raw/embeddings/<encoder>_<rev>.parquet and applies a "
+            "softmax(-Delta t / lambda) weighted mean over the four "
+            "most recent prior statements per event. Default 'none' "
+            "keeps the rich-features-only path byte-identical."
+        ),
+    )
+    parser.add_argument(
+        "--text-adapter-dim",
+        type=int,
+        choices=list(TEXT_ADAPTER_DIM_CHOICES),
+        default=DEFAULT_TEXT_ADAPTER_DIM,
+        help=(
+            "Projection target for the encoder-agnostic text-embedding "
+            "adapter. The sweep iterates over {32, 64, 128} so the "
+            "diminishing-returns curve across adapter widths is visible "
+            "in the aggregator table."
+        ),
+    )
+    parser.add_argument(
+        "--text-pool-lambda-inv-days",
+        type=float,
+        default=DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS,
+        help=(
+            "Time-decay window for the prior-4 statement pool. Smaller "
+            "values concentrate the weight on the most recent statement, "
+            "larger values spread the weight across all four."
+        ),
+    )
+    parser.add_argument(
+        "--no-text-embeddings",
+        dest="use_text_embeddings",
+        action="store_false",
+        help=(
+            "Zero the text-embedding slice while keeping the model "
+            "input shape constant. Mirrors the per-family ablation "
+            "pattern from PR #173 -- the model architecture is fixed "
+            "across the with/without rows so a single sweep can "
+            "measure text-embedding lift without retraining."
+        ),
+    )
+    parser.add_argument(
+        "--shuffle-targets-control",
+        action="store_true",
+        help=(
+            "Permute the target column per fold (seed-fixed) before "
+            "training. macro-RMSE on the shuffled-targets run should "
+            "sit near the constant-mean predictor; a real-targets run "
+            "whose RMSE is close to its shuffled counterpart is "
+            "memorising, not learning."
+        ),
+    )
+    parser.add_argument(
+        "--weight-decay",
+        type=float,
+        default=1e-4,
+        help=(
+            "AdamW weight decay. Default 1e-4 preserves the pre-PR-#176 "
+            "regularisation; the sweep searches over {0, 1e-4, 1e-3}."
+        ),
+    )
+    parser.set_defaults(use_text_embeddings=True)
     parser.add_argument(
         "--sweep",
         action="store_true",
@@ -269,6 +359,22 @@ def _parse_args() -> argparse.Namespace:
         nargs="+",
         type=int,
         help="Grid-search values for epochs.",
+    )
+    parser.add_argument(
+        "--weight-decays",
+        nargs="+",
+        type=float,
+        help="Grid-search values for AdamW weight decay.",
+    )
+    parser.add_argument(
+        "--text-adapter-dims",
+        nargs="+",
+        type=int,
+        choices=list(TEXT_ADAPTER_DIM_CHOICES),
+        help=(
+            "Grid-search values for the text-embedding adapter "
+            "projection dim. Ignored when --text-encoder=none."
+        ),
     )
     parser.add_argument(
         "--report-path",
@@ -310,15 +416,27 @@ def _parse_args() -> argparse.Namespace:
     return args
 
 
+def _text_path_active(args: argparse.Namespace) -> bool:
+    """Return True when the text-embedding path is wired for this run."""
+
+    encoder = str(getattr(args, "text_encoder", "none") or "none")
+    use_text = bool(getattr(args, "use_text_embeddings", True))
+    use_package_path = bool(getattr(args, "training_package_id", None))
+    return encoder != "none" and use_text and use_package_path
+
+
 def _resolved_input_size(args: argparse.Namespace) -> int:
-    """Return the per-bar input size implied by the rich-feature flag.
+    """Return the per-bar scalar input size implied by the rich-feature flag.
 
     The rich-feature input only takes effect when the loader actually
     populates the rich payload (``--training-package-id`` set AND
     ``--rich-features`` on). On the legacy ``--data-dir`` JSON / JSONL
     path the per-bar size stays at ``FEATURE_SIZE`` regardless of the
     flag, so the regression-test contract on the
-    ``--data-dir`` code path is unaffected.
+    ``--data-dir`` code path is unaffected. The text-embedding adapter
+    slot is widened separately inside ``ForecasterModel`` via
+    ``text_adapter_dim`` so this scalar size stays at 35 even when
+    text embeddings are on.
     """
 
     rich_on = bool(getattr(args, "rich_features", False))
@@ -326,6 +444,46 @@ def _resolved_input_size(args: argparse.Namespace) -> int:
     if rich_on and use_package_path:
         return RICH_FEATURE_SIZE
     return FEATURE_SIZE
+
+
+def _resolved_text_adapter_dim(args: argparse.Namespace, override: int | None = None) -> int:
+    """Return the adapter dim for the current run (0 disables the path)."""
+
+    if not _text_path_active(args):
+        return 0
+    if override is not None:
+        return int(override)
+    return int(getattr(args, "text_adapter_dim", DEFAULT_TEXT_ADAPTER_DIM))
+
+
+def _resolve_text_embedding_dim(args: argparse.Namespace) -> int:
+    """Resolve the encoder-native pooled embedding dim for the current encoder.
+
+    The model needs the encoder-native ``in_dim`` to materialise the
+    adapter; the loader emits embeddings of that width per row. The
+    helper reads the first non-empty pooled row off the loader's
+    output via a peek-style import, but the simpler approach used
+    here is to pin the dim from a small static table that matches
+    the registry. The forecaster sweep CLI does not have the parquet
+    open at this point so we fall back to a registry table; a
+    mismatch surfaces at the adapter's first forward pass.
+    """
+
+    if not _text_path_active(args):
+        return 0
+    table = {
+        "finbert": 768,
+        "finbert_fomc": 768,
+        "finbert_fed_adjacent": 768,
+        "bert_base_fed_adjacent": 768,
+        "bge_large_en_v15": 1024,
+        "nomic_embed_text_v15": 768,
+        "voyage_finance_2": 1024,
+    }
+    encoder = str(getattr(args, "text_encoder", "none") or "none")
+    if encoder == "none":
+        return 0
+    return int(table.get(encoder, 768))
 
 
 def _build_model_config(args: argparse.Namespace) -> ModelConfig:
@@ -337,6 +495,8 @@ def _build_model_config(args: argparse.Namespace) -> ModelConfig:
         head_hidden_size=args.head_hidden_size,
         architecture=args.architecture,
         credibility_features=bool(args.credibility_features),
+        text_embedding_dim=_resolve_text_embedding_dim(args),
+        text_adapter_dim=_resolved_text_adapter_dim(args),
     )
 
 
@@ -390,6 +550,24 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
     learning_rates = args.learning_rates or [args.learning_rate]
     epochs_options = args.epochs_grid or [args.epochs]
     architectures = args.architectures or [args.architecture]
+    # ``getattr`` fallbacks below keep the existing
+    # ``test_build_sweep_candidates_creates_cartesian_product`` namespace
+    # (which predates the weight-decay / text-adapter axes) intact while
+    # the production CLI runs always pass the new flags through.
+    weight_decays = (
+        getattr(args, "weight_decays", None)
+        or [getattr(args, "weight_decay", 1e-4)]
+    )
+    # Text-adapter-dim axis. Iterated only when the text-embedding path
+    # is wired; on the no-text path the iteration collapses to a single
+    # dummy value so the loop product stays one-deep.
+    if _text_path_active(args):
+        text_adapter_dims = (
+            getattr(args, "text_adapter_dims", None)
+            or [getattr(args, "text_adapter_dim", DEFAULT_TEXT_ADAPTER_DIM)]
+        )
+    else:
+        text_adapter_dims = [0]
     # When the caller asks for an architecture sweep but doesn't list seeds we
     # fall back to the official five-seed set; this matches the bake-off
     # aggregator and avoids accidentally publishing a single-seed table.
@@ -401,13 +579,26 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
         seeds = [args.seed]
 
     candidates: list[dict[str, Any]] = []
-    for architecture, hidden_size, num_layers, dropout, learning_rate, epochs, seed in itertools.product(
+    text_embedding_dim = _resolve_text_embedding_dim(args)
+    for (
+        architecture,
+        hidden_size,
+        num_layers,
+        dropout,
+        learning_rate,
+        epochs,
+        weight_decay,
+        text_adapter_dim,
+        seed,
+    ) in itertools.product(
         architectures,
         hidden_sizes,
         num_layers_options,
         dropouts,
         learning_rates,
         epochs_options,
+        weight_decays,
+        text_adapter_dims,
         seeds,
     ):
         candidates.append(
@@ -420,9 +611,13 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                     head_hidden_size=args.head_hidden_size,
                     architecture=str(architecture),
                     credibility_features=bool(args.credibility_features),
+                    text_embedding_dim=int(text_embedding_dim) if int(text_adapter_dim) > 0 else 0,
+                    text_adapter_dim=int(text_adapter_dim),
                 ),
                 "learning_rate": float(learning_rate),
                 "epochs": int(epochs),
+                "weight_decay": float(weight_decay),
+                "text_adapter_dim": int(text_adapter_dim),
                 "seed": int(seed) if seed is not None else None,
             }
         )
@@ -432,6 +627,7 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
 def _flatten_trial_record(record: dict[str, Any]) -> dict[str, Any]:
     summary = record["summary"]
     metrics = summary.get("metrics") or {}
+    train_metrics = summary.get("train_metrics") or {}
     model_config = summary.get("model_config") or {}
     return {
         "trial_index": record["trial_index"],
@@ -449,10 +645,20 @@ def _flatten_trial_record(record: dict[str, Any]) -> dict[str, Any]:
         "batch_size": summary.get("batch_size"),
         "validation_split": summary.get("validation_split"),
         "best_epoch": summary.get("best_epoch"),
+        "weight_decay": summary.get("weight_decay"),
+        "target_mode": summary.get("target_mode"),
+        "text_encoder": summary.get("text_encoder"),
+        "text_adapter_dim": summary.get("text_adapter_dim") or model_config.get("text_adapter_dim"),
+        "text_embedding_dim": model_config.get("text_embedding_dim"),
+        "text_pool_lambda_inv_days": summary.get("text_pool_lambda_inv_days"),
         "combined_rmse": metrics.get("combined_rmse"),
         "loss": metrics.get("loss"),
         "close_rmse": metrics.get("close_rmse"),
         "volatility_rmse": metrics.get("volatility_rmse"),
+        "train_combined_rmse": train_metrics.get("combined_rmse"),
+        "train_close_rmse": train_metrics.get("close_rmse"),
+        "train_volatility_rmse": train_metrics.get("volatility_rmse"),
+        "train_loss": train_metrics.get("loss"),
         "checkpoint_saved": summary.get("checkpoint_saved"),
         "checkpoint_path": summary.get("checkpoint_path"),
     }
@@ -486,6 +692,10 @@ def _run_single_training(
     save_checkpoint: bool,
     seed: int | None = None,
     sequence_groups: Sequence[Sequence[FeatureVector]] | None = None,
+    weight_decay: float = 1e-4,
+    shuffle_targets_control: bool = False,
+    text_encoder: str | None = None,
+    text_pool_lambda_inv_days: float = 0.0,
 ) -> TrainingRunSummary:
     # ``validation_fraction`` is the new idiomatic kwarg name. The
     # underlying ``train_model`` keeps ``validation_split`` for backwards
@@ -508,6 +718,10 @@ def _run_single_training(
             device=device,
             model_config=model_config,
             seed=seed,
+            weight_decay=weight_decay,
+            shuffle_targets_control=shuffle_targets_control,
+            text_encoder=text_encoder,
+            text_pool_lambda_inv_days=text_pool_lambda_inv_days,
         )
     else:
         result = train_model(
@@ -522,6 +736,10 @@ def _run_single_training(
             device=device,
             model_config=model_config,
             seed=seed,
+            weight_decay=weight_decay,
+            shuffle_targets_control=shuffle_targets_control,
+            text_encoder=text_encoder,
+            text_pool_lambda_inv_days=text_pool_lambda_inv_days,
         )
     return result.summary
 
@@ -539,6 +757,10 @@ def _train_model_with_groups(
     device: torch.device,
     model_config: ModelConfig,
     seed: int | None,
+    weight_decay: float = 1e-4,
+    shuffle_targets_control: bool = False,
+    text_encoder: str | None = None,
+    text_pool_lambda_inv_days: float = 0.0,
 ) -> Any:
     """Invoke ``train_model`` against pre-loaded sequence groups.
 
@@ -562,6 +784,10 @@ def _train_model_with_groups(
         device=device,
         model_config=model_config,
         seed=seed,
+        weight_decay=weight_decay,
+        shuffle_targets_control=shuffle_targets_control,
+        text_encoder=text_encoder,
+        text_pool_lambda_inv_days=text_pool_lambda_inv_days,
     )
 
 
@@ -583,10 +809,15 @@ def _run_sweep(
     print(f"Starting hyperparameter sweep with {len(candidates)} trial(s)...")
     trial_records: list[dict[str, Any]] = []
     summaries: list[TrainingRunSummary] = []
+    text_encoder_arg = (
+        None if str(getattr(args, "text_encoder", "none")) == "none" else str(args.text_encoder)
+    )
+    text_pool_lambda = float(getattr(args, "text_pool_lambda_inv_days", 0.0))
     for index, candidate in enumerate(candidates, start=1):
         model_config = candidate["model_config"]
         learning_rate = candidate["learning_rate"]
         epochs = candidate["epochs"]
+        weight_decay = candidate.get("weight_decay", args.weight_decay)
         seed = candidate.get("seed")
         summary = _run_single_training(
             data_dir=data_dir,
@@ -601,6 +832,10 @@ def _run_sweep(
             save_checkpoint=False,
             seed=seed,
             sequence_groups=sequence_groups,
+            weight_decay=float(weight_decay),
+            shuffle_targets_control=bool(args.shuffle_targets_control),
+            text_encoder=text_encoder_arg,
+            text_pool_lambda_inv_days=text_pool_lambda,
         )
         summaries.append(summary)
         trial_records.append(
@@ -643,6 +878,7 @@ def _run_sweep(
         f"dropout={best_model_config.dropout:.3f}, lr={best_summary.learning_rate:.6g}, "
         f"epochs={best_summary.epochs_requested}"
     )
+    best_weight_decay = candidates[best_trial_index - 1].get("weight_decay", args.weight_decay)
     final_summary = _run_single_training(
         data_dir=data_dir,
         checkpoint_path=checkpoint_path,
@@ -652,14 +888,18 @@ def _run_sweep(
         learning_rate=best_summary.learning_rate,
         # ``best_summary.validation_split`` is the persisted summary
         # field (frozen for back-compat with the existing
-        # TrainingRunSummary dataclass); we pass it under the new
-        # idiomatic ``validation_fraction`` kwarg.
+        # TrainingRunSummary dataclass); the kwarg routes under the
+        # current ``validation_fraction`` name.
         validation_fraction=best_summary.validation_split,
         early_stopping_patience=best_summary.early_stopping_patience,
         model_config=best_model_config,
         save_checkpoint=True,
         seed=best_seed,
         sequence_groups=sequence_groups,
+        weight_decay=float(best_weight_decay),
+        shuffle_targets_control=bool(args.shuffle_targets_control),
+        text_encoder=text_encoder_arg,
+        text_pool_lambda_inv_days=text_pool_lambda,
     )
     for trial in trial_records:
         trial["selected"] = trial["trial_index"] == best_trial_index
@@ -679,6 +919,12 @@ def _run_sweep(
             "mp_surprise": bool(args.use_mp_surprise),
             "multi_axis": bool(args.use_multi_axis),
         },
+        "text_embeddings": {
+            "encoder": text_encoder_arg,
+            "use_text_embeddings": bool(args.use_text_embeddings),
+            "pool_lambda_inv_days": text_pool_lambda,
+        },
+        "shuffle_targets_control": bool(args.shuffle_targets_control),
         "architectures": sorted({trial["architecture"] for trial in trial_records}),
         "seeds": sorted({trial["seed"] for trial in trial_records if trial["seed"] is not None}),
         "trial_count": len(trial_records),
@@ -724,6 +970,9 @@ def main() -> int:
             f"(credibility={args.use_credibility}, linguistic={args.use_linguistic}, "
             f"mp_surprise={args.use_mp_surprise}, multi_axis={args.use_multi_axis})"
         )
+        loader_text_encoder = (
+            None if str(args.text_encoder) == "none" else str(args.text_encoder)
+        )
         package_sequences = load_training_sequences_from_package(
             args.training_package_id,
             target_mode=args.target_mode,
@@ -732,6 +981,10 @@ def main() -> int:
             use_linguistic=bool(args.use_linguistic),
             use_mp_surprise=bool(args.use_mp_surprise),
             use_multi_axis=bool(args.use_multi_axis),
+            text_encoder=loader_text_encoder,
+            text_adapter_dim=int(args.text_adapter_dim),
+            text_pool_lambda_inv_days=float(args.text_pool_lambda_inv_days),
+            use_text_embeddings=bool(args.use_text_embeddings),
         )
         sequence_count = len(package_sequences)
         observation_count = sum(len(sequence) for sequence in package_sequences)
@@ -787,6 +1040,8 @@ def main() -> int:
             args.epochs_grid,
             args.architectures,
             args.seeds,
+            args.weight_decays,
+            args.text_adapter_dims,
         )
     )
     if sweep_mode:
@@ -817,6 +1072,10 @@ def main() -> int:
         save_checkpoint=True,
         seed=args.seed,
         sequence_groups=package_sequences,
+        weight_decay=float(args.weight_decay),
+        shuffle_targets_control=bool(args.shuffle_targets_control),
+        text_encoder=None if str(args.text_encoder) == "none" else str(args.text_encoder),
+        text_pool_lambda_inv_days=float(args.text_pool_lambda_inv_days),
     )
     metrics = summary.metrics
     if metrics is not None:

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -759,7 +759,7 @@ def _read_chunk_embedding_lookup(
 
     if not lookup:
         return {}
-    lookup["__event_dates__"] = event_dates  # type: ignore[assignment]
+    lookup["__event_dates__"] = event_dates
     return lookup
 
 

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import csv
 import datetime
 import json
+import logging
 import warnings
 from pathlib import Path
 from typing import Any, Literal, Sequence
@@ -14,10 +15,14 @@ from app.evaluation.metrics import TrainingDataSourceSummary
 from app.models.config import (
     DEFAULT_CLOSE_SCALE,
     DEFAULT_DATA_DIR,
+    DEFAULT_TEXT_ADAPTER_DIM,
+    DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS,
     RICH_LINGUISTIC_DIM,
     SEQUENCE_LENGTH,
     FeatureVector,
 )
+
+_logger = logging.getLogger(__name__)
 
 # Ordered linguistic-feature columns expected on
 # ``linguistic_features.parquet``. The order mirrors the
@@ -622,6 +627,215 @@ def _read_mp_surprise_lookup(
     return lookup
 
 
+def _read_chunk_embedding_lookup(
+    encoder_alias: str,
+    *,
+    cache_dir: Path | None = None,
+) -> dict[str, "Any"]:
+    """Return ``text_hash -> pooled embedding`` for one encoder.
+
+    Reads ``data/raw/embeddings/<encoder_alias>_<rev>.parquet`` (the
+    artefact ``app.data.embedding_cache.build_cache`` writes per
+    encoder x training-package). The cache stores one row per
+    document chunk for classifier/MLM encoders and one row per
+    document for sentence-embedding encoders; this helper collapses
+    all rows under a given ``record_id`` to a single mean-pooled
+    vector so the downstream prior-4 weighting sees one embedding per
+    statement.
+
+    The cache schema does NOT carry a ``text_hash`` column directly,
+    so the lookup is keyed on ``record_id`` -- the
+    ``training-package`` event row's ``text_hash`` is what the cache
+    builder writes into ``record_id``. The collapsed dict maps
+    ``record_id`` -> ``numpy.ndarray`` (the per-statement pooled
+    embedding) and additionally carries the ``event_date`` of each
+    statement under ``__event_dates__`` so the pooler can look up
+    Delta t without re-reading the parquet.
+
+    Returns an empty dict when the parquet is missing; the caller
+    emits zeros + a missing flag for every row.
+    """
+
+    import numpy as np
+    import pandas as pd
+
+    # Local import keeps the heavy embedding-cache module out of the
+    # training-time import path on the legacy ``--data-dir`` flow.
+    from app.data.embedding_cache import resolve_cache_paths
+    from app.models.registry import revision_for
+
+    revision = revision_for(encoder_alias)
+    if revision is None:
+        _logger.warning(
+            "encoder %r is not pinned in models/registry.yaml; "
+            "text-embedding lookup will return empty",
+            encoder_alias,
+        )
+        return {}
+    paths = resolve_cache_paths(encoder_alias, revision=revision, cache_dir=cache_dir)
+    if not paths.parquet.exists():
+        _logger.warning(
+            "embedding cache parquet missing for encoder=%r at %s; "
+            "text-embedding lookup will return empty",
+            encoder_alias,
+            paths.parquet,
+        )
+        return {}
+
+    frame = pd.read_parquet(paths.parquet)
+    if "embedding" not in frame.columns or "event_date" not in frame.columns:
+        _logger.warning(
+            "embedding cache parquet at %s missing required columns "
+            "(embedding / event_date); text-embedding lookup empty",
+            paths.parquet,
+        )
+        return {}
+    # Prefer ``record_id`` (Phase 8 cache builder) and fall back to
+    # ``doc_id`` for backwards compatibility with older caches.
+    key_column: str | None = None
+    for candidate in ("record_id", "doc_id"):
+        if candidate in frame.columns:
+            key_column = candidate
+            break
+    if key_column is None:
+        _logger.warning(
+            "embedding cache parquet at %s carries neither record_id "
+            "nor doc_id; text-embedding lookup empty",
+            paths.parquet,
+        )
+        return {}
+
+    lookup: dict[str, "Any"] = {}
+    event_dates: dict[str, str] = {}
+    grouped = frame.groupby(key_column, sort=False)
+    for key_value, chunk in grouped:
+        key_str = str(key_value).strip()
+        if not key_str:
+            continue
+        stacked: list[np.ndarray] = []
+        for embedding in chunk["embedding"].tolist():
+            try:
+                vec = np.asarray(embedding, dtype=np.float32)
+            except (TypeError, ValueError):
+                continue
+            if vec.ndim != 1 or vec.size == 0:
+                continue
+            stacked.append(vec)
+        if not stacked:
+            continue
+        # Drop rows whose embedding dim mismatches the first chunk; a
+        # mixed-dim parquet means the cache was rebuilt with two
+        # different encoders and silently appended -- safer to skip
+        # than to mean-pool across dims.
+        ref_dim = stacked[0].shape[0]
+        cleaned = [vec for vec in stacked if vec.shape[0] == ref_dim]
+        if not cleaned:
+            continue
+        pooled = np.mean(np.stack(cleaned, axis=0), axis=0)
+        lookup[key_str] = pooled
+        event_dates[key_str] = str(chunk["event_date"].iloc[0])[:10]
+
+    if not lookup:
+        return {}
+    lookup["__event_dates__"] = event_dates  # type: ignore[assignment]
+    return lookup
+
+
+def _compute_prior4_pooled_embedding(
+    *,
+    text_hash: str,
+    event_row_text_hash: str,
+    current_event_date: datetime.date,
+    embedding_lookup: dict[str, "Any"],
+    prior_text_hashes: Sequence[tuple[datetime.date, str]],
+    lambda_inv_days: float,
+    max_prior: int = 4,
+) -> "Any | None":
+    """Pool the four most recent prior-statement embeddings with time decay.
+
+    Parameters
+    ----------
+    text_hash:
+        ``text_hash`` (== embedding-cache ``record_id``) of the event
+        being processed. Used only for diagnostics; the pooler reads
+        prior statements off ``prior_text_hashes``.
+    current_event_date:
+        Statement date of the event being processed. Prior statements
+        are restricted to those strictly before this date.
+    embedding_lookup:
+        Output of :func:`_read_chunk_embedding_lookup`. Keys are
+        ``record_id`` strings, values are 1-D ``numpy.ndarray`` per
+        statement. ``__event_dates__`` is reserved (carries the
+        statement date per record_id).
+    prior_text_hashes:
+        Chronologically-sorted list of ``(statement_date, text_hash)``
+        tuples for every statement in the corpus. The pooler filters
+        on ``statement_date < current_event_date`` and picks the
+        ``max_prior`` most recent surviving rows.
+    lambda_inv_days:
+        Time-decay window. Weights derive from
+        ``softmax(-Delta t_days / lambda_inv_days)``; smaller values
+        concentrate the weight on the most recent statement, larger
+        values spread it across the four.
+
+    Returns
+    -------
+    ``numpy.ndarray`` (the weighted mean over ``min(4, n_prior)``
+    statements) or ``None`` when no usable prior is found.
+    """
+
+    import numpy as np
+
+    if not embedding_lookup:
+        return None
+    if lambda_inv_days <= 0:
+        raise ValueError(
+            f"lambda_inv_days must be positive; got {lambda_inv_days}"
+        )
+
+    # Filter to statements strictly before the current event date that
+    # actually have a pooled embedding in the lookup, then keep the
+    # ``max_prior`` most recent.
+    candidates: list[tuple[datetime.date, str]] = []
+    for statement_date, prior_hash in prior_text_hashes:
+        if statement_date >= current_event_date:
+            continue
+        if prior_hash not in embedding_lookup:
+            continue
+        if prior_hash.startswith("__"):
+            continue
+        candidates.append((statement_date, prior_hash))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    selected = candidates[:max_prior]
+
+    delta_days = np.array(
+        [float((current_event_date - statement_date).days) for statement_date, _ in selected],
+        dtype=np.float64,
+    )
+    logits = -delta_days / float(lambda_inv_days)
+    # Numerically-stable softmax: subtract max so exp does not overflow.
+    logits -= logits.max()
+    weights = np.exp(logits)
+    weights_sum = weights.sum()
+    if weights_sum <= 0:
+        return None
+    weights = weights / weights_sum
+
+    vectors = [np.asarray(embedding_lookup[h], dtype=np.float32) for _, h in selected]
+    # Tolerate ragged-dim entries by trimming to the shortest -- the
+    # lookup builder already filters mixed dims per record_id, but a
+    # cross-encoder corpus could still mix dims across records. Skip
+    # the pool entirely if the dims are not coherent.
+    ref_dim = vectors[0].shape[0]
+    if any(vec.shape[0] != ref_dim for vec in vectors):
+        return None
+    matrix = np.stack(vectors, axis=0)
+    pooled = (matrix * weights[:, None]).sum(axis=0)
+    return pooled.astype(np.float32)
+
+
 def _attach_rich_features(
     vectors: list[FeatureVector],
     *,
@@ -786,6 +1000,11 @@ def load_training_sequences_from_package(
     use_linguistic: bool = True,
     use_mp_surprise: bool = True,
     use_multi_axis: bool = True,
+    text_encoder: str | None = None,
+    text_adapter_dim: int = DEFAULT_TEXT_ADAPTER_DIM,
+    text_pool_lambda_inv_days: float = DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS,
+    use_text_embeddings: bool = True,
+    text_embedding_cache_dir: Path | str | None = None,
 ) -> list[list[FeatureVector]]:
     """Load one prior-window sequence per FOMC event in a training package.
 
@@ -857,6 +1076,26 @@ def load_training_sequences_from_package(
     ``as_rich_list`` falls back to ``as_list`` plus zero-padding (no
     rich payload attached), and the per-family ablation flags are
     ignored.
+
+    When ``text_encoder`` is set and ``use_text_embeddings`` is True
+    the loader pulls the per-statement embeddings from
+    ``data/raw/embeddings/<encoder>_<rev>.parquet`` (built by
+    ``app.data.embedding_cache``), pools the four most recent prior
+    statements with ``softmax(-Delta t_days / text_pool_lambda_inv_days)``
+    weights, and attaches the resulting ``in_dim``-vector to every
+    bar of the prior window plus the event-day target frame as
+    ``FeatureVector.text_embedding_pooled``. The pooled vector stays
+    encoder-native (FinBERT 768, voyage-finance-2 1024, ...); the
+    adapter projection to ``text_adapter_dim`` runs inside the model
+    forward so the recurrent core sees a fixed per-bar feature size.
+    When fewer than one prior statement is available (e.g. the first
+    event in the corpus), the pooled vector is filled with zeros and
+    ``FeatureVector.text_embedding_missing`` flips to ``1.0`` so the
+    model can tell "no prior signal" apart from "neutral prior
+    signal". Setting ``text_encoder=None`` or
+    ``use_text_embeddings=False`` skips the pooling step entirely and
+    every row keeps the default empty pooled list + missing-flag at
+    ``1.0``.
     """
 
     if target_mode not in _VALID_TARGET_MODES:
@@ -893,6 +1132,29 @@ def load_training_sequences_from_package(
         linguistic_lookup = _read_linguistic_lookup(package_dir)
         mp_surprise_lookup = _read_mp_surprise_lookup(package_dir)
 
+    # Text-embedding lookup. Loaded once per package; the per-event
+    # softmax-weighted pool runs against this dict. When the encoder
+    # is unset or the parquet is missing, the lookup stays empty and
+    # ``_compute_prior4_pooled_embedding`` returns None for every
+    # event so the model sees the zero + missing-flag pair.
+    embedding_lookup: dict[str, Any] = {}
+    use_text_path = bool(text_encoder) and bool(use_text_embeddings)
+    text_adapter_dim_int = int(text_adapter_dim)
+    if use_text_path:
+        if text_adapter_dim_int <= 0:
+            raise ValueError(
+                f"text_adapter_dim must be a positive integer; got {text_adapter_dim}"
+            )
+        cache_dir = (
+            Path(text_embedding_cache_dir)
+            if text_embedding_cache_dir is not None
+            else None
+        )
+        embedding_lookup = _read_chunk_embedding_lookup(
+            text_encoder,
+            cache_dir=cache_dir,
+        )
+
     # Deduplicate to one row per text_hash. Prefer horizon=1 so the
     # appended target frame is the next trading day's close. Within a
     # text_hash bucket, lower horizons rank first; the chronological
@@ -910,16 +1172,33 @@ def load_training_sequences_from_package(
     by_text_hash: dict[str, dict[str, Any]] = {}
     records = frame.to_dict("records")
     records.sort(key=_row_rank)
+    # Track every text_hash + event_date seen in the package -- INCLUDING
+    # rows excluded from the training loss -- so the prior-4 statement
+    # pool sees the full historical chronology when scoring a training
+    # event. A val / test statement that chronologically precedes a
+    # train statement is still a "prior" for that train statement and
+    # contributes to the pooled embedding.
+    prior_chronology_set: set[tuple[datetime.date, str]] = set()
     for row in records:
-        text_hash = str(row.get("text_hash", ""))
-        if not text_hash:
+        candidate_hash = str(row.get("text_hash", ""))
+        if not candidate_hash:
             continue
-        if text_hash in excluded_text_hashes:
+        candidate_date_raw = str(row.get("event_date", ""))[:10]
+        if not candidate_date_raw:
             continue
-        if text_hash in seen:
+        try:
+            candidate_date = datetime.date.fromisoformat(candidate_date_raw)
+        except ValueError:
             continue
-        seen.add(text_hash)
-        by_text_hash[text_hash] = row
+        prior_chronology_set.add((candidate_date, candidate_hash))
+        if candidate_hash in excluded_text_hashes:
+            continue
+        if candidate_hash in seen:
+            continue
+        seen.add(candidate_hash)
+        by_text_hash[candidate_hash] = row
+
+    prior_chronology: list[tuple[datetime.date, str]] = sorted(prior_chronology_set)
 
     ordered_rows = sorted(
         by_text_hash.values(),
@@ -982,6 +1261,29 @@ def load_training_sequences_from_package(
                 use_mp_surprise=use_mp_surprise,
                 use_multi_axis=use_multi_axis,
             )
+        if use_text_path:
+            pooled = _compute_prior4_pooled_embedding(
+                text_hash=row_text_hash,
+                event_row_text_hash=row_text_hash,
+                current_event_date=event_date,
+                embedding_lookup=embedding_lookup,
+                prior_text_hashes=prior_chronology,
+                lambda_inv_days=float(text_pool_lambda_inv_days),
+                max_prior=4,
+            )
+            if pooled is None:
+                # Either the first event in the corpus (no prior to
+                # pool) or the encoder cache is missing/empty. Emit
+                # zeros + flip the missing flag so the model sees
+                # "no prior signal" rather than a hallucinated mean.
+                missing_flag = 1.0
+                pooled_list: list[float] = []
+            else:
+                missing_flag = 0.0
+                pooled_list = [float(v) for v in pooled.tolist()]
+            for vector in vectors:
+                vector.text_embedding_pooled = list(pooled_list)
+                vector.text_embedding_missing = missing_flag
         sequences.append(vectors)
     return sequences
 
@@ -1084,6 +1386,59 @@ def _build_training_tensors(
     x = torch.tensor(sequences, dtype=torch.float32)
     y = torch.tensor(targets, dtype=torch.float32)
     return x, y, fitted_scale
+
+
+def _build_text_embedding_tensors(
+    sequence_groups: Sequence[Sequence[FeatureVector]],
+) -> tuple[torch.Tensor | None, torch.Tensor | None, int]:
+    """Materialise the (pooled, missing_flag, in_dim) triple per training window.
+
+    For each window the per-event pooled embedding lives on every
+    ``FeatureVector`` in the group; the helper reads the embedding
+    off the LAST prior bar (index ``SEQUENCE_LENGTH - 1``) so the
+    chosen vector matches the supervised window the trainer sees.
+    Missing rows materialise a zero ``in_dim``-vector + a ``1.0``
+    missing flag so the model's adapter projects the same zero slot
+    it would in the encoder-disabled path.
+
+    Returns ``(None, None, 0)`` when none of the sequences carry a
+    pooled embedding. Callers that hit the no-text path then skip the
+    text-embedding kwargs on the model forward entirely.
+    """
+
+    in_dim = 0
+    for sequence_group in sequence_groups:
+        for item in sequence_group:
+            pooled = getattr(item, "text_embedding_pooled", None) or []
+            if pooled:
+                in_dim = len(pooled)
+                break
+        if in_dim:
+            break
+    if in_dim == 0:
+        return None, None, 0
+
+    pooled_rows: list[list[float]] = []
+    missing_rows: list[list[float]] = []
+    for sequence_group in sequence_groups:
+        if len(sequence_group) < SEQUENCE_LENGTH + 1:
+            continue
+        for idx in range(SEQUENCE_LENGTH, len(sequence_group)):
+            anchor = sequence_group[idx - 1]
+            pooled_payload = list(getattr(anchor, "text_embedding_pooled", []) or [])
+            missing_flag = float(getattr(anchor, "text_embedding_missing", 1.0))
+            if not pooled_payload or len(pooled_payload) != in_dim:
+                pooled_payload = [0.0] * in_dim
+                missing_flag = 1.0
+            pooled_rows.append(pooled_payload)
+            missing_rows.append([missing_flag])
+
+    if not pooled_rows:
+        return None, None, in_dim
+
+    pooled_tensor = torch.tensor(pooled_rows, dtype=torch.float32)
+    missing_tensor = torch.tensor(missing_rows, dtype=torch.float32)
+    return pooled_tensor, missing_tensor, in_dim
 
 
 def _split_train_validation(

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -631,6 +631,7 @@ def _read_chunk_embedding_lookup(
     encoder_alias: str,
     *,
     cache_dir: Path | None = None,
+    registry_path: Path | None = None,
 ) -> dict[str, "Any"]:
     """Return ``text_hash -> pooled embedding`` for one encoder.
 
@@ -643,14 +644,13 @@ def _read_chunk_embedding_lookup(
     vector so the downstream prior-4 weighting sees one embedding per
     statement.
 
-    The cache schema does NOT carry a ``text_hash`` column directly,
-    so the lookup is keyed on ``record_id`` -- the
-    ``training-package`` event row's ``text_hash`` is what the cache
-    builder writes into ``record_id``. The collapsed dict maps
-    ``record_id`` -> ``numpy.ndarray`` (the per-statement pooled
-    embedding) and additionally carries the ``event_date`` of each
-    statement under ``__event_dates__`` so the pooler can look up
-    Delta t without re-reading the parquet.
+    The cache schema persists ``record_id`` rather than ``text_hash``.
+    When ``registry_path`` is supplied the loader walks
+    ``registry_normalized.jsonl`` to build a ``record_id -> text_hash``
+    mapping; the returned dict is then keyed on ``text_hash`` so the
+    per-event lookup matches the ``events.parquet`` join key directly.
+    When the registry is unavailable the lookup falls back to
+    ``record_id`` keys and the caller's text_hash lookup will miss.
 
     Returns an empty dict when the parquet is missing; the caller
     emits zeros + a missing flag for every row.
@@ -705,6 +705,25 @@ def _read_chunk_embedding_lookup(
         )
         return {}
 
+    # Build the ``record_id -> text_hash`` mapping when the registry is
+    # available. Without it the lookup stays keyed on record_id and
+    # the per-event text_hash join misses every row.
+    record_to_text_hash: dict[str, str] = {}
+    if registry_path is not None and registry_path.exists():
+        with registry_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    record = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+                rec_id = str(record.get("record_id") or "")
+                text_hash_str = str(record.get("text_hash") or "")
+                if rec_id and text_hash_str:
+                    record_to_text_hash[rec_id] = text_hash_str
+
     lookup: dict[str, "Any"] = {}
     event_dates: dict[str, str] = {}
     grouped = frame.groupby(key_column, sort=False)
@@ -732,8 +751,11 @@ def _read_chunk_embedding_lookup(
         if not cleaned:
             continue
         pooled = np.mean(np.stack(cleaned, axis=0), axis=0)
-        lookup[key_str] = pooled
-        event_dates[key_str] = str(chunk["event_date"].iloc[0])[:10]
+        # Prefer the text_hash key when the registry resolved one for
+        # this record_id; fall back to record_id otherwise.
+        join_key = record_to_text_hash.get(key_str, key_str)
+        lookup[join_key] = pooled
+        event_dates[join_key] = str(chunk["event_date"].iloc[0])[:10]
 
     if not lookup:
         return {}
@@ -1150,9 +1172,53 @@ def load_training_sequences_from_package(
             if text_embedding_cache_dir is not None
             else None
         )
+        # The embedding cache builder keys rows on ``record_id``;
+        # events.parquet joins on ``text_hash``. The registry parquet
+        # under the training package carries both columns, so the
+        # lookup walks it once to materialise the record_id ->
+        # text_hash join. When the registry is absent the lookup
+        # falls back to record_id keys and the per-event join
+        # silently misses every row -- that's logged via the
+        # missing-flag count downstream.
+        registry_parquet = package_dir / "registry_normalized.parquet"
+        registry_jsonl = package_dir / "registry_normalized.jsonl"
+        registry_for_lookup: Path | None
+        if registry_jsonl.exists():
+            registry_for_lookup = registry_jsonl
+        elif registry_parquet.exists():
+            # When only the parquet is available, materialise a
+            # registry_normalized.jsonl-style view of the
+            # ``record_id`` / ``text_hash`` columns in-memory and
+            # ship that to the lookup helper via a tmp file. The
+            # parquet schema carries the same columns so the join
+            # remains exact.
+            import pandas as pd
+
+            reg_frame = pd.read_parquet(registry_parquet)
+            reg_subset = reg_frame[[c for c in ("record_id", "text_hash") if c in reg_frame.columns]]
+            if not reg_subset.empty and "record_id" in reg_subset.columns and "text_hash" in reg_subset.columns:
+                tmp_path = package_dir / "_registry_record_to_text_hash.jsonl"
+                with tmp_path.open("w", encoding="utf-8") as handle:
+                    for record in reg_subset.to_dict("records"):
+                        handle.write(
+                            json.dumps(
+                                {
+                                    "record_id": str(record.get("record_id") or ""),
+                                    "text_hash": str(record.get("text_hash") or ""),
+                                },
+                                sort_keys=True,
+                            )
+                            + "\n"
+                        )
+                registry_for_lookup = tmp_path
+            else:
+                registry_for_lookup = None
+        else:
+            registry_for_lookup = None
         embedding_lookup = _read_chunk_embedding_lookup(
             text_encoder,
             cache_dir=cache_dir,
+            registry_path=registry_for_lookup,
         )
 
     # Deduplicate to one row per text_hash. Prefer horizon=1 so the
@@ -1390,6 +1456,8 @@ def _build_training_tensors(
 
 def _build_text_embedding_tensors(
     sequence_groups: Sequence[Sequence[FeatureVector]],
+    *,
+    fallback_in_dim: int = 0,
 ) -> tuple[torch.Tensor | None, torch.Tensor | None, int]:
     """Materialise the (pooled, missing_flag, in_dim) triple per training window.
 
@@ -1401,9 +1469,19 @@ def _build_text_embedding_tensors(
     missing flag so the model's adapter projects the same zero slot
     it would in the encoder-disabled path.
 
+    ``fallback_in_dim`` lets the caller pin the expected encoder dim
+    when every sequence in the batch is missing (e.g. the prefix of
+    the corpus before any prior statement is available). Without
+    that fallback the helper would return ``(None, None, 0)`` and
+    the training loop would skip the text path entirely; with the
+    fallback it materialises a zero-payload tensor of the requested
+    width so the model's adapter still runs and the missing flag
+    drives the output to zero.
+
     Returns ``(None, None, 0)`` when none of the sequences carry a
-    pooled embedding. Callers that hit the no-text path then skip the
-    text-embedding kwargs on the model forward entirely.
+    pooled embedding AND no ``fallback_in_dim`` is supplied. Callers
+    that hit the no-text path then skip the text-embedding kwargs
+    on the model forward entirely.
     """
 
     in_dim = 0
@@ -1416,7 +1494,9 @@ def _build_text_embedding_tensors(
         if in_dim:
             break
     if in_dim == 0:
-        return None, None, 0
+        if fallback_in_dim <= 0:
+            return None, None, 0
+        in_dim = int(fallback_in_dim)
 
     pooled_rows: list[list[float]] = []
     missing_rows: list[list[float]] = []

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -216,8 +216,15 @@ def train_model(
     # inference can recover the original price magnitude. See
     # `app.training.loaders.fit_close_scale` for the fit details.
     x, y, close_scale = _build_training_tensors(sequence_groups)
+    # When the model is configured for the text path, pin the
+    # fallback in_dim so a batch whose every sequence is missing
+    # (e.g. the pre-corpus prefix) still materialises a zero-payload
+    # tensor of the right width. The model's adapter then projects a
+    # zero slot driven by the missing flag.
+    fallback_text_in_dim = int(getattr(active_model_config, "text_embedding_dim", 0) or 0)
     text_emb_tensor, text_missing_tensor, text_emb_dim = _build_text_embedding_tensors(
-        sequence_groups
+        sequence_groups,
+        fallback_in_dim=fallback_text_in_dim,
     )
     if x is None or y is None:
         model = copy.deepcopy(base_model).to(device_obj) if base_model is not None else _build_model(active_model_config, device=device_obj)

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -29,6 +29,7 @@ from app.models.config import (
 )
 from app.models.lstm import ForecasterModel
 from app.training.loaders import (
+    _build_text_embedding_tensors,
     _build_training_tensors,
     _split_train_validation,
     load_training_sequences_from_data,
@@ -56,6 +57,8 @@ def _coerce_model_config(model_config: ModelConfig | dict[str, Any] | None = Non
             embedding_adapter_dim=int(model_config.get("embedding_adapter_dim", 128)),
             credibility_features=bool(model_config.get("credibility_features", False)),
             architecture=str(model_config.get("architecture", "lstm")),
+            text_embedding_dim=int(model_config.get("text_embedding_dim", 0) or 0),
+            text_adapter_dim=int(model_config.get("text_adapter_dim", 0) or 0),
         )
     return ModelConfig()
 
@@ -91,6 +94,30 @@ def _zero_credibility(model: ForecasterModel, batch_size: int, device: torch.dev
     return torch.zeros((batch_size, dim), dtype=torch.float32, device=device)
 
 
+def _unpack_batch(batch: Any) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    """Decode a DataLoader batch into (x, y, text_embedding, text_missing).
+
+    Two batch shapes are tolerated:
+
+    - ``(batch_x, batch_y)`` -- legacy two-tensor batch, used on the
+      pre-PR-#176 path. ``text_embedding`` and ``text_embedding_missing``
+      are ``None``.
+    - ``(batch_x, batch_y, batch_text_embedding, batch_text_missing)``
+      -- four-tensor batch emitted when the text-embedding path is
+      active. The model forward picks the extras up by name.
+    """
+
+    if len(batch) == 4:
+        batch_x, batch_y, batch_text, batch_text_missing = batch
+        return batch_x, batch_y, batch_text, batch_text_missing
+    if len(batch) == 2:
+        batch_x, batch_y = batch
+        return batch_x, batch_y, None, None
+    raise ValueError(
+        f"unexpected batch arity from DataLoader: {len(batch)} (want 2 or 4)"
+    )
+
+
 def _evaluate_model(
     model: ForecasterModel,
     loader: DataLoader[Any],
@@ -103,11 +130,22 @@ def _evaluate_model(
     close_squared_error = 0.0
     volatility_squared_error = 0.0
     with torch.no_grad():
-        for batch_x, batch_y in loader:
+        for batch in loader:
+            batch_x, batch_y, batch_text, batch_text_missing = _unpack_batch(batch)
             batch_x = batch_x.to(device, non_blocking=device.type == "cuda")
             batch_y = batch_y.to(device, non_blocking=device.type == "cuda")
             credibility = _zero_credibility(model, batch_x.size(0), device)
-            kwargs = {"credibility": credibility} if credibility is not None else {}
+            kwargs: dict[str, torch.Tensor] = {}
+            if credibility is not None:
+                kwargs["credibility"] = credibility
+            if batch_text is not None and getattr(model, "_text_path_active", False):
+                kwargs["text_embedding"] = batch_text.to(
+                    device, non_blocking=device.type == "cuda"
+                )
+                if batch_text_missing is not None:
+                    kwargs["text_embedding_missing"] = batch_text_missing.to(
+                        device, non_blocking=device.type == "cuda"
+                    )
             predictions = model(batch_x, **kwargs)
             loss = loss_fn(predictions, batch_y)
             batch_size = batch_x.size(0)
@@ -149,6 +187,10 @@ def train_model(
     save_checkpoint: bool = True,
     device: str | torch.device | None = None,
     seed: int | None = None,
+    weight_decay: float = 1e-4,
+    shuffle_targets_control: bool = False,
+    text_encoder: str | None = None,
+    text_pool_lambda_inv_days: float = 0.0,
 ) -> TrainingResult:
     if seed is not None:
         enable_deterministic_mode(seed)
@@ -174,6 +216,9 @@ def train_model(
     # inference can recover the original price magnitude. See
     # `app.training.loaders.fit_close_scale` for the fit details.
     x, y, close_scale = _build_training_tensors(sequence_groups)
+    text_emb_tensor, text_missing_tensor, text_emb_dim = _build_text_embedding_tensors(
+        sequence_groups
+    )
     if x is None or y is None:
         model = copy.deepcopy(base_model).to(device_obj) if base_model is not None else _build_model(active_model_config, device=device_obj)
         model.eval()
@@ -196,16 +241,50 @@ def train_model(
                 checkpoint_saved=False,
                 best_epoch=None,
                 metrics=None,
+                weight_decay=float(weight_decay),
+                target_mode="shuffled" if shuffle_targets_control else "real",
+                text_encoder=text_encoder,
+                text_adapter_dim=int(getattr(model, "text_adapter_dim", 0) or 0),
+                text_pool_lambda_inv_days=float(text_pool_lambda_inv_days),
             ),
         )
 
+    # Mitigation 3: shuffled-targets control. Deterministically permute
+    # the target column so the model has no signal beyond the per-fold
+    # mean. macro-RMSE on the shuffled-targets run should sit near
+    # the constant-mean predictor; a real-targets run whose RMSE is
+    # close to its shuffled counterpart is memorising, not learning.
+    if shuffle_targets_control:
+        if seed is None:
+            shuffle_seed = 11
+        else:
+            shuffle_seed = int(seed)
+        shuffle_generator = torch.Generator()
+        shuffle_generator.manual_seed(shuffle_seed)
+        perm = torch.randperm(y.shape[0], generator=shuffle_generator)
+        y = y[perm].clone()
+
     train_x, train_y, val_x, val_y = _split_train_validation(x, y, validation_split)
+    if text_emb_tensor is not None and text_missing_tensor is not None:
+        train_text_emb = text_emb_tensor[: len(train_x)]
+        val_text_emb = text_emb_tensor[len(train_x) :]
+        train_text_missing = text_missing_tensor[: len(train_x)]
+        val_text_missing = text_missing_tensor[len(train_x) :]
+    else:
+        train_text_emb = val_text_emb = None
+        train_text_missing = val_text_missing = None
     # The current Torch build emits deprecation warnings from DataLoader pinning internals.
     # For this dataset size, disabling pinning keeps training clean without a meaningful throughput hit.
     pin_memory = False
     loader_generator = make_generator(seed) if seed is not None else None
+    if train_text_emb is not None and train_text_missing is not None:
+        train_dataset = TensorDataset(train_x, train_y, train_text_emb, train_text_missing)
+        val_dataset = TensorDataset(val_x, val_y, val_text_emb, val_text_missing)
+    else:
+        train_dataset = TensorDataset(train_x, train_y)
+        val_dataset = TensorDataset(val_x, val_y)
     train_loader = DataLoader(
-        TensorDataset(train_x, train_y),
+        train_dataset,
         batch_size=min(batch_size, len(train_x)),
         shuffle=True,
         pin_memory=pin_memory,
@@ -213,7 +292,7 @@ def train_model(
         worker_init_fn=seed_worker if seed is not None else None,
     )
     val_loader = DataLoader(
-        TensorDataset(val_x, val_y),
+        val_dataset,
         batch_size=min(batch_size, len(val_x)),
         shuffle=False,
         pin_memory=pin_memory,
@@ -226,7 +305,7 @@ def train_model(
         else _build_model(active_model_config, device=device_obj)
     )
     work_model.train()
-    optimizer = torch.optim.AdamW(work_model.parameters(), lr=learning_rate, weight_decay=1e-4)
+    optimizer = torch.optim.AdamW(work_model.parameters(), lr=learning_rate, weight_decay=float(weight_decay))
     scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.5, patience=3)
     loss_fn = nn.SmoothL1Loss(beta=0.02)
 
@@ -239,12 +318,23 @@ def train_model(
 
     for epoch_index in range(epochs):
         work_model.train()
-        for batch_x, batch_y in train_loader:
+        for batch in train_loader:
+            batch_x, batch_y, batch_text, batch_text_missing = _unpack_batch(batch)
             batch_x = batch_x.to(device_obj, non_blocking=device_obj.type == "cuda")
             batch_y = batch_y.to(device_obj, non_blocking=device_obj.type == "cuda")
             optimizer.zero_grad(set_to_none=True)
             credibility = _zero_credibility(work_model, batch_x.size(0), device_obj)
-            kwargs = {"credibility": credibility} if credibility is not None else {}
+            kwargs: dict[str, torch.Tensor] = {}
+            if credibility is not None:
+                kwargs["credibility"] = credibility
+            if batch_text is not None and getattr(work_model, "_text_path_active", False):
+                kwargs["text_embedding"] = batch_text.to(
+                    device_obj, non_blocking=device_obj.type == "cuda"
+                )
+                if batch_text_missing is not None:
+                    kwargs["text_embedding_missing"] = batch_text_missing.to(
+                        device_obj, non_blocking=device_obj.type == "cuda"
+                    )
             predictions = work_model(batch_x, **kwargs)
             loss = loss_fn(predictions, batch_y)
             loss.backward()
@@ -269,6 +359,19 @@ def train_model(
     work_model.eval()
     if best_metrics is None:
         best_metrics = _evaluate_model(work_model, val_loader, device_obj, loss_fn)
+    # Mitigation 4: compute final-state training-set metrics so the
+    # aggregator can emit holdout_train_gap = (val_rmse - train_rmse) /
+    # train_rmse. The training set is re-evaluated through the same
+    # eval path (no dropout / no grad / fixed batch ordering) so the
+    # number is comparable to ``metrics``.
+    train_eval_loader = DataLoader(
+        train_dataset,
+        batch_size=min(batch_size, len(train_x)),
+        shuffle=False,
+        pin_memory=pin_memory,
+        worker_init_fn=seed_worker if seed is not None else None,
+    )
+    train_metrics = _evaluate_model(work_model, train_eval_loader, device_obj, loss_fn)
 
     summary = TrainingRunSummary(
         model_config=ModelConfig.from_model(work_model),
@@ -287,6 +390,12 @@ def train_model(
         checkpoint_saved=save_checkpoint,
         best_epoch=best_epoch,
         metrics=best_metrics,
+        train_metrics=train_metrics,
+        weight_decay=float(weight_decay),
+        target_mode="shuffled" if shuffle_targets_control else "real",
+        text_encoder=text_encoder,
+        text_adapter_dim=int(getattr(work_model, "text_adapter_dim", 0) or 0),
+        text_pool_lambda_inv_days=float(text_pool_lambda_inv_days),
     )
 
     if save_checkpoint:

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -924,109 +924,12 @@ pre-PR-#173 6-feature input. The per-family flags are no-ops when
 
 #### Make targets
 
-- `make forecaster-sweep TRAINING_PACKAGE_ID=<id> TEXT_ENCODER=<alias>`
-  — 8-architecture rich-feature sweep (lstm, lstm_attn, gru, tcn,
-  transformer, dlinear, informer, tft) across the official
-  five-seed set. The grid now sweeps hidden_size {32, 64, 128} x
-  num_layers {1, 2, 3} x dropout {0.1, 0.2, 0.3, 0.4} x
-  learning_rate {1e-3, 3e-4} x weight_decay {0, 1e-4, 1e-3} x
-  text_adapter_dim {32, 64, 128}. Pass `TEXT_ENCODER=none` for the
-  text-off baseline row.
-- `make forecaster-sweep-shuffled-control TRAINING_PACKAGE_ID=<id>
-  TEXT_ENCODER=<alias>` — same architecture roster and seed set,
-  median HP combo, `--shuffle-targets-control` on. The
-  memorisation-control row lands in the aggregator's
-  "Shuffled-targets control" section.
+- `make forecaster-sweep TRAINING_PACKAGE_ID=<id>` — 8-architecture
+  rich-feature sweep (lstm, lstm_attn, gru, tcn, transformer, dlinear,
+  informer, tft) across the official five-seed set.
 - `make forecaster-sweep-baseline TRAINING_PACKAGE_ID=<id>` — the
   pre-PR-#173 6-feature path against the original six architectures,
   preserved for back-compat smoke checks against earlier sweep numbers.
-
-### Forecaster text-embedding input space
-
-The training-package loader optionally pulls per-statement
-embeddings from `data/raw/embeddings/<encoder>_<rev>.parquet` (built
-by `app.data.embedding_cache`) and feeds them to the forecaster as
-a fifth feature family on top of the 35-dim rich-feature scalar
-input. The encoder pick is exposed through the
-`--text-encoder {finbert, finbert_fomc, finbert_fed_adjacent,
-bert_base_fed_adjacent, bge_large_en_v15, nomic_embed_text_v15,
-voyage_finance_2, none}` CLI flag; the default `none` keeps the
-rich-features-only path byte-identical.
-
-#### Pooling formula
-
-For each event the loader picks the four most recent FOMC
-statements strictly before the event date and pools them with
-softmax-weighted means:
-
-```
-w_i = softmax_i ( - Delta t_i / lambda_inv_days )
-pooled = sum_i ( w_i * embedding_i )
-```
-
-where `Delta t_i` is the day count between the prior statement and
-the current event. `lambda_inv_days` defaults to 30.0 (override
-through `--text-pool-lambda-inv-days`). The closer the prior
-statement, the larger its weight; at `lambda_inv = 30` the most
-recent statement carries roughly half the mass when the prior was
-30 days back.
-
-#### Encoder list and pooled dim
-
-| Encoder alias              | Pooled `in_dim` | Source           |
-| -------------------------- | ---:           | ---------------- |
-| `finbert`                  | 768            | ProsusAI/finbert (Araci 2019) |
-| `finbert_fomc`             | 768            | ZiweiChen/FinBERT-FOMC |
-| `finbert_fed_adjacent`     | 768            | local continued-pretrain on BIS + Fed adjacent |
-| `bert_base_fed_adjacent`   | 768            | local continued-pretrain control |
-| `bge_large_en_v15`         | 1024           | BAAI/bge-large-en-v1.5 |
-| `nomic_embed_text_v15`     | 768            | nomic-ai/nomic-embed-text-v1.5 |
-| `voyage_finance_2`         | 1024           | voyageai/voyage-finance-2 |
-
-The encoder-native dim flows onto the `FeatureVector` as
-`text_embedding_pooled: list[float]`; the adapter projection from
-`in_dim` to `text_adapter_dim` runs inside `ForecasterModel.forward`
-so the recurrent core sees a fixed per-bar feature size regardless
-of which encoder is active. Adapter shape is
-`Linear(in_dim, out_dim) -> LayerNorm(out_dim) -> GELU`, zero-init
-so a freshly enabled text path forwards to the same point in
-feature space as the rich-features-only baseline.
-
-#### Per-bar input size when the text path is on
-
-| Slice                                    | Width  | Notes |
-| ---------------------------------------- | ------ | ----- |
-| `[0:35]`                                 | 35     | Existing scalar rich-feature slice (`as_rich_list`). |
-| `[35:35 + text_adapter_dim]`             | 32 / 64 / 128 | Adapter output broadcast onto every bar. |
-| `[35 + text_adapter_dim]`                | 1      | `text_embedding_missing` flag (1.0 when fewer than one prior statement is available). |
-
-#### Missing semantics
-
-When the four-statement pool can't materialise (e.g. the
-chronologically-earliest event in the corpus has no prior), the
-loader emits a zero `in_dim`-vector and flips
-`text_embedding_missing` to 1.0. The model multiplies the adapter
-output by `(1 - missing)` so the recurrent core sees an
-unambiguous zero slot rather than an interpolated mean. When the
-encoder parquet is missing from `data/raw/embeddings/`, the loader
-emits a single `WARNING` log line and the entire run degrades to
-the missing-flag path.
-
-#### Shuffled-targets memorisation control
-
-`--shuffle-targets-control` permutes the target column per fold
-(seed-fixed for reproducibility) before training. macro-RMSE on
-the shuffled-targets run should sit near the constant-mean
-predictor; a real-targets run whose RMSE is close to its shuffled
-counterpart is memorising rather than learning the input-target
-mapping. The aggregator reports the shuffled run in a separate
-"Shuffled-targets control" section so the headline real-target
-table is not contaminated.
-
-The `forecaster_sweep_aggregator` markdown table grows
-`train-RMSE`, `holdout-RMSE`, and `holdout/train gap` columns
-alongside the existing close / volatility / combined CIs. Rows
-whose mean gap crosses 0.5 get a trailing `!` on the gap cell.
 
 ## Pipeline schema validation
 

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -924,12 +924,109 @@ pre-PR-#173 6-feature input. The per-family flags are no-ops when
 
 #### Make targets
 
-- `make forecaster-sweep TRAINING_PACKAGE_ID=<id>` — 8-architecture
-  rich-feature sweep (lstm, lstm_attn, gru, tcn, transformer, dlinear,
-  informer, tft) across the official five-seed set.
+- `make forecaster-sweep TRAINING_PACKAGE_ID=<id> TEXT_ENCODER=<alias>`
+  — 8-architecture rich-feature sweep (lstm, lstm_attn, gru, tcn,
+  transformer, dlinear, informer, tft) across the official
+  five-seed set. The grid now sweeps hidden_size {32, 64, 128} x
+  num_layers {1, 2, 3} x dropout {0.1, 0.2, 0.3, 0.4} x
+  learning_rate {1e-3, 3e-4} x weight_decay {0, 1e-4, 1e-3} x
+  text_adapter_dim {32, 64, 128}. Pass `TEXT_ENCODER=none` for the
+  text-off baseline row.
+- `make forecaster-sweep-shuffled-control TRAINING_PACKAGE_ID=<id>
+  TEXT_ENCODER=<alias>` — same architecture roster and seed set,
+  median HP combo, `--shuffle-targets-control` on. The
+  memorisation-control row lands in the aggregator's
+  "Shuffled-targets control" section.
 - `make forecaster-sweep-baseline TRAINING_PACKAGE_ID=<id>` — the
   pre-PR-#173 6-feature path against the original six architectures,
   preserved for back-compat smoke checks against earlier sweep numbers.
+
+### Forecaster text-embedding input space
+
+The training-package loader optionally pulls per-statement
+embeddings from `data/raw/embeddings/<encoder>_<rev>.parquet` (built
+by `app.data.embedding_cache`) and feeds them to the forecaster as
+a fifth feature family on top of the 35-dim rich-feature scalar
+input. The encoder pick is exposed through the
+`--text-encoder {finbert, finbert_fomc, finbert_fed_adjacent,
+bert_base_fed_adjacent, bge_large_en_v15, nomic_embed_text_v15,
+voyage_finance_2, none}` CLI flag; the default `none` keeps the
+rich-features-only path byte-identical.
+
+#### Pooling formula
+
+For each event the loader picks the four most recent FOMC
+statements strictly before the event date and pools them with
+softmax-weighted means:
+
+```
+w_i = softmax_i ( - Delta t_i / lambda_inv_days )
+pooled = sum_i ( w_i * embedding_i )
+```
+
+where `Delta t_i` is the day count between the prior statement and
+the current event. `lambda_inv_days` defaults to 30.0 (override
+through `--text-pool-lambda-inv-days`). The closer the prior
+statement, the larger its weight; at `lambda_inv = 30` the most
+recent statement carries roughly half the mass when the prior was
+30 days back.
+
+#### Encoder list and pooled dim
+
+| Encoder alias              | Pooled `in_dim` | Source           |
+| -------------------------- | ---:           | ---------------- |
+| `finbert`                  | 768            | ProsusAI/finbert (Araci 2019) |
+| `finbert_fomc`             | 768            | ZiweiChen/FinBERT-FOMC |
+| `finbert_fed_adjacent`     | 768            | local continued-pretrain on BIS + Fed adjacent |
+| `bert_base_fed_adjacent`   | 768            | local continued-pretrain control |
+| `bge_large_en_v15`         | 1024           | BAAI/bge-large-en-v1.5 |
+| `nomic_embed_text_v15`     | 768            | nomic-ai/nomic-embed-text-v1.5 |
+| `voyage_finance_2`         | 1024           | voyageai/voyage-finance-2 |
+
+The encoder-native dim flows onto the `FeatureVector` as
+`text_embedding_pooled: list[float]`; the adapter projection from
+`in_dim` to `text_adapter_dim` runs inside `ForecasterModel.forward`
+so the recurrent core sees a fixed per-bar feature size regardless
+of which encoder is active. Adapter shape is
+`Linear(in_dim, out_dim) -> LayerNorm(out_dim) -> GELU`, zero-init
+so a freshly enabled text path forwards to the same point in
+feature space as the rich-features-only baseline.
+
+#### Per-bar input size when the text path is on
+
+| Slice                                    | Width  | Notes |
+| ---------------------------------------- | ------ | ----- |
+| `[0:35]`                                 | 35     | Existing scalar rich-feature slice (`as_rich_list`). |
+| `[35:35 + text_adapter_dim]`             | 32 / 64 / 128 | Adapter output broadcast onto every bar. |
+| `[35 + text_adapter_dim]`                | 1      | `text_embedding_missing` flag (1.0 when fewer than one prior statement is available). |
+
+#### Missing semantics
+
+When the four-statement pool can't materialise (e.g. the
+chronologically-earliest event in the corpus has no prior), the
+loader emits a zero `in_dim`-vector and flips
+`text_embedding_missing` to 1.0. The model multiplies the adapter
+output by `(1 - missing)` so the recurrent core sees an
+unambiguous zero slot rather than an interpolated mean. When the
+encoder parquet is missing from `data/raw/embeddings/`, the loader
+emits a single `WARNING` log line and the entire run degrades to
+the missing-flag path.
+
+#### Shuffled-targets memorisation control
+
+`--shuffle-targets-control` permutes the target column per fold
+(seed-fixed for reproducibility) before training. macro-RMSE on
+the shuffled-targets run should sit near the constant-mean
+predictor; a real-targets run whose RMSE is close to its shuffled
+counterpart is memorising rather than learning the input-target
+mapping. The aggregator reports the shuffled run in a separate
+"Shuffled-targets control" section so the headline real-target
+table is not contaminated.
+
+The `forecaster_sweep_aggregator` markdown table grows
+`train-RMSE`, `holdout-RMSE`, and `holdout/train gap` columns
+alongside the existing close / volatility / combined CIs. Rows
+whose mean gap crosses 0.5 get a trailing `!` on the gap cell.
 
 ## Pipeline schema validation
 

--- a/tests/unit/test_embedding_cache.py
+++ b/tests/unit/test_embedding_cache.py
@@ -38,6 +38,17 @@ def test_resolve_cache_paths_handles_unpinned_revision(tmp_path: Path) -> None:
     assert paths.parquet.name == "finbert_fed_adjacent_unpinned.parquet"
 
 
+def test_resolve_cache_paths_normalises_hyphens_in_revision(tmp_path: Path) -> None:
+    """Voyage-style revisions carry hyphens; the cache writer normalises
+    them to underscores. The resolver must apply the same normalisation
+    so the loader finds the parquet on disk."""
+
+    paths = ec.resolve_cache_paths(
+        "voyage_finance_2", revision="voyage-finance-2", cache_dir=tmp_path
+    )
+    assert paths.parquet.name == "voyage_finance_2_voyage_finan.parquet"
+
+
 def test_build_cache_hard_fails_without_allow_network(tmp_path: Path, monkeypatch) -> None:
     """The training-time invariant: never silently download at runtime."""
 

--- a/tests/unit/test_forecaster_shuffled_control.py
+++ b/tests/unit/test_forecaster_shuffled_control.py
@@ -1,0 +1,168 @@
+"""Tests for the shuffled-targets memorisation control on the forecaster.
+
+The shuffled-targets control runs the model against a deterministic
+permutation of the target column. macro-RMSE on the shuffled-targets
+run should sit near the constant-mean predictor; a real-targets run
+whose RMSE is close to its shuffled counterpart is memorising rather
+than learning the input-target mapping.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.config import FeatureVector, ModelConfig
+from app.training.loop import train_model
+
+
+def _synthetic_vectors(n: int) -> list[FeatureVector]:
+    """Build a single small sequence the train loop can window over."""
+
+    out: list[FeatureVector] = []
+    for i in range(n):
+        sentiment = math.sin(i * 0.41) * 0.6 + 0.1
+        close = 4000.0 + 12.0 * i + 5.0 * math.sin(i * 0.3)
+        vol = 0.012 + 0.003 * math.sin(i * 0.7 + 1.1)
+        prev_close = (
+            4000.0 + 12.0 * (i - 1) + 5.0 * math.sin((i - 1) * 0.3) if i else close
+        )
+        prev_vol = (
+            0.012 + 0.003 * math.sin((i - 1) * 0.7 + 1.1) if i else vol
+        )
+        out.append(
+            FeatureVector.from_market_state(
+                date=f"2024-01-{i + 1:02d}",
+                sentiment_score=sentiment,
+                market_close=close,
+                market_volatility=vol,
+                previous_close=prev_close,
+                previous_volatility=prev_vol,
+                elapsed_time=float(i % 30),
+            )
+        )
+    return out
+
+
+_MODEL_CONFIG = ModelConfig(
+    input_size=6,
+    hidden_size=8,
+    num_layers=1,
+    dropout=0.0,
+    head_hidden_size=8,
+)
+
+
+def _train_summary(
+    *,
+    vectors: list[FeatureVector],
+    seed: int,
+    shuffle_targets_control: bool,
+    checkpoint: Path,
+):
+    result = train_model(
+        vectors=vectors,
+        epochs=4,
+        batch_size=8,
+        learning_rate=1e-3,
+        validation_split=0.25,
+        early_stopping_patience=2,
+        save_checkpoint=False,
+        checkpoint_path=checkpoint,
+        device="cpu",
+        seed=seed,
+        model_config=_MODEL_CONFIG,
+        shuffle_targets_control=shuffle_targets_control,
+    )
+    return result.summary
+
+
+def test_shuffled_targets_seed_determinism(tmp_path: Path) -> None:
+    """Same seed produces the same permutation -> same metrics."""
+
+    vectors = _synthetic_vectors(28)
+    first = _train_summary(
+        vectors=vectors,
+        seed=11,
+        shuffle_targets_control=True,
+        checkpoint=tmp_path / "first.pt",
+    )
+    second = _train_summary(
+        vectors=vectors,
+        seed=11,
+        shuffle_targets_control=True,
+        checkpoint=tmp_path / "second.pt",
+    )
+    assert first.metrics is not None and second.metrics is not None
+    assert first.metrics.combined_rmse == pytest.approx(
+        second.metrics.combined_rmse, abs=1e-8
+    )
+    assert first.target_mode == "shuffled"
+    assert second.target_mode == "shuffled"
+
+
+def test_shuffled_targets_independent_per_fold(tmp_path: Path) -> None:
+    """Different seeds produce different shuffles -> different metrics.
+
+    The shuffle generator is seeded by the run seed, so two folds with
+    different seeds see different target permutations and the trained
+    model converges to different validation RMSEs.
+    """
+
+    vectors = _synthetic_vectors(28)
+    seed_11 = _train_summary(
+        vectors=vectors,
+        seed=11,
+        shuffle_targets_control=True,
+        checkpoint=tmp_path / "s11.pt",
+    )
+    seed_29 = _train_summary(
+        vectors=vectors,
+        seed=29,
+        shuffle_targets_control=True,
+        checkpoint=tmp_path / "s29.pt",
+    )
+    assert seed_11.metrics is not None and seed_29.metrics is not None
+    assert seed_11.metrics.combined_rmse != pytest.approx(
+        seed_29.metrics.combined_rmse, abs=1e-6
+    )
+
+
+def test_shuffled_targets_marks_summary(tmp_path: Path) -> None:
+    """The summary's ``target_mode`` flips to ``shuffled`` on the control."""
+
+    vectors = _synthetic_vectors(28)
+    real_summary = _train_summary(
+        vectors=vectors,
+        seed=11,
+        shuffle_targets_control=False,
+        checkpoint=tmp_path / "real.pt",
+    )
+    shuffled_summary = _train_summary(
+        vectors=vectors,
+        seed=11,
+        shuffle_targets_control=True,
+        checkpoint=tmp_path / "shuffled.pt",
+    )
+    assert real_summary.target_mode == "real"
+    assert shuffled_summary.target_mode == "shuffled"
+
+
+def test_summary_carries_train_metrics(tmp_path: Path) -> None:
+    """``TrainingRunSummary`` exposes train_metrics for the gap derivative."""
+
+    vectors = _synthetic_vectors(28)
+    summary = _train_summary(
+        vectors=vectors,
+        seed=11,
+        shuffle_targets_control=False,
+        checkpoint=tmp_path / "real.pt",
+    )
+    assert summary.train_metrics is not None
+    assert math.isfinite(summary.train_metrics.combined_rmse)
+    assert summary.metrics is not None
+    assert math.isfinite(summary.metrics.combined_rmse)

--- a/tests/unit/test_text_embedding_adapter.py
+++ b/tests/unit/test_text_embedding_adapter.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("torch")
+
+import torch  # noqa: E402
+from torch import nn  # noqa: E402
+
+from app.models.text_embedding_adapter import TextEmbeddingAdapter
+
+
+def test_adapter_shape_invariant() -> None:
+    """Pooled (batch, 1024) projects to (batch, 64) regardless of batch."""
+
+    adapter = TextEmbeddingAdapter(in_dim=1024, out_dim=64, zero_init=False)
+    pooled = torch.randn(16, 1024)
+    out = adapter(pooled)
+    assert out.shape == (16, 64)
+    assert out.dtype == pooled.dtype
+
+
+def test_adapter_layernorm_then_gelu() -> None:
+    """Layer order is Linear -> LayerNorm -> GELU.
+
+    Hooks fire on the underlying submodules during the forward pass and
+    must be invoked in the documented order.
+    """
+
+    adapter = TextEmbeddingAdapter(in_dim=768, out_dim=32, zero_init=False)
+    fired: list[str] = []
+
+    def _record(name: str):
+        def _hook(_module: nn.Module, _inputs, _output) -> None:
+            fired.append(name)
+
+        return _hook
+
+    adapter.linear.register_forward_hook(_record("linear"))
+    adapter.norm.register_forward_hook(_record("norm"))
+    adapter.activation.register_forward_hook(_record("activation"))
+
+    adapter(torch.randn(4, 768))
+    assert fired == ["linear", "norm", "activation"]
+
+
+def test_adapter_handles_zero_input_without_nan() -> None:
+    """All-zero pooled input passes cleanly through the adapter.
+
+    LayerNorm of a zero tensor maps to zero (with eps in the
+    denominator); GELU(0) is 0. The adapter must emit a finite tensor
+    even on a row whose pooled embedding is all zeros (the
+    ``text_embedding_missing == 1.0`` case the loader writes when there
+    are fewer than one prior statement).
+    """
+
+    adapter = TextEmbeddingAdapter(in_dim=512, out_dim=64, zero_init=True)
+    pooled = torch.zeros(2, 512)
+    out = adapter(pooled)
+    assert out.shape == (2, 64)
+    assert torch.isfinite(out).all().item()
+    # zero_init plus zero input collapses to a zero tensor through the
+    # whole stack.
+    assert torch.allclose(out, torch.zeros_like(out), atol=1e-5)
+
+
+def test_adapter_rejects_wrong_in_dim() -> None:
+    adapter = TextEmbeddingAdapter(in_dim=768, out_dim=32, zero_init=False)
+    with pytest.raises(ValueError):
+        adapter(torch.randn(2, 1024))
+
+
+def test_adapter_rejects_non_positive_dims() -> None:
+    with pytest.raises(ValueError):
+        TextEmbeddingAdapter(in_dim=0, out_dim=64)
+    with pytest.raises(ValueError):
+        TextEmbeddingAdapter(in_dim=768, out_dim=0)
+
+
+def test_adapter_1d_input_is_unsqueezed() -> None:
+    """A single un-batched pooled vector is accepted and projected."""
+
+    adapter = TextEmbeddingAdapter(in_dim=768, out_dim=64, zero_init=False)
+    out = adapter(torch.randn(768))
+    assert out.shape == (1, 64)

--- a/tests/unit/test_training_package_loader.py
+++ b/tests/unit/test_training_package_loader.py
@@ -828,3 +828,400 @@ def test_rebuilt_assets_drive_nonzero_mp_surprise_and_pivot_distance(
     assert nonzero_mp_seen, (
         "mp_surprises.parquet did not feed the MP-surprise slice"
     )
+
+
+# ---------------------------------------------------------------------------
+# Text-embedding tests (PR #176)
+#
+# The four tests below exercise the prior-4 statement pool, the missing-
+# flag semantics on the first event in the corpus, the encoder-driven
+# in_dim, and the byte-identical no-text path. They use a synthetic
+# embedding parquet under ``tmp_path`` so no real encoder fires; the
+# test patches ``revision_for`` and ``resolve_cache_paths`` so the
+# loader resolves to the synthetic file.
+# ---------------------------------------------------------------------------
+
+
+def _write_synthetic_embedding_parquet(
+    cache_dir: Path,
+    encoder_alias: str,
+    *,
+    rows: list[dict[str, "Any"]],
+    revision: str = "abc1234",
+) -> Path:
+    """Materialise a synthetic embedding-cache parquet on disk."""
+
+    import pandas as pd
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    parquet_path = cache_dir / f"{encoder_alias}_{revision[:12]}.parquet"
+    pd.DataFrame(rows).to_parquet(parquet_path, index=False)
+    return parquet_path
+
+
+def _patch_encoder_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    encoder_alias: str,
+    revision: str = "abc1234",
+    cache_dir: Path | None = None,
+) -> None:
+    """Patch the registry + cache paths to point at a tmp_path artefact."""
+
+    from app.data import embedding_cache as embedding_cache_module
+    from app.training import loaders as loaders_module
+
+    def _revision_for(_alias: str) -> str:
+        return revision
+
+    monkeypatch.setattr(loaders_module, "_logger", loaders_module._logger)
+
+    # The loader does ``from app.models.registry import revision_for``
+    # inside ``_read_chunk_embedding_lookup`` -- patch the registry
+    # module itself so the import resolves to our stub.
+    import app.models.registry as registry_module
+
+    monkeypatch.setattr(registry_module, "revision_for", _revision_for)
+    monkeypatch.setattr(
+        embedding_cache_module, "DEFAULT_CACHE_DIR", cache_dir or embedding_cache_module.DEFAULT_CACHE_DIR
+    )
+
+
+def test_text_embedding_pool_weighting_decays_with_age(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The most recent prior statement gets the largest weight.
+
+    Synthesise four prior statements at Delta t = 0, 30, 60, 90 days.
+    The current event is the fifth statement, dated 90 days after the
+    oldest. With ``lambda_inv_days = 30`` the most recent (Delta t = 0)
+    statement contributes >0.5 of the pooled mass and the farthest
+    (Delta t = 90) contributes <0.1.
+    """
+
+    import numpy as np
+
+    package_id = "tp_unit_text_embed_weighting"
+    package_dir = tmp_path / "processed" / package_id
+    package_dir.mkdir(parents=True)
+    cache_dir = tmp_path / "raw" / "embeddings"
+
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+    _patch_encoder_registry(monkeypatch, encoder_alias="finbert", cache_dir=cache_dir)
+    monkeypatch.setattr(loaders, "_logger", loaders._logger)
+
+    # Five statements spaced 30 days apart, base_close stays constant.
+    dates = ["2024-01-01", "2024-01-31", "2024-03-01", "2024-03-31", "2024-04-30"]
+    text_hashes = [f"hash_{i}" for i in range(5)]
+    events = []
+    for date_str, hash_str in zip(dates, text_hashes):
+        events.append(
+            _event_row(
+                event_date=date_str,
+                text_hash=hash_str,
+                axis_stance="hawkish",
+                realized_return=0.001,
+                realized_date=f"{date_str[:8]}{int(date_str[8:]) + 1:02d}",
+                base_close=4500.0,
+            )
+        )
+    pd.DataFrame(events).to_parquet(package_dir / "events.parquet", index=False)
+    pd.DataFrame(
+        [{"text_hash": h, "split_tag": "train"} for h in text_hashes]
+    ).to_parquet(package_dir / "splits_train_val_test.parquet", index=False)
+
+    # Build four distinct embedding vectors so the pooled mean is
+    # identifiable. The fifth statement (current event) carries its
+    # own embedding too, but the pooler reads only the four priors.
+    in_dim = 8
+    embedding_rows = []
+    for i, (date_str, hash_str) in enumerate(zip(dates, text_hashes)):
+        vec = np.zeros(in_dim, dtype=np.float32)
+        vec[i] = 1.0
+        embedding_rows.append(
+            {
+                "record_id": hash_str,
+                "doc_id": hash_str,
+                "event_date": date_str,
+                "chunk_index": 0,
+                "chunk_preview": "",
+                "embedding": vec.tolist(),
+            }
+        )
+    _write_synthetic_embedding_parquet(
+        cache_dir, "finbert", rows=embedding_rows
+    )
+
+    sequences = loaders.load_training_sequences_from_package(
+        package_id,
+        text_encoder="finbert",
+        text_adapter_dim=64,
+        text_pool_lambda_inv_days=30.0,
+        text_embedding_cache_dir=cache_dir,
+    )
+    # 5 events all tagged train -> 5 sequences.
+    assert len(sequences) == 5
+
+    # Final event (hash_4) has 4 priors at Delta t = 30, 60, 90, 120.
+    # Expected softmax weights at lambda=30: exp(-1, -2, -3, -4)
+    # normalised. Most recent (hash_3, idx=3) > 0.5, oldest (hash_0,
+    # idx=0) < 0.1.
+    target_event = sequences[-1][0]
+    pooled = np.asarray(target_event.text_embedding_pooled, dtype=np.float32)
+    assert pooled.shape == (in_dim,)
+    # Weights on (hash_3, hash_2, hash_1, hash_0) -- the four prior
+    # statements in chronological order on the lookup. The most
+    # recent (hash_3 at Delta t = 30) places the largest mass on
+    # vec[3]; the oldest (hash_0 at Delta t = 120) gets the smallest.
+    weight_recent = float(pooled[3])
+    weight_oldest = float(pooled[0])
+    assert weight_recent > 0.5
+    assert weight_oldest < 0.1
+    assert target_event.text_embedding_missing == pytest.approx(0.0)
+
+
+def test_text_embedding_missing_when_fewer_than_one_prior(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The chronologically-earliest event has no prior to pool over."""
+
+    import numpy as np
+
+    package_id = "tp_unit_text_embed_missing"
+    package_dir = tmp_path / "processed" / package_id
+    package_dir.mkdir(parents=True)
+    cache_dir = tmp_path / "raw" / "embeddings"
+
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+    _patch_encoder_registry(monkeypatch, encoder_alias="finbert", cache_dir=cache_dir)
+
+    events = [
+        _event_row(
+            event_date="2024-01-01",
+            text_hash="hash_first",
+            axis_stance="hawkish",
+            realized_return=0.001,
+            realized_date="2024-01-02",
+            base_close=4500.0,
+        ),
+        _event_row(
+            event_date="2024-02-01",
+            text_hash="hash_second",
+            axis_stance="dovish",
+            realized_return=-0.001,
+            realized_date="2024-02-02",
+            base_close=4500.0,
+        ),
+    ]
+    pd.DataFrame(events).to_parquet(package_dir / "events.parquet", index=False)
+    pd.DataFrame(
+        [
+            {"text_hash": "hash_first", "split_tag": "train"},
+            {"text_hash": "hash_second", "split_tag": "train"},
+        ]
+    ).to_parquet(package_dir / "splits_train_val_test.parquet", index=False)
+
+    in_dim = 8
+    embedding_rows = [
+        {
+            "record_id": h,
+            "doc_id": h,
+            "event_date": d,
+            "chunk_index": 0,
+            "chunk_preview": "",
+            "embedding": np.eye(in_dim)[i].astype(np.float32).tolist(),
+        }
+        for i, (h, d) in enumerate(
+            [("hash_first", "2024-01-01"), ("hash_second", "2024-02-01")]
+        )
+    ]
+    _write_synthetic_embedding_parquet(
+        cache_dir, "finbert", rows=embedding_rows
+    )
+
+    sequences = loaders.load_training_sequences_from_package(
+        package_id,
+        text_encoder="finbert",
+        text_adapter_dim=64,
+        text_embedding_cache_dir=cache_dir,
+    )
+    assert len(sequences) == 2
+
+    by_event_date = {seq[0].date[:10]: seq for seq in sequences}
+    # First sequence's event_date doesn't have a chronological prior
+    # statement -> missing flag 1.0, pooled empty.
+    first = sequences[0]
+    assert first[0].text_embedding_missing == pytest.approx(1.0)
+    assert first[0].text_embedding_pooled == []
+    del by_event_date
+    # Second sequence has hash_first as its prior; pool should land on
+    # the eye[0] basis vector at full weight.
+    second = sequences[1]
+    assert second[0].text_embedding_missing == pytest.approx(0.0)
+    assert len(second[0].text_embedding_pooled) == in_dim
+    assert second[0].text_embedding_pooled[0] == pytest.approx(1.0)
+
+
+def test_text_embedding_encoder_choice_changes_input_dim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pooled embedding inherits the encoder's native dim."""
+
+    import numpy as np
+
+    package_id = "tp_unit_text_embed_dim"
+    package_dir = tmp_path / "processed" / package_id
+    package_dir.mkdir(parents=True)
+    cache_dir = tmp_path / "raw" / "embeddings"
+
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+
+    events = [
+        _event_row(
+            event_date=f"2024-{month:02d}-15",
+            text_hash=f"hash_{i}",
+            axis_stance="hawkish",
+            realized_return=0.001,
+            realized_date=f"2024-{month:02d}-16",
+            base_close=4500.0,
+        )
+        for i, month in enumerate([1, 2, 3])
+    ]
+    pd.DataFrame(events).to_parquet(package_dir / "events.parquet", index=False)
+    pd.DataFrame(
+        [{"text_hash": e["text_hash"], "split_tag": "train"} for e in events]
+    ).to_parquet(package_dir / "splits_train_val_test.parquet", index=False)
+
+    def _row_with_dim(dim: int) -> list[dict]:
+        return [
+            {
+                "record_id": e["text_hash"],
+                "doc_id": e["text_hash"],
+                "event_date": e["event_date"],
+                "chunk_index": 0,
+                "chunk_preview": "",
+                "embedding": np.ones(dim, dtype=np.float32).tolist(),
+            }
+            for e in events
+        ]
+
+    # FinBERT path: in_dim = 768.
+    _patch_encoder_registry(monkeypatch, encoder_alias="finbert", cache_dir=cache_dir)
+    _write_synthetic_embedding_parquet(
+        cache_dir, "finbert", rows=_row_with_dim(768)
+    )
+    finbert_sequences = loaders.load_training_sequences_from_package(
+        package_id,
+        text_encoder="finbert",
+        text_adapter_dim=64,
+        text_embedding_cache_dir=cache_dir,
+    )
+    second_event = finbert_sequences[1][0]
+    assert len(second_event.text_embedding_pooled) == 768
+
+    # voyage_finance_2 path: in_dim = 1024. Clear caches so the second
+    # invocation re-reads the synthetic parquet rather than reusing
+    # the FinBERT 768-dim payload.
+    _patch_encoder_registry(monkeypatch, encoder_alias="voyage_finance_2", cache_dir=cache_dir)
+    _write_synthetic_embedding_parquet(
+        cache_dir, "voyage_finance_2", rows=_row_with_dim(1024)
+    )
+    voyage_sequences = loaders.load_training_sequences_from_package(
+        package_id,
+        text_encoder="voyage_finance_2",
+        text_adapter_dim=64,
+        text_embedding_cache_dir=cache_dir,
+    )
+    voyage_second = voyage_sequences[1][0]
+    assert len(voyage_second.text_embedding_pooled) == 1024
+
+
+def test_no_text_embeddings_zeros_slice_but_shape_preserved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``use_text_embeddings=False`` skips the encoder lookup entirely."""
+
+    import numpy as np
+
+    package_id = "tp_unit_text_embed_off"
+    package_dir = tmp_path / "processed" / package_id
+    package_dir.mkdir(parents=True)
+    cache_dir = tmp_path / "raw" / "embeddings"
+
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+    _patch_encoder_registry(monkeypatch, encoder_alias="finbert", cache_dir=cache_dir)
+
+    events = [
+        _event_row(
+            event_date="2024-02-15",
+            text_hash="hash_a",
+            axis_stance="hawkish",
+            realized_return=0.001,
+            realized_date="2024-02-16",
+            base_close=4500.0,
+        ),
+        _event_row(
+            event_date="2024-03-15",
+            text_hash="hash_b",
+            axis_stance="dovish",
+            realized_return=-0.001,
+            realized_date="2024-03-16",
+            base_close=4500.0,
+        ),
+    ]
+    pd.DataFrame(events).to_parquet(package_dir / "events.parquet", index=False)
+    pd.DataFrame(
+        [{"text_hash": "hash_a", "split_tag": "train"}, {"text_hash": "hash_b", "split_tag": "train"}]
+    ).to_parquet(package_dir / "splits_train_val_test.parquet", index=False)
+
+    _write_synthetic_embedding_parquet(
+        cache_dir,
+        "finbert",
+        rows=[
+            {
+                "record_id": "hash_a",
+                "doc_id": "hash_a",
+                "event_date": "2024-02-15",
+                "chunk_index": 0,
+                "chunk_preview": "",
+                "embedding": np.ones(768, dtype=np.float32).tolist(),
+            }
+        ],
+    )
+
+    sequences_off = loaders.load_training_sequences_from_package(
+        package_id,
+        text_encoder="finbert",
+        text_adapter_dim=64,
+        use_text_embeddings=False,
+        text_embedding_cache_dir=cache_dir,
+    )
+    # text path off -> no pooled vector, missing-flag stays at the
+    # ``FeatureVector`` default (1.0).
+    for sequence in sequences_off:
+        for vector in sequence:
+            assert vector.text_embedding_pooled == []
+            assert vector.text_embedding_missing == pytest.approx(1.0)
+
+    sequences_on = loaders.load_training_sequences_from_package(
+        package_id,
+        text_encoder="finbert",
+        text_adapter_dim=64,
+        use_text_embeddings=True,
+        text_embedding_cache_dir=cache_dir,
+    )
+    # Both flag values produce the same number of sequences and the
+    # same per-bar scalar 35-dim slice. The only difference is the
+    # pooled list + missing-flag pair on the FeatureVector.
+    assert len(sequences_on) == len(sequences_off)
+    on_scalar = sequences_on[0][0].as_rich_list()
+    off_scalar = sequences_off[0][0].as_rich_list()
+    assert on_scalar == off_scalar
+    # hash_b (chronologically second) hits the pool with hash_a as the
+    # prior; the pooled embedding lands at the eye[0] basis vector.
+    chronological = sorted(
+        sequences_on, key=lambda seq: seq[-1].date[:10]
+    )
+    second_event = chronological[1][0]
+    assert len(second_event.text_embedding_pooled) == 768
+    assert second_event.text_embedding_missing == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

- New TextEmbeddingAdapter (in_dim -> out_dim, LayerNorm + GELU) under backend/app/models/. Encoder-agnostic.
- Loader pools the 4 most recent FOMC statement embeddings with softmax(-Delta t / lambda) weights (default lambda=30 days), attaches the resulting in_dim vector to every bar of the prior window + the event-day target frame.
- New --text-encoder flag (finbert / finbert_fomc / finbert_fed_adjacent / bert_base_fed_adjacent / bge_large_en_v15 / nomic_embed_text_v15 / voyage_finance_2 / none). Default none keeps the rich-features-only path byte-identical.
- --text-adapter-dim {32, 64, 128} controls the projection dim; --text-pool-lambda-inv-days controls the time-decay window.
- forecaster-sweep target widens the HP grid: dropout {0.1, 0.2, 0.3, 0.4}, weight_decay {0, 1e-4, 1e-3}, adapter_dim {32, 64, 128}. 216 HP combos x 8 architectures x 5 seeds.
- New --shuffle-targets-control flag + companion sweep target for the memorisation-control row.
- forecaster_sweep_aggregator emits train/val/holdout RMSE + holdout_train_gap + gap_flag in the markdown table.
- 9 new unit tests + a regression byte-identity audit on the no-text path.

## Test plan

- [ ] `docker compose run --rm --no-deps backend pytest tests/unit/test_training_package_loader.py tests/unit/test_text_embedding_adapter.py tests/unit/test_forecaster_shuffled_control.py tests/regression/ -q`
- [ ] Real-package smoke with --text-encoder finbert produces 895 sequences with pooled 768-dim embeddings.
- [ ] `make forecaster-sweep` end-to-end on the rich-features+text path runs (fired after merge).

Follows #173 + #174.