### PR TITLE
Forecaster sweep iterates the four walk-forward folds for cross-regime CIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ forecaster-sweep:
 		--rich-features \
 		--architectures lstm lstm_attn gru tcn transformer dlinear informer tft \
 		--seeds 11 29 47 71 97 \
+		--folds wf_fold_1 wf_fold_2 wf_fold_3 wf_fold_4 \
 		--hidden-sizes 32 64 128 \
 		--num-layers-grid 1 2 3 \
 		--dropouts 0.1 0.2 0.3 0.4 \

--- a/backend/app/evaluation/forecaster_sweep_aggregator.py
+++ b/backend/app/evaluation/forecaster_sweep_aggregator.py
@@ -29,6 +29,12 @@ from typing import Any, Iterable
 from app.evaluation.bootstrap import BootstrapCI, block_bootstrap_ci
 
 
+# Sentinel used in the ``fold`` slot of an ``ArchitectureRow`` when the
+# row aggregates across every fold in the sweep. Real per-fold rows
+# carry their fold id (e.g. ``wf_fold_2``) here.
+ALL_FOLDS_LABEL = "all-folds"
+
+
 @dataclass(frozen=True)
 class ArchitectureRow:
     architecture: str
@@ -57,6 +63,12 @@ class ArchitectureRow:
     holdout_train_gap: float = 0.0
     gap_flag: str = "ok"
     target_mode: str = "real"
+    # ``fold`` carries the fold id for per-fold rows; the aggregated
+    # row across every fold under an (architecture, target_mode) bucket
+    # uses ``ALL_FOLDS_LABEL``. Single-fold sweeps (pre-PR contract)
+    # emit one row per architecture with fold == ALL_FOLDS_LABEL and
+    # no per-fold rows underneath it.
+    fold: str = ALL_FOLDS_LABEL
 
 
 def _load_report(path: Path) -> dict[str, Any]:
@@ -139,18 +151,71 @@ def _trial_target_mode(trial: dict[str, Any]) -> str:
     return "real"
 
 
-def _bucket_key(architecture: str, target_mode: str) -> str:
+def _trial_fold_id(trial: dict[str, Any]) -> str | None:
+    fold = trial.get("fold_id")
+    if fold is None:
+        summary = trial.get("summary") or {}
+        fold = summary.get("fold_id")
+    if fold is None:
+        return None
+    fold_str = str(fold).strip()
+    return fold_str or None
+
+
+def _bucket_key(architecture: str, target_mode: str, fold: str) -> str:
     """Compose the dict key the aggregator groups by.
 
     Shuffled-target trials sit in a separate bucket so the
     memorisation-control row does not contaminate the headline table.
-    The key is ``"<architecture>"`` for ``target_mode == "real"`` and
-    ``"<architecture>::shuffled"`` otherwise.
+    The fold component pins per-fold rows to their own bucket; the
+    ``all-folds`` aggregate row is materialised separately from the
+    per-fold buckets at row-build time.
     """
 
-    if target_mode == "real":
-        return architecture
-    return f"{architecture}::{target_mode}"
+    base = architecture if target_mode == "real" else f"{architecture}::{target_mode}"
+    return f"{base}::{fold}"
+
+
+def _empty_bucket(
+    *,
+    architecture: str,
+    target_mode: str,
+    credibility_features: bool,
+    fold: str,
+) -> dict[str, Any]:
+    return {
+        "architecture": architecture,
+        "target_mode": target_mode,
+        "fold": fold,
+        "seeds": [],
+        "combined_rmse": [],
+        "close_rmse": [],
+        "volatility_rmse": [],
+        "train_combined_rmse": [],
+        "credibility_features": credibility_features,
+    }
+
+
+def _accumulate_trial(bucket: dict[str, Any], trial: dict[str, Any]) -> None:
+    combined = _trial_metric(trial, "combined_rmse")
+    if combined is None:
+        return
+    seed = _trial_seed(trial)
+    if seed is not None:
+        bucket["seeds"].append(seed)
+    bucket["combined_rmse"].append(combined)
+    close = _trial_metric(trial, "close_rmse")
+    if close is not None:
+        bucket["close_rmse"].append(close)
+    vol = _trial_metric(trial, "volatility_rmse")
+    if vol is not None:
+        bucket["volatility_rmse"].append(vol)
+    train_combined = _trial_train_metric(trial, "combined_rmse")
+    if train_combined is not None:
+        bucket["train_combined_rmse"].append(train_combined)
+    # Once any credibility-on trial lands for an architecture the
+    # bucket flips on so the headline label stays honest.
+    bucket["credibility_features"] = bucket["credibility_features"] or _trial_credibility(trial)
 
 
 def _collect_per_architecture(reports: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
@@ -159,39 +224,37 @@ def _collect_per_architecture(reports: list[dict[str, Any]]) -> dict[str, dict[s
         for trial in report.get("trials") or []:
             architecture = _trial_architecture(trial)
             target_mode = _trial_target_mode(trial)
-            key = _bucket_key(architecture, target_mode)
-            bucket = by_arch.setdefault(
-                key,
-                {
-                    "architecture": architecture,
-                    "target_mode": target_mode,
-                    "seeds": [],
-                    "combined_rmse": [],
-                    "close_rmse": [],
-                    "volatility_rmse": [],
-                    "train_combined_rmse": [],
-                    "credibility_features": _trial_credibility(trial),
-                },
+            fold = _trial_fold_id(trial) or ALL_FOLDS_LABEL
+            # Per-fold bucket: only materialised when the trial carries
+            # a real fold_id. The all-folds aggregate row is built off
+            # the same trials in a second pass below.
+            if fold != ALL_FOLDS_LABEL:
+                per_fold_key = _bucket_key(architecture, target_mode, fold)
+                bucket = by_arch.setdefault(
+                    per_fold_key,
+                    _empty_bucket(
+                        architecture=architecture,
+                        target_mode=target_mode,
+                        credibility_features=_trial_credibility(trial),
+                        fold=fold,
+                    ),
+                )
+                _accumulate_trial(bucket, trial)
+            # All-folds aggregate. Single-fold sweeps land their entire
+            # trial set here so the headline number is the aggregate
+            # across every cell under the (architecture, target_mode)
+            # pair.
+            all_folds_key = _bucket_key(architecture, target_mode, ALL_FOLDS_LABEL)
+            all_bucket = by_arch.setdefault(
+                all_folds_key,
+                _empty_bucket(
+                    architecture=architecture,
+                    target_mode=target_mode,
+                    credibility_features=_trial_credibility(trial),
+                    fold=ALL_FOLDS_LABEL,
+                ),
             )
-            combined = _trial_metric(trial, "combined_rmse")
-            if combined is None:
-                continue
-            seed = _trial_seed(trial)
-            if seed is not None:
-                bucket["seeds"].append(seed)
-            bucket["combined_rmse"].append(combined)
-            close = _trial_metric(trial, "close_rmse")
-            if close is not None:
-                bucket["close_rmse"].append(close)
-            vol = _trial_metric(trial, "volatility_rmse")
-            if vol is not None:
-                bucket["volatility_rmse"].append(vol)
-            train_combined = _trial_train_metric(trial, "combined_rmse")
-            if train_combined is not None:
-                bucket["train_combined_rmse"].append(train_combined)
-            # Once any credibility-on trial lands for an architecture the
-            # bucket flips on so the headline label stays honest.
-            bucket["credibility_features"] = bucket["credibility_features"] or _trial_credibility(trial)
+            _accumulate_trial(all_bucket, trial)
     return by_arch
 
 
@@ -209,6 +272,7 @@ def _build_rows(
             continue
         architecture = str(payload.get("architecture", _bucket_key_str))
         target_mode = str(payload.get("target_mode", "real"))
+        fold = str(payload.get("fold", ALL_FOLDS_LABEL))
         train_values = list(payload.get("train_combined_rmse") or [])
         val_values = list(payload["combined_rmse"])
         train_mean = (sum(train_values) / len(train_values)) if train_values else 0.0
@@ -271,13 +335,33 @@ def _build_rows(
                 holdout_train_gap=float(gap),
                 gap_flag=gap_flag,
                 target_mode=target_mode,
+                fold=fold,
             )
         )
-    # Lower combined-RMSE is better, so ascending sort gives rank order.
-    # Real-target rows sort first so the headline table is the
-    # production-relevant ranking; shuffled rows trail underneath in
-    # the same ascending order.
-    rows.sort(key=lambda r: (0 if r.target_mode == "real" else 1, r.combined_rmse_ci.point))
+    # Ordering: real-target rows first (the shuffled-control trails
+    # underneath); within an (architecture, target_mode) pair, per-fold
+    # rows ascend by ``fold`` and the ``all-folds`` row trails so the
+    # per-regime detail sits above the headline aggregate. Across
+    # architectures the per-fold-and-all-folds groups sort by the
+    # ``all-folds`` combined-RMSE so the headline ranking is the
+    # production-relevant ordering.
+    fold_priority = {ALL_FOLDS_LABEL: 1}
+    all_folds_rank: dict[tuple[str, str], float] = {}
+    for row in rows:
+        if row.fold == ALL_FOLDS_LABEL:
+            all_folds_rank[(row.architecture, row.target_mode)] = row.combined_rmse_ci.point
+
+    def _sort_key(row: ArchitectureRow) -> tuple[int, float, str, int, str]:
+        anchor = all_folds_rank.get((row.architecture, row.target_mode), row.combined_rmse_ci.point)
+        return (
+            0 if row.target_mode == "real" else 1,
+            anchor,
+            row.architecture,
+            fold_priority.get(row.fold, 0),
+            row.fold,
+        )
+
+    rows.sort(key=_sort_key)
     return rows
 
 
@@ -292,9 +376,9 @@ def render_markdown(rows: list[ArchitectureRow], *, coverage: float) -> str:
     lines: list[str] = []
     if real_rows:
         lines.append(
-            f"| Rank | Architecture | Credibility | n | mode | train-RMSE | holdout-RMSE | holdout/train gap | combined-RMSE (mean, {coverage_pct}% CI) | close-RMSE | volatility-RMSE |"
+            f"| Rank | Architecture | fold | Credibility | n | mode | train-RMSE | holdout-RMSE | holdout/train gap | combined-RMSE (mean, {coverage_pct}% CI) | close-RMSE | volatility-RMSE |"
         )
-        lines.append("|---:|---|:-:|---:|:-:|---|---|---:|---|---|---|")
+        lines.append("|---:|---|:-:|:-:|---:|:-:|---|---|---:|---|---|---|")
         for rank, row in enumerate(real_rows, start=1):
             lines.append(_render_row_line(row, rank, coverage_pct))
 
@@ -303,9 +387,9 @@ def render_markdown(rows: list[ArchitectureRow], *, coverage: float) -> str:
         lines.append("### Shuffled-targets control")
         lines.append("")
         lines.append(
-            f"| Rank | Architecture | Credibility | n | mode | train-RMSE | holdout-RMSE | holdout/train gap | combined-RMSE (mean, {coverage_pct}% CI) | close-RMSE | volatility-RMSE |"
+            f"| Rank | Architecture | fold | Credibility | n | mode | train-RMSE | holdout-RMSE | holdout/train gap | combined-RMSE (mean, {coverage_pct}% CI) | close-RMSE | volatility-RMSE |"
         )
-        lines.append("|---:|---|:-:|---:|:-:|---|---|---:|---|---|---|")
+        lines.append("|---:|---|:-:|:-:|---:|:-:|---|---|---:|---|---|---|")
         for rank, row in enumerate(shuffled_rows, start=1):
             lines.append(_render_row_line(row, rank, coverage_pct))
 
@@ -324,6 +408,7 @@ def _render_row_line(row: ArchitectureRow, rank: int, coverage_pct: int) -> str:
         gap_text = f"{gap_text}!"
     return (
         f"| {rank} | `{row.architecture}` | "
+        f"{row.fold} | "
         f"{'on' if row.credibility_features else 'off'} | {n} | "
         f"{row.target_mode} | "
         f"{train_ci.point:.4f} [{train_ci.lo:.4f}, {train_ci.hi:.4f}] | "
@@ -339,6 +424,7 @@ def _row_to_json(row: ArchitectureRow) -> dict[str, Any]:
     return {
         "architecture": row.architecture,
         "target_mode": row.target_mode,
+        "fold": row.fold,
         "seeds": row.seeds,
         "credibility_features": row.credibility_features,
         "combined_rmse": {

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -1477,18 +1477,18 @@ def main() -> int:
         loader_text_encoder = (
             None if str(args.text_encoder) == "none" else str(args.text_encoder)
         )
-        loader_kwargs: dict[str, Any] = dict(
-            target_mode=args.target_mode,
-            rich_features=bool(args.rich_features),
-            use_credibility=bool(args.use_credibility),
-            use_linguistic=bool(args.use_linguistic),
-            use_mp_surprise=bool(args.use_mp_surprise),
-            use_multi_axis=bool(args.use_multi_axis),
-            text_encoder=loader_text_encoder,
-            text_adapter_dim=int(args.text_adapter_dim),
-            text_pool_lambda_inv_days=float(args.text_pool_lambda_inv_days),
-            use_text_embeddings=bool(args.use_text_embeddings),
-        )
+        loader_kwargs: dict[str, Any] = {
+            "target_mode": args.target_mode,
+            "rich_features": bool(args.rich_features),
+            "use_credibility": bool(args.use_credibility),
+            "use_linguistic": bool(args.use_linguistic),
+            "use_mp_surprise": bool(args.use_mp_surprise),
+            "use_multi_axis": bool(args.use_multi_axis),
+            "text_encoder": loader_text_encoder,
+            "text_adapter_dim": int(args.text_adapter_dim),
+            "text_pool_lambda_inv_days": float(args.text_pool_lambda_inv_days),
+            "use_text_embeddings": bool(args.use_text_embeddings),
+        }
         folds_axis = list(getattr(args, "folds", None) or [])
         if folds_axis:
             print(f"Walk-forward folds: {' '.join(folds_axis)}")

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -435,6 +435,20 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--folds",
+        nargs="+",
+        default=[],
+        help=(
+            "Walk-forward fold ids to iterate (e.g. wf_fold_1 wf_fold_2 "
+            "wf_fold_3 wf_fold_4). Each fold materialises one cell per "
+            "(architecture, seed, hp_combo) tuple by restricting the "
+            "training sequences to the fold's test window via "
+            "fold_manifest_expanding_walk_forward.json. Default empty "
+            "list keeps single-fold behaviour (the package's default "
+            "split tag drives the partition)."
+        ),
+    )
+    parser.add_argument(
         "--parallel-workers",
         type=int,
         default=1,
@@ -718,6 +732,13 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
 
     use_random_search = bool(getattr(args, "random_search", False))
     text_embedding_dim = _resolve_text_embedding_dim(args)
+    # ``--folds`` defaults to an empty list. An empty list keeps the
+    # single-fold behaviour and the per-cell record carries no
+    # ``fold_id`` field; a non-empty list multiplies the candidate set
+    # by ``len(folds)`` and tags each cell with its ``fold_id`` so the
+    # aggregator can group per-fold and across-folds for the headline
+    # row.
+    folds_axis = list(getattr(args, "folds", None) or [])
 
     if use_random_search:
         # Random-search path: subsample the HP grid before the
@@ -731,30 +752,32 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
             int(getattr(args, "random_search_seed", DEFAULT_RANDOM_SEARCH_SEED)),
         )
         candidates: list[dict[str, Any]] = []
-        for architecture, seed in itertools.product(architectures, seeds):
+        fold_iter: list[str | None] = list(folds_axis) if folds_axis else [None]
+        for architecture, seed, fold in itertools.product(architectures, seeds, fold_iter):
             for hp_combo_id, hp in sampled_hp:
                 text_adapter_dim = int(hp["text_adapter_dim"])
-                candidates.append(
-                    {
-                        "model_config": ModelConfig(
-                            input_size=_resolved_input_size(args),
-                            hidden_size=hp["hidden_size"],
-                            num_layers=hp["num_layers"],
-                            dropout=hp["dropout"],
-                            head_hidden_size=args.head_hidden_size,
-                            architecture=str(architecture),
-                            credibility_features=bool(args.credibility_features),
-                            text_embedding_dim=int(text_embedding_dim) if text_adapter_dim > 0 else 0,
-                            text_adapter_dim=text_adapter_dim,
-                        ),
-                        "learning_rate": float(hp["learning_rate"]),
-                        "epochs": int(hp["epochs"]),
-                        "weight_decay": float(hp["weight_decay"]),
-                        "text_adapter_dim": text_adapter_dim,
-                        "seed": int(seed) if seed is not None else None,
-                        "hp_combo_id": int(hp_combo_id),
-                    }
-                )
+                record: dict[str, Any] = {
+                    "model_config": ModelConfig(
+                        input_size=_resolved_input_size(args),
+                        hidden_size=hp["hidden_size"],
+                        num_layers=hp["num_layers"],
+                        dropout=hp["dropout"],
+                        head_hidden_size=args.head_hidden_size,
+                        architecture=str(architecture),
+                        credibility_features=bool(args.credibility_features),
+                        text_embedding_dim=int(text_embedding_dim) if text_adapter_dim > 0 else 0,
+                        text_adapter_dim=text_adapter_dim,
+                    ),
+                    "learning_rate": float(hp["learning_rate"]),
+                    "epochs": int(hp["epochs"]),
+                    "weight_decay": float(hp["weight_decay"]),
+                    "text_adapter_dim": text_adapter_dim,
+                    "seed": int(seed) if seed is not None else None,
+                    "hp_combo_id": int(hp_combo_id),
+                }
+                if fold is not None:
+                    record["fold_id"] = str(fold)
+                candidates.append(record)
         return candidates
 
     # Exhaustive path: byte-identical to the pre-PR enumeration order so
@@ -776,6 +799,38 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
     else:
         text_adapter_dims = [0]
     candidates = []
+    if folds_axis:
+        # Fold axis is the innermost slot under the seed axis so the
+        # per-(architecture, seed, hp_combo) tuple emits its four folds
+        # contiguously; downstream aggregation groups on
+        # (architecture, fold_id) for the per-fold rows.
+        outer = itertools.product(
+            architectures,
+            hidden_sizes,
+            num_layers_options,
+            dropouts,
+            learning_rates,
+            epochs_options,
+            weight_decays,
+            text_adapter_dims,
+            seeds,
+            folds_axis,
+        )
+    else:
+        outer = (
+            tup + (None,)
+            for tup in itertools.product(
+                architectures,
+                hidden_sizes,
+                num_layers_options,
+                dropouts,
+                learning_rates,
+                epochs_options,
+                weight_decays,
+                text_adapter_dims,
+                seeds,
+            )
+        )
     for (
         architecture,
         hidden_size,
@@ -786,37 +841,29 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
         weight_decay,
         text_adapter_dim,
         seed,
-    ) in itertools.product(
-        architectures,
-        hidden_sizes,
-        num_layers_options,
-        dropouts,
-        learning_rates,
-        epochs_options,
-        weight_decays,
-        text_adapter_dims,
-        seeds,
-    ):
-        candidates.append(
-            {
-                "model_config": ModelConfig(
-                    input_size=_resolved_input_size(args),
-                    hidden_size=hidden_size,
-                    num_layers=num_layers,
-                    dropout=dropout,
-                    head_hidden_size=args.head_hidden_size,
-                    architecture=str(architecture),
-                    credibility_features=bool(args.credibility_features),
-                    text_embedding_dim=int(text_embedding_dim) if int(text_adapter_dim) > 0 else 0,
-                    text_adapter_dim=int(text_adapter_dim),
-                ),
-                "learning_rate": float(learning_rate),
-                "epochs": int(epochs),
-                "weight_decay": float(weight_decay),
-                "text_adapter_dim": int(text_adapter_dim),
-                "seed": int(seed) if seed is not None else None,
-            }
-        )
+        fold,
+    ) in outer:
+        record = {
+            "model_config": ModelConfig(
+                input_size=_resolved_input_size(args),
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                dropout=dropout,
+                head_hidden_size=args.head_hidden_size,
+                architecture=str(architecture),
+                credibility_features=bool(args.credibility_features),
+                text_embedding_dim=int(text_embedding_dim) if int(text_adapter_dim) > 0 else 0,
+                text_adapter_dim=int(text_adapter_dim),
+            ),
+            "learning_rate": float(learning_rate),
+            "epochs": int(epochs),
+            "weight_decay": float(weight_decay),
+            "text_adapter_dim": int(text_adapter_dim),
+            "seed": int(seed) if seed is not None else None,
+        }
+        if fold is not None:
+            record["fold_id"] = str(fold)
+        candidates.append(record)
     return candidates
 
 
@@ -863,6 +910,10 @@ def _flatten_trial_record(record: dict[str, Any]) -> dict[str, Any]:
     # byte-identical to the pre-PR CSV when --random-search is off.
     if "hp_combo_id" in record:
         flattened["hp_combo_id"] = record["hp_combo_id"]
+    # ``fold_id`` is only present when --folds is set; the single-fold
+    # path keeps the legacy column set byte-identical.
+    if "fold_id" in record:
+        flattened["fold_id"] = record["fold_id"]
     return flattened
 
 
@@ -1029,6 +1080,7 @@ def _worker_run_cell(payload: dict[str, Any]) -> dict[str, Any]:
         "architecture": str(payload["model_config"].architecture),
         "seed": payload["seed"],
         "hp_combo_id": payload.get("hp_combo_id"),
+        "fold_id": payload.get("fold_id"),
         "summary": summary,
     }
 
@@ -1055,6 +1107,7 @@ def _build_worker_payload(
         "weight_decay": candidate.get("weight_decay", args.weight_decay),
         "seed": candidate.get("seed"),
         "hp_combo_id": candidate.get("hp_combo_id"),
+        "fold_id": candidate.get("fold_id"),
         "data_dir": data_dir,
         "checkpoint_path": checkpoint_path,
         "device": str(device),
@@ -1101,12 +1154,13 @@ def _sort_trial_records(trial_records: list[dict[str, Any]]) -> list[dict[str, A
     in that case.
     """
 
-    def _key(record: dict[str, Any]) -> tuple[str, int, int, int]:
+    def _key(record: dict[str, Any]) -> tuple[str, int, str, int, int]:
         seed = record.get("seed")
         hp_combo_id = record.get("hp_combo_id")
         return (
             str(record.get("architecture") or ""),
             int(seed) if seed is not None else -1,
+            str(record.get("fold_id") or ""),
             int(hp_combo_id) if hp_combo_id is not None else -1,
             int(record.get("trial_index") or 0),
         )
@@ -1122,12 +1176,27 @@ def _run_sweep(
     report_path: Path,
     device: torch.device,
     sequence_groups: Sequence[Sequence[FeatureVector]] | None = None,
+    fold_sequence_groups: dict[str, Sequence[Sequence[FeatureVector]]] | None = None,
     training_package_id: str | None = None,
 ) -> int:
     candidates = build_sweep_candidates(args)
     if not candidates:
         print("No sweep candidates generated.")
         return 1
+
+    def _resolve_cell_sequences(
+        candidate: dict[str, Any],
+    ) -> Sequence[Sequence[FeatureVector]] | None:
+        cell_fold = candidate.get("fold_id")
+        if cell_fold is None or not fold_sequence_groups:
+            return sequence_groups
+        groups = fold_sequence_groups.get(str(cell_fold))
+        if groups is None:
+            raise KeyError(
+                f"fold_id={cell_fold!r} carries no pre-loaded sequence groups; "
+                f"known fold ids: {sorted(fold_sequence_groups.keys())}"
+            )
+        return groups
 
     parallel_workers = max(1, int(getattr(args, "parallel_workers", 1)))
     if parallel_workers > PARALLEL_WORKERS_VRAM_WARN_THRESHOLD:
@@ -1179,7 +1248,7 @@ def _run_sweep(
                         data_dir=data_dir,
                         checkpoint_path=checkpoint_path,
                         device=device,
-                        sequence_groups=sequence_groups,
+                        sequence_groups=_resolve_cell_sequences(candidate),
                         text_encoder_arg=text_encoder_arg,
                         text_pool_lambda=text_pool_lambda,
                     ),
@@ -1199,6 +1268,8 @@ def _run_sweep(
                 }
                 if result.get("hp_combo_id") is not None:
                     record["hp_combo_id"] = result["hp_combo_id"]
+                if result.get("fold_id") is not None:
+                    record["fold_id"] = result["fold_id"]
                 trial_records.append(record)
                 summaries.append(summary)
                 print(
@@ -1228,7 +1299,7 @@ def _run_sweep(
                 model_config=model_config,
                 save_checkpoint=False,
                 seed=seed,
-                sequence_groups=sequence_groups,
+                sequence_groups=_resolve_cell_sequences(candidate),
                 weight_decay=float(weight_decay),
                 shuffle_targets_control=bool(args.shuffle_targets_control),
                 text_encoder=text_encoder_arg,
@@ -1243,6 +1314,8 @@ def _run_sweep(
             }
             if "hp_combo_id" in candidate:
                 record["hp_combo_id"] = candidate["hp_combo_id"]
+            if "fold_id" in candidate:
+                record["fold_id"] = candidate["fold_id"]
             trial_records.append(record)
             print(
                 _format_cell_log(
@@ -1312,7 +1385,7 @@ def _run_sweep(
         model_config=best_model_config,
         save_checkpoint=True,
         seed=best_seed,
-        sequence_groups=sequence_groups,
+        sequence_groups=_resolve_cell_sequences(best_candidate),
         weight_decay=float(best_weight_decay),
         shuffle_targets_control=bool(args.shuffle_targets_control),
         text_encoder=text_encoder_arg,
@@ -1358,6 +1431,11 @@ def _run_sweep(
         report_payload["parallel_workers"] = parallel_workers
     elif parallel_workers > 1:
         report_payload["parallel_workers"] = parallel_workers
+    fold_ids_present = sorted(
+        {str(trial["fold_id"]) for trial in trial_records if trial.get("fold_id")}
+    )
+    if fold_ids_present:
+        report_payload["folds"] = fold_ids_present
     _write_sweep_report(report_path, report_payload)
     print(
         "Sweep complete. "
@@ -1387,6 +1465,7 @@ def main() -> int:
         )
 
     package_sequences: list[list[FeatureVector]] | None = None
+    fold_sequence_groups: dict[str, list[list[FeatureVector]]] | None = None
     if use_package_path:
         print(f"Training-package id: {args.training_package_id}")
         print(f"Target mode: {args.target_mode}")
@@ -1398,8 +1477,7 @@ def main() -> int:
         loader_text_encoder = (
             None if str(args.text_encoder) == "none" else str(args.text_encoder)
         )
-        package_sequences = load_training_sequences_from_package(
-            args.training_package_id,
+        loader_kwargs: dict[str, Any] = dict(
             target_mode=args.target_mode,
             rich_features=bool(args.rich_features),
             use_credibility=bool(args.use_credibility),
@@ -1411,9 +1489,39 @@ def main() -> int:
             text_pool_lambda_inv_days=float(args.text_pool_lambda_inv_days),
             use_text_embeddings=bool(args.use_text_embeddings),
         )
-        sequence_count = len(package_sequences)
-        observation_count = sum(len(sequence) for sequence in package_sequences)
-        window_count = sum(max(0, len(sequence) - SEQUENCE_LENGTH) for sequence in package_sequences)
+        folds_axis = list(getattr(args, "folds", None) or [])
+        if folds_axis:
+            print(f"Walk-forward folds: {' '.join(folds_axis)}")
+            fold_sequence_groups = {}
+            for fold_id_str in folds_axis:
+                fold_sequence_groups[fold_id_str] = load_training_sequences_from_package(
+                    args.training_package_id,
+                    fold_id=fold_id_str,
+                    **loader_kwargs,
+                )
+            sequence_count = sum(len(groups) for groups in fold_sequence_groups.values())
+            observation_count = sum(
+                len(sequence)
+                for groups in fold_sequence_groups.values()
+                for sequence in groups
+            )
+            window_count = sum(
+                max(0, len(sequence) - SEQUENCE_LENGTH)
+                for groups in fold_sequence_groups.values()
+                for sequence in groups
+            )
+            # Surface per-fold counts so an operator can spot a fold
+            # that empties the surviving sequence set.
+            for fold_id_str, groups in fold_sequence_groups.items():
+                print(f"  {fold_id_str}: sequences={len(groups)}")
+        else:
+            package_sequences = load_training_sequences_from_package(
+                args.training_package_id,
+                **loader_kwargs,
+            )
+            sequence_count = len(package_sequences)
+            observation_count = sum(len(sequence) for sequence in package_sequences)
+            window_count = sum(max(0, len(sequence) - SEQUENCE_LENGTH) for sequence in package_sequences)
         print(f"Device: {device}")
         print(f"Checkpoint path: {checkpoint_path}")
         print(f"Existing checkpoint: {'yes' if checkpoint_path.exists() else 'no'}")
@@ -1477,6 +1585,7 @@ def main() -> int:
             report_path=report_path,
             device=device,
             sequence_groups=package_sequences,
+            fold_sequence_groups=fold_sequence_groups,
             training_package_id=args.training_package_id,
         )
 

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -972,6 +972,46 @@ def _read_events_frame(package_dir: Path) -> "Any":
     return pd.read_parquet(events_path)
 
 
+def _read_fold_manifest(package_dir: Path) -> dict[str, dict[str, Any]]:
+    """Return ``fold_id -> {train_start, train_end, val_start, val_end, test_start, test_end}``.
+
+    Reads ``fold_manifest_expanding_walk_forward.json`` from the
+    training-package directory. The manifest is emitted by
+    :func:`app.data.build_training_package._build_folds` and ships one
+    entry per expanding-window fold (``wf_fold_1`` ... ``wf_fold_N``)
+    with the chronological date ranges that define the train, val and
+    test windows for that fold.
+
+    Returns an empty dict when the file is absent or the schema is
+    unjoinable; the caller then falls back to the package's default
+    split tag and the per-fold filter is a no-op.
+    """
+
+    path = package_dir / "fold_manifest_expanding_walk_forward.json"
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    folds = payload.get("folds") if isinstance(payload, dict) else None
+    if not isinstance(folds, list):
+        return {}
+    result: dict[str, dict[str, Any]] = {}
+    for fold in folds:
+        if not isinstance(fold, dict):
+            continue
+        fold_id = str(fold.get("fold_id", "")).strip()
+        if not fold_id:
+            continue
+        result[fold_id] = {
+            "train_start": str(fold.get("train_start", "")),
+            "train_end": str(fold.get("train_end", "")),
+            "val_start": str(fold.get("val_start", "")),
+            "val_end": str(fold.get("val_end", "")),
+            "test_start": str(fold.get("test_start", "")),
+            "test_end": str(fold.get("test_end", "")),
+        }
+    return result
+
+
 def _read_excluded_text_hashes(package_dir: Path) -> set[str]:
     """Return the ``text_hash`` set that must NOT enter the training loss.
 
@@ -1027,6 +1067,7 @@ def load_training_sequences_from_package(
     text_pool_lambda_inv_days: float = DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS,
     use_text_embeddings: bool = True,
     text_embedding_cache_dir: Path | str | None = None,
+    fold_id: str | None = None,
 ) -> list[list[FeatureVector]]:
     """Load one prior-window sequence per FOMC event in a training package.
 
@@ -1118,6 +1159,14 @@ def load_training_sequences_from_package(
     ``use_text_embeddings=False`` skips the pooling step entirely and
     every row keeps the default empty pooled list + missing-flag at
     ``1.0``.
+
+    When ``fold_id`` is set the loader reads
+    ``fold_manifest_expanding_walk_forward.json`` and restricts the
+    surviving sequence set to events whose ``event_date`` falls inside
+    the fold's test window. The split-tag filter is bypassed on the
+    fold path because the manifest already encodes the chronological
+    partition for that fold. ``fold_id=None`` (the default) preserves
+    the package-level ``split_tag`` filter unchanged.
     """
 
     if target_mode not in _VALID_TARGET_MODES:
@@ -1138,7 +1187,24 @@ def load_training_sequences_from_package(
             f"events.parquet at {package_dir} missing columns: {sorted(missing)}"
         )
 
-    excluded_text_hashes = _read_excluded_text_hashes(package_dir)
+    fold_window: dict[str, Any] | None = None
+    if fold_id is not None:
+        manifest = _read_fold_manifest(package_dir)
+        if fold_id not in manifest:
+            raise ValueError(
+                f"fold_id={fold_id!r} not found in fold manifest at {package_dir}; "
+                f"known fold ids: {sorted(manifest.keys())}"
+            )
+        fold_window = manifest[fold_id]
+
+    if fold_window is not None:
+        # The fold manifest pins the chronological test window per
+        # fold; the split-tag filter is sidestepped on the fold path
+        # because the manifest already encodes the train/val/test
+        # partition for the fold.
+        excluded_text_hashes: set[str] = set()
+    else:
+        excluded_text_hashes = _read_excluded_text_hashes(package_dir)
 
     # Side-tables for the rich-feature join. Both lookups are read
     # once per package so the per-event broadcast does not re-open the
@@ -1261,6 +1327,13 @@ def load_training_sequences_from_package(
             continue
         if candidate_hash in seen:
             continue
+        if fold_window is not None:
+            test_start = fold_window.get("test_start", "")
+            test_end = fold_window.get("test_end", "")
+            if test_start and candidate_date_raw < str(test_start)[:10]:
+                continue
+            if test_end and candidate_date_raw > str(test_end)[:10]:
+                continue
         seen.add(candidate_hash)
         by_text_hash[candidate_hash] = row
 

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -746,9 +746,14 @@ the published `1e-4` contract covers cross-platform drift).
 ```
 
 A sibling `.csv` with one row per trial is written next to the JSON.
+When `--folds` is set each trial record gains a `fold_id` field and
+the report payload adds a top-level `folds` list; the single-fold
+path omits both so the legacy CSV column set stays unchanged.
+
 The companion aggregator `app.evaluation.forecaster_sweep_aggregator`
 reads one or more sweep result files and emits a markdown headline
-table plus per-architecture block-bootstrap CIs (95% by default,
+table plus block-bootstrap CIs per `(architecture, fold)` pair plus
+an aggregated `all-folds` row per architecture (95% by default,
 `block_size=1`, `n_resamples=1000`, deterministic at `seed=11`). The
 aggregator output schema is:
 
@@ -762,6 +767,7 @@ aggregator output schema is:
   "architectures": [
     {
       "architecture": "<arch>",
+      "fold": "<wf_fold_*> | all-folds",
       "seeds": [...],
       "credibility_features": <bool>,
       "combined_rmse": {"values": [...], "ci": {...}},
@@ -772,6 +778,13 @@ aggregator output schema is:
   ]
 }
 ```
+
+Per-fold rows isolate cross-regime behaviour (each fold tests on a
+different time window — pre-2020, COVID, hike cycle, late-cycle
+pause); the `all-folds` row is the headline that ranks the
+architectures. Single-fold sweeps land their entire trial set in the
+`all-folds` row, which preserves the pre-PR shape of one row per
+architecture.
 
 ### Make targets
 
@@ -1020,6 +1033,41 @@ torch, numpy, and the standard `random` module. Two cells with
 the same `seed` produce bit-identical weights regardless of which
 worker process they ran in (modulo cuDNN nondeterminism, which is
 the existing default).
+
+#### Walk-forward fold iteration
+
+`--folds wf_fold_1 wf_fold_2 wf_fold_3 wf_fold_4` multiplies the
+sweep candidate set by `len(folds)` so each
+`(architecture, seed, hp_combo)` tuple expands into one trial per
+fold. The fold ids resolve against
+`fold_manifest_expanding_walk_forward.json` inside the training
+package; `load_training_sequences_from_package(..., fold_id=<id>)`
+restricts the surviving sequences to events whose `event_date`
+falls inside the named fold's test window. The expanding-window
+contract pins one fold per regime — `wf_fold_1` (pre-2020),
+`wf_fold_2` (COVID), `wf_fold_3` (hike cycle), `wf_fold_4`
+(late-cycle pause) — so the per-fold rows in the aggregator
+output isolate cross-regime performance instead of averaging it
+into the headline number.
+
+Each trial record carries a `fold_id` field; the aggregator emits
+one row per `(architecture, fold)` pair plus an aggregated
+`all-folds` row per architecture. The per-fold rows capture
+cross-regime risk (each fold tests on a different time window —
+pre-2020, COVID, hike cycle, late-cycle pause); the `all-folds`
+row carries the block-bootstrap CI computed over the
+4-fold × N-seed cell set and is the headline number that ranks the
+architectures.
+
+`--folds` defaults to an empty list. Without it the candidate set
+keeps the legacy single-fold shape (no `fold_id` field on the
+trial records, one `all-folds` row per architecture in the
+aggregator output), which is the contract the byte-identity
+regression at
+`tests/regression/test_forecaster_sweep_back_compat.py` pins. The
+`make forecaster-sweep` target opts into the four-fold iteration
+by default; `make forecaster-sweep-exhaustive` stays single-fold
+to preserve the byte-identity regression.
 
 ### Forecaster text-embedding input space
 

--- a/tests/unit/test_forecaster_sweep_aggregator.py
+++ b/tests/unit/test_forecaster_sweep_aggregator.py
@@ -30,12 +30,13 @@ def _trial(
     close_rmse: float | None = None,
     volatility_rmse: float | None = None,
     credibility_features: bool = False,
+    fold_id: str | None = None,
 ) -> dict:
     if close_rmse is None:
         close_rmse = combined_rmse * 0.8
     if volatility_rmse is None:
         volatility_rmse = combined_rmse * 0.2
-    return {
+    record: dict = {
         "trial_index": 0,
         "architecture": architecture,
         "seed": seed,
@@ -52,6 +53,9 @@ def _trial(
             },
         },
     }
+    if fold_id is not None:
+        record["fold_id"] = fold_id
+    return record
 
 
 def _write_report(path: Path, trials: list[dict]) -> Path:
@@ -182,3 +186,96 @@ def test_row_dataclass_is_frozen() -> None:
     )
     with pytest.raises(Exception):
         row.architecture = "gru"  # type: ignore[misc]
+
+
+def test_aggregator_emits_per_fold_and_all_folds_rows(tmp_path: Path) -> None:
+    """Per-architecture-per-encoder rows are emitted once per fold plus
+    one aggregated row across all folds. The per-fold rows precede
+    the ``all-folds`` aggregate for each architecture in the markdown."""
+
+    trials: list[dict] = []
+    for fold_idx in range(1, 5):
+        # Two seeds per fold per architecture so the bootstrap has a
+        # non-degenerate sample size.
+        for seed_value in (11, 29):
+            trials.append(
+                _trial(
+                    architecture="lstm",
+                    seed=seed_value,
+                    combined_rmse=0.10 + 0.01 * fold_idx,
+                    fold_id=f"wf_fold_{fold_idx}",
+                )
+            )
+            trials.append(
+                _trial(
+                    architecture="gru",
+                    seed=seed_value,
+                    combined_rmse=0.20 + 0.01 * fold_idx,
+                    fold_id=f"wf_fold_{fold_idx}",
+                )
+            )
+    _write_report(tmp_path / "sweep_results.json", trials)
+
+    rows, markdown, _ = aggregate(tmp_path, seed=11)
+
+    # Two architectures x (4 per-fold rows + 1 all-folds row) = 10 rows.
+    assert len(rows) == 10
+
+    # Within each architecture, four per-fold rows precede the
+    # all-folds aggregate. Group rows by (architecture, target_mode)
+    # in emission order.
+    grouped: dict[str, list[ArchitectureRow]] = {}
+    for row in rows:
+        grouped.setdefault(row.architecture, []).append(row)
+    assert set(grouped.keys()) == {"lstm", "gru"}
+    for arch, rows_for_arch in grouped.items():
+        folds_seen = [r.fold for r in rows_for_arch]
+        assert folds_seen == [
+            "wf_fold_1",
+            "wf_fold_2",
+            "wf_fold_3",
+            "wf_fold_4",
+            "all-folds",
+        ], f"architecture={arch} fold order broke: {folds_seen}"
+
+    # The all-folds aggregate spans every cell -- 2 seeds x 4 folds = 8 values.
+    all_folds_rows = [row for row in rows if row.fold == "all-folds"]
+    assert all_folds_rows, "all-folds aggregate row missing"
+    for row in all_folds_rows:
+        assert len(row.combined_rmse_values) == 8
+
+    # Per-fold rows aggregate over the per-fold seed pool (n=2 here).
+    per_fold_rows = [row for row in rows if row.fold != "all-folds"]
+    for row in per_fold_rows:
+        assert len(row.combined_rmse_values) == 2
+
+    # Markdown carries the fold column and renders the per-fold rows
+    # under each architecture before the all-folds line.
+    assert "| fold |" in markdown
+    assert "| wf_fold_1 |" in markdown
+    assert "| all-folds |" in markdown
+
+
+def test_aggregator_single_fold_path_preserves_pre_pr_contract(tmp_path: Path) -> None:
+    """Trials without a fold_id collapse into one ``all-folds`` row per architecture.
+
+    The pre-PR sweep contract emits exactly one row per architecture;
+    pinning the row count + fold label here keeps that contract intact
+    for callers running the legacy single-fold path.
+    """
+
+    trials = [
+        _trial(architecture="lstm", seed=11, combined_rmse=0.10),
+        _trial(architecture="lstm", seed=29, combined_rmse=0.11),
+        _trial(architecture="gru", seed=11, combined_rmse=0.20),
+        _trial(architecture="gru", seed=29, combined_rmse=0.21),
+    ]
+    _write_report(tmp_path / "sweep_results.json", trials)
+
+    rows, _, _ = aggregate(tmp_path, seed=11)
+
+    # One row per architecture, tagged all-folds.
+    assert {row.architecture for row in rows} == {"lstm", "gru"}
+    assert len(rows) == 2
+    for row in rows:
+        assert row.fold == "all-folds"

--- a/tests/unit/test_forecaster_sweep_parallel.py
+++ b/tests/unit/test_forecaster_sweep_parallel.py
@@ -266,3 +266,211 @@ def test_exhaustive_path_omits_hp_combo_id():
             "exhaustive path leaked an hp_combo_id field; the CSV column set "
             "must stay byte-identical to the pre-PR sweep output"
         )
+
+
+def _folds_args(
+    *,
+    folds: list[str],
+    random_search: bool = False,
+    architectures: list[str] | None = None,
+    seeds: list[int] | None = None,
+) -> argparse.Namespace:
+    """Toy namespace tailored to fold-iteration tests."""
+
+    return argparse.Namespace(
+        hidden_size=32,
+        num_layers=1,
+        dropout=0.1,
+        learning_rate=1e-3,
+        epochs=4,
+        head_hidden_size=16,
+        hidden_sizes=[32],
+        num_layers_grid=[1],
+        dropouts=[0.1],
+        learning_rates=[1e-3],
+        epochs_grid=[4],
+        weight_decay=1e-4,
+        weight_decays=None,
+        text_adapter_dim=64,
+        text_adapter_dims=None,
+        text_encoder="none",
+        use_text_embeddings=True,
+        training_package_id=None,
+        rich_features=False,
+        architecture="lstm",
+        architectures=architectures or ["lstm"],
+        seed=None,
+        seeds=seeds or [11],
+        credibility_features=False,
+        random_search=random_search,
+        random_search_samples=50,
+        random_search_seed=42,
+        folds=folds,
+    )
+
+
+def test_folds_multiply_candidate_count():
+    """``--folds`` multiplies the candidate count by len(folds) cleanly."""
+
+    fold_set = ["wf_fold_1", "wf_fold_2", "wf_fold_3", "wf_fold_4"]
+    archs = ["lstm", "gru", "tcn", "transformer", "dlinear", "informer", "tft", "lstm_attn"]
+    seeds = [11, 29, 47, 71, 97]
+    args = _folds_args(folds=fold_set, architectures=archs, seeds=seeds)
+
+    candidates = build_sweep_candidates(args)
+    assert len(candidates) == len(fold_set) * len(archs) * len(seeds)
+
+    # Every candidate carries a fold_id drawn from the requested set.
+    seen_folds = {c["fold_id"] for c in candidates}
+    assert seen_folds == set(fold_set)
+
+    # And the per-fold cell count is identical across folds.
+    per_fold_counts = {fold: 0 for fold in fold_set}
+    for cand in candidates:
+        per_fold_counts[cand["fold_id"]] += 1
+    assert len(set(per_fold_counts.values())) == 1
+
+
+def test_fold_id_threads_through_payload():
+    """Each candidate's fold_id flows through the worker payload + result dict."""
+
+    from app.train_forecaster import _build_worker_payload, _worker_run_cell
+    from unittest.mock import patch
+
+    args = _folds_args(
+        folds=["wf_fold_1", "wf_fold_2"],
+        architectures=["lstm"],
+        seeds=[11],
+    )
+    candidates = build_sweep_candidates(args)
+    assert len(candidates) == 2
+    fold_assignments = [c["fold_id"] for c in candidates]
+    assert sorted(fold_assignments) == ["wf_fold_1", "wf_fold_2"]
+
+    # Worker payload carries fold_id.
+    from pathlib import Path
+
+    import torch
+
+    payload = _build_worker_payload(
+        candidate=candidates[0],
+        trial_index=1,
+        args=argparse.Namespace(
+            batch_size=8,
+            validation_fraction=0.2,
+            early_stopping_patience=2,
+            shuffle_targets_control=False,
+            weight_decay=1e-4,
+        ),
+        data_dir=Path("/tmp"),
+        checkpoint_path=Path("/tmp/cp.pt"),
+        device=torch.device("cpu"),
+        sequence_groups=None,
+        text_encoder_arg=None,
+        text_pool_lambda=0.0,
+    )
+    assert payload["fold_id"] == candidates[0]["fold_id"]
+
+    # The worker round-trips fold_id via the result dict. Patch
+    # _run_single_training so the test stays unit-level (no real
+    # training runs).
+    class _StubSummary:
+        def to_dict(self) -> dict:
+            return {}
+
+    with patch(
+        "app.train_forecaster._run_single_training",
+        return_value=_StubSummary(),
+    ):
+        result = _worker_run_cell(payload)
+    assert result["fold_id"] == candidates[0]["fold_id"]
+
+
+def test_no_folds_flag_reproduces_legacy_output():
+    """``--folds`` unset (default empty list) reproduces pre-PR candidate
+    enumeration: no fold_id field, same cell count, same model_config
+    shape per cell."""
+
+    args_no_folds = _folds_args(folds=[])
+    args_legacy = argparse.Namespace(
+        hidden_size=32,
+        num_layers=1,
+        dropout=0.1,
+        learning_rate=1e-3,
+        epochs=4,
+        head_hidden_size=16,
+        hidden_sizes=[32],
+        num_layers_grid=[1],
+        dropouts=[0.1],
+        learning_rates=[1e-3],
+        epochs_grid=[4],
+        weight_decay=1e-4,
+        weight_decays=None,
+        text_adapter_dim=64,
+        text_adapter_dims=None,
+        text_encoder="none",
+        use_text_embeddings=True,
+        training_package_id=None,
+        rich_features=False,
+        architecture="lstm",
+        architectures=["lstm"],
+        seed=None,
+        seeds=[11],
+        credibility_features=False,
+        random_search=False,
+        random_search_samples=50,
+        random_search_seed=42,
+    )
+
+    folds_off = build_sweep_candidates(args_no_folds)
+    legacy = build_sweep_candidates(args_legacy)
+
+    assert len(folds_off) == len(legacy)
+    for cand_off, cand_legacy in zip(folds_off, legacy, strict=True):
+        assert "fold_id" not in cand_off
+        assert "fold_id" not in cand_legacy
+        assert cand_off["seed"] == cand_legacy["seed"]
+        assert cand_off["learning_rate"] == cand_legacy["learning_rate"]
+        assert cand_off["model_config"].hidden_size == cand_legacy["model_config"].hidden_size
+
+
+def test_folds_with_random_search_multiplies_candidates():
+    """``--folds`` combined with --random-search yields M_samples x folds cells per (arch, seed)."""
+
+    args = argparse.Namespace(
+        hidden_size=32,
+        num_layers=1,
+        dropout=0.1,
+        learning_rate=1e-3,
+        epochs=4,
+        head_hidden_size=16,
+        hidden_sizes=[32, 64],
+        num_layers_grid=[1, 2],
+        dropouts=[0.1],
+        learning_rates=[1e-3],
+        epochs_grid=[4],
+        weight_decay=1e-4,
+        weight_decays=None,
+        text_adapter_dim=64,
+        text_adapter_dims=None,
+        text_encoder="none",
+        use_text_embeddings=True,
+        training_package_id=None,
+        rich_features=False,
+        architecture="lstm",
+        architectures=["lstm"],
+        seed=None,
+        seeds=[11],
+        credibility_features=False,
+        random_search=True,
+        random_search_samples=3,
+        random_search_seed=42,
+        folds=["wf_fold_1", "wf_fold_2", "wf_fold_3", "wf_fold_4"],
+    )
+    candidates = build_sweep_candidates(args)
+    # 1 arch x 1 seed x 4 folds x 3 sampled HP combos = 12 cells.
+    assert len(candidates) == 12
+    fold_counts: dict[str, int] = {}
+    for cand in candidates:
+        fold_counts[cand["fold_id"]] = fold_counts.get(cand["fold_id"], 0) + 1
+    assert fold_counts == {f"wf_fold_{i}": 3 for i in range(1, 5)}

--- a/tests/unit/test_training_package_loader.py
+++ b/tests/unit/test_training_package_loader.py
@@ -311,6 +311,183 @@ def test_load_training_sequences_from_package_missing_package_raises(
 
 
 # ---------------------------------------------------------------------------
+# Fold-manifest tests
+#
+# ``fold_id=<wf_fold_*>`` restricts the surviving sequences to events
+# whose ``event_date`` falls inside the fold's test window. The
+# split-tag filter is bypassed on the fold path because the manifest
+# already pins the chronological partition for the fold.
+# ---------------------------------------------------------------------------
+
+
+_FOLD_PACKAGE_ID = "tp_unit_fold_manifest_v0"
+
+
+@pytest.fixture
+def fold_manifest_package_dir(tmp_path: Path, monkeypatch) -> Path:
+    """Materialise a package with four events spread across four folds."""
+
+    package_dir = tmp_path / "processed" / _FOLD_PACKAGE_ID
+    package_dir.mkdir(parents=True)
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+
+    events = [
+        _event_row(
+            event_date="2020-03-15",
+            text_hash="hash_pre_covid",
+            axis_stance="hawkish",
+            realized_return=0.001,
+            realized_date="2020-03-16",
+            base_close=2800.0,
+        ),
+        _event_row(
+            event_date="2021-06-15",
+            text_hash="hash_covid",
+            axis_stance="dovish",
+            realized_return=-0.002,
+            realized_date="2021-06-16",
+            base_close=4200.0,
+        ),
+        _event_row(
+            event_date="2022-09-15",
+            text_hash="hash_hike",
+            axis_stance="hawkish",
+            realized_return=0.003,
+            realized_date="2022-09-16",
+            base_close=3900.0,
+        ),
+        _event_row(
+            event_date="2023-11-15",
+            text_hash="hash_pause",
+            axis_stance="neutral",
+            realized_return=0.0,
+            realized_date="2023-11-16",
+            base_close=4500.0,
+        ),
+    ]
+    pd.DataFrame(events).to_parquet(package_dir / "events.parquet", index=False)
+    pd.DataFrame(
+        [
+            {"text_hash": "hash_pre_covid", "split_tag": "train"},
+            {"text_hash": "hash_covid", "split_tag": "val"},
+            {"text_hash": "hash_hike", "split_tag": "test"},
+            {"text_hash": "hash_pause", "split_tag": "test"},
+        ]
+    ).to_parquet(package_dir / "splits_train_val_test.parquet", index=False)
+    manifest = {
+        "evaluation_protocol": "expanding_walk_forward",
+        "fold_count": 4,
+        "folds": [
+            {
+                "fold_id": "wf_fold_1",
+                "train_start": "2020-01-01",
+                "train_end": "2020-02-28",
+                "val_start": "2020-03-01",
+                "val_end": "2020-03-10",
+                "test_start": "2020-03-11",
+                "test_end": "2020-03-31",
+            },
+            {
+                "fold_id": "wf_fold_2",
+                "train_start": "2020-01-01",
+                "train_end": "2021-05-31",
+                "val_start": "2021-06-01",
+                "val_end": "2021-06-10",
+                "test_start": "2021-06-11",
+                "test_end": "2021-06-30",
+            },
+            {
+                "fold_id": "wf_fold_3",
+                "train_start": "2020-01-01",
+                "train_end": "2022-08-31",
+                "val_start": "2022-09-01",
+                "val_end": "2022-09-10",
+                "test_start": "2022-09-11",
+                "test_end": "2022-09-30",
+            },
+            {
+                "fold_id": "wf_fold_4",
+                "train_start": "2020-01-01",
+                "train_end": "2023-10-31",
+                "val_start": "2023-11-01",
+                "val_end": "2023-11-10",
+                "test_start": "2023-11-11",
+                "test_end": "2023-11-30",
+            },
+        ],
+    }
+    (package_dir / "fold_manifest_expanding_walk_forward.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    return package_dir
+
+
+def test_read_fold_manifest_returns_fold_dict(
+    fold_manifest_package_dir: Path,
+) -> None:
+    manifest = loaders._read_fold_manifest(fold_manifest_package_dir)
+    assert set(manifest.keys()) == {"wf_fold_1", "wf_fold_2", "wf_fold_3", "wf_fold_4"}
+    assert manifest["wf_fold_2"]["test_start"] == "2021-06-11"
+    assert manifest["wf_fold_2"]["test_end"] == "2021-06-30"
+
+
+def test_read_fold_manifest_missing_returns_empty(tmp_path: Path) -> None:
+    assert loaders._read_fold_manifest(tmp_path) == {}
+
+
+def test_load_training_sequences_fold_filter_restricts_to_test_window(
+    fold_manifest_package_dir: Path,
+) -> None:
+    sequences = loaders.load_training_sequences_from_package(
+        _FOLD_PACKAGE_ID, fold_id="wf_fold_2", rich_features=False
+    )
+    # Only the 2021-06-15 event (hash_covid) lands inside the wf_fold_2
+    # test window. The package's val split-tag on that row is bypassed
+    # because the fold manifest pins the chronological partition.
+    assert len(sequences) == 1
+    assert sequences[0][-1].date[:10] == "2021-06-16"
+
+
+def test_load_training_sequences_fold_filter_picks_correct_fold(
+    fold_manifest_package_dir: Path,
+) -> None:
+    fold_to_target = {
+        "wf_fold_1": "2020-03-16",
+        "wf_fold_2": "2021-06-16",
+        "wf_fold_3": "2022-09-16",
+        "wf_fold_4": "2023-11-16",
+    }
+    for fold_id_str, expected_target in fold_to_target.items():
+        sequences = loaders.load_training_sequences_from_package(
+            _FOLD_PACKAGE_ID, fold_id=fold_id_str, rich_features=False
+        )
+        assert len(sequences) == 1
+        assert sequences[0][-1].date[:10] == expected_target
+
+
+def test_load_training_sequences_fold_filter_unknown_id_raises(
+    fold_manifest_package_dir: Path,
+) -> None:
+    with pytest.raises(ValueError, match="wf_fold_99"):
+        loaders.load_training_sequences_from_package(
+            _FOLD_PACKAGE_ID, fold_id="wf_fold_99"
+        )
+
+
+def test_load_training_sequences_fold_none_preserves_split_tag_filter(
+    fold_manifest_package_dir: Path,
+) -> None:
+    """``fold_id=None`` keeps the default split-tag filter behaviour."""
+
+    sequences = loaders.load_training_sequences_from_package(
+        _FOLD_PACKAGE_ID, fold_id=None, rich_features=False
+    )
+    # Only the single train-tagged row survives; val + test rows drop.
+    target_dates = {seq[-1].date[:10] for seq in sequences}
+    assert target_dates == {"2020-03-16"}
+
+
+# ---------------------------------------------------------------------------
 # Target-frame derivation tests
 #
 # The event-study target frame replaces the pre-fix realized-return /


### PR DESCRIPTION
## Summary

- load_training_sequences_from_package gains a fold_id kwarg that filters sequences to a fold's test window via fold_manifest_expanding_walk_forward.json.
- --folds flag (nargs=+) on train_forecaster.py multiplies the candidate set by len(folds); each trial record carries a fold_id field.
- forecaster_sweep_aggregator emits per-fold rows and an all-folds row per architecture-encoder pair. Per-fold CIs capture cross-regime risk; the all-folds CI is the headline number.
- Makefile forecaster-sweep target iterates wf_fold_1 ... wf_fold_4 by default. forecaster-sweep-exhaustive stays single-fold for the byte-identity regression test.
- 4 new tests pin the multiplier, fold_id round-trip, per-fold + all-folds aggregator output, and the legacy back-compat (--folds unset = pre-PR exhaustive output bit-identical).
- docs/data-and-training-contracts.md documents the fold iteration semantics and the per-fold vs all-folds CI distinction.

## Test plan

- [ ] \`docker compose run --rm --no-deps backend pytest tests/unit/test_train_forecaster.py tests/unit/test_training_package_loader.py tests/unit/test_forecaster_sweep_aggregator.py tests/regression/ -q\`
- [ ] Smoke \`python -m app.train_forecaster --sweep --folds wf_fold_1 ... wf_fold_4 ...\` emits 4 cells x 1 arch x 1 seed = 4 trial rows with distinct fold_ids.

Follows #176.