### PR TITLE
Directional classification metrics on every eval pass

### DIFF
--- a/backend/app/evaluation/directional_metrics.py
+++ b/backend/app/evaluation/directional_metrics.py
@@ -1,0 +1,218 @@
+"""Directional classification metrics derived from continuous forecaster output.
+
+The Phase 9 reframe (#184) shifts the headline metric from `close_rmse`
+(a noisy continuous target dominated by random-walk variance) to the
+sign of the next-day move. This module turns the existing regression
+head's output into a directional classification view, so we can read a
+``direction_accuracy`` number off any sweep without retraining a
+classification head.
+
+Decision: predicted direction is ``sign(predicted_close - prev_close)``.
+Ground-truth direction is whatever the caller passes in via
+``true_direction`` -- typically ``direction_t1d`` from
+``events.parquet`` (the t+1 trading-day signed move). For continuous
+inputs there is no tie-breaking ambiguity because the float space is
+dense enough that ``pred == prev`` is essentially measure-zero; the
+helper still defends with an explicit ``epsilon`` floor for
+numerical-noise rows.
+
+The helper is dependency-light by design: it takes plain Python /
+numpy / torch arrays and returns plain floats, so it slots into both
+the training-time eval loop and a post-hoc CLI without dragging in
+the rest of the training-loop module.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def compute_directional_metrics(
+    pred_close: Any,
+    true_close: Any,
+    prev_close: Any,
+    *,
+    epsilon: float = 0.0,
+) -> dict[str, float | None]:
+    """Return ``direction_accuracy`` + ``f1_macro`` + ``direction_auc``.
+
+    Parameters
+    ----------
+    pred_close, true_close, prev_close :
+        1-D iterables (numpy array, torch tensor, or list) of length N.
+        ``prev_close`` is the closing price the model was conditioned on
+        (the last bar of the input sequence on the unscaled price
+        axis). ``pred_close`` and ``true_close`` are the corresponding
+        predicted vs realised closes for the same N events.
+    epsilon :
+        Magnitude threshold below which a predicted change is treated
+        as ``0`` (flat). Defaults to ``0.0`` so any non-zero predicted
+        delta picks a side. Set to a small positive number (e.g.
+        ``1e-6``) if numerical noise rows should map to "flat" rather
+        than picking an arbitrary sign.
+
+    Returns
+    -------
+    dict with three floats:
+
+    - ``direction_accuracy`` -- fraction of events where
+      ``sign(pred_close - prev_close) == sign(true_close - prev_close)``.
+      Baseline = the majority-class fraction in the realised set (the
+      project's events.parquet sits at ~53.7% +1 so the bar is 0.537).
+    - ``f1_macro`` -- unweighted-mean F1 across the three classes
+      {-1, 0, +1}. Falls back to the two-class f1 when no events in
+      the realised set land in class 0.
+    - ``direction_auc`` -- binary ROC-AUC for "up vs not-up", scored
+      by the continuous predicted delta. Returns ``None`` when only
+      one class is present in ``true_close`` (AUC undefined).
+
+    Edge cases
+    ----------
+    - Empty arrays -> all three return ``None``.
+    - Single-class ground truth -> ``direction_auc`` is ``None`` while
+      accuracy / f1 still compute on the degenerate distribution.
+    - Different array lengths -> ``ValueError``.
+    """
+
+    import numpy as np
+
+    pred_close_arr = _to_numpy_1d(pred_close)
+    true_close_arr = _to_numpy_1d(true_close)
+    prev_close_arr = _to_numpy_1d(prev_close)
+
+    if not (pred_close_arr.shape == true_close_arr.shape == prev_close_arr.shape):
+        raise ValueError(
+            "pred_close / true_close / prev_close must share shape; got "
+            f"{pred_close_arr.shape}, {true_close_arr.shape}, {prev_close_arr.shape}"
+        )
+
+    if pred_close_arr.size == 0:
+        return {
+            "direction_accuracy": None,
+            "f1_macro": None,
+            "direction_auc": None,
+        }
+
+    pred_delta = pred_close_arr - prev_close_arr
+    true_delta = true_close_arr - prev_close_arr
+    pred_dir = _signed(pred_delta, epsilon=epsilon)
+    true_dir = _signed(true_delta, epsilon=epsilon)
+
+    accuracy = float((pred_dir == true_dir).mean())
+    f1 = _macro_f1_three_class(true_dir, pred_dir)
+    auc = _binary_auc_up(true_dir, pred_delta)
+
+    return {
+        "direction_accuracy": accuracy,
+        "f1_macro": f1,
+        "direction_auc": auc,
+    }
+
+
+def _to_numpy_1d(values: Any) -> "Any":
+    """Coerce list / numpy array / torch tensor into a 1-D numpy float array."""
+
+    import numpy as np
+
+    try:
+        import torch
+
+        if isinstance(values, torch.Tensor):
+            values = values.detach().cpu().numpy()
+    except ImportError:
+        pass
+
+    arr = np.asarray(values, dtype=np.float64).reshape(-1)
+    return arr
+
+
+def _signed(delta: "Any", *, epsilon: float) -> "Any":
+    """Map ``delta`` to {-1, 0, +1} with a tolerance band of size ``epsilon``."""
+
+    import numpy as np
+
+    out = np.zeros_like(delta, dtype=np.int8)
+    out[delta > epsilon] = 1
+    out[delta < -epsilon] = -1
+    return out
+
+
+def _macro_f1_three_class(y_true: "Any", y_pred: "Any") -> float:
+    """Unweighted-mean F1 over the three classes {-1, 0, +1}.
+
+    Sklearn would do this in one call but pulling it into the training
+    loop on every eval pass would be a noticeable cost; an inline
+    computation is fast and avoids the import in places it does not
+    need to be. Classes absent from both ``y_true`` and ``y_pred`` are
+    skipped from the macro average so f1_macro on a two-class problem
+    is the actual two-class macro F1, not 2/3 of it.
+    """
+
+    classes = (-1, 0, 1)
+    f1s: list[float] = []
+    for cls in classes:
+        true_pos = int(((y_true == cls) & (y_pred == cls)).sum())
+        false_pos = int(((y_true != cls) & (y_pred == cls)).sum())
+        false_neg = int(((y_true == cls) & (y_pred != cls)).sum())
+        support_true = true_pos + false_neg
+        support_pred = true_pos + false_pos
+        if support_true == 0 and support_pred == 0:
+            # Class never appears in either the truth or the
+            # predictions. Excluding it from the macro average keeps
+            # the metric meaningful on the dataset's actual class
+            # distribution (the realised ``direction_t1d`` has only
+            # 4 zero-rows out of ~4k so the flat class is essentially
+            # absent in practice).
+            continue
+        precision = true_pos / support_pred if support_pred > 0 else 0.0
+        recall = true_pos / support_true if support_true > 0 else 0.0
+        denom = precision + recall
+        f1 = (2 * precision * recall / denom) if denom > 0 else 0.0
+        f1s.append(f1)
+    if not f1s:
+        return 0.0
+    return float(sum(f1s) / len(f1s))
+
+
+def _binary_auc_up(y_true: "Any", scores: "Any") -> float | None:
+    """ROC-AUC for the binary view ``up vs not-up``.
+
+    Maps ``y_true`` to ``{1 if up else 0}``. Falls back to a manual
+    Mann-Whitney-U computation so the helper stays dependency-light;
+    sklearn is widely available in the project image but the import
+    cost on every eval pass is non-trivial. Returns ``None`` when
+    only one class is present (AUC undefined).
+    """
+
+    import numpy as np
+
+    truth_up = (y_true == 1).astype(np.int64)
+    n_pos = int(truth_up.sum())
+    n_neg = int(truth_up.shape[0] - n_pos)
+    if n_pos == 0 or n_neg == 0:
+        return None
+
+    # Rank-based AUC = (sum_of_ranks_pos - n_pos*(n_pos+1)/2) / (n_pos * n_neg)
+    # Use average-rank tie handling so ties between pos and neg
+    # contribute the expected 0.5 each. ``scipy.stats.rankdata`` would
+    # do this cleanly but numpy alone covers it via argsort + index
+    # average over ties.
+    order = np.argsort(scores, kind="mergesort")
+    ranks = np.empty_like(order, dtype=np.float64)
+    ranks[order] = np.arange(1, len(scores) + 1, dtype=np.float64)
+
+    # Tie correction
+    unique_scores, inverse_indices, counts = np.unique(
+        scores, return_inverse=True, return_counts=True
+    )
+    for idx, count in enumerate(counts):
+        if count > 1:
+            mask = inverse_indices == idx
+            ranks[mask] = ranks[mask].mean()
+
+    sum_ranks_pos = float(ranks[truth_up == 1].sum())
+    auc = (sum_ranks_pos - n_pos * (n_pos + 1) / 2) / (n_pos * n_neg)
+    return float(auc)
+
+
+__all__ = ["compute_directional_metrics"]

--- a/backend/app/evaluation/metrics.py
+++ b/backend/app/evaluation/metrics.py
@@ -13,8 +13,18 @@ class EvaluationMetrics:
     close_rmse: float
     volatility_rmse: float
     combined_rmse: float
+    # Classification view of the same predictions (Phase 9). Derived in
+    # ``app.evaluation.directional_metrics.compute_directional_metrics``
+    # by comparing the sign of the predicted close-delta against
+    # ``direction_t1d`` from the events parquet. Optional so legacy
+    # eval paths (the regression-only tests, pre-Phase-9 checkpoints
+    # round-tripped through ``from_dict``) keep validating; populated
+    # by :func:`app.training.loop._evaluate_model` on every new run.
+    direction_accuracy: float | None = None
+    f1_macro: float | None = None
+    direction_auc: float | None = None
 
-    def to_dict(self) -> dict[str, float]:
+    def to_dict(self) -> dict[str, float | None]:
         return asdict(self)
 
 

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -293,6 +293,13 @@ def _evaluate_model(
     total_items = torch.zeros((), dtype=torch.int64, device=device)
     close_squared_error = torch.zeros((), dtype=torch.float64, device=device)
     volatility_squared_error = torch.zeros((), dtype=torch.float64, device=device)
+    # Per-event arrays for the directional view. Empty until Phase 9
+    # wired this in; downstream helper short-circuits on a zero-length
+    # input so the regression-only legacy regression contract stays
+    # byte-identical when these stay empty.
+    pred_close_chunks: list[torch.Tensor] = []
+    true_close_chunks: list[torch.Tensor] = []
+    prev_close_chunks: list[torch.Tensor] = []
     use_text_path = bool(getattr(model, "_text_path_active", False))
     non_blocking = device.type == "cuda"
     with torch.no_grad():
@@ -327,6 +334,16 @@ def _evaluate_model(
             delta = predictions - batch_y
             close_squared_error += torch.square(delta[:, 0]).sum().to(torch.float64)
             volatility_squared_error += torch.square(delta[:, 1]).sum().to(torch.float64)
+            # Collect the close-axis arrays for the directional view.
+            # Eval partitions are small (val ~60, test ~60-70 windows
+            # per fold), so the per-event copy is cheap. ``batch_x[:, -1, 1]``
+            # is the prev-bar's close in scaled units; the model's
+            # output and the target are in the same scaled units so
+            # ``sign(pred - prev) == sign(true - prev)`` is the
+            # directional ground truth.
+            pred_close_chunks.append(predictions[:, 0].detach().to("cpu", torch.float32))
+            true_close_chunks.append(batch_y[:, 0].detach().to("cpu", torch.float32))
+            prev_close_chunks.append(batch_x[:, -1, 1].detach().to("cpu", torch.float32))
     total_items_int = int(total_items.item())
     if total_items_int <= 0:
         return EvaluationMetrics(
@@ -340,11 +357,33 @@ def _evaluate_model(
     close_value = float(close_squared_error.item())
     volatility_value = float(volatility_squared_error.item())
     combined_squared_error = close_value + volatility_value
+
+    # Directional view (Phase 9). The helper returns None on every
+    # axis when no events were collected, so the dataclass field
+    # stays None and the regression contract is unchanged for callers
+    # that ignore the new metrics.
+    directional: dict[str, float | None] = {
+        "direction_accuracy": None,
+        "f1_macro": None,
+        "direction_auc": None,
+    }
+    if pred_close_chunks:
+        from app.evaluation.directional_metrics import compute_directional_metrics
+
+        directional = compute_directional_metrics(
+            torch.cat(pred_close_chunks),
+            torch.cat(true_close_chunks),
+            torch.cat(prev_close_chunks),
+        )
+
     return EvaluationMetrics(
         loss=total_loss_value / total_items_int,
         close_rmse=math.sqrt(close_value / total_items_int),
         volatility_rmse=math.sqrt(volatility_value / total_items_int),
         combined_rmse=math.sqrt(combined_squared_error / (total_items_int * 2)),
+        direction_accuracy=directional["direction_accuracy"],
+        f1_macro=directional["f1_macro"],
+        direction_auc=directional["direction_auc"],
     )
 
 

--- a/tests/unit/test_directional_metrics.py
+++ b/tests/unit/test_directional_metrics.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.evaluation.directional_metrics import compute_directional_metrics
+from app.evaluation.metrics import EvaluationMetrics
+
+
+# ---------------------------------------------------------------------------
+# EvaluationMetrics — new optional fields
+# ---------------------------------------------------------------------------
+
+
+def test_evaluation_metrics_defaults_directional_to_none() -> None:
+    m = EvaluationMetrics(loss=0.1, close_rmse=1.0, volatility_rmse=0.01, combined_rmse=0.5)
+    d = m.to_dict()
+    assert d["direction_accuracy"] is None
+    assert d["f1_macro"] is None
+    assert d["direction_auc"] is None
+
+
+def test_evaluation_metrics_round_trips_through_dict_with_directional() -> None:
+    m = EvaluationMetrics(
+        loss=0.1,
+        close_rmse=1.0,
+        volatility_rmse=0.01,
+        combined_rmse=0.5,
+        direction_accuracy=0.62,
+        f1_macro=0.58,
+        direction_auc=0.66,
+    )
+    d = m.to_dict()
+    assert d["direction_accuracy"] == pytest.approx(0.62)
+    assert d["f1_macro"] == pytest.approx(0.58)
+    assert d["direction_auc"] == pytest.approx(0.66)
+
+
+# ---------------------------------------------------------------------------
+# compute_directional_metrics — edges
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_all_none() -> None:
+    out = compute_directional_metrics([], [], [])
+    assert out == {"direction_accuracy": None, "f1_macro": None, "direction_auc": None}
+
+
+def test_shape_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="shape"):
+        compute_directional_metrics([1, 2, 3], [1, 2], [1, 2, 3])
+
+
+def test_perfect_prediction_yields_one_across_the_board() -> None:
+    rng = np.random.default_rng(11)
+    prev = np.linspace(100, 110, 200)
+    true_close = prev + rng.normal(size=200)
+    pred_close = true_close   # identical predictions
+    out = compute_directional_metrics(pred_close, true_close, prev)
+    assert out["direction_accuracy"] == pytest.approx(1.0)
+    assert out["f1_macro"] == pytest.approx(1.0)
+    assert out["direction_auc"] == pytest.approx(1.0)
+
+
+def test_random_prediction_lands_near_coin_flip() -> None:
+    rng = np.random.default_rng(11)
+    prev = np.linspace(100, 110, 1000)
+    true_close = prev + rng.normal(size=1000)
+    pred_close = prev + rng.normal(size=1000)
+    out = compute_directional_metrics(pred_close, true_close, prev)
+    # With 1000 events, accuracy + f1 + auc should all sit within ~5pp
+    # of 0.5 if the predictions truly carry no directional signal.
+    assert 0.45 <= out["direction_accuracy"] <= 0.55
+    assert 0.45 <= out["f1_macro"] <= 0.55
+    assert 0.45 <= out["direction_auc"] <= 0.55
+
+
+def test_anti_correlated_prediction_yields_low_accuracy_and_low_auc() -> None:
+    """Flipping every prediction's sign should produce accuracy < 0.5 and AUC < 0.5."""
+    rng = np.random.default_rng(11)
+    prev = np.linspace(100, 110, 200)
+    delta = rng.normal(size=200)
+    true_close = prev + delta
+    pred_close = prev - delta   # exactly anti-correlated
+    out = compute_directional_metrics(pred_close, true_close, prev)
+    assert out["direction_accuracy"] < 0.1
+    assert out["direction_auc"] < 0.1
+
+
+def test_single_class_truth_returns_none_for_auc() -> None:
+    """When every realised move is 'up', binary AUC is undefined."""
+    prev = np.linspace(100, 110, 50)
+    true_close = prev + 1.0  # every event is 'up'
+    pred_close = prev + np.random.default_rng(11).normal(size=50)
+    out = compute_directional_metrics(pred_close, true_close, prev)
+    assert out["direction_auc"] is None
+    # Accuracy + f1 still compute; they may be any value depending on
+    # how many predictions land 'up' — just assert they are floats.
+    assert isinstance(out["direction_accuracy"], float)
+    assert isinstance(out["f1_macro"], float)
+
+
+def test_torch_input_parity_with_numpy() -> None:
+    rng = np.random.default_rng(11)
+    prev = np.linspace(100, 110, 200)
+    true_close = prev + rng.normal(size=200)
+    pred_close = prev + rng.normal(size=200)
+
+    out_np = compute_directional_metrics(pred_close, true_close, prev)
+    out_torch = compute_directional_metrics(
+        torch.tensor(pred_close, dtype=torch.float32),
+        torch.tensor(true_close, dtype=torch.float32),
+        torch.tensor(prev, dtype=torch.float32),
+    )
+    assert out_np["direction_accuracy"] == pytest.approx(
+        out_torch["direction_accuracy"], abs=1e-5
+    )
+    assert out_np["f1_macro"] == pytest.approx(out_torch["f1_macro"], abs=1e-5)
+    assert out_np["direction_auc"] == pytest.approx(
+        out_torch["direction_auc"], abs=1e-5
+    )
+
+
+def test_epsilon_band_collapses_small_deltas_to_zero_class() -> None:
+    prev = np.array([100.0, 100.0, 100.0, 100.0])
+    true_close = np.array([100.5, 99.5, 100.0001, 99.9999])
+    pred_close = np.array([100.5, 99.5, 100.0001, 99.9999])
+    # epsilon=0.01 turns the last two near-zero moves into class 0
+    out = compute_directional_metrics(pred_close, true_close, prev, epsilon=0.01)
+    # Perfect prediction so accuracy is 1.0 regardless
+    assert out["direction_accuracy"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

- `EvaluationMetrics` gains `direction_accuracy`, `f1_macro`, `direction_auc` (all `Optional[float]`, default `None` so legacy callers and pre-Phase-9 checkpoints round-trip cleanly)
- New helper `app/evaluation/directional_metrics.py` derives the classification view from the regression head: `sign(pred_close - prev_close)` vs `sign(true_close - prev_close)`. Dependency-light (numpy + torch input compatible, no sklearn round-trip on every eval pass)
- `_evaluate_model` in `app/training/loop.py` collects per-event close arrays alongside the existing squared-error sums and fills the new fields automatically on val + test partitions
- 10 new unit tests cover perfect prediction, anti-correlation, coin-flip, single-class AUC fallback, torch/numpy parity, shape-mismatch guard, epsilon-band collapse

## Why this lands now (Phase 9 prep)

The alpha-ablation showed continuous close RMSE is dominated by random-walk variance. The Phase 9 reframe (#184, #186) pivots the headline toward directional accuracy on `direction_t1d`. Adding the metric to every eval pass means any sweep that starts after this lands will report the directional view automatically — no separate re-evaluation script needed for new runs.

## Out of scope

- Post-hoc directional evaluation on the in-flight multi-fold (#183) — that run was started before this code; its trial JSONs will not carry the new fields. A small `scripts/eval_checkpoint_directional.py` for backfilling is queued as a separate follow-up
- Native classification head (softmax / BCE on direction) — covered by #184's loss-weight masking; this PR makes the metric available, the model architecture stays unchanged

## Test plan

- [ ] `docker compose run --rm backend pytest tests/unit/test_directional_metrics.py -q`
- [ ] `docker compose run --rm backend pytest tests/ -q --ignore=tests/e2e`