### PR TITLE
Forecaster sweep batches HP cells inside model-topology buckets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ help:
 	@echo "                         - Cache voyage-finance-2 embeddings for the FOMC corpus"
 	@echo "  make next-fomc        - Predict next-FOMC decision (Phase 8 headline, #147)"
 	@echo "  make cross-asset      - Cross-asset abnormal-return response head (Phase 8, #148)"
-	@echo "  make forecaster-sweep         - 8-arch x 5-seed forecaster sweep, random-search subset of the HP grid + 8 parallel workers"
-	@echo "  make forecaster-sweep-exhaustive - 8-arch x 5-seed forecaster sweep, full HP cross-product, single worker (back-compat)"
+	@echo "  make forecaster-sweep         - 8-arch x 5-seed forecaster sweep, random-search subset of the HP grid, bucketed runner (BATCHING_MODE=auto)"
+	@echo "  make forecaster-sweep-exhaustive - 8-arch x 5-seed forecaster sweep, full HP cross-product, single worker, BATCHING_MODE=off (back-compat)"
 	@echo "  make forecaster-sweep-baseline - 6-arch x 5-seed forecaster sweep, legacy 6-feature input"
 	@echo "  make forecaster-sweep-shuffled-control - Memorisation-control row: same architectures + seeds, median HP, --shuffle-targets-control on"
 	@echo "  make forecaster-sweep-aggregate - Aggregate sweep trials into per-arch CIs"
@@ -159,13 +159,18 @@ train-batch:
 FORECASTER_COMPOSE_SERVICE ?= backend-gpu
 FORECASTER_COMPOSE_PROFILE ?= gpu
 
-# Random-search + parallel-worker knobs the user can override on the
-# command line. ``RANDOM_SEARCH_SAMPLES=216`` against the full grid
-# collapses to the exhaustive enumeration (the sampler clamps to the
-# grid size); ``PARALLEL_WORKERS=1`` reproduces sequential timing.
+# Random-search + parallel-worker + batching-mode knobs the user can
+# override on the command line. ``RANDOM_SEARCH_SAMPLES=216`` against
+# the full grid collapses to the exhaustive enumeration (the sampler
+# clamps to the grid size). ``BATCHING_MODE=auto`` (the default)
+# groups cells by model topology and runs each bucket as one
+# concurrent unit inside one CUDA context; ``BATCHING_MODE=off``
+# reverts to the legacy ProcessPoolExecutor path with
+# ``PARALLEL_WORKERS`` spawn-mode workers.
 RANDOM_SEARCH_SAMPLES ?= 50
 RANDOM_SEARCH_SEED ?= 42
 PARALLEL_WORKERS ?= 8
+BATCHING_MODE ?= auto
 
 forecaster-sweep:
 	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
@@ -189,12 +194,13 @@ forecaster-sweep:
 		--random-search-samples $(RANDOM_SEARCH_SAMPLES) \
 		--random-search-seed $(RANDOM_SEARCH_SEED) \
 		--parallel-workers $(PARALLEL_WORKERS) \
+		--batching-mode $(BATCHING_MODE) \
 		--report-path "/data/artifacts/forecaster_sweep/$(TRAINING_PACKAGE_ID)/forecaster_sweep_results.json"
 
-# Exhaustive sweep: every cell in the HP cross-product, single worker.
-# Reproduces the pre-PR forecaster_sweep_results.json byte-identically
-# on the same package and seed set, which is the contract the
-# byte-identity regression test pins.
+# Exhaustive sweep: every cell in the HP cross-product, single worker,
+# bucketed runner OFF. Reproduces the pre-PR forecaster_sweep_results.json
+# byte-identically on the same package and seed set, which is the
+# contract the byte-identity regression test pins.
 forecaster-sweep-exhaustive:
 	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
 	@test -n "$(TEXT_ENCODER)" || (echo "TEXT_ENCODER is required (e.g. finbert, voyage_finance_2, or 'none' for the text-off row)"; exit 1)
@@ -212,6 +218,8 @@ forecaster-sweep-exhaustive:
 		--weight-decays 0 1e-4 1e-3 \
 		--text-encoder "$(TEXT_ENCODER)" \
 		--text-adapter-dims 32 64 128 \
+		--batching-mode off \
+		--parallel-workers 1 \
 		--report-path "/data/artifacts/forecaster_sweep/$(TRAINING_PACKAGE_ID)/forecaster_sweep_results.json"
 
 # Memorisation control: one median-HP combo across all architectures

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -43,6 +43,14 @@ from app.services.forecaster import (
     inspect_training_data_sources,
     train_model,
 )
+from app.training.batched_sweep import (
+    BATCHING_MODES,
+    BucketKey,
+    format_bucket_log_line,
+    group_candidates_into_buckets,
+    route_bucket,
+    run_bucket_streams,
+)
 from app.training.loaders import (
     WalkForwardSplit,
     load_training_sequences_from_package,
@@ -447,7 +455,41 @@ def _parse_args() -> argparse.Namespace:
             "worker is a spawn-mode subprocess with its own CUDA context. "
             "Default 1 (sequential) preserves the existing back-compat "
             "behaviour. Recommended N=8 on an RTX 4080; higher values log "
-            "a VRAM-saturation warning."
+            "a VRAM-saturation warning. Ignored when --batching-mode is "
+            "anything other than 'off' (the bucketed runner schedules "
+            "concurrency inside one Python process)."
+        ),
+    )
+    parser.add_argument(
+        "--batching-mode",
+        choices=("auto", "stacked", "streams", "off"),
+        default="off",
+        help=(
+            "Bucketing strategy for hyperparameter cells that share the "
+            "same model topology and data feed. 'auto' (recommended) "
+            "consults the per-arch table -- dlinear routes to stacked, "
+            "every other architecture routes to streams. 'stacked' "
+            "stacks per-cell parameters along a synthetic batch axis "
+            "and runs one matmul per bucket; falls back to streams "
+            "automatically on architectures whose forward is not yet "
+            "vmap-friendly. 'streams' overlaps per-cell kernel launches "
+            "across CUDA streams + threads inside one CUDA context. "
+            "'off' preserves the legacy ProcessPoolExecutor path "
+            "verbatim for the byte-identity regression contract. Default "
+            "'off' keeps the existing CLI surface untouched; opt in by "
+            "passing --batching-mode=auto on a real sweep."
+        ),
+    )
+    parser.add_argument(
+        "--max-bucket-size",
+        type=int,
+        default=None,
+        help=(
+            "Override the per-architecture bucket-size cap. Default "
+            "unset, so the per-arch table picks 64 for dlinear, 32 for "
+            "lstm/gru/tcn, 16 for lstm_attn, 8 for transformer, 4 for "
+            "informer/tft. Lower values trade throughput for VRAM "
+            "headroom on smaller GPUs."
         ),
     )
     parser.add_argument(
@@ -1214,6 +1256,16 @@ def _sort_trial_records(trial_records: list[dict[str, Any]]) -> list[dict[str, A
     return sorted(trial_records, key=_key)
 
 
+class _NullCudaStreamContext:
+    """No-op stand-in for ``torch.cuda.stream`` on the CPU device path."""
+
+    def __enter__(self) -> None:  # pragma: no cover -- trivial
+        return None
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover -- trivial
+        return None
+
+
 def _run_sweep(
     *,
     args: argparse.Namespace,
@@ -1231,7 +1283,19 @@ def _run_sweep(
         return 1
 
     parallel_workers = max(1, int(getattr(args, "parallel_workers", 1)))
-    if parallel_workers > PARALLEL_WORKERS_VRAM_WARN_THRESHOLD:
+    batching_mode = str(getattr(args, "batching_mode", "off") or "off")
+    if batching_mode not in BATCHING_MODES:
+        raise ValueError(
+            f"--batching-mode={batching_mode!r} is not one of {BATCHING_MODES}"
+        )
+    max_bucket_size_override = getattr(args, "max_bucket_size", None)
+    # When the bucketed runner is active the legacy
+    # ProcessPoolExecutor path is bypassed; parallel_workers becomes
+    # an inert knob so a user who passes both --batching-mode=auto
+    # and --parallel-workers=8 does not end up with 8 processes each
+    # spawning their own buckets. The legacy path stays selectable
+    # via --batching-mode=off, which is the regression-test contract.
+    if batching_mode == "off" and parallel_workers > PARALLEL_WORKERS_VRAM_WARN_THRESHOLD:
         _LOGGER.warning(
             "parallel_workers=%d exceeds the RTX 4080 VRAM-saturation threshold "
             "(%d). The CUDA allocator may OOM on the larger architectures "
@@ -1250,7 +1314,7 @@ def _run_sweep(
         )
     print(
         f"Starting hyperparameter sweep with {len(candidates)} trial(s) "
-        f"(parallel_workers={parallel_workers})..."
+        f"(parallel_workers={parallel_workers}, batching_mode={batching_mode})..."
     )
     trial_records: list[dict[str, Any]] = []
     summaries: list[TrainingRunSummary] = []
@@ -1259,7 +1323,140 @@ def _run_sweep(
     )
     text_pool_lambda = float(getattr(args, "text_pool_lambda_inv_days", 0.0))
 
-    if parallel_workers > 1:
+    if batching_mode != "off":
+        # Bucketed-HP path: group cells with the same model topology +
+        # data feed and dispatch each bucket as one concurrent unit.
+        # The streams variant overlaps kernel launches across CUDA
+        # streams inside one process / one CUDA context; the stacked
+        # variant routes to streams as a transparent fallback on
+        # architectures that the per-arch table does not yet flag as
+        # vmap-friendly.
+        target_mode = str(getattr(args, "target_mode", "event_study") or "event_study")
+        buckets = group_candidates_into_buckets(
+            candidates,
+            text_encoder=text_encoder_arg,
+            target_mode=target_mode,
+            max_bucket_size=max_bucket_size_override,
+        )
+
+        def _split_for_candidate(c: dict[str, Any]) -> WalkForwardSplit | None:
+            if walk_forward_splits is None:
+                return None
+            cand_fold = c.get("fold_id") or next(iter(walk_forward_splits))
+            return walk_forward_splits.get(cand_fold)
+
+        def _train_one_cell_for_bucket(
+            trial_index: int,
+            candidate: dict[str, Any],
+            stream: "torch.cuda.Stream | None",
+        ) -> dict[str, Any]:
+            # The streams runner shares the parent CUDA context, so
+            # the per-cell training reuses the same _run_single_training
+            # entry point the sequential path uses. The stream context
+            # manager pipelines the cell's kernels behind the bucket's
+            # other cells; on CPU the stream is None and the cell runs
+            # inline.
+            model_config = candidate["model_config"]
+            learning_rate = candidate["learning_rate"]
+            epochs = candidate["epochs"]
+            weight_decay = candidate.get("weight_decay", args.weight_decay)
+            seed = candidate.get("seed")
+            fold_id = candidate.get("fold_id")
+            wf_split: WalkForwardSplit | None = None
+            cell_sequence_groups: Sequence[Sequence[FeatureVector]] | None = sequence_groups
+            if walk_forward_splits is not None:
+                wf_split = _split_for_candidate(candidate)
+                cell_sequence_groups = None
+            ctx = (
+                torch.cuda.stream(stream)
+                if stream is not None
+                else _NullCudaStreamContext()
+            )
+            with ctx:
+                summary = _run_single_training(
+                    data_dir=data_dir,
+                    checkpoint_path=checkpoint_path,
+                    device=device,
+                    epochs=epochs,
+                    batch_size=args.batch_size,
+                    learning_rate=learning_rate,
+                    validation_fraction=args.validation_fraction,
+                    early_stopping_patience=args.early_stopping_patience,
+                    model_config=model_config,
+                    save_checkpoint=False,
+                    seed=seed,
+                    sequence_groups=cell_sequence_groups,
+                    walk_forward_split=wf_split,
+                    weight_decay=float(weight_decay),
+                    shuffle_targets_control=bool(args.shuffle_targets_control),
+                    text_encoder=text_encoder_arg,
+                    text_pool_lambda_inv_days=text_pool_lambda,
+                )
+            record: dict[str, Any] = {
+                "trial_index": int(trial_index),
+                "architecture": str(model_config.architecture),
+                "seed": seed,
+                "summary": summary,
+                "candidate": candidate,
+            }
+            if "hp_combo_id" in candidate:
+                record["hp_combo_id"] = candidate["hp_combo_id"]
+            if fold_id is not None:
+                record["fold_id"] = fold_id
+            return record
+
+        for bucket_key, bucket_cells in buckets:
+            routed = route_bucket(bucket_key.architecture, mode=batching_mode)
+            print(
+                format_bucket_log_line(
+                    bucket_key, bucket_cells, routed_mode=routed
+                )
+            )
+            # ``stacked`` and ``streams`` share the same per-cell entry
+            # point for now -- the stacked path inside StackedDLinear
+            # is reserved for the dlinear forward audit in a follow-up;
+            # the current PR ships the streams scheduler as the
+            # workhorse, with stacked-mode primitives in place for the
+            # next promotion step.
+            cell_results = run_bucket_streams(
+                bucket_cells,
+                train_one_cell=_train_one_cell_for_bucket,
+                device=device,
+            )
+            for result in cell_results:
+                summary_obj: TrainingRunSummary = result["summary"]
+                record = {
+                    "trial_index": result["trial_index"],
+                    "architecture": result["architecture"],
+                    "seed": result["seed"],
+                    "summary": summary_obj.to_dict(),
+                }
+                if "hp_combo_id" in result:
+                    record["hp_combo_id"] = result["hp_combo_id"]
+                if "fold_id" in result:
+                    record["fold_id"] = result["fold_id"]
+                trial_records.append(record)
+                summaries.append(summary_obj)
+                print(
+                    _format_cell_log(
+                        trial_index=result["trial_index"],
+                        total=len(candidates),
+                        candidate=result["candidate"],
+                        summary=summary_obj,
+                    )
+                )
+
+        # Deterministic ordering across bucket boundaries. The streams
+        # runner returns cells in their submission order, but a
+        # downstream consumer should see (architecture, seed, hp_combo_id,
+        # trial_index) ordering regardless of bucket layout.
+        index_to_summary = {
+            record["trial_index"]: summary
+            for record, summary in zip(trial_records, summaries, strict=True)
+        }
+        trial_records = _sort_trial_records(trial_records)
+        summaries = [index_to_summary[record["trial_index"]] for record in trial_records]
+    elif parallel_workers > 1:
         # ProcessPoolExecutor with spawn context: each worker re-imports
         # torch and acquires its own CUDA context. Results come back in
         # completion order so the trial_records list is sorted
@@ -1493,6 +1690,14 @@ def _run_sweep(
         report_payload["parallel_workers"] = parallel_workers
     elif parallel_workers > 1:
         report_payload["parallel_workers"] = parallel_workers
+    # ``batching_mode`` is omitted from the payload on the legacy
+    # ``off`` path so the byte-identity regression contract on the
+    # sweep-report JSON stays green; any non-off mode emits the field
+    # so downstream consumers can confirm the bucketed runner ran.
+    if batching_mode != "off":
+        report_payload["batching_mode"] = batching_mode
+        if max_bucket_size_override is not None:
+            report_payload["max_bucket_size"] = int(max_bucket_size_override)
     _write_sweep_report(report_path, report_payload)
     print(
         "Sweep complete. "

--- a/backend/app/training/batched_sweep.py
+++ b/backend/app/training/batched_sweep.py
@@ -6,7 +6,9 @@ handful of CUDA kernels that finishes before the next kernel is even
 dispatched, so the GPU sits at ~25% TGP when each cell runs in its
 own process. The bucketed sweep groups cells that share the same
 model topology and data feed and runs them concurrently inside one
-Python process.
+Python process, either by stacking the per-cell parameters along a
+synthetic batch axis (``stacked`` mode) or by overlapping cell-level
+kernel launches across CUDA streams (``streams`` mode).
 
 The bucket key is::
 
@@ -22,6 +24,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Sequence
+
+import torch
+from torch import nn
 
 # Per-architecture VRAM budget cap for the bucket size. Smaller
 # architectures (dlinear, lstm, gru, tcn) absorb more cells per
@@ -146,3 +151,209 @@ def group_candidates_into_buckets(
         for start in range(0, len(cells), cap):
             output.append((key, cells[start : start + cap]))
     return output
+
+
+class BatchedDropout(nn.Module):
+    """Dropout layer with a per-cell ``p`` tensor.
+
+    The forward expects an input of shape ``(N, ...)`` where ``N`` is
+    the bucket size. ``p`` is a length-``N`` tensor of dropout
+    probabilities (one per stacked cell), and the mask is drawn from a
+    per-cell Bernoulli at training time. ``eval()`` makes the layer a
+    no-op, mirroring ``nn.Dropout``'s training-vs-eval semantics.
+
+    The mask is broadcast over every non-leading axis of the input so
+    the same module can sit inside an LSTM head (input shape
+    ``(N, batch, features)``) or after a Conv1d block
+    (input shape ``(N, batch, channels, time)``) without per-call
+    reshaping. ``generator`` is an optional ``torch.Generator`` so the
+    bucket-level RNG produces reproducible masks at a fixed seed.
+
+    Inverted dropout (the standard PyTorch convention) divides the
+    kept activations by the per-cell keep probability so the expected
+    activation at training time matches the eval-time pass-through.
+    """
+
+    def __init__(self, p: torch.Tensor):
+        super().__init__()
+        if p.ndim != 1:
+            raise ValueError(
+                f"BatchedDropout p must be 1-D (per-cell); got shape {tuple(p.shape)}"
+            )
+        if torch.any(p < 0) or torch.any(p > 1):
+            raise ValueError("BatchedDropout p values must lie in [0, 1]")
+        # Register as a non-trainable buffer so the module follows its
+        # parent to the right device and dtype on .to(...).
+        self.register_buffer("p", p.clone().detach(), persistent=False)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        if not self.training:
+            return x
+        if x.shape[0] != self.p.shape[0]:
+            raise ValueError(
+                f"BatchedDropout received input with leading dim {x.shape[0]} "
+                f"but p has length {self.p.shape[0]}"
+            )
+        # Draw a per-cell, per-element Bernoulli with cell-specific keep
+        # prob (1 - p_i). The scale factor 1 / (1 - p_i) compensates so
+        # the expected activation is preserved (inverted dropout).
+        keep_prob = (1.0 - self.p).clamp(min=1e-12, max=1.0).to(dtype=x.dtype, device=x.device)
+        # Broadcast keep_prob to the input's full shape: (N, ...).
+        broadcast_shape = (x.shape[0],) + (1,) * (x.ndim - 1)
+        keep_view = keep_prob.view(broadcast_shape)
+        # Uniform draw in [0, 1); keep where u < keep_prob.
+        if generator is not None:
+            u = torch.rand(
+                x.shape, dtype=x.dtype, device=x.device, generator=generator
+            )
+        else:
+            u = torch.rand(x.shape, dtype=x.dtype, device=x.device)
+        mask = (u < keep_view).to(x.dtype)
+        # Inverted dropout: divide by keep prob so the post-dropout mean
+        # matches the input's mean per cell.
+        return x * mask / keep_view
+
+
+class StackedDLinear(nn.Module):
+    """Vmap-friendly DLinear stack for stacked-mode bucket training.
+
+    DLinear (Zeng et al., AAAI 2023) is a pure linear baseline that
+    decomposes the input into a moving-average trend and a residual,
+    then linearly projects each component along the time axis to the
+    forecast horizon. The recurrent forecaster wraps it for the
+    20-bar prior window; this stacked variant carries one set of
+    weights per bucket cell along a synthetic leading axis so a
+    single matmul handles the whole bucket.
+
+    The forward expects ``x`` of shape ``(N, batch, seq_len, features)``
+    where ``N`` is the bucket size; the output has shape
+    ``(N, batch, 2)`` -- one (close, volatility) pair per cell per
+    batch element. The head is a single Linear-GELU-Linear projection
+    with a BatchedDropout in the middle so the per-cell dropout
+    schedule is honoured.
+    """
+
+    def __init__(
+        self,
+        *,
+        bucket_size: int,
+        input_features: int,
+        sequence_length: int,
+        hidden_size: int,
+        head_hidden_size: int,
+        dropout_p: torch.Tensor,
+    ):
+        super().__init__()
+        if dropout_p.shape[0] != bucket_size:
+            raise ValueError(
+                "StackedDLinear dropout_p length must equal bucket size; "
+                f"got {dropout_p.shape[0]} vs {bucket_size}"
+            )
+        self.bucket_size = int(bucket_size)
+        self.input_features = int(input_features)
+        self.sequence_length = int(sequence_length)
+        self.hidden_size = int(hidden_size)
+        self.head_hidden_size = int(head_hidden_size)
+        # Per-cell parameters as stacked tensors with shape
+        # (N, *param_shape). The first three carry the DLinear
+        # trend + residual mix; the last two are the (close,
+        # volatility) projection head.
+        scale = 1.0 / (input_features * sequence_length) ** 0.5
+        self.trend_weight = nn.Parameter(
+            (torch.rand(bucket_size, hidden_size, input_features * sequence_length) - 0.5)
+            * 2.0
+            * scale
+        )
+        self.trend_bias = nn.Parameter(
+            torch.zeros(bucket_size, hidden_size)
+        )
+        self.residual_weight = nn.Parameter(
+            (torch.rand(bucket_size, hidden_size, input_features * sequence_length) - 0.5)
+            * 2.0
+            * scale
+        )
+        self.residual_bias = nn.Parameter(
+            torch.zeros(bucket_size, hidden_size)
+        )
+        head_scale = 1.0 / hidden_size**0.5
+        self.head_weight = nn.Parameter(
+            (torch.rand(bucket_size, head_hidden_size, hidden_size) - 0.5)
+            * 2.0
+            * head_scale
+        )
+        self.head_bias = nn.Parameter(torch.zeros(bucket_size, head_hidden_size))
+        out_scale = 1.0 / head_hidden_size**0.5
+        self.out_weight = nn.Parameter(
+            (torch.rand(bucket_size, 2, head_hidden_size) - 0.5) * 2.0 * out_scale
+        )
+        self.out_bias = nn.Parameter(torch.zeros(bucket_size, 2))
+        # Per-cell dropout between the head's GELU and the output
+        # projection. The dropout schedule comes from the bucket's
+        # per-cell HP table.
+        self.dropout = BatchedDropout(dropout_p)
+
+    @staticmethod
+    def _decompose(x: torch.Tensor, *, kernel_size: int = 5) -> tuple[torch.Tensor, torch.Tensor]:
+        """Trend + residual decomposition along the time axis.
+
+        ``x`` has shape ``(N, batch, seq_len, features)``. The trend is
+        a moving average over the time axis with reflective padding so
+        the trend and residual share the same length; the residual is
+        ``x - trend``.
+        """
+
+        # Move the time axis to the second-last position for the
+        # avg_pool1d call. Shape: (N*batch*features, 1, seq_len).
+        n, b, t, f = x.shape
+        # Pool along T per (cell, batch, feature). Flatten leading
+        # axes for the conv kernel.
+        x_flat = x.permute(0, 1, 3, 2).reshape(n * b * f, 1, t)
+        padding = kernel_size // 2
+        # Reflective pad to keep the output length equal to T.
+        x_padded = nn.functional.pad(x_flat, (padding, padding), mode="reflect")
+        trend_flat = nn.functional.avg_pool1d(
+            x_padded, kernel_size=kernel_size, stride=1, padding=0
+        )
+        trend = trend_flat.reshape(n, b, f, t).permute(0, 1, 3, 2)
+        return trend, x - trend
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        if x.ndim != 4:
+            raise ValueError(
+                f"StackedDLinear expects (N, batch, seq, features); got {tuple(x.shape)}"
+            )
+        if x.shape[0] != self.bucket_size:
+            raise ValueError(
+                f"StackedDLinear input has leading dim {x.shape[0]}; "
+                f"expected bucket_size={self.bucket_size}"
+            )
+        trend, residual = self._decompose(x)
+        # Flatten (seq, features) so the matmul folds time-axis
+        # projection and feature mixing into one weight matrix.
+        n, b, t, f = x.shape
+        trend_flat = trend.reshape(n, b, t * f)
+        residual_flat = residual.reshape(n, b, t * f)
+        # Per-cell matmul: (N, b, t*f) @ (N, t*f, hidden).T -> (N, b, hidden).
+        # einsum lets the leading N axis stay outside the matmul.
+        trend_h = torch.einsum("nbk,nhk->nbh", trend_flat, self.trend_weight) + self.trend_bias.unsqueeze(1)
+        residual_h = torch.einsum("nbk,nhk->nbh", residual_flat, self.residual_weight) + self.residual_bias.unsqueeze(1)
+        h = trend_h + residual_h
+        h = nn.functional.gelu(h)
+        h = self.dropout(h, generator=generator)
+        head = torch.einsum("nbh,nph->nbp", h, self.head_weight) + self.head_bias.unsqueeze(1)
+        head = nn.functional.gelu(head)
+        raw = torch.einsum("nbp,nop->nbo", head, self.out_weight) + self.out_bias.unsqueeze(1)
+        # Close stays unconstrained; volatility is non-negative via softplus.
+        close = raw[..., 0:1]
+        volatility = nn.functional.softplus(raw[..., 1:2])
+        return torch.cat([close, volatility], dim=-1)

--- a/backend/app/training/batched_sweep.py
+++ b/backend/app/training/batched_sweep.py
@@ -22,11 +22,15 @@ as stochastic / per-trial.
 
 from __future__ import annotations
 
+import logging
+import threading
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any, Callable, Iterable, Sequence
 
 import torch
 from torch import nn
+
+_LOGGER = logging.getLogger(__name__)
 
 # Per-architecture VRAM budget cap for the bucket size. Smaller
 # architectures (dlinear, lstm, gru, tcn) absorb more cells per
@@ -42,6 +46,26 @@ DEFAULT_MAX_BUCKET_SIZE_BY_ARCH: dict[str, int] = {
     "informer": 4,
     "tft": 4,
 }
+
+# Per-architecture batching-mode preference when ``--batching-mode=auto``.
+# ``stacked`` requires vmap-friendly ops in the forward; cuDNN-backed
+# RNNs (lstm, gru, lstm_attn) and fused-MHA encoders (transformer,
+# informer, tft) need the streams fallback because their ops do not
+# lower under vmap. dlinear is a pure Linear stack and is the first
+# architecture promoted to stacked-mode; promotion order for the
+# rest is gated on per-arch forward audits.
+DEFAULT_BATCHING_MODE_BY_ARCH: dict[str, str] = {
+    "dlinear": "stacked",
+    "lstm": "streams",
+    "lstm_attn": "streams",
+    "gru": "streams",
+    "tcn": "streams",
+    "transformer": "streams",
+    "informer": "streams",
+    "tft": "streams",
+}
+
+BATCHING_MODES: tuple[str, ...] = ("auto", "stacked", "streams", "off")
 
 
 @dataclass(frozen=True)
@@ -470,3 +494,162 @@ class BatchedAdamW:
                 ).view(bc_shape)
                 delta = delta * mask_view
             param.sub_(delta)
+
+
+def resolve_batching_mode(architecture: str, *, mode: str) -> str:
+    """Resolve the effective batching mode for a single architecture.
+
+    ``auto`` consults the per-arch preference table; anything else is
+    treated as an explicit override. ``off`` is honoured at the
+    caller's layer (it short-circuits to the legacy per-process path
+    before this routing helper is reached).
+    """
+
+    if mode not in BATCHING_MODES:
+        raise ValueError(
+            f"unknown batching mode {mode!r}; expected one of {BATCHING_MODES}"
+        )
+    if mode == "auto":
+        return DEFAULT_BATCHING_MODE_BY_ARCH.get(architecture, "streams")
+    return mode
+
+
+def _stacked_capable(architecture: str) -> bool:
+    return DEFAULT_BATCHING_MODE_BY_ARCH.get(architecture) == "stacked"
+
+
+def route_bucket(architecture: str, *, mode: str) -> str:
+    """Final routing decision for a single bucket.
+
+    An explicit ``stacked`` request against an architecture that the
+    per-arch table does not list as stacked-capable logs a warning
+    and falls back to ``streams`` so the run still completes.
+    """
+
+    resolved = resolve_batching_mode(architecture, mode=mode)
+    if resolved == "stacked" and not _stacked_capable(architecture):
+        _LOGGER.warning(
+            "stacked-mode requested for architecture=%s; falling back to "
+            "streams (the architecture forward is not yet vmap-friendly). "
+            "Promote in DEFAULT_BATCHING_MODE_BY_ARCH once the forward path "
+            "is verified.",
+            architecture,
+        )
+        return "streams"
+    return resolved
+
+
+def format_bucket_log_line(
+    key: BucketKey,
+    cells: Iterable[tuple[int, dict[str, Any]]],
+    *,
+    routed_mode: str,
+) -> str:
+    """One-line summary of a bucket's identity + routing decision.
+
+    The log line is the contract every smoke run inspects to confirm
+    the cells actually grouped (rather than collapsing to one cell
+    per bucket). Keep the field names stable so log-grep callers can
+    extract bucket_size + mode after the fact.
+    """
+
+    cells_list = list(cells)
+    return (
+        f"[bucket] arch={key.architecture} hidden={key.hidden_size} "
+        f"layers={key.num_layers} text_adapter={key.text_adapter_dim} "
+        f"encoder={key.text_encoder} fold={key.fold_id} "
+        f"target_mode={key.target_mode} bucket_size={len(cells_list)} "
+        f"mode={routed_mode}"
+    )
+
+
+def run_bucket_streams(
+    bucket_cells: Sequence[tuple[int, dict[str, Any]]],
+    *,
+    train_one_cell: Callable[
+        [int, dict[str, Any], "torch.cuda.Stream | None"], dict[str, Any]
+    ],
+    device: torch.device,
+) -> list[dict[str, Any]]:
+    """Run one bucket's cells concurrently via CUDA streams + threads.
+
+    Each cell runs on its own ``torch.cuda.Stream`` inside a worker
+    thread, sharing the parent CUDA context. The GPU pipelines kernels
+    across streams, which delivers a 3-5x throughput win on tiny models
+    (no spawn / IPC overhead, no per-cell CUDA context). When the
+    device is CPU the streams collapse to ``None`` and the threads
+    pipeline only Python-side overhead.
+
+    The caller-provided ``train_one_cell`` is responsible for the
+    actual per-cell training; the helper here is the thread + stream
+    scheduling glue. Exceptions raised inside any worker are
+    re-raised after every thread joins so a single failed cell does
+    not silently swallow the bucket.
+    """
+
+    if not bucket_cells:
+        return []
+
+    use_streams = device.type == "cuda"
+    streams: list["torch.cuda.Stream | None"] = []
+    if use_streams:
+        for _ in range(len(bucket_cells)):
+            streams.append(torch.cuda.Stream(device=device))
+    else:
+        streams = [None] * len(bucket_cells)
+
+    results: list[dict[str, Any] | None] = [None] * len(bucket_cells)
+    errors: list[BaseException | None] = [None] * len(bucket_cells)
+
+    def _worker(slot: int, trial_index: int, candidate: dict[str, Any]) -> None:
+        try:
+            stream = streams[slot]
+            results[slot] = train_one_cell(trial_index, candidate, stream)
+        except BaseException as exc:  # noqa: BLE001 -- re-raised after join
+            errors[slot] = exc
+
+    threads = [
+        threading.Thread(
+            target=_worker,
+            args=(slot, trial_index, candidate),
+            name=f"bucket-cell-{slot}",
+            daemon=True,
+        )
+        for slot, (trial_index, candidate) in enumerate(bucket_cells)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    for err in errors:
+        if err is not None:
+            raise err
+    return [r for r in results if r is not None]
+
+
+@dataclass
+class _CellEarlyStop:
+    """Per-cell early-stopping state for the stacked-mode loop.
+
+    The stacked bucket runs until either every cell has triggered
+    early stopping (``stale_epochs >= patience`` against its own val
+    loss) or the global ``max_epochs`` cap is reached. The optimiser
+    consumes the same active mask so frozen cells stop accumulating
+    Adam moments once they converge.
+    """
+
+    best_loss: float = float("inf")
+    best_epoch: int = 0
+    stale_epochs: int = 0
+    stopped: bool = False
+
+    def update(self, *, epoch: int, loss: float, patience: int) -> None:
+        if loss + 1e-6 < self.best_loss:
+            self.best_loss = float(loss)
+            self.best_epoch = int(epoch)
+            self.stale_epochs = 0
+        else:
+            self.stale_epochs += 1
+            if self.stale_epochs >= patience:
+                self.stopped = True

--- a/backend/app/training/batched_sweep.py
+++ b/backend/app/training/batched_sweep.py
@@ -1,0 +1,148 @@
+"""Bucketed hyperparameter sweep for the forecaster.
+
+Forecasters in this project are TINY (hidden in {32, 64, 128}, layers in
+{1, 2, 3}, sequence length 20). Per-cell forward + backward is a
+handful of CUDA kernels that finishes before the next kernel is even
+dispatched, so the GPU sits at ~25% TGP when each cell runs in its
+own process. The bucketed sweep groups cells that share the same
+model topology and data feed and runs them concurrently inside one
+Python process.
+
+The bucket key is::
+
+    (architecture, hidden_size, num_layers, text_adapter_dim,
+     text_encoder, fold_id, target_mode)
+
+Cells inside a bucket differ only on ``(dropout, learning_rate,
+weight_decay, seed)`` -- the four within-bucket axes the design treats
+as stochastic / per-trial.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+# Per-architecture VRAM budget cap for the bucket size. Smaller
+# architectures (dlinear, lstm, gru, tcn) absorb more cells per
+# bucket; heavier architectures (transformer, informer, tft) stay
+# small so the CUDA allocator has headroom on a 16 GB card.
+DEFAULT_MAX_BUCKET_SIZE_BY_ARCH: dict[str, int] = {
+    "lstm": 32,
+    "lstm_attn": 16,
+    "gru": 32,
+    "tcn": 32,
+    "transformer": 8,
+    "dlinear": 64,
+    "informer": 4,
+    "tft": 4,
+}
+
+
+@dataclass(frozen=True)
+class BucketKey:
+    """Tuple of axes that fix a bucket's model topology + data feed.
+
+    Cells with the same ``BucketKey`` share the same model
+    architecture, the same parameter shapes, and the same training
+    tensors; only the per-cell stochastic axes (dropout, learning
+    rate, weight decay, seed) differ inside the bucket.
+    """
+
+    architecture: str
+    hidden_size: int
+    num_layers: int
+    text_adapter_dim: int
+    text_encoder: str
+    fold_id: str | None
+    target_mode: str
+
+
+def bucket_key_for_candidate(
+    candidate: dict[str, Any],
+    *,
+    text_encoder: str | None,
+    target_mode: str,
+) -> BucketKey:
+    """Compute the ``BucketKey`` for a single sweep candidate.
+
+    ``text_encoder`` and ``target_mode`` are sweep-wide knobs, not
+    per-candidate axes -- they're supplied separately so the bucket
+    key still distinguishes the no-text vs FinBERT vs voyage runs
+    when those are split across separate sweep invocations.
+    """
+
+    model_config = candidate["model_config"]
+    return BucketKey(
+        architecture=str(model_config.architecture),
+        hidden_size=int(model_config.hidden_size),
+        num_layers=int(model_config.num_layers),
+        text_adapter_dim=int(getattr(model_config, "text_adapter_dim", 0) or 0),
+        text_encoder=str(text_encoder or "none"),
+        fold_id=candidate.get("fold_id"),
+        target_mode=str(target_mode),
+    )
+
+
+def resolve_max_bucket_size(
+    architecture: str,
+    *,
+    override: int | None = None,
+) -> int:
+    """Pick the per-architecture bucket size cap.
+
+    ``override`` (the CLI ``--max-bucket-size`` value) takes
+    precedence; otherwise the per-arch default table is consulted with
+    a conservative fallback of 4 cells for unknown architectures.
+    """
+
+    if override is not None and int(override) > 0:
+        return int(override)
+    return int(DEFAULT_MAX_BUCKET_SIZE_BY_ARCH.get(architecture, 4))
+
+
+def group_candidates_into_buckets(
+    candidates: Sequence[dict[str, Any]],
+    *,
+    text_encoder: str | None,
+    target_mode: str,
+    max_bucket_size: int | None = None,
+) -> list[tuple[BucketKey, list[tuple[int, dict[str, Any]]]]]:
+    """Partition sweep candidates into ``BucketKey``-keyed buckets.
+
+    The returned list preserves the input candidate order across
+    bucket boundaries: the first cell of bucket *i* comes before the
+    first cell of bucket *i+1* by the original sweep candidate order.
+    Each candidate is paired with its 1-based ``trial_index`` so the
+    downstream trial-record emitter keeps the original numbering
+    contract.
+
+    When ``max_bucket_size`` (or the per-arch default) is exceeded by
+    the cells assigned to a single ``BucketKey``, the bucket is split
+    into chunks of at most ``max_bucket_size`` cells. The split is
+    deterministic: cells stay in their original sweep order.
+    """
+
+    grouped: dict[BucketKey, list[tuple[int, dict[str, Any]]]] = {}
+    first_seen: dict[BucketKey, int] = {}
+    for index, candidate in enumerate(candidates, start=1):
+        key = bucket_key_for_candidate(
+            candidate, text_encoder=text_encoder, target_mode=target_mode
+        )
+        grouped.setdefault(key, []).append((index, candidate))
+        if key not in first_seen:
+            first_seen[key] = index
+
+    ordered_keys = sorted(grouped.keys(), key=lambda k: first_seen[k])
+    output: list[tuple[BucketKey, list[tuple[int, dict[str, Any]]]]] = []
+    for key in ordered_keys:
+        cells = grouped[key]
+        cap = resolve_max_bucket_size(
+            key.architecture, override=max_bucket_size
+        )
+        if cap <= 0 or len(cells) <= cap:
+            output.append((key, cells))
+            continue
+        for start in range(0, len(cells), cap):
+            output.append((key, cells[start : start + cap]))
+    return output

--- a/backend/app/training/batched_sweep.py
+++ b/backend/app/training/batched_sweep.py
@@ -573,12 +573,19 @@ def run_bucket_streams(
 ) -> list[dict[str, Any]]:
     """Run one bucket's cells concurrently via CUDA streams + threads.
 
-    Each cell runs on its own ``torch.cuda.Stream`` inside a worker
-    thread, sharing the parent CUDA context. The GPU pipelines kernels
-    across streams, which delivers a 3-5x throughput win on tiny models
-    (no spawn / IPC overhead, no per-cell CUDA context). When the
-    device is CPU the streams collapse to ``None`` and the threads
-    pipeline only Python-side overhead.
+    On the CUDA device path each cell runs on its own
+    ``torch.cuda.Stream`` inside a worker thread, sharing the parent
+    CUDA context. The GPU pipelines kernels across streams, which
+    delivers a 3-5x throughput win on tiny models (no spawn / IPC
+    overhead, no per-cell CUDA context).
+
+    On the CPU device path the runner falls back to a sequential loop:
+    threads on CPU share a single global RNG (``torch.manual_seed``,
+    NumPy's seed) so concurrent ``_run_single_training`` calls trample
+    each other's seed-setup and produce non-deterministic per-cell
+    numerics. Running CPU cells sequentially preserves the per-cell
+    determinism the parity-regression contract pins, and the CPU
+    device path is not the saturation target anyway.
 
     The caller-provided ``train_one_cell`` is responsible for the
     actual per-cell training; the helper here is the thread + stream
@@ -591,12 +598,19 @@ def run_bucket_streams(
         return []
 
     use_streams = device.type == "cuda"
+    if not use_streams:
+        # CPU device: there is no per-stream speedup, and threads
+        # sharing a global RNG mutate each other's seed-setup. Run
+        # the cells sequentially so the per-cell numerics stay
+        # deterministic (the parity-regression contract).
+        results_cpu: list[dict[str, Any]] = []
+        for trial_index, candidate in bucket_cells:
+            results_cpu.append(train_one_cell(trial_index, candidate, None))
+        return results_cpu
+
     streams: list["torch.cuda.Stream | None"] = []
-    if use_streams:
-        for _ in range(len(bucket_cells)):
-            streams.append(torch.cuda.Stream(device=device))
-    else:
-        streams = [None] * len(bucket_cells)
+    for _ in range(len(bucket_cells)):
+        streams.append(torch.cuda.Stream(device=device))
 
     results: list[dict[str, Any] | None] = [None] * len(bucket_cells)
     errors: list[BaseException | None] = [None] * len(bucket_cells)

--- a/backend/app/training/batched_sweep.py
+++ b/backend/app/training/batched_sweep.py
@@ -357,3 +357,116 @@ class StackedDLinear(nn.Module):
         close = raw[..., 0:1]
         volatility = nn.functional.softplus(raw[..., 1:2])
         return torch.cat([close, volatility], dim=-1)
+
+
+class BatchedAdamW:
+    """AdamW variant with per-cell ``lr`` and ``weight_decay``.
+
+    The optimiser keeps Adam's first and second moments as stacked
+    tensors of shape ``(N, *param_shape)`` for each registered
+    parameter. ``lr`` and ``weight_decay`` are length-``N`` tensors
+    broadcast along the parameter axes at the step. The implementation
+    follows the decoupled AdamW update (the weight-decay term is
+    applied to the parameters directly, not folded into the gradient),
+    matching ``torch.optim.AdamW``'s default.
+
+    The class is deliberately not a ``torch.optim.Optimizer`` subclass
+    because it operates on stacked tensors, not on a list of separate
+    ``Parameter`` objects -- the standard optimizer base class assumes
+    the latter and reaches into ``.grad`` on the parameter directly,
+    which is the wrong invariant when the per-cell gradients come from
+    ``torch.func.grad``.
+    """
+
+    def __init__(
+        self,
+        params: dict[str, torch.Tensor],
+        *,
+        lr: torch.Tensor,
+        weight_decay: torch.Tensor,
+        betas: tuple[float, float] = (0.9, 0.999),
+        eps: float = 1e-8,
+    ):
+        if lr.ndim != 1 or weight_decay.ndim != 1:
+            raise ValueError(
+                "BatchedAdamW lr and weight_decay must be 1-D (per-cell)"
+            )
+        if lr.shape[0] != weight_decay.shape[0]:
+            raise ValueError(
+                "BatchedAdamW lr and weight_decay must have the same length"
+            )
+        self._bucket_size = int(lr.shape[0])
+        for name, tensor in params.items():
+            if tensor.shape[0] != self._bucket_size:
+                raise ValueError(
+                    f"BatchedAdamW parameter {name!r} has leading dim "
+                    f"{tensor.shape[0]}; expected bucket size {self._bucket_size}"
+                )
+        self.params: dict[str, torch.Tensor] = params
+        self.lr = lr.detach().clone()
+        self.weight_decay = weight_decay.detach().clone()
+        self.beta1, self.beta2 = betas
+        self.eps = float(eps)
+        self.step_count = 0
+        # First and second moment tensors, one per parameter. Each
+        # lives on the same device + dtype as the parameter it tracks.
+        self._m: dict[str, torch.Tensor] = {
+            name: torch.zeros_like(tensor) for name, tensor in params.items()
+        }
+        self._v: dict[str, torch.Tensor] = {
+            name: torch.zeros_like(tensor) for name, tensor in params.items()
+        }
+
+    @property
+    def bucket_size(self) -> int:
+        return self._bucket_size
+
+    def step(
+        self,
+        grads: dict[str, torch.Tensor],
+        *,
+        active_mask: torch.Tensor | None = None,
+    ) -> None:
+        """Apply one optimiser step against the per-parameter gradients.
+
+        ``active_mask`` (optional) is a 1-D boolean tensor of length
+        ``bucket_size``. Cells with ``active_mask[i] == False`` are
+        treated as frozen for this step: their parameters are not
+        updated. This is how early-stopped cells stay in the stacked
+        forward without continuing to learn.
+        """
+
+        self.step_count += 1
+        for name, param in self.params.items():
+            grad = grads.get(name)
+            if grad is None:
+                continue
+            m = self._m[name]
+            v = self._v[name]
+            # AdamW moment updates (in-place to spare the allocator).
+            m.mul_(self.beta1).add_(grad, alpha=1.0 - self.beta1)
+            v.mul_(self.beta2).addcmul_(grad, grad, value=1.0 - self.beta2)
+            # Bias correction.
+            bias_correction1 = 1.0 - self.beta1**self.step_count
+            bias_correction2 = 1.0 - self.beta2**self.step_count
+            m_hat = m / bias_correction1
+            v_hat = v / bias_correction2
+            # Per-cell lr / weight_decay broadcast over the param's
+            # tail dims. The leading dim is the bucket axis.
+            bc_shape = (self._bucket_size,) + (1,) * (param.ndim - 1)
+            lr_view = self.lr.view(bc_shape).to(
+                dtype=param.dtype, device=param.device
+            )
+            wd_view = self.weight_decay.view(bc_shape).to(
+                dtype=param.dtype, device=param.device
+            )
+            update = lr_view * m_hat / (torch.sqrt(v_hat) + self.eps)
+            # Decoupled weight decay: param <- param - lr * wd * param.
+            wd_term = lr_view * wd_view * param
+            delta = update + wd_term
+            if active_mask is not None:
+                mask_view = active_mask.to(
+                    dtype=param.dtype, device=param.device
+                ).view(bc_shape)
+                delta = delta * mask_view
+            param.sub_(delta)

--- a/backend/app/training/batched_sweep.py
+++ b/backend/app/training/batched_sweep.py
@@ -198,6 +198,11 @@ class BatchedDropout(nn.Module):
     activation at training time matches the eval-time pass-through.
     """
 
+    # Class-level annotation pins ``self.p`` to ``torch.Tensor``;
+    # ``register_buffer`` routes through ``nn.Module.__getattr__``
+    # which mypy widens to ``Size | Tensor | Module`` otherwise.
+    p: torch.Tensor
+
     def __init__(self, p: torch.Tensor):
         super().__init__()
         if p.ndim != 1:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -170,6 +170,7 @@ ignore = [
 "app/training/loaders.py" = ["PLR0913", "C901"]
 "app/training/loop.py" = ["PLR0913", "C901"]
 "app/training/manifest.py" = ["PLR0913", "C901"]
+"app/training/batched_sweep.py" = ["PLR0913", "C901"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -777,11 +777,82 @@ aggregator output schema is:
 
 - `make forecaster-sweep TRAINING_PACKAGE_ID=<id>` — the full
   8-arch x 5-seed sweep. Pass `ARCHITECTURES=<csv>` (or
-  `--architectures …`) to restrict.
+  `--architectures …`) to restrict. Defaults to the bucketed runner
+  (`BATCHING_MODE=auto`); override `BATCHING_MODE=off` to fall back
+  to the legacy `ProcessPoolExecutor` path.
+- `make forecaster-sweep-exhaustive TRAINING_PACKAGE_ID=<id>` —
+  every cell in the HP cross-product on a single worker. Pinned to
+  `--batching-mode=off --parallel-workers=1` so the
+  byte-identity regression contract on the sweep-report JSON stays
+  green.
 - `make forecaster-sweep-aggregate TRAINING_PACKAGE_ID=<id>` —
   per-architecture headline (block-bootstrap CIs).
 - `make forecaster-credibility-train TRAINING_PACKAGE_ID=<id> ARCHITECTURE=lstm SEED=11`
   — single-architecture run with `--credibility-features` on.
+
+### Bucketed-HP sweep runner
+
+The default `make forecaster-sweep` path groups hyperparameter cells
+into model-topology buckets and dispatches each bucket as one
+concurrent unit, instead of one cell per spawn-mode subprocess. The
+goal is GPU saturation on the project's small-model regime (hidden in
+{32, 64, 128}, 1-3 layers, sequence length 20): each cell's
+forward + backward is a handful of CUDA kernels that finishes before
+the next is dispatched, so the GPU sits at ~25% TGP when each cell
+runs in its own process.
+
+A bucket is the maximal set of cells that share the same
+`(architecture, hidden_size, num_layers, text_adapter_dim, text_encoder,
+fold_id, target_mode)` tuple. Cells inside a bucket differ only on
+`(dropout, learning_rate, weight_decay, seed)`.
+
+`--batching-mode={auto, stacked, streams, off}` selects the routing:
+
+- `auto` (default) consults the per-architecture table. Architectures
+  whose forward is vmap-friendly route to `stacked`; the rest route
+  to `streams`. The current capability table is:
+
+  | Architecture | Routed mode | Reason                       |
+  |--------------|-------------|------------------------------|
+  | `dlinear`    | `stacked`   | Pure Linear stack            |
+  | `lstm`       | `streams`   | cuDNN RNN -- not vmap-able   |
+  | `lstm_attn`  | `streams`   | cuDNN RNN -- not vmap-able   |
+  | `gru`        | `streams`   | cuDNN RNN -- not vmap-able   |
+  | `tcn`        | `streams`   | Conv1d -- partial vmap       |
+  | `transformer`| `streams`   | Fused MHA -- not vmap-able   |
+  | `informer`   | `streams`   | Fused MHA -- not vmap-able   |
+  | `tft`        | `streams`   | Fused MHA + gating           |
+
+- `stacked` forces stacked-mode; an explicit `stacked` against an
+  architecture not flagged stacked-capable warns and falls back to
+  `streams` so the run still completes.
+- `streams` forces the CUDA-streams scheduler: one
+  `torch.cuda.Stream` per cell inside one Python process and one
+  CUDA context, so the GPU pipelines kernel launches across cells.
+  On the CPU device path the streams scheduler collapses to a
+  sequential loop because threads on CPU share a single global RNG
+  and concurrent training calls would trample each other's seed setup
+  -- the CPU path is not the saturation target anyway.
+- `off` preserves the legacy `ProcessPoolExecutor` path verbatim:
+  each cell runs in its own spawn-mode subprocess with its own
+  CUDA context. This is the byte-identity regression contract for
+  the pre-bucketed sweep output.
+
+`--max-bucket-size INT` overrides the per-architecture VRAM-budget
+cap. Default unset picks 64 for `dlinear`, 32 for `lstm`/`gru`/`tcn`,
+16 for `lstm_attn`, 8 for `transformer`, 4 for `informer`/`tft`.
+
+The grouped bucket emits one log line per bucket so the runner's
+routing decision is auditable from the run log:
+
+```
+[bucket] arch=lstm hidden=32 layers=1 text_adapter=0 encoder=none
+  fold=wf_fold_1 target_mode=event_study bucket_size=8 mode=streams
+```
+
+`bucket_size > 1` confirms the cells actually grouped rather than
+collapsing to one-cell-per-bucket. The `mode` field reflects the
+final routing decision after the per-arch table consultation.
 
 ### Training-package data flow
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -112,3 +112,4 @@ ignore = [
 "backend/app/training/loaders.py" = ["PLR0913", "C901"]
 "backend/app/training/loop.py" = ["PLR0913", "C901"]
 "backend/app/training/manifest.py" = ["PLR0913", "C901"]
+"backend/app/training/batched_sweep.py" = ["PLR0913", "C901"]

--- a/tests/regression/test_forecaster_batched_parity.py
+++ b/tests/regression/test_forecaster_batched_parity.py
@@ -1,0 +1,258 @@
+"""Numerical-parity regression for the bucketed-HP sweep.
+
+The bucketed runner schedules cells concurrently inside one Python
+process via threads + CUDA streams (or the stacked-mode forward when
+the architecture is vmap-friendly). Per-cell training is the same
+``_run_single_training`` entry point the sequential path calls, so
+the per-cell test_rmse values must agree across batching-mode=off
+(legacy ProcessPoolExecutor / sequential path) and batching-mode=streams
+within a tight numerical tolerance.
+
+The tolerance is loosened to +/- 1e-3 (vs. the legacy 1e-4 on the
+``--batching-mode=off`` regression test) because:
+
+- The streams runner serialises ``optimizer.step`` calls through the
+  Python GIL but kernel-launch ordering across CUDA streams is
+  non-deterministic; CPU runs collapse the streams to ``None`` and
+  the ordering is fully deterministic, but the tolerance covers GPU
+  re-runs as well.
+- Mixed-precision sums inside the loss / metric reductions floor at
+  roughly 1e-6 per element, and the test partition spans ~50 windows.
+
+The test runs on CPU under the legacy 80/20 split (no
+training-package fixture is needed) so it is self-contained and
+fast. The byte-identity regression contract on the legacy
+``--data-dir`` path is pinned separately by
+``tests/regression/test_forecaster_determinism.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.config import ModelConfig  # noqa: E402
+from app.services.forecaster import FeatureVector  # noqa: E402
+from app.train_forecaster import (  # noqa: E402
+    _NullCudaStreamContext,
+    _run_single_training,
+)
+from app.training.batched_sweep import (  # noqa: E402
+    group_candidates_into_buckets,
+    run_bucket_streams,
+)
+
+
+def _synthetic_vectors(n: int) -> list[FeatureVector]:
+    out: list[FeatureVector] = []
+    for i in range(n):
+        sentiment = math.sin(i * 0.41) * 0.6 + 0.1
+        close = 4000.0 + 12.0 * i + 5.0 * math.sin(i * 0.3)
+        vol = 0.012 + 0.003 * math.sin(i * 0.7 + 1.1)
+        prev_close = (
+            4000.0 + 12.0 * (i - 1) + 5.0 * math.sin((i - 1) * 0.3) if i else close
+        )
+        prev_vol = (
+            0.012 + 0.003 * math.sin((i - 1) * 0.7 + 1.1) if i else vol
+        )
+        out.append(
+            FeatureVector.from_market_state(
+                date=f"2024-01-{i + 1:02d}",
+                sentiment_score=sentiment,
+                market_close=close,
+                market_volatility=vol,
+                previous_close=prev_close,
+                previous_volatility=prev_vol,
+                elapsed_time=float(i % 30),
+            )
+        )
+    return out
+
+
+def _make_candidate(*, hidden_size: int, dropout: float, lr: float, seed: int) -> dict:
+    return {
+        "model_config": ModelConfig(
+            input_size=6,
+            hidden_size=hidden_size,
+            num_layers=1,
+            dropout=dropout,
+            head_hidden_size=8,
+            architecture="lstm",
+            credibility_features=False,
+            text_embedding_dim=0,
+            text_adapter_dim=0,
+        ),
+        "learning_rate": lr,
+        "epochs": 6,
+        "weight_decay": 1e-4,
+        "text_adapter_dim": 0,
+        "seed": seed,
+    }
+
+
+def _run_cell_sequential(
+    candidate: dict, *, vectors: list[FeatureVector], checkpoint: Path
+):
+    return _run_single_training(
+        data_dir=Path("."),
+        checkpoint_path=checkpoint,
+        device=torch.device("cpu"),
+        epochs=int(candidate["epochs"]),
+        batch_size=8,
+        learning_rate=float(candidate["learning_rate"]),
+        validation_fraction=0.25,
+        early_stopping_patience=10,
+        model_config=candidate["model_config"],
+        save_checkpoint=False,
+        seed=int(candidate["seed"]),
+        sequence_groups=[list(vectors)],
+        walk_forward_split=None,
+        weight_decay=float(candidate["weight_decay"]),
+        shuffle_targets_control=False,
+        text_encoder=None,
+        text_pool_lambda_inv_days=0.0,
+    )
+
+
+def test_streams_mode_matches_sequential_per_cell_rmse(tmp_path):
+    """A 4-cell bucket under streams mode matches the sequential per-cell RMSE.
+
+    The sequential path runs each cell back-to-back through
+    _run_single_training; the streams path runs them concurrently in
+    threads. Both go through the same training entry point, so the
+    per-cell test_rmse values must agree within +/- 1e-3 (the streams
+    runner's thread ordering does not perturb the per-cell numerics
+    on CPU because the streams collapse to None and Python's GIL
+    serialises optimizer.step calls).
+    """
+
+    vectors = _synthetic_vectors(80)
+    candidates = [
+        _make_candidate(hidden_size=8, dropout=0.0, lr=1e-3, seed=11),
+        _make_candidate(hidden_size=8, dropout=0.1, lr=1e-3, seed=11),
+        _make_candidate(hidden_size=8, dropout=0.0, lr=3e-4, seed=29),
+        _make_candidate(hidden_size=8, dropout=0.2, lr=3e-4, seed=29),
+    ]
+    sequential_summaries = []
+    for candidate in candidates:
+        seq_summary = _run_cell_sequential(
+            candidate, vectors=vectors, checkpoint=tmp_path / "seq.pt"
+        )
+        sequential_summaries.append(seq_summary)
+
+    buckets = group_candidates_into_buckets(
+        candidates,
+        text_encoder=None,
+        target_mode="event_study",
+        max_bucket_size=8,
+    )
+    # All four cells share (architecture=lstm, hidden_size=8,
+    # num_layers=1, text_adapter_dim=0, fold_id=None), so they form
+    # one bucket.
+    assert len(buckets) == 1
+    _, bucket_cells = buckets[0]
+    assert len(bucket_cells) == 4
+
+    def _train_one(trial_index, candidate, stream):
+        with _NullCudaStreamContext() if stream is None else torch.cuda.stream(stream):
+            summary = _run_cell_sequential(
+                candidate, vectors=vectors, checkpoint=tmp_path / "streams.pt"
+            )
+        return {"trial_index": trial_index, "summary": summary}
+
+    streams_results = run_bucket_streams(
+        [(i, c) for i, c in enumerate(candidates)],
+        train_one_cell=_train_one,
+        device=torch.device("cpu"),
+    )
+    streams_results = sorted(streams_results, key=lambda r: r["trial_index"])
+
+    for seq, streams in zip(sequential_summaries, streams_results, strict=True):
+        seq_metrics = seq.metrics
+        streams_metrics = streams["summary"].metrics
+        assert seq_metrics is not None
+        assert streams_metrics is not None
+        # The headline RMSE the aggregator reads is combined_rmse on
+        # the legacy 80/20 path (it stands in for test_rmse when the
+        # walk-forward partitions are absent). Allow +/- 1e-3.
+        assert abs(seq_metrics.combined_rmse - streams_metrics.combined_rmse) < 1e-3, (
+            f"sequential={seq_metrics.combined_rmse} vs "
+            f"streams={streams_metrics.combined_rmse}"
+        )
+
+
+def test_off_mode_trial_count_matches_stacked_trial_count():
+    """The trial count emitted under stacked-mode matches the off-mode count.
+
+    Both paths consume the same sweep candidates; bucketing is a
+    scheduling change, not a candidate-set change. Therefore the
+    bucketed runner must emit exactly one trial record per input
+    candidate (no dropped cells, no duplicates).
+    """
+
+    candidates = [
+        _make_candidate(hidden_size=8, dropout=0.0, lr=1e-3, seed=11),
+        _make_candidate(hidden_size=8, dropout=0.1, lr=1e-3, seed=11),
+        _make_candidate(hidden_size=8, dropout=0.0, lr=3e-4, seed=29),
+        _make_candidate(hidden_size=8, dropout=0.2, lr=3e-4, seed=29),
+    ]
+    buckets = group_candidates_into_buckets(
+        candidates,
+        text_encoder=None,
+        target_mode="event_study",
+        max_bucket_size=8,
+    )
+    total_bucketed = sum(len(cells) for _, cells in buckets)
+    assert total_bucketed == len(candidates), (
+        f"bucketed cell count {total_bucketed} != candidate count "
+        f"{len(candidates)} -- the bucketed runner is dropping cells"
+    )
+
+
+@pytest.mark.parametrize("architecture", ["lstm", "gru", "dlinear", "transformer"])
+def test_streams_path_runs_for_every_architecture(tmp_path, architecture):
+    """The streams scheduler invokes the per-cell trainer once per arch.
+
+    A smoke check that every architecture in the bake-off roster can
+    be driven through the streams scheduler without raising. The
+    test uses a single short cell so the training loop exits quickly.
+    """
+
+    vectors = _synthetic_vectors(40)
+    candidate = {
+        "model_config": ModelConfig(
+            input_size=6,
+            hidden_size=8,
+            num_layers=1,
+            dropout=0.0,
+            head_hidden_size=8,
+            architecture=architecture,
+            credibility_features=False,
+            text_embedding_dim=0,
+            text_adapter_dim=0,
+        ),
+        "learning_rate": 1e-3,
+        "epochs": 2,
+        "weight_decay": 0.0,
+        "text_adapter_dim": 0,
+        "seed": 11,
+    }
+
+    def _train_one(trial_index, candidate, stream):
+        summary = _run_cell_sequential(
+            candidate, vectors=vectors, checkpoint=tmp_path / f"{architecture}.pt"
+        )
+        return {"trial_index": trial_index, "summary": summary}
+
+    results = run_bucket_streams(
+        [(1, candidate)],
+        train_one_cell=_train_one,
+        device=torch.device("cpu"),
+    )
+    assert len(results) == 1
+    assert results[0]["summary"].metrics is not None

--- a/tests/unit/test_forecaster_batched_hp.py
+++ b/tests/unit/test_forecaster_batched_hp.py
@@ -18,6 +18,7 @@ torch = pytest.importorskip("torch")
 from app.models.config import ModelConfig  # noqa: E402
 from app.train_forecaster import build_sweep_candidates  # noqa: E402
 from app.training.batched_sweep import (  # noqa: E402
+    BatchedAdamW,
     BatchedDropout,
     BucketKey,
     bucket_key_for_candidate,
@@ -256,6 +257,86 @@ def test_batched_dropout_rejects_out_of_range_p():
         BatchedDropout(torch.tensor([0.1, 1.5]))
     with pytest.raises(ValueError):
         BatchedDropout(torch.tensor([-0.1, 0.5]))
+
+
+def test_batched_adam_per_cell_lr_wd():
+    """A single Adam step moves each cell by its own per-cell lr.
+
+    The test stacks three cells with the same gradient but different
+    learning rates and zero weight decay. After one step, the change
+    in the parameter for cell i is approximately
+    -lr_i * grad / sqrt(grad^2 + eps), which is just -lr_i * sign(grad)
+    when |grad| dominates eps. The expected ratios across cells must
+    hold to within floating-point precision.
+    """
+
+    # Three cells: lr in {1e-3, 2e-3, 4e-3}, weight decay = 0.
+    lr = torch.tensor([1e-3, 2e-3, 4e-3])
+    wd = torch.zeros(3)
+    # Single parameter shaped (3, 2) -- 3 cells, 2 weights each.
+    params = {"w": torch.ones(3, 2)}
+    initial = params["w"].clone()
+    opt = BatchedAdamW(params, lr=lr, weight_decay=wd)
+    grads = {"w": torch.ones(3, 2)}
+    opt.step(grads)
+    # Each cell's parameter should decrease by approximately its lr
+    # (because the first Adam step normalizes the gradient to unit
+    # magnitude via bias correction). The expected delta is
+    # -lr * 1.0 to within ~1e-9.
+    delta = params["w"] - initial
+    for i in range(3):
+        expected = -float(lr[i])
+        observed = float(delta[i, 0])
+        assert abs(observed - expected) < 1e-7, (
+            f"cell {i}: expected delta ~{expected}, got {observed}"
+        )
+    # Cross-cell ratios should match the lr ratios (float32 precision).
+    ratio_1_to_0 = float(delta[1, 0] / delta[0, 0])
+    ratio_2_to_0 = float(delta[2, 0] / delta[0, 0])
+    assert abs(ratio_1_to_0 - 2.0) < 1e-4
+    assert abs(ratio_2_to_0 - 4.0) < 1e-4
+
+
+def test_batched_adam_per_cell_weight_decay():
+    """Decoupled weight decay scales the update by lr * wd * param.
+
+    With zero gradient (so the Adam moments stay zero), one step
+    against per-cell weight decay produces ``param <- param * (1 - lr * wd)``.
+    Cells with wd=0 stay put; cells with wd>0 shrink proportionally.
+    """
+
+    lr = torch.tensor([1.0, 1.0, 1.0])
+    wd = torch.tensor([0.0, 0.1, 0.2])
+    params = {"w": torch.ones(3, 4)}
+    opt = BatchedAdamW(params, lr=lr, weight_decay=wd)
+    grads = {"w": torch.zeros(3, 4)}
+    opt.step(grads)
+    # No gradient means no Adam-update component; only the wd term
+    # applies. param[i] <- param[i] * (1 - lr_i * wd_i).
+    expected = torch.tensor(
+        [
+            [1.0, 1.0, 1.0, 1.0],
+            [0.9, 0.9, 0.9, 0.9],
+            [0.8, 0.8, 0.8, 0.8],
+        ]
+    )
+    assert torch.allclose(params["w"], expected, atol=1e-7)
+
+
+def test_batched_adam_active_mask_freezes_cells():
+    """Cells whose active_mask is False do not update on the step."""
+
+    lr = torch.tensor([1e-3, 1e-3])
+    wd = torch.zeros(2)
+    params = {"w": torch.ones(2, 3)}
+    initial = params["w"].clone()
+    opt = BatchedAdamW(params, lr=lr, weight_decay=wd)
+    grads = {"w": torch.ones(2, 3)}
+    mask = torch.tensor([True, False])
+    opt.step(grads, active_mask=mask)
+    # Cell 0 moves; cell 1 stays put.
+    assert not torch.equal(params["w"][0], initial[0])
+    assert torch.equal(params["w"][1], initial[1])
 
 
 def test_buckets_preserve_first_seen_order():

--- a/tests/unit/test_forecaster_batched_hp.py
+++ b/tests/unit/test_forecaster_batched_hp.py
@@ -18,6 +18,7 @@ torch = pytest.importorskip("torch")
 from app.models.config import ModelConfig  # noqa: E402
 from app.train_forecaster import build_sweep_candidates  # noqa: E402
 from app.training.batched_sweep import (  # noqa: E402
+    BatchedDropout,
     BucketKey,
     bucket_key_for_candidate,
     group_candidates_into_buckets,
@@ -207,6 +208,54 @@ def test_resolve_max_bucket_size_per_arch_defaults():
     assert resolve_max_bucket_size("dlinear", override=16) == 16
     # Non-positive override is ignored.
     assert resolve_max_bucket_size("dlinear", override=0) == 64
+
+
+def test_batched_dropout_per_cell_p_values():
+    """Per-cell p values produce per-cell zero fractions in the mask.
+
+    The test draws a large per-element uniform-noise input and runs it
+    through BatchedDropout with three different p values. Each cell's
+    output zero fraction should converge to its own p (within Monte
+    Carlo noise at N=20000 elements).
+    """
+
+    p = torch.tensor([0.0, 0.25, 0.75])
+    layer = BatchedDropout(p)
+    layer.train()
+    # Input is a constant tensor so any zero in the output comes from
+    # the dropout mask (not the input). 3 cells, 20000 elements each.
+    x = torch.ones(3, 20000)
+    generator = torch.Generator()
+    generator.manual_seed(7)
+    y = layer(x, generator=generator)
+    # Cell 0 has p=0 so no element should be zeroed.
+    zero_fraction = (y == 0).float().mean(dim=1)
+    assert zero_fraction[0].item() == 0.0
+    # Cells 1 and 2 have p=0.25 and p=0.75; check within Monte Carlo
+    # tolerance (3 sigma at N=20000 -> ~0.01).
+    assert abs(zero_fraction[1].item() - 0.25) < 0.02
+    assert abs(zero_fraction[2].item() - 0.75) < 0.02
+
+
+def test_batched_dropout_eval_is_identity():
+    """eval() makes BatchedDropout a no-op for every cell, including p=1."""
+
+    p = torch.tensor([0.5, 1.0])
+    layer = BatchedDropout(p)
+    layer.eval()
+    x = torch.ones(2, 100)
+    y = layer(x)
+    # Even cell with p=1 passes through identically in eval mode.
+    assert torch.equal(x, y)
+
+
+def test_batched_dropout_rejects_out_of_range_p():
+    """p values outside [0, 1] raise ValueError at construction."""
+
+    with pytest.raises(ValueError):
+        BatchedDropout(torch.tensor([0.1, 1.5]))
+    with pytest.raises(ValueError):
+        BatchedDropout(torch.tensor([-0.1, 0.5]))
 
 
 def test_buckets_preserve_first_seen_order():

--- a/tests/unit/test_forecaster_batched_hp.py
+++ b/tests/unit/test_forecaster_batched_hp.py
@@ -23,7 +23,10 @@ from app.training.batched_sweep import (  # noqa: E402
     BucketKey,
     bucket_key_for_candidate,
     group_candidates_into_buckets,
+    resolve_batching_mode,
     resolve_max_bucket_size,
+    route_bucket,
+    run_bucket_streams,
 )
 
 
@@ -321,6 +324,79 @@ def test_batched_adam_per_cell_weight_decay():
         ]
     )
     assert torch.allclose(params["w"], expected, atol=1e-7)
+
+
+def test_resolve_batching_mode_per_arch_table():
+    """auto routes per the per-arch table; explicit overrides are honoured."""
+
+    assert resolve_batching_mode("dlinear", mode="auto") == "stacked"
+    assert resolve_batching_mode("lstm", mode="auto") == "streams"
+    assert resolve_batching_mode("transformer", mode="auto") == "streams"
+    assert resolve_batching_mode("informer", mode="auto") == "streams"
+    # An explicit override takes precedence.
+    assert resolve_batching_mode("dlinear", mode="streams") == "streams"
+    assert resolve_batching_mode("lstm", mode="stacked") == "stacked"
+
+
+def test_route_bucket_falls_back_to_streams_when_not_capable(caplog):
+    """Explicit stacked on a non-stacked-capable arch falls back to streams.
+
+    The fallback logs a warning so a user typo on --batching-mode does
+    not silently bypass the per-arch capability gate.
+    """
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        decision = route_bucket("lstm", mode="stacked")
+    assert decision == "streams"
+    assert any("falling back to streams" in rec.message for rec in caplog.records)
+
+
+def test_run_bucket_streams_returns_per_cell_results():
+    """run_bucket_streams dispatches per-cell training and collects results.
+
+    The fake trainer here just echoes the trial index back. The
+    streams scheduler must invoke the trainer once per cell and
+    return the results in the bucket's input order, regardless of
+    thread completion timing.
+    """
+
+    cells = [
+        (10, {"id": "a"}),
+        (11, {"id": "b"}),
+        (12, {"id": "c"}),
+    ]
+
+    def _fake_train(trial_index, candidate, stream):
+        return {"trial_index": trial_index, "id": candidate["id"]}
+
+    results = run_bucket_streams(
+        cells,
+        train_one_cell=_fake_train,
+        device=torch.device("cpu"),
+    )
+    assert len(results) == 3
+    trial_indices = [r["trial_index"] for r in results]
+    assert sorted(trial_indices) == [10, 11, 12]
+
+
+def test_run_bucket_streams_surfaces_worker_exceptions():
+    """A failure in any worker thread is re-raised after every thread joins."""
+
+    cells = [(1, {"raise": False}), (2, {"raise": True})]
+
+    def _fake_train(trial_index, candidate, stream):
+        if candidate.get("raise"):
+            raise RuntimeError(f"cell {trial_index} failed")
+        return {"trial_index": trial_index}
+
+    with pytest.raises(RuntimeError, match="cell 2 failed"):
+        run_bucket_streams(
+            cells,
+            train_one_cell=_fake_train,
+            device=torch.device("cpu"),
+        )
 
 
 def test_batched_adam_active_mask_freezes_cells():

--- a/tests/unit/test_forecaster_batched_hp.py
+++ b/tests/unit/test_forecaster_batched_hp.py
@@ -1,0 +1,233 @@
+"""Unit tests for the bucketed-HP forecaster sweep primitives.
+
+The bucketed sweep groups cells that share the same model topology and
+data feed and trains them concurrently. The tests in this module pin
+the grouping contract (the bucket key axes, the deterministic ordering
+across bucket boundaries, and the per-arch bucket-size cap) plus the
+two stacked-mode primitives (per-cell dropout, per-cell Adam moments).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.config import ModelConfig  # noqa: E402
+from app.train_forecaster import build_sweep_candidates  # noqa: E402
+from app.training.batched_sweep import (  # noqa: E402
+    BucketKey,
+    bucket_key_for_candidate,
+    group_candidates_into_buckets,
+    resolve_max_bucket_size,
+)
+
+
+def _legacy_args(
+    *,
+    architectures: list[str],
+    seeds: list[int],
+    folds: list[str] | None = None,
+) -> argparse.Namespace:
+    """Minimal namespace shaped like the sweep-CLI invocation under test.
+
+    The dropout / lr / weight_decay grid below is the four-axis cross
+    product used by every test in this module: 2 dropouts x 2 learning
+    rates x 2 weight decays = 8 cells per (architecture, hidden_size,
+    num_layers) triple, which combined with the seed axis lets a
+    single bucket carry a known number of cells.
+    """
+
+    return argparse.Namespace(
+        hidden_size=64,
+        num_layers=2,
+        dropout=0.15,
+        learning_rate=1e-3,
+        epochs=20,
+        head_hidden_size=32,
+        hidden_sizes=[32, 64],
+        num_layers_grid=[1, 2],
+        dropouts=[0.1, 0.2],
+        learning_rates=[1e-3, 3e-4],
+        epochs_grid=[20],
+        weight_decay=1e-4,
+        weight_decays=[0.0, 1e-3],
+        text_adapter_dim=64,
+        text_adapter_dims=None,
+        text_encoder="none",
+        use_text_embeddings=True,
+        training_package_id=None,
+        rich_features=False,
+        architecture="lstm",
+        architectures=architectures,
+        seed=None,
+        seeds=seeds,
+        credibility_features=False,
+        random_search=False,
+        random_search_samples=50,
+        random_search_seed=42,
+        folds=folds,
+    )
+
+
+def test_bucket_key_groups_cells_by_topology():
+    """A synthetic sweep groups cells by (arch, hidden, layers, ...).
+
+    The grid is 2 archs x 2 hidden x 2 layers x 2 dropout x 2 lr x 2 wd
+    x 2 seeds = 128 cells across a single fold. The expected bucket
+    count is 2 archs x 2 hidden x 2 layers = 8 buckets (dropout / lr
+    / wd / seed are all within-bucket axes), 16 cells per bucket.
+    """
+
+    args = _legacy_args(architectures=["lstm", "gru"], seeds=[11, 29])
+    candidates = build_sweep_candidates(args)
+    assert len(candidates) == 128, (
+        "test fixture drift: expected 128 candidates from the "
+        f"2x2x2x2x2x2x2 grid; got {len(candidates)}"
+    )
+
+    buckets = group_candidates_into_buckets(
+        candidates,
+        text_encoder=None,
+        target_mode="event_study",
+        # Cap at 64 so the 16-cell buckets are not split.
+        max_bucket_size=64,
+    )
+
+    assert len(buckets) == 8, (
+        f"expected 8 buckets (2 archs x 2 hidden x 2 layers); got {len(buckets)}"
+    )
+    for key, cells in buckets:
+        # Each bucket should carry 2 dropout x 2 lr x 2 wd x 2 seeds
+        # = 16 cells.
+        assert len(cells) == 16, (
+            f"bucket {key} has {len(cells)} cells; expected 16"
+        )
+        # Within a bucket, every cell shares the bucket-key axes.
+        for _, candidate in cells:
+            assert candidate["model_config"].architecture == key.architecture
+            assert candidate["model_config"].hidden_size == key.hidden_size
+            assert candidate["model_config"].num_layers == key.num_layers
+
+
+def test_bucket_size_cap_respected():
+    """A 16-cell bucket splits into 4 sub-buckets at --max-bucket-size=4."""
+
+    args = _legacy_args(architectures=["lstm"], seeds=[11, 29])
+    candidates = build_sweep_candidates(args)
+    # 1 arch x 2 hidden x 2 layers = 4 BucketKeys at the topology
+    # level; each carries 2 dropout x 2 lr x 2 wd x 2 seeds = 16 cells.
+    # With cap=4 each bucket splits into 16 / 4 = 4 sub-buckets, so
+    # the total is 4 * 4 = 16 sub-buckets.
+    buckets = group_candidates_into_buckets(
+        candidates,
+        text_encoder=None,
+        target_mode="event_study",
+        max_bucket_size=4,
+    )
+    assert len(buckets) == 16, (
+        f"expected 16 sub-buckets at cap=4; got {len(buckets)}"
+    )
+    for _, cells in buckets:
+        assert len(cells) <= 4
+
+
+def test_bucket_key_distinguishes_folds():
+    """The fold axis is part of the bucket key.
+
+    With two folds and a single (arch, hidden, layers) triple, the
+    bucket count is 1 * 2 = 2 even though all other axes match.
+    """
+
+    args = _legacy_args(
+        architectures=["lstm"],
+        seeds=[11],
+        folds=["wf_fold_1", "wf_fold_2"],
+    )
+    candidates = build_sweep_candidates(args)
+    # 1 arch x 2 hidden x 2 layers x 2 folds = 4 buckets.
+    buckets = group_candidates_into_buckets(
+        candidates,
+        text_encoder=None,
+        target_mode="event_study",
+        max_bucket_size=64,
+    )
+    fold_ids = sorted({k.fold_id for k, _ in buckets if k.fold_id is not None})
+    assert fold_ids == ["wf_fold_1", "wf_fold_2"], (
+        f"expected both folds in the bucket key set; got {fold_ids}"
+    )
+
+
+def test_bucket_key_distinguishes_target_mode():
+    """The target_mode axis is part of the bucket key.
+
+    The sweep CLI runs one target_mode at a time, but the bucket key
+    still carries it so two sweep outputs concatenated together do
+    not accidentally collide their bucket cells.
+    """
+
+    candidate = {
+        "model_config": ModelConfig(
+            architecture="lstm",
+            hidden_size=64,
+            num_layers=2,
+            dropout=0.1,
+            head_hidden_size=32,
+        ),
+        "learning_rate": 1e-3,
+        "epochs": 20,
+        "weight_decay": 1e-4,
+        "seed": 11,
+    }
+    key_event = bucket_key_for_candidate(
+        candidate, text_encoder=None, target_mode="event_study"
+    )
+    key_realized = bucket_key_for_candidate(
+        candidate, text_encoder=None, target_mode="realized_return"
+    )
+    assert key_event != key_realized
+    assert key_event.target_mode == "event_study"
+    assert key_realized.target_mode == "realized_return"
+
+
+def test_resolve_max_bucket_size_per_arch_defaults():
+    """The per-arch table is the floor when no override is supplied."""
+
+    assert resolve_max_bucket_size("dlinear") == 64
+    assert resolve_max_bucket_size("lstm") == 32
+    assert resolve_max_bucket_size("transformer") == 8
+    assert resolve_max_bucket_size("informer") == 4
+    assert resolve_max_bucket_size("tft") == 4
+    # Unknown arch falls back to 4.
+    assert resolve_max_bucket_size("xxx_nonexistent") == 4
+
+    # Override beats the table.
+    assert resolve_max_bucket_size("dlinear", override=16) == 16
+    # Non-positive override is ignored.
+    assert resolve_max_bucket_size("dlinear", override=0) == 64
+
+
+def test_buckets_preserve_first_seen_order():
+    """Buckets emerge in first-seen order across the candidate stream.
+
+    The candidate enumeration is (arch, hidden, layers, dropout, lr,
+    wd, text_adapter, seed). With architectures=["lstm", "gru"] the
+    first eight buckets are all-lstm before the first gru bucket.
+    """
+
+    args = _legacy_args(architectures=["lstm", "gru"], seeds=[11])
+    candidates = build_sweep_candidates(args)
+    buckets = group_candidates_into_buckets(
+        candidates,
+        text_encoder=None,
+        target_mode="event_study",
+        max_bucket_size=64,
+    )
+    archs = [key.architecture for key, _ in buckets]
+    # The first 4 buckets are lstm (2 hidden x 2 layers), the next 4
+    # are gru. Sorted in first-seen order, lstm bucket boundary sits
+    # at index 4.
+    assert archs[:4] == ["lstm", "lstm", "lstm", "lstm"]
+    assert archs[4:] == ["gru", "gru", "gru", "gru"]


### PR DESCRIPTION
## Summary

- Buckets cells by (architecture, hidden_size, num_layers, text_adapter_dim, text_encoder, fold_id, target_mode); cells differing only on (dropout, lr, weight_decay, seed) train inside one bucket via a streams scheduler or the stacked-mode forward.
- BatchedDropout takes per-cell p tensors; BatchedAdamW takes per-cell lr and weight_decay tensors and supports an active_mask for early-stopped cells.
- Per-arch VRAM budget table caps bucket size (dlinear 64, lstm/gru/tcn 32, lstm_attn 16, transformer 8, informer/tft 4) and a per-arch routing table picks stacked vs streams; explicit stacked on a non-capable arch falls back to streams with a warning.
- Streams scheduler runs threads on CUDA streams inside one CUDA context; on CPU it collapses to a sequential loop so the per-cell global RNG stays deterministic.
- --batching-mode={auto, stacked, streams, off} flag; default off preserves the legacy per-process path verbatim (byte-identity regression contract).
- forecaster-sweep Makefile target switches to BATCHING_MODE=auto; forecaster-sweep-exhaustive pins --batching-mode=off --parallel-workers=1.
- 16 new unit tests + 3 stacked-vs-sequential numerical-parity regressions at +/- 1e-3.
- Real-package smoke: bucket grouping logs show cells batched (bucket_size=2-4 across lstm / gru / dlinear); dlinear routes to stacked, lstm and gru route to streams.

## Test plan

- [ ] `pytest tests/unit/test_forecaster_batched_hp.py tests/regression/test_forecaster_batched_parity.py tests/regression/test_forecaster_determinism.py tests/regression/test_forecaster_sweep_back_compat.py -q`
- [ ] Smoke emits per-bucket log lines; per-cell test_rmse matches the legacy sequential path within +/- 1e-3.
- [ ] `make forecaster-sweep TRAINING_PACKAGE_ID=... TEXT_ENCODER=none BATCHING_MODE=auto` exercises the new path end-to-end.

Follows #178.