### PR TITLE
A2: per-bar realised-vol horizons (20d, 60d) on the rich-feature block (#207)

### DIFF
--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -158,6 +158,13 @@ DEFAULT_ASSET = "^GSPC"
 DEFAULT_BENCHMARK = "^GSPC"
 DEFAULT_HORIZONS = (1, 5, 10, 30)
 PRIOR_WINDOW_DAYS = 20
+# A2 (#207) realised-vol horizons beyond the default 5-day window. The
+# 20d horizon captures the canonical "one month" of trading days and
+# the 60d horizon catches the slow-moving regime component (Engle &
+# Rangel, 2008; Christoffersen, 2012). Both fit the historical
+# vol-regime literature; together with the existing 5d window they
+# give the model access to short / medium / long horizons.
+EXTRA_VOL_WINDOWS: tuple[int, ...] = (20, 60)
 MARKET_MODEL_WINDOW_DAYS = 252
 VOL_WINDOW_DAYS = 10
 ROLLING_VOL_DAYS = 5
@@ -289,6 +296,13 @@ class _PriorBar:
     volume: float
     vol_5d: float
     cum_return_20d: float
+    # A2 (#207): additional realised-vol horizons. Computed as the
+    # sample standard deviation of log returns over the trailing N
+    # trading days anchored at this bar (right-inclusive). Default
+    # 0.0 keeps any legacy bar-builder path that doesn't compute
+    # these working without crashing the schema.
+    vol_20d: float = 0.0
+    vol_60d: float = 0.0
 
 
 @dataclass
@@ -656,6 +670,12 @@ def _build_prior_window(
         return None
     if start_idx - vol_window < 0:
         return None
+    # A2 (#207) backstop: we also compute trailing 20d / 60d vol per
+    # bar. Each requires N+1 prior closes from the bar itself; the
+    # earliest bar (start_idx) must therefore have at least
+    # ``max(EXTRA_VOL_WINDOWS)`` log returns behind it. When the
+    # series is too short we emit 0.0 for the affected horizon rather
+    # than dropping the event entirely.
 
     log_rets_all = _log_returns(series.close[: last_idx + 1])
     # log_rets_all[i] corresponds to close[i+1]. Rolling std at close-index j
@@ -673,6 +693,18 @@ def _build_prior_window(
         mean = sum(chunk) / vol_window
         var = sum((x - mean) ** 2 for x in chunk) / (vol_window - 1)
         vol = var**0.5
+        # A2 (#207) extra realised-vol horizons. We re-use the same
+        # log-return slice machinery; insufficient history -> 0.0 for
+        # that horizon only.
+        extra_vols: dict[int, float] = {}
+        for w in EXTRA_VOL_WINDOWS:
+            if i - w < 0 or len(log_rets_all[i - w : i]) < w:
+                extra_vols[w] = 0.0
+                continue
+            w_chunk = log_rets_all[i - w : i]
+            w_mean = sum(w_chunk) / w
+            w_var = sum((x - w_mean) ** 2 for x in w_chunk) / (w - 1)
+            extra_vols[w] = w_var**0.5
         cum_return = (series.close[i] - base_close) / base_close if base_close > 0 else 0.0
         bars.append(
             _PriorBar(
@@ -681,6 +713,8 @@ def _build_prior_window(
                 volume=series.volume[i],
                 vol_5d=vol,
                 cum_return_20d=cum_return,
+                vol_20d=extra_vols.get(20, 0.0),
+                vol_60d=extra_vols.get(60, 0.0),
             )
         )
     # Enforce no look-ahead: last prior bar must be < as_of
@@ -1025,6 +1059,8 @@ def _prior_window_sha(bars: Sequence[_PriorBar]) -> str:
                     f"{b.close:.10f}",
                     f"{b.volume:.4f}",
                     f"{b.vol_5d:.10f}",
+                    f"{b.vol_20d:.10f}",
+                    f"{b.vol_60d:.10f}",
                     f"{b.cum_return_20d:.10f}",
                 ]
             )
@@ -1039,6 +1075,8 @@ def _bars_to_json(bars: Sequence[_PriorBar]) -> str:
             "close": round(b.close, 10),
             "volume": round(b.volume, 4),
             "vol_5d": round(b.vol_5d, 10),
+            "vol_20d": round(b.vol_20d, 10),
+            "vol_60d": round(b.vol_60d, 10),
             "cum_return_20d": round(b.cum_return_20d, 10),
         }
         for b in bars

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -51,11 +51,19 @@ RICH_CREDIBILITY_DIM = 4
 RICH_LINGUISTIC_DIM = 15
 RICH_MP_SURPRISE_DIM = 4
 RICH_MULTI_AXIS_DIM = 6
+# A2 (#207): additional realised-vol horizons (20d, 60d). The existing
+# market slice already carries vol_5d as ``market_volatility``; this
+# extra slice extends the vol-autocorrelation surface so the model can
+# anchor against longer realised-vol windows, which the literature
+# consistently identifies as the strongest single predictor of forward
+# vol regime.
+RICH_REALIZED_VOL_DIM = 2
 RICH_EXTRA_FEATURE_SIZE = (
     RICH_CREDIBILITY_DIM
     + RICH_LINGUISTIC_DIM
     + RICH_MP_SURPRISE_DIM
     + RICH_MULTI_AXIS_DIM
+    + RICH_REALIZED_VOL_DIM
 )
 RICH_FEATURE_SIZE = FEATURE_SIZE + RICH_EXTRA_FEATURE_SIZE
 
@@ -79,6 +87,11 @@ RICH_MP_SURPRISE_SLICE = slice(
 RICH_MULTI_AXIS_SLICE = slice(
     RICH_MP_SURPRISE_SLICE.stop,
     RICH_MP_SURPRISE_SLICE.stop + RICH_MULTI_AXIS_DIM,
+)
+# A2 (#207) realised-vol horizons slice (positions [35:37]).
+RICH_REALIZED_VOL_SLICE = slice(
+    RICH_MULTI_AXIS_SLICE.stop,
+    RICH_MULTI_AXIS_SLICE.stop + RICH_REALIZED_VOL_DIM,
 )
 
 # Text-embedding adapter dim search axis. The forecaster sweep iterates
@@ -365,6 +378,12 @@ class FeatureVector:
     time_label_forward: float = 0.0
     certain_label_certain: float = 0.0
     stance_missing: float = 1.0
+    # A2 (#207) realised-vol autoregressive horizons. Default 0.0 so
+    # FeatureVectors built without rich-payload flow stay byte-identical
+    # on the as_list (6-feature) path. Populated by the events.parquet
+    # loader on the rich-feature path from per-bar prior_bars_json.
+    realized_vol_20d: float = 0.0
+    realized_vol_60d: float = 0.0
     rich_payload: bool = False
     # Phase 9 V2 (#195) classification target. The forward 10-trading-day
     # realised volatility lives on the target row (the last vector in
@@ -463,7 +482,11 @@ class FeatureVector:
             float(self.certain_label_certain),
             float(self.stance_missing),
         ]
-        return market + credibility + linguistic + mp_surprise + multi_axis
+        realized_vol = [
+            float(self.realized_vol_20d),
+            float(self.realized_vol_60d),
+        ]
+        return market + credibility + linguistic + mp_surprise + multi_axis + realized_vol
 
 
 def build_lookback_sequence(vectors: Iterable[FeatureVector], length: int = SEQUENCE_LENGTH) -> list[FeatureVector]:

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -415,18 +415,24 @@ def _bars_to_feature_vectors(
             continue
         close_value = float(bar.get("close", 0.0))
         volatility_value = float(bar.get("vol_5d", 0.0))
+        # A2 (#207) per-bar realised-vol horizons. Older events.parquet
+        # vintages predating PR #218+ won't have these keys; .get() with
+        # default 0.0 keeps the deser tolerant.
+        vol_20d_value = float(bar.get("vol_20d", 0.0))
+        vol_60d_value = float(bar.get("vol_60d", 0.0))
         elapsed_time = float((bar_date - event_date).days)
-        vectors.append(
-            FeatureVector.from_market_state(
-                date=date_value,
-                sentiment_score=sentiment_score,
-                market_close=close_value,
-                market_volatility=volatility_value,
-                previous_close=previous_close,
-                previous_volatility=previous_volatility,
-                elapsed_time=elapsed_time,
-            )
+        fv = FeatureVector.from_market_state(
+            date=date_value,
+            sentiment_score=sentiment_score,
+            market_close=close_value,
+            market_volatility=volatility_value,
+            previous_close=previous_close,
+            previous_volatility=previous_volatility,
+            elapsed_time=elapsed_time,
         )
+        fv.realized_vol_20d = vol_20d_value
+        fv.realized_vol_60d = vol_60d_value
+        vectors.append(fv)
         previous_close = close_value
         previous_volatility = volatility_value
     return vectors

--- a/tests/unit/test_feature_vector_as_rich_list.py
+++ b/tests/unit/test_feature_vector_as_rich_list.py
@@ -16,9 +16,15 @@ def _base_vector(**overrides) -> FeatureVector:
     return FeatureVector(**base)
 
 
-def test_as_rich_list_length_is_thirty_five() -> None:
+def test_as_rich_list_length_matches_rich_feature_size() -> None:
+    """The per-bar feature vector emits exactly ``RICH_FEATURE_SIZE``
+    floats. The numeric size changes as new families land (35 at the
+    Phase 8 milestone; 37 after A2 (#207) introduced the realised-vol
+    horizons slice); the contract this test enforces is that the
+    function's output length tracks the module constant."""
+
     fv = _base_vector()
-    assert len(fv.as_rich_list()) == RICH_FEATURE_SIZE == 35
+    assert len(fv.as_rich_list()) == RICH_FEATURE_SIZE
 
 
 def test_option_a_slot_default_is_stance_missing() -> None:
@@ -60,3 +66,28 @@ def test_market_block_unchanged_at_positions_zero_to_six() -> None:
     rich = fv.as_rich_list()
     legacy = fv.as_list()
     assert rich[:6] == legacy
+
+
+def test_realized_vol_slice_emits_at_documented_positions() -> None:
+    """A2 (#207) realised-vol horizons land at positions [35:37].
+
+    The legacy fields default to 0.0 (no vol history attached) so a
+    rich-feature vector built from the bar serdes carries the values
+    the loader set, including 0.0 when the underlying parquet predated
+    the A2 schema bump."""
+
+    from app.models.config import RICH_REALIZED_VOL_SLICE
+
+    fv = _base_vector(realized_vol_20d=0.0123, realized_vol_60d=0.0456)
+    rich = fv.as_rich_list()
+    assert rich[RICH_REALIZED_VOL_SLICE] == [0.0123, 0.0456]
+
+
+def test_realized_vol_slice_default_is_zero() -> None:
+    """A FeatureVector built without realised-vol payload (e.g. from
+    legacy fixtures or pre-A2 events.parquet) leaves the slice at 0.0."""
+
+    from app.models.config import RICH_REALIZED_VOL_SLICE
+
+    fv = _base_vector()
+    assert fv.as_rich_list()[RICH_REALIZED_VOL_SLICE] == [0.0, 0.0]


### PR DESCRIPTION
A1's result confirmed Tier 1's collapse is feature-deep, not loss-shape-deep. Volatility is the most autocorrelated time series in finance; the previous rich-feature block lacked any vol-history horizon beyond rolling 5-day std. This PR adds 20-day and 60-day trailing realised-vol per bar.

## What this PR ships

- ``_PriorBar.vol_20d`` + ``_PriorBar.vol_60d`` computed in ``_build_prior_window`` from log returns over the trailing N trading days. History-backstop graceful: 0.0 for the affected horizon when the series lacks N+1 prior closes (rather than dropping the event).
- ``prior_bars_json`` carries the new horizons; ``_prior_window_sha`` includes them.
- ``_bars_to_feature_vectors`` deser reads them with ``.get()`` defaults so older events.parquet vintages stay loadable.
- ``FeatureVector.realized_vol_20d`` + ``realized_vol_60d`` (default 0.0). ``as_rich_list`` appends them at positions [35:37] under the new ``RICH_REALIZED_VOL_SLICE``.
- ``RICH_FEATURE_SIZE`` 35 → 37; ``RICH_REALIZED_VOL_DIM`` = 2.

## Contract preservation

- Regression-mode determinism contract preserved (legacy ``as_list`` 6-feature path unchanged).
- ``tests/regression/test_forecaster_determinism.py`` stays green.

## Validation

events.parquet rebuilt against the canonical training package; 46 unit + regression tests pass.

3-tier baseline sweep with A1 + A2 running in parallel; numbers landing in wiki §6.6.

## Closes

- Closes #207

## Test plan

```bash
docker compose run --rm backend python -m app.data.event_dataset_builder --training-package-id <pkg>
docker compose run --rm backend pytest tests/regression/ tests/unit/test_phase9_partition_tensors.py
make regime-baseline-tiers TRAINING_PACKAGE_ID=<pkg>
```