### PR TITLE
A1: per-fold inverse-frequency class weighting (#206)

### DIFF
--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -2023,6 +2023,49 @@ def fit_vol_regime_quantiles(
     return tuple(float(c) for c in cutoffs)
 
 
+def fit_class_weights(
+    forward_vols: Sequence[float],
+    quantiles: Sequence[float],
+    *,
+    n_classes: int,
+    smoothing: float = 1.0,
+) -> tuple[float, ...]:
+    """Return inverse-frequency class weights fitted on a train slice (#206).
+
+    Computes per-class counts under the supplied quantile cutoffs, then
+    returns weights proportional to ``1 / (count + smoothing)`` so a
+    class with no events still receives finite weight rather than
+    blowing up the loss. The weights are normalised so they sum to
+    ``n_classes`` -- a class with the dataset's average frequency gets
+    weight ~1, a rare class gets > 1, a dominant class gets < 1.
+
+    Returns ``()`` (empty) when no quantile cutoffs are available; the
+    caller then falls back to uniform weighting via the standard
+    ``CrossEntropyLoss`` default.
+
+    The motivation is the Tier 1 collapse in §6.3 of the wiki: the
+    optimiser learns the training-distribution prior because the loss
+    path of least resistance is "predict the majority class". Inverse-
+    frequency weights flatten that prior so the gradient is forced to
+    discriminate the minority classes.
+    """
+
+    if not quantiles or n_classes < 2:
+        return ()
+    counts = [0] * n_classes
+    for v in forward_vols:
+        if v is None or v != v:
+            continue
+        cls = vol_regime_class_for(v, quantiles)
+        if 0 <= cls < n_classes:
+            counts[cls] += 1
+    if sum(counts) == 0:
+        return ()
+    raw = [1.0 / (c + smoothing) for c in counts]
+    total = sum(raw)
+    return tuple((w / total) * n_classes for w in raw)
+
+
 def vol_regime_class_for(value: float | None, quantiles: Sequence[float]) -> int:
     """Map a forward-vol value to a class index using fitted quantiles.
 

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -37,6 +37,7 @@ from app.training.loaders import (
     _split_train_validation,
     apply_rich_feature_scaler_tensor,
     collect_forward_vols,
+    fit_class_weights,
     fit_rich_feature_scaler_tensor,
     fit_vol_regime_quantiles,
     load_training_sequences_from_data,
@@ -624,8 +625,20 @@ def train_model(
             active_model_config = dataclasses.replace(
                 active_model_config, vol_regime_quantiles=fitted_quantiles
             )
+            # A1 (#206) per-fold class weighting. Counts each class in
+            # the train slice under the just-fitted quantile cutoffs,
+            # then builds inverse-frequency weights so the loss path
+            # of least resistance is no longer "predict the majority
+            # prior". Train-only fit; val + test see the same weights
+            # but only at loss computation, not in their own slices.
+            fitted_class_weights = fit_class_weights(
+                train_forward_vols,
+                fitted_quantiles,
+                n_classes=n_classes_active,
+            )
         else:
             fitted_quantiles = ()
+            fitted_class_weights = ()
         # Fit the close-scale on the training partition only; never on
         # the val or test rows. The walk-forward protocol forbids
         # fitting any scaler over held-out events.
@@ -878,7 +891,17 @@ def train_model(
     _active_output_mode = str(getattr(work_model, "output_mode", "regression"))
     loss_fn: nn.Module
     if _active_output_mode == "classification":
-        loss_fn = nn.CrossEntropyLoss()
+        # A1 (#206) -- pass the per-fold class weights when available.
+        # ``walk_forward_path`` is the only branch that computes
+        # ``fitted_class_weights``; the legacy 80/20 path leaves it
+        # absent and the loss falls back to uniform weighting.
+        weights_tuple = locals().get("fitted_class_weights", ())
+        class_weight_tensor: torch.Tensor | None = None
+        if weights_tuple:
+            class_weight_tensor = torch.tensor(
+                list(weights_tuple), dtype=torch.float32, device=device_obj
+            )
+        loss_fn = nn.CrossEntropyLoss(weight=class_weight_tensor)
     else:
         loss_fn = nn.SmoothL1Loss(beta=0.02)
 

--- a/tests/unit/test_phase9_vol_regime_helpers.py
+++ b/tests/unit/test_phase9_vol_regime_helpers.py
@@ -89,3 +89,95 @@ def test_train_quantile_roundtrip_yields_balanced_classes() -> None:
     counts = [labels.count(c) for c in range(3)]
     for c in counts:
         assert 270 <= c <= 330, f"class counts {counts} should be near 300 each"
+
+
+# ---------------------------------------------------------------------------
+# A1 (#206) per-fold class weighting
+# ---------------------------------------------------------------------------
+
+
+def test_class_weights_invert_frequency_on_balanced_train_slice() -> None:
+    """Perfectly-balanced train slice -> weights all close to 1.0."""
+
+    from app.training.loaders import fit_class_weights
+
+    quantiles = (0.01, 0.02)
+    # 30 events evenly across the 3 classes
+    vols = [0.005] * 10 + [0.015] * 10 + [0.025] * 10
+    weights = fit_class_weights(vols, quantiles, n_classes=3)
+    assert len(weights) == 3
+    # All near 1.0 (perfect balance); sum should equal n_classes
+    assert sum(weights) == pytest.approx(3.0)
+    for w in weights:
+        assert 0.9 < w < 1.1
+
+
+def test_class_weights_upweight_minority_class() -> None:
+    """A rare class gets the largest weight; the dominant class the
+    smallest. Inverse-frequency invariant."""
+
+    from app.training.loaders import fit_class_weights
+
+    quantiles = (0.01, 0.02)
+    # 90% calm, 5% normal, 5% high
+    vols = [0.005] * 90 + [0.015] * 5 + [0.025] * 5
+    weights = fit_class_weights(vols, quantiles, n_classes=3)
+    # calm has lowest weight; normal + high tied at the top
+    assert weights[0] < weights[1]
+    assert weights[0] < weights[2]
+    assert weights[1] == pytest.approx(weights[2], abs=0.05)
+
+
+def test_class_weights_handle_missing_class_via_smoothing() -> None:
+    """A class with zero training rows must still get a finite weight
+    -- the smoothing constant prevents 1/0 blow-up."""
+
+    from app.training.loaders import fit_class_weights
+
+    quantiles = (0.01, 0.02)
+    # No "high" class events
+    vols = [0.005] * 20 + [0.015] * 20
+    weights = fit_class_weights(vols, quantiles, n_classes=3)
+    assert len(weights) == 3
+    assert all(w > 0 for w in weights)
+    # The empty class should have the highest weight
+    assert weights[2] >= weights[0]
+    assert weights[2] >= weights[1]
+
+
+def test_class_weights_empty_quantiles_returns_empty() -> None:
+    from app.training.loaders import fit_class_weights
+
+    weights = fit_class_weights([0.01, 0.02, 0.03], (), n_classes=3)
+    assert weights == ()
+
+
+def test_class_weights_empty_vols_returns_empty() -> None:
+    from app.training.loaders import fit_class_weights
+
+    weights = fit_class_weights([], (0.01, 0.02), n_classes=3)
+    assert weights == ()
+
+
+def test_class_weights_normalisation_sums_to_n_classes() -> None:
+    """The normalisation contract: weights sum to ``n_classes`` so a
+    class at the dataset's average frequency gets weight ~1.0."""
+
+    from app.training.loaders import fit_class_weights
+
+    quantiles = (0.01, 0.02)
+    vols = [0.005] * 50 + [0.015] * 30 + [0.025] * 20
+    weights = fit_class_weights(vols, quantiles, n_classes=3)
+    assert sum(weights) == pytest.approx(3.0, abs=1e-6)
+
+
+def test_class_weights_skip_nan_and_none() -> None:
+    from app.training.loaders import fit_class_weights
+
+    quantiles = (0.01, 0.02)
+    vols = [0.005, 0.015, 0.025, None, float("nan")]
+    weights = fit_class_weights(vols, quantiles, n_classes=3)
+    # 3 valid events, one per class -> balanced
+    assert sum(weights) == pytest.approx(3.0)
+    for w in weights:
+        assert 0.9 < w < 1.1


### PR DESCRIPTION
Tier 1 in the §6.3 leaderboard collapsed to predicting \`calm\` for 97% of test events. The proximate cause is the cross-entropy loss path of least resistance — the training-distribution prior is heavy on calm, so the optimiser predicts the prior. This PR breaks that.

## What this PR ships

- ``fit_class_weights(forward_vols, quantiles, n_classes)`` in \`backend/app/training/loaders.py\` — computes per-class counts under the train-slice quantile cutoffs, returns inverse-frequency weights with smoothing, normalised so ``sum == n_classes``.
- The training loop wires the per-fold weights into ``nn.CrossEntropyLoss(weight=…)``. Train-only fit; rides alongside the existing per-fold ``vol_regime_quantiles`` flow.
- 7 unit tests cover balanced / imbalanced / missing-class / empty-input / NaN-skip / normalisation-invariant.

## Contract preservation

- Regression-mode default path is byte-identical (legacy 80/20 leaves weights absent → CE falls back to uniform)
- Determinism regression at \`tests/regression/test_forecaster_determinism.py\` stays green
- All 52 phase-9 + regression tests pass

## Expected result

If the Tier 1 collapse was truly the loss prior, this should lift Tier 1 macro-F1 from 0.159 ± 0.111 toward the 0.30+ range and keep Tier 2 / Tier 3 roughly stable. Validation sweep running in parallel; numbers landing in §6.3 + §6.6.

## Closes

- Closes #206

## Test plan

```bash
docker compose run --rm backend pytest tests/unit/test_phase9_vol_regime_helpers.py tests/regression/
make regime-baseline-tiers TRAINING_PACKAGE_ID=tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0
```