### PR TITLE
Forecaster sweep uses real train + val + held-out test partitions (proper walk-forward CV)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ forecaster-sweep:
 		--rich-features \
 		--architectures lstm lstm_attn gru tcn transformer dlinear informer tft \
 		--seeds 11 29 47 71 97 \
+		--folds wf_fold_1 wf_fold_2 wf_fold_3 wf_fold_4 \
 		--hidden-sizes 32 64 128 \
 		--num-layers-grid 1 2 3 \
 		--dropouts 0.1 0.2 0.3 0.4 \

--- a/backend/app/evaluation/forecaster_sweep_aggregator.py
+++ b/backend/app/evaluation/forecaster_sweep_aggregator.py
@@ -40,23 +40,28 @@ class ArchitectureRow:
     combined_rmse_ci: BootstrapCI
     close_rmse_ci: BootstrapCI
     volatility_rmse_ci: BootstrapCI
-    # Mitigation 4: per-row train + val RMSE and the gap derivative.
-    # ``train_rmse_values`` and ``val_rmse_values`` collect every trial
-    # under the architecture (one per seed x HP combo); the aggregator
-    # bootstraps the mean and emits a ``gap_flag`` when the mean gap
-    # crosses 0.5. The headline "val" label maps to the holdout-side
-    # RMSE the loop reports as ``combined_rmse``; "train" is the
-    # final-state training-set RMSE captured by
-    # ``TrainingRunSummary.train_metrics``. Defaults stay zero-valued
-    # so older callers / unit fixtures that predate the train-metrics
-    # column build a row without naming them.
+    # Per-row train / val / test RMSE + the test/train gap derivative.
+    # ``train_rmse_values`` is the final-state training-set RMSE;
+    # ``val_rmse_values`` is the best early-stopping checkpoint's val
+    # RMSE; ``test_rmse_values`` is the held-out test RMSE (the
+    # headline number the markdown emits as ``test-RMSE``). On the
+    # legacy 80/20 path no real held-out exists, so test_rmse_values
+    # collapses to val_rmse_values and the gap stays comparable to
+    # the pre-PR holdout_train_gap. Defaults stay zero-valued so
+    # callers that predate the new columns build a row without
+    # naming them.
     train_rmse_values: list[float] = field(default_factory=list)
     val_rmse_values: list[float] = field(default_factory=list)
+    test_rmse_values: list[float] = field(default_factory=list)
     train_rmse_ci: BootstrapCI | None = None
     val_rmse_ci: BootstrapCI | None = None
+    test_rmse_ci: BootstrapCI | None = None
     holdout_train_gap: float = 0.0
+    test_train_gap: float = 0.0
     gap_flag: str = "ok"
     target_mode: str = "real"
+    fold_id: str | None = None
+    protocol: str = "single-fold"
 
 
 def _load_report(path: Path) -> dict[str, Any]:
@@ -131,6 +136,55 @@ def _trial_train_metric(trial: dict[str, Any], key: str) -> float | None:
         return None
 
 
+def _trial_val_metric(trial: dict[str, Any], key: str) -> float | None:
+    summary = trial.get("summary") or {}
+    val_metrics = summary.get("val_metrics") or {}
+    value = val_metrics.get(key)
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _trial_test_metric(trial: dict[str, Any], key: str) -> float | None:
+    """Return the held-out test RMSE.
+
+    Falls back to the trial's headline ``metrics`` block on the legacy
+    80/20 path where ``test_metrics`` is absent, so the aggregator's
+    test-RMSE column has a value in both protocols.
+    """
+
+    summary = trial.get("summary") or {}
+    test_metrics = summary.get("test_metrics") or summary.get("metrics") or {}
+    value = test_metrics.get(key)
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _trial_fold_id(trial: dict[str, Any]) -> str | None:
+    if trial.get("fold_id"):
+        return str(trial["fold_id"])
+    summary = trial.get("summary") or {}
+    fold_id = summary.get("fold_id")
+    if fold_id:
+        return str(fold_id)
+    return None
+
+
+def _trial_protocol(trial: dict[str, Any]) -> str:
+    summary = trial.get("summary") or {}
+    protocol = summary.get("protocol")
+    if isinstance(protocol, str) and protocol:
+        return protocol
+    return "single-fold"
+
+
 def _trial_target_mode(trial: dict[str, Any]) -> str:
     summary = trial.get("summary") or {}
     mode = summary.get("target_mode")
@@ -139,37 +193,47 @@ def _trial_target_mode(trial: dict[str, Any]) -> str:
     return "real"
 
 
-def _bucket_key(architecture: str, target_mode: str) -> str:
+def _bucket_key(
+    architecture: str, target_mode: str, fold_id: str | None
+) -> str:
     """Compose the dict key the aggregator groups by.
 
     Shuffled-target trials sit in a separate bucket so the
     memorisation-control row does not contaminate the headline table.
-    The key is ``"<architecture>"`` for ``target_mode == "real"`` and
-    ``"<architecture>::shuffled"`` otherwise.
+    Walk-forward fold rows carry an explicit ``fold_id`` suffix so the
+    aggregator emits one row per (architecture, fold) pair plus an
+    all-folds aggregate row per architecture.
     """
 
-    if target_mode == "real":
-        return architecture
-    return f"{architecture}::{target_mode}"
+    base = architecture if target_mode == "real" else f"{architecture}::{target_mode}"
+    if fold_id:
+        return f"{base}::{fold_id}"
+    return base
 
 
-def _collect_per_architecture(reports: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+def _collect_per_architecture(reports: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:  # noqa: C901
     by_arch: dict[str, dict[str, Any]] = {}
     for report in reports:
         for trial in report.get("trials") or []:
             architecture = _trial_architecture(trial)
             target_mode = _trial_target_mode(trial)
-            key = _bucket_key(architecture, target_mode)
+            fold_id = _trial_fold_id(trial)
+            protocol = _trial_protocol(trial)
+            key = _bucket_key(architecture, target_mode, fold_id)
             bucket = by_arch.setdefault(
                 key,
                 {
                     "architecture": architecture,
                     "target_mode": target_mode,
+                    "fold_id": fold_id,
+                    "protocol": protocol,
                     "seeds": [],
                     "combined_rmse": [],
                     "close_rmse": [],
                     "volatility_rmse": [],
                     "train_combined_rmse": [],
+                    "val_combined_rmse": [],
+                    "test_combined_rmse": [],
                     "credibility_features": _trial_credibility(trial),
                 },
             )
@@ -189,13 +253,60 @@ def _collect_per_architecture(reports: list[dict[str, Any]]) -> dict[str, dict[s
             train_combined = _trial_train_metric(trial, "combined_rmse")
             if train_combined is not None:
                 bucket["train_combined_rmse"].append(train_combined)
+            val_combined = _trial_val_metric(trial, "combined_rmse")
+            if val_combined is not None:
+                bucket["val_combined_rmse"].append(val_combined)
+            test_combined = _trial_test_metric(trial, "combined_rmse")
+            if test_combined is not None:
+                bucket["test_combined_rmse"].append(test_combined)
             # Once any credibility-on trial lands for an architecture the
             # bucket flips on so the headline label stays honest.
             bucket["credibility_features"] = bucket["credibility_features"] or _trial_credibility(trial)
+    # Emit an all-folds aggregate row per (architecture, target_mode)
+    # when any per-fold bucket is present. The all-folds row collects
+    # every per-fold trial so the bootstrap CI is computed across
+    # (seed, fold) cells.
+    aggregate_keys: dict[str, dict[str, Any]] = {}
+    for _key, bucket in list(by_arch.items()):
+        fold_id = bucket.get("fold_id")
+        if not fold_id:
+            continue
+        agg_key = _bucket_key(bucket["architecture"], bucket["target_mode"], None) + "::all-folds"
+        agg_bucket = aggregate_keys.setdefault(
+            agg_key,
+            {
+                "architecture": bucket["architecture"],
+                "target_mode": bucket["target_mode"],
+                "fold_id": "all-folds",
+                "protocol": bucket["protocol"],
+                "seeds": [],
+                "combined_rmse": [],
+                "close_rmse": [],
+                "volatility_rmse": [],
+                "train_combined_rmse": [],
+                "val_combined_rmse": [],
+                "test_combined_rmse": [],
+                "credibility_features": bucket["credibility_features"],
+            },
+        )
+        for field_name in (
+            "seeds",
+            "combined_rmse",
+            "close_rmse",
+            "volatility_rmse",
+            "train_combined_rmse",
+            "val_combined_rmse",
+            "test_combined_rmse",
+        ):
+            agg_bucket[field_name].extend(bucket[field_name])
+        agg_bucket["credibility_features"] = (
+            agg_bucket["credibility_features"] or bucket["credibility_features"]
+        )
+    by_arch.update(aggregate_keys)
     return by_arch
 
 
-def _build_rows(
+def _build_rows(  # noqa: C901
     by_arch: dict[str, dict[str, Any]],
     *,
     block_size: int,
@@ -209,25 +320,41 @@ def _build_rows(
             continue
         architecture = str(payload.get("architecture", _bucket_key_str))
         target_mode = str(payload.get("target_mode", "real"))
+        fold_id = payload.get("fold_id")
+        protocol = str(payload.get("protocol", "single-fold"))
         train_values = list(payload.get("train_combined_rmse") or [])
-        val_values = list(payload["combined_rmse"])
+        val_values_field = list(payload.get("val_combined_rmse") or [])
+        test_values_field = list(payload.get("test_combined_rmse") or [])
+        headline_values = list(payload["combined_rmse"])
+        # Walk-forward path emits explicit test_metrics; fall back to
+        # the trial's headline ``combined_rmse`` when test_metrics is
+        # absent (legacy 80/20 reports). The aggregator's ``test-RMSE``
+        # column always reflects the held-out RMSE on the walk-forward
+        # path and the val RMSE on the legacy path.
+        if not test_values_field:
+            test_values_field = list(headline_values)
+        if not val_values_field:
+            val_values_field = list(headline_values)
         train_mean = (sum(train_values) / len(train_values)) if train_values else 0.0
-        val_mean = sum(val_values) / len(val_values) if val_values else 0.0
+        val_mean = sum(val_values_field) / len(val_values_field) if val_values_field else 0.0
+        test_mean = sum(test_values_field) / len(test_values_field) if test_values_field else 0.0
         if train_mean > 0.0:
-            gap = (val_mean - train_mean) / train_mean
+            holdout_gap = (val_mean - train_mean) / train_mean
+            test_gap = (test_mean - train_mean) / train_mean
         else:
-            gap = 0.0
-        gap_flag = "high" if gap > 0.5 else "ok"
+            holdout_gap = 0.0
+            test_gap = 0.0
+        gap_flag = "high" if test_gap > 0.5 else "ok"
         rows.append(
             ArchitectureRow(
                 architecture=architecture,
                 seeds=sorted(set(payload["seeds"])),
                 credibility_features=bool(payload["credibility_features"]),
-                combined_rmse_values=val_values,
+                combined_rmse_values=headline_values,
                 close_rmse_values=list(payload["close_rmse"]),
                 volatility_rmse_values=list(payload["volatility_rmse"]),
                 combined_rmse_ci=block_bootstrap_ci(
-                    val_values,
+                    headline_values,
                     statistic="mean",
                     block_size=block_size,
                     n_resamples=n_resamples,
@@ -251,7 +378,8 @@ def _build_rows(
                     seed=seed,
                 ),
                 train_rmse_values=train_values,
-                val_rmse_values=val_values,
+                val_rmse_values=val_values_field,
+                test_rmse_values=test_values_field,
                 train_rmse_ci=block_bootstrap_ci(
                     train_values or [0.0],
                     statistic="mean",
@@ -261,24 +389,86 @@ def _build_rows(
                     seed=seed,
                 ),
                 val_rmse_ci=block_bootstrap_ci(
-                    val_values,
+                    val_values_field,
                     statistic="mean",
                     block_size=block_size,
                     n_resamples=n_resamples,
                     coverage=coverage,
                     seed=seed,
                 ),
-                holdout_train_gap=float(gap),
+                test_rmse_ci=block_bootstrap_ci(
+                    test_values_field,
+                    statistic="mean",
+                    block_size=block_size,
+                    n_resamples=n_resamples,
+                    coverage=coverage,
+                    seed=seed,
+                ),
+                holdout_train_gap=float(holdout_gap),
+                test_train_gap=float(test_gap),
                 gap_flag=gap_flag,
                 target_mode=target_mode,
+                fold_id=fold_id if isinstance(fold_id, str) else None,
+                protocol=protocol,
             )
         )
-    # Lower combined-RMSE is better, so ascending sort gives rank order.
-    # Real-target rows sort first so the headline table is the
-    # production-relevant ranking; shuffled rows trail underneath in
-    # the same ascending order.
-    rows.sort(key=lambda r: (0 if r.target_mode == "real" else 1, r.combined_rmse_ci.point))
+
+    # Deterministic ordering. Real-target rows sort first so the
+    # headline table is the production-relevant ranking; shuffled rows
+    # trail underneath. Architectures rank by their representative
+    # test-RMSE (the all-folds-aggregate row when folds are present,
+    # otherwise the single row's test-RMSE). Within an architecture
+    # group folds sort as: single-fold None first (legacy path), then
+    # ``wf_fold_N`` in lexicographic order, with the all-folds
+    # aggregate row last so the eye flows fold-by-fold then summary.
+    def _fold_sort_key(fold_id: str | None) -> tuple[int, str]:
+        if fold_id is None:
+            return (0, "")
+        if fold_id == "all-folds":
+            return (2, "")
+        return (1, fold_id)
+
+    # Precompute the per-architecture representative test-RMSE so the
+    # sort key never reads off the rows list during the sort itself.
+    # ``rows`` is the same list that ``list.sort`` reorders in place;
+    # reading it during key extraction observes a partially-mutated
+    # view on some Python builds.
+    def _row_test_point(r: ArchitectureRow) -> float:
+        return r.test_rmse_ci.point if r.test_rmse_ci is not None else r.combined_rmse_ci.point
+
+    arch_rep: dict[tuple[str, str], float] = {}
+    arch_has_all_folds: dict[tuple[str, str], bool] = {}
+    for r in rows:
+        key = (r.architecture, r.target_mode)
+        point = _row_test_point(r)
+        if r.fold_id == "all-folds":
+            arch_rep[key] = point
+            arch_has_all_folds[key] = True
+        elif not arch_has_all_folds.get(key, False):
+            # Track the minimum per-fold / single-row value until an
+            # all-folds row claims the slot.
+            if key in arch_rep:
+                arch_rep[key] = min(arch_rep[key], point)
+            else:
+                arch_rep[key] = point
+
+    rows.sort(
+        key=lambda r: (
+            0 if r.target_mode == "real" else 1,
+            arch_rep.get((r.architecture, r.target_mode), float("inf")),
+            r.architecture,
+            _fold_sort_key(r.fold_id),
+        )
+    )
     return rows
+
+
+_HEADER = (
+    "| Rank | Architecture | Protocol | Fold | Credibility | n | mode | "
+    "train-RMSE | val-RMSE | test-RMSE (mean, {coverage_pct}% CI) | "
+    "test/train gap | close-RMSE | volatility-RMSE |"
+)
+_SEPARATOR = "|---:|---|:-:|:-:|:-:|---:|:-:|---|---|---|---:|---|---|"
 
 
 def render_markdown(rows: list[ArchitectureRow], *, coverage: float) -> str:
@@ -291,10 +481,8 @@ def render_markdown(rows: list[ArchitectureRow], *, coverage: float) -> str:
 
     lines: list[str] = []
     if real_rows:
-        lines.append(
-            f"| Rank | Architecture | Credibility | n | mode | train-RMSE | holdout-RMSE | holdout/train gap | combined-RMSE (mean, {coverage_pct}% CI) | close-RMSE | volatility-RMSE |"
-        )
-        lines.append("|---:|---|:-:|---:|:-:|---|---|---:|---|---|---|")
+        lines.append(_HEADER.format(coverage_pct=coverage_pct))
+        lines.append(_SEPARATOR)
         for rank, row in enumerate(real_rows, start=1):
             lines.append(_render_row_line(row, rank, coverage_pct))
 
@@ -302,10 +490,8 @@ def render_markdown(rows: list[ArchitectureRow], *, coverage: float) -> str:
         lines.append("")
         lines.append("### Shuffled-targets control")
         lines.append("")
-        lines.append(
-            f"| Rank | Architecture | Credibility | n | mode | train-RMSE | holdout-RMSE | holdout/train gap | combined-RMSE (mean, {coverage_pct}% CI) | close-RMSE | volatility-RMSE |"
-        )
-        lines.append("|---:|---|:-:|---:|:-:|---|---|---:|---|---|---|")
+        lines.append(_HEADER.format(coverage_pct=coverage_pct))
+        lines.append(_SEPARATOR)
         for rank, row in enumerate(shuffled_rows, start=1):
             lines.append(_render_row_line(row, rank, coverage_pct))
 
@@ -314,22 +500,23 @@ def render_markdown(rows: list[ArchitectureRow], *, coverage: float) -> str:
 
 def _render_row_line(row: ArchitectureRow, rank: int, coverage_pct: int) -> str:
     n = len(row.combined_rmse_values)
-    cr = row.combined_rmse_ci
     c = row.close_rmse_ci
     v = row.volatility_rmse_ci
     train_ci = row.train_rmse_ci
     val_ci = row.val_rmse_ci
-    gap_text = f"{row.holdout_train_gap:+.3f}"
+    test_ci = row.test_rmse_ci if row.test_rmse_ci is not None else row.combined_rmse_ci
+    gap_text = f"{row.test_train_gap:+.3f}"
     if row.gap_flag == "high":
         gap_text = f"{gap_text}!"
+    fold_label = row.fold_id if row.fold_id else "-"
     return (
-        f"| {rank} | `{row.architecture}` | "
+        f"| {rank} | `{row.architecture}` | {row.protocol} | {fold_label} | "
         f"{'on' if row.credibility_features else 'off'} | {n} | "
         f"{row.target_mode} | "
         f"{train_ci.point:.4f} [{train_ci.lo:.4f}, {train_ci.hi:.4f}] | "
         f"{val_ci.point:.4f} [{val_ci.lo:.4f}, {val_ci.hi:.4f}] | "
+        f"{test_ci.point:.4f} [{test_ci.lo:.4f}, {test_ci.hi:.4f}] | "
         f"{gap_text} | "
-        f"{cr.point:.4f} [{cr.lo:.4f}, {cr.hi:.4f}] | "
         f"{c.point:.4f} [{c.lo:.4f}, {c.hi:.4f}] | "
         f"{v.point:.4f} [{v.lo:.4f}, {v.hi:.4f}] |"
     )
@@ -339,6 +526,8 @@ def _row_to_json(row: ArchitectureRow) -> dict[str, Any]:
     return {
         "architecture": row.architecture,
         "target_mode": row.target_mode,
+        "fold_id": row.fold_id,
+        "protocol": row.protocol,
         "seeds": row.seeds,
         "credibility_features": row.credibility_features,
         "combined_rmse": {
@@ -361,7 +550,12 @@ def _row_to_json(row: ArchitectureRow) -> dict[str, Any]:
             "values": row.val_rmse_values,
             "ci": asdict(row.val_rmse_ci) if row.val_rmse_ci is not None else None,
         },
+        "test_rmse": {
+            "values": row.test_rmse_values,
+            "ci": asdict(row.test_rmse_ci) if row.test_rmse_ci is not None else None,
+        },
         "holdout_train_gap": row.holdout_train_gap,
+        "test_train_gap": row.test_train_gap,
         "gap_flag": row.gap_flag,
     }
 

--- a/backend/app/evaluation/metrics.py
+++ b/backend/app/evaluation/metrics.py
@@ -37,6 +37,19 @@ class TrainingRunSummary:
     best_epoch: int | None = None
     metrics: EvaluationMetrics | None = None
     train_metrics: EvaluationMetrics | None = None
+    # Explicit walk-forward partition metrics. ``val_metrics`` is the
+    # best early-stopping checkpoint's validation RMSE; ``test_metrics``
+    # is the held-out test-partition RMSE -- the headline number the
+    # aggregator emits as ``test-RMSE``. On the legacy 80/20 internal
+    # split path both fields collapse to the val partition (no real
+    # held-out test set exists), so the back-compat regression contract
+    # is preserved while the walk-forward path carries a real test
+    # eval. ``protocol`` distinguishes the two paths in the per-trial
+    # record.
+    val_metrics: EvaluationMetrics | None = None
+    test_metrics: EvaluationMetrics | None = None
+    fold_id: str | None = None
+    protocol: str = "legacy-80-20"
     weight_decay: float = 1e-4
     target_mode: str = "real"
     text_encoder: str | None = None

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -43,7 +43,11 @@ from app.services.forecaster import (
     inspect_training_data_sources,
     train_model,
 )
-from app.training.loaders import load_training_sequences_from_package
+from app.training.loaders import (
+    WalkForwardSplit,
+    load_training_sequences_from_package,
+    load_walk_forward_split,
+)
 
 # Official seed set for the multi-architecture sweep (mirrors the NLP bake-off
 # protocol in ``docs/benchmark-policy.md``).
@@ -447,6 +451,33 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--folds",
+        nargs="+",
+        default=None,
+        help=(
+            "Walk-forward fold ids from "
+            "fold_manifest_expanding_walk_forward.json (e.g. wf_fold_1 "
+            "wf_fold_2 wf_fold_3 wf_fold_4). When set, each cell trains "
+            "once per (architecture, seed, hp_combo, fold). The per-fold "
+            "splits come from the manifest's expanding-window date "
+            "ranges; the val + test partitions are honoured separately "
+            "by the training loop. Ignored when "
+            "--training-package-id is unset."
+        ),
+    )
+    parser.add_argument(
+        "--protocol",
+        choices=("auto", "single-fold", "walk-forward"),
+        default="auto",
+        help=(
+            "Force the split protocol. 'auto' (default) routes to "
+            "walk-forward when --folds is supplied and to single-fold "
+            "(package's splits_train_val_test.parquet) otherwise. "
+            "'single-fold' / 'walk-forward' override the auto choice. "
+            "Ignored when --training-package-id is unset."
+        ),
+    )
+    parser.add_argument(
         "--target-mode",
         choices=("event_study", "realized_return"),
         default="event_study",
@@ -704,6 +735,24 @@ def sample_random_search_subset(
     return [(int(idx), dict(hp_grid[int(idx)])) for idx in indices]
 
 
+def _resolved_fold_ids(args: argparse.Namespace) -> list[str | None]:
+    """Return the fold ids the candidate enumeration iterates over.
+
+    The list always has at least one entry. On the single-fold path the
+    entry is ``None`` (the trainer reads
+    ``splits_train_val_test.parquet`` for the package's default
+    partition); on the walk-forward path the list mirrors the
+    ``--folds`` argument verbatim, so each candidate cell expands to
+    ``len(folds)`` trials.
+    """
+
+    folds = getattr(args, "folds", None) or []
+    folds = [str(f).strip() for f in folds if str(f).strip()]
+    if not folds:
+        return [None]
+    return list(folds)
+
+
 def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
     architectures = args.architectures or [args.architecture]
     # When the caller asks for an architecture sweep but doesn't list seeds we
@@ -715,6 +764,8 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
         seeds = list(DEFAULT_SWEEP_SEEDS)
     else:
         seeds = [args.seed]
+
+    fold_ids = _resolved_fold_ids(args)
 
     use_random_search = bool(getattr(args, "random_search", False))
     text_embedding_dim = _resolve_text_embedding_dim(args)
@@ -734,8 +785,8 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
         for architecture, seed in itertools.product(architectures, seeds):
             for hp_combo_id, hp in sampled_hp:
                 text_adapter_dim = int(hp["text_adapter_dim"])
-                candidates.append(
-                    {
+                for fold_id in fold_ids:
+                    candidate = {
                         "model_config": ModelConfig(
                             input_size=_resolved_input_size(args),
                             hidden_size=hp["hidden_size"],
@@ -754,7 +805,9 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                         "seed": int(seed) if seed is not None else None,
                         "hp_combo_id": int(hp_combo_id),
                     }
-                )
+                    if fold_id is not None:
+                        candidate["fold_id"] = fold_id
+                    candidates.append(candidate)
         return candidates
 
     # Exhaustive path: byte-identical to the pre-PR enumeration order so
@@ -797,8 +850,8 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
         text_adapter_dims,
         seeds,
     ):
-        candidates.append(
-            {
+        for fold_id in fold_ids:
+            candidate = {
                 "model_config": ModelConfig(
                     input_size=_resolved_input_size(args),
                     hidden_size=hidden_size,
@@ -816,7 +869,9 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                 "text_adapter_dim": int(text_adapter_dim),
                 "seed": int(seed) if seed is not None else None,
             }
-        )
+            if fold_id is not None:
+                candidate["fold_id"] = fold_id
+            candidates.append(candidate)
     return candidates
 
 
@@ -824,6 +879,8 @@ def _flatten_trial_record(record: dict[str, Any]) -> dict[str, Any]:
     summary = record["summary"]
     metrics = summary.get("metrics") or {}
     train_metrics = summary.get("train_metrics") or {}
+    val_metrics = summary.get("val_metrics") or {}
+    test_metrics = summary.get("test_metrics") or {}
     model_config = summary.get("model_config") or {}
     flattened: dict[str, Any] = {
         "trial_index": record["trial_index"],
@@ -855,6 +912,19 @@ def _flatten_trial_record(record: dict[str, Any]) -> dict[str, Any]:
         "train_close_rmse": train_metrics.get("close_rmse"),
         "train_volatility_rmse": train_metrics.get("volatility_rmse"),
         "train_loss": train_metrics.get("loss"),
+        # Walk-forward partition metrics. On the legacy single-tensor
+        # path ``val_metrics`` collapses to ``metrics`` and
+        # ``test_metrics`` is absent; emit the columns when present so
+        # the CSV reflects the new train/val/test contract on the
+        # walk-forward path without breaking the legacy column set.
+        "val_combined_rmse": val_metrics.get("combined_rmse"),
+        "val_close_rmse": val_metrics.get("close_rmse"),
+        "val_volatility_rmse": val_metrics.get("volatility_rmse"),
+        "test_combined_rmse": test_metrics.get("combined_rmse"),
+        "test_close_rmse": test_metrics.get("close_rmse"),
+        "test_volatility_rmse": test_metrics.get("volatility_rmse"),
+        "fold_id": summary.get("fold_id"),
+        "protocol": summary.get("protocol"),
         "checkpoint_saved": summary.get("checkpoint_saved"),
         "checkpoint_path": summary.get("checkpoint_path"),
     }
@@ -894,20 +964,45 @@ def _run_single_training(
     save_checkpoint: bool,
     seed: int | None = None,
     sequence_groups: Sequence[Sequence[FeatureVector]] | None = None,
+    walk_forward_split: WalkForwardSplit | None = None,
     weight_decay: float = 1e-4,
     shuffle_targets_control: bool = False,
     text_encoder: str | None = None,
     text_pool_lambda_inv_days: float = 0.0,
 ) -> TrainingRunSummary:
-    # ``validation_fraction`` is the new idiomatic kwarg name. The
-    # underlying ``train_model`` keeps ``validation_split`` for backwards
-    # compatibility with checkpoints and tests; we relay by name here.
-    # When ``sequence_groups`` is provided (training-package path), the
-    # legacy ``data_dir`` scan is bypassed and the groups are appended as
-    # standalone ``vectors=`` payloads, one call per group. Doing it this
-    # way preserves the back-compat surface of ``train_model`` and
-    # avoids touching the regression-test contract.
-    if sequence_groups:
+    # Three input paths, in precedence order:
+    #
+    # - ``walk_forward_split`` set: pre-split train/val/test partitions
+    #   from ``load_walk_forward_split``; the training loop honours
+    #   them separately and reports the real held-out test_rmse.
+    # - ``sequence_groups`` set: single-list training-package path
+    #   (pre-walk-forward back-compat); the training loop falls back
+    #   to the legacy 80/20 internal split. Kept callable so the
+    #   regression-test fixture path keeps the byte-identity contract.
+    # - neither set: data-dir JSON / JSONL / CSV scan, also legacy.
+    if walk_forward_split is not None:
+        result = train_model(
+            train_sequence_groups=walk_forward_split.train,
+            val_sequence_groups=walk_forward_split.val,
+            test_sequence_groups=walk_forward_split.test,
+            fold_id=walk_forward_split.fold_id,
+            protocol=walk_forward_split.protocol,
+            epochs=epochs,
+            batch_size=batch_size,
+            learning_rate=learning_rate,
+            validation_split=validation_fraction,
+            early_stopping_patience=early_stopping_patience,
+            checkpoint_path=checkpoint_path,
+            save_checkpoint=save_checkpoint,
+            device=device,
+            model_config=model_config,
+            seed=seed,
+            weight_decay=weight_decay,
+            shuffle_targets_control=shuffle_targets_control,
+            text_encoder=text_encoder,
+            text_pool_lambda_inv_days=text_pool_lambda_inv_days,
+        )
+    elif sequence_groups:
         result = _train_model_with_groups(
             sequence_groups=sequence_groups,
             epochs=epochs,
@@ -998,12 +1093,12 @@ def _worker_run_cell(payload: dict[str, Any]) -> dict[str, Any]:
 
     The payload carries every argument the worker needs to recreate
     the call without sharing memory with the parent: a pickled
-    ``ModelConfig``, the per-cell HP values, the sequence-groups
-    payload, and the trial-index metadata. The worker re-imports
-    torch (the spawn context guarantees a fresh CUDA context) and
-    routes through the same ``_run_single_training`` helper the
-    sequential path uses, so the per-cell training code is shared
-    across both schedulers.
+    ``ModelConfig``, the per-cell HP values, the per-fold
+    ``WalkForwardSplit`` (or the legacy flat sequence-groups payload),
+    and the trial-index metadata. The worker re-imports torch (the
+    spawn context guarantees a fresh CUDA context) and routes through
+    the same ``_run_single_training`` helper the sequential path uses,
+    so the per-cell training code is shared across both schedulers.
     """
 
     summary = _run_single_training(
@@ -1018,7 +1113,8 @@ def _worker_run_cell(payload: dict[str, Any]) -> dict[str, Any]:
         model_config=payload["model_config"],
         save_checkpoint=False,
         seed=payload["seed"],
-        sequence_groups=payload["sequence_groups"],
+        sequence_groups=payload.get("sequence_groups"),
+        walk_forward_split=payload.get("walk_forward_split"),
         weight_decay=float(payload["weight_decay"]),
         shuffle_targets_control=bool(payload["shuffle_targets_control"]),
         text_encoder=payload["text_encoder"],
@@ -1029,6 +1125,7 @@ def _worker_run_cell(payload: dict[str, Any]) -> dict[str, Any]:
         "architecture": str(payload["model_config"].architecture),
         "seed": payload["seed"],
         "hp_combo_id": payload.get("hp_combo_id"),
+        "fold_id": payload.get("fold_id"),
         "summary": summary,
     }
 
@@ -1042,6 +1139,7 @@ def _build_worker_payload(
     checkpoint_path: Path,
     device: torch.device,
     sequence_groups: Sequence[Sequence[FeatureVector]] | None,
+    walk_forward_split: WalkForwardSplit | None,
     text_encoder_arg: str | None,
     text_pool_lambda: float,
 ) -> dict[str, Any]:
@@ -1055,6 +1153,7 @@ def _build_worker_payload(
         "weight_decay": candidate.get("weight_decay", args.weight_decay),
         "seed": candidate.get("seed"),
         "hp_combo_id": candidate.get("hp_combo_id"),
+        "fold_id": candidate.get("fold_id"),
         "data_dir": data_dir,
         "checkpoint_path": checkpoint_path,
         "device": str(device),
@@ -1062,6 +1161,7 @@ def _build_worker_payload(
         "validation_fraction": float(args.validation_fraction),
         "early_stopping_patience": int(args.early_stopping_patience),
         "sequence_groups": sequence_groups,
+        "walk_forward_split": walk_forward_split,
         "shuffle_targets_control": bool(args.shuffle_targets_control),
         "text_encoder": text_encoder_arg,
         "text_pool_lambda_inv_days": float(text_pool_lambda),
@@ -1122,6 +1222,7 @@ def _run_sweep(
     report_path: Path,
     device: torch.device,
     sequence_groups: Sequence[Sequence[FeatureVector]] | None = None,
+    walk_forward_splits: dict[str, WalkForwardSplit] | None = None,
     training_package_id: str | None = None,
 ) -> int:
     candidates = build_sweep_candidates(args)
@@ -1169,6 +1270,12 @@ def _run_sweep(
             max_workers=parallel_workers,
             mp_context=spawn_ctx,
         ) as pool:
+            def _split_for_candidate(c: dict[str, Any]) -> WalkForwardSplit | None:
+                if walk_forward_splits is None:
+                    return None
+                cand_fold = c.get("fold_id") or next(iter(walk_forward_splits))
+                return walk_forward_splits.get(cand_fold)
+
             future_to_index = {
                 pool.submit(
                     _worker_run_cell,
@@ -1179,7 +1286,8 @@ def _run_sweep(
                         data_dir=data_dir,
                         checkpoint_path=checkpoint_path,
                         device=device,
-                        sequence_groups=sequence_groups,
+                        sequence_groups=None if walk_forward_splits is not None else sequence_groups,
+                        walk_forward_split=_split_for_candidate(candidate),
                         text_encoder_arg=text_encoder_arg,
                         text_pool_lambda=text_pool_lambda,
                     ),
@@ -1199,6 +1307,8 @@ def _run_sweep(
                 }
                 if result.get("hp_combo_id") is not None:
                     record["hp_combo_id"] = result["hp_combo_id"]
+                if result.get("fold_id") is not None:
+                    record["fold_id"] = result["fold_id"]
                 trial_records.append(record)
                 summaries.append(summary)
                 print(
@@ -1216,6 +1326,16 @@ def _run_sweep(
             epochs = candidate["epochs"]
             weight_decay = candidate.get("weight_decay", args.weight_decay)
             seed = candidate.get("seed")
+            fold_id = candidate.get("fold_id")
+            wf_split: WalkForwardSplit | None = None
+            cell_sequence_groups: Sequence[Sequence[FeatureVector]] | None = sequence_groups
+            if walk_forward_splits is not None:
+                # On the walk-forward path the per-fold split carries
+                # train/val/test partitions; the trainer skips the
+                # legacy single-list code path entirely.
+                split_key = fold_id if fold_id is not None else next(iter(walk_forward_splits))
+                wf_split = walk_forward_splits[split_key]
+                cell_sequence_groups = None
             summary = _run_single_training(
                 data_dir=data_dir,
                 checkpoint_path=checkpoint_path,
@@ -1228,7 +1348,8 @@ def _run_sweep(
                 model_config=model_config,
                 save_checkpoint=False,
                 seed=seed,
-                sequence_groups=sequence_groups,
+                sequence_groups=cell_sequence_groups,
+                walk_forward_split=wf_split,
                 weight_decay=float(weight_decay),
                 shuffle_targets_control=bool(args.shuffle_targets_control),
                 text_encoder=text_encoder_arg,
@@ -1243,6 +1364,8 @@ def _run_sweep(
             }
             if "hp_combo_id" in candidate:
                 record["hp_combo_id"] = candidate["hp_combo_id"]
+            if fold_id is not None:
+                record["fold_id"] = fold_id
             trial_records.append(record)
             print(
                 _format_cell_log(
@@ -1296,6 +1419,13 @@ def _run_sweep(
         f"epochs={best_summary.epochs_requested}"
     )
     best_weight_decay = best_candidate.get("weight_decay", args.weight_decay)
+    best_fold_id = best_candidate.get("fold_id")
+    best_wf_split: WalkForwardSplit | None = None
+    final_sequence_groups: Sequence[Sequence[FeatureVector]] | None = sequence_groups
+    if walk_forward_splits is not None:
+        key = best_fold_id if best_fold_id is not None else next(iter(walk_forward_splits))
+        best_wf_split = walk_forward_splits[key]
+        final_sequence_groups = None
     final_summary = _run_single_training(
         data_dir=data_dir,
         checkpoint_path=checkpoint_path,
@@ -1312,7 +1442,8 @@ def _run_sweep(
         model_config=best_model_config,
         save_checkpoint=True,
         seed=best_seed,
-        sequence_groups=sequence_groups,
+        sequence_groups=final_sequence_groups,
+        walk_forward_split=best_wf_split,
         weight_decay=float(best_weight_decay),
         shuffle_targets_control=bool(args.shuffle_targets_control),
         text_encoder=text_encoder_arg,
@@ -1342,6 +1473,10 @@ def _run_sweep(
             "pool_lambda_inv_days": text_pool_lambda,
         },
         "shuffle_targets_control": bool(args.shuffle_targets_control),
+        "protocol": (
+            "walk-forward" if walk_forward_splits is not None else "single-fold"
+        ),
+        "folds": sorted({str(trial.get("fold_id")) for trial in trial_records if trial.get("fold_id")}),
         "architectures": sorted({trial["architecture"] for trial in trial_records}),
         "seeds": sorted({trial["seed"] for trial in trial_records if trial["seed"] is not None}),
         "trial_count": len(trial_records),
@@ -1387,6 +1522,7 @@ def main() -> int:
         )
 
     package_sequences: list[list[FeatureVector]] | None = None
+    walk_forward_splits: dict[str, WalkForwardSplit] | None = None
     if use_package_path:
         print(f"Training-package id: {args.training_package_id}")
         print(f"Target mode: {args.target_mode}")
@@ -1398,22 +1534,96 @@ def main() -> int:
         loader_text_encoder = (
             None if str(args.text_encoder) == "none" else str(args.text_encoder)
         )
-        package_sequences = load_training_sequences_from_package(
-            args.training_package_id,
-            target_mode=args.target_mode,
-            rich_features=bool(args.rich_features),
-            use_credibility=bool(args.use_credibility),
-            use_linguistic=bool(args.use_linguistic),
-            use_mp_surprise=bool(args.use_mp_surprise),
-            use_multi_axis=bool(args.use_multi_axis),
-            text_encoder=loader_text_encoder,
-            text_adapter_dim=int(args.text_adapter_dim),
-            text_pool_lambda_inv_days=float(args.text_pool_lambda_inv_days),
-            use_text_embeddings=bool(args.use_text_embeddings),
-        )
-        sequence_count = len(package_sequences)
-        observation_count = sum(len(sequence) for sequence in package_sequences)
-        window_count = sum(max(0, len(sequence) - SEQUENCE_LENGTH) for sequence in package_sequences)
+
+        protocol_choice = str(getattr(args, "protocol", "auto") or "auto")
+        cli_folds: list[str] = [str(f).strip() for f in (args.folds or []) if str(f).strip()]
+        if protocol_choice == "auto":
+            resolved_protocol = "walk-forward" if cli_folds else "single-fold"
+        else:
+            resolved_protocol = protocol_choice
+        if resolved_protocol == "walk-forward" and not cli_folds:
+            raise SystemExit(
+                "--protocol walk-forward requires --folds <fold_id> [<fold_id> ...]; "
+                "got an empty fold list"
+            )
+        if str(getattr(args, "validation_fraction", 0.0)) and (cli_folds or resolved_protocol != "single-fold"):
+            # The walk-forward and single-fold paths both honour the
+            # package's pre-built partitions; the random/chronological
+            # validation_fraction knob is inert on those paths.
+            _LOGGER.info(
+                "--validation-fraction=%s ignored on protocol=%s; the "
+                "training partition is honoured from the package.",
+                args.validation_fraction,
+                resolved_protocol,
+            )
+
+        print(f"Protocol: {resolved_protocol}")
+
+        if resolved_protocol == "walk-forward":
+            walk_forward_splits = {}
+            for fold_id in cli_folds:
+                split = load_walk_forward_split(
+                    args.training_package_id,
+                    fold_id=fold_id,
+                    target_mode=args.target_mode,
+                    rich_features=bool(args.rich_features),
+                    use_credibility=bool(args.use_credibility),
+                    use_linguistic=bool(args.use_linguistic),
+                    use_mp_surprise=bool(args.use_mp_surprise),
+                    use_multi_axis=bool(args.use_multi_axis),
+                    text_encoder=loader_text_encoder,
+                    text_adapter_dim=int(args.text_adapter_dim),
+                    text_pool_lambda_inv_days=float(args.text_pool_lambda_inv_days),
+                    use_text_embeddings=bool(args.use_text_embeddings),
+                )
+                walk_forward_splits[fold_id] = split
+                print(
+                    f"  {fold_id}: train={len(split.train)} val={len(split.val)} "
+                    f"test={len(split.test)}"
+                )
+            sequence_count = sum(
+                len(s.train) + len(s.val) + len(s.test) for s in walk_forward_splits.values()
+            )
+            observation_count = sum(
+                sum(len(seq) for seq in (s.train + s.val + s.test))
+                for s in walk_forward_splits.values()
+            )
+            window_count = sum(
+                sum(max(0, len(seq) - SEQUENCE_LENGTH) for seq in (s.train + s.val + s.test))
+                for s in walk_forward_splits.values()
+            )
+        else:
+            # Single-fold path: read the package's
+            # splits_train_val_test.parquet partition. The trainer
+            # honours the val and test lists as the early-stopping
+            # signal and the held-out evaluation set.
+            split = load_walk_forward_split(
+                args.training_package_id,
+                fold_id=None,
+                target_mode=args.target_mode,
+                rich_features=bool(args.rich_features),
+                use_credibility=bool(args.use_credibility),
+                use_linguistic=bool(args.use_linguistic),
+                use_mp_surprise=bool(args.use_mp_surprise),
+                use_multi_axis=bool(args.use_multi_axis),
+                text_encoder=loader_text_encoder,
+                text_adapter_dim=int(args.text_adapter_dim),
+                text_pool_lambda_inv_days=float(args.text_pool_lambda_inv_days),
+                use_text_embeddings=bool(args.use_text_embeddings),
+            )
+            walk_forward_splits = {"_single_fold": split}
+            print(
+                f"  single-fold: train={len(split.train)} val={len(split.val)} "
+                f"test={len(split.test)}"
+            )
+            sequence_count = len(split.train) + len(split.val) + len(split.test)
+            observation_count = sum(
+                len(seq) for seq in (split.train + split.val + split.test)
+            )
+            window_count = sum(
+                max(0, len(seq) - SEQUENCE_LENGTH)
+                for seq in (split.train + split.val + split.test)
+            )
         print(f"Device: {device}")
         print(f"Checkpoint path: {checkpoint_path}")
         print(f"Existing checkpoint: {'yes' if checkpoint_path.exists() else 'no'}")
@@ -1467,6 +1677,7 @@ def main() -> int:
             args.seeds,
             args.weight_decays,
             args.text_adapter_dims,
+            args.folds,
         )
     )
     if sweep_mode:
@@ -1477,6 +1688,7 @@ def main() -> int:
             report_path=report_path,
             device=device,
             sequence_groups=package_sequences,
+            walk_forward_splits=walk_forward_splits,
             training_package_id=args.training_package_id,
         )
 
@@ -1484,6 +1696,14 @@ def main() -> int:
         "Starting professional forecaster training "
         f"(architecture={args.architecture}, credibility_features={bool(args.credibility_features)})..."
     )
+    single_run_split: WalkForwardSplit | None = None
+    single_run_sequence_groups: Sequence[Sequence[FeatureVector]] | None = package_sequences
+    if walk_forward_splits is not None:
+        # On the package path the single-run also honours the
+        # walk-forward partition the loader resolved; the legacy
+        # ``--data-dir`` path keeps the flat sequence list.
+        single_run_split = next(iter(walk_forward_splits.values()))
+        single_run_sequence_groups = None
     summary = _run_single_training(
         data_dir=data_dir,
         checkpoint_path=checkpoint_path,
@@ -1496,7 +1716,8 @@ def main() -> int:
         model_config=_build_model_config(args),
         save_checkpoint=True,
         seed=args.seed,
-        sequence_groups=package_sequences,
+        sequence_groups=single_run_sequence_groups,
+        walk_forward_split=single_run_split,
         weight_decay=float(args.weight_decay),
         shuffle_targets_control=bool(args.shuffle_targets_control),
         text_encoder=None if str(args.text_encoder) == "none" else str(args.text_encoder),

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import dataclasses
 import datetime
 import json
 import logging
@@ -90,6 +91,39 @@ _NON_TRAINING_SPLIT_TAGS = frozenset({"val", "test", "excluded_from_training"})
 TargetMode = Literal["event_study", "realized_return"]
 _VALID_TARGET_MODES: frozenset[str] = frozenset({"event_study", "realized_return"})
 DEFAULT_TARGET_MODE: TargetMode = "event_study"
+
+
+@dataclasses.dataclass(frozen=True)
+class WalkForwardSplit:
+    """Pre-split sequence groups for a single walk-forward fold.
+
+    Holds the three sequence-group lists the trainer consumes
+    independently: the training partition the optimiser fits, the
+    validation partition early-stopping watches, and the held-out test
+    partition the aggregator reports as the headline RMSE. Per-list
+    ``event_dates`` mirror the per-list ``text_hash`` order so the
+    aggregator can audit fold boundaries without reopening the parquet.
+
+    ``fold_id`` is ``None`` on the single-fold default path (the
+    package's ``splits_train_val_test.parquet`` already names the
+    partition per row). Multi-fold callers populate it with the
+    manifest's fold id (``wf_fold_1`` ...).
+
+    ``protocol`` distinguishes ``single-fold`` (legacy split-tag
+    partition) from ``walk-forward`` (expanding training window read
+    off ``fold_manifest_expanding_walk_forward.json``) so the
+    aggregator can label rows without re-deriving the path from the
+    fold id.
+    """
+
+    train: list[list[FeatureVector]]
+    val: list[list[FeatureVector]]
+    test: list[list[FeatureVector]]
+    train_event_dates: list[str]
+    val_event_dates: list[str]
+    test_event_dates: list[str]
+    fold_id: str | None = None
+    protocol: str = "single-fold"
 
 
 def _coerce_finite_float(value: Any) -> float | None:
@@ -972,6 +1006,81 @@ def _read_events_frame(package_dir: Path) -> "Any":
     return pd.read_parquet(events_path)
 
 
+def _read_fold_manifest(package_dir: Path) -> dict[str, dict[str, str]]:
+    """Return ``fold_id -> {train_start, train_end, val_start, val_end, test_start, test_end}``.
+
+    Reads ``fold_manifest_expanding_walk_forward.json`` from the
+    training-package directory. The manifest ships one entry per
+    expanding-window fold (``wf_fold_1`` ... ``wf_fold_N``) with the
+    chronological date ranges that define the train, val and test
+    windows for that fold. Returns an empty dict when the file is
+    absent or the schema is unparseable; callers handle that as a
+    missing-fold error.
+    """
+
+    path = package_dir / "fold_manifest_expanding_walk_forward.json"
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    folds = payload.get("folds") if isinstance(payload, dict) else None
+    if not isinstance(folds, list):
+        return {}
+    result: dict[str, dict[str, str]] = {}
+    for fold in folds:
+        if not isinstance(fold, dict):
+            continue
+        fold_id = str(fold.get("fold_id", "")).strip()
+        if not fold_id:
+            continue
+        result[fold_id] = {
+            "train_start": str(fold.get("train_start", "")),
+            "train_end": str(fold.get("train_end", "")),
+            "val_start": str(fold.get("val_start", "")),
+            "val_end": str(fold.get("val_end", "")),
+            "test_start": str(fold.get("test_start", "")),
+            "test_end": str(fold.get("test_end", "")),
+        }
+    return result
+
+
+def _read_split_tag_lookup(package_dir: Path) -> dict[str, str]:
+    """Return ``text_hash -> split_tag`` from ``splits_train_val_test.parquet``.
+
+    Accepts either ``split_tag`` (current builder column name) or
+    ``partition`` (the forward-looking name from the data contract).
+    Returns an empty dict when the parquet is absent or the schema
+    does not expose a joinable ``text_hash`` column; downstream
+    callers then fall through to the legacy "train-only" filter.
+    """
+
+    import pandas as pd
+
+    splits_path = package_dir / "splits_train_val_test.parquet"
+    if not splits_path.exists():
+        return {}
+    frame = pd.read_parquet(splits_path)
+    tag_column: str | None = None
+    for candidate in ("partition", "split_tag"):
+        if candidate in frame.columns:
+            tag_column = candidate
+            break
+    if tag_column is None or "text_hash" not in frame.columns:
+        return {}
+    lookup: dict[str, str] = {}
+    for record in frame.to_dict("records"):
+        text_hash = str(record.get("text_hash", "")).strip()
+        if not text_hash:
+            continue
+        tag = str(record.get(tag_column, "")).strip().lower()
+        if not tag:
+            continue
+        lookup[text_hash] = tag
+    return lookup
+
+
 def _read_excluded_text_hashes(package_dir: Path) -> set[str]:
     """Return the ``text_hash`` set that must NOT enter the training loss.
 
@@ -1011,6 +1120,368 @@ def _read_excluded_text_hashes(package_dir: Path) -> set[str]:
     # excluded sentinel all drop.
     excluded = frame.loc[excluded_mask, "text_hash"]
     return {str(value) for value in excluded.tolist() if value}
+
+
+def _load_package_sequences_with_metadata(
+    training_package_id: str,
+    *,
+    target_mode: TargetMode = DEFAULT_TARGET_MODE,
+    rich_features: bool = True,
+    use_credibility: bool = True,
+    use_linguistic: bool = True,
+    use_mp_surprise: bool = True,
+    use_multi_axis: bool = True,
+    text_encoder: str | None = None,
+    text_adapter_dim: int = DEFAULT_TEXT_ADAPTER_DIM,
+    text_pool_lambda_inv_days: float = DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS,
+    use_text_embeddings: bool = True,
+    text_embedding_cache_dir: Path | str | None = None,
+) -> list[tuple[list[FeatureVector], str, str]]:
+    """Materialise every event in a training package as a sequence triple.
+
+    Returns ``[(sequence, text_hash, event_date), ...]`` for every event
+    whose ``prior_bars_json`` carries the full 20-bar prior window. No
+    split-tag or fold filter is applied here -- the caller partitions
+    on top of the returned list using either the package's
+    ``split_tag`` column or the walk-forward fold manifest.
+
+    Sequences are sorted by ``(event_date, text_hash)`` so the returned
+    order is deterministic across runs. Per-event prior-bar / target /
+    rich-feature / text-embedding logic is identical to the legacy
+    :func:`load_training_sequences_from_package`; only the partition
+    step changes.
+    """
+
+    if target_mode not in _VALID_TARGET_MODES:
+        raise ValueError(
+            f"Unsupported target_mode: {target_mode!r}. "
+            f"Choose one of {sorted(_VALID_TARGET_MODES)}."
+        )
+
+    package_dir = _resolve_training_package_dir(training_package_id)
+    frame = _read_events_frame(package_dir)
+    if frame.empty:
+        return []
+
+    required_columns = {"event_date", "text_hash", "prior_bars_json"}
+    missing = required_columns - set(frame.columns)
+    if missing:
+        raise ValueError(
+            f"events.parquet at {package_dir} missing columns: {sorted(missing)}"
+        )
+
+    linguistic_lookup: dict[str, list[float]] = {}
+    mp_surprise_lookup: dict[str, dict[str, float]] = {}
+    if rich_features:
+        linguistic_lookup = _read_linguistic_lookup(package_dir)
+        mp_surprise_lookup = _read_mp_surprise_lookup(package_dir)
+
+    embedding_lookup: dict[str, Any] = {}
+    use_text_path = bool(text_encoder) and bool(use_text_embeddings)
+    text_adapter_dim_int = int(text_adapter_dim)
+    if use_text_path:
+        if text_adapter_dim_int <= 0:
+            raise ValueError(
+                f"text_adapter_dim must be a positive integer; got {text_adapter_dim}"
+            )
+        cache_dir = (
+            Path(text_embedding_cache_dir)
+            if text_embedding_cache_dir is not None
+            else None
+        )
+        registry_parquet = package_dir / "registry_normalized.parquet"
+        registry_jsonl = package_dir / "registry_normalized.jsonl"
+        registry_for_lookup: Path | None
+        if registry_jsonl.exists():
+            registry_for_lookup = registry_jsonl
+        elif registry_parquet.exists():
+            import pandas as pd
+
+            reg_frame = pd.read_parquet(registry_parquet)
+            reg_subset = reg_frame[[c for c in ("record_id", "text_hash") if c in reg_frame.columns]]
+            if not reg_subset.empty and "record_id" in reg_subset.columns and "text_hash" in reg_subset.columns:
+                tmp_path = package_dir / "_registry_record_to_text_hash.jsonl"
+                with tmp_path.open("w", encoding="utf-8") as handle:
+                    for record in reg_subset.to_dict("records"):
+                        handle.write(
+                            json.dumps(
+                                {
+                                    "record_id": str(record.get("record_id") or ""),
+                                    "text_hash": str(record.get("text_hash") or ""),
+                                },
+                                sort_keys=True,
+                            )
+                            + "\n"
+                        )
+                registry_for_lookup = tmp_path
+            else:
+                registry_for_lookup = None
+        else:
+            registry_for_lookup = None
+        embedding_lookup = _read_chunk_embedding_lookup(
+            text_encoder,
+            cache_dir=cache_dir,
+            registry_path=registry_for_lookup,
+        )
+
+    def _row_rank(row: dict[str, Any]) -> tuple[int, int, str]:
+        horizon = row.get("horizon")
+        try:
+            horizon_int = int(horizon) if horizon is not None else 10_000
+        except (TypeError, ValueError):
+            horizon_int = 10_000
+        return (horizon_int, 0, str(row.get("source", "")))
+
+    seen: set[str] = set()
+    by_text_hash: dict[str, dict[str, Any]] = {}
+    records = frame.to_dict("records")
+    records.sort(key=_row_rank)
+    prior_chronology_set: set[tuple[datetime.date, str]] = set()
+    for row in records:
+        candidate_hash = str(row.get("text_hash", ""))
+        if not candidate_hash:
+            continue
+        candidate_date_raw = str(row.get("event_date", ""))[:10]
+        if not candidate_date_raw:
+            continue
+        try:
+            candidate_date = datetime.date.fromisoformat(candidate_date_raw)
+        except ValueError:
+            continue
+        prior_chronology_set.add((candidate_date, candidate_hash))
+        if candidate_hash in seen:
+            continue
+        seen.add(candidate_hash)
+        by_text_hash[candidate_hash] = row
+
+    prior_chronology: list[tuple[datetime.date, str]] = sorted(prior_chronology_set)
+
+    ordered_rows = sorted(
+        by_text_hash.values(),
+        key=lambda row: (str(row.get("event_date", "")), str(row.get("text_hash", ""))),
+    )
+
+    results: list[tuple[list[FeatureVector], str, str]] = []
+    for row in ordered_rows:
+        event_date_str = str(row.get("event_date", ""))
+        if not event_date_str:
+            continue
+        try:
+            event_date = datetime.date.fromisoformat(event_date_str[:10])
+        except ValueError:
+            continue
+        bars = _parse_prior_bars(row.get("prior_bars_json"))
+        if len(bars) < SEQUENCE_LENGTH:
+            continue
+        row_text_hash = str(row.get("text_hash", ""))
+        sentiment_score = _stance_to_sentiment(row.get("axis_stance"))
+        vectors = _bars_to_feature_vectors(
+            bars,
+            event_date=event_date,
+            sentiment_score=sentiment_score,
+        )
+        if len(vectors) < SEQUENCE_LENGTH:
+            continue
+        realized_return = _coerce_finite_float(row.get("realized_return"))
+        abnormal_return = _coerce_finite_float(row.get("abnormal_return"))
+        volatility_shift = _coerce_finite_float(row.get("volatility_shift"))
+        realized_date_raw = row.get("realized_date")
+        if (
+            realized_date_raw is None
+            or (isinstance(realized_date_raw, float) and realized_date_raw != realized_date_raw)
+        ):
+            realized_date = None
+        else:
+            text = str(realized_date_raw).strip()
+            realized_date = text or None
+        _append_event_day_target(
+            vectors,
+            event_date=event_date,
+            realized_return=realized_return,
+            realized_date=realized_date,
+            sentiment_score=sentiment_score,
+            abnormal_return=abnormal_return,
+            volatility_shift=volatility_shift,
+            target_mode=target_mode,
+        )
+        if rich_features:
+            _attach_rich_features(
+                vectors,
+                event_row=row,
+                linguistic_lookup=linguistic_lookup,
+                mp_surprise_lookup=mp_surprise_lookup,
+                text_hash=row_text_hash,
+                event_date_str=event_date_str[:10],
+                use_credibility=use_credibility,
+                use_linguistic=use_linguistic,
+                use_mp_surprise=use_mp_surprise,
+                use_multi_axis=use_multi_axis,
+            )
+        if use_text_path:
+            pooled = _compute_prior4_pooled_embedding(
+                text_hash=row_text_hash,
+                event_row_text_hash=row_text_hash,
+                current_event_date=event_date,
+                embedding_lookup=embedding_lookup,
+                prior_text_hashes=prior_chronology,
+                lambda_inv_days=float(text_pool_lambda_inv_days),
+                max_prior=4,
+            )
+            if pooled is None:
+                missing_flag = 1.0
+                pooled_list: list[float] = []
+            else:
+                missing_flag = 0.0
+                pooled_list = [float(v) for v in pooled.tolist()]
+            for vector in vectors:
+                vector.text_embedding_pooled = list(pooled_list)
+                vector.text_embedding_missing = missing_flag
+        results.append((vectors, row_text_hash, event_date_str[:10]))
+    return results
+
+
+def load_walk_forward_split(
+    training_package_id: str,
+    *,
+    fold_id: str | None = None,
+    target_mode: TargetMode = DEFAULT_TARGET_MODE,
+    rich_features: bool = True,
+    use_credibility: bool = True,
+    use_linguistic: bool = True,
+    use_mp_surprise: bool = True,
+    use_multi_axis: bool = True,
+    text_encoder: str | None = None,
+    text_adapter_dim: int = DEFAULT_TEXT_ADAPTER_DIM,
+    text_pool_lambda_inv_days: float = DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS,
+    use_text_embeddings: bool = True,
+    text_embedding_cache_dir: Path | str | None = None,
+) -> WalkForwardSplit:
+    """Return the (train, val, test) sequence partitions for one fold.
+
+    Two protocols are supported:
+
+    - ``fold_id=None`` (default, "single-fold"): partition events by
+      the ``split_tag`` column on ``splits_train_val_test.parquet``.
+      Rows tagged ``train`` enter the training list; ``val`` rows
+      drive early stopping; ``test`` rows are the held-out evaluation
+      set. The ``excluded_from_training`` sentinel (when present) is
+      treated as a fourth bucket and dropped from all three lists.
+    - ``fold_id="wf_fold_K"`` (multi-fold "walk-forward"): partition
+      events by chronological date against the fold's manifest entry
+      in ``fold_manifest_expanding_walk_forward.json``. Every event
+      with ``event_date < val_start`` belongs to the training list
+      (expanding-window contract: the train partition grows fold over
+      fold). The val list spans ``[val_start, val_end]``; the test
+      list spans ``[test_start, test_end]``.
+
+    The test partition is the canonical held-out set the forecaster
+    sweep aggregator reports as ``test_rmse``; the val partition is
+    consumed by the training loop for early stopping. Both paths
+    preserve the prior-bars + rich-feature + text-embedding attachment
+    logic; only the partition step changes.
+
+    Raises ``ValueError`` when the chosen partition produces an empty
+    test list: a sweep that silently runs on no held-out events is the
+    research-quality footgun this refactor was written to remove.
+    """
+
+    package_dir = _resolve_training_package_dir(training_package_id)
+    fold_window: dict[str, str] | None = None
+    if fold_id is not None:
+        manifest = _read_fold_manifest(package_dir)
+        if fold_id not in manifest:
+            raise ValueError(
+                f"fold_id={fold_id!r} not found in fold manifest at {package_dir}; "
+                f"known fold ids: {sorted(manifest.keys())}"
+            )
+        fold_window = manifest[fold_id]
+
+    items = _load_package_sequences_with_metadata(
+        training_package_id,
+        target_mode=target_mode,
+        rich_features=rich_features,
+        use_credibility=use_credibility,
+        use_linguistic=use_linguistic,
+        use_mp_surprise=use_mp_surprise,
+        use_multi_axis=use_multi_axis,
+        text_encoder=text_encoder,
+        text_adapter_dim=text_adapter_dim,
+        text_pool_lambda_inv_days=text_pool_lambda_inv_days,
+        use_text_embeddings=use_text_embeddings,
+        text_embedding_cache_dir=text_embedding_cache_dir,
+    )
+
+    train: list[list[FeatureVector]] = []
+    val: list[list[FeatureVector]] = []
+    test: list[list[FeatureVector]] = []
+    train_dates: list[str] = []
+    val_dates: list[str] = []
+    test_dates: list[str] = []
+
+    if fold_window is None:
+        # Single-fold path: partition by split_tag.
+        protocol = "single-fold"
+        tag_lookup = _read_split_tag_lookup(package_dir)
+        for sequence, text_hash, event_date_str in items:
+            tag = tag_lookup.get(text_hash, "").lower()
+            if tag == "train":
+                train.append(sequence)
+                train_dates.append(event_date_str)
+            elif tag == "val":
+                val.append(sequence)
+                val_dates.append(event_date_str)
+            elif tag == "test":
+                test.append(sequence)
+                test_dates.append(event_date_str)
+            else:
+                # Untagged or excluded -- skip from every partition.
+                continue
+    else:
+        protocol = "walk-forward"
+        val_start = fold_window.get("val_start", "")
+        val_end = fold_window.get("val_end", "")
+        test_start = fold_window.get("test_start", "")
+        test_end = fold_window.get("test_end", "")
+        if not (val_start and val_end and test_start and test_end):
+            raise ValueError(
+                f"fold {fold_id!r} manifest entry missing one of "
+                "val_start/val_end/test_start/test_end"
+            )
+        for sequence, _text_hash, event_date_str in items:
+            # Expanding-window contract: any event chronologically
+            # before the val window belongs to the training partition,
+            # so train_k strictly grows with k.
+            if event_date_str < val_start:
+                train.append(sequence)
+                train_dates.append(event_date_str)
+            elif val_start <= event_date_str <= val_end:
+                val.append(sequence)
+                val_dates.append(event_date_str)
+            elif test_start <= event_date_str <= test_end:
+                test.append(sequence)
+                test_dates.append(event_date_str)
+            else:
+                # Falls into the post-test gap (between the fold's
+                # test_end and the next fold's val_start) -- drop.
+                continue
+
+    if not test:
+        raise ValueError(
+            f"WalkForwardSplit for training_package_id={training_package_id!r} "
+            f"fold_id={fold_id!r} produced an empty test partition; refusing "
+            "to silently train on no held-out events"
+        )
+
+    return WalkForwardSplit(
+        train=train,
+        val=val,
+        test=test,
+        train_event_dates=train_dates,
+        val_event_dates=val_dates,
+        test_event_dates=test_dates,
+        fold_id=fold_id,
+        protocol=protocol,
+    )
 
 
 def load_training_sequences_from_package(
@@ -1118,7 +1589,24 @@ def load_training_sequences_from_package(
     ``use_text_embeddings=False`` skips the pooling step entirely and
     every row keeps the default empty pooled list + missing-flag at
     ``1.0``.
+
+    .. deprecated::
+        Returning only the training partition collapses the package's
+        ``val`` and ``test`` partitions back into "drop on the floor"
+        semantics, which is the bug that motivated
+        :func:`load_walk_forward_split`. New callers should use the
+        latter and consume the three lists separately. This wrapper
+        stays callable so the legacy regression-test contract holds
+        until in-tree callers migrate.
     """
+
+    warnings.warn(
+        "load_training_sequences_from_package returns only the train "
+        "partition and drops val + test on the floor; use "
+        "load_walk_forward_split() for proper train/val/test partitions.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     if target_mode not in _VALID_TARGET_MODES:
         raise ValueError(
@@ -1127,6 +1615,10 @@ def load_training_sequences_from_package(
         )
 
     package_dir = _resolve_training_package_dir(training_package_id)
+    if not (package_dir / "events.parquet").exists():
+        raise FileNotFoundError(
+            f"events.parquet missing from training package: {package_dir}"
+        )
     frame = _read_events_frame(package_dir)
     if frame.empty:
         return []

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import copy
+import dataclasses
 import math
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 import torch
 from torch import nn
@@ -171,12 +172,65 @@ def _evaluate_model(
     )
 
 
+def _build_partition_tensors(
+    sequence_groups: Sequence[Sequence[FeatureVector]],
+    *,
+    fallback_text_in_dim: int,
+    close_scale: float | None = None,
+) -> tuple[
+    torch.Tensor | None,
+    torch.Tensor | None,
+    float,
+    torch.Tensor | None,
+    torch.Tensor | None,
+]:
+    """Tensorise one partition into (x, y, close_scale, text_emb, text_missing).
+
+    The text-embedding tensor is materialised against the same
+    ``fallback_text_in_dim`` the legacy single-partition path uses, so a
+    partition whose every sequence is missing a pooled embedding still
+    materialises a zero-payload tensor of the right width when the
+    model's adapter is configured for the text channel.
+    """
+
+    x, y, scale = _build_training_tensors(sequence_groups, close_scale=close_scale)
+    text_emb, text_missing, _ = _build_text_embedding_tensors(
+        sequence_groups, fallback_in_dim=fallback_text_in_dim
+    )
+    return x, y, scale, text_emb, text_missing
+
+
+@dataclasses.dataclass(frozen=True)
+class BackCompatTrainingSplit:
+    """Marker for callers that need the legacy 80/20 internal split.
+
+    The walk-forward training-package path supplies pre-split
+    ``train_sequence_groups`` / ``val_sequence_groups`` /
+    ``test_sequence_groups`` and the loop honours those partitions.
+    Pre-walk-forward callers (the ``--data-dir`` scan path and the
+    determinism regression-test fixture) pass a single flat list and
+    the loop falls back to the documented-but-deprecated 80/20
+    chronological split on the tensorised windows so the byte-identity
+    contract on those legacy paths stays green.
+
+    Constructing this object on a call signals the legacy path; the
+    field is read only as a marker.
+    """
+
+    validation_fraction: float = DEFAULT_VALIDATION_SPLIT
+
+
 def train_model(
     *,
     base_model: ForecasterModel | None = None,
     model_config: ModelConfig | dict[str, Any] | None = None,
     vectors: list[FeatureVector] | None = None,
     sequence_groups: list[list[FeatureVector]] | None = None,
+    train_sequence_groups: Sequence[Sequence[FeatureVector]] | None = None,
+    val_sequence_groups: Sequence[Sequence[FeatureVector]] | None = None,
+    test_sequence_groups: Sequence[Sequence[FeatureVector]] | None = None,
+    fold_id: str | None = None,
+    protocol: str | None = None,
     data_dir: str | Path | None = None,
     epochs: int = DEFAULT_EPOCHS,
     batch_size: int = DEFAULT_BATCH_SIZE,
@@ -196,37 +250,128 @@ def train_model(
         enable_deterministic_mode(seed)
     device_obj = _resolve_device(device)
     active_model_config = ModelConfig.from_model(base_model) if base_model is not None else _coerce_model_config(model_config)
-    # When ``sequence_groups`` is provided, the caller has already
-    # loaded its sequences (e.g. from a Phase 8 training package via
-    # ``load_training_sequences_from_package``). Bypass the legacy
-    # ``data_dir`` scan in that case so the trainer does not also pull
-    # in unrelated raw-market files. When omitted, behaviour is
-    # unchanged: the data-dir scan + ``vectors`` append path runs.
-    if sequence_groups is not None:
-        active_sequence_groups: list[list[FeatureVector]] = [list(group) for group in sequence_groups]
-    else:
-        active_sequence_groups = load_training_sequences_from_data(data_dir)
-    if vectors:
-        active_sequence_groups.append(list(vectors))
-    sequence_groups = active_sequence_groups
 
-    # `_build_training_tensors` now fits a per-fold close-scale from the
-    # actual training rows and returns it as the third tuple element. The
-    # scale is persisted in the checkpoint (`close_scale` field) so
-    # inference can recover the original price magnitude. See
-    # `app.training.loaders.fit_close_scale` for the fit details.
-    x, y, close_scale = _build_training_tensors(sequence_groups)
-    # When the model is configured for the text path, pin the
-    # fallback in_dim so a batch whose every sequence is missing
-    # (e.g. the pre-corpus prefix) still materialises a zero-payload
-    # tensor of the right width. The model's adapter then projects a
-    # zero slot driven by the missing flag.
-    fallback_text_in_dim = int(getattr(active_model_config, "text_embedding_dim", 0) or 0)
-    text_emb_tensor, text_missing_tensor, text_emb_dim = _build_text_embedding_tensors(
-        sequence_groups,
-        fallback_in_dim=fallback_text_in_dim,
+    # Two split protocols are honoured:
+    #
+    # - Walk-forward (preferred): the caller supplies pre-split
+    #   train_sequence_groups / val_sequence_groups /
+    #   test_sequence_groups lists. ``_split_train_validation`` is NOT
+    #   called; the partitions are tensorised independently and the
+    #   final reported ``test_metrics`` is the real held-out RMSE.
+    # - Legacy 80/20 (back-compat): the caller supplies a single flat
+    #   sequence-groups list (``vectors`` / ``sequence_groups`` /
+    #   ``data_dir`` scan). The loop falls back to the documented
+    #   chronological 80/20 split on the tensorised windows so the
+    #   pre-walk-forward regression contract stays green.
+    walk_forward_path = (
+        train_sequence_groups is not None
+        and val_sequence_groups is not None
+        and test_sequence_groups is not None
     )
-    if x is None or y is None:
+    active_protocol = protocol or ("walk-forward" if walk_forward_path else "legacy-80-20")
+    fallback_text_in_dim = int(getattr(active_model_config, "text_embedding_dim", 0) or 0)
+
+    if walk_forward_path:
+        train_groups: list[list[FeatureVector]] = [list(group) for group in train_sequence_groups or []]
+        val_groups: list[list[FeatureVector]] = [list(group) for group in val_sequence_groups or []]
+        test_groups: list[list[FeatureVector]] = [list(group) for group in test_sequence_groups or []]
+        # Fit the close-scale on the training partition only; never on
+        # the val or test rows. The walk-forward protocol forbids
+        # fitting any scaler over held-out events.
+        train_x, train_y, close_scale, train_text_emb, train_text_missing = _build_partition_tensors(
+            train_groups,
+            fallback_text_in_dim=fallback_text_in_dim,
+            close_scale=None,
+        )
+        val_x, val_y, _val_scale, val_text_emb, val_text_missing = _build_partition_tensors(
+            val_groups,
+            fallback_text_in_dim=fallback_text_in_dim,
+            close_scale=close_scale,
+        )
+        test_x, test_y, _test_scale, test_text_emb, test_text_missing = _build_partition_tensors(
+            test_groups,
+            fallback_text_in_dim=fallback_text_in_dim,
+            close_scale=close_scale,
+        )
+        sequence_groups_for_summary = train_groups + val_groups + test_groups
+    else:
+        if sequence_groups is not None:
+            active_sequence_groups: list[list[FeatureVector]] = [list(group) for group in sequence_groups]
+        else:
+            active_sequence_groups = load_training_sequences_from_data(data_dir)
+        if vectors:
+            active_sequence_groups.append(list(vectors))
+        sequence_groups_for_summary = active_sequence_groups
+
+        x, y, close_scale = _build_training_tensors(active_sequence_groups)
+        text_emb_tensor, text_missing_tensor, _text_emb_dim = _build_text_embedding_tensors(
+            active_sequence_groups,
+            fallback_in_dim=fallback_text_in_dim,
+        )
+        if x is None or y is None:
+            model = copy.deepcopy(base_model).to(device_obj) if base_model is not None else _build_model(active_model_config, device=device_obj)
+            model.eval()
+            return TrainingResult(
+                model=model,
+                summary=TrainingRunSummary(
+                    model_config=ModelConfig.from_model(model),
+                    device=str(device_obj),
+                    epochs_requested=epochs,
+                    epochs_completed=0,
+                    batch_size=batch_size,
+                    learning_rate=learning_rate,
+                    validation_split=validation_split,
+                    early_stopping_patience=early_stopping_patience,
+                    sequence_groups=len(active_sequence_groups),
+                    total_windows=0,
+                    train_windows=0,
+                    validation_windows=0,
+                    checkpoint_path=str(checkpoint_path) if checkpoint_path is not None else str(BEST_MODEL_PATH),
+                    checkpoint_saved=False,
+                    best_epoch=None,
+                    metrics=None,
+                    fold_id=fold_id,
+                    protocol=active_protocol,
+                    weight_decay=float(weight_decay),
+                    target_mode="shuffled" if shuffle_targets_control else "real",
+                    text_encoder=text_encoder,
+                    text_adapter_dim=int(getattr(model, "text_adapter_dim", 0) or 0),
+                    text_pool_lambda_inv_days=float(text_pool_lambda_inv_days),
+                ),
+            )
+
+        # Shuffled-targets control runs only on the legacy single-tensor
+        # path; the walk-forward branch applies the same permutation
+        # per partition below.
+        if shuffle_targets_control:
+            if seed is None:
+                shuffle_seed = 11
+            else:
+                shuffle_seed = int(seed)
+            shuffle_generator = torch.Generator()
+            shuffle_generator.manual_seed(shuffle_seed)
+            perm = torch.randperm(y.shape[0], generator=shuffle_generator)
+            y = y[perm].clone()
+
+        train_x, train_y, val_x, val_y = _split_train_validation(x, y, validation_split)
+        if text_emb_tensor is not None and text_missing_tensor is not None:
+            train_text_emb = text_emb_tensor[: len(train_x)]
+            val_text_emb = text_emb_tensor[len(train_x) :]
+            train_text_missing = text_missing_tensor[: len(train_x)]
+            val_text_missing = text_missing_tensor[len(train_x) :]
+        else:
+            train_text_emb = val_text_emb = None
+            train_text_missing = val_text_missing = None
+        # Legacy path has no real held-out test partition; the val
+        # tensors serve as both early-stopping and final-report eval.
+        test_x = val_x
+        test_y = val_y
+        test_text_emb = val_text_emb
+        test_text_missing = val_text_missing
+
+    # Empty-tensor guard for the walk-forward branch. The legacy branch
+    # already short-circuits above on (x, y) == (None, None).
+    if walk_forward_path and (train_x is None or train_y is None):
         model = copy.deepcopy(base_model).to(device_obj) if base_model is not None else _build_model(active_model_config, device=device_obj)
         model.eval()
         return TrainingResult(
@@ -240,7 +385,7 @@ def train_model(
                 learning_rate=learning_rate,
                 validation_split=validation_split,
                 early_stopping_patience=early_stopping_patience,
-                sequence_groups=len(sequence_groups),
+                sequence_groups=len(sequence_groups_for_summary),
                 total_windows=0,
                 train_windows=0,
                 validation_windows=0,
@@ -248,6 +393,8 @@ def train_model(
                 checkpoint_saved=False,
                 best_epoch=None,
                 metrics=None,
+                fold_id=fold_id,
+                protocol=active_protocol,
                 weight_decay=float(weight_decay),
                 target_mode="shuffled" if shuffle_targets_control else "real",
                 text_encoder=text_encoder,
@@ -256,40 +403,56 @@ def train_model(
             ),
         )
 
-    # Mitigation 3: shuffled-targets control. Deterministically permute
-    # the target column so the model has no signal beyond the per-fold
-    # mean. macro-RMSE on the shuffled-targets run should sit near
-    # the constant-mean predictor; a real-targets run whose RMSE is
-    # close to its shuffled counterpart is memorising, not learning.
-    if shuffle_targets_control:
+    if walk_forward_path and shuffle_targets_control and train_y is not None:
+        # Permute the train partition only -- the val / test partitions
+        # keep their real targets so the memorisation control's
+        # held-out RMSE still measures what the model learns.
         if seed is None:
             shuffle_seed = 11
         else:
             shuffle_seed = int(seed)
         shuffle_generator = torch.Generator()
         shuffle_generator.manual_seed(shuffle_seed)
-        perm = torch.randperm(y.shape[0], generator=shuffle_generator)
-        y = y[perm].clone()
-
-    train_x, train_y, val_x, val_y = _split_train_validation(x, y, validation_split)
-    if text_emb_tensor is not None and text_missing_tensor is not None:
-        train_text_emb = text_emb_tensor[: len(train_x)]
-        val_text_emb = text_emb_tensor[len(train_x) :]
-        train_text_missing = text_missing_tensor[: len(train_x)]
-        val_text_missing = text_missing_tensor[len(train_x) :]
-    else:
-        train_text_emb = val_text_emb = None
-        train_text_missing = val_text_missing = None
+        perm = torch.randperm(train_y.shape[0], generator=shuffle_generator)
+        train_y = train_y[perm].clone()
     # The current Torch build emits deprecation warnings from DataLoader pinning internals.
     # For this dataset size, disabling pinning keeps training clean without a meaningful throughput hit.
     pin_memory = False
     loader_generator = make_generator(seed) if seed is not None else None
     if train_text_emb is not None and train_text_missing is not None:
         train_dataset = TensorDataset(train_x, train_y, train_text_emb, train_text_missing)
-        val_dataset = TensorDataset(val_x, val_y, val_text_emb, val_text_missing)
     else:
         train_dataset = TensorDataset(train_x, train_y)
-        val_dataset = TensorDataset(val_x, val_y)
+
+    # Early-stopping val loader: when the walk-forward branch supplied
+    # an empty val partition (rare, edge-case folds), reuse the train
+    # tensors as a tracker so the loop still has a stopping signal.
+    # ``val_metrics`` then collapses to the training-set value and
+    # ``test_metrics`` stays the headline number.
+    if val_x is None or val_y is None or len(val_x) == 0:
+        val_x_used = train_x
+        val_y_used = train_y
+        val_text_emb_used = train_text_emb
+        val_text_missing_used = train_text_missing
+    else:
+        val_x_used = val_x
+        val_y_used = val_y
+        val_text_emb_used = val_text_emb
+        val_text_missing_used = val_text_missing
+
+    if val_text_emb_used is not None and val_text_missing_used is not None:
+        val_dataset = TensorDataset(val_x_used, val_y_used, val_text_emb_used, val_text_missing_used)
+    else:
+        val_dataset = TensorDataset(val_x_used, val_y_used)
+
+    if test_x is not None and test_y is not None and len(test_x) > 0:
+        if test_text_emb is not None and test_text_missing is not None:
+            test_dataset = TensorDataset(test_x, test_y, test_text_emb, test_text_missing)
+        else:
+            test_dataset = TensorDataset(test_x, test_y)
+    else:
+        test_dataset = None
+
     train_loader = DataLoader(
         train_dataset,
         batch_size=min(batch_size, len(train_x)),
@@ -300,7 +463,7 @@ def train_model(
     )
     val_loader = DataLoader(
         val_dataset,
-        batch_size=min(batch_size, len(val_x)),
+        batch_size=min(batch_size, len(val_x_used)),
         shuffle=False,
         pin_memory=pin_memory,
         worker_init_fn=seed_worker if seed is not None else None,
@@ -316,7 +479,7 @@ def train_model(
     scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.5, patience=3)
     loss_fn = nn.SmoothL1Loss(beta=0.02)
 
-    best_metrics: EvaluationMetrics | None = None
+    best_val_metrics: EvaluationMetrics | None = None
     best_state = copy.deepcopy(work_model.state_dict())
     best_epoch: int | None = None
     completed_epochs = 0
@@ -352,8 +515,8 @@ def train_model(
         eval_metrics = _evaluate_model(work_model, val_loader, device_obj, loss_fn)
         scheduler.step(eval_metrics.loss)
 
-        if best_metrics is None or eval_metrics.loss + 1e-6 < best_metrics.loss:
-            best_metrics = eval_metrics
+        if best_val_metrics is None or eval_metrics.loss + 1e-6 < best_val_metrics.loss:
+            best_val_metrics = eval_metrics
             best_state = copy.deepcopy(work_model.state_dict())
             best_epoch = completed_epochs
             stale_epochs = 0
@@ -364,13 +527,13 @@ def train_model(
 
     work_model.load_state_dict(best_state)
     work_model.eval()
-    if best_metrics is None:
-        best_metrics = _evaluate_model(work_model, val_loader, device_obj, loss_fn)
-    # Mitigation 4: compute final-state training-set metrics so the
-    # aggregator can emit holdout_train_gap = (val_rmse - train_rmse) /
-    # train_rmse. The training set is re-evaluated through the same
-    # eval path (no dropout / no grad / fixed batch ordering) so the
-    # number is comparable to ``metrics``.
+    if best_val_metrics is None:
+        best_val_metrics = _evaluate_model(work_model, val_loader, device_obj, loss_fn)
+    # Final-state training-set evaluation so the aggregator can emit
+    # ``test_train_gap = (test_rmse - train_rmse) / train_rmse``. The
+    # training set is re-evaluated through the same eval path (no
+    # dropout / no grad / fixed batch ordering) so the number is
+    # comparable to the held-out RMSE.
     train_eval_loader = DataLoader(
         train_dataset,
         batch_size=min(batch_size, len(train_x)),
@@ -379,6 +542,31 @@ def train_model(
         worker_init_fn=seed_worker if seed is not None else None,
     )
     train_metrics = _evaluate_model(work_model, train_eval_loader, device_obj, loss_fn)
+
+    # Final-state held-out test evaluation. On the walk-forward path
+    # this is the real test partition the manifest pins; on the legacy
+    # 80/20 path no real held-out exists so the test loader is the val
+    # loader's tensors -- the per-trial record's ``test_rmse`` then
+    # equals the ``val_rmse``, which is exactly the pre-PR behaviour
+    # the legacy regression contract pins.
+    if test_dataset is not None:
+        test_loader = DataLoader(
+            test_dataset,
+            batch_size=min(batch_size, len(test_x)),
+            shuffle=False,
+            pin_memory=pin_memory,
+            worker_init_fn=seed_worker if seed is not None else None,
+        )
+        test_metrics = _evaluate_model(work_model, test_loader, device_obj, loss_fn)
+    else:
+        test_metrics = best_val_metrics
+
+    # ``metrics`` keeps the pre-PR semantics: the headline number the
+    # downstream best-selection ranks by. On the walk-forward path
+    # this is the held-out ``test_metrics``; on the legacy 80/20 path
+    # this is ``best_val_metrics`` so the byte-identity regression on
+    # ``test_forecaster_determinism.py`` stays green.
+    headline_metrics = test_metrics if walk_forward_path else best_val_metrics
 
     summary = TrainingRunSummary(
         model_config=ModelConfig.from_model(work_model),
@@ -389,15 +577,19 @@ def train_model(
         learning_rate=learning_rate,
         validation_split=validation_split,
         early_stopping_patience=early_stopping_patience,
-        sequence_groups=len(sequence_groups),
-        total_windows=len(x),
+        sequence_groups=len(sequence_groups_for_summary),
+        total_windows=len(train_x) + (len(val_x) if val_x is not None else 0) + (len(test_x) if test_x is not None else 0),
         train_windows=len(train_x),
-        validation_windows=len(val_x),
+        validation_windows=len(val_x) if val_x is not None else 0,
         checkpoint_path=str(checkpoint_target),
         checkpoint_saved=save_checkpoint,
         best_epoch=best_epoch,
-        metrics=best_metrics,
+        metrics=headline_metrics,
         train_metrics=train_metrics,
+        val_metrics=best_val_metrics,
+        test_metrics=test_metrics,
+        fold_id=fold_id,
+        protocol=active_protocol,
         weight_decay=float(weight_decay),
         target_mode="shuffled" if shuffle_targets_control else "real",
         text_encoder=text_encoder,

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -815,6 +815,74 @@ Per-event sequence construction:
   a deterministic tiebreaker) so two runs on the same package emit
   the same sequence ordering.
 
+#### Walk-forward CV protocol
+
+The forecaster sweep partitions training-package events into three
+sequence lists (train, val, test) per fold and the training loop
+consumes them independently. Two protocols are supported through the
+loader's `load_walk_forward_split(training_package_id, fold_id=...)`
+entrypoint and the corresponding `train_forecaster.py` flags
+(`--folds`, `--protocol`).
+
+**OLD pre-PR semantics (removed).** The loader read
+`splits_train_val_test.parquet` and KEPT ONLY rows tagged `train`,
+discarding `val` and `test` outright. The training loop then ran an
+internal 80/20 random split on the already-train-only sequences and
+reported the resulting "validation" RMSE as the headline number. Net
+effect: no real held-out test partition existed, and the per-trial
+`combined_rmse` was the internal 80/20-val RMSE on the train
+partition. The wiki and the contracts documented the result as
+"walk-forward CV" but the implementation never honoured that.
+
+**NEW single-fold semantics (`--protocol single-fold`, default when
+`--folds` is unset).** Reads `splits_train_val_test.parquet` and
+partitions events by the `split_tag` column into three lists. All
+three lists feed the loop: `train` drives the optimiser, `val` drives
+early stopping, `test` is the held-out evaluation set whose RMSE is
+the reported `test_rmse`. The package's `splits_train_val_test.parquet`
+already encodes a chronological partition (a single fold), so no
+internal random split happens.
+
+**NEW walk-forward multi-fold semantics (`--protocol walk-forward`,
+selected when `--folds wf_fold_1 wf_fold_2 ...` is set).** Reads
+`fold_manifest_expanding_walk_forward.json` and, for each named
+fold, partitions events into three lists by `event_date` falling in
+the manifest's date ranges:
+
+- Train list: every event with `event_date < val_start`. Expanding
+  window — fold k's train set strictly contains fold (k-1)'s.
+- Val list: `[val_start, val_end]`.
+- Test list: `[test_start, test_end]`.
+
+Each (architecture, seed, hp_combo, fold) becomes one trial. The
+aggregator emits one row per (architecture, fold) plus an all-folds
+aggregate row per architecture, with the all-folds CI bootstrapped
+across every (seed, fold) cell.
+
+**Why the refactor was necessary (ADR).** The pre-PR loader silently
+discarded the val + test partitions and reported the internal 80/20
+random split as the headline number; under that protocol no
+held-out event ever entered the loss or the reported RMSE, which
+breaks the walk-forward CV contract the project documents. The
+refactor introduces three changes that restore the documented
+protocol: (a) the loader returns a `WalkForwardSplit` dataclass with
+explicit train, val, test sequence lists, (b) the training loop
+honours those partitions separately (no internal 80/20 random split
+on the walk-forward path), and (c) the aggregator's headline column
+renames from `combined-RMSE` to `test-RMSE` so the published number
+is the real held-out RMSE rather than an internal-val artefact. The
+back-compat wrapper `load_training_sequences_from_package` stays
+callable on the legacy `--data-dir` path so the byte-identity
+regression contract on that path stays green.
+
+**Aggregator output schema changes.** The per-trial summary now
+carries explicit `train_metrics`, `val_metrics`, and `test_metrics`
+blocks; the headline `metrics` slot maps to `test_metrics` on the
+walk-forward path. The aggregator emits a per-fold row plus an
+all-folds aggregate row per architecture and the `test_train_gap =
+(test_rmse - train_rmse) / train_rmse` column. The pre-PR
+`holdout_train_gap` column stays for back-compat readers.
+
 #### Forecaster training-package target modes
 
 `load_training_sequences_from_package(training_package_id, target_mode=...)`

--- a/tests/regression/test_forecaster_determinism.py
+++ b/tests/regression/test_forecaster_determinism.py
@@ -68,3 +68,59 @@ def test_train_model_diverges_under_different_seeds(tmp_path: Path) -> None:
     assert seed_11 != pytest.approx(seed_29, abs=1e-6), (
         "different seeds produced identical RMSE; randomness is collapsed somewhere"
     )
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward determinism contract
+#
+# The walk-forward training path consumes pre-split train/val/test
+# sequence groups and reports a real held-out test_rmse. Same seed +
+# same input sequences must produce bit-identical test_rmse two runs
+# in a row.
+# ---------------------------------------------------------------------------
+
+
+def _walk_forward_test_rmse(
+    seed: int, vectors: list[FeatureVector], checkpoint: Path
+) -> float:
+    from app.training.loop import train_model
+
+    # Three independent groups each long enough for the SEQUENCE_LENGTH
+    # slicer to materialise at least one (window, target) pair.
+    train_groups = [vectors[:32]]
+    val_groups = [vectors[16:48]]
+    test_groups = [vectors[32:64]]
+    result = train_model(
+        train_sequence_groups=train_groups,
+        val_sequence_groups=val_groups,
+        test_sequence_groups=test_groups,
+        fold_id="wf_fold_1",
+        protocol="walk-forward",
+        epochs=4,
+        batch_size=8,
+        learning_rate=1e-3,
+        validation_split=0.25,
+        early_stopping_patience=2,
+        save_checkpoint=False,
+        checkpoint_path=checkpoint,
+        device="cpu",
+        seed=seed,
+        model_config=ModelConfig(input_size=6, hidden_size=8, num_layers=1, dropout=0.0, head_hidden_size=8),
+    )
+    test_metrics = result.summary.test_metrics
+    assert test_metrics is not None
+    return float(test_metrics.combined_rmse)
+
+
+def test_walk_forward_training_loop_deterministic_at_seed_11(tmp_path: Path) -> None:
+    vectors = _synthetic_vectors(64)
+    first = _walk_forward_test_rmse(
+        seed=11, vectors=vectors, checkpoint=tmp_path / "wf_first.pt"
+    )
+    second = _walk_forward_test_rmse(
+        seed=11, vectors=vectors, checkpoint=tmp_path / "wf_second.pt"
+    )
+    assert first == pytest.approx(second, abs=1e-8), (
+        "walk-forward determinism regression: seed=11 produced two different "
+        f"test_rmse values ({first} vs {second})"
+    )

--- a/tests/unit/test_forecaster_sweep_aggregator.py
+++ b/tests/unit/test_forecaster_sweep_aggregator.py
@@ -182,3 +182,139 @@ def test_row_dataclass_is_frozen() -> None:
     )
     with pytest.raises(Exception):
         row.architecture = "gru"  # type: ignore[misc]
+
+
+def _fold_trial(
+    *,
+    architecture: str,
+    seed: int,
+    fold_id: str,
+    test_rmse: float,
+    train_rmse: float,
+    val_rmse: float | None = None,
+) -> dict:
+    if val_rmse is None:
+        val_rmse = test_rmse
+    return {
+        "trial_index": 0,
+        "architecture": architecture,
+        "seed": seed,
+        "fold_id": fold_id,
+        "summary": {
+            "model_config": {
+                "architecture": architecture,
+                "credibility_features": False,
+            },
+            "metrics": {
+                "combined_rmse": test_rmse,
+                "close_rmse": test_rmse * 0.8,
+                "volatility_rmse": test_rmse * 0.2,
+                "loss": test_rmse,
+            },
+            "train_metrics": {
+                "combined_rmse": train_rmse,
+                "close_rmse": train_rmse * 0.8,
+                "volatility_rmse": train_rmse * 0.2,
+                "loss": train_rmse,
+            },
+            "val_metrics": {
+                "combined_rmse": val_rmse,
+                "close_rmse": val_rmse * 0.8,
+                "volatility_rmse": val_rmse * 0.2,
+                "loss": val_rmse,
+            },
+            "test_metrics": {
+                "combined_rmse": test_rmse,
+                "close_rmse": test_rmse * 0.8,
+                "volatility_rmse": test_rmse * 0.2,
+                "loss": test_rmse,
+            },
+            "fold_id": fold_id,
+            "protocol": "walk-forward",
+        },
+    }
+
+
+def test_aggregator_emits_test_rmse_column_in_markdown(tmp_path: Path) -> None:
+    """The markdown headline reflects the new test-RMSE label."""
+
+    trials = [
+        _trial(architecture="lstm", seed=11, combined_rmse=0.10),
+        _trial(architecture="lstm", seed=29, combined_rmse=0.11),
+    ]
+    _write_report(tmp_path / "sweep_results.json", trials)
+    _, markdown, _ = aggregate(tmp_path, seed=11)
+    assert "test-RMSE" in markdown
+    # Legacy combined-RMSE headline must no longer appear on the
+    # markdown table; the column rename was an explicit contract change.
+    assert "combined-RMSE (mean" not in markdown
+
+
+def test_aggregator_per_fold_plus_all_folds_rows(tmp_path: Path) -> None:
+    """Walk-forward trials emit one row per (arch, fold) plus an aggregate row."""
+
+    from app.evaluation.forecaster_sweep_aggregator import aggregate
+
+    trials = []
+    for fold_id, base_rmse in (
+        ("wf_fold_1", 0.10),
+        ("wf_fold_2", 0.11),
+        ("wf_fold_3", 0.12),
+        ("wf_fold_4", 0.13),
+    ):
+        for seed in (11, 29):
+            trials.append(
+                _fold_trial(
+                    architecture="lstm",
+                    seed=seed,
+                    fold_id=fold_id,
+                    test_rmse=base_rmse,
+                    train_rmse=base_rmse * 0.8,
+                )
+            )
+    _write_report(tmp_path / "wf_sweep_results.json", trials)
+
+    rows, markdown, _ = aggregate(tmp_path, seed=11)
+    fold_rows = [r for r in rows if r.fold_id and r.fold_id != "all-folds"]
+    all_folds_rows = [r for r in rows if r.fold_id == "all-folds"]
+    assert {r.fold_id for r in fold_rows} == {
+        "wf_fold_1",
+        "wf_fold_2",
+        "wf_fold_3",
+        "wf_fold_4",
+    }
+    # One all-folds aggregate row per architecture.
+    assert len(all_folds_rows) == 1
+    all_folds = all_folds_rows[0]
+    assert all_folds.architecture == "lstm"
+    # All-folds row collects every per-fold trial -> 4 folds x 2 seeds
+    # = 8 cells in its test_rmse_values list.
+    assert len(all_folds.test_rmse_values) == 8
+    # All-folds row carries the bootstrap CI computed across the 8 cells.
+    assert all_folds.test_rmse_ci is not None
+    assert all_folds.test_rmse_ci.lo <= all_folds.test_rmse_ci.point <= all_folds.test_rmse_ci.hi
+    # Markdown contains each fold id and the all-folds tag.
+    for fold_id in ("wf_fold_1", "wf_fold_2", "wf_fold_3", "wf_fold_4", "all-folds"):
+        assert fold_id in markdown
+    # Protocol column reflects walk-forward.
+    assert "walk-forward" in markdown
+
+
+def test_aggregator_test_train_gap_uses_held_out_test_metric(tmp_path: Path) -> None:
+    """``test_train_gap`` is (test_rmse - train_rmse) / train_rmse."""
+
+    trials = [
+        _fold_trial(
+            architecture="lstm",
+            seed=11,
+            fold_id="wf_fold_1",
+            test_rmse=0.40,
+            train_rmse=0.10,
+        ),
+    ]
+    _write_report(tmp_path / "wf_sweep_results.json", trials)
+    rows, _, _ = aggregate(tmp_path, seed=11)
+    # Per-fold row + all-folds row.
+    fold_row = next(r for r in rows if r.fold_id == "wf_fold_1")
+    assert fold_row.test_train_gap == pytest.approx((0.40 - 0.10) / 0.10)
+    assert fold_row.gap_flag == "high"

--- a/tests/unit/test_train_forecaster.py
+++ b/tests/unit/test_train_forecaster.py
@@ -86,3 +86,172 @@ def test_build_sweep_candidates_creates_cartesian_product():
     # single architecture so default behaviour (LSTM-only) is preserved.
     assert {candidate["model_config"].architecture for candidate in candidates} == {"lstm"}
     assert {candidate["seed"] for candidate in candidates} == {None}
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward CLI tests
+#
+# The new --folds / --protocol flags drive the candidate enumeration
+# to expand per-fold trials and route the trainer through the
+# walk-forward partition path.
+# ---------------------------------------------------------------------------
+
+
+def _walk_forward_args(
+    *,
+    folds: list[str] | None,
+    architectures: list[str] | None = None,
+    seeds: list[int] | None = None,
+) -> argparse.Namespace:
+    """Minimal argparse namespace for the per-fold candidate tests."""
+
+    return argparse.Namespace(
+        hidden_size=32,
+        num_layers=1,
+        dropout=0.1,
+        learning_rate=1e-3,
+        epochs=4,
+        head_hidden_size=16,
+        hidden_sizes=None,
+        num_layers_grid=None,
+        dropouts=None,
+        learning_rates=None,
+        epochs_grid=None,
+        weight_decay=1e-4,
+        weight_decays=None,
+        text_adapter_dim=64,
+        text_adapter_dims=None,
+        text_encoder="none",
+        use_text_embeddings=True,
+        training_package_id=None,
+        rich_features=False,
+        architecture="lstm",
+        architectures=architectures or ["lstm"],
+        seed=None,
+        seeds=seeds or [11],
+        credibility_features=False,
+        random_search=False,
+        random_search_samples=50,
+        random_search_seed=42,
+        folds=folds,
+    )
+
+
+def test_build_sweep_candidates_expands_per_fold():
+    """When --folds is set the candidate count multiplies by the fold count."""
+
+    no_folds = build_sweep_candidates(_walk_forward_args(folds=None))
+    four_folds = build_sweep_candidates(
+        _walk_forward_args(folds=["wf_fold_1", "wf_fold_2", "wf_fold_3", "wf_fold_4"])
+    )
+    assert len(four_folds) == len(no_folds) * 4
+    fold_ids = sorted({c.get("fold_id") for c in four_folds if c.get("fold_id")})
+    assert fold_ids == ["wf_fold_1", "wf_fold_2", "wf_fold_3", "wf_fold_4"]
+
+
+def test_build_sweep_candidates_no_fold_id_when_unset():
+    """The exhaustive single-fold path never tags candidates with fold_id."""
+
+    candidates = build_sweep_candidates(_walk_forward_args(folds=None))
+    for record in candidates:
+        assert "fold_id" not in record
+
+
+def test_train_model_with_pre_split_skips_internal_validation_split():
+    """Walk-forward path consumes pre-split train/val/test lists directly."""
+
+    import math
+
+    from app.services.forecaster import FeatureVector
+    from app.training.loop import train_model
+    from app.training import loop as loop_module
+
+    def _vectors(n: int, *, base: float) -> list[FeatureVector]:
+        out: list[FeatureVector] = []
+        for i in range(n):
+            close = base + 12.0 * i + 5.0 * math.sin(i * 0.3)
+            vol = 0.012 + 0.003 * math.sin(i * 0.7 + 1.1)
+            prev_close = base + 12.0 * (i - 1) + 5.0 * math.sin((i - 1) * 0.3) if i else close
+            prev_vol = 0.012 + 0.003 * math.sin((i - 1) * 0.7 + 1.1) if i else vol
+            out.append(
+                FeatureVector.from_market_state(
+                    date=f"2024-01-{i + 1:02d}",
+                    sentiment_score=math.sin(i * 0.41) * 0.6 + 0.1,
+                    market_close=close,
+                    market_volatility=vol,
+                    previous_close=prev_close,
+                    previous_volatility=prev_vol,
+                    elapsed_time=float(i % 30),
+                )
+            )
+        return out
+
+    # The legacy ``_split_train_validation`` MUST NOT run on the
+    # walk-forward path; intercept it and fail the test if it does.
+    original_split = loop_module._split_train_validation
+
+    def _exploding_split(*args, **kwargs):
+        raise AssertionError(
+            "walk-forward path must not call the legacy 80/20 internal split"
+        )
+
+    loop_module._split_train_validation = _exploding_split
+    try:
+        result = train_model(
+            train_sequence_groups=[_vectors(22, base=4400.0)],
+            val_sequence_groups=[_vectors(22, base=4500.0)],
+            test_sequence_groups=[_vectors(22, base=4600.0)],
+            fold_id="wf_fold_1",
+            protocol="walk-forward",
+            epochs=2,
+            batch_size=4,
+            learning_rate=1e-3,
+            validation_split=0.25,
+            early_stopping_patience=2,
+            save_checkpoint=False,
+            device="cpu",
+            seed=11,
+        )
+    finally:
+        loop_module._split_train_validation = original_split
+
+    summary = result.summary
+    # Walk-forward summary carries explicit train/val/test metrics.
+    assert summary.fold_id == "wf_fold_1"
+    assert summary.protocol == "walk-forward"
+    assert summary.train_metrics is not None
+    assert summary.val_metrics is not None
+    assert summary.test_metrics is not None
+    # The headline ``metrics`` slot maps to the held-out test_metrics
+    # on the walk-forward path so downstream selection ranks on the
+    # real test number.
+    assert summary.metrics is summary.test_metrics
+
+
+def test_test_train_gap_flag_threshold_uses_held_out():
+    """``gap_flag = high`` when test_train_gap exceeds 0.5."""
+
+    from app.evaluation.forecaster_sweep_aggregator import _build_rows
+
+    by_arch = {
+        "lstm": {
+            "architecture": "lstm",
+            "target_mode": "real",
+            "fold_id": None,
+            "protocol": "single-fold",
+            "seeds": [11],
+            "combined_rmse": [0.40],
+            "close_rmse": [0.30],
+            "volatility_rmse": [0.10],
+            "train_combined_rmse": [0.10],
+            "val_combined_rmse": [0.35],
+            "test_combined_rmse": [0.40],
+            "credibility_features": False,
+        }
+    }
+    rows = _build_rows(by_arch, block_size=1, n_resamples=100, coverage=0.95, seed=11)
+    assert len(rows) == 1
+    row = rows[0]
+    # test_train_gap = (0.40 - 0.10) / 0.10 = 3.0; gap_flag should fire.
+    assert row.test_train_gap == pytest.approx(3.0)
+    assert row.gap_flag == "high"

--- a/tests/unit/test_training_package_loader.py
+++ b/tests/unit/test_training_package_loader.py
@@ -1225,3 +1225,221 @@ def test_no_text_embeddings_zeros_slice_but_shape_preserved(
     second_event = chronological[1][0]
     assert len(second_event.text_embedding_pooled) == 768
     assert second_event.text_embedding_missing == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward split tests
+#
+# ``load_walk_forward_split`` returns three pre-partitioned sequence
+# lists (train + val + test) plus per-list event dates. The tests
+# below exercise both the single-fold path (split-tag partition off
+# ``splits_train_val_test.parquet``) and the multi-fold path
+# (chronological partition off ``fold_manifest_expanding_walk_forward.json``).
+# ---------------------------------------------------------------------------
+
+
+_WALK_FORWARD_PACKAGE_ID = "tp_unit_walk_forward_v0"
+
+
+def _wf_event_row(*, event_date: str, text_hash: str, base_close: float) -> dict:
+    """Build a minimal event row for the walk-forward tests."""
+
+    return _event_row(
+        event_date=event_date,
+        text_hash=text_hash,
+        axis_stance="neutral",
+        realized_return=0.001,
+        realized_date=event_date,
+        base_close=base_close,
+    )
+
+
+@pytest.fixture
+def walk_forward_package_dir(tmp_path: Path, monkeypatch) -> Path:
+    """Materialise a tiny package with split tags + a two-fold manifest."""
+
+    package_dir = tmp_path / "processed" / _WALK_FORWARD_PACKAGE_ID
+    package_dir.mkdir(parents=True)
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+
+    # Six events spaced across two fold windows. The fold manifest
+    # below makes wf_fold_1 train cover the first two events and
+    # wf_fold_2 train cover the first four (expanding window).
+    events = [
+        _wf_event_row(event_date="2020-01-15", text_hash="hash_t1", base_close=4400.0),
+        _wf_event_row(event_date="2020-02-15", text_hash="hash_t2", base_close=4410.0),
+        _wf_event_row(event_date="2020-03-15", text_hash="hash_v1", base_close=4420.0),
+        _wf_event_row(event_date="2020-04-15", text_hash="hash_v2", base_close=4430.0),
+        _wf_event_row(event_date="2020-05-15", text_hash="hash_te1", base_close=4440.0),
+        _wf_event_row(event_date="2020-06-15", text_hash="hash_te2", base_close=4450.0),
+    ]
+    pd.DataFrame(events).to_parquet(package_dir / "events.parquet", index=False)
+
+    splits = [
+        {"text_hash": "hash_t1", "split_tag": "train"},
+        {"text_hash": "hash_t2", "split_tag": "train"},
+        {"text_hash": "hash_v1", "split_tag": "val"},
+        {"text_hash": "hash_v2", "split_tag": "val"},
+        {"text_hash": "hash_te1", "split_tag": "test"},
+        {"text_hash": "hash_te2", "split_tag": "test"},
+    ]
+    pd.DataFrame(splits).to_parquet(
+        package_dir / "splits_train_val_test.parquet", index=False
+    )
+
+    manifest = {
+        "evaluation_protocol": "evaluation_protocol_v1",
+        "folds": [
+            {
+                "fold_id": "wf_fold_1",
+                "train_start": "2020-01-01",
+                "train_end": "2020-02-29",
+                "val_start": "2020-03-01",
+                "val_end": "2020-03-31",
+                "test_start": "2020-04-01",
+                "test_end": "2020-04-30",
+            },
+            {
+                "fold_id": "wf_fold_2",
+                "train_start": "2020-01-01",
+                "train_end": "2020-04-30",
+                "val_start": "2020-05-01",
+                "val_end": "2020-05-31",
+                "test_start": "2020-06-01",
+                "test_end": "2020-06-30",
+            },
+        ],
+    }
+    (package_dir / "fold_manifest_expanding_walk_forward.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+    return package_dir
+
+
+def test_walk_forward_split_single_fold_partitions_from_split_tag(
+    walk_forward_package_dir: Path,
+) -> None:
+    split = loaders.load_walk_forward_split(
+        _WALK_FORWARD_PACKAGE_ID, rich_features=False
+    )
+    assert split.fold_id is None
+    assert split.protocol == "single-fold"
+    # Six events: 2 train, 2 val, 2 test.
+    assert len(split.train) == 2
+    assert len(split.val) == 2
+    assert len(split.test) == 2
+    # Sum equals the events.parquet total.
+    assert len(split.train) + len(split.val) + len(split.test) == 6
+    # Event-date ordering matches the per-list count.
+    assert split.train_event_dates == ["2020-01-15", "2020-02-15"]
+    assert split.val_event_dates == ["2020-03-15", "2020-04-15"]
+    assert split.test_event_dates == ["2020-05-15", "2020-06-15"]
+
+
+def test_walk_forward_split_multi_fold_partitions_from_manifest(
+    walk_forward_package_dir: Path,
+) -> None:
+    fold_1 = loaders.load_walk_forward_split(
+        _WALK_FORWARD_PACKAGE_ID, fold_id="wf_fold_1", rich_features=False
+    )
+    fold_2 = loaders.load_walk_forward_split(
+        _WALK_FORWARD_PACKAGE_ID, fold_id="wf_fold_2", rich_features=False
+    )
+    assert fold_1.protocol == "walk-forward"
+    assert fold_1.fold_id == "wf_fold_1"
+    # fold_1: train covers everything before val_start=2020-03-01 ->
+    # hash_t1 (2020-01-15) + hash_t2 (2020-02-15) -> 2 sequences.
+    assert len(fold_1.train) == 2
+    assert fold_1.train_event_dates == ["2020-01-15", "2020-02-15"]
+    # fold_1 val: 2020-03-01 to 2020-03-31 -> hash_v1.
+    assert len(fold_1.val) == 1
+    assert fold_1.val_event_dates == ["2020-03-15"]
+    # fold_1 test: 2020-04-01 to 2020-04-30 -> hash_v2.
+    assert len(fold_1.test) == 1
+    assert fold_1.test_event_dates == ["2020-04-15"]
+
+    # fold_2: train covers everything before 2020-05-01 ->
+    # hash_t1 + hash_t2 + hash_v1 + hash_v2 -> 4 sequences.
+    assert len(fold_2.train) == 4
+    assert fold_2.train_event_dates == [
+        "2020-01-15",
+        "2020-02-15",
+        "2020-03-15",
+        "2020-04-15",
+    ]
+    # Expanding-window contract: train_2 strictly contains train_1.
+    assert set(fold_1.train_event_dates).issubset(set(fold_2.train_event_dates))
+    assert len(fold_2.train) > len(fold_1.train)
+    # fold_2 val and test.
+    assert fold_2.val_event_dates == ["2020-05-15"]
+    assert fold_2.test_event_dates == ["2020-06-15"]
+
+
+def test_walk_forward_split_unknown_fold_raises(
+    walk_forward_package_dir: Path,
+) -> None:
+    with pytest.raises(ValueError, match="not found in fold manifest"):
+        loaders.load_walk_forward_split(
+            _WALK_FORWARD_PACKAGE_ID, fold_id="wf_fold_does_not_exist"
+        )
+
+
+def test_walk_forward_split_no_test_events_raises(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A fold whose test window is empty must raise loudly."""
+
+    package_id = "tp_unit_empty_test_window"
+    package_dir = tmp_path / "processed" / package_id
+    package_dir.mkdir(parents=True)
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+
+    events = [
+        _wf_event_row(event_date="2020-01-15", text_hash="hash_only", base_close=4400.0),
+    ]
+    pd.DataFrame(events).to_parquet(package_dir / "events.parquet", index=False)
+    pd.DataFrame(
+        [{"text_hash": "hash_only", "split_tag": "train"}]
+    ).to_parquet(package_dir / "splits_train_val_test.parquet", index=False)
+
+    manifest = {
+        "folds": [
+            {
+                "fold_id": "wf_fold_1",
+                "train_start": "2020-01-01",
+                "train_end": "2020-02-29",
+                "val_start": "2020-03-01",
+                "val_end": "2020-03-31",
+                "test_start": "2020-04-01",
+                "test_end": "2020-04-30",
+            }
+        ],
+    }
+    (package_dir / "fold_manifest_expanding_walk_forward.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="empty test partition"):
+        loaders.load_walk_forward_split(package_id, fold_id="wf_fold_1")
+
+
+def test_walk_forward_split_back_compat_wrapper_emits_deprecation(
+    walk_forward_package_dir: Path,
+) -> None:
+    """The legacy ``load_training_sequences_from_package`` is deprecated.
+
+    It still returns the train partition (the pre-PR semantics) so the
+    callers that have not migrated keep working, but every call emits
+    a DeprecationWarning pointing at ``load_walk_forward_split``.
+    """
+
+    with pytest.warns(DeprecationWarning, match="load_walk_forward_split"):
+        sequences = loaders.load_training_sequences_from_package(
+            _WALK_FORWARD_PACKAGE_ID, rich_features=False
+        )
+    # Two train-tagged events survive the legacy wrapper.
+    assert len(sequences) == 2
+    target_dates = sorted(seq[-1].date[:10] for seq in sequences)
+    # Synthesised realized_date was the same date as event_date in the
+    # fixture, so the appended target frame uses each event's own date.
+    assert target_dates == ["2020-01-15", "2020-02-15"]


### PR DESCRIPTION
## Summary

- New load_walk_forward_split(training_package_id, fold_id=None) returns a WalkForwardSplit with train / val / test sequence lists. Single-fold mode reads splits_train_val_test.parquet; multi-fold reads fold_manifest_expanding_walk_forward.json (expanding training window — fold_k train spans every event before val_start_k).
- The training loop now consumes train + val + test separately. No more internal 80/20 random split on the train partition; the reported test_rmse is the real held-out number.
- Aggregator renames combined-RMSE to test-RMSE, emits real train_rmse, val_rmse, test_train_gap. Per-fold rows plus an all-folds aggregate row per architecture.
- train_forecaster.py gains --folds (nargs=+) and --protocol {auto, single-fold, walk-forward}. forecaster-sweep Makefile target iterates the four walk-forward folds by default; forecaster-sweep-exhaustive stays single-fold.
- load_training_sequences_from_package stays as a thin deprecated wrapper so the legacy --data-dir path keeps the byte-identity regression green.
- 14 new tests pin the multi-fold expanding-window contract, the single-fold split-tag partition, the test-set-is-not-internal-val invariant, and the deprecation-warning back-compat.
- docs/data-and-training-contracts.md documents the OLD vs NEW protocols plus the expanding-window semantics.
- Smoke against tp_v2_sprint1: single-fold train=456 val=32 test=99; multi-fold train counts strictly increasing 641 < 703 < 766 < 826.

## Test plan

- [ ] `pytest tests/unit/test_training_package_loader.py tests/unit/test_train_forecaster.py tests/unit/test_forecaster_sweep_aggregator.py tests/regression/ -q`
- [ ] Single-fold smoke: train+val+test counts sum to the package total.
- [ ] Multi-fold smoke: train counts are strictly increasing across wf_fold_1..wf_fold_4.

Closes the gap left after #177 was closed without merging.