### PR TITLE
A3: per-bar cross-asset close levels (VIX, DXY, TNX, gold) (#208)

### DIFF
--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -165,6 +165,15 @@ PRIOR_WINDOW_DAYS = 20
 # vol-regime literature; together with the existing 5d window they
 # give the model access to short / medium / long horizons.
 EXTRA_VOL_WINDOWS: tuple[int, ...] = (20, 60)
+# A3 (#208) cross-asset yfinance symbols joined onto every prior bar
+# by date. Symbol → FeatureVector field-name mapping; consumed by the
+# pipeline orchestrator below and the per-bar attachment helper.
+CROSS_ASSET_SYMBOLS: tuple[tuple[str, str], ...] = (
+    ("^VIX", "vix_close"),
+    ("DX-Y.NYB", "dxy_close"),
+    ("^TNX", "tnx_close"),
+    ("GC=F", "gold_close"),
+)
 MARKET_MODEL_WINDOW_DAYS = 252
 VOL_WINDOW_DAYS = 10
 ROLLING_VOL_DAYS = 5
@@ -303,6 +312,15 @@ class _PriorBar:
     # these working without crashing the schema.
     vol_20d: float = 0.0
     vol_60d: float = 0.0
+    # A3 (#208): cross-asset close levels at this bar's date. Joined
+    # in from independent yfinance caches at the top of the pipeline;
+    # a series with no observation on the bar's date emits 0.0 rather
+    # than blocking the whole bar (e.g. VIX pre-1990, gold front-month
+    # contract roll days).
+    vix_close: float = 0.0
+    dxy_close: float = 0.0
+    tnx_close: float = 0.0
+    gold_close: float = 0.0
 
 
 @dataclass
@@ -645,12 +663,36 @@ def _log_returns(closes: Sequence[float]) -> list[float]:
     return out
 
 
+def _build_cross_asset_lookup(
+    series_by_symbol: dict[str, _CloseSeries],
+) -> dict[_dt.date, dict[str, float]]:
+    """Build ``{date: {field_name: close}}`` for O(1) per-bar joins.
+
+    Sparse: a date present in only one series's calendar still produces
+    an entry, but only that series's field is populated. The
+    ``_build_prior_window`` attachment fills missing fields with 0.0
+    at read time.
+    """
+
+    out: dict[_dt.date, dict[str, float]] = {}
+    field_by_symbol = dict(CROSS_ASSET_SYMBOLS)
+    for symbol, series in series_by_symbol.items():
+        field_name = field_by_symbol.get(symbol)
+        if field_name is None:
+            continue
+        for d, c in zip(series.dates, series.close):
+            row = out.setdefault(d, {})
+            row[field_name] = float(c)
+    return out
+
+
 def _build_prior_window(
     series: _CloseSeries,
     as_of: _dt.date,
     *,
     window_days: int = PRIOR_WINDOW_DAYS,
     vol_window: int = ROLLING_VOL_DAYS,
+    cross_asset_lookup: dict[_dt.date, dict[str, float]] | None = None,
 ) -> list[_PriorBar] | None:
     """Return ``window_days`` prior bars ending strictly before ``as_of``.
 
@@ -706,15 +748,29 @@ def _build_prior_window(
             w_var = sum((x - w_mean) ** 2 for x in w_chunk) / (w - 1)
             extra_vols[w] = w_var**0.5
         cum_return = (series.close[i] - base_close) / base_close if base_close > 0 else 0.0
+        # A3 (#208) cross-asset join. Lookup is keyed on the bar's
+        # date; absent fields default to 0.0 because non-trading days
+        # for one asset (e.g. VIX before 1990, gold futures contract
+        # roll gaps) should not block the bar.
+        bar_date = series.dates[i]
+        cross_asset_row = (
+            cross_asset_lookup.get(bar_date, {})
+            if cross_asset_lookup is not None
+            else {}
+        )
         bars.append(
             _PriorBar(
-                date=series.dates[i],
+                date=bar_date,
                 close=series.close[i],
                 volume=series.volume[i],
                 vol_5d=vol,
                 cum_return_20d=cum_return,
                 vol_20d=extra_vols.get(20, 0.0),
                 vol_60d=extra_vols.get(60, 0.0),
+                vix_close=float(cross_asset_row.get("vix_close", 0.0)),
+                dxy_close=float(cross_asset_row.get("dxy_close", 0.0)),
+                tnx_close=float(cross_asset_row.get("tnx_close", 0.0)),
+                gold_close=float(cross_asset_row.get("gold_close", 0.0)),
             )
         )
     # Enforce no look-ahead: last prior bar must be < as_of
@@ -1062,6 +1118,10 @@ def _prior_window_sha(bars: Sequence[_PriorBar]) -> str:
                     f"{b.vol_20d:.10f}",
                     f"{b.vol_60d:.10f}",
                     f"{b.cum_return_20d:.10f}",
+                    f"{b.vix_close:.6f}",
+                    f"{b.dxy_close:.6f}",
+                    f"{b.tnx_close:.6f}",
+                    f"{b.gold_close:.6f}",
                 ]
             )
         )
@@ -1078,6 +1138,10 @@ def _bars_to_json(bars: Sequence[_PriorBar]) -> str:
             "vol_20d": round(b.vol_20d, 10),
             "vol_60d": round(b.vol_60d, 10),
             "cum_return_20d": round(b.cum_return_20d, 10),
+            "vix_close": round(b.vix_close, 6),
+            "dxy_close": round(b.dxy_close, 6),
+            "tnx_close": round(b.tnx_close, 6),
+            "gold_close": round(b.gold_close, 6),
         }
         for b in bars
     ]
@@ -1120,12 +1184,15 @@ def _build_event_rows(
     macro_release_calendar: MacroReleaseCalendar,
     concurrent_macro_window_days: int = CONCURRENT_MACRO_TRADING_DAY_RADIUS,
     intra_meeting_shift: dict[str, float] | None = None,
+    cross_asset_lookup: dict[_dt.date, dict[str, float]] | None = None,
 ) -> list[dict[str, Any]]:
     event_date = _date(doc.event_date)
     as_of_ts = _as_of_for_event(doc.event_date, doc.event_kind)
     as_of_date = event_date  # placeholder time is same-day; window cuts on date
 
-    prior_bars = _build_prior_window(asset_series, as_of_date)
+    prior_bars = _build_prior_window(
+        asset_series, as_of_date, cross_asset_lookup=cross_asset_lookup
+    )
     if prior_bars is None:
         return []
     _assert_no_lookahead(as_of_date, prior_bars)
@@ -1415,6 +1482,26 @@ def build_event_rows(
                 benchmark, start=earliest, end=latest, cache_dir=market_cache_dir
             )
 
+    # A3 (#208) cross-asset cache pre-fetch + lookup index. Each symbol
+    # fails gracefully -- a missing symbol's contribution to every bar
+    # collapses to 0.0 rather than blocking the whole pipeline. This
+    # matters because the historical coverage of VIX (1990+),
+    # DX-Y.NYB, ^TNX, and GC=F is not uniform and we still want event
+    # rows from earlier years to land with their existing features.
+    cross_asset_series: dict[str, _CloseSeries] = {}
+    for symbol, _field_name in CROSS_ASSET_SYMBOLS:
+        try:
+            cross_asset_series[symbol] = _fetch_close_series(
+                symbol, start=earliest, end=latest, cache_dir=market_cache_dir
+            )
+        except RuntimeError as exc:
+            print(
+                f"[event_dataset_builder] cross-asset fetch failed for "
+                f"{symbol}: {exc}; field will be 0.0 across all bars.",
+                file=sys.stderr,
+            )
+    cross_asset_lookup = _build_cross_asset_lookup(cross_asset_series)
+
     credibility_kwargs = {
         "embedding_path": embedding_path,
         "stance_by_date": tuple(stance_by_date),
@@ -1435,6 +1522,7 @@ def build_event_rows(
             macro_release_calendar=macro_release_calendar,
             concurrent_macro_window_days=concurrent_macro_window_days,
             intra_meeting_shift=intra_meeting_shifts.get(doc.event_date),
+            cross_asset_lookup=cross_asset_lookup,
         )
         if not rows:
             summary.dropped_no_prior_window += 1

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -58,12 +58,18 @@ RICH_MULTI_AXIS_DIM = 6
 # consistently identifies as the strongest single predictor of forward
 # vol regime.
 RICH_REALIZED_VOL_DIM = 2
+# A3 (#208): cross-asset daily close levels (VIX, USD index, 10Y yield,
+# gold). Each is a single float per bar. VIX is the market's own
+# forward-vol forecast; the others capture risk-on/risk-off (DXY),
+# the rates-pricing layer (TNX), and flight-to-safety (gold).
+RICH_CROSS_ASSET_DIM = 4
 RICH_EXTRA_FEATURE_SIZE = (
     RICH_CREDIBILITY_DIM
     + RICH_LINGUISTIC_DIM
     + RICH_MP_SURPRISE_DIM
     + RICH_MULTI_AXIS_DIM
     + RICH_REALIZED_VOL_DIM
+    + RICH_CROSS_ASSET_DIM
 )
 RICH_FEATURE_SIZE = FEATURE_SIZE + RICH_EXTRA_FEATURE_SIZE
 
@@ -92,6 +98,11 @@ RICH_MULTI_AXIS_SLICE = slice(
 RICH_REALIZED_VOL_SLICE = slice(
     RICH_MULTI_AXIS_SLICE.stop,
     RICH_MULTI_AXIS_SLICE.stop + RICH_REALIZED_VOL_DIM,
+)
+# A3 (#208) cross-asset slice (positions [37:41]).
+RICH_CROSS_ASSET_SLICE = slice(
+    RICH_REALIZED_VOL_SLICE.stop,
+    RICH_REALIZED_VOL_SLICE.stop + RICH_CROSS_ASSET_DIM,
 )
 
 # Text-embedding adapter dim search axis. The forecaster sweep iterates
@@ -384,6 +395,15 @@ class FeatureVector:
     # loader on the rich-feature path from per-bar prior_bars_json.
     realized_vol_20d: float = 0.0
     realized_vol_60d: float = 0.0
+    # A3 (#208) cross-asset close levels per bar. Joined from
+    # independent yfinance caches; a series with no observation on the
+    # bar's date emits 0.0 rather than blocking the whole bar. The
+    # per-fold RobustScaler handles the cross-symbol scale mismatch
+    # downstream.
+    vix_close: float = 0.0
+    dxy_close: float = 0.0
+    tnx_close: float = 0.0
+    gold_close: float = 0.0
     rich_payload: bool = False
     # Phase 9 V2 (#195) classification target. The forward 10-trading-day
     # realised volatility lives on the target row (the last vector in
@@ -486,7 +506,21 @@ class FeatureVector:
             float(self.realized_vol_20d),
             float(self.realized_vol_60d),
         ]
-        return market + credibility + linguistic + mp_surprise + multi_axis + realized_vol
+        cross_asset = [
+            float(self.vix_close),
+            float(self.dxy_close),
+            float(self.tnx_close),
+            float(self.gold_close),
+        ]
+        return (
+            market
+            + credibility
+            + linguistic
+            + mp_surprise
+            + multi_axis
+            + realized_vol
+            + cross_asset
+        )
 
 
 def build_lookback_sequence(vectors: Iterable[FeatureVector], length: int = SEQUENCE_LENGTH) -> list[FeatureVector]:

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -420,6 +420,13 @@ def _bars_to_feature_vectors(
         # default 0.0 keeps the deser tolerant.
         vol_20d_value = float(bar.get("vol_20d", 0.0))
         vol_60d_value = float(bar.get("vol_60d", 0.0))
+        # A3 (#208) cross-asset close levels. Same back-compat
+        # contract as A2 -- pre-A3 events.parquet emits 0.0 for every
+        # cross-asset axis and the rich-feature block keeps loading.
+        vix_close_value = float(bar.get("vix_close", 0.0))
+        dxy_close_value = float(bar.get("dxy_close", 0.0))
+        tnx_close_value = float(bar.get("tnx_close", 0.0))
+        gold_close_value = float(bar.get("gold_close", 0.0))
         elapsed_time = float((bar_date - event_date).days)
         fv = FeatureVector.from_market_state(
             date=date_value,
@@ -432,6 +439,10 @@ def _bars_to_feature_vectors(
         )
         fv.realized_vol_20d = vol_20d_value
         fv.realized_vol_60d = vol_60d_value
+        fv.vix_close = vix_close_value
+        fv.dxy_close = dxy_close_value
+        fv.tnx_close = tnx_close_value
+        fv.gold_close = gold_close_value
         vectors.append(fv)
         previous_close = close_value
         previous_volatility = volatility_value

--- a/tests/unit/test_feature_vector_as_rich_list.py
+++ b/tests/unit/test_feature_vector_as_rich_list.py
@@ -91,3 +91,27 @@ def test_realized_vol_slice_default_is_zero() -> None:
 
     fv = _base_vector()
     assert fv.as_rich_list()[RICH_REALIZED_VOL_SLICE] == [0.0, 0.0]
+
+
+def test_cross_asset_slice_emits_at_documented_positions() -> None:
+    """A3 (#208) cross-asset close levels land at positions [37:41]
+    in the order VIX, DXY, TNX, gold."""
+
+    from app.models.config import RICH_CROSS_ASSET_SLICE
+
+    fv = _base_vector(
+        vix_close=22.3,
+        dxy_close=104.5,
+        tnx_close=4.21,
+        gold_close=1942.0,
+    )
+    assert fv.as_rich_list()[RICH_CROSS_ASSET_SLICE] == [22.3, 104.5, 4.21, 1942.0]
+
+
+def test_cross_asset_slice_default_is_zero() -> None:
+    """Legacy / pre-A3 FeatureVectors carry 0.0 across all 4 axes."""
+
+    from app.models.config import RICH_CROSS_ASSET_SLICE
+
+    fv = _base_vector()
+    assert fv.as_rich_list()[RICH_CROSS_ASSET_SLICE] == [0.0, 0.0, 0.0, 0.0]


### PR DESCRIPTION
After A2 lifted Tier 2/3 macro-F1 to ~0.39-0.40 with vol horizons, the next gap is the consensus signal: the model has no access to what the rest of the market thinks the regime is. VIX is the market's own forward-vol forecast over the next 30 days — directly aligned with our 10-day vol-regime target. DXY, TNX, and gold layer on risk-on/risk-off, rates-pricing, and flight-to-safety.

## What this PR ships

- ``CROSS_ASSET_SYMBOLS`` = ``(^VIX, DX-Y.NYB, ^TNX, GC=F)`` symbol → field-name mapping
- ``_build_cross_asset_lookup(series_by_symbol) -> {date: {field: close}}`` for O(1) per-bar joins
- ``_build_prior_window`` accepts ``cross_asset_lookup`` kwarg; each bar's date looks up its 4-vector. Missing-date fields default to 0.0 (pre-VIX 1990-, gold contract-roll days)
- ``_PriorBar`` + JSON serdes + ``_prior_window_sha`` extended with the new 4 floats
- ``FeatureVector.vix_close`` / ``dxy_close`` / ``tnx_close`` / ``gold_close`` (default 0.0). ``as_rich_list`` appends at positions ``[37:41]`` under ``RICH_CROSS_ASSET_SLICE``
- Pipeline orchestrator pre-fetches each symbol via the existing ``_fetch_close_series`` caching; symbol-level fetch failures degrade gracefully
- ``RICH_FEATURE_SIZE`` 37 → 41; ``RICH_CROSS_ASSET_DIM`` = 4

## Contract preservation

- Regression-mode determinism contract preserved (legacy ``as_list`` 6-feature path unchanged)
- ``tests/regression/test_forecaster_determinism.py`` stays green

## Validation

- events.parquet rebuilt; VIX coverage 89% across all bars (gap = pre-1990 events + 60d-backstop early-window padding)
- 31 unit + regression tests pass
- 3-tier baseline sweep running on GPU; numbers landing in wiki §6.6

## Closes

- Closes #208

## Test plan

```bash
docker compose run --rm backend python -m app.data.event_dataset_builder --training-package-id <pkg>
docker compose run --rm backend pytest tests/regression/ tests/unit/test_feature_vector_as_rich_list.py
make regime-baseline-tiers TRAINING_PACKAGE_ID=<pkg>
```