### PR TITLE
Rich-feature data pipeline: credibility wiring + stance/gtfintechlab multi-axis slot + RobustScaler

### DIFF
--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -130,6 +130,7 @@ import argparse
 import datetime as _dt
 import hashlib
 import json
+import logging
 import math
 import sys
 from collections import defaultdict
@@ -262,6 +263,12 @@ class _EventDoc:
     text: str
     record_ids: list[str]
     multi_axis: dict[str, str | None]
+    # Populated from registry ``multi_axis_extras`` when available. Only the
+    # gtfintechlab cross-bank corpora carry these labels today; every other
+    # source leaves them ``None`` and downstream consumers encode them as
+    # 0.0 in the rich-feature slot.
+    time_label: str | None = None       # "forward looking" / "not forward looking"
+    certain_label: str | None = None    # "certain" / "uncertain"
 
     @property
     def source_record_id(self) -> str:
@@ -359,6 +366,14 @@ def _aggregate_events(rows: Iterable[_RegistryRow]) -> list[_EventDoc]:
             "factor": None,
             "topic": None,
         }
+        # gtfintechlab cross-bank corpora ship two extra categorical labels
+        # ("time_label" forward/not-forward, "certain_label" certain/uncertain)
+        # on ``multi_axis_extras``. Lift them into the event doc so the
+        # rich-feature loader can use them as Option-A indicators on the
+        # multi-axis slot. Initialised per bucket iteration to prevent any
+        # leakage between adjacent (source, date, kind) groups.
+        time_label: str | None = None
+        certain_label: str | None = None
         # Use the first row whose mapped_label or axes carry a value as the
         # document-level label. Deterministic because bucket is sorted.
         # ``val is not None`` (not truthy) preserves legitimate zeros for
@@ -375,8 +390,14 @@ def _aggregate_events(rows: Iterable[_RegistryRow]) -> list[_EventDoc]:
                     val = r.axes.get(axis_name)
                     if val is not None:
                         multi_axis[axis_name] = str(val)
-            # multi_axis_extras (Op-Fed opinion etc.) is recorded only via
-            # axes; the raw extras dict is not lifted into event rows.
+            if time_label is None:
+                candidate = r.multi_axis_extras.get("gtfintechlab_time_label")
+                if isinstance(candidate, str) and candidate.strip():
+                    time_label = candidate.strip().lower()
+            if certain_label is None:
+                candidate = r.multi_axis_extras.get("gtfintechlab_certain_label")
+                if isinstance(candidate, str) and candidate.strip():
+                    certain_label = candidate.strip().lower()
         docs.append(
             _EventDoc(
                 source=source,
@@ -385,9 +406,44 @@ def _aggregate_events(rows: Iterable[_RegistryRow]) -> list[_EventDoc]:
                 text=text,
                 record_ids=[r.source_record_id for r in bucket_sorted],
                 multi_axis=multi_axis,
+                time_label=time_label,
+                certain_label=certain_label,
             )
         )
     return docs
+
+
+_STANCE_SCORE: dict[str, float] = {"hawkish": 1.0, "dovish": -1.0, "neutral": 0.0}
+
+
+def _derive_stance_by_date(
+    registry_rows: Sequence[_RegistryRow],
+) -> tuple[tuple[str, float], ...]:
+    """Aggregate per-date stance scores from registry ``mapped_label``.
+
+    Encodes hawkish=+1, dovish=-1, neutral=0 and averages the score per
+    ``event_date`` so the credibility loader has a stance history to
+    correlate against the FRED-DFF realized path
+    (``realized_vs_stated_gap``) and to count sign flips for the
+    ``months_since_reversal`` axis. The auto-derivation is what previously
+    forced both axes to 0.0 — the CLI never exposed ``--stance-by-date``,
+    so every event_dataset_builder run before 2026-05-17 silently passed
+    an empty tuple.
+
+    Returns a chronologically-sorted tuple of (date_iso, mean_score)
+    pairs. Empty for packages where no row carries a mapped stance label.
+    """
+
+    by_date: dict[str, list[float]] = defaultdict(list)
+    for row in registry_rows:
+        score = _STANCE_SCORE.get((row.mapped_label or "").lower())
+        if score is None or not row.event_date:
+            continue
+        by_date[row.event_date].append(float(score))
+    return tuple(
+        (date, sum(scores) / len(scores))
+        for date, scores in sorted(by_date.items())
+    )
 
 
 def _choose_preferred(docs: list[_EventDoc]) -> list[_EventDoc]:
@@ -1081,6 +1137,8 @@ def _build_event_rows(
                 "axis_certainty": doc.multi_axis.get("certainty"),
                 "axis_factor": doc.multi_axis.get("factor"),
                 "axis_topic": doc.multi_axis.get("topic"),
+                "axis_time_label": doc.time_label,
+                "axis_certain_label": doc.certain_label,
                 "credibility_drift_score": float(cred.drift_score),
                 "credibility_realized_vs_stated_gap": float(cred.realized_vs_stated_gap),
                 "credibility_market_implied_gap": float(cred.market_implied_gap),
@@ -1111,6 +1169,9 @@ def _build_event_rows(
     return rows
 
 
+_CREDIBILITY_EMPTY_INPUTS_WARNED = False
+
+
 def _safe_credibility(as_of_ts: str, kwargs: dict[str, Any]) -> CredibilityVector:
     """Wrap ``load_credibility_for_run`` so missing inputs degrade to zeros.
 
@@ -1118,7 +1179,27 @@ def _safe_credibility(as_of_ts: str, kwargs: dict[str, Any]) -> CredibilityVecto
     but we still catch ValueError so a malformed ``as_of_ts`` placeholder
     never aborts the whole build. Documented behaviour: zero vector means
     "credibility unknown", not "credibility zero".
+
+    Logs a one-shot warning when ``embedding_path`` is None AND
+    ``stance_by_date`` is empty — that combination guarantees a zero
+    credibility vector and was the silent-failure mode in pre-2026-05-17
+    events.parquet builds.
     """
+
+    global _CREDIBILITY_EMPTY_INPUTS_WARNED
+    if (
+        not _CREDIBILITY_EMPTY_INPUTS_WARNED
+        and kwargs.get("embedding_path") is None
+        and not kwargs.get("stance_by_date")
+    ):
+        logging.getLogger(__name__).warning(
+            "credibility inputs empty (no embedding_path, no stance_by_date); "
+            "all four credibility axes will be 0.0 for every event. "
+            "Pass --embedding-path data/raw/embeddings/<encoder>_<rev>.parquet "
+            "to enable drift_score, and confirm the registry carries "
+            "mapped_label values so the auto-derived stance series is non-empty."
+        )
+        _CREDIBILITY_EMPTY_INPUTS_WARNED = True
 
     try:
         return load_credibility_for_run(as_of_ts=as_of_ts, **kwargs)
@@ -1146,6 +1227,8 @@ COLUMN_ORDER = (
     "axis_certainty",
     "axis_factor",
     "axis_topic",
+    "axis_time_label",
+    "axis_certain_label",
     "credibility_drift_score",
     "credibility_realized_vs_stated_gap",
     "credibility_market_implied_gap",
@@ -1211,6 +1294,16 @@ def build_event_rows(
         macro_release_calendar = _resolve_macro_calendar(macro_release_csv_path)
 
     registry_rows = _load_registry_rows(package_dir)
+
+    # Auto-derive a stance series from the registry when the caller did not
+    # supply one. The credibility loader needs this to compute
+    # ``realized_vs_stated_gap`` (Pearson against the FRED-DFF window) and
+    # ``months_since_reversal`` (sign flips); without it both axes degrade
+    # silently to 0.0. Explicit ``stance_by_date`` callers (tests, smoke
+    # runs) keep their override unchanged.
+    if not stance_by_date:
+        stance_by_date = _derive_stance_by_date(registry_rows)
+
     docs_all = _aggregate_events(registry_rows)
     docs = list(docs_all) if keep_all_sources else _choose_preferred(docs_all)
     if not docs:
@@ -1351,8 +1444,16 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--embedding-path",
-        default=None,
-        help="Optional per-encoder embedding parquet for credibility drift.",
+        default=str(
+            DEFAULT_DATA_DIR / "raw" / "embeddings" / "finbert_4556d1301521.parquet"
+        ),
+        help=(
+            "Per-encoder embedding parquet for the credibility drift axis. "
+            "Defaults to the cached FinBERT parquet so the builder is "
+            "batteries-included; pass 'none' (or an empty string) to skip "
+            "the drift computation. Non-'none' values must point at an "
+            "existing file -- missing-file is a hard error."
+        ),
     )
     parser.add_argument(
         "--fred-cache-dir",
@@ -1382,6 +1483,30 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _resolve_embedding_path(raw: str | None) -> Path | None:
+    """Resolve the ``--embedding-path`` CLI value.
+
+    Empty string or the literal ``"none"`` (case-insensitive) opts out of
+    the drift axis. Any other value must exist on disk -- a typo that
+    misses the cache parquet has to be a hard error so the
+    silent-zero-credibility regression from pre-2026-05-17 cannot recur.
+    """
+
+    if raw is None:
+        return None
+    cleaned = str(raw).strip()
+    if not cleaned or cleaned.lower() == "none":
+        return None
+    path = Path(cleaned)
+    if not path.exists():
+        raise SystemExit(
+            f"--embedding-path points at a missing file: {path}. "
+            "Pass 'none' to skip drift computation, or point at an existing "
+            "data/raw/embeddings/<encoder>_<rev>.parquet."
+        )
+    return path
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     package_dir = DEFAULT_DATA_DIR / "processed" / args.training_package_id
@@ -1407,7 +1532,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         horizons=horizons,
         market_cache_dir=market_cache_dir,
         concurrent_macro_window_days=int(args.concurrent_macro_window_days),
-        embedding_path=Path(args.embedding_path) if args.embedding_path else None,
+        embedding_path=_resolve_embedding_path(args.embedding_path),
         fred_cache_dir=Path(args.fred_cache_dir) if args.fred_cache_dir else None,
         summary=summary,
         macro_release_calendar=macro_calendar,
@@ -1443,7 +1568,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             horizons=horizons,
             market_cache_dir=market_cache_dir,
             concurrent_macro_window_days=int(args.concurrent_macro_window_days),
-            embedding_path=Path(args.embedding_path) if args.embedding_path else None,
+            embedding_path=_resolve_embedding_path(args.embedding_path),
             fred_cache_dir=Path(args.fred_cache_dir) if args.fred_cache_dir else None,
             summary=full_summary,
             macro_release_calendar=macro_calendar,

--- a/backend/app/data/schemas.py
+++ b/backend/app/data/schemas.py
@@ -466,6 +466,20 @@ _EVENT_ROW_COLUMNS: dict[str, Column] = {
         nullable=True,
         required=True,
     ),
+    # String indicators lifted off ``multi_axis_extras`` (only the
+    # gtfintechlab cross-bank corpora ship them today). Required=False
+    # so older events.parquet files validate; the loader treats absent
+    # columns as ``None`` everywhere.
+    "axis_time_label": Column(
+        checks=Check(_nullable_in_set({"forward looking", "not forward looking"})),
+        nullable=True,
+        required=False,
+    ),
+    "axis_certain_label": Column(
+        checks=Check(_nullable_in_set({"certain", "uncertain"})),
+        nullable=True,
+        required=False,
+    ),
     "credibility_drift_score": Column(float, nullable=False, required=True, coerce=True),
     "credibility_realized_vs_stated_gap": Column(
         float, nullable=False, required=True, coerce=True

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -192,6 +192,80 @@ class ModelConfig:
         return asdict(self)
 
 
+@dataclass(frozen=True)
+class RichFeatureScalerParams:
+    """Median + IQR fitted on the rich-feature block [FEATURE_SIZE:RICH_FEATURE_SIZE].
+
+    Fitted on the training slice only via
+    ``app.training.loaders.fit_rich_feature_scaler_tensor`` and persisted
+    into the checkpoint payload alongside ``close_scale`` so resume + the
+    inference path apply the same transform deterministically.
+
+    The scaler is a robust z-score ``(x - median) / iqr``. Constant
+    columns (IQR < ``epsilon`` on the train slice) get their IQR coerced
+    to ``1.0`` so the transform reduces to a pure centering step --
+    safe against the placeholder ``credibility_market_implied_gap``
+    (always 0.0 by contract today) and against any per-family ablation
+    that zeros a slot before the scaler sees it.
+    """
+
+    medians: tuple[float, ...]
+    iqrs: tuple[float, ...]
+    epsilon: float = 1e-6
+    fitted_at_utc: str = ""
+    n_train_observations: int = 0
+
+    def __post_init__(self) -> None:
+        if len(self.medians) != RICH_EXTRA_FEATURE_SIZE:
+            raise ValueError(
+                "RichFeatureScalerParams.medians must have length "
+                f"{RICH_EXTRA_FEATURE_SIZE}; got {len(self.medians)}"
+            )
+        if len(self.iqrs) != RICH_EXTRA_FEATURE_SIZE:
+            raise ValueError(
+                "RichFeatureScalerParams.iqrs must have length "
+                f"{RICH_EXTRA_FEATURE_SIZE}; got {len(self.iqrs)}"
+            )
+        for i, iqr in enumerate(self.iqrs):
+            if iqr <= 0.0:
+                raise ValueError(
+                    f"RichFeatureScalerParams.iqrs[{i}] must be positive "
+                    "(constant columns are floored to 1.0 at fit time); "
+                    f"got {iqr}"
+                )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "medians": list(self.medians),
+            "iqrs": list(self.iqrs),
+            "epsilon": float(self.epsilon),
+            "fitted_at_utc": str(self.fitted_at_utc),
+            "n_train_observations": int(self.n_train_observations),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> "RichFeatureScalerParams | None":
+        """Rehydrate from a checkpoint payload entry.
+
+        Returns ``None`` on any malformed input so legacy checkpoints
+        without the scaler key load cleanly under the unscaled-train
+        regression contract.
+        """
+
+        if not isinstance(data, dict) or not data:
+            return None
+        try:
+            return cls(
+                medians=tuple(float(x) for x in data["medians"]),
+                iqrs=tuple(float(x) for x in data["iqrs"]),
+                epsilon=float(data.get("epsilon", 1e-6)),
+                fitted_at_utc=str(data.get("fitted_at_utc", "")),
+                n_train_observations=int(data.get("n_train_observations", 0)),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+
 @dataclass
 class FeatureVector:
     """Per-bar feature row consumed by the forecaster.
@@ -222,12 +296,17 @@ class FeatureVector:
     - positions ``[25:29]`` -- MP-surprise 4-vector
       (``mp_surprise_level`` / ``mp_surprise_path_factor`` /
       ``fed_info_factor`` / ``mp_is_intermeeting``).
-    - positions ``[29:35]`` -- 6-dim multi-axis vector
-      (``axis_factor`` / ``axis_factor_missing`` /
-      ``axis_certainty`` / ``axis_certainty_missing`` /
-      ``axis_time`` / ``axis_time_missing``). NaN inputs collapse to
-      ``0.0`` and the paired ``*_missing`` flag flips to ``1.0`` so
-      the model can tell "no signal" apart from "neutral signal".
+    - positions ``[29:35]`` -- 6-dim Option-A multi-axis slot:
+      ``stance_hawk`` / ``stance_dove`` / ``stance_neutral`` (one-hot
+      from ``axis_stance`` on events.parquet) plus
+      ``time_label_forward`` / ``certain_label_certain`` (binary
+      indicators lifted off ``multi_axis_extras`` for gtfintechlab
+      cross-bank rows) plus ``stance_missing`` (1.0 when the stance
+      label is absent so the model can tell "unknown" apart from a
+      genuine neutral). Replaces the pre-2026-05-17 numeric axes
+      (``axis_factor`` / ``axis_certainty`` / ``axis_time``) that were
+      0% populated upstream. Slot size unchanged so existing checkpoints
+      load without state_dict reshape.
     """
 
     date: str
@@ -253,12 +332,17 @@ class FeatureVector:
     mp_surprise_path_factor: float = 0.0
     fed_info_factor: float = 0.0
     mp_is_intermeeting: float = 0.0
-    axis_factor: float = 0.0
-    axis_factor_missing: float = 1.0
-    axis_certainty: float = 0.0
-    axis_certainty_missing: float = 1.0
-    axis_time: float = 0.0
-    axis_time_missing: float = 1.0
+    # Option-A multi-axis slot (PR after 2026-05-17). Slot positions
+    # [29:35] in ``as_rich_list``; field-order in this dataclass is
+    # cosmetic. ``stance_missing`` defaults to 1.0 ("unknown" prior)
+    # so a default-constructed FeatureVector behaves as "no stance
+    # signal" rather than "stance=hawkish/dovish/neutral with weight 0".
+    stance_hawk: float = 0.0
+    stance_dove: float = 0.0
+    stance_neutral: float = 0.0
+    time_label_forward: float = 0.0
+    certain_label_certain: float = 0.0
+    stance_missing: float = 1.0
     rich_payload: bool = False
     # Pooled text-embedding payload (PR #176 onward). Carries the
     # variable-length encoder-output vector (FinBERT 768, voyage-finance-2
@@ -343,12 +427,12 @@ class FeatureVector:
             float(self.mp_is_intermeeting),
         ]
         multi_axis = [
-            float(self.axis_factor),
-            float(self.axis_factor_missing),
-            float(self.axis_certainty),
-            float(self.axis_certainty_missing),
-            float(self.axis_time),
-            float(self.axis_time_missing),
+            float(self.stance_hawk),
+            float(self.stance_dove),
+            float(self.stance_neutral),
+            float(self.time_label_forward),
+            float(self.certain_label_certain),
+            float(self.stance_missing),
         ]
         return market + credibility + linguistic + mp_surprise + multi_axis
 

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -46,6 +46,8 @@ from app.models.config import (
     ELAPSED_TIME_FEATURE_INDEX,
     FEATURE_SIZE,
     FORECAST_CONFIDENCE_LEVEL,
+    RICH_FEATURE_SIZE,
+    RichFeatureScalerParams,
     MODELS_DIR,
     SENTIMENT_FEATURE_INDEX,
     SEQUENCE_LENGTH,
@@ -138,9 +140,37 @@ def _set_singleton_after_train(
         )
 
 
+def _build_inference_tensor(
+    sequence: list[FeatureVector],
+    model: ForecasterModel,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build the per-event input tensor for one forward pass.
+
+    Dispatches on the loaded model's ``input_size``: rich-features
+    models (input_size == RICH_FEATURE_SIZE = 35) use
+    ``as_rich_list`` and apply the persisted RobustScaler from the
+    checkpoint metadata so inference matches training-time
+    normalisation. Legacy 6-feature models keep the byte-identical
+    ``as_list`` path so the existing /analyze contract is unchanged.
+    """
+
+    if int(getattr(model, "input_size", FEATURE_SIZE)) == RICH_FEATURE_SIZE:
+        rows = [item.as_rich_list() for item in sequence]
+        x = torch.tensor([rows], dtype=torch.float32, device=device)
+        scaler = (_model_artifact_metadata or {}).get("rich_feature_scaler")
+        if scaler is not None:
+            from app.training.loaders import apply_rich_feature_scaler_tensor
+
+            x = apply_rich_feature_scaler_tensor(x, scaler)
+        return x
+    rows = [item.as_list() for item in sequence]
+    return torch.tensor([rows], dtype=torch.float32, device=device)
+
+
 def _predict_next_point(model: ForecasterModel, sequence: list[FeatureVector]) -> tuple[float, float]:
     device = next(model.parameters()).device
-    x = torch.tensor([[item.as_list() for item in sequence]], dtype=torch.float32, device=device)
+    x = _build_inference_tensor(sequence, model, device)
     kwargs: dict[str, torch.Tensor] = {}
     if getattr(model, "credibility_features", False):
         # Inference-side credibility uses a zero vector by default; the live

--- a/backend/app/training/checkpoint.py
+++ b/backend/app/training/checkpoint.py
@@ -13,6 +13,7 @@ from app.models.config import (
     FEATURE_SIZE,
     SEQUENCE_LENGTH,
     ModelConfig,
+    RichFeatureScalerParams,
 )
 from app.models.lstm import ForecasterModel
 
@@ -126,6 +127,11 @@ def _checkpoint_metadata(
             if isinstance(payload, dict)
             else float(DEFAULT_CLOSE_SCALE)
         ),
+        "rich_feature_scaler": (
+            RichFeatureScalerParams.from_dict(payload.get("rich_feature_scaler"))
+            if isinstance(payload, dict)
+            else None
+        ),
         "sequence_length": (
             int(payload.get("sequence_length", SEQUENCE_LENGTH))
             if isinstance(payload, dict)
@@ -200,6 +206,7 @@ def _checkpoint_payload(
     summary: TrainingRunSummary,
     *,
     close_scale: float | None = None,
+    rich_feature_scaler: RichFeatureScalerParams | None = None,
 ) -> dict[str, Any]:
     """Build the dict torch.save writes for one trained model.
 
@@ -209,6 +216,13 @@ def _checkpoint_payload(
     not thread the fitted scale through (e.g. bare manifest exports) keep
     working unchanged. New callers always pass the fitted value so resume-
     from-checkpoint matches the training-time normalisation.
+
+    ``rich_feature_scaler`` is the RobustScaler (median + IQR) fitted in
+    ``app.training.loaders.fit_rich_feature_scaler_tensor`` over the
+    train slice of the rich-feature block [FEATURE_SIZE:RICH_FEATURE_SIZE].
+    ``None`` is the legacy 6-feature path -- it serialises to a literal
+    None key so the rehydration side returns no scaler and inference
+    falls back to the identity transform.
     """
 
     return {
@@ -220,6 +234,11 @@ def _checkpoint_payload(
         "input_size": FEATURE_SIZE,
         "sequence_length": SEQUENCE_LENGTH,
         "close_scale": float(close_scale) if close_scale is not None else float(DEFAULT_CLOSE_SCALE),
+        "rich_feature_scaler": (
+            rich_feature_scaler.to_dict()
+            if rich_feature_scaler is not None
+            else None
+        ),
         "rng_state": _capture_rng_state(),
     }
 
@@ -230,10 +249,16 @@ def _save_model_checkpoint(
     summary: TrainingRunSummary,
     *,
     close_scale: float | None = None,
+    rich_feature_scaler: RichFeatureScalerParams | None = None,
 ) -> None:
     checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(
-        _checkpoint_payload(model, summary, close_scale=close_scale),
+        _checkpoint_payload(
+            model,
+            summary,
+            close_scale=close_scale,
+            rich_feature_scaler=rich_feature_scaler,
+        ),
         checkpoint_path,
     )
     try:

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -18,7 +18,10 @@ from app.models.config import (
     DEFAULT_DATA_DIR,
     DEFAULT_TEXT_ADAPTER_DIM,
     DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS,
+    FEATURE_SIZE,
+    RICH_FEATURE_SIZE,
     RICH_LINGUISTIC_DIM,
+    RichFeatureScalerParams,
     SEQUENCE_LENGTH,
     FeatureVector,
 )
@@ -963,23 +966,43 @@ def _attach_rich_features(
     else:
         mp_level = mp_path = fed_info = mp_intermeeting = 0.0
 
-    # Multi-axis 6-vector (3 values + 3 missing flags). NaN flips the
-    # missing flag for that axis but the value still collapses to
-    # zero, so the model sees "no signal" rather than "neutral
-    # numeric value".
+    # Option-A multi-axis slot: stance one-hot + gtfintechlab indicators
+    # + stance_missing flag. Replaces the pre-2026-05-17 numeric axes
+    # (axis_factor / axis_certainty / axis_time) that were 0% populated
+    # upstream. ``use_multi_axis=False`` zeros every position including
+    # ``stance_missing`` so the per-family ablation reads as a true
+    # "no slot" rather than "stance is unknown".
     if use_multi_axis:
-        factor_raw = _coerce_finite_float(event_row.get("axis_factor"))
-        certainty_raw = _coerce_finite_float(event_row.get("axis_certainty"))
-        time_raw = _coerce_finite_float(event_row.get("axis_time"))
-        axis_factor = factor_raw if factor_raw is not None else 0.0
-        axis_factor_missing = 0.0 if factor_raw is not None else 1.0
-        axis_certainty = certainty_raw if certainty_raw is not None else 0.0
-        axis_certainty_missing = 0.0 if certainty_raw is not None else 1.0
-        axis_time = time_raw if time_raw is not None else 0.0
-        axis_time_missing = 0.0 if time_raw is not None else 1.0
+        stance_raw = event_row.get("axis_stance")
+        stance = (
+            str(stance_raw).strip().lower()
+            if isinstance(stance_raw, str) and stance_raw.strip()
+            else None
+        )
+        stance_hawk = 1.0 if stance == "hawkish" else 0.0
+        stance_dove = 1.0 if stance == "dovish" else 0.0
+        stance_neutral = 1.0 if stance == "neutral" else 0.0
+        stance_missing = 1.0 if stance is None else 0.0
+
+        time_raw = event_row.get("axis_time_label")
+        time_label_forward = (
+            1.0
+            if isinstance(time_raw, str)
+            and time_raw.strip().lower() == "forward looking"
+            else 0.0
+        )
+
+        certain_raw = event_row.get("axis_certain_label")
+        certain_label_certain = (
+            1.0
+            if isinstance(certain_raw, str)
+            and certain_raw.strip().lower() == "certain"
+            else 0.0
+        )
     else:
-        axis_factor = axis_certainty = axis_time = 0.0
-        axis_factor_missing = axis_certainty_missing = axis_time_missing = 0.0
+        stance_hawk = stance_dove = stance_neutral = 0.0
+        time_label_forward = certain_label_certain = 0.0
+        stance_missing = 0.0
 
     for vector in vectors:
         vector.credibility_drift_score = cred_drift
@@ -991,12 +1014,12 @@ def _attach_rich_features(
         vector.mp_surprise_path_factor = mp_path
         vector.fed_info_factor = fed_info
         vector.mp_is_intermeeting = mp_intermeeting
-        vector.axis_factor = axis_factor
-        vector.axis_factor_missing = axis_factor_missing
-        vector.axis_certainty = axis_certainty
-        vector.axis_certainty_missing = axis_certainty_missing
-        vector.axis_time = axis_time
-        vector.axis_time_missing = axis_time_missing
+        vector.stance_hawk = stance_hawk
+        vector.stance_dove = stance_dove
+        vector.stance_neutral = stance_neutral
+        vector.time_label_forward = time_label_forward
+        vector.certain_label_certain = certain_label_certain
+        vector.stance_missing = stance_missing
         vector.rich_payload = True
 
 
@@ -1860,6 +1883,84 @@ def load_training_sequences_from_package(
                 vector.text_embedding_missing = missing_flag
         sequences.append(vectors)
     return sequences
+
+
+def fit_rich_feature_scaler_tensor(
+    train_x: "torch.Tensor",
+    *,
+    epsilon: float = 1e-6,
+) -> "RichFeatureScalerParams | None":
+    """Fit per-column median + IQR over positions [FEATURE_SIZE:RICH_FEATURE_SIZE].
+
+    Operates on the TRAIN tensor only -- never call on val / test rows.
+    The walk-forward and legacy paths in ``app.training.loop`` both
+    honour this by fitting before any val / test transform is applied.
+    Quantiles are estimated over the full (n_windows x sequence_length)
+    population so each feature gets the maximum statistical mass; at
+    the small corpus size the autocorrelation tax is well under the
+    sparsity tax on the linguistic right tail.
+
+    Returns ``None`` when the tensor isn't rich-payload (input_dim
+    != ``RICH_FEATURE_SIZE``). Keeps the legacy 6-feature training
+    path byte-identical for the existing regression contract at
+    ``tests/regression/test_forecaster_determinism.py``.
+
+    Constant columns (IQR < ``epsilon`` on the train slice) get their
+    IQR coerced to ``1.0`` so the transform reduces to a pure
+    centering step. Catches the placeholder
+    ``credibility_market_implied_gap`` (always 0.0 by contract today)
+    and any per-family ablation that zeros a slot before fit time.
+    """
+
+    import numpy as np
+    from datetime import datetime, timezone
+
+    if train_x is None or train_x.numel() == 0:
+        return None
+    if train_x.shape[-1] != RICH_FEATURE_SIZE:
+        return None
+
+    flat = train_x.reshape(-1, RICH_FEATURE_SIZE)
+    rich_block = flat[:, FEATURE_SIZE:RICH_FEATURE_SIZE].detach().cpu().numpy()
+    medians = np.median(rich_block, axis=0)
+    q1 = np.quantile(rich_block, 0.25, axis=0)
+    q3 = np.quantile(rich_block, 0.75, axis=0)
+    iqrs = q3 - q1
+    iqrs = np.where(iqrs < epsilon, 1.0, iqrs)
+    return RichFeatureScalerParams(
+        medians=tuple(float(v) for v in medians.tolist()),
+        iqrs=tuple(float(v) for v in iqrs.tolist()),
+        epsilon=float(epsilon),
+        fitted_at_utc=datetime.now(timezone.utc).isoformat(),
+        n_train_observations=int(rich_block.shape[0]),
+    )
+
+
+def apply_rich_feature_scaler_tensor(
+    x: "torch.Tensor",
+    scaler: "RichFeatureScalerParams | None",
+) -> "torch.Tensor":
+    """Apply ``(x - median) / iqr`` to positions [FEATURE_SIZE:RICH_FEATURE_SIZE].
+
+    No-op when ``scaler`` is ``None`` or when the tensor isn't
+    rich-payload (input_dim != ``RICH_FEATURE_SIZE``). The market
+    block [0:FEATURE_SIZE] passes through untouched -- the
+    ``close_scale`` fitted in :func:`fit_close_scale` is the only
+    transform on the legacy six positions.
+    """
+
+    if scaler is None or x is None or x.numel() == 0:
+        return x
+    if x.shape[-1] != RICH_FEATURE_SIZE:
+        return x
+
+    medians = torch.tensor(scaler.medians, dtype=x.dtype, device=x.device)
+    iqrs = torch.tensor(scaler.iqrs, dtype=x.dtype, device=x.device)
+    out = x.clone()
+    out[..., FEATURE_SIZE:RICH_FEATURE_SIZE] = (
+        x[..., FEATURE_SIZE:RICH_FEATURE_SIZE] - medians
+    ) / iqrs
+    return out
 
 
 def fit_close_scale(sequence_groups: Sequence[Sequence[FeatureVector]]) -> float:

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -34,6 +34,8 @@ from app.training.loaders import (
     _build_text_embedding_tensors,
     _build_training_tensors,
     _split_train_validation,
+    apply_rich_feature_scaler_tensor,
+    fit_rich_feature_scaler_tensor,
     load_training_sequences_from_data,
 )
 
@@ -460,16 +462,25 @@ def train_model(
             fallback_text_in_dim=fallback_text_in_dim,
             close_scale=None,
         )
+        # Fit the rich-feature RobustScaler on the TRAIN tensor only;
+        # no-op for legacy 6-feature tensors so the regression contract
+        # at tests/regression/test_forecaster_determinism.py stays
+        # byte-identical. Apply to every partition with the same
+        # parameters so val + test see the train-time normalisation.
+        rich_feature_scaler = fit_rich_feature_scaler_tensor(train_x)
+        train_x = apply_rich_feature_scaler_tensor(train_x, rich_feature_scaler)
         val_x, val_y, _val_scale, val_text_emb, val_text_missing = _build_partition_tensors(
             val_groups,
             fallback_text_in_dim=fallback_text_in_dim,
             close_scale=close_scale,
         )
+        val_x = apply_rich_feature_scaler_tensor(val_x, rich_feature_scaler)
         test_x, test_y, _test_scale, test_text_emb, test_text_missing = _build_partition_tensors(
             test_groups,
             fallback_text_in_dim=fallback_text_in_dim,
             close_scale=close_scale,
         )
+        test_x = apply_rich_feature_scaler_tensor(test_x, rich_feature_scaler)
         sequence_groups_for_summary = train_groups + val_groups + test_groups
     else:
         if sequence_groups is not None:
@@ -531,6 +542,11 @@ def train_model(
             y = y[perm].clone()
 
         train_x, train_y, val_x, val_y = _split_train_validation(x, y, validation_split)
+        # Fit rich-feature scaler on the train slice; legacy 6-feature
+        # tensors short-circuit to no-op.
+        rich_feature_scaler = fit_rich_feature_scaler_tensor(train_x)
+        train_x = apply_rich_feature_scaler_tensor(train_x, rich_feature_scaler)
+        val_x = apply_rich_feature_scaler_tensor(val_x, rich_feature_scaler)
         if text_emb_tensor is not None and text_missing_tensor is not None:
             train_text_emb = text_emb_tensor[: len(train_x)]
             val_text_emb = text_emb_tensor[len(train_x) :]
@@ -878,7 +894,11 @@ def train_model(
         # the original price magnitude. The two values must agree byte-for-
         # byte across save/load — see the determinism regression test.
         _save_model_checkpoint(
-            work_model, checkpoint_target, summary, close_scale=close_scale
+            work_model,
+            checkpoint_target,
+            summary,
+            close_scale=close_scale,
+            rich_feature_scaler=rich_feature_scaler,
         )
         # Lazy-import the services facade so subsequent inference picks up the
         # freshly trained weights without a process restart. Doing this at the

--- a/tests/unit/test_event_dataset_builder_axis_labels.py
+++ b/tests/unit/test_event_dataset_builder_axis_labels.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from app.data.event_dataset_builder import (
+    _RegistryRow,
+    _aggregate_events,
+)
+
+
+def _row(
+    source: str,
+    event_date: str,
+    *,
+    mapped_label: str | None = "hawkish",
+    time_label: str | None = None,
+    certain_label: str | None = None,
+) -> _RegistryRow:
+    extras: dict[str, object] = {}
+    if time_label is not None:
+        extras["gtfintechlab_time_label"] = time_label
+    if certain_label is not None:
+        extras["gtfintechlab_certain_label"] = certain_label
+    return _RegistryRow(
+        source=source,
+        source_record_id=f"rec-{source}-{event_date}",
+        document_type="statement",
+        event_date=event_date,
+        text="dummy text",
+        mapped_label=mapped_label,
+        multi_axis_extras=extras,
+        axes={"stance": None, "time": None, "certainty": None, "factor": None, "topic": None},
+    )
+
+
+def test_aggregate_events_lifts_gtfintechlab_labels() -> None:
+    rows = [
+        _row(
+            "gtfintechlab_federal_reserve_system",
+            "2024-09-18",
+            time_label="forward looking",
+            certain_label="certain",
+        )
+    ]
+    docs = _aggregate_events(rows)
+    assert len(docs) == 1
+    doc = docs[0]
+    assert doc.time_label == "forward looking"
+    assert doc.certain_label == "certain"
+
+
+def test_aggregate_events_leaves_labels_none_for_non_gtfintechlab_rows() -> None:
+    rows = [_row("hf_fomc_communication", "2024-09-18")]
+    docs = _aggregate_events(rows)
+    assert docs[0].time_label is None
+    assert docs[0].certain_label is None
+
+
+def test_label_state_does_not_leak_across_buckets() -> None:
+    """A populated bucket must not leak its labels into the next iteration."""
+
+    rows = [
+        _row(
+            "gtfintechlab_federal_reserve_system",
+            "2024-09-18",
+            time_label="not forward looking",
+            certain_label="uncertain",
+        ),
+        # Different source + date — fresh bucket; labels must start at None.
+        _row("hf_fomc_communication", "2024-11-07"),
+    ]
+    docs = sorted(_aggregate_events(rows), key=lambda d: d.event_date)
+    assert docs[0].time_label == "not forward looking"
+    assert docs[0].certain_label == "uncertain"
+    assert docs[1].time_label is None
+    assert docs[1].certain_label is None
+
+
+def test_aggregate_events_lowercases_and_strips_label_strings() -> None:
+    rows = [
+        _row(
+            "gtfintechlab_federal_reserve_system",
+            "2024-09-18",
+            time_label="  Forward Looking  ",
+            certain_label="CERTAIN",
+        )
+    ]
+    docs = _aggregate_events(rows)
+    assert docs[0].time_label == "forward looking"
+    assert docs[0].certain_label == "certain"

--- a/tests/unit/test_event_dataset_builder_credibility.py
+++ b/tests/unit/test_event_dataset_builder_credibility.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+
+from app.data import event_dataset_builder as edb
+from app.data.event_dataset_builder import (
+    _RegistryRow,
+    _derive_stance_by_date,
+    _resolve_embedding_path,
+)
+
+
+def _row(event_date: str, mapped_label: str | None) -> _RegistryRow:
+    return _RegistryRow(
+        source="hf_fomc_communication",
+        source_record_id=f"rec-{event_date}-{mapped_label}",
+        document_type="fomc_statement",
+        event_date=event_date,
+        text="dummy",
+        mapped_label=mapped_label,
+        multi_axis_extras={},
+        axes={"stance": None, "time": None, "certainty": None, "factor": None, "topic": None},
+    )
+
+
+def test_derive_stance_by_date_returns_sorted_means() -> None:
+    rows = [
+        _row("2024-09-18", "hawkish"),
+        _row("2024-09-18", "neutral"),
+        _row("2024-07-31", "dovish"),
+        _row("2024-11-07", "hawkish"),
+    ]
+    out = _derive_stance_by_date(rows)
+    assert out == (
+        ("2024-07-31", -1.0),
+        ("2024-09-18", 0.5),    # mean of hawkish (1.0) + neutral (0.0)
+        ("2024-11-07", 1.0),
+    )
+
+
+def test_derive_stance_by_date_drops_unmapped_rows() -> None:
+    rows = [
+        _row("2024-09-18", None),                # unmapped → skipped
+        _row("2024-09-18", "not-a-stance"),      # unknown label → skipped
+        _row("2024-09-18", "hawkish"),
+    ]
+    out = _derive_stance_by_date(rows)
+    assert out == (("2024-09-18", 1.0),)
+
+
+def test_derive_stance_by_date_empty_on_zero_mapped_rows() -> None:
+    rows = [_row("2024-09-18", None), _row("2024-11-07", None)]
+    assert _derive_stance_by_date(rows) == ()
+
+
+def test_resolve_embedding_path_none_sentinel(tmp_path) -> None:
+    assert _resolve_embedding_path(None) is None
+    assert _resolve_embedding_path("") is None
+    assert _resolve_embedding_path("none") is None
+    assert _resolve_embedding_path("NONE") is None
+    assert _resolve_embedding_path("  None  ") is None
+
+
+def test_resolve_embedding_path_existing_file(tmp_path) -> None:
+    p = tmp_path / "fake.parquet"
+    p.write_bytes(b"")
+    assert _resolve_embedding_path(str(p)) == p
+
+
+def test_resolve_embedding_path_missing_file_is_hard_error(tmp_path) -> None:
+    missing = tmp_path / "no-such-file.parquet"
+    with pytest.raises(SystemExit) as exc_info:
+        _resolve_embedding_path(str(missing))
+    assert "missing" in str(exc_info.value).lower()
+
+
+def test_safe_credibility_logs_warning_when_inputs_empty(caplog) -> None:
+    edb._CREDIBILITY_EMPTY_INPUTS_WARNED = False
+    with caplog.at_level("WARNING", logger="app.data.event_dataset_builder"):
+        edb._safe_credibility(
+            "2024-09-18T14:00:00+00:00",
+            {"embedding_path": None, "stance_by_date": (), "fred_cache_dir": None},
+        )
+    assert any(
+        "credibility inputs empty" in rec.message for rec in caplog.records
+    )

--- a/tests/unit/test_feature_vector_as_rich_list.py
+++ b/tests/unit/test_feature_vector_as_rich_list.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from app.models.config import FeatureVector, RICH_FEATURE_SIZE
+
+
+def _base_vector(**overrides) -> FeatureVector:
+    base = dict(
+        date="2024-09-18",
+        sentiment_score=0.42,
+        market_close=4321.0,
+        market_volatility=0.01,
+    )
+    base.update(overrides)
+    return FeatureVector(**base)
+
+
+def test_as_rich_list_length_is_thirty_five() -> None:
+    fv = _base_vector()
+    assert len(fv.as_rich_list()) == RICH_FEATURE_SIZE == 35
+
+
+def test_option_a_slot_default_is_stance_missing() -> None:
+    fv = _base_vector()
+    slot = fv.as_rich_list()[29:35]
+    assert slot == [0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+
+
+def test_option_a_slot_emits_in_documented_order() -> None:
+    fv = _base_vector(
+        stance_hawk=1.0,
+        stance_dove=0.0,
+        stance_neutral=0.0,
+        time_label_forward=1.0,
+        certain_label_certain=1.0,
+        stance_missing=0.0,
+    )
+    assert fv.as_rich_list()[29:35] == [1.0, 0.0, 0.0, 1.0, 1.0, 0.0]
+
+
+@pytest.mark.parametrize(
+    "stance_fields,expected_one_hot",
+    [
+        ({"stance_hawk": 1.0}, [1.0, 0.0, 0.0]),
+        ({"stance_dove": 1.0}, [0.0, 1.0, 0.0]),
+        ({"stance_neutral": 1.0}, [0.0, 0.0, 1.0]),
+    ],
+)
+def test_stance_one_hot_positions(
+    stance_fields: dict[str, float],
+    expected_one_hot: list[float],
+) -> None:
+    fv = _base_vector(stance_missing=0.0, **stance_fields)
+    assert fv.as_rich_list()[29:32] == expected_one_hot
+
+
+def test_market_block_unchanged_at_positions_zero_to_six() -> None:
+    fv = _base_vector(stance_hawk=1.0, stance_missing=0.0)
+    rich = fv.as_rich_list()
+    legacy = fv.as_list()
+    assert rich[:6] == legacy

--- a/tests/unit/test_rich_feature_scaler.py
+++ b/tests/unit/test_rich_feature_scaler.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+torch = pytest.importorskip("torch")
+np = pytest.importorskip("numpy")
+
+from app.models.config import (
+    FEATURE_SIZE,
+    RICH_EXTRA_FEATURE_SIZE,
+    RICH_FEATURE_SIZE,
+    RichFeatureScalerParams,
+)
+from app.training.loaders import (
+    apply_rich_feature_scaler_tensor,
+    fit_rich_feature_scaler_tensor,
+)
+
+
+# ---------------------------------------------------------------------------
+# RichFeatureScalerParams dataclass
+# ---------------------------------------------------------------------------
+
+
+def _ones_params(**overrides):
+    base = dict(
+        medians=tuple(0.0 for _ in range(RICH_EXTRA_FEATURE_SIZE)),
+        iqrs=tuple(1.0 for _ in range(RICH_EXTRA_FEATURE_SIZE)),
+        epsilon=1e-6,
+        fitted_at_utc="2026-05-17T00:00:00Z",
+        n_train_observations=100,
+    )
+    base.update(overrides)
+    return RichFeatureScalerParams(**base)
+
+
+def test_dataclass_round_trips_through_dict() -> None:
+    params = _ones_params(
+        medians=tuple(float(i) for i in range(RICH_EXTRA_FEATURE_SIZE)),
+        iqrs=tuple(0.5 + i for i in range(RICH_EXTRA_FEATURE_SIZE)),
+    )
+    restored = RichFeatureScalerParams.from_dict(params.to_dict())
+    assert restored is not None
+    assert restored.medians == params.medians
+    assert restored.iqrs == params.iqrs
+    assert restored.epsilon == params.epsilon
+    assert restored.fitted_at_utc == params.fitted_at_utc
+    assert restored.n_train_observations == params.n_train_observations
+
+
+def test_dataclass_rejects_wrong_length_medians() -> None:
+    with pytest.raises(ValueError, match="medians"):
+        RichFeatureScalerParams(
+            medians=(0.0, 0.0),  # too short
+            iqrs=tuple(1.0 for _ in range(RICH_EXTRA_FEATURE_SIZE)),
+        )
+
+
+def test_dataclass_rejects_non_positive_iqr() -> None:
+    bad_iqrs = list(1.0 for _ in range(RICH_EXTRA_FEATURE_SIZE))
+    bad_iqrs[3] = 0.0
+    with pytest.raises(ValueError, match=r"iqrs\[3\]"):
+        RichFeatureScalerParams(
+            medians=tuple(0.0 for _ in range(RICH_EXTRA_FEATURE_SIZE)),
+            iqrs=tuple(bad_iqrs),
+        )
+
+
+@pytest.mark.parametrize("payload", [None, {}, [], "string", 12, {"medians": [0.0]}])
+def test_from_dict_returns_none_on_malformed(payload) -> None:
+    assert RichFeatureScalerParams.from_dict(payload) is None
+
+
+# ---------------------------------------------------------------------------
+# fit_rich_feature_scaler_tensor
+# ---------------------------------------------------------------------------
+
+
+def test_fit_returns_none_for_legacy_six_feature_tensor() -> None:
+    x = torch.randn(8, 20, FEATURE_SIZE)
+    assert fit_rich_feature_scaler_tensor(x) is None
+
+
+def test_fit_returns_none_for_empty_tensor() -> None:
+    x = torch.empty(0, 20, RICH_FEATURE_SIZE)
+    assert fit_rich_feature_scaler_tensor(x) is None
+    assert fit_rich_feature_scaler_tensor(None) is None  # type: ignore[arg-type]
+
+
+def test_fit_recovers_known_median_and_iqr() -> None:
+    """Construct a tensor where every rich column has known stats."""
+    # 100 windows x 1 bar each → 100 observations per column
+    n = 100
+    market = torch.zeros(n, 1, FEATURE_SIZE)
+    # Rich block: column 0 is values 0..99, column 1 is 100..199, etc.
+    rich = torch.stack(
+        [torch.arange(n).float() + col * n for col in range(RICH_EXTRA_FEATURE_SIZE)],
+        dim=1,
+    ).unsqueeze(1)  # shape (n, 1, RICH_EXTRA_FEATURE_SIZE)
+    x = torch.cat([market, rich], dim=-1)
+
+    params = fit_rich_feature_scaler_tensor(x)
+    assert params is not None
+    assert params.n_train_observations == n
+    # For values 0..99, the median is 49.5 and IQR is (74.75 - 24.75) = 50.0
+    # numpy uses linear interpolation by default; allow a tiny tolerance.
+    for col in range(RICH_EXTRA_FEATURE_SIZE):
+        expected_median = 49.5 + col * n
+        expected_iqr = 49.5  # numpy linear-interp IQR for 0..99
+        assert math.isclose(params.medians[col], expected_median, abs_tol=1e-6)
+        assert math.isclose(params.iqrs[col], expected_iqr, abs_tol=1e-6)
+
+
+def test_fit_floors_constant_column_iqr_to_one() -> None:
+    """A column whose IQR is 0 must not produce divide-by-zero downstream."""
+    n = 50
+    x = torch.zeros(n, 20, RICH_FEATURE_SIZE)
+    # Column 4 of the rich block has a real distribution; everything else
+    # stays at the constant 0.0 so its IQR is 0 → must be floored to 1.0.
+    x[..., FEATURE_SIZE + 4] = torch.arange(20).float().unsqueeze(0).expand(n, 20)
+    params = fit_rich_feature_scaler_tensor(x)
+    assert params is not None
+    for col in range(RICH_EXTRA_FEATURE_SIZE):
+        if col == 4:
+            assert params.iqrs[col] > 1.0
+        else:
+            assert params.iqrs[col] == 1.0   # floored
+
+
+def test_fit_records_n_train_observations_over_all_bars() -> None:
+    """Stats are estimated over (n_windows * sequence_length) population."""
+    n_windows = 7
+    seq_len = 13
+    x = torch.randn(n_windows, seq_len, RICH_FEATURE_SIZE)
+    params = fit_rich_feature_scaler_tensor(x)
+    assert params is not None
+    assert params.n_train_observations == n_windows * seq_len
+
+
+# ---------------------------------------------------------------------------
+# apply_rich_feature_scaler_tensor
+# ---------------------------------------------------------------------------
+
+
+def test_apply_is_noop_when_scaler_is_none() -> None:
+    x = torch.randn(4, 20, RICH_FEATURE_SIZE)
+    out = apply_rich_feature_scaler_tensor(x, None)
+    assert torch.equal(out, x)
+
+
+def test_apply_is_noop_for_legacy_six_feature_tensor() -> None:
+    """Even with a scaler, a 6-dim tensor must pass through unchanged."""
+    params = _ones_params()
+    x = torch.randn(4, 20, FEATURE_SIZE)
+    out = apply_rich_feature_scaler_tensor(x, params)
+    assert torch.equal(out, x)
+
+
+def test_apply_market_block_passes_through() -> None:
+    params = _ones_params(medians=tuple(10.0 for _ in range(RICH_EXTRA_FEATURE_SIZE)))
+    x = torch.randn(5, 20, RICH_FEATURE_SIZE)
+    out = apply_rich_feature_scaler_tensor(x, params)
+    assert torch.equal(out[..., :FEATURE_SIZE], x[..., :FEATURE_SIZE])
+
+
+def test_apply_rich_block_is_z_scored() -> None:
+    """(x - median) / iqr applied column-wise to the rich block."""
+    medians = tuple(float(i) for i in range(RICH_EXTRA_FEATURE_SIZE))
+    iqrs = tuple(float(i + 1) for i in range(RICH_EXTRA_FEATURE_SIZE))
+    params = _ones_params(medians=medians, iqrs=iqrs)
+    x = torch.ones(2, 3, RICH_FEATURE_SIZE) * 5.0
+    out = apply_rich_feature_scaler_tensor(x, params)
+    for col in range(RICH_EXTRA_FEATURE_SIZE):
+        expected = (5.0 - medians[col]) / iqrs[col]
+        assert torch.allclose(out[..., FEATURE_SIZE + col], torch.tensor(expected))
+
+
+def test_fit_then_apply_yields_unit_iqr_on_train_slice() -> None:
+    """Round-trip invariant: applying the scaler to its own train slice
+    should produce a slice whose IQR is ~1.0 column-wise."""
+    n_windows = 80
+    seq_len = 20
+    # Use a fixed seed so the IQR estimate is stable.
+    g = torch.Generator()
+    g.manual_seed(11)
+    x = torch.randn(n_windows, seq_len, RICH_FEATURE_SIZE, generator=g) * 5.0
+
+    params = fit_rich_feature_scaler_tensor(x)
+    assert params is not None
+    out = apply_rich_feature_scaler_tensor(x, params)
+    rich_block = out[..., FEATURE_SIZE:RICH_FEATURE_SIZE].reshape(
+        -1, RICH_EXTRA_FEATURE_SIZE
+    ).numpy()
+    q1 = np.quantile(rich_block, 0.25, axis=0)
+    q3 = np.quantile(rich_block, 0.75, axis=0)
+    iqrs = q3 - q1
+    assert np.allclose(iqrs, 1.0, atol=1e-5)
+
+
+def test_apply_preserves_dtype_and_device() -> None:
+    params = _ones_params()
+    x = torch.randn(2, 3, RICH_FEATURE_SIZE, dtype=torch.float64)
+    out = apply_rich_feature_scaler_tensor(x, params)
+    assert out.dtype == torch.float64
+    assert out.device == x.device

--- a/tests/unit/test_training_package_loader.py
+++ b/tests/unit/test_training_package_loader.py
@@ -65,6 +65,8 @@ def _event_row(
     realized_date: str,
     base_close: float,
     horizon: int = 1,
+    axis_time_label: str | None = None,
+    axis_certain_label: str | None = None,
 ) -> dict:
     return {
         "event_date": event_date,
@@ -81,6 +83,8 @@ def _event_row(
         "axis_certainty": None,
         "axis_factor": None,
         "axis_topic": None,
+        "axis_time_label": axis_time_label,
+        "axis_certain_label": axis_certain_label,
         "credibility_drift_score": 0.0,
         "credibility_realized_vs_stated_gap": 0.0,
         "credibility_market_implied_gap": 0.0,
@@ -531,28 +535,36 @@ def rich_feature_package_dir(tmp_path: Path, monkeypatch) -> Path:
     monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
 
     events = []
-    for text_hash, event_date, realized_date, base_close, base, factor, certainty in (
-        ("hash_a", "2024-01-31", "2024-02-01", 4400.0, 0.10, 0.25, 0.5),
-        ("hash_b", "2024-02-15", "2024-02-16", 4500.0, 0.20, -0.40, 0.8),
-        ("hash_no_ling", "2024-03-15", "2024-03-16", 4600.0, 0.30, 0.10, 0.2),
+    for (
+        text_hash,
+        event_date,
+        realized_date,
+        base_close,
+        base,
+        stance,
+        time_label,
+        certain_label,
+    ) in (
+        ("hash_a", "2024-01-31", "2024-02-01", 4400.0, 0.10, "hawkish", "forward looking", "certain"),
+        ("hash_b", "2024-02-15", "2024-02-16", 4500.0, 0.20, "dovish", "not forward looking", "uncertain"),
+        ("hash_no_ling", "2024-03-15", "2024-03-16", 4600.0, 0.30, "neutral", None, None),
     ):
         row = _event_row(
             event_date=event_date,
             text_hash=text_hash,
-            axis_stance="hawkish",
+            axis_stance=stance,
             realized_return=0.001,
             realized_date=realized_date,
             base_close=base_close,
+            axis_time_label=time_label,
+            axis_certain_label=certain_label,
         )
-        # Pin credibility + multi-axis to distinguishable, non-zero
-        # values so the per-bar slice assertions are observable.
+        # Pin credibility to distinguishable non-zero values so the
+        # per-bar slice assertions remain observable.
         row["credibility_drift_score"] = base + 0.001
         row["credibility_realized_vs_stated_gap"] = base + 0.002
         row["credibility_market_implied_gap"] = base + 0.003
         row["credibility_months_since_reversal"] = int(base * 10)
-        row["axis_factor"] = factor
-        row["axis_certainty"] = certainty
-        row["axis_time"] = base + 0.5
         events.append(row)
     pd.DataFrame(events).to_parquet(package_dir / "events.parquet", index=False)
     pd.DataFrame(
@@ -622,8 +634,11 @@ def test_rich_features_emit_35_per_bar(rich_feature_package_dir: Path) -> None:
     # hash_a has base=0.10 in the mp parquet (is_intermeeting=False).
     assert mp_slice == pytest.approx([0.101, 0.102, 0.103, 0.0])
     multi_axis_slice = rich[RICH_MULTI_AXIS_SLICE]
-    # All three axes present -> missing flags zero.
-    assert multi_axis_slice == pytest.approx([0.25, 0.0, 0.5, 0.0, 0.6, 0.0])
+    # Option-A slot: [stance_hawk, stance_dove, stance_neutral,
+    # time_label_forward, certain_label_certain, stance_missing].
+    # hash_a fixture: stance="hawkish", time="forward looking",
+    # certain="certain" -> 1, 0, 0, 1, 1, 0.
+    assert multi_axis_slice == pytest.approx([1.0, 0.0, 0.0, 1.0, 1.0, 0.0])
 
 
 def test_rich_features_missing_linguistic_row_zeros_and_flags(
@@ -648,7 +663,9 @@ def test_rich_features_missing_linguistic_row_zeros_and_flags(
     target = no_ling_sequence[-1].as_rich_list()
     assert target[RICH_CREDIBILITY_SLICE][0] == pytest.approx(0.301)
     assert target[RICH_MP_SURPRISE_SLICE][0] == pytest.approx(0.301)
-    assert target[RICH_MULTI_AXIS_SLICE][2] == pytest.approx(0.2)
+    # hash_no_ling fixture: stance="neutral", no gtfintechlab labels.
+    # Slot position 2 is the stance_neutral one-hot bit -> 1.0.
+    assert target[RICH_MULTI_AXIS_SLICE][2] == pytest.approx(1.0)
 
 
 def test_rich_features_per_family_ablation_zeros_correct_slice(
@@ -677,13 +694,14 @@ def test_rich_features_per_family_ablation_zeros_correct_slice(
     hash_a_target = by_target_date["2024-02-01"][-1].as_rich_list()
     assert hash_a_target[RICH_LINGUISTIC_SLICE][0] == pytest.approx(0.11)
     assert hash_a_target[RICH_MP_SURPRISE_SLICE][0] == pytest.approx(0.101)
-    assert hash_a_target[RICH_MULTI_AXIS_SLICE][0] == pytest.approx(0.25)
+    # hash_a fixture: stance="hawkish" -> Option-A slot[0] = stance_hawk = 1.0.
+    assert hash_a_target[RICH_MULTI_AXIS_SLICE][0] == pytest.approx(1.0)
 
 
 def test_rich_features_multi_axis_missing_flips_missing_flag(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """NaN multi-axis fields collapse to zero and flip the missing flag."""
+    """Absent ``axis_stance`` flips the ``stance_missing`` flag to 1.0."""
 
     package_id = "tp_unit_multi_axis_missing_v0"
     package_dir = tmp_path / "processed" / package_id
@@ -693,14 +711,15 @@ def test_rich_features_multi_axis_missing_flips_missing_flag(
     row = _event_row(
         event_date="2024-04-30",
         text_hash="hash_nan_axes",
-        axis_stance="neutral",
+        axis_stance=None,
         realized_return=0.0,
         realized_date="2024-05-01",
         base_close=4700.0,
     )
-    # axis_factor / axis_certainty / axis_time stay None (default
-    # from ``_event_row``); the loader must collapse them to 0.0 and
-    # flip each *_missing flag to 1.0.
+    # ``axis_time_label`` / ``axis_certain_label`` default to None;
+    # the loader emits 0.0 in each indicator position and trips the
+    # ``stance_missing`` flag (slot position 5) because ``axis_stance``
+    # is also absent.
     pd.DataFrame([row]).to_parquet(package_dir / "events.parquet", index=False)
     pd.DataFrame(
         [{"text_hash": "hash_nan_axes", "split_tag": "train"}]
@@ -712,9 +731,10 @@ def test_rich_features_multi_axis_missing_flips_missing_flag(
     assert len(sequences) == 1
     target = sequences[0][-1].as_rich_list()
     multi_axis = target[RICH_MULTI_AXIS_SLICE]
-    # axis_factor, axis_factor_missing, axis_certainty,
-    # axis_certainty_missing, axis_time, axis_time_missing
-    assert multi_axis == pytest.approx([0.0, 1.0, 0.0, 1.0, 0.0, 1.0])
+    # Option-A slot: [stance_hawk, stance_dove, stance_neutral,
+    # time_label_forward, certain_label_certain, stance_missing].
+    # All inputs absent -> only stance_missing fires.
+    assert multi_axis == pytest.approx([0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
 
 
 def test_no_rich_features_reproduces_legacy_6dim_path(


### PR DESCRIPTION
## Summary

- `credibility_drift_score` / `realized_vs_stated_gap` / `months_since_reversal` were silently zero on every events.parquet row — CLI never wired stance_by_date and `--embedding-path` defaulted to None. Now auto-derived from the registry; `--embedding-path` defaults to the cached FinBERT parquet.
- Multi-axis slot [29:35] was reading the never-populated numeric `axis_factor/certainty/time` columns. Reused for Option A: stance one-hot from `axis_stance` + `time_label_forward` / `certain_label_certain` from gtfintechlab labels + `stance_missing` flag. `RICH_FEATURE_SIZE` stays 35.
- New `RichFeatureScalerParams` (median + IQR) fit on TRAIN tensor only over the rich block [6:35], floored at `epsilon=1e-6` to defuse constant-column divide-by-zero, persisted into the checkpoint, applied on the inference path.
- Legacy 6-feature path stays byte-identical (regression contract preserved).
- 935 unit tests pass; new `test_rich_feature_scaler.py`, `test_event_dataset_builder_credibility.py`, `test_event_dataset_builder_axis_labels.py`, `test_feature_vector_as_rich_list.py`. Existing `test_training_package_loader.py` rich-feature tests updated for Option-A semantics.

## Post-rebuild events.parquet stats

| Axis | non-zero rows | range |
|---|---:|---|
| credibility_drift_score | 99.9% | [0, 1.21] |
| credibility_realized_vs_stated_gap | 50.4% | [-0.37, 0.31] |
| credibility_months_since_reversal | 99.7% | [0, 12] |
| credibility_market_implied_gap | 0% | placeholder (SEP/Eurodollar scraper out of scope) |
| axis_time_label populated | 116 / 4103 (gtfintechlab) | — |
| axis_certain_label populated | 116 / 4103 (gtfintechlab) | — |

## Test plan

- [ ] `docker compose run --rm backend pytest tests/unit -q`
- [ ] `docker compose run --rm backend python -m app.data.event_dataset_builder --training-package-id tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0` then inspect `describe()` on credibility + axis_*_label columns

## Out of scope

- `credibility_market_implied_gap` SEP/Eurodollar scraper.
- Rich-features end-to-end at `/analyze` (only inference dispatch is in this PR; rich-features `/analyze` flow needs separate work on `services/forecaster.py` feature builder).
- `tests/e2e/test_api_e2e.py::test_analyze_contract_e2e_with_real_forecaster` payload-keys mismatch — pre-existing, unrelated to this branch.