### PR TITLE
Diagnostic tooling: directional eval + linear-probe NLP bake-off + data health

### DIFF
--- a/scripts/diagnose_data_health.py
+++ b/scripts/diagnose_data_health.py
@@ -1,0 +1,502 @@
+"""Two structural sanity checks on the events parquet + market data.
+
+Check 1 -- Feature Sparsity & Variance (PCA)
+    Loads the 35-dim rich-feature vector for every event, computes the
+    fraction of exact-zero cells, and fits PCA after standardisation
+    to report how many components explain 95% of the variance. If
+    that count is tiny (< 5), the rich-feature matrix is effectively
+    low-rank and the extra dimensions are noise.
+
+Check 2 -- Event-Day Volatility Bias
+    Loads the full SPX daily close series for the event-date range,
+    computes daily absolute return and ``vol_post_10d - vol_pre_10d``
+    for every trading day, then compares the EVENT-DAY distribution
+    against the NON-EVENT-DAY distribution. Two-sample t-tests on the
+    means and Kolmogorov-Smirnov tests on the full distributions
+    answer "are event days actually special?".
+
+The two checks are independent; either may be run in isolation by
+commenting out the other ``main()`` step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from app.config import DATA_DIR
+from app.models.config import (
+    FEATURE_SIZE,
+    RICH_CREDIBILITY_SLICE,
+    RICH_FEATURE_SIZE,
+    RICH_LINGUISTIC_DIM,
+    RICH_LINGUISTIC_SLICE,
+    RICH_MP_SURPRISE_SLICE,
+    RICH_MULTI_AXIS_SLICE,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--training-package-id",
+        required=True,
+        help="Training-package id under ``data/processed/<id>``.",
+    )
+    parser.add_argument(
+        "--linguistic-parquet",
+        default=None,
+        help="Override path to linguistic_features.parquet. Defaults to "
+        "<package_dir>/linguistic_features.parquet.",
+    )
+    parser.add_argument(
+        "--mp-surprise-parquet",
+        default=None,
+        help="Override path to mp_surprises.parquet. Defaults to "
+        "data/external/fred/mp_surprises.parquet.",
+    )
+    parser.add_argument(
+        "--vol-window",
+        type=int,
+        default=10,
+        help="Trading-day window for the pre/post volatility shift "
+        "comparison in Check 2 (default 10 to match the project's "
+        "event-study target frame in PR #172).",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional JSON output path. Diagnostic results, machine-readable.",
+    )
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Check 1: rich-feature sparsity + PCA
+# ---------------------------------------------------------------------------
+
+
+_LINGUISTIC_COLUMNS: tuple[str, ...] = (
+    "topic_share_inflation",
+    "topic_share_employment",
+    "topic_share_financial_stability",
+    "topic_share_growth",
+    "topic_share_balance_sheet",
+    "topic_share_misc_1",
+    "topic_share_misc_2",
+    "topic_share_misc_3",
+    "hedge_density",
+    "comparison_density",
+    "forward_density",
+    "concrete_ratio",
+    "hawk_dove_asymmetry",
+    "log_token_count",
+    "pivot_distance",
+)
+
+
+def _stance_one_hot(value: Any) -> tuple[float, float, float, float]:
+    """Return (hawk, dove, neutral, missing) one-hot for ``axis_stance``."""
+    if not isinstance(value, str):
+        return (0.0, 0.0, 0.0, 1.0)
+    val = value.strip().lower()
+    if val == "hawkish":
+        return (1.0, 0.0, 0.0, 0.0)
+    if val == "dovish":
+        return (0.0, 1.0, 0.0, 0.0)
+    if val == "neutral":
+        return (0.0, 0.0, 1.0, 0.0)
+    return (0.0, 0.0, 0.0, 1.0)
+
+
+def _build_rich_matrix(
+    package_dir: Path,
+    linguistic_path: Path,
+    mp_surprise_path: Path,
+) -> tuple[np.ndarray, list[str]]:
+    """Construct one rich-feature vector per unique event_date.
+
+    Mirrors the layout that ``FeatureVector.as_rich_list`` emits at
+    positions [6:35]; we skip the market block [0:6] because it
+    varies per-bar and is not meaningful at event-level. The output
+    is (n_events, 29) -- the rich-extra slice only.
+    """
+
+    events = pd.read_parquet(package_dir / "events.parquet")
+    # One row per (event_date, source) collapsed view; deduplicate to
+    # one row per event_date for the PCA.
+    events = events.drop_duplicates(subset=["event_date"], keep="first")
+    events["event_date"] = events["event_date"].astype(str)
+
+    # Linguistic join keyed on text_hash. Pad missing rows with zeros.
+    if linguistic_path.exists():
+        ling = pd.read_parquet(linguistic_path)
+        ling = ling.set_index("text_hash")
+    else:
+        ling = pd.DataFrame()
+
+    # MP-surprise join keyed on event_date.
+    if mp_surprise_path.exists():
+        mp = pd.read_parquet(mp_surprise_path)
+        mp["event_date"] = mp["event_date"].astype(str)
+        mp = mp.set_index("event_date")
+    else:
+        mp = pd.DataFrame()
+
+    columns = [
+        # credibility (4)
+        "credibility_drift_score",
+        "credibility_realized_vs_stated_gap",
+        "credibility_market_implied_gap",
+        "credibility_months_since_reversal",
+        # linguistic (15)
+        *_LINGUISTIC_COLUMNS,
+        # mp-surprise (4)
+        "mp_surprise_level",
+        "mp_surprise_path_factor",
+        "fed_info_factor",
+        "mp_is_intermeeting",
+        # multi-axis (6) -- one-hot reconstruction
+        "stance_hawk",
+        "stance_dove",
+        "stance_neutral",
+        "time_label_forward",
+        "certain_label_certain",
+        "stance_missing",
+    ]
+
+    rows: list[list[float]] = []
+    for _, ev in events.iterrows():
+        row: list[float] = []
+        # credibility
+        for col in (
+            "credibility_drift_score",
+            "credibility_realized_vs_stated_gap",
+            "credibility_market_implied_gap",
+            "credibility_months_since_reversal",
+        ):
+            v = ev.get(col)
+            row.append(0.0 if v is None or (isinstance(v, float) and np.isnan(v)) else float(v))
+        # linguistic
+        text_hash = ev.get("text_hash")
+        if text_hash and not ling.empty and text_hash in ling.index:
+            ling_row = ling.loc[text_hash]
+            for c in _LINGUISTIC_COLUMNS:
+                v = ling_row.get(c) if isinstance(ling_row, pd.Series) else None
+                row.append(
+                    0.0 if v is None or (isinstance(v, float) and np.isnan(v)) else float(v)
+                )
+        else:
+            row.extend([0.0] * RICH_LINGUISTIC_DIM)
+        # mp-surprise
+        edate = ev.get("event_date")
+        if edate and not mp.empty and edate in mp.index:
+            mp_row = mp.loc[edate]
+            for c in (
+                "mp_surprise_level",
+                "mp_surprise_path_factor",
+                "fed_info_factor",
+                "mp_is_intermeeting",
+            ):
+                v = mp_row.get(c) if isinstance(mp_row, pd.Series) else None
+                if isinstance(v, bool):
+                    row.append(1.0 if v else 0.0)
+                else:
+                    row.append(
+                        0.0
+                        if v is None or (isinstance(v, float) and np.isnan(v))
+                        else float(v)
+                    )
+        else:
+            row.extend([0.0] * 4)
+        # multi-axis Option-A slot (six floats)
+        hawk, dove, neutral, missing = _stance_one_hot(ev.get("axis_stance"))
+        time_raw = ev.get("axis_time_label")
+        certain_raw = ev.get("axis_certain_label")
+        time_fwd = (
+            1.0
+            if isinstance(time_raw, str) and time_raw.strip().lower() == "forward looking"
+            else 0.0
+        )
+        certain_cert = (
+            1.0
+            if isinstance(certain_raw, str) and certain_raw.strip().lower() == "certain"
+            else 0.0
+        )
+        row.extend([hawk, dove, neutral, time_fwd, certain_cert, missing])
+        rows.append(row)
+
+    return np.array(rows, dtype=np.float64), columns
+
+
+def _run_check_1(args: argparse.Namespace) -> dict[str, Any]:
+    from sklearn.decomposition import PCA
+    from sklearn.preprocessing import StandardScaler
+
+    package_dir = DATA_DIR / "processed" / args.training_package_id
+    linguistic_path = (
+        Path(args.linguistic_parquet)
+        if args.linguistic_parquet
+        else package_dir / "linguistic_features.parquet"
+    )
+    mp_path = (
+        Path(args.mp_surprise_parquet)
+        if args.mp_surprise_parquet
+        else DATA_DIR / "external" / "fred" / "mp_surprises.parquet"
+    )
+
+    X, columns = _build_rich_matrix(package_dir, linguistic_path, mp_path)
+    n_events, n_features = X.shape
+    print("==== Check 1: Rich-Feature Sparsity + PCA ====")
+    print(f"  matrix shape:                       {X.shape}")
+    print(f"  total cells:                        {X.size}")
+    zero_cells = int(np.sum(X == 0.0))
+    sparsity = zero_cells / X.size
+    print(f"  exact-zero cells:                   {zero_cells} ({sparsity:.2%})")
+    print()
+
+    # Per-column zero rate
+    col_zero_rate = (X == 0.0).mean(axis=0)
+    col_std = X.std(axis=0)
+    print(f"  {'feature':<42}{'zero rate':>12}{'std':>12}")
+    print("  " + "-" * 66)
+    for name, zr, std in zip(columns, col_zero_rate, col_std):
+        marker = "  (dead)" if std < 1e-9 else ""
+        print(f"  {name:<42}{zr:>12.2%}{std:>12.4f}{marker}")
+    print()
+
+    n_dead = int((col_std < 1e-9).sum())
+    print(f"  dead columns (std < 1e-9):          {n_dead}/{n_features}")
+    print()
+
+    # Drop dead columns for PCA so the standard-scaler doesn't NaN.
+    live_mask = col_std > 1e-9
+    X_live = X[:, live_mask]
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(X_live)
+
+    pca = PCA(n_components=min(X_scaled.shape))
+    pca.fit(X_scaled)
+    cum_var = np.cumsum(pca.explained_variance_ratio_)
+    thresholds = (0.50, 0.80, 0.90, 0.95, 0.99)
+    print(f"  PCA on standardised LIVE columns ({X_live.shape[1]} dims):")
+    print(f"  {'cumulative variance':<24}{'components needed':>22}")
+    print("  " + "-" * 46)
+    components_for = {}
+    for t in thresholds:
+        n = int(np.searchsorted(cum_var, t) + 1)
+        n = min(n, len(cum_var))
+        components_for[t] = n
+        print(f"  >= {t:.2f}                {n:>22d}")
+    print()
+
+    # Print top-10 explained-variance ratios for inspection
+    print(f"  top 10 components' explained-variance ratios:")
+    for i, ratio in enumerate(pca.explained_variance_ratio_[:10], start=1):
+        print(f"    PC{i:>2}: {ratio:.4f}   (cum {cum_var[i-1]:.4f})")
+    print()
+
+    verdict = ""
+    n95 = components_for[0.95]
+    if n95 <= 4:
+        verdict = (
+            f"VERDICT: thin/sparse -- {n95} components explain 95% of variance. "
+            "The 35-dim rich vector is effectively low-rank; most positions "
+            "are noise."
+        )
+    elif n95 <= 10:
+        verdict = (
+            f"VERDICT: moderate dimensionality -- {n95} components explain 95%. "
+            "Real signal in a handful of axes; the rest is redundant."
+        )
+    else:
+        verdict = (
+            f"VERDICT: dense -- {n95} components needed for 95%. "
+            "The rich-feature space is using its dimensions."
+        )
+    print(f"  {verdict}")
+    print()
+
+    return {
+        "matrix_shape": list(X.shape),
+        "sparsity": float(sparsity),
+        "n_dead_columns": n_dead,
+        "components_for_thresholds": {f"{t:.2f}": int(n) for t, n in components_for.items()},
+        "per_column_zero_rate": {
+            columns[i]: float(col_zero_rate[i]) for i in range(n_features)
+        },
+        "per_column_std": {columns[i]: float(col_std[i]) for i in range(n_features)},
+        "top_pcs": [float(r) for r in pca.explained_variance_ratio_[:10]],
+        "verdict": verdict,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Check 2: event-day vs non-event-day volatility bias
+# ---------------------------------------------------------------------------
+
+
+def _run_check_2(args: argparse.Namespace) -> dict[str, Any]:
+    from scipy import stats
+
+    package_dir = DATA_DIR / "processed" / args.training_package_id
+    events = pd.read_parquet(package_dir / "events.parquet")
+    events["event_date"] = events["event_date"].astype(str)
+    event_dates = set(events["event_date"].unique())
+
+    # SPX continuous bars cached under the package.
+    market_path = package_dir / "_market_cache" / "GSPC.parquet"
+    if not market_path.exists():
+        raise SystemExit(
+            f"Continuous SPX cache not found at {market_path}. "
+            "Re-run event_dataset_builder first to populate the cache."
+        )
+    spx = pd.read_parquet(market_path)
+    # Common columns: 'date', 'close', 'open', 'high', 'low', 'volume' --
+    # confirm date column name dynamically.
+    date_col = "date" if "date" in spx.columns else "Date"
+    close_col = "close" if "close" in spx.columns else "Close"
+    spx[date_col] = pd.to_datetime(spx[date_col]).dt.strftime("%Y-%m-%d")
+    spx = spx.sort_values(date_col).reset_index(drop=True)
+
+    # Restrict to the date range of the event corpus to avoid
+    # comparing apples (calm 1990s) to oranges (volatile 2020).
+    event_dates_sorted = sorted(event_dates)
+    earliest = event_dates_sorted[0]
+    latest = event_dates_sorted[-1]
+    in_range = (spx[date_col] >= earliest) & (spx[date_col] <= latest)
+    spx_window = spx.loc[in_range].reset_index(drop=True)
+
+    # Daily log-return and absolute return
+    spx_window["log_return"] = np.log(
+        spx_window[close_col] / spx_window[close_col].shift(1)
+    )
+    spx_window["abs_return"] = spx_window["log_return"].abs()
+
+    # Rolling vol windows for the volatility shift target
+    window = int(args.vol_window)
+    spx_window["pre_vol"] = (
+        spx_window["log_return"].rolling(window=window, min_periods=window).std()
+    )
+    spx_window["post_vol"] = (
+        spx_window["log_return"]
+        .shift(-window)
+        .rolling(window=window, min_periods=window)
+        .std()
+    )
+    spx_window["vol_shift"] = spx_window["post_vol"] - spx_window["pre_vol"]
+
+    spx_window["is_event"] = spx_window[date_col].isin(event_dates)
+
+    valid = spx_window.dropna(subset=["abs_return", "vol_shift"]).reset_index(drop=True)
+    event_mask = valid["is_event"]
+    n_event = int(event_mask.sum())
+    n_non = int((~event_mask).sum())
+
+    print("==== Check 2: Event-Day vs Non-Event-Day Volatility Bias ====")
+    print(f"  date range:               {earliest} -> {latest}")
+    print(f"  trading days in window:   {len(valid)}")
+    print(f"  event days observed:      {n_event}")
+    print(f"  non-event days:           {n_non}")
+    print()
+
+    def _summary(group: pd.Series) -> dict[str, float]:
+        return {
+            "n": int(group.shape[0]),
+            "mean": float(group.mean()),
+            "median": float(group.median()),
+            "std": float(group.std()),
+            "abs_mean": float(group.abs().mean()),
+        }
+
+    abs_event = valid.loc[event_mask, "abs_return"]
+    abs_non = valid.loc[~event_mask, "abs_return"]
+    vs_event = valid.loc[event_mask, "vol_shift"]
+    vs_non = valid.loc[~event_mask, "vol_shift"]
+
+    abs_event_stats = _summary(abs_event)
+    abs_non_stats = _summary(abs_non)
+    vs_event_stats = _summary(vs_event)
+    vs_non_stats = _summary(vs_non)
+
+    print(f"  abs_return  event mean:   {abs_event_stats['mean']:.6f}  (std {abs_event_stats['std']:.6f})")
+    print(f"  abs_return  non-event:    {abs_non_stats['mean']:.6f}  (std {abs_non_stats['std']:.6f})")
+    print(f"  abs_return  ratio:        {abs_event_stats['mean'] / max(abs_non_stats['mean'], 1e-12):.3f}x")
+    print()
+    print(f"  vol_shift   event mean:   {vs_event_stats['mean']:.6f}  (std {vs_event_stats['std']:.6f})")
+    print(f"  vol_shift   non-event:    {vs_non_stats['mean']:.6f}  (std {vs_non_stats['std']:.6f})")
+    print(f"  vol_shift   |mean| ratio: {abs(vs_event_stats['mean']) / max(abs(vs_non_stats['mean']), 1e-12):.3f}x")
+    print()
+
+    # Welch t-tests (unequal variance) on means
+    t_abs = stats.ttest_ind(abs_event, abs_non, equal_var=False)
+    t_vs = stats.ttest_ind(vs_event, vs_non, equal_var=False)
+    ks_abs = stats.ks_2samp(abs_event, abs_non)
+    ks_vs = stats.ks_2samp(vs_event, vs_non)
+    print("  statistical tests:")
+    print(f"    abs_return  Welch t-test    t={t_abs.statistic:+.3f}  p={t_abs.pvalue:.4g}")
+    print(f"    abs_return  Kolmogorov-Smirnov D={ks_abs.statistic:.3f}  p={ks_abs.pvalue:.4g}")
+    print(f"    vol_shift   Welch t-test    t={t_vs.statistic:+.3f}  p={t_vs.pvalue:.4g}")
+    print(f"    vol_shift   Kolmogorov-Smirnov D={ks_vs.statistic:.3f}  p={ks_vs.pvalue:.4g}")
+    print()
+
+    def _interpret(p_t: float, p_ks: float) -> str:
+        if p_t < 0.01 and p_ks < 0.01:
+            return "STRONG difference (event days are significantly distinct)"
+        if p_t < 0.05 or p_ks < 0.05:
+            return "WEAK difference (some evidence event days differ)"
+        return "INDISTINGUISHABLE (event days look like generic market noise)"
+
+    abs_verdict = _interpret(t_abs.pvalue, ks_abs.pvalue)
+    vs_verdict = _interpret(t_vs.pvalue, ks_vs.pvalue)
+    print(f"  verdict abs_return:       {abs_verdict}")
+    print(f"  verdict vol_shift:        {vs_verdict}")
+    print()
+
+    return {
+        "date_range": [earliest, latest],
+        "n_event": n_event,
+        "n_non_event": n_non,
+        "abs_return": {
+            "event": abs_event_stats,
+            "non_event": abs_non_stats,
+            "ratio_mean": abs_event_stats["mean"] / max(abs_non_stats["mean"], 1e-12),
+            "ttest": {"t": float(t_abs.statistic), "p": float(t_abs.pvalue)},
+            "ks": {"D": float(ks_abs.statistic), "p": float(ks_abs.pvalue)},
+            "verdict": abs_verdict,
+        },
+        "vol_shift": {
+            "event": vs_event_stats,
+            "non_event": vs_non_stats,
+            "ttest": {"t": float(t_vs.statistic), "p": float(t_vs.pvalue)},
+            "ks": {"D": float(ks_vs.statistic), "p": float(ks_vs.pvalue)},
+            "verdict": vs_verdict,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args()
+    out: dict[str, Any] = {}
+    out["check_1_rich_pca"] = _run_check_1(args)
+    out["check_2_event_vs_non"] = _run_check_2(args)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(out, indent=2, default=float))
+        print(f"  json written to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/eval_checkpoint_directional.py
+++ b/scripts/eval_checkpoint_directional.py
@@ -1,0 +1,336 @@
+"""Post-hoc directional evaluation of a saved forecaster checkpoint.
+
+Loads one ``forecaster_best.pt`` and runs inference across every fold's
+test partition, deriving the directional view from the continuous
+predictions. Reports per-fold ``direction_accuracy``, ``f1_macro``,
+``direction_auc`` against the dataset's majority-class baseline.
+
+Single-checkpoint scope is intentional: the sweep harness persists
+only the best trial across the entire sweep, so per-(architecture,
+seed, fold) breakdown is not available without retraining. This
+script answers "does the BEST sweep model carry directional signal
+on the held-out test partitions?" -- the empirical gate that decides
+whether the Phase 9 classification head + 4-layer NLP investment is
+warranted.
+
+Usage::
+
+    python -m scripts.eval_checkpoint_directional \\
+        --training-package-id tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0 \\
+        --checkpoint /app/models/forecaster_best.pt
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from app.config import DATA_DIR
+from app.evaluation.directional_metrics import compute_directional_metrics
+from app.models.config import (
+    FEATURE_SIZE,
+    RICH_FEATURE_SIZE,
+    RichFeatureScalerParams,
+)
+from app.models.factory import build_forecaster
+from app.training.checkpoint import _coerce_payload_config
+from app.training.loaders import (
+    apply_rich_feature_scaler_tensor,
+    load_walk_forward_split,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--training-package-id",
+        required=True,
+        help="Training-package id under ``data/processed/<id>``.",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        default="/app/models/forecaster_best.pt",
+        help="Path to the saved forecaster checkpoint (.pt).",
+    )
+    parser.add_argument(
+        "--folds",
+        nargs="+",
+        default=("wf_fold_1", "wf_fold_2", "wf_fold_3", "wf_fold_4"),
+        help="Fold ids to evaluate against (one per --folds value).",
+    )
+    parser.add_argument(
+        "--device",
+        default=None,
+        help="Explicit device override (e.g. cuda or cpu). Auto-detects when omitted.",
+    )
+    parser.add_argument(
+        "--baseline-accuracy",
+        type=float,
+        default=0.537,
+        help=(
+            "Majority-class baseline for the directional target on the "
+            "current package. Default 0.537 = 2204 / 4099 +1 rows in "
+            "events.parquet after excluding 4 zero-direction rows."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional JSON output path. Prints to stdout regardless.",
+    )
+    return parser.parse_args()
+
+
+def _resolve_device(arg: str | None) -> torch.device:
+    if arg is not None:
+        return torch.device(arg)
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def _load_checkpoint(path: Path, device: torch.device) -> dict[str, Any]:
+    if not path.exists():
+        raise SystemExit(f"checkpoint not found: {path}")
+    payload = torch.load(path, map_location=device, weights_only=False)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"checkpoint at {path} is not a dict payload")
+    required = ("model_state_dict", "model_config")
+    missing = [k for k in required if k not in payload]
+    if missing:
+        raise SystemExit(f"checkpoint missing required keys: {missing}")
+    return payload
+
+
+def _build_model_from_payload(
+    payload: dict[str, Any],
+    device: torch.device,
+) -> torch.nn.Module:
+    config = _coerce_payload_config(payload)
+    model = build_forecaster(config).to(device)
+    model.load_state_dict(payload["model_state_dict"])
+    model.eval()
+    return model
+
+
+def _build_partition_tensor(
+    sequences: Any,
+    *,
+    rich_payload_expected: bool,
+    close_scale: float,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Convert a list-of-windows partition into (x, y, prev_close) tensors.
+
+    ``y`` and ``prev_close`` are emitted in the SAME scaled-close
+    units the model was trained against (``close / close_scale``).
+    ``close_scale`` comes from the checkpoint payload; the eval would
+    otherwise compute ``sign(unscaled_true_close - scaled_prev_close)``
+    which is positive on every row and silently produces a
+    100%-accuracy artefact instead of a real directional read.
+
+    Returns tensors on the target device, ready for one forward pass.
+    """
+
+    if not sequences:
+        return (
+            torch.empty(0, dtype=torch.float32, device=device),
+            torch.empty(0, dtype=torch.float32, device=device),
+            torch.empty(0, dtype=torch.float32, device=device),
+        )
+
+    rows_x: list[list[list[float]]] = []
+    rows_y: list[tuple[float, float]] = []
+    rows_prev: list[float] = []
+
+    for window in sequences:
+        if len(window) < 2:
+            continue
+        target_vector = window[-1]
+        history = window[:-1]
+        row_x = [
+            v.as_rich_list(close_scale=close_scale)
+            if rich_payload_expected
+            else v.as_list(close_scale=close_scale)
+            for v in history
+        ]
+        rows_x.append(row_x)
+        # Apply the same scaling to the target close so the directional
+        # comparison stays in a single unit system.
+        rows_y.append(
+            (
+                float(target_vector.market_close) / float(close_scale),
+                float(target_vector.market_volatility),
+            )
+        )
+        # Last bar of the input sequence's close, already scaled by
+        # ``as_list`` / ``as_rich_list``. Position [1] is the close
+        # slot in both layouts.
+        last_bar_close_scaled = row_x[-1][1]
+        rows_prev.append(last_bar_close_scaled)
+
+    if not rows_x:
+        return (
+            torch.empty(0, dtype=torch.float32, device=device),
+            torch.empty(0, dtype=torch.float32, device=device),
+            torch.empty(0, dtype=torch.float32, device=device),
+        )
+
+    x = torch.tensor(rows_x, dtype=torch.float32, device=device)
+    y = torch.tensor(rows_y, dtype=torch.float32, device=device)
+    prev = torch.tensor(rows_prev, dtype=torch.float32, device=device)
+    return x, y, prev
+
+
+def _run_inference(
+    model: torch.nn.Module,
+    x: torch.Tensor,
+    rich_scaler: RichFeatureScalerParams | None,
+) -> torch.Tensor:
+    x_in = apply_rich_feature_scaler_tensor(x, rich_scaler) if rich_scaler else x
+    with torch.no_grad():
+        predictions = model(x_in)
+    return predictions
+
+
+def _evaluate_fold(
+    *,
+    fold_id: str,
+    package_id: str,
+    rich_payload_expected: bool,
+    close_scale: float,
+    model: torch.nn.Module,
+    rich_scaler: RichFeatureScalerParams | None,
+    device: torch.device,
+) -> dict[str, Any]:
+    split = load_walk_forward_split(
+        package_id,
+        fold_id=fold_id,
+        rich_features=rich_payload_expected,
+    )
+    test_sequences = split.test if split.test else []
+
+    x, y, prev = _build_partition_tensor(
+        test_sequences,
+        rich_payload_expected=rich_payload_expected,
+        close_scale=close_scale,
+        device=device,
+    )
+
+    if x.numel() == 0:
+        return {
+            "fold_id": fold_id,
+            "n_events": 0,
+            "skipped": "empty test partition",
+        }
+
+    predictions = _run_inference(model, x, rich_scaler)
+    pred_close = predictions[:, 0]
+    true_close = y[:, 0]
+    metrics = compute_directional_metrics(pred_close, true_close, prev)
+    return {
+        "fold_id": fold_id,
+        "n_events": int(x.shape[0]),
+        **metrics,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args()
+    device = _resolve_device(args.device)
+    checkpoint_path = Path(args.checkpoint)
+    payload = _load_checkpoint(checkpoint_path, device)
+    model = _build_model_from_payload(payload, device)
+
+    rich_payload_expected = int(
+        payload["model_config"].get("input_size", FEATURE_SIZE)
+    ) == RICH_FEATURE_SIZE
+
+    rich_scaler = RichFeatureScalerParams.from_dict(
+        payload.get("rich_feature_scaler")
+    )
+    close_scale = float(payload.get("close_scale", 10000.0))
+
+    print("==== checkpoint context ====")
+    print(f"  path:           {checkpoint_path}")
+    print(f"  device:         {device}")
+    print(f"  input_size:     {payload['model_config'].get('input_size')}")
+    print(f"  architecture:   {payload['model_config'].get('architecture')}")
+    print(f"  rich_features:  {rich_payload_expected}")
+    print(f"  close_scale:    {close_scale}")
+    print(f"  has scaler:     {rich_scaler is not None}")
+    print(f"  baseline acc:   {args.baseline_accuracy:.3f} (majority class)")
+    print()
+
+    per_fold: list[dict[str, Any]] = []
+    for fold_id in args.folds:
+        result = _evaluate_fold(
+            fold_id=fold_id,
+            package_id=args.training_package_id,
+            rich_payload_expected=rich_payload_expected,
+            close_scale=close_scale,
+            model=model,
+            rich_scaler=rich_scaler,
+            device=device,
+        )
+        per_fold.append(result)
+
+    print(
+        f"{'fold':<14}{'n':>6}{'accuracy':>12}{'f1_macro':>12}{'auc':>10}{'vs baseline':>14}"
+    )
+    print("-" * 70)
+    accs: list[float] = []
+    for row in per_fold:
+        if "skipped" in row:
+            print(f"  {row['fold_id']:<12}{row['n_events']:>6}  {row['skipped']}")
+            continue
+        acc = row.get("direction_accuracy")
+        f1 = row.get("f1_macro")
+        auc = row.get("direction_auc")
+        acc_str = f"{acc:.3f}" if isinstance(acc, float) else "None"
+        f1_str = f"{f1:.3f}" if isinstance(f1, float) else "None"
+        auc_str = f"{auc:.3f}" if isinstance(auc, float) else "None"
+        delta = (
+            f"{(acc - args.baseline_accuracy):+.3f}"
+            if isinstance(acc, float)
+            else "None"
+        )
+        print(
+            f"  {row['fold_id']:<12}"
+            f"{row['n_events']:>6}"
+            f"{acc_str:>12}"
+            f"{f1_str:>12}"
+            f"{auc_str:>10}"
+            f"{delta:>14}"
+        )
+        if isinstance(acc, float):
+            accs.append(acc)
+
+    if accs:
+        mean_acc = float(np.mean(accs))
+        median_acc = float(np.median(accs))
+        print()
+        print(
+            f"  aggregate    mean acc = {mean_acc:.3f}   "
+            f"median acc = {median_acc:.3f}   "
+            f"baseline = {args.baseline_accuracy:.3f}"
+        )
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(per_fold, indent=2))
+        print(f"\n  json written to {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/linear_probe_embeddings.py
+++ b/scripts/linear_probe_embeddings.py
@@ -1,0 +1,500 @@
+"""Linear probe over NLP embeddings against the directional target.
+
+Isolation test: does the raw text representation carry directional
+information that the TFT failed to extract, or is there nothing in
+the embeddings to begin with?
+
+For each encoder, mean-pools chunks per ``event_date`` to get one
+embedding per FOMC event, joins to ``events.parquet`` (filtered to
+``horizon == 1`` so ``direction_t1d`` matches the prediction window
+and one row per event), and trains an L2-regularised
+``LogisticRegression`` (regularisation auto-tuned via ``LogisticRegressionCV``)
+on each walk-forward fold's training partition to predict
+``direction_t1d > 0`` on the test partition.
+
+Reports per-fold accuracy + ROC-AUC + the mean across folds, against
+the 53.7% majority-class baseline.
+
+Decision matrix the caller cares about:
+
+- mean accuracy > 53.7% on any encoder -> text embeddings carry
+  directional signal the TFT did not extract; architecture was the
+  bottleneck; classification head + 4-layer NLP remain viable
+- mean accuracy <= 53.7% across every encoder -> text definitively
+  lacks daily-resolution directional signal; abandon directional
+  prediction and pivot to volatility / regime
+
+Usage::
+
+    python -m scripts.linear_probe_embeddings \\
+        --training-package-id tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0 \\
+        --encoders finbert finbert_fed_adjacent voyage_finance_2
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from app.config import DATA_DIR
+
+
+def _discover_cached_encoders() -> list[str]:
+    """Scan ``data/raw/embeddings/`` and return one alias per cache file.
+
+    The cache filenames follow ``<alias>_<rev>.parquet``; the alias is
+    every char before the final underscore-then-revision tail. Some
+    aliases (``bge_large_en_v15``, ``nomic_embed_text_v15``) carry
+    underscores themselves, so the naive last-underscore split is
+    incorrect. Resolve by stripping the file extension and matching
+    against a curated suffix list.
+    """
+
+    cache_dir = DATA_DIR / "raw" / "embeddings"
+    if not cache_dir.exists():
+        return []
+    seen: set[str] = set()
+    for path in sorted(cache_dir.glob("*.parquet")):
+        stem = path.stem
+        # Curated alias list -- prefer the longest matching prefix so
+        # ``bge_large_en_v15_d4aa..`` resolves to ``bge_large_en_v15``,
+        # not ``bge_large_en``.
+        for candidate in sorted(
+            (
+                "bert_base_fed_adjacent",
+                "bert_base_uncased",
+                "bge_large_en_v15",
+                "finbert",
+                "finbert_fed_adjacent",
+                "finbert_fomc",
+                "fomc_roberta",
+                "nomic_embed_text_v15",
+                "voyage_finance_2",
+            ),
+            key=len,
+            reverse=True,
+        ):
+            if stem.startswith(candidate + "_"):
+                seen.add(candidate)
+                break
+    return sorted(seen)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--training-package-id",
+        required=True,
+        help="Training-package id under ``data/processed/<id>``.",
+    )
+    parser.add_argument(
+        "--encoders",
+        nargs="+",
+        default=None,
+        help=(
+            "Encoder aliases to probe. Each must resolve via glob to "
+            "``data/raw/embeddings/<alias>_*.parquet``. When omitted "
+            "(default), every cached encoder under "
+            "``data/raw/embeddings/`` enters the bake-off."
+        ),
+    )
+    parser.add_argument(
+        "--folds",
+        nargs="+",
+        default=("wf_fold_1", "wf_fold_2", "wf_fold_3", "wf_fold_4"),
+        help="Walk-forward fold ids to evaluate against.",
+    )
+    parser.add_argument(
+        "--baseline-accuracy",
+        type=float,
+        default=0.537,
+        help="Majority-class baseline (default 0.537 = +1-class share).",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional JSON output path. Per-fold + aggregate results.",
+    )
+    parser.add_argument(
+        "--max-iter",
+        type=int,
+        default=2000,
+        help="LogisticRegressionCV solver max-iter. Default 2000.",
+    )
+    return parser.parse_args()
+
+
+_KNOWN_ALIASES: tuple[str, ...] = (
+    "bert_base_fed_adjacent",
+    "bert_base_uncased",
+    "bge_large_en_v15",
+    "finbert_fed_adjacent",
+    "finbert_fomc",
+    "finbert",
+    "fomc_roberta",
+    "nomic_embed_text_v15",
+    "voyage_finance_2",
+)
+
+
+def _canonical_alias_for_file(stem: str) -> str | None:
+    """Return the LONGEST known alias the filename starts with (alias + underscore)."""
+    candidates = [
+        alias
+        for alias in _KNOWN_ALIASES
+        if stem.startswith(alias + "_")
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=len)
+
+
+def _resolve_embedding_parquet(alias: str) -> Path:
+    """Find the parquet whose CANONICAL alias matches ``alias`` exactly.
+
+    Naive glob ``<alias>_*.parquet`` over-matches: globbing on ``finbert``
+    swallows ``finbert_fomc_*.parquet`` and ``finbert_fed_adjacent_*.parquet``
+    too, producing silent encoder duplication in the leaderboard. Resolve
+    by walking the cache directory, computing the LONGEST-prefix alias
+    for each file, and returning only files whose canonical alias
+    equals the requested one.
+    """
+    cache_dir = DATA_DIR / "raw" / "embeddings"
+    matches: list[Path] = []
+    for path in sorted(cache_dir.glob("*.parquet")):
+        canonical = _canonical_alias_for_file(path.stem)
+        if canonical == alias:
+            matches.append(path)
+    if not matches:
+        raise FileNotFoundError(
+            f"No embedding parquet has canonical alias={alias!r} under "
+            f"{cache_dir}. Known aliases: {_KNOWN_ALIASES}"
+        )
+    if len(matches) > 1:
+        print(
+            f"  warning: multiple parquets resolve to alias={alias!r}: "
+            f"{[p.name for p in matches]}; picking {matches[-1].name}",
+            file=sys.stderr,
+        )
+    return matches[-1]
+
+
+def _pool_embeddings_per_event(emb_df: pd.DataFrame) -> pd.DataFrame:
+    """Mean-pool chunks within each event_date to get one vector per event."""
+    if "event_date" not in emb_df.columns or "embedding" not in emb_df.columns:
+        raise ValueError(
+            f"Embedding parquet missing required columns; got {list(emb_df.columns)}"
+        )
+    emb_df = emb_df.copy()
+    emb_df["event_date"] = emb_df["event_date"].astype(str)
+    emb_df["embedding"] = emb_df["embedding"].apply(
+        lambda v: np.asarray(v, dtype=np.float32) if v is not None else None
+    )
+    grouped: dict[str, np.ndarray] = {}
+    counts: dict[str, int] = {}
+    for date, vec in zip(emb_df["event_date"], emb_df["embedding"]):
+        if vec is None or len(vec) == 0:
+            continue
+        running = grouped.get(date)
+        if running is None:
+            grouped[date] = vec.astype(np.float64)
+            counts[date] = 1
+        else:
+            grouped[date] = running + vec.astype(np.float64)
+            counts[date] += 1
+    rows = [
+        {"event_date": date, "embedding": (grouped[date] / counts[date]).astype(np.float32)}
+        for date in sorted(grouped)
+    ]
+    return pd.DataFrame(rows)
+
+
+def _load_event_targets(package_dir: Path) -> pd.DataFrame:
+    """Load events.parquet filtered to horizon=1 with non-zero direction."""
+    events = pd.read_parquet(package_dir / "events.parquet")
+    h1 = events[events["horizon"] == 1].copy()
+    h1["event_date"] = h1["event_date"].astype(str)
+    h1 = h1[h1["direction_t1d"].isin([-1, 1])]   # drop the 4 zero-rows
+    # One row per event_date (the per-asset multiplicity has already
+    # been collapsed during the event_row build, but defensive dedupe).
+    h1 = h1.drop_duplicates(subset=["event_date"], keep="first")
+    return h1[["event_date", "direction_t1d"]].reset_index(drop=True)
+
+
+def _load_fold_manifest(package_dir: Path) -> dict[str, dict[str, str]]:
+    """Return ``fold_id -> {train_start, train_end, test_start, test_end}``."""
+    manifest = json.loads(
+        (package_dir / "fold_manifest_expanding_walk_forward.json").read_text()
+    )
+    out: dict[str, dict[str, str]] = {}
+    for fold in manifest.get("folds", []):
+        fid = fold.get("fold_id")
+        if not fid:
+            continue
+        out[fid] = {
+            "train_start": str(fold.get("train_start", "")),
+            "train_end": str(fold.get("train_end", "")),
+            "val_start": str(fold.get("val_start", "")),
+            "val_end": str(fold.get("val_end", "")),
+            "test_start": str(fold.get("test_start", "")),
+            "test_end": str(fold.get("test_end", "")),
+        }
+    return out
+
+
+def _evaluate_fold(
+    *,
+    joined: pd.DataFrame,
+    fold_id: str,
+    fold_dates: dict[str, str],
+    max_iter: int,
+) -> dict[str, Any]:
+    """Fit LogisticRegression on this fold's train slice, evaluate on test."""
+
+    from sklearn.linear_model import LogisticRegressionCV
+    from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
+
+    train_mask = (
+        (joined["event_date"] >= fold_dates["train_start"])
+        & (joined["event_date"] < fold_dates["val_start"])
+    )
+    test_mask = (
+        (joined["event_date"] >= fold_dates["test_start"])
+        & (joined["event_date"] < fold_dates.get("test_end", "9999-12-31"))
+        | (joined["event_date"] == fold_dates["test_start"])
+    )
+    # The fold manifest uses [train_start, val_start) ; [test_start, test_end)
+    # half-open windows. The OR clause above defends against
+    # zero-length test sets when test_start == test_end on the
+    # final fold's calendar boundary.
+    train_df = joined.loc[train_mask]
+    test_df = joined.loc[test_mask]
+
+    if len(train_df) < 20 or len(test_df) < 5:
+        return {
+            "fold_id": fold_id,
+            "n_train": int(len(train_df)),
+            "n_test": int(len(test_df)),
+            "skipped": "partition too small for a defensible fit",
+        }
+
+    X_train = np.vstack(train_df["embedding"].values).astype(np.float32)
+    y_train = (train_df["direction_t1d"] > 0).astype(np.int64).values
+    X_test = np.vstack(test_df["embedding"].values).astype(np.float32)
+    y_test = (test_df["direction_t1d"] > 0).astype(np.int64).values
+
+    if len(np.unique(y_train)) < 2:
+        return {
+            "fold_id": fold_id,
+            "n_train": int(len(train_df)),
+            "n_test": int(len(test_df)),
+            "skipped": "train slice carries only one class",
+        }
+
+    # LogisticRegressionCV picks C via 5-fold cross-validation on the
+    # training slice; defends against the high-dim / small-N
+    # overfitting risk that a fixed-C LogisticRegression would hit.
+    clf = LogisticRegressionCV(
+        Cs=10,
+        cv=5,
+        scoring="roc_auc",
+        max_iter=max_iter,
+        n_jobs=-1,
+    )
+    clf.fit(X_train, y_train)
+    proba = clf.predict_proba(X_test)[:, 1]
+    pred = (proba >= 0.5).astype(np.int64)
+
+    accuracy = float(accuracy_score(y_test, pred))
+    f1 = float(f1_score(y_test, pred, average="macro", zero_division=0))
+    auc = (
+        float(roc_auc_score(y_test, proba))
+        if len(np.unique(y_test)) > 1
+        else None
+    )
+    return {
+        "fold_id": fold_id,
+        "n_train": int(len(train_df)),
+        "n_test": int(len(test_df)),
+        "best_C": float(clf.C_[0]),
+        "accuracy": accuracy,
+        "f1_macro": f1,
+        "auc": auc,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    # Quiet sklearn FutureWarnings -- they obscure the leaderboard
+    # and the deprecations are scheduled for sklearn 1.10, not load-
+    # bearing for this short-lived script.
+    import warnings
+
+    warnings.filterwarnings("ignore", category=FutureWarning)
+
+    args = _parse_args()
+    package_dir = DATA_DIR / "processed" / args.training_package_id
+
+    encoders = args.encoders or _discover_cached_encoders()
+    if not encoders:
+        print("  no encoders specified and no parquets discovered under data/raw/embeddings/")
+        return 1
+
+    print("==== linear probe over embeddings (NLP bake-off) ====")
+    print(f"  package:   {args.training_package_id}")
+    print(f"  encoders:  {encoders}")
+    print(f"  folds:     {list(args.folds)}")
+    print(f"  baseline:  {args.baseline_accuracy:.3f}")
+    print()
+
+    target_df = _load_event_targets(package_dir)
+    fold_dates = _load_fold_manifest(package_dir)
+    print(f"  events at horizon=1 (non-zero direction): {len(target_df)}")
+    print(f"  folds in manifest:                        {list(fold_dates.keys())}")
+    print()
+
+    summary: dict[str, Any] = {}
+    for alias in encoders:
+        print(f"---- {alias} ----")
+        try:
+            emb_path = _resolve_embedding_parquet(alias)
+        except FileNotFoundError as exc:
+            print(f"  {exc}")
+            continue
+        print(f"  parquet:   {emb_path.name}")
+        raw_emb = pd.read_parquet(emb_path)
+        pooled = _pool_embeddings_per_event(raw_emb)
+        joined = pooled.merge(target_df, on="event_date", how="inner")
+        if joined.empty:
+            print("  no overlap between embedding event_dates and target events")
+            continue
+        emb_dim = int(joined.iloc[0]["embedding"].shape[0])
+        print(
+            f"  events joined: {len(joined)}  "
+            f"(embedding dim={emb_dim}, dropped "
+            f"{len(target_df) - len(joined)} unmatched targets)"
+        )
+        fold_results: list[dict[str, Any]] = []
+        for fold_id in args.folds:
+            if fold_id not in fold_dates:
+                print(f"  fold {fold_id} not in manifest; skipping")
+                continue
+            result = _evaluate_fold(
+                joined=joined,
+                fold_id=fold_id,
+                fold_dates=fold_dates[fold_id],
+                max_iter=args.max_iter,
+            )
+            fold_results.append(result)
+        summary[alias] = fold_results
+        _print_encoder_table(alias, fold_results, baseline=args.baseline_accuracy)
+        print()
+
+    print("==== NLP encoder leaderboard (sorted by mean directional accuracy) ====")
+    rows: list[dict[str, Any]] = []
+    for alias in encoders:
+        fold_rows = [
+            r
+            for r in summary.get(alias, [])
+            if "skipped" not in r and r.get("accuracy") is not None
+        ]
+        if not fold_rows:
+            continue
+        mean_acc = float(np.mean([r["accuracy"] for r in fold_rows]))
+        std_acc = float(np.std([r["accuracy"] for r in fold_rows], ddof=1)) if len(fold_rows) > 1 else 0.0
+        mean_f1 = float(np.mean([r["f1_macro"] for r in fold_rows]))
+        aucs = [r["auc"] for r in fold_rows if r["auc"] is not None]
+        mean_auc = float(np.mean(aucs)) if aucs else float("nan")
+        rows.append(
+            {
+                "encoder": alias,
+                "n_folds": len(fold_rows),
+                "mean_accuracy": mean_acc,
+                "std_accuracy": std_acc,
+                "mean_f1_macro": mean_f1,
+                "mean_auc": mean_auc,
+                "vs_baseline": mean_acc - args.baseline_accuracy,
+                "beats_baseline": mean_acc > args.baseline_accuracy,
+            }
+        )
+
+    rows.sort(key=lambda r: r["mean_accuracy"], reverse=True)
+
+    header = (
+        f"  {'rank':>4}  {'encoder':<26}{'folds':>7}"
+        f"{'acc (mean ± std)':>24}{'f1_macro':>12}{'auc':>10}"
+        f"{'vs baseline':>14}  beat?"
+    )
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for idx, r in enumerate(rows, start=1):
+        beat_marker = "  yes" if r["beats_baseline"] else "   no"
+        acc_str = f"{r['mean_accuracy']:.3f} ± {r['std_accuracy']:.3f}"
+        print(
+            f"  {idx:>4}  {r['encoder']:<26}{r['n_folds']:>7}"
+            f"{acc_str:>24}{r['mean_f1_macro']:>12.3f}{r['mean_auc']:>10.3f}"
+            f"{r['vs_baseline']:>+14.3f}{beat_marker}"
+        )
+
+    print()
+    above_baseline = [r for r in rows if r["beats_baseline"]]
+    if above_baseline:
+        winner = above_baseline[0]
+        print(
+            f"  Winner: {winner['encoder']} (mean accuracy "
+            f"{winner['mean_accuracy']:.3f}, "
+            f"{winner['vs_baseline']:+.3f} vs {args.baseline_accuracy:.3f} baseline)"
+        )
+    else:
+        best = rows[0] if rows else None
+        if best:
+            print(
+                f"  No encoder beats the {args.baseline_accuracy:.3f} majority-class "
+                f"baseline. Best so far: {best['encoder']} at "
+                f"{best['mean_accuracy']:.3f} ({best['vs_baseline']:+.3f}). "
+                "Text definitively lacks daily directional signal."
+            )
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(summary, indent=2))
+        print(f"\n  json written to {out_path}")
+
+    return 0
+
+
+def _print_encoder_table(alias: str, rows: list[dict[str, Any]], *, baseline: float) -> None:
+    header = (
+        f"  {'fold':<14}{'n_train':>10}{'n_test':>8}{'accuracy':>12}"
+        f"{'f1_macro':>12}{'auc':>10}{'C':>10}"
+    )
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for r in rows:
+        if "skipped" in r:
+            print(
+                f"  {r['fold_id']:<12}{r['n_train']:>10}{r['n_test']:>8}  {r['skipped']}"
+            )
+            continue
+        acc_str = f"{r['accuracy']:.3f}" if r.get("accuracy") is not None else "None"
+        f1_str = f"{r['f1_macro']:.3f}" if r.get("f1_macro") is not None else "None"
+        auc_str = f"{r['auc']:.3f}" if r.get("auc") is not None else "None"
+        c_str = f"{r['best_C']:.3g}" if r.get("best_C") is not None else "None"
+        print(
+            f"  {r['fold_id']:<14}{r['n_train']:>10}{r['n_test']:>8}"
+            f"{acc_str:>12}{f1_str:>12}{auc_str:>10}{c_str:>10}"
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Three diagnostic scripts under `scripts/` that answered the empirical-gate questions for the Phase 9 pivot. All read-only; no app-code changes. Each emits a JSON sidecar for downstream aggregation and a human-readable table to stdout.

- `eval_checkpoint_directional.py` — loads a saved forecaster checkpoint and runs inference across every fold's test partition; derives directional accuracy / f1_macro / AUC from `sign(predicted_close - prev_close)` vs `sign(true_close - prev_close)`. Handles the RobustScaler rehydration and reads `close_scale` + `model_config` off the payload.
- `linear_probe_embeddings.py` — NLP bake-off across every cached encoder under `data/raw/embeddings/`. Mean-pools chunk embeddings per `event_date`, joins to `events.parquet` at horizon=1, fits `LogisticRegressionCV` per walk-forward fold on `direction_t1d > 0`. Emits a sorted leaderboard. Includes a canonical-alias resolver fixing the silent `finbert` / `finbert_fomc` / `finbert_fed_adjacent` glob collision.
- `diagnose_data_health.py` — Check 1: rich-feature sparsity + PCA on the 29-dim rich slice; reports per-column zero rate, dead columns, and components needed for 50/80/90/95/99 percent of standardised variance. Check 2: event-day vs non-event-day vol bias — Welch t-tests + KS 2-sample on `abs_return` and `vol_shift`.

## Empirical findings these scripts produced (already used to set Phase 9 direction)

- Directional accuracy on the in-flight multi-fold checkpoint: 48.1% mean (below 53.7% majority-class baseline)
- Linear probe leaderboard: BGE wins at 54.0% but +0.3pp is inside fold-noise; all FinBERT-family encoders sit at 45–47%
- Data health: 4 dead rich-feature columns (`credibility_market_implied_gap`, `topic_share_inflation`, `topic_share_employment`, `mp_is_intermeeting`), 17 PCs for 95% variance on the 25 live columns
- Event-day `vol_shift` distribution statistically indistinguishable from non-event-day distribution (Welch t p=0.63, KS p=0.11)

These results triggered the regime-classification target pivot now tracked separately.

## Test plan

- [ ] `docker compose run --rm backend python /app/scripts/diagnose_data_health.py --training-package-id tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0`
- [ ] `docker compose run --rm backend python /app/scripts/linear_probe_embeddings.py --training-package-id tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0`