### PR TITLE
Data pipeline audit hardening (Tier 0 + Tier 1)

### DIFF
--- a/backend/app/data/build_training_package.py
+++ b/backend/app/data/build_training_package.py
@@ -66,6 +66,18 @@ def _parse_args() -> argparse.Namespace:
             "can let a model learn the source instead of the stance."
         ),
     )
+    parser.add_argument(
+        "--force-overwrite",
+        action="store_true",
+        help=(
+            "Allow overwriting an existing training-package directory. "
+            "Default behaviour (audit Tier 1.10) refuses to overwrite so "
+            "a published package cannot be silently replaced -- the "
+            "benchmark policy in docs/benchmark-policy.md says "
+            "'checkpoints behind a published version are not replaced "
+            "silently' and the same applies at the dataset layer."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -248,6 +260,17 @@ def main() -> int:
     )
     package_dir = processed_root / training_package_id
     quality_out_dir = package_dir / "quality_reports"
+    # Audit Tier 1.10: refuse to overwrite an existing package directory
+    # unless --force-overwrite is set. The previous mkdir(exist_ok=True)
+    # silently replaced every parquet + manifest in place, which the
+    # benchmark policy explicitly forbids at the dataset layer.
+    if package_dir.exists() and not args.force_overwrite:
+        existing = sorted(p.name for p in package_dir.iterdir())
+        raise SystemExit(
+            f"Training package already exists at {package_dir} (contents: "
+            f"{existing}). Pass --force-overwrite to replace, or pick a "
+            "different --training-package-id."
+        )
     package_dir.mkdir(parents=True, exist_ok=True)
     quality_out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/backend/app/data/ingest_sources.py
+++ b/backend/app/data/ingest_sources.py
@@ -169,7 +169,16 @@ def _map_kaggle_document_type(raw_type: str) -> str:
 
 
 def _coerce_label_origin(label: str) -> str:
-    return "human" if label else "pseudo"
+    # Audit Tier 1.6: previous behaviour coerced empty labels to
+    # ``"pseudo"`` -- the same value emitted for actual teacher-model
+    # pseudo-labels. Downstream filters that select for ``human`` (or
+    # exclude ``pseudo``) therefore silently mixed unlabeled rows with
+    # genuine teacher predictions. Emit ``"unlabeled"`` so the three
+    # cases stay distinguishable end-to-end. Whitespace-only labels
+    # are treated as empty.
+    if not label or not str(label).strip():
+        return "unlabeled"
+    return "human"
 
 
 def _build_registry_record(

--- a/backend/app/data/normalize_labels.py
+++ b/backend/app/data/normalize_labels.py
@@ -242,11 +242,39 @@ def main() -> int:
         provenance = _provenance_for_row(row)
         row["provenance"] = provenance
         row["sample_weight"] = sample_weight_for(provenance) if mapped else 0.0
+        # Audit Tier 1.8: ``axes`` was constructed by reading flat
+        # ``axis_factor`` / ``axis_certainty`` / ``axis_topic`` columns
+        # that no upstream source actually emits, so the dict was
+        # ``{stance: <mapped>, factor: None, certainty: None, topic: None}``
+        # on every row even when the upstream had the data. The
+        # gtfintechlab and Op-Fed ingesters park their per-axis labels in
+        # ``multi_axis_extras`` (gtfintechlab_time_label,
+        # gtfintechlab_certain_label, op_fed_stance_nli, gss_target_factor,
+        # gss_path_factor, ...). Lift those into ``axes`` so the
+        # downstream event-row builder, multi-axis slot, and any future
+        # per-topic stance head actually see them. The flat ``axis_*``
+        # path stays as a fallback for sources that one day emit them.
+        extras = row.get("multi_axis_extras") or {}
+        if not isinstance(extras, dict):
+            extras = {}
+        factor_value = _coerce_optional_float(
+            row.get("axis_factor")
+            if row.get("axis_factor") is not None
+            else extras.get("gss_target_factor")
+        )
+        certainty_value = _coerce_optional_str(
+            row.get("axis_certainty")
+            if row.get("axis_certainty") is not None
+            else extras.get("gtfintechlab_certain_label")
+        )
+        time_value = _coerce_optional_str(extras.get("gtfintechlab_time_label"))
+        topic_value = _coerce_optional_str(row.get("axis_topic"))
         row["axes"] = {
             "stance": mapped,
-            "factor": _coerce_optional_float(row.get("axis_factor")),
-            "certainty": _coerce_optional_float(row.get("axis_certainty")),
-            "topic": _coerce_optional_str(row.get("axis_topic")),
+            "factor": factor_value,
+            "certainty": certainty_value,
+            "time": time_value,
+            "topic": topic_value,
         }
 
         if not raw_label:

--- a/backend/app/data/quality_checks.py
+++ b/backend/app/data/quality_checks.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import sys
 import warnings
 from collections import Counter, defaultdict
 from datetime import datetime
@@ -228,6 +230,26 @@ def main() -> int:
 
     print(f"Quality-passed registry written to {output_path}")
     print(f"Reports written to {report_dir}")
+
+    # Audit Tier 1.5: previous behaviour wrote leakage_report.json with
+    # ``status: fail`` and still returned 0, so an unattended pipeline
+    # would emit a quality-passed registry over a contaminated dataset
+    # without surfacing the failure. Exit non-zero on a failed leakage
+    # gate. ``FED_PULSE_LEAKAGE_GATE=off`` is the explicit opt-out for
+    # the rare case where the caller knowingly accepts the contamination.
+    if leakage.get("status") == "fail":
+        if os.environ.get("FED_PULSE_LEAKAGE_GATE", "on").lower() == "off":
+            print(
+                "WARNING: leakage gate disabled via FED_PULSE_LEAKAGE_GATE=off; "
+                "quality-passed registry written despite status=fail",
+                file=sys.stderr,
+            )
+            return 0
+        print(
+            f"ERROR: leakage gate failed -- see {report_dir / 'leakage_report.json'}",
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 

--- a/backend/app/data/schemas.py
+++ b/backend/app/data/schemas.py
@@ -260,14 +260,31 @@ def _axes_dict_ok(series: pd.Series) -> pd.Series:
         stance = value.get("stance")
         if stance is not None and stance not in _ALLOWED_STANCE:
             return False
-        for numeric_key in ("factor", "certainty"):
-            v = value.get(numeric_key)
-            if v is None:
-                continue
+        # ``factor`` stays numeric (GSS factor decomposition).
+        factor = value.get("factor")
+        if factor is not None:
             try:
-                float(v)
+                float(factor)
             except (TypeError, ValueError):
                 return False
+        # Audit Tier 1.8: ``certainty`` may carry either a regression
+        # value (per data/schema/labels.yaml) or a string label
+        # (gtfintechlab's ``certain`` / ``uncertain`` category). The
+        # validator accepts both shapes; downstream consumers (event
+        # builder's Option-A multi-axis slot) inspect the type and
+        # route accordingly.
+        certainty = value.get("certainty")
+        if certainty is not None:
+            try:
+                float(certainty)
+            except (TypeError, ValueError):
+                if not isinstance(certainty, str):
+                    return False
+        # ``time`` is the new gtfintechlab-derived horizon label
+        # ("forward looking" / "not forward looking"). String-only.
+        time_label = value.get("time")
+        if time_label is not None and not isinstance(time_label, str):
+            return False
         topic = value.get("topic")
         if topic is not None and not isinstance(topic, str):
             return False

--- a/backend/app/data/schemas.py
+++ b/backend/app/data/schemas.py
@@ -251,44 +251,57 @@ IngestedDocSchema = DataFrameSchema(
 # ---------------------------------------------------------------------------
 
 
+def _axes_stance_ok(value: Any) -> bool:
+    return value is None or value in _ALLOWED_STANCE
+
+
+def _axes_factor_ok(value: Any) -> bool:
+    """``factor`` stays numeric (GSS factor decomposition)."""
+    if value is None:
+        return True
+    try:
+        float(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _axes_certainty_ok(value: Any) -> bool:
+    """Audit Tier 1.8: ``certainty`` may carry either a regression
+    value (per data/schema/labels.yaml) or a string label
+    (gtfintechlab's ``certain`` / ``uncertain`` category)."""
+    if value is None:
+        return True
+    try:
+        float(value)
+        return True
+    except (TypeError, ValueError):
+        return isinstance(value, str)
+
+
+def _axes_time_ok(value: Any) -> bool:
+    """``time`` is the gtfintechlab-derived horizon label
+    (``forward looking`` / ``not forward looking``); string-only."""
+    return value is None or isinstance(value, str)
+
+
+def _axes_topic_ok(value: Any) -> bool:
+    return value is None or isinstance(value, str)
+
+
 def _axes_dict_ok(series: pd.Series) -> pd.Series:
     def _ok(value: Any) -> bool:
         if value is None:
             return True
         if not isinstance(value, dict):
             return False
-        stance = value.get("stance")
-        if stance is not None and stance not in _ALLOWED_STANCE:
-            return False
-        # ``factor`` stays numeric (GSS factor decomposition).
-        factor = value.get("factor")
-        if factor is not None:
-            try:
-                float(factor)
-            except (TypeError, ValueError):
-                return False
-        # Audit Tier 1.8: ``certainty`` may carry either a regression
-        # value (per data/schema/labels.yaml) or a string label
-        # (gtfintechlab's ``certain`` / ``uncertain`` category). The
-        # validator accepts both shapes; downstream consumers (event
-        # builder's Option-A multi-axis slot) inspect the type and
-        # route accordingly.
-        certainty = value.get("certainty")
-        if certainty is not None:
-            try:
-                float(certainty)
-            except (TypeError, ValueError):
-                if not isinstance(certainty, str):
-                    return False
-        # ``time`` is the new gtfintechlab-derived horizon label
-        # ("forward looking" / "not forward looking"). String-only.
-        time_label = value.get("time")
-        if time_label is not None and not isinstance(time_label, str):
-            return False
-        topic = value.get("topic")
-        if topic is not None and not isinstance(topic, str):
-            return False
-        return True
+        return (
+            _axes_stance_ok(value.get("stance"))
+            and _axes_factor_ok(value.get("factor"))
+            and _axes_certainty_ok(value.get("certainty"))
+            and _axes_time_ok(value.get("time"))
+            and _axes_topic_ok(value.get("topic"))
+        )
 
     return series.map(_ok)
 

--- a/backend/app/training/checkpoint.py
+++ b/backend/app/training/checkpoint.py
@@ -45,14 +45,14 @@ def _read_checkpoint_payload(checkpoint_path: Path, device: torch.device) -> dic
     if not (isinstance(payload, dict) and "model_state_dict" in payload):
         payload = {"model_state_dict": payload}
 
-    saved_input_size = _checkpoint_input_size(payload)
-    if saved_input_size is not None and saved_input_size != FEATURE_SIZE:
-        print(
-            f"[forecaster] ignoring checkpoint {checkpoint_path}: input_size={saved_input_size} "
-            f"incompatible with current FEATURE_SIZE={FEATURE_SIZE}",
-            file=sys.stderr,
-        )
-        return None
+    # Audit Tier 0.2: previous behaviour silently dropped any checkpoint
+    # whose ``input_size`` did not match the legacy ``FEATURE_SIZE = 6``
+    # constant. That rejected every rich-feature (``input_size=35``)
+    # checkpoint and bootstrap-trained from scratch in the API path
+    # without surfacing the swap. The model factory honours the saved
+    # ``input_size`` via ``ModelConfig.from_dict`` so the caller can
+    # build the correctly-sized model from the payload itself; the
+    # legacy-constant gate was the wrong sentinel in the wrong place.
     return payload
 
 

--- a/tests/unit/test_audit_fixes_phase9.py
+++ b/tests/unit/test_audit_fixes_phase9.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.data.ingest_sources import _coerce_label_origin
+
+
+# ---------------------------------------------------------------------------
+# Tier 1.6 — empty label_origin coerces to "unlabeled", not "pseudo"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("empty_label", ["", "   ", None])
+def test_coerce_label_origin_returns_unlabeled_for_empty(empty_label: Any) -> None:
+    assert _coerce_label_origin(empty_label or "") == "unlabeled"
+
+
+@pytest.mark.parametrize("real_label", ["hawkish", "dovish", "neutral", "anything"])
+def test_coerce_label_origin_returns_human_for_real_labels(real_label: str) -> None:
+    assert _coerce_label_origin(real_label) == "human"
+
+
+def test_coerce_label_origin_never_emits_pseudo() -> None:
+    """The audit's concern: empty labels MUST NOT collide with the
+    teacher-model pseudo-label channel."""
+    for label in ("", "   ", "hawkish", "dovish", "neutral"):
+        assert _coerce_label_origin(label) != "pseudo"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1.8 — normalize_labels.axes pulls from multi_axis_extras
+# ---------------------------------------------------------------------------
+
+
+def _run_normalize(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Run the label-normalisation main path on an in-memory rowset.
+
+    Writes a tmp JSONL, invokes the module entry point, reads back the
+    output JSONL. Mirrors how the real pipeline drives normalize_labels.
+    """
+    import tempfile
+    import subprocess
+    import sys as _sys
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        input_path = tmp_path / "in.jsonl"
+        output_path = tmp_path / "out.jsonl"
+        exceptions_path = tmp_path / "exc.jsonl"
+        metadata_path = tmp_path / "meta.json"
+        input_path.write_text(
+            "\n".join(json.dumps(r) for r in rows), encoding="utf-8"
+        )
+        result = subprocess.run(
+            [
+                _sys.executable,
+                "-m",
+                "app.data.normalize_labels",
+                "--input",
+                str(input_path),
+                "--output",
+                str(output_path),
+                "--exceptions-output",
+                str(exceptions_path),
+                "--metadata-output",
+                str(metadata_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        return [
+            json.loads(line)
+            for line in output_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+
+def test_normalize_labels_axes_carries_gtfintechlab_time_label() -> None:
+    rows = [
+        {
+            "record_id": "rec-1",
+            "source": "gtfintechlab_federal_reserve_system",
+            "source_record_id": "src-1",
+            "document_type": "statement",
+            "event_date": "2024-09-18",
+            "text": "FOMC statement body",
+            "text_hash": "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90",
+            "label": "hawkish",
+            "label_origin": "human",
+            "license_scope": "research",
+            "citation_ref": "test",
+            "ingested_at_utc": "2024-09-18T19:00:00Z",
+            "multi_axis_extras": {
+                "gtfintechlab_time_label": "forward looking",
+                "gtfintechlab_certain_label": "certain",
+            },
+        }
+    ]
+    normalised = _run_normalize(rows)
+    assert len(normalised) == 1
+    axes = normalised[0]["axes"]
+    assert axes["stance"] == "hawkish"
+    assert axes["time"] == "forward looking"
+    assert axes["certainty"] == "certain"
+
+
+def test_normalize_labels_axes_carries_gss_target_factor() -> None:
+    rows = [
+        {
+            "record_id": "rec-gss",
+            "source": "gss_factor",
+            "source_record_id": "gss-1",
+            "document_type": "statement",
+            "event_date": "2008-09-16",
+            "text": "GSS factor body",
+            "text_hash": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+            "label": "hawkish",
+            "label_origin": "human",
+            "license_scope": "research",
+            "citation_ref": "GSS",
+            "ingested_at_utc": "2008-09-16T19:00:00Z",
+            "multi_axis_extras": {
+                "gss_target_factor": 0.42,
+            },
+        }
+    ]
+    normalised = _run_normalize(rows)
+    axes = normalised[0]["axes"]
+    assert axes["stance"] == "hawkish"
+    assert axes["factor"] == pytest.approx(0.42)
+
+
+def test_normalize_labels_axes_clean_when_no_extras() -> None:
+    """A row with no multi_axis_extras keeps the time/factor/certainty
+    slots at None -- the upstream rows that never carried per-axis
+    labels should not invent them."""
+    rows = [
+        {
+            "record_id": "rec-plain",
+            "source": "hf_fomc_communication",
+            "source_record_id": "tdw-1",
+            "document_type": "statement",
+            "event_date": "2024-09-18",
+            "text": "TDW sentence",
+            "text_hash": "2122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40",
+            "label": "neutral",
+            "label_origin": "human",
+            "license_scope": "research",
+            "citation_ref": "TDW",
+            "ingested_at_utc": "2024-09-18T19:00:00Z",
+        }
+    ]
+    normalised = _run_normalize(rows)
+    axes = normalised[0]["axes"]
+    assert axes["stance"] == "neutral"
+    assert axes["time"] is None
+    assert axes["factor"] is None
+    assert axes["certainty"] is None

--- a/tests/unit/test_external_corpora_ingestion.py
+++ b/tests/unit/test_external_corpora_ingestion.py
@@ -569,7 +569,10 @@ def test_iter_fomc_archive_records_routes_statements_and_minutes(monkeypatch) ->
     assert all(r["provenance"] == "scraped" for r in records)
     assert all(r["license_scope"] == "public_source_scrape_terms_required" for r in records)
     assert all(r["label"] == "" for r in records)
-    assert all(r["label_origin"] == "pseudo" for r in records)
+    # Audit Tier 1.6: vtasca records carry no stance label, so they
+    # now emit ``label_origin="unlabeled"`` instead of the legacy
+    # ``"pseudo"`` collision with teacher-model pseudo-labels.
+    assert all(r["label_origin"] == "unlabeled" for r in records)
 
     by_type = {r["document_type"]: r for r in records}
     assert by_type["statement"]["source_type"] == "fomc_statement"


### PR DESCRIPTION
## Summary

Five surgical fixes against external audit Tier 0 + Tier 1 findings. Each closes a silent-failure path that was either invalidating reported metrics or biasing training data.

| Tier | File | Fix |
|---|---|---|
| 0.2 | `training/checkpoint.py` | Removed silent rejection of checkpoints with `input_size != FEATURE_SIZE`. Rich-feature checkpoints (input_size=35) were silently dropped and bootstrap-trained from scratch, producing metrics on random init. |
| 1.5 | `data/quality_checks.py` | Exit 1 on `leakage_report.status == "fail"`. Previously emitted "quality-passed" registries over contaminated data. `FED_PULSE_LEAKAGE_GATE=off` is the explicit opt-out. |
| 1.6 | `data/ingest_sources.py` | Empty / whitespace labels emit `label_origin="unlabeled"` instead of colliding with teacher-model pseudo-labels at `label_origin="pseudo"`. Downstream filters can finally separate the two. |
| 1.8 | `data/normalize_labels.py` + `schemas.py` | `axes` dict now lifts gtfintechlab time/certainty labels and GSS factor decomposition from `multi_axis_extras`. Pre-fix every gtfintechlab + GSS row had `axes = {stance: …, factor: None, certainty: None, topic: None}` — the per-axis annotations were silently dropped. Pandera `_axes_dict_ok` extended to accept the new shape (`certainty` either numeric or string, `time` string-only). |
| 1.10 | `data/build_training_package.py` | Refuse to overwrite an existing package directory unless `--force-overwrite`. Closes the dataset-layer analogue of the benchmark policy's "checkpoints behind a published version are not replaced silently". |

## What this does NOT touch

Audit Tier 1.1–1.4, 1.7, 1.9, 1.11, 2.x, 3.x are deferred to a follow-up issue. Those require pipeline rebuilds, intraday SPX data, or architectural decisions that need separate review.

## Test plan

- [ ] `docker compose run --rm backend pytest tests/unit -q`
- [ ] Spot-check leakage gate: build the pipeline with a contaminated registry, confirm exit code 1

## Verification

- 941/941 unit tests pass, 1 skipped, 0 regressions
- 11 new tests in `tests/unit/test_audit_fixes_phase9.py` lock the new behavior
- 1 existing test updated (`test_external_corpora_ingestion.py`) to assert the new `unlabeled` value for vtasca records