### PR TITLE
Classification breakdown evaluator (#199)

### DIFF
--- a/backend/app/evaluation/classification_breakdown.py
+++ b/backend/app/evaluation/classification_breakdown.py
@@ -151,7 +151,7 @@ def _binary_pr_auc(scores: Sequence[float], labels: Sequence[int]) -> float | No
     last_recall = 0.0
     last_precision = 1.0
     area = 0.0
-    for score, label in indexed:
+    for _score, label in indexed:
         if label == 1:
             tp += 1
         else:

--- a/backend/app/evaluation/classification_breakdown.py
+++ b/backend/app/evaluation/classification_breakdown.py
@@ -1,0 +1,312 @@
+"""Per-class breakdown for the vol-regime classifier (#199).
+
+The training-loop classification evaluator at
+``app.training.loop._evaluate_model`` reports a single accuracy, macro-F1
+and cross-entropy loss per partition. That headline number does not say
+*which* class the model handles well, which one it confuses, or whether
+the class probabilities are calibrated.
+
+This module supplies the per-class breakdown the appendix + UI need:
+
+- 3x3 confusion matrix
+- per-class precision / recall / F1 / support
+- one-vs-rest ROC-AUC + PR-AUC
+
+The helpers are pure Python (no sklearn dependency) so they ship through
+the same CI gates as the rest of the eval surface; the math is small
+enough that an explicit implementation is easier to audit than the
+sklearn equivalent.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from collections.abc import Sequence
+from typing import Any
+
+
+@dataclasses.dataclass(frozen=True)
+class PerClassMetrics:
+    """Precision / recall / F1 / support for a single class index."""
+
+    class_id: int
+    precision: float
+    recall: float
+    f1: float
+    support: int
+    roc_auc: float | None = None
+    pr_auc: float | None = None
+
+    def to_dict(self) -> dict[str, float | int | None]:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass(frozen=True)
+class ClassificationBreakdown:
+    """Full per-class breakdown over a (predictions, targets) pair.
+
+    ``confusion_matrix`` is ``[n_classes][n_classes]`` with
+    ``rows = true class, columns = predicted class``. ``per_class`` is a
+    tuple of ``PerClassMetrics`` indexed by class id.
+
+    Cell coverage:
+    - macro_precision / macro_recall / macro_f1 are unweighted means over
+      classes that have at least one ground-truth occurrence (support>0).
+    - weighted_f1 weights per-class F1 by support.
+    - macro_roc_auc / macro_pr_auc are unweighted means over the
+      per-class one-vs-rest curves that could be computed (i.e. that had
+      both a positive and a negative example in the partition).
+    """
+
+    n_classes: int
+    confusion_matrix: tuple[tuple[int, ...], ...]
+    per_class: tuple[PerClassMetrics, ...]
+    macro_precision: float
+    macro_recall: float
+    macro_f1: float
+    weighted_f1: float
+    macro_roc_auc: float | None = None
+    macro_pr_auc: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "n_classes": self.n_classes,
+            "confusion_matrix": [list(row) for row in self.confusion_matrix],
+            "per_class": [m.to_dict() for m in self.per_class],
+            "macro_precision": self.macro_precision,
+            "macro_recall": self.macro_recall,
+            "macro_f1": self.macro_f1,
+            "weighted_f1": self.weighted_f1,
+            "macro_roc_auc": self.macro_roc_auc,
+            "macro_pr_auc": self.macro_pr_auc,
+        }
+
+
+def _safe_div(numerator: float, denominator: float) -> float:
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator
+
+
+def _binary_roc_auc(scores: Sequence[float], labels: Sequence[int]) -> float | None:
+    """One-vs-rest ROC-AUC via the Mann-Whitney U identity.
+
+    Returns ``None`` when the partition has no positive or no negative
+    example (degenerate ROC curve); avoids the division-by-zero that a
+    naive trapezoid implementation would hit.
+    """
+
+    if len(scores) != len(labels):
+        raise ValueError("scores and labels must have the same length")
+    if len(scores) < 2:
+        return None
+    pos_count = sum(1 for y in labels if y == 1)
+    neg_count = len(labels) - pos_count
+    if pos_count == 0 or neg_count == 0:
+        return None
+    # Rank-sum via average ranks to handle ties deterministically.
+    indexed = sorted(enumerate(scores), key=lambda kv: kv[1])
+    ranks = [0.0] * len(scores)
+    i = 0
+    while i < len(indexed):
+        j = i
+        while j + 1 < len(indexed) and indexed[j + 1][1] == indexed[i][1]:
+            j += 1
+        avg_rank = (i + j) / 2.0 + 1.0  # 1-based ranks; ties averaged
+        for k in range(i, j + 1):
+            ranks[indexed[k][0]] = avg_rank
+        i = j + 1
+    rank_sum_pos = sum(rank for rank, label in zip(ranks, labels) if label == 1)
+    # AUC = (R_pos - n_pos * (n_pos + 1) / 2) / (n_pos * n_neg)
+    auc = (rank_sum_pos - pos_count * (pos_count + 1) / 2.0) / (
+        pos_count * neg_count
+    )
+    return float(auc)
+
+
+def _binary_pr_auc(scores: Sequence[float], labels: Sequence[int]) -> float | None:
+    """One-vs-rest PR-AUC via the trapezoidal-rule integral of P(R).
+
+    Returns ``None`` when no positive example exists (recall is undefined).
+    """
+
+    if len(scores) != len(labels):
+        raise ValueError("scores and labels must have the same length")
+    pos_count = sum(1 for y in labels if y == 1)
+    if pos_count == 0:
+        return None
+    if len(scores) == 0:
+        return None
+    # Sort by score descending; tie-break by label ascending so the
+    # negative wins (rank stays conservative on ties).
+    indexed = sorted(
+        zip(scores, labels),
+        key=lambda sl: (-float(sl[0]), int(sl[1])),
+    )
+    tp = 0
+    fp = 0
+    precisions: list[float] = []
+    recalls: list[float] = []
+    last_recall = 0.0
+    last_precision = 1.0
+    area = 0.0
+    for score, label in indexed:
+        if label == 1:
+            tp += 1
+        else:
+            fp += 1
+        precision = _safe_div(tp, tp + fp)
+        recall = _safe_div(tp, pos_count)
+        # Trapezoidal step between last and current point.
+        area += (recall - last_recall) * (precision + last_precision) / 2.0
+        last_recall = recall
+        last_precision = precision
+        precisions.append(precision)
+        recalls.append(recall)
+    # If the last cumulative recall is < 1.0, close to (recall=1, p=0).
+    if last_recall < 1.0:
+        area += (1.0 - last_recall) * last_precision / 2.0
+    return float(area)
+
+
+def _confusion_matrix(
+    predictions: Sequence[int],
+    targets: Sequence[int],
+    n_classes: int,
+) -> tuple[tuple[int, ...], ...]:
+    if len(predictions) != len(targets):
+        raise ValueError(
+            "predictions and targets must have the same length; "
+            f"got {len(predictions)} vs {len(targets)}"
+        )
+    matrix = [[0 for _ in range(n_classes)] for _ in range(n_classes)]
+    for true_y, pred_y in zip(targets, predictions):
+        if not (0 <= true_y < n_classes and 0 <= pred_y < n_classes):
+            continue
+        matrix[int(true_y)][int(pred_y)] += 1
+    return tuple(tuple(row) for row in matrix)
+
+
+def compute_classification_breakdown(
+    predictions: Sequence[int],
+    targets: Sequence[int],
+    *,
+    n_classes: int,
+    class_scores: Sequence[Sequence[float]] | None = None,
+) -> ClassificationBreakdown:
+    """Compute the full per-class breakdown for a partition's predictions.
+
+    ``predictions`` carries the argmax class index per row;
+    ``targets`` carries the ground-truth class index per row;
+    ``class_scores`` (optional) carries the per-class softmax probability
+    so the ROC / PR helpers can compute one-vs-rest AUCs. When omitted
+    the AUC fields are ``None``.
+    """
+
+    if n_classes < 2:
+        raise ValueError(f"n_classes must be >= 2; got {n_classes}")
+    cm = _confusion_matrix(predictions, targets, n_classes=n_classes)
+    per_class: list[PerClassMetrics] = []
+    for c in range(n_classes):
+        tp = cm[c][c]
+        fn = sum(cm[c][k] for k in range(n_classes) if k != c)
+        fp = sum(cm[r][c] for r in range(n_classes) if r != c)
+        support = tp + fn
+        precision = _safe_div(tp, tp + fp)
+        recall = _safe_div(tp, tp + fn)
+        f1 = (
+            _safe_div(2 * precision * recall, precision + recall)
+            if (precision + recall) > 0
+            else 0.0
+        )
+        roc_auc: float | None = None
+        pr_auc: float | None = None
+        if class_scores is not None:
+            # One-vs-rest: positive label when target == c, score is the
+            # class-c softmax probability.
+            scores = [float(row[c]) for row in class_scores]
+            ovr_labels = [1 if int(y) == c else 0 for y in targets]
+            roc_auc = _binary_roc_auc(scores, ovr_labels)
+            pr_auc = _binary_pr_auc(scores, ovr_labels)
+        per_class.append(
+            PerClassMetrics(
+                class_id=c,
+                precision=float(precision),
+                recall=float(recall),
+                f1=float(f1),
+                support=int(support),
+                roc_auc=roc_auc,
+                pr_auc=pr_auc,
+            )
+        )
+
+    classes_with_support = [m for m in per_class if m.support > 0]
+    if classes_with_support:
+        macro_precision = sum(m.precision for m in classes_with_support) / len(
+            classes_with_support
+        )
+        macro_recall = sum(m.recall for m in classes_with_support) / len(
+            classes_with_support
+        )
+        macro_f1 = sum(m.f1 for m in classes_with_support) / len(classes_with_support)
+        total_support = sum(m.support for m in classes_with_support)
+        weighted_f1 = (
+            sum(m.f1 * m.support for m in classes_with_support) / total_support
+            if total_support > 0
+            else 0.0
+        )
+    else:
+        macro_precision = macro_recall = macro_f1 = weighted_f1 = 0.0
+
+    roc_values = [m.roc_auc for m in per_class if m.roc_auc is not None]
+    pr_values = [m.pr_auc for m in per_class if m.pr_auc is not None]
+    macro_roc_auc = sum(roc_values) / len(roc_values) if roc_values else None
+    macro_pr_auc = sum(pr_values) / len(pr_values) if pr_values else None
+
+    return ClassificationBreakdown(
+        n_classes=int(n_classes),
+        confusion_matrix=cm,
+        per_class=tuple(per_class),
+        macro_precision=float(macro_precision),
+        macro_recall=float(macro_recall),
+        macro_f1=float(macro_f1),
+        weighted_f1=float(weighted_f1),
+        macro_roc_auc=macro_roc_auc,
+        macro_pr_auc=macro_pr_auc,
+    )
+
+
+def render_confusion_matrix_text(
+    breakdown: ClassificationBreakdown,
+    *,
+    class_labels: Sequence[str] | None = None,
+) -> str:
+    """Render the confusion matrix as a fixed-width text table for logs."""
+
+    n = breakdown.n_classes
+    labels = (
+        list(class_labels)
+        if class_labels is not None and len(class_labels) == n
+        else [str(c) for c in range(n)]
+    )
+    column_width = max(6, *(len(label) for label in labels))
+    header = "true\\pred".ljust(column_width) + " " + " ".join(
+        label.rjust(column_width) for label in labels
+    )
+    rows = []
+    for r, label in enumerate(labels):
+        row_cells = " ".join(
+            str(breakdown.confusion_matrix[r][c]).rjust(column_width)
+            for c in range(n)
+        )
+        rows.append(label.ljust(column_width) + " " + row_cells)
+    return "\n".join([header, *rows])
+
+
+__all__ = [
+    "PerClassMetrics",
+    "ClassificationBreakdown",
+    "compute_classification_breakdown",
+    "render_confusion_matrix_text",
+]

--- a/backend/app/evaluation/metrics.py
+++ b/backend/app/evaluation/metrics.py
@@ -32,8 +32,14 @@ class EvaluationMetrics:
     regime_accuracy: float | None = None
     regime_f1_macro: float | None = None
     regime_loss: float | None = None
+    # Per-class breakdown for the regime classifier (#199). The
+    # dataclass lives in ``app.evaluation.classification_breakdown`` but
+    # serialises to a dict here so the existing JSON contract on
+    # ``EvaluationMetrics.to_dict()`` keeps round-tripping cleanly.
+    # ``None`` on regression-only runs so the legacy contract holds.
+    classification_breakdown: dict[str, Any] | None = None
 
-    def to_dict(self) -> dict[str, float | None]:
+    def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 

--- a/backend/app/training/checkpoint.py
+++ b/backend/app/training/checkpoint.py
@@ -61,11 +61,11 @@ def _metrics_from_payload(payload: dict[str, Any] | None) -> EvaluationMetrics |
         return None
     metrics = payload.get("metrics")
     if isinstance(metrics, dict):
-        # Phase 9 V2 (#195) classification fields are nullable and
-        # default to None on EvaluationMetrics; passing missing keys
-        # explicitly keeps the regression-mode contract byte-identical
-        # while letting a classification-mode checkpoint round-trip its
-        # regime_accuracy / regime_f1_macro / regime_loss annotations.
+        # Phase 9 V2 (#195, #199) classification fields are nullable
+        # and default to None on EvaluationMetrics; passing missing
+        # keys explicitly keeps the regression-mode contract
+        # byte-identical while letting a classification-mode checkpoint
+        # round-trip its regime metrics + classification_breakdown.
         def _opt_float(key: str) -> float | None:
             value = metrics.get(key)
             if value is None:
@@ -74,6 +74,9 @@ def _metrics_from_payload(payload: dict[str, Any] | None) -> EvaluationMetrics |
                 return float(value)
             except (TypeError, ValueError):
                 return None
+
+        breakdown_raw = metrics.get("classification_breakdown")
+        breakdown = breakdown_raw if isinstance(breakdown_raw, dict) else None
 
         try:
             return EvaluationMetrics(
@@ -87,6 +90,7 @@ def _metrics_from_payload(payload: dict[str, Any] | None) -> EvaluationMetrics |
                 regime_accuracy=_opt_float("regime_accuracy"),
                 regime_f1_macro=_opt_float("regime_f1_macro"),
                 regime_loss=_opt_float("regime_loss"),
+                classification_breakdown=breakdown,
             )
         except (KeyError, TypeError, ValueError):
             return None

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -310,6 +310,7 @@ def _evaluate_model(
     # regression runs.
     pred_class_chunks: list[torch.Tensor] = []
     true_class_chunks: list[torch.Tensor] = []
+    class_score_chunks: list[torch.Tensor] = []
     use_text_path = bool(getattr(model, "_text_path_active", False))
     non_blocking = device.type == "cuda"
     with torch.no_grad():
@@ -346,6 +347,13 @@ def _evaluate_model(
                     predictions.argmax(dim=1).detach().to("cpu", torch.long)
                 )
                 true_class_chunks.append(batch_y.detach().to("cpu", torch.long))
+                # Per-class softmax probabilities ride alongside the
+                # argmax so the breakdown helper can compute one-vs-rest
+                # ROC-AUC + PR-AUC at the end of the loop. Keep on CPU
+                # in float32 to bound memory on long partitions.
+                class_score_chunks.append(
+                    torch.softmax(predictions, dim=1).detach().to("cpu", torch.float32)
+                )
             else:
                 delta = predictions - batch_y
                 close_squared_error += torch.square(delta[:, 0]).sum().to(torch.float64)
@@ -375,34 +383,46 @@ def _evaluate_model(
         # Classification partition: surface accuracy + macro-F1 on the
         # regime axis, leave the regression columns at +inf so legacy
         # consumers that read them notice immediately rather than seeing
-        # zeros that look like a perfect regression fit.
+        # zeros that look like a perfect regression fit. The full
+        # breakdown (confusion matrix + per-class P/R/F1 + one-vs-rest
+        # AUC) lives on ``EvaluationMetrics.classification_breakdown``.
+        from app.evaluation.classification_breakdown import (
+            compute_classification_breakdown,
+        )
+
         pred_classes = torch.cat(pred_class_chunks) if pred_class_chunks else torch.empty(0, dtype=torch.long)
         true_classes = torch.cat(true_class_chunks) if true_class_chunks else torch.empty(0, dtype=torch.long)
+        class_scores_tensor = (
+            torch.cat(class_score_chunks) if class_score_chunks else None
+        )
         n_classes_eval = int(getattr(model, "n_classes", 3) or 3)
-        regime_acc = float((pred_classes == true_classes).float().mean().item()) if pred_classes.numel() else 0.0
-        # Macro-F1: unweighted mean of per-class F1. Computed in pure
-        # torch so this works in containers without sklearn pinned.
-        per_class_f1: list[float] = []
-        for cls in range(n_classes_eval):
-            tp = int(((pred_classes == cls) & (true_classes == cls)).sum().item())
-            fp = int(((pred_classes == cls) & (true_classes != cls)).sum().item())
-            fn = int(((pred_classes != cls) & (true_classes == cls)).sum().item())
-            if tp + fp + fn == 0:
-                continue
-            precision = tp / (tp + fp) if (tp + fp) else 0.0
-            recall = tp / (tp + fn) if (tp + fn) else 0.0
-            f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
-            per_class_f1.append(f1)
-        regime_f1 = float(sum(per_class_f1) / len(per_class_f1)) if per_class_f1 else 0.0
+        regime_acc = (
+            float((pred_classes == true_classes).float().mean().item())
+            if pred_classes.numel()
+            else 0.0
+        )
         regime_loss = total_loss_value / total_items_int
+
+        class_scores_list: list[list[float]] | None = None
+        if class_scores_tensor is not None and class_scores_tensor.numel():
+            class_scores_list = class_scores_tensor.tolist()
+
+        breakdown = compute_classification_breakdown(
+            predictions=pred_classes.tolist(),
+            targets=true_classes.tolist(),
+            n_classes=n_classes_eval,
+            class_scores=class_scores_list,
+        )
+
         return EvaluationMetrics(
             loss=regime_loss,
             close_rmse=float("inf"),
             volatility_rmse=float("inf"),
             combined_rmse=float("inf"),
             regime_accuracy=regime_acc,
-            regime_f1_macro=regime_f1,
+            regime_f1_macro=float(breakdown.macro_f1),
             regime_loss=regime_loss,
+            classification_breakdown=breakdown.to_dict(),
         )
 
     close_value = float(close_squared_error.item())

--- a/scripts/eda_data_integrity.py
+++ b/scripts/eda_data_integrity.py
@@ -1,0 +1,257 @@
+"""Data integrity audit on a published training package (#200).
+
+Produces the per-fold, per-source, per-target diagnostics the report
+appendix needs so every headline number can be traced back to a
+reproducible row count + class balance. Outputs land under
+``data/artifacts/eda/<training_package_id>/`` and the wiki page at
+``../fed-pulse.wiki/15_Data_Integrity_Report.md`` reads from them.
+
+Run with::
+
+    python scripts/eda_data_integrity.py --training-package-id <pkg>
+
+The script is read-only on the package directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import pandas as pd
+
+
+def _resolve_package_dir(training_package_id: str) -> Path:
+    """Find the events.parquet for ``training_package_id`` regardless of
+    whether we're running inside the backend container (``/data`` mount)
+    or directly on the host filesystem."""
+
+    candidates = [
+        Path(f"/data/processed/{training_package_id}"),
+        Path(f"data/processed/{training_package_id}"),
+        Path(f"backend/data/processed/{training_package_id}"),
+    ]
+    for c in candidates:
+        if (c / "events.parquet").exists():
+            return c
+    raise FileNotFoundError(
+        f"events.parquet not found for {training_package_id}; tried: "
+        + ", ".join(str(c) for c in candidates)
+    )
+
+
+def _resolve_output_root(training_package_id: str) -> Path:
+    base = Path(os.environ.get("FED_PULSE_DATA_DIR", "data"))
+    out = base / "artifacts" / "eda" / training_package_id
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def _load_fold_manifest(pkg_dir: Path) -> dict[str, dict[str, str]] | None:
+    p = pkg_dir / "fold_manifest_expanding_walk_forward.json"
+    if not p.exists():
+        return None
+    try:
+        payload = json.loads(p.read_text())
+    except json.JSONDecodeError:
+        return None
+    folds = payload.get("folds") if isinstance(payload, dict) else None
+    if not isinstance(folds, list):
+        return None
+    out: dict[str, dict[str, str]] = {}
+    for f in folds:
+        if not isinstance(f, dict):
+            continue
+        fid = str(f.get("fold_id", "")).strip()
+        if fid:
+            out[fid] = {
+                "train_start": str(f.get("train_start", "")),
+                "train_end": str(f.get("train_end", "")),
+                "val_start": str(f.get("val_start", "")),
+                "val_end": str(f.get("val_end", "")),
+                "test_start": str(f.get("test_start", "")),
+                "test_end": str(f.get("test_end", "")),
+            }
+    return out
+
+
+def _fold_partition(event_date: str, fold: dict[str, str]) -> str | None:
+    """Map an event_date to its train/val/test slot under a fold's
+    chronological boundaries. Returns ``None`` when the date falls
+    outside every window."""
+
+    if not event_date:
+        return None
+    if fold["train_start"] <= event_date <= fold["train_end"]:
+        return "train"
+    if fold["val_start"] <= event_date <= fold["val_end"]:
+        return "val"
+    if fold["test_start"] <= event_date <= fold["test_end"]:
+        return "test"
+    return None
+
+
+def _per_fold_partition_counts(
+    df: pd.DataFrame, folds: dict[str, dict[str, str]]
+) -> dict[str, dict[str, int]]:
+    """Returns ``{fold_id: {partition: row_count}}`` using event_date bounds."""
+
+    counts: dict[str, dict[str, int]] = {}
+    for fid, fold in folds.items():
+        partitions: dict[str, int] = defaultdict(int)
+        for event_date in df["event_date"].astype(str):
+            slot = _fold_partition(event_date, fold)
+            if slot:
+                partitions[slot] += 1
+        counts[fid] = dict(partitions)
+    return counts
+
+
+def _per_fold_class_balance(
+    df: pd.DataFrame,
+    folds: dict[str, dict[str, str]],
+    *,
+    n_classes: int = 3,
+) -> dict[str, dict[str, dict[int, int]]]:
+    """Per-fold, per-partition class membership counts.
+
+    The class boundary is fitted on each fold's TRAIN slice only --
+    matches what the training-loop quantile fitter does, so the audit
+    measures the same boundary the optimiser saw.
+    """
+
+    out: dict[str, dict[str, dict[int, int]]] = {}
+    qs = [(i + 1) / n_classes for i in range(n_classes - 1)]
+    for fid, fold in folds.items():
+        train_mask = df["event_date"].between(fold["train_start"], fold["train_end"])
+        train_vols = df.loc[train_mask, "forward_realized_vol_10d"].dropna()
+        if train_vols.empty:
+            out[fid] = {}
+            continue
+        cutoffs = list(train_vols.quantile(qs))
+        partition_counts: dict[str, dict[int, int]] = {}
+        for partition in ("train", "val", "test"):
+            mask = df["event_date"].between(
+                fold[f"{partition}_start"], fold[f"{partition}_end"]
+            )
+            vols = df.loc[mask, "forward_realized_vol_10d"]
+            class_counts = defaultdict(int)
+            for v in vols:
+                if pd.isna(v):
+                    class_counts[-1] += 1
+                    continue
+                cls = next(
+                    (i for i, q in enumerate(cutoffs) if v < q), len(cutoffs)
+                )
+                class_counts[cls] += 1
+            partition_counts[partition] = dict(class_counts)
+        out[fid] = partition_counts
+        out[fid]["__cutoffs__"] = {i: float(c) for i, c in enumerate(cutoffs)}
+    return out
+
+
+def _per_source_counts(df: pd.DataFrame) -> dict[str, int]:
+    if "source" not in df.columns:
+        return {}
+    return df["source"].astype(str).value_counts().to_dict()
+
+
+def _missingness_audit(df: pd.DataFrame) -> dict[str, dict[str, float | int]]:
+    """For every analysis-relevant column, report rows + null fraction."""
+
+    columns = [
+        "forward_realized_vol_10d",
+        "axis_stance",
+        "credibility_drift_score",
+        "credibility_realized_vs_stated_gap",
+        "credibility_market_implied_gap",
+        "credibility_months_since_reversal",
+        "mp_surprise_level",
+        "mp_surprise_path_factor",
+        "fed_info_factor",
+        "realized_return",
+        "abnormal_return",
+        "volatility_shift",
+        "direction_t1d",
+    ]
+    out: dict[str, dict[str, float | int]] = {}
+    for col in columns:
+        if col not in df.columns:
+            continue
+        total = len(df)
+        nulls = int(df[col].isna().sum())
+        out[col] = {
+            "total_rows": int(total),
+            "null_rows": nulls,
+            "null_fraction": round(nulls / total, 6) if total else 0.0,
+        }
+    return out
+
+
+def _event_date_timeline(df: pd.DataFrame) -> dict[str, int]:
+    """Per-year row counts so the timeline coverage is plot-able."""
+
+    if "event_date" not in df.columns:
+        return {}
+    years = df["event_date"].astype(str).str[:4]
+    return dict(years.value_counts().sort_index().items())
+
+
+def _quantile_drift_table(
+    fold_class_balance: dict[str, dict[str, dict[int, int]]]
+) -> dict[str, dict[int, float]]:
+    """Surface the per-fold cutoffs in one table so the drift across
+    walk-forward folds is visible at a glance."""
+
+    out: dict[str, dict[int, float]] = {}
+    for fid, partitions in fold_class_balance.items():
+        cutoffs = partitions.get("__cutoffs__", {})
+        if cutoffs:
+            out[fid] = cutoffs
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="EDA / data-integrity audit (#200)")
+    p.add_argument("--training-package-id", required=True)
+    p.add_argument("--n-classes", type=int, default=3)
+    args = p.parse_args(argv)
+
+    pkg_dir = _resolve_package_dir(args.training_package_id)
+    out_dir = _resolve_output_root(args.training_package_id)
+
+    df = pd.read_parquet(pkg_dir / "events.parquet")
+    folds = _load_fold_manifest(pkg_dir) or {}
+
+    summary: dict[str, object] = {
+        "training_package_id": args.training_package_id,
+        "package_dir": str(pkg_dir),
+        "n_rows": int(len(df)),
+        "n_columns": int(len(df.columns)),
+        "columns": sorted(df.columns.tolist()),
+        "fold_manifest": folds,
+        "per_fold_partition_counts": _per_fold_partition_counts(df, folds),
+        "per_fold_class_balance": _per_fold_class_balance(
+            df, folds, n_classes=args.n_classes
+        ),
+        "per_source_counts": _per_source_counts(df),
+        "missingness": _missingness_audit(df),
+        "event_date_timeline": _event_date_timeline(df),
+    }
+    summary["per_fold_quantile_drift"] = _quantile_drift_table(
+        summary["per_fold_class_balance"]  # type: ignore[arg-type]
+    )
+
+    out_path = out_dir / "data_integrity.json"
+    out_path.write_text(json.dumps(summary, indent=2, sort_keys=True))
+    print(f"wrote {out_path}", flush=True)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/run_tier3_capacity_sweep.py
+++ b/scripts/run_tier3_capacity_sweep.py
@@ -1,0 +1,131 @@
+"""Tier 3 NLP capacity sweep for the vol-regime classifier (#198).
+
+Tracks whether the NLP integration redundancy seen in the 3-tier baseline
+(PR #197, §6.3 of 06_Deep_Learning_Roadmap.md) survives a small
+adapter-dim × encoder search. Holds architecture / seeds / folds /
+HP fixed except for the two NLP knobs.
+
+Grid:
+    adapter dims: 32, 64, 128
+    encoders:     finbert_fed_adjacent, bge_large_en_v15
+    architecture: lstm
+    seeds:        official 5
+    folds:        wf_fold_1 .. wf_fold_4
+
+Total trials: 3 × 2 × 5 × 4 = 120.
+
+Per-encoder JSON lands at
+``data/artifacts/regime_baseline_tiers/<pkg>/tier3_capacity_sweep/<encoder>/forecaster_sweep_results.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+_DEFAULT_REPORT_ROOT = Path("data/artifacts/regime_baseline_tiers")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Tier 3 NLP capacity sweep (#198)")
+    p.add_argument("--training-package-id", required=True)
+    p.add_argument(
+        "--encoders",
+        nargs="+",
+        default=["finbert_fed_adjacent", "bge_large_en_v15"],
+        help="Cached encoder aliases to sweep.",
+    )
+    p.add_argument(
+        "--adapter-dims",
+        nargs="+",
+        type=int,
+        default=[32, 64, 128],
+        help="Text-adapter output dimensions to sweep.",
+    )
+    p.add_argument("--architecture", default="lstm")
+    p.add_argument(
+        "--seeds", nargs="+", type=int, default=[11, 29, 47, 71, 97]
+    )
+    p.add_argument(
+        "--folds",
+        nargs="+",
+        default=["wf_fold_1", "wf_fold_2", "wf_fold_3", "wf_fold_4"],
+    )
+    p.add_argument("--hidden-size", type=int, default=64)
+    p.add_argument("--num-layers", type=int, default=2)
+    p.add_argument("--dropout", type=float, default=0.2)
+    p.add_argument("--learning-rate", type=float, default=1e-3)
+    p.add_argument("--weight-decay", type=float, default=1e-4)
+    p.add_argument("--vol-regime-classes", type=int, default=3)
+    p.add_argument("--report-root", type=Path, default=_DEFAULT_REPORT_ROOT)
+    p.add_argument("--dry-run", action="store_true")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    pkg_root = args.report_root / args.training_package_id / "tier3_capacity_sweep"
+    pkg_root.mkdir(parents=True, exist_ok=True)
+
+    for encoder in args.encoders:
+        encoder_dir = pkg_root / encoder
+        encoder_dir.mkdir(parents=True, exist_ok=True)
+        report_path = encoder_dir / "forecaster_sweep_results.json"
+        cmd = [
+            sys.executable,
+            "-m",
+            "app.train_forecaster",
+            "--training-package-id",
+            args.training_package_id,
+            "--sweep",
+            "--rich-features",
+            "--architectures",
+            args.architecture,
+            "--seeds",
+            *[str(s) for s in args.seeds],
+            "--folds",
+            *args.folds,
+            "--hidden-sizes",
+            str(args.hidden_size),
+            "--num-layers-grid",
+            str(args.num_layers),
+            "--dropouts",
+            str(args.dropout),
+            "--learning-rates",
+            str(args.learning_rate),
+            "--weight-decays",
+            str(args.weight_decay),
+            "--text-encoder",
+            encoder,
+            "--text-adapter-dims",
+            *[str(d) for d in args.adapter_dims],
+            "--output-mode",
+            "classification",
+            "--vol-regime-classes",
+            str(args.vol_regime_classes),
+            "--report-path",
+            str(report_path),
+        ]
+        print(f"[tier3_capacity] encoder={encoder} -> {report_path}", flush=True)
+        print(f"[tier3_capacity] cmd: {shlex.join(cmd)}", flush=True)
+        if args.dry_run:
+            continue
+        env = os.environ.copy()
+        result = subprocess.run(cmd, env=env)
+        if result.returncode != 0:
+            print(
+                f"[tier3_capacity] encoder={encoder} exited {result.returncode}; "
+                "stopping remaining encoders.",
+                file=sys.stderr,
+            )
+            return result.returncode
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_classification_breakdown.py
+++ b/tests/unit/test_classification_breakdown.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import pytest
+
+from app.evaluation.classification_breakdown import (
+    ClassificationBreakdown,
+    compute_classification_breakdown,
+    render_confusion_matrix_text,
+)
+
+
+# ---------------------------------------------------------------------------
+# Confusion matrix shape + indexing
+# ---------------------------------------------------------------------------
+
+
+def test_confusion_matrix_dimensions_match_n_classes() -> None:
+    breakdown = compute_classification_breakdown(
+        predictions=[0, 1, 2, 0],
+        targets=[0, 1, 2, 0],
+        n_classes=3,
+    )
+    assert breakdown.n_classes == 3
+    assert len(breakdown.confusion_matrix) == 3
+    assert all(len(row) == 3 for row in breakdown.confusion_matrix)
+
+
+def test_perfect_predictions_have_identity_confusion() -> None:
+    """Diagonal = support, off-diagonal = 0 for perfect predictions."""
+
+    breakdown = compute_classification_breakdown(
+        predictions=[0, 1, 2, 0, 1, 2],
+        targets=[0, 1, 2, 0, 1, 2],
+        n_classes=3,
+    )
+    expected = ((2, 0, 0), (0, 2, 0), (0, 0, 2))
+    assert breakdown.confusion_matrix == expected
+    assert breakdown.macro_precision == pytest.approx(1.0)
+    assert breakdown.macro_recall == pytest.approx(1.0)
+    assert breakdown.macro_f1 == pytest.approx(1.0)
+
+
+def test_off_diagonal_picks_up_misclassifications() -> None:
+    """row 0 col 1 means true=0, pred=1."""
+
+    breakdown = compute_classification_breakdown(
+        predictions=[1, 1, 2],
+        targets=[0, 1, 2],
+        n_classes=3,
+    )
+    assert breakdown.confusion_matrix[0][1] == 1  # one 0->1 misclassification
+    assert breakdown.confusion_matrix[1][1] == 1
+    assert breakdown.confusion_matrix[2][2] == 1
+
+
+# ---------------------------------------------------------------------------
+# Per-class metrics
+# ---------------------------------------------------------------------------
+
+
+def test_per_class_precision_recall_f1_on_known_split() -> None:
+    """class 0: TP=2 FP=1 FN=0 -> P=2/3, R=1, F1=0.8
+    class 1: TP=2 FP=0 FN=1 -> P=1, R=2/3, F1=0.8
+    class 2: TP=1 FP=0 FN=0 -> P=1, R=1, F1=1"""
+
+    breakdown = compute_classification_breakdown(
+        predictions=[0, 0, 0, 1, 1, 2],
+        targets=[0, 0, 1, 1, 1, 2],
+        n_classes=3,
+    )
+    p = {m.class_id: m for m in breakdown.per_class}
+    assert p[0].precision == pytest.approx(2 / 3)
+    assert p[0].recall == pytest.approx(1.0)
+    assert p[0].f1 == pytest.approx(0.8)
+    assert p[1].precision == pytest.approx(1.0)
+    assert p[1].recall == pytest.approx(2 / 3)
+    assert p[1].f1 == pytest.approx(0.8)
+    assert p[2].precision == pytest.approx(1.0)
+    assert p[2].recall == pytest.approx(1.0)
+    assert p[2].f1 == pytest.approx(1.0)
+
+
+def test_per_class_support_counts_targets_not_predictions() -> None:
+    """Support is the number of true examples of that class."""
+
+    breakdown = compute_classification_breakdown(
+        predictions=[0, 0, 0, 0],
+        targets=[0, 1, 2, 2],
+        n_classes=3,
+    )
+    supports = {m.class_id: m.support for m in breakdown.per_class}
+    assert supports == {0: 1, 1: 1, 2: 2}
+
+
+def test_class_with_zero_support_does_not_break_macro_average() -> None:
+    """A class with no ground-truth example is excluded from macro mean."""
+
+    breakdown = compute_classification_breakdown(
+        predictions=[0, 0, 1],
+        targets=[0, 0, 1],
+        n_classes=3,
+    )
+    # Class 2 has support=0 -> should not be in the macro average
+    classes_with_support = [m for m in breakdown.per_class if m.support > 0]
+    assert len(classes_with_support) == 2
+    assert breakdown.macro_f1 == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Weighted F1
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_f1_weights_by_support() -> None:
+    """Weighted F1 should differ from macro F1 when class supports differ."""
+
+    breakdown = compute_classification_breakdown(
+        predictions=[0, 0, 0, 0, 1, 1, 2, 0],
+        targets=[0, 0, 0, 0, 1, 1, 2, 0],
+        n_classes=3,
+    )
+    # Perfect predictions -> all F1=1 regardless of weighting
+    assert breakdown.macro_f1 == pytest.approx(1.0)
+    assert breakdown.weighted_f1 == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# AUC computation
+# ---------------------------------------------------------------------------
+
+
+def test_roc_auc_perfect_score_is_one() -> None:
+    """Perfect probability scores give AUC=1 for every class."""
+
+    scores = [
+        [0.9, 0.05, 0.05],
+        [0.9, 0.05, 0.05],
+        [0.05, 0.9, 0.05],
+        [0.05, 0.9, 0.05],
+        [0.05, 0.05, 0.9],
+        [0.05, 0.05, 0.9],
+    ]
+    breakdown = compute_classification_breakdown(
+        predictions=[0, 0, 1, 1, 2, 2],
+        targets=[0, 0, 1, 1, 2, 2],
+        n_classes=3,
+        class_scores=scores,
+    )
+    for m in breakdown.per_class:
+        assert m.roc_auc == pytest.approx(1.0)
+    assert breakdown.macro_roc_auc == pytest.approx(1.0)
+
+
+def test_roc_auc_random_score_is_about_half() -> None:
+    """Uniform probabilities should give AUC near 0.5."""
+
+    n = 30
+    scores = [[1 / 3, 1 / 3, 1 / 3] for _ in range(n)]
+    targets = [(i % 3) for i in range(n)]
+    breakdown = compute_classification_breakdown(
+        predictions=[0] * n,
+        targets=targets,
+        n_classes=3,
+        class_scores=scores,
+    )
+    # Constant scores -> all rank ties -> AUC == 0.5 exactly.
+    for m in breakdown.per_class:
+        assert m.roc_auc == pytest.approx(0.5)
+
+
+def test_roc_auc_none_when_no_positives_or_negatives() -> None:
+    """A class with no positive (or no negative) example has undefined ROC."""
+
+    scores = [[0.5, 0.5, 0.0]] * 3
+    breakdown = compute_classification_breakdown(
+        predictions=[0, 0, 0],
+        targets=[0, 0, 0],  # only class 0 appears
+        n_classes=3,
+        class_scores=scores,
+    )
+    by_id = {m.class_id: m for m in breakdown.per_class}
+    # Class 1 and class 2 have no positives -> ROC undefined
+    assert by_id[1].roc_auc is None
+    assert by_id[2].roc_auc is None
+    # Class 0 has no negatives -> ROC undefined too
+    assert by_id[0].roc_auc is None
+
+
+def test_macro_auc_skips_undefined_classes() -> None:
+    """Macro AUC averages only classes whose AUC could be computed."""
+
+    scores = [
+        [0.9, 0.1, 0.0],
+        [0.1, 0.9, 0.0],
+        [0.9, 0.1, 0.0],
+        [0.1, 0.9, 0.0],
+    ]
+    breakdown = compute_classification_breakdown(
+        predictions=[0, 1, 0, 1],
+        targets=[0, 1, 0, 1],  # class 2 never appears
+        n_classes=3,
+        class_scores=scores,
+    )
+    # Macro AUC should equal the mean of class-0 and class-1 AUCs only.
+    by_id = {m.class_id: m for m in breakdown.per_class}
+    assert by_id[2].roc_auc is None
+    assert breakdown.macro_roc_auc is not None
+    assert breakdown.macro_roc_auc == pytest.approx(
+        (by_id[0].roc_auc + by_id[1].roc_auc) / 2.0
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip via to_dict
+# ---------------------------------------------------------------------------
+
+
+def test_breakdown_round_trips_through_dict() -> None:
+    breakdown = compute_classification_breakdown(
+        predictions=[0, 1, 2],
+        targets=[0, 1, 2],
+        n_classes=3,
+    )
+    payload = breakdown.to_dict()
+    assert payload["n_classes"] == 3
+    assert payload["macro_f1"] == pytest.approx(1.0)
+    assert isinstance(payload["confusion_matrix"], list)
+    assert isinstance(payload["per_class"], list)
+    assert len(payload["per_class"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Text-table renderer
+# ---------------------------------------------------------------------------
+
+
+def test_text_renderer_returns_grid_of_expected_shape() -> None:
+    breakdown = compute_classification_breakdown(
+        predictions=[0, 1, 2, 1],
+        targets=[0, 1, 2, 0],
+        n_classes=3,
+    )
+    text = render_confusion_matrix_text(
+        breakdown, class_labels=("calm", "normal", "high")
+    )
+    lines = text.split("\n")
+    assert len(lines) == 4  # 1 header + 3 rows
+    assert "calm" in lines[1]
+    assert "normal" in lines[2]
+    assert "high" in lines[3]
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_mismatched_lengths_raise() -> None:
+    with pytest.raises(ValueError, match="same length"):
+        compute_classification_breakdown(
+            predictions=[0, 1],
+            targets=[0],
+            n_classes=2,
+        )
+
+
+def test_n_classes_below_two_raises() -> None:
+    with pytest.raises(ValueError, match="n_classes"):
+        compute_classification_breakdown(
+            predictions=[0, 0],
+            targets=[0, 0],
+            n_classes=1,
+        )


### PR DESCRIPTION
Confusion matrix + per-class P/R/F1 + one-vs-rest ROC/PR AUC for the vol-regime classifier eval path. Drives the appendix visuals + the regime-classifier UI cards.

## Headline

- ``app/evaluation/classification_breakdown.py`` — pure-Python ``compute_classification_breakdown(predictions, targets, *, n_classes, class_scores=…) -> ClassificationBreakdown`` plus the text-table renderer.
- ``EvaluationMetrics.classification_breakdown`` field; ``None`` on regression so the byte-identity contract holds.
- ``_evaluate_model`` populates the field on the classification path using per-batch softmax probabilities.
- ``_metrics_from_payload`` round-trips the breakdown across checkpoint save / load.
- ``scripts/run_tier3_capacity_sweep.py`` driver for #198 (adapter_dim x encoder grid).
- 24 new unit tests; full regression suite still green (11/11).

## Tier 3 capacity sweep result (run via the new script)

Best Tier 3 cell sits at the Tier 2 baseline — pooled text embeddings on top of the rich-feature block do not lift macro-F1 above the no-NLP control across 120 trials (3 adapter dims × 2 encoders × 5 seeds × 4 folds). Full per-cell table going into ``06_Deep_Learning_Roadmap.md`` §6.3 in the wiki commit that follows this merge.

## Closes

- #199 (richer evaluator)

## Test plan

```bash
docker compose run --rm backend pytest tests/unit/test_classification_breakdown.py tests/unit/test_phase9_classification_head.py tests/unit/test_phase9_partition_tensors.py tests/regression/
```