### PR TITLE
Phase A: architecture sweep + ensemble + pooled-fold aggregator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate
 
 help:
 	@echo "Targets:"
@@ -290,6 +290,38 @@ regime-baseline-tiers:
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
 		--nlp-text-encoder "$(NLP_TEXT_ENCODER)" \
 		--report-root /data/artifacts/regime_baseline_tiers
+
+# Phase A (#226) architecture sweep -- per-architecture random-search
+# HP at the A5 best-cell neighbourhood, all on the Tier 5 surface
+# (rich + LLM, no NLP) by default. The downstream
+# ``regime-ensemble-aggregate`` target consumes the per-architecture
+# JSONs and reports mean-logit / mean-softmax / plurality-vote macro-F1.
+USE_LLM_FEATURES ?= on
+regime-arch-sweep:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	docker compose --profile "$(FORECASTER_COMPOSE_PROFILE)" run --rm "$(FORECASTER_COMPOSE_SERVICE)" \
+		python scripts/run_regime_architecture_sweep.py \
+		--training-package-id "$(TRAINING_PACKAGE_ID)" \
+		$(if $(filter on,$(USE_LLM_FEATURES)),--use-llm-features,--no-llm-features) \
+		$(if $(NLP_TEXT_ENCODER),--text-encoder "$(NLP_TEXT_ENCODER)",) \
+		--report-root /data/artifacts/regime_arch_sweep
+
+# Pooled-fold macro-F1 with bootstrap CIs across every per-fold trial in
+# INPUT_DIR. INPUT_DIR is recursively walked for
+# forecaster_sweep_results.json files.
+regime-pooled-aggregate:
+	@test -n "$(INPUT_DIR)" || (echo "INPUT_DIR is required"; exit 1)
+	docker compose run --rm backend \
+		python -m app.evaluation.regime_pooled_aggregator \
+		--input-dir "$(INPUT_DIR)"
+
+# Multi-architecture ensemble macro-F1. ARCH_SWEEP_DIR is the parent of
+# the per-architecture subdirectories produced by ``regime-arch-sweep``.
+regime-ensemble-aggregate:
+	@test -n "$(ARCH_SWEEP_DIR)" || (echo "ARCH_SWEEP_DIR is required"; exit 1)
+	docker compose run --rm backend \
+		python -m app.evaluation.ensemble_aggregator \
+		--arch-sweep-dir "$(ARCH_SWEEP_DIR)"
 
 # Single-architecture training with --credibility-features ON. Used for
 # isolated credibility-vs-baseline comparisons; defaults to ARCHITECTURE=lstm

--- a/backend/app/evaluation/ensemble_aggregator.py
+++ b/backend/app/evaluation/ensemble_aggregator.py
@@ -1,0 +1,496 @@
+"""Multi-architecture ensemble aggregator.
+
+Reads N per-architecture sweep JSONs (one per architecture under a shared
+training package), aligns the test-partition predictions on each
+``(fold_id, seed)`` cell, and reports macro-F1 for three classical
+ensemble strategies — **mean-logit / mean-softmax / plurality-vote**.
+
+Inputs to the aggregator are the same ``forecaster_sweep_results.json``
+files :mod:`app.evaluation.regime_pooled_aggregator` consumes. Trials
+must carry ``test_metrics.predictions``, ``test_metrics.targets``, and
+``test_metrics.class_scores`` (PR #226 wired all three onto
+:class:`EvaluationMetrics`).
+
+The cell alignment contract: trials from different architecture JSONs
+are matched by ``(fold_id, seed)``. The per-architecture best HP cell
+is selected first via the same selection-metric path as
+:mod:`regime_pooled_aggregator`, then the selected trials from each
+architecture are aligned and averaged.
+
+Three strategies:
+
+1. **mean-logit** -- average ``log(class_score)`` element-wise across
+   architectures, take ``argmax``. Treats each model as a calibrated
+   logit producer; reduces to per-class log-prob averaging.
+2. **mean-softmax** -- average ``class_scores`` (already softmax
+   probabilities) element-wise, take ``argmax``. The default for
+   uncalibrated heads with overlapping class supports.
+3. **plurality-vote** -- per-row majority vote across architectures'
+   argmax predictions. Ties broken by lowest class index.
+
+Macro-F1 reported with the same block-bootstrap CI surface as the
+pooled-fold aggregator, so the two outputs sit cleanly next to each
+other in the report appendix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import math
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from app.evaluation.bootstrap import BootstrapCI
+from app.evaluation.classification_breakdown import (
+    ClassificationBreakdown,
+    compute_classification_breakdown,
+)
+from app.evaluation.regime_pooled_aggregator import (
+    _cell_key,
+    _select_best_cell,
+    _test_predictions,
+    _trial_summary,
+)
+
+
+_STRATEGIES = ("mean_logit", "mean_softmax", "plurality_vote")
+
+
+@dataclasses.dataclass(frozen=True)
+class EnsembleCell:
+    strategy: str
+    architectures: tuple[str, ...]
+    fold_id: str | None
+    seed: int | None
+    n_rows: int
+    breakdown: ClassificationBreakdown
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "strategy": self.strategy,
+            "architectures": list(self.architectures),
+            "fold_id": self.fold_id,
+            "seed": self.seed,
+            "n_rows": self.n_rows,
+            "breakdown": self.breakdown.to_dict(),
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class EnsemblePooled:
+    strategy: str
+    architectures: tuple[str, ...]
+    n_pooled: int
+    breakdown: ClassificationBreakdown
+    macro_f1_ci: BootstrapCI
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "strategy": self.strategy,
+            "architectures": list(self.architectures),
+            "n_pooled": self.n_pooled,
+            "breakdown": self.breakdown.to_dict(),
+            "macro_f1_ci": {
+                "point": self.macro_f1_ci.point,
+                "lo": self.macro_f1_ci.lo,
+                "hi": self.macro_f1_ci.hi,
+                "coverage": self.macro_f1_ci.coverage,
+                "n_resamples": self.macro_f1_ci.n_resamples,
+                "block_size": self.macro_f1_ci.block_size,
+            },
+        }
+
+
+def _trial_class_scores(trial: Mapping[str, object]) -> list[list[float]] | None:
+    summary = _trial_summary(trial)
+    test_metrics = summary.get("test_metrics")
+    if not isinstance(test_metrics, Mapping):
+        return None
+    scores = test_metrics.get("class_scores")
+    if not isinstance(scores, list) or not scores:
+        return None
+    rows: list[list[float]] = []
+    for row in scores:
+        if not isinstance(row, list):
+            return None
+        rows.append([float(x) for x in row])
+    return rows
+
+
+def _mean_logit(per_arch_scores: Sequence[Sequence[float]]) -> int:
+    eps = 1e-12
+    n_classes = len(per_arch_scores[0])
+    log_sums = [0.0] * n_classes
+    for scores in per_arch_scores:
+        for c, p in enumerate(scores):
+            log_sums[c] += math.log(max(eps, float(p)))
+    best = 0
+    best_val = log_sums[0]
+    for c in range(1, n_classes):
+        if log_sums[c] > best_val:
+            best = c
+            best_val = log_sums[c]
+    return best
+
+
+def _mean_softmax(per_arch_scores: Sequence[Sequence[float]]) -> int:
+    n_classes = len(per_arch_scores[0])
+    sums = [0.0] * n_classes
+    for scores in per_arch_scores:
+        for c, p in enumerate(scores):
+            sums[c] += float(p)
+    best = 0
+    best_val = sums[0]
+    for c in range(1, n_classes):
+        if sums[c] > best_val:
+            best = c
+            best_val = sums[c]
+    return best
+
+
+def _plurality_vote(per_arch_argmaxes: Sequence[int]) -> int:
+    counter = Counter(per_arch_argmaxes)
+    # Break ties by lowest class index.
+    best_count = max(counter.values())
+    return min(c for c, n in counter.items() if n == best_count)
+
+
+def _align_per_cell(
+    selected_trials_per_arch: Mapping[str, Sequence[Mapping[str, object]]]
+) -> dict[tuple[str | None, int | None], dict[str, Mapping[str, object]]]:
+    """Group selected trials by ``(fold_id, seed)`` so the ensemble
+    averages run only on cells where every architecture has data.
+    Cells with incomplete coverage are dropped."""
+
+    by_cell: dict[tuple[str | None, int | None], dict[str, Mapping[str, object]]] = (
+        defaultdict(dict)
+    )
+    for arch, trials in selected_trials_per_arch.items():
+        for trial in trials:
+            fold = trial.get("fold_id")
+            seed_value = trial.get("seed")
+            fold_key = fold if isinstance(fold, str) else None
+            seed_key = int(seed_value) if isinstance(seed_value, int) else None
+            by_cell[(fold_key, seed_key)][arch] = trial
+    return by_cell
+
+
+def _ensemble_predictions_for_cell(  # noqa: C901
+    arch_trials: Mapping[str, Mapping[str, object]],
+    strategy: str,
+) -> tuple[list[int], list[int]] | None:
+    """For a single (fold, seed) cell shared by every architecture,
+    produce the ensemble's predictions + the (shared) targets."""
+
+    if not arch_trials:
+        return None
+
+    arch_payloads: dict[str, tuple[list[int], list[int], list[list[float]] | None]] = {}
+    n_rows: int | None = None
+    pooled_targets: list[int] | None = None
+    for arch, trial in arch_trials.items():
+        rows = _test_predictions(trial)
+        if rows is None:
+            return None
+        preds, targets = rows
+        if pooled_targets is None:
+            pooled_targets = targets
+            n_rows = len(targets)
+        elif targets != pooled_targets:
+            # If two architectures disagree on the target sequence
+            # ordering for the same (fold, seed) cell, the underlying
+            # event ordering has drifted and the ensemble alignment is
+            # unsafe. Skip the cell.
+            return None
+        scores = _trial_class_scores(trial)
+        arch_payloads[arch] = (preds, targets, scores)
+
+    if pooled_targets is None or n_rows is None:
+        return None
+
+    ensemble_preds: list[int] = []
+    for i in range(n_rows):
+        per_arch_argmaxes: list[int] = []
+        per_arch_scores: list[list[float]] = []
+        for _arch, (preds, _targets, scores) in arch_payloads.items():
+            per_arch_argmaxes.append(int(preds[i]))
+            if scores is not None and i < len(scores):
+                per_arch_scores.append(scores[i])
+        if strategy == "plurality_vote":
+            ensemble_preds.append(_plurality_vote(per_arch_argmaxes))
+        elif strategy == "mean_logit":
+            if not per_arch_scores:
+                # Fall back to plurality when scores are unavailable.
+                ensemble_preds.append(_plurality_vote(per_arch_argmaxes))
+            else:
+                ensemble_preds.append(_mean_logit(per_arch_scores))
+        elif strategy == "mean_softmax":
+            if not per_arch_scores:
+                ensemble_preds.append(_plurality_vote(per_arch_argmaxes))
+            else:
+                ensemble_preds.append(_mean_softmax(per_arch_scores))
+        else:
+            raise ValueError(f"unknown ensemble strategy: {strategy!r}")
+    return ensemble_preds, list(pooled_targets)
+
+
+def aggregate(  # noqa: C901, PLR0913
+    per_arch_sweep_blobs: Mapping[str, Sequence[Mapping[str, object]]],
+    *,
+    strategies: Sequence[str] = _STRATEGIES,
+    n_classes: int = 3,
+    block_size: int = 20,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    bootstrap_seed: int = 11,
+    selection_metric: str | None = None,
+) -> dict[str, list[EnsembleCell] | list[EnsemblePooled]]:
+    """Compute per-cell + all-cells-pooled ensemble macro-F1 for each
+    strategy. Returns a dict with keys ``per_cell`` (list) and
+    ``pooled`` (list)."""
+
+    # Step 1: select the best (arch, hp) from each architecture's sweep.
+    per_arch_best_trials: dict[str, list[Mapping[str, object]]] = {}
+    for arch, blobs in per_arch_sweep_blobs.items():
+        cells: dict[tuple[str, str | None], list[Mapping[str, object]]] = defaultdict(
+            list
+        )
+        inferred_metric = "macro_f1"
+        for blob in blobs:
+            trials = blob.get("trials", [])
+            metric = blob.get("selection_metric")
+            if isinstance(metric, str) and selection_metric is None:
+                inferred_metric = metric
+            if not isinstance(trials, list):
+                continue
+            for trial in trials:
+                if not isinstance(trial, Mapping):
+                    continue
+                cells[_cell_key(trial)].append(trial)
+        if not cells:
+            continue
+        chosen = _select_best_cell(cells, selection_metric or inferred_metric)
+        if arch in chosen:
+            per_arch_best_trials[arch] = list(cells[chosen[arch]])
+
+    if len(per_arch_best_trials) < 2:
+        raise ValueError(
+            "ensemble aggregator requires at least 2 architectures with "
+            f"selectable cells; got {sorted(per_arch_best_trials.keys())!r}"
+        )
+
+    aligned = _align_per_cell(per_arch_best_trials)
+
+    architectures = tuple(sorted(per_arch_best_trials.keys()))
+
+    per_cell_rows: list[EnsembleCell] = []
+    pooled_rows: list[EnsemblePooled] = []
+    for strategy in strategies:
+        all_preds: list[int] = []
+        all_targets: list[int] = []
+        for (fold_id, seed), arch_trials in sorted(
+            aligned.items(),
+            key=lambda kv: ((kv[0][0] or ""), (kv[0][1] or -1)),
+        ):
+            if set(arch_trials.keys()) != set(architectures):
+                # Skip cells where some architecture is missing.
+                continue
+            payload = _ensemble_predictions_for_cell(arch_trials, strategy)
+            if payload is None:
+                continue
+            ens_preds, targets = payload
+            cell_breakdown = compute_classification_breakdown(
+                predictions=ens_preds,
+                targets=targets,
+                n_classes=n_classes,
+            )
+            per_cell_rows.append(
+                EnsembleCell(
+                    strategy=strategy,
+                    architectures=architectures,
+                    fold_id=fold_id,
+                    seed=seed,
+                    n_rows=len(targets),
+                    breakdown=cell_breakdown,
+                )
+            )
+            all_preds.extend(ens_preds)
+            all_targets.extend(targets)
+
+        pooled_breakdown = compute_classification_breakdown(
+            predictions=all_preds,
+            targets=all_targets,
+            n_classes=n_classes,
+        )
+        # Block-bootstrap CI on the pooled ensemble macro-F1. Same logic
+        # as :func:`regime_pooled_aggregator.pool_cell` for parity in the
+        # report appendix.
+        import random
+
+        rng = random.Random(bootstrap_seed)
+        resampled: list[float] = []
+        n = len(all_preds)
+        if n == 0:
+            ci = BootstrapCI(
+                point=float("nan"),
+                lo=float("nan"),
+                hi=float("nan"),
+                coverage=coverage,
+                n_resamples=n_resamples,
+                block_size=block_size,
+            )
+        else:
+            for _ in range(n_resamples):
+                idx: list[int] = []
+                n_blocks = max(1, (n + block_size - 1) // block_size)
+                for _ in range(n_blocks):
+                    start = rng.randint(0, max(0, n - block_size))
+                    idx.extend(range(start, min(n, start + block_size)))
+                idx = idx[:n]
+                rs_preds = [all_preds[i] for i in idx]
+                rs_targets = [all_targets[i] for i in idx]
+                rs_breakdown = compute_classification_breakdown(
+                    predictions=rs_preds,
+                    targets=rs_targets,
+                    n_classes=n_classes,
+                )
+                resampled.append(float(rs_breakdown.macro_f1))
+            resampled.sort()
+            alpha = (1.0 - coverage) / 2.0
+            lo_idx = max(0, min(n_resamples - 1, int(alpha * n_resamples)))
+            hi_idx = max(
+                0, min(n_resamples - 1, int((1.0 - alpha) * n_resamples) - 1)
+            )
+            ci = BootstrapCI(
+                point=float(pooled_breakdown.macro_f1),
+                lo=resampled[lo_idx],
+                hi=resampled[hi_idx],
+                coverage=coverage,
+                n_resamples=n_resamples,
+                block_size=block_size,
+            )
+
+        pooled_rows.append(
+            EnsemblePooled(
+                strategy=strategy,
+                architectures=architectures,
+                n_pooled=len(all_preds),
+                breakdown=pooled_breakdown,
+                macro_f1_ci=ci,
+            )
+        )
+
+    return {"per_cell": per_cell_rows, "pooled": pooled_rows}
+
+
+def _render_markdown(payload: Mapping[str, object]) -> str:
+    lines: list[str] = []
+    lines.append("# Multi-architecture ensemble macro-F1")
+    lines.append("")
+    pooled = payload.get("pooled", [])
+    architectures: tuple[str, ...] = ()
+    if isinstance(pooled, list) and pooled:
+        first = pooled[0]
+        if isinstance(first, EnsemblePooled):
+            architectures = first.architectures
+    if architectures:
+        lines.append(
+            "Ensembling architectures: " + ", ".join(f"`{a}`" for a in architectures)
+        )
+        lines.append("")
+    lines.append("| Strategy | n_pooled | macro-F1 | 95% CI |")
+    lines.append("| --- | ---: | ---: | --- |")
+    if isinstance(pooled, list):
+        for row in pooled:
+            if isinstance(row, EnsemblePooled):
+                ci = row.macro_f1_ci
+                lines.append(
+                    f"| {row.strategy} | {row.n_pooled} | {ci.point:.4f} | "
+                    f"[{ci.lo:.4f}, {ci.hi:.4f}] |"
+                )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compute multi-architecture ensemble macro-F1 (mean-logit, "
+            "mean-softmax, plurality-vote) by aligning test-partition "
+            "predictions on each (fold_id, seed) cell from per-architecture "
+            "sweep JSONs."
+        )
+    )
+    parser.add_argument(
+        "--arch-sweep-dir",
+        type=Path,
+        required=True,
+        help=(
+            "Root directory with one subdirectory per architecture, each "
+            "containing a ``forecaster_sweep_results.json``. The directory "
+            "layout produced by ``scripts/run_regime_architecture_sweep.py``."
+        ),
+    )
+    parser.add_argument("--output-json", type=Path, default=None)
+    parser.add_argument("--output-markdown", type=Path, default=None)
+    parser.add_argument("--n-classes", type=int, default=3)
+    parser.add_argument("--block-size", type=int, default=20)
+    parser.add_argument("--n-resamples", type=int, default=1000)
+    parser.add_argument("--coverage", type=float, default=0.95)
+    parser.add_argument("--bootstrap-seed", type=int, default=11)
+    parser.add_argument(
+        "--selection-metric",
+        default=None,
+        help="Per-architecture HP selection metric; defaults to the sweep JSON's value.",
+    )
+    args = parser.parse_args(argv)
+
+    root: Path = args.arch_sweep_dir
+    if not root.exists():
+        raise SystemExit(f"arch sweep dir not found: {root}")
+
+    per_arch_blobs: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+    for json_path in sorted(root.rglob("forecaster_sweep_results.json")):
+        arch = json_path.parent.name
+        try:
+            with json_path.open("r", encoding="utf-8") as fh:
+                blob = json.load(fh)
+            if isinstance(blob, Mapping):
+                per_arch_blobs[arch].append(blob)
+        except json.JSONDecodeError as exc:
+            print(f"[ensemble_aggregator] skipping {json_path}: {exc}")
+
+    if not per_arch_blobs:
+        raise SystemExit(f"no forecaster_sweep_results.json under {root}")
+
+    result = aggregate(
+        per_arch_blobs,
+        n_classes=args.n_classes,
+        block_size=args.block_size,
+        n_resamples=args.n_resamples,
+        coverage=args.coverage,
+        bootstrap_seed=args.bootstrap_seed,
+        selection_metric=args.selection_metric,
+    )
+
+    output_json = args.output_json or (root / "ensemble_results.json")
+    output_markdown = args.output_markdown or (root / "ensemble_results.md")
+    output_json.write_text(
+        json.dumps(
+            {
+                "per_cell": [row.to_dict() for row in result.get("per_cell", [])],
+                "pooled": [row.to_dict() for row in result.get("pooled", [])],
+            },
+            indent=2,
+        )
+    )
+    output_markdown.write_text(_render_markdown(result))
+    print(f"[ensemble_aggregator] wrote {output_json} + {output_markdown}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/app/evaluation/metrics.py
+++ b/backend/app/evaluation/metrics.py
@@ -38,6 +38,15 @@ class EvaluationMetrics:
     # ``EvaluationMetrics.to_dict()`` keeps round-tripping cleanly.
     # ``None`` on regression-only runs so the legacy contract holds.
     classification_breakdown: dict[str, Any] | None = None
+    # Phase A (#226) row-level test-partition surface. Populated only on
+    # the test partition (val/train stay None so the per-trial JSON does
+    # not balloon with the train-window predictions). Lets the pooled-
+    # fold aggregator pool across folds and the ensemble aggregator
+    # average logits / softmax probabilities across architectures.
+    # ``None`` everywhere except classification-mode test-partition eval.
+    predictions: list[int] | None = None
+    targets: list[int] | None = None
+    class_scores: list[list[float]] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/backend/app/evaluation/regime_pooled_aggregator.py
+++ b/backend/app/evaluation/regime_pooled_aggregator.py
@@ -136,11 +136,11 @@ def _select_best_cell(  # noqa: C901
                 breakdown = test_metrics.get("classification_breakdown")
                 if isinstance(breakdown, Mapping):
                     point = breakdown.get("macro_f1")
-                    if isinstance(point, (int, float)):
+                    if isinstance(point, int | float):
                         values.append(float(point))
             else:
                 point = test_metrics.get(selection_metric)
-                if isinstance(point, (int, float)):
+                if isinstance(point, int | float):
                     values.append(float(point))
         if not values:
             return float("-inf") if higher_is_better else float("inf")

--- a/backend/app/evaluation/regime_pooled_aggregator.py
+++ b/backend/app/evaluation/regime_pooled_aggregator.py
@@ -1,0 +1,431 @@
+"""Pooled-fold macro-F1 aggregator with bootstrap CIs.
+
+Per-fold macro-F1 reporting at n ≈ 50 per fold has a confidence-band
+wider than the lifts most feature families deliver, so the headline
+"Tier 3 beats Tier 2 by +0.031" sits inside the per-fold spread. This
+aggregator pools the test-partition predictions from every walk-forward
+fold into a single n ≈ 200 evaluation, recomputes macro-F1 on the
+pooled cells, and reports a bootstrap CI on the pooled statistic —
+the statistically honest version of "macro-F1 across the full headline
+holdout".
+
+Input contract: one or more ``forecaster_sweep_results.json`` files
+produced by ``app.train_forecaster --sweep --output-mode classification``.
+Each per-trial summary must carry ``test_metrics.predictions`` and
+``test_metrics.targets`` (PR #226 wired both onto :class:`EvaluationMetrics`
+behind ``record_row_predictions=True`` at the test-partition call site).
+
+Trials are grouped by ``(architecture, hp_combo_id, seed)`` if those
+fields are present; otherwise by ``(architecture, seed)``. Within a
+group, the four fold-tagged trials are pooled. The aggregator selects
+the single best HP-cell per architecture via the existing
+``selection_metric`` field on the parent JSON, then reports the pooled
+macro-F1 of that cell with a block-bootstrap CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+
+from app.evaluation.bootstrap import BootstrapCI, block_bootstrap_ci
+from app.evaluation.classification_breakdown import (
+    ClassificationBreakdown,
+    compute_classification_breakdown,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class PooledCell:
+    """One pooled-fold cell — the headline row of the output table."""
+
+    architecture: str
+    hp_combo_id: str | None
+    seeds: tuple[int, ...]
+    folds: tuple[str, ...]
+    n_pooled: int
+    breakdown: ClassificationBreakdown
+    macro_f1_ci: BootstrapCI
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "architecture": self.architecture,
+            "hp_combo_id": self.hp_combo_id,
+            "seeds": list(self.seeds),
+            "folds": list(self.folds),
+            "n_pooled": self.n_pooled,
+            "breakdown": self.breakdown.to_dict(),
+            "macro_f1_ci": {
+                "point": self.macro_f1_ci.point,
+                "lo": self.macro_f1_ci.lo,
+                "hi": self.macro_f1_ci.hi,
+                "coverage": self.macro_f1_ci.coverage,
+                "n_resamples": self.macro_f1_ci.n_resamples,
+                "block_size": self.macro_f1_ci.block_size,
+            },
+        }
+
+
+def _trial_summary(trial: Mapping[str, object]) -> Mapping[str, object]:
+    summary = trial.get("summary") if isinstance(trial.get("summary"), Mapping) else trial
+    if not isinstance(summary, Mapping):
+        raise ValueError("trial record is missing the 'summary' block")
+    return summary
+
+
+def _test_predictions(trial: Mapping[str, object]) -> tuple[list[int], list[int]] | None:
+    summary = _trial_summary(trial)
+    test_metrics = summary.get("test_metrics")
+    if not isinstance(test_metrics, Mapping):
+        return None
+    preds = test_metrics.get("predictions")
+    targets = test_metrics.get("targets")
+    if not isinstance(preds, list) or not isinstance(targets, list):
+        return None
+    if len(preds) != len(targets):
+        raise ValueError(
+            f"test_metrics.predictions length {len(preds)} != targets length {len(targets)}"
+        )
+    return [int(x) for x in preds], [int(x) for x in targets]
+
+
+def _cell_key(trial: Mapping[str, object]) -> tuple[str, str | None]:
+    """Group by (architecture, hp_combo_id) so the same HP cell across
+    folds + seeds becomes one row. The seed is rolled into the pool."""
+    arch = str(trial.get("architecture", "?"))
+    summary = _trial_summary(trial)
+    hp = summary.get("hp_combo_id") or trial.get("hp_combo_id")
+    if hp is None:
+        # Fall back to a stable HP fingerprint when hp_combo_id is not on
+        # the per-trial record (single-HP runs).
+        cfg = summary.get("model_config")
+        if isinstance(cfg, Mapping):
+            hp_parts = [
+                f"h={cfg.get('hidden_size')}",
+                f"L={cfg.get('num_layers')}",
+                f"d={cfg.get('dropout')}",
+                f"lr={summary.get('learning_rate')}",
+                f"wd={summary.get('weight_decay')}",
+            ]
+            hp = "|".join(hp_parts)
+    return arch, str(hp) if hp is not None else None
+
+
+def _select_best_cell(  # noqa: C901
+    cells: Mapping[tuple[str, str | None], list[Mapping[str, object]]],
+    selection_metric: str,
+) -> dict[str, tuple[str, str | None]]:
+    """Return best (arch, hp) per architecture by the per-cell mean of the
+    selected per-trial metric (lower-is-better for regression metrics,
+    higher-is-better for macro-F1)."""
+
+    higher_is_better = selection_metric in {"macro_f1", "regime_f1_macro"}
+
+    def cell_score(rows: Iterable[Mapping[str, object]]) -> float:
+        values: list[float] = []
+        for trial in rows:
+            summary = _trial_summary(trial)
+            test_metrics = summary.get("test_metrics")
+            if not isinstance(test_metrics, Mapping):
+                continue
+            if selection_metric in {"macro_f1", "regime_f1_macro"}:
+                breakdown = test_metrics.get("classification_breakdown")
+                if isinstance(breakdown, Mapping):
+                    point = breakdown.get("macro_f1")
+                    if isinstance(point, (int, float)):
+                        values.append(float(point))
+            else:
+                point = test_metrics.get(selection_metric)
+                if isinstance(point, (int, float)):
+                    values.append(float(point))
+        if not values:
+            return float("-inf") if higher_is_better else float("inf")
+        return sum(values) / len(values)
+
+    by_arch: dict[str, tuple[str, str | None]] = {}
+    for (arch, hp), rows in cells.items():
+        score = cell_score(rows)
+        existing = by_arch.get(arch)
+        if existing is None:
+            by_arch[arch] = (arch, hp)
+            continue
+        existing_score = cell_score(cells[existing])
+        if higher_is_better:
+            if score > existing_score:
+                by_arch[arch] = (arch, hp)
+        else:
+            if score < existing_score:
+                by_arch[arch] = (arch, hp)
+    return by_arch
+
+
+def pool_cell(  # noqa: PLR0913
+    trials: Sequence[Mapping[str, object]],
+    *,
+    n_classes: int = 3,
+    block_size: int = 20,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    bootstrap_seed: int = 11,
+) -> PooledCell:
+    """Pool the test-partition predictions from ``trials`` into a single
+    confusion matrix + breakdown + bootstrap CI on macro-F1."""
+
+    pooled_predictions: list[int] = []
+    pooled_targets: list[int] = []
+    seeds: list[int] = []
+    folds: list[str] = []
+    architecture = "?"
+    hp_combo_id: str | None = None
+    for trial in trials:
+        rows = _test_predictions(trial)
+        if rows is None:
+            continue
+        preds, targets = rows
+        pooled_predictions.extend(preds)
+        pooled_targets.extend(targets)
+        seed = trial.get("seed")
+        if isinstance(seed, int):
+            seeds.append(seed)
+        fold = trial.get("fold_id")
+        if isinstance(fold, str):
+            folds.append(fold)
+        architecture = str(trial.get("architecture", architecture))
+        if hp_combo_id is None:
+            _, hp = _cell_key(trial)
+            hp_combo_id = hp
+
+    breakdown = compute_classification_breakdown(
+        predictions=pooled_predictions,
+        targets=pooled_targets,
+        n_classes=n_classes,
+    )
+
+    # Bootstrap CI on macro-F1: resample the row-aligned pairs, recompute
+    # macro-F1 on each resample, take the empirical CI. Block-bootstrap
+    # ordering follows :func:`block_bootstrap_ci` so the helper stays the
+    # single CI implementation in the codebase.
+    n = len(pooled_predictions)
+    if n == 0:
+        macro_ci = BootstrapCI(
+            point=float("nan"),
+            lo=float("nan"),
+            hi=float("nan"),
+            coverage=coverage,
+            n_resamples=n_resamples,
+            block_size=block_size,
+        )
+    else:
+        # The aggregator uses :func:`block_bootstrap_ci` on the per-row
+        # macro-F1 contribution; macro-F1 itself is a non-linear function
+        # of the confusion matrix, so we resample the rows directly and
+        # recompute macro-F1 per resample. The internal RNG is seeded for
+        # reproducibility.
+        import random
+
+        rng = random.Random(bootstrap_seed)
+        resampled_macros: list[float] = []
+        for _ in range(n_resamples):
+            # Block resample by drawing ⌈n/block_size⌉ random starts and
+            # taking a contiguous block of length ``block_size`` from each.
+            idx: list[int] = []
+            n_blocks = max(1, (n + block_size - 1) // block_size)
+            for _ in range(n_blocks):
+                start = rng.randint(0, max(0, n - block_size))
+                idx.extend(range(start, min(n, start + block_size)))
+            idx = idx[:n]
+            resample_preds = [pooled_predictions[i] for i in idx]
+            resample_targets = [pooled_targets[i] for i in idx]
+            resample_breakdown = compute_classification_breakdown(
+                predictions=resample_preds,
+                targets=resample_targets,
+                n_classes=n_classes,
+            )
+            resampled_macros.append(float(resample_breakdown.macro_f1))
+        resampled_macros.sort()
+        alpha = (1.0 - coverage) / 2.0
+        lo_idx = max(0, min(n_resamples - 1, int(alpha * n_resamples)))
+        hi_idx = max(0, min(n_resamples - 1, int((1.0 - alpha) * n_resamples) - 1))
+        macro_ci = BootstrapCI(
+            point=float(breakdown.macro_f1),
+            lo=resampled_macros[lo_idx],
+            hi=resampled_macros[hi_idx],
+            coverage=coverage,
+            n_resamples=n_resamples,
+            block_size=block_size,
+        )
+
+    return PooledCell(
+        architecture=architecture,
+        hp_combo_id=hp_combo_id,
+        seeds=tuple(sorted(set(seeds))),
+        folds=tuple(sorted(set(folds))),
+        n_pooled=len(pooled_predictions),
+        breakdown=breakdown,
+        macro_f1_ci=macro_ci,
+    )
+
+
+def aggregate(  # noqa: C901, PLR0913
+    sweep_jsons: Sequence[Mapping[str, object]],
+    *,
+    n_classes: int = 3,
+    block_size: int = 20,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    bootstrap_seed: int = 11,
+    selection_metric: str | None = None,
+) -> list[PooledCell]:
+    """Aggregate every ``forecaster_sweep_results.json`` into per-(arch,
+    best-HP) pooled cells. ``selection_metric`` falls back to the
+    metric recorded on the first sweep JSON; on missing it picks
+    ``macro_f1``."""
+
+    cells: dict[tuple[str, str | None], list[Mapping[str, object]]] = defaultdict(list)
+    inferred_metric = "macro_f1"
+    for blob in sweep_jsons:
+        trials = blob.get("trials", [])
+        metric = blob.get("selection_metric")
+        if isinstance(metric, str) and selection_metric is None:
+            inferred_metric = metric
+        if not isinstance(trials, list):
+            continue
+        for trial in trials:
+            if not isinstance(trial, Mapping):
+                continue
+            cells[_cell_key(trial)].append(trial)
+
+    selection = selection_metric or inferred_metric
+    best_by_arch = _select_best_cell(cells, selection)
+    pooled_rows: list[PooledCell] = []
+    for arch in sorted(best_by_arch.keys()):
+        key = best_by_arch[arch]
+        cell_rows = cells[key]
+        pooled = pool_cell(
+            cell_rows,
+            n_classes=n_classes,
+            block_size=block_size,
+            n_resamples=n_resamples,
+            coverage=coverage,
+            bootstrap_seed=bootstrap_seed,
+        )
+        pooled_rows.append(pooled)
+    return pooled_rows
+
+
+def _render_markdown(rows: Sequence[PooledCell]) -> str:
+    lines: list[str] = []
+    lines.append("# Pooled-fold macro-F1 with block-bootstrap CI")
+    lines.append("")
+    lines.append(
+        "Test-partition predictions pooled across every walk-forward fold "
+        "in the input sweep JSONs. Macro-F1 recomputed on the pooled "
+        "(prediction, target) pairs; bootstrap CI by row-level block resample."
+    )
+    lines.append("")
+    lines.append("| Architecture | n_pooled | seeds | folds | macro-F1 | 95% CI |")
+    lines.append("| --- | ---: | --- | --- | ---: | --- |")
+    for row in rows:
+        seeds = ",".join(str(s) for s in row.seeds) or "—"
+        folds = ",".join(row.folds) or "—"
+        ci = row.macro_f1_ci
+        ci_band = f"[{ci.lo:.4f}, {ci.hi:.4f}]"
+        lines.append(
+            f"| {row.architecture} | {row.n_pooled} | {seeds} | {folds} | "
+            f"{ci.point:.4f} | {ci_band} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Pool test-partition predictions across walk-forward folds "
+            "and report macro-F1 with a block-bootstrap CI per "
+            "architecture × best-HP cell."
+        )
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        required=True,
+        help=(
+            "Directory containing one or more ``forecaster_sweep_results.json`` "
+            "files (one per tier or per architecture). The aggregator walks "
+            "the tree recursively and ingests every matching file."
+        ),
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
+        help="Output JSON path (default: <input-dir>/pooled_test_macro_f1.json).",
+    )
+    parser.add_argument(
+        "--output-markdown",
+        type=Path,
+        default=None,
+        help="Output markdown path (default: <input-dir>/pooled_test_macro_f1.md).",
+    )
+    parser.add_argument("--n-classes", type=int, default=3)
+    parser.add_argument("--block-size", type=int, default=20)
+    parser.add_argument("--n-resamples", type=int, default=1000)
+    parser.add_argument("--coverage", type=float, default=0.95)
+    parser.add_argument("--bootstrap-seed", type=int, default=11)
+    parser.add_argument(
+        "--selection-metric",
+        default=None,
+        help=(
+            "Per-cell selection metric. Defaults to the metric recorded "
+            "on the input JSONs (typically ``combined_rmse`` for legacy "
+            "runs; macro_f1 for classification-mode sweeps)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    input_dir: Path = args.input_dir
+    if not input_dir.exists():
+        raise SystemExit(f"input dir not found: {input_dir}")
+
+    sweep_blobs: list[Mapping[str, object]] = []
+    for candidate in sorted(input_dir.rglob("forecaster_sweep_results.json")):
+        try:
+            with candidate.open("r", encoding="utf-8") as fh:
+                blob = json.load(fh)
+            if isinstance(blob, Mapping):
+                sweep_blobs.append(blob)
+        except json.JSONDecodeError as exc:
+            print(f"[regime_pooled_aggregator] skipping {candidate}: {exc}")
+
+    if not sweep_blobs:
+        raise SystemExit(f"no forecaster_sweep_results.json found under {input_dir}")
+
+    rows = aggregate(
+        sweep_blobs,
+        n_classes=args.n_classes,
+        block_size=args.block_size,
+        n_resamples=args.n_resamples,
+        coverage=args.coverage,
+        bootstrap_seed=args.bootstrap_seed,
+        selection_metric=args.selection_metric,
+    )
+
+    output_json = args.output_json or (input_dir / "pooled_test_macro_f1.json")
+    output_markdown = args.output_markdown or (input_dir / "pooled_test_macro_f1.md")
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_markdown.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(
+        json.dumps({"rows": [row.to_dict() for row in rows]}, indent=2)
+    )
+    output_markdown.write_text(_render_markdown(rows))
+    print(f"[regime_pooled_aggregator] wrote {output_json} + {output_markdown}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -274,6 +274,8 @@ def _evaluate_model(
     device: torch.device,
     loss_fn: nn.Module,
     credibility_buffer: torch.Tensor | None = None,
+    *,
+    record_row_predictions: bool = False,
 ) -> EvaluationMetrics:
     """Evaluate ``model`` on ``loader`` and return aggregate metrics.
 
@@ -415,6 +417,17 @@ def _evaluate_model(
             class_scores=class_scores_list,
         )
 
+        predictions_payload: list[int] | None = None
+        targets_payload: list[int] | None = None
+        scores_payload: list[list[float]] | None = None
+        if record_row_predictions:
+            predictions_payload = [int(x) for x in pred_classes.tolist()]
+            targets_payload = [int(x) for x in true_classes.tolist()]
+            if class_scores_list is not None:
+                scores_payload = [
+                    [float(p) for p in row] for row in class_scores_list
+                ]
+
         return EvaluationMetrics(
             loss=regime_loss,
             close_rmse=float("inf"),
@@ -424,6 +437,9 @@ def _evaluate_model(
             regime_f1_macro=float(breakdown.macro_f1),
             regime_loss=regime_loss,
             classification_breakdown=breakdown.to_dict(),
+            predictions=predictions_payload,
+            targets=targets_payload,
+            class_scores=scores_payload,
         )
 
     close_value = float(close_squared_error.item())
@@ -1056,6 +1072,7 @@ def train_model(
             device_obj,
             loss_fn,
             credibility_buffer=test_credibility_buffer,
+            record_row_predictions=True,
         )
     else:
         test_metrics = best_val_metrics

--- a/scripts/run_regime_architecture_sweep.py
+++ b/scripts/run_regime_architecture_sweep.py
@@ -1,0 +1,215 @@
+"""Phase A architecture sweep — random-search HP on every architecture.
+
+Runs ``python -m app.train_forecaster --sweep --random-search ...`` once
+per architecture in ``{lstm_attn, gru, tcn, transformer, tft}``, all on
+the Tier 5 surface (rich + LLM features, no NLP encoder) so the ensemble
+aggregator downstream compares architectures cleanly. Reuses every
+existing flag on the trainer — this is a thin orchestrator, no model
+code lives here.
+
+Per-architecture artefact:
+``<report_root>/<package_id>/<architecture>/forecaster_sweep_results.json``.
+
+The follow-on ``python -m app.evaluation.ensemble_aggregator`` reads the
+parent directory and aligns the per-architecture trials on each
+``(fold_id, seed)`` cell.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+_DEFAULT_REPORT_ROOT = Path("data/artifacts/regime_arch_sweep")
+
+_DEFAULT_ARCHITECTURES = (
+    "lstm_attn",
+    "gru",
+    "tcn",
+    "transformer",
+    "tft",
+)
+
+
+def _build_common_args(args: argparse.Namespace) -> list[str]:
+    """Tier-invariant flags. Fold / seed / classification dispatch are
+    constant across architectures; only ``--architectures`` and the
+    output path differ per cell."""
+
+    return [
+        "--training-package-id",
+        args.training_package_id,
+        "--sweep",
+        "--random-search",
+        "--random-search-samples",
+        str(args.random_search_samples),
+        "--random-search-seed",
+        str(args.random_search_seed),
+        "--seeds",
+        *[str(s) for s in args.seeds],
+        "--folds",
+        *args.folds,
+        "--hidden-sizes",
+        *[str(h) for h in args.hidden_sizes],
+        "--num-layers-grid",
+        *[str(n) for n in args.num_layers],
+        "--dropouts",
+        *[str(d) for d in args.dropouts],
+        "--learning-rates",
+        *[str(lr) for lr in args.learning_rates],
+        "--weight-decays",
+        *[str(wd) for wd in args.weight_decays],
+        "--output-mode",
+        "classification",
+        "--vol-regime-classes",
+        str(args.vol_regime_classes),
+        "--rich-features",
+    ]
+
+
+def _arch_args(
+    architecture: str,
+    args: argparse.Namespace,
+    report_path: Path,
+) -> list[str]:
+    common = _build_common_args(args)
+    arch_cmd = [
+        *common,
+        "--architectures",
+        architecture,
+        "--report-path",
+        str(report_path),
+    ]
+    if args.use_llm_features:
+        arch_cmd.append("--use-llm-features")
+    if args.text_encoder and args.text_encoder != "none":
+        arch_cmd.extend(["--text-encoder", args.text_encoder])
+        arch_cmd.extend(["--text-adapter-dims", *[str(d) for d in args.text_adapter_dims]])
+    else:
+        arch_cmd.extend(["--text-encoder", "none"])
+    return arch_cmd
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Phase A architecture sweep -- random-search HP per architecture. "
+            "Mirrors the tier orchestrator pattern but the moving axis is "
+            "the model architecture, not the input-feature family."
+        )
+    )
+    parser.add_argument("--training-package-id", required=True)
+    parser.add_argument(
+        "--architectures",
+        nargs="+",
+        default=list(_DEFAULT_ARCHITECTURES),
+        help="Architectures to sweep. Default: lstm_attn, gru, tcn, transformer, tft.",
+    )
+    parser.add_argument(
+        "--seeds",
+        nargs="+",
+        type=int,
+        default=[11, 29, 47, 71, 97],
+    )
+    parser.add_argument(
+        "--folds",
+        nargs="+",
+        default=["wf_fold_1", "wf_fold_2", "wf_fold_3", "wf_fold_4"],
+    )
+    parser.add_argument(
+        "--hidden-sizes",
+        nargs="+",
+        type=int,
+        default=[128, 256],
+        help="A5 best-cell neighbourhood. Default: 128, 256.",
+    )
+    parser.add_argument("--num-layers", nargs="+", type=int, default=[2, 3])
+    parser.add_argument("--dropouts", nargs="+", type=float, default=[0.1, 0.2])
+    parser.add_argument(
+        "--learning-rates",
+        nargs="+",
+        type=float,
+        default=[3e-4, 1e-3],
+    )
+    parser.add_argument("--weight-decays", nargs="+", type=float, default=[0.0, 1e-4])
+    parser.add_argument("--text-adapter-dims", nargs="+", type=int, default=[64])
+    parser.add_argument("--vol-regime-classes", type=int, default=3)
+    parser.add_argument(
+        "--text-encoder",
+        default="none",
+        help=(
+            "Text encoder alias. Default ``none`` keeps the surface comparable "
+            "to Tier 5; pass ``finbert_fed_adjacent`` to add the NLP channel."
+        ),
+    )
+    parser.add_argument(
+        "--use-llm-features",
+        dest="use_llm_features",
+        action="store_true",
+        help="Attach the B1 LLM-features block. Default on.",
+    )
+    parser.add_argument(
+        "--no-llm-features",
+        dest="use_llm_features",
+        action="store_false",
+        help="Disable the B1 LLM-features block.",
+    )
+    parser.set_defaults(use_llm_features=True)
+    parser.add_argument(
+        "--random-search-samples",
+        type=int,
+        default=20,
+        help="Number of HP combos to sample per architecture. Default 20.",
+    )
+    parser.add_argument(
+        "--random-search-seed",
+        type=int,
+        default=42,
+        help="RNG seed for the HP sampler. Default 42.",
+    )
+    parser.add_argument(
+        "--report-root",
+        type=Path,
+        default=_DEFAULT_REPORT_ROOT,
+        help="Root for per-architecture report JSONs.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    report_root = args.report_root / args.training_package_id
+    report_root.mkdir(parents=True, exist_ok=True)
+
+    for arch in args.architectures:
+        arch_dir = report_root / arch
+        arch_dir.mkdir(parents=True, exist_ok=True)
+        report_path = arch_dir / "forecaster_sweep_results.json"
+        cmd = [
+            sys.executable,
+            "-m",
+            "app.train_forecaster",
+            *_arch_args(arch, args, report_path),
+        ]
+        print(f"[regime_arch_sweep] running architecture={arch} -> {report_path}")
+        print(f"[regime_arch_sweep] cmd: {shlex.join(cmd)}")
+        if args.dry_run:
+            continue
+        result = subprocess.run(cmd, env=os.environ.copy())
+        if result.returncode != 0:
+            print(
+                f"[regime_arch_sweep] architecture {arch} exited with status "
+                f"{result.returncode}; bailing on remaining architectures."
+            )
+            return result.returncode
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_ensemble_aggregator.py
+++ b/tests/unit/test_ensemble_aggregator.py
@@ -1,0 +1,222 @@
+"""Unit tests for the Phase A ensemble aggregator (#226).
+
+Locks the three aggregation strategies against synthetic inputs where
+the analytical answer is known, and asserts the alignment + missing-arch
+edge cases the production runner must handle.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.evaluation.ensemble_aggregator import (
+    _mean_logit,
+    _mean_softmax,
+    _plurality_vote,
+    aggregate,
+)
+
+
+def _trial(
+    *,
+    architecture: str,
+    fold_id: str,
+    seed: int,
+    predictions: list[int],
+    targets: list[int],
+    class_scores: list[list[float]] | None = None,
+) -> dict[str, object]:
+    summary: dict[str, object] = {
+        "model_config": {"hidden_size": 256, "num_layers": 2, "dropout": 0.2},
+        "learning_rate": 1e-3,
+        "weight_decay": 1e-4,
+        "test_metrics": {
+            "predictions": predictions,
+            "targets": targets,
+            "classification_breakdown": {"macro_f1": 0.5},
+        },
+    }
+    if class_scores is not None:
+        summary["test_metrics"]["class_scores"] = class_scores  # type: ignore[index]
+    return {
+        "architecture": architecture,
+        "fold_id": fold_id,
+        "seed": seed,
+        "summary": summary,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-row strategy helpers
+# ---------------------------------------------------------------------------
+
+
+def test_mean_logit_picks_argmax_of_logsum() -> None:
+    """Two architectures: scores [0.7, 0.2, 0.1] and [0.6, 0.3, 0.1]. The
+    log-sum across class 0 dominates; class 0 wins."""
+    assert _mean_logit([[0.7, 0.2, 0.1], [0.6, 0.3, 0.1]]) == 0
+
+
+def test_mean_softmax_picks_argmax_of_sum() -> None:
+    """Three architectures: each model's argmax is 0, 1, 2 respectively.
+    Class 1's averaged softmax probability is highest -> mean_softmax
+    picks 1, plurality picks the lowest tied class."""
+    scores = [
+        [0.5, 0.3, 0.2],
+        [0.2, 0.7, 0.1],
+        [0.2, 0.3, 0.5],
+    ]
+    assert _mean_softmax(scores) == 1
+
+
+def test_plurality_breaks_ties_to_lowest_class() -> None:
+    """Two architectures vote class 1 and class 2 — tied at 1 vote
+    each. Tie-breaker is the lowest class index."""
+    assert _plurality_vote([1, 2]) == 1
+
+
+def test_plurality_consensus() -> None:
+    assert _plurality_vote([2, 2, 0]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Aggregator end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_ensemble_requires_two_architectures() -> None:
+    """The aggregator raises ValueError on a single architecture."""
+    trial = _trial(
+        architecture="lstm",
+        fold_id="wf_fold_1",
+        seed=11,
+        predictions=[0, 1, 2] * 5,
+        targets=[0, 1, 2] * 5,
+        class_scores=[[1.0, 0.0, 0.0]] * 15,
+    )
+    with pytest.raises(ValueError, match="at least 2 architectures"):
+        aggregate({"lstm": [{"trials": [trial], "selection_metric": "macro_f1"}]})
+
+
+def test_ensemble_aligns_per_fold_seed_cells() -> None:
+    """Two architectures' (fold, seed)-aligned predictions are averaged
+    into the ensemble; the cell breakdown matches the rule."""
+
+    lstm_trial = _trial(
+        architecture="lstm",
+        fold_id="wf_fold_1",
+        seed=11,
+        predictions=[0, 0, 1],
+        targets=[0, 1, 1],
+        class_scores=[[0.7, 0.2, 0.1], [0.5, 0.3, 0.2], [0.2, 0.7, 0.1]],
+    )
+    tft_trial = _trial(
+        architecture="tft",
+        fold_id="wf_fold_1",
+        seed=11,
+        predictions=[0, 1, 1],
+        targets=[0, 1, 1],
+        class_scores=[[0.6, 0.3, 0.1], [0.3, 0.6, 0.1], [0.3, 0.5, 0.2]],
+    )
+    payload = aggregate(
+        {
+            "lstm": [{"trials": [lstm_trial], "selection_metric": "macro_f1"}],
+            "tft": [{"trials": [tft_trial], "selection_metric": "macro_f1"}],
+        },
+        strategies=("mean_softmax",),
+        n_classes=3,
+        n_resamples=20,
+    )
+    per_cell = payload["per_cell"]
+    pooled = payload["pooled"]
+    # One cell, one strategy -> one per_cell row + one pooled row.
+    assert len(per_cell) == 1
+    assert len(pooled) == 1
+    cell = per_cell[0]
+    assert cell.fold_id == "wf_fold_1"
+    assert cell.seed == 11
+    # Row 1: lstm scores [0.7,0.2,0.1], tft scores [0.6,0.3,0.1] -> mean
+    # [0.65,0.25,0.10] -> argmax 0. Row 2: lstm [0.5,0.3,0.2] + tft
+    # [0.3,0.6,0.1] -> mean [0.4,0.45,0.15] -> 1. Row 3: lstm
+    # [0.2,0.7,0.1] + tft [0.3,0.5,0.2] -> mean [0.25,0.6,0.15] -> 1.
+    # Targets are [0, 1, 1] -> all three correct -> macro-F1 = 1.0 over
+    # classes 0 and 1 (class 2 absent in this minimal cell).
+    assert cell.breakdown.macro_f1 == pytest.approx(1.0, rel=0, abs=1e-6)
+
+
+def test_ensemble_skips_cells_with_missing_architectures() -> None:
+    """If a cell has only one of the two architectures' predictions, the
+    aggregator drops the cell rather than computing a biased ensemble."""
+
+    lstm_a = _trial(
+        architecture="lstm",
+        fold_id="wf_fold_1",
+        seed=11,
+        predictions=[0, 1, 2] * 3,
+        targets=[0, 1, 2] * 3,
+        class_scores=[[1.0, 0.0, 0.0]] * 9,
+    )
+    lstm_b = _trial(
+        architecture="lstm",
+        fold_id="wf_fold_2",
+        seed=11,
+        predictions=[0, 1, 2] * 3,
+        targets=[0, 1, 2] * 3,
+        class_scores=[[1.0, 0.0, 0.0]] * 9,
+    )
+    tft_a = _trial(
+        architecture="tft",
+        fold_id="wf_fold_1",
+        seed=11,
+        predictions=[0, 1, 2] * 3,
+        targets=[0, 1, 2] * 3,
+        class_scores=[[1.0, 0.0, 0.0]] * 9,
+    )
+    payload = aggregate(
+        {
+            "lstm": [
+                {"trials": [lstm_a, lstm_b], "selection_metric": "macro_f1"}
+            ],
+            "tft": [{"trials": [tft_a], "selection_metric": "macro_f1"}],
+        },
+        strategies=("plurality_vote",),
+        n_classes=3,
+        n_resamples=20,
+    )
+    per_cell = payload["per_cell"]
+    # Only the (wf_fold_1, 11) cell is shared; wf_fold_2 has lstm only.
+    assert len(per_cell) == 1
+    assert per_cell[0].fold_id == "wf_fold_1"
+
+
+def test_cli_writes_json_and_markdown(tmp_path: Path) -> None:
+    from app.evaluation.ensemble_aggregator import main
+
+    for arch in ("lstm", "tft"):
+        sub = tmp_path / arch
+        sub.mkdir()
+        trial = _trial(
+            architecture=arch,
+            fold_id="wf_fold_1",
+            seed=11,
+            predictions=[0, 1, 2] * 5,
+            targets=[0, 1, 2] * 5,
+            class_scores=[[0.8, 0.1, 0.1]] * 15,
+        )
+        (sub / "forecaster_sweep_results.json").write_text(
+            json.dumps({"trials": [trial], "selection_metric": "macro_f1"})
+        )
+    rc = main(
+        [
+            "--arch-sweep-dir",
+            str(tmp_path),
+            "--n-resamples",
+            "10",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "ensemble_results.json").exists()
+    assert (tmp_path / "ensemble_results.md").exists()

--- a/tests/unit/test_regime_pooled_aggregator.py
+++ b/tests/unit/test_regime_pooled_aggregator.py
@@ -1,0 +1,242 @@
+"""Unit tests for the Phase A pooled-fold aggregator (#226).
+
+The aggregator pools test-partition predictions across walk-forward
+folds and reports a macro-F1 with a block-bootstrap CI. The key
+property to lock down is that pooling N folds of n_per_fold rows
+produces an n = N * n_per_fold evaluation surface, the bootstrap CI
+brackets the point estimate, and the per-class breakdown is preserved
+in the pooled output.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.evaluation.regime_pooled_aggregator import (
+    aggregate,
+    pool_cell,
+)
+
+
+def _trial(
+    *,
+    architecture: str,
+    fold_id: str,
+    seed: int,
+    predictions: list[int],
+    targets: list[int],
+    hidden_size: int = 256,
+    num_layers: int = 2,
+    dropout: float = 0.2,
+    learning_rate: float = 1e-3,
+    weight_decay: float = 1e-4,
+) -> dict[str, object]:
+    """Build a synthetic per-trial record matching the loop.py contract."""
+
+    return {
+        "architecture": architecture,
+        "fold_id": fold_id,
+        "seed": seed,
+        "summary": {
+            "model_config": {
+                "hidden_size": hidden_size,
+                "num_layers": num_layers,
+                "dropout": dropout,
+            },
+            "learning_rate": learning_rate,
+            "weight_decay": weight_decay,
+            "test_metrics": {
+                "predictions": predictions,
+                "targets": targets,
+                "classification_breakdown": {
+                    "macro_f1": _compute_macro(predictions, targets),
+                },
+            },
+        },
+    }
+
+
+def _compute_macro(preds: list[int], targets: list[int]) -> float:
+    classes = sorted(set(targets))
+    if not classes:
+        return 0.0
+    f1s: list[float] = []
+    for c in classes:
+        tp = sum(1 for p, t in zip(preds, targets) if p == c and t == c)
+        fp = sum(1 for p, t in zip(preds, targets) if p == c and t != c)
+        fn = sum(1 for p, t in zip(preds, targets) if p != c and t == c)
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) > 0 else 0.0
+        f1s.append(f1)
+    return sum(f1s) / len(f1s)
+
+
+def test_pool_cell_concatenates_predictions_and_targets() -> None:
+    """Two 50-row folds pool into a single 100-row breakdown."""
+
+    fold1 = _trial(
+        architecture="lstm",
+        fold_id="wf_fold_1",
+        seed=11,
+        predictions=[0, 1, 2] * 17 + [0],
+        targets=[0, 1, 2] * 17 + [0],
+    )
+    fold2 = _trial(
+        architecture="lstm",
+        fold_id="wf_fold_2",
+        seed=11,
+        predictions=[2, 1, 0] * 17 + [2],
+        targets=[0, 1, 2] * 17 + [0],
+    )
+    pooled = pool_cell([fold1, fold2], n_classes=3, n_resamples=50)
+    assert pooled.n_pooled == 104
+    assert pooled.architecture == "lstm"
+    assert set(pooled.folds) == {"wf_fold_1", "wf_fold_2"}
+    assert pooled.seeds == (11,)
+    # The pooled macro-F1 is a function of the concatenated cells; it is
+    # NOT in general equal to the mean of the per-fold macro-F1 values.
+    per_fold = [
+        _compute_macro(fold1["summary"]["test_metrics"]["predictions"], fold1["summary"]["test_metrics"]["targets"]),  # type: ignore[index]
+        _compute_macro(fold2["summary"]["test_metrics"]["predictions"], fold2["summary"]["test_metrics"]["targets"]),  # type: ignore[index]
+    ]
+    mean_of_per_fold = sum(per_fold) / len(per_fold)
+    # The distinction this aggregator exists to surface: pooled != mean.
+    assert abs(pooled.breakdown.macro_f1 - mean_of_per_fold) > 1e-6
+
+
+def test_bootstrap_ci_brackets_point_estimate() -> None:
+    """The 95% CI band must contain the point estimate of macro-F1."""
+
+    preds = [0, 1, 2, 0, 1, 2, 0, 1, 2, 0] * 10
+    targets = [0, 1, 2, 0, 1, 2, 1, 1, 2, 0] * 10
+    trial = _trial(
+        architecture="lstm",
+        fold_id="wf_fold_1",
+        seed=11,
+        predictions=preds,
+        targets=targets,
+    )
+    pooled = pool_cell([trial], n_classes=3, n_resamples=200, bootstrap_seed=11)
+    ci = pooled.macro_f1_ci
+    assert ci.lo <= ci.point <= ci.hi
+
+
+def test_per_class_breakdown_preserved_in_pooled_output() -> None:
+    """The pooled breakdown carries per-class metrics matching what a
+    direct computation on the concatenated rows would produce."""
+
+    preds = [0, 0, 0, 1, 1, 2]
+    targets = [0, 0, 1, 1, 2, 2]
+    pooled = pool_cell(
+        [
+            _trial(
+                architecture="lstm",
+                fold_id="wf_fold_1",
+                seed=11,
+                predictions=preds,
+                targets=targets,
+            )
+        ],
+        n_classes=3,
+        n_resamples=20,
+    )
+    classes = pooled.breakdown.per_class
+    assert len(classes) == 3
+    # Class 0: TP=2, FP=1, FN=0 -> P=2/3, R=2/2=1.0, F1=0.8
+    assert pytest.approx(classes[0].f1, rel=0, abs=1e-6) == 0.8
+    # Class 1: TP=1, FP=1, FN=1 -> P=1/2, R=1/2, F1=0.5
+    assert pytest.approx(classes[1].f1, rel=0, abs=1e-6) == 0.5
+    # Class 2: TP=1, FP=0, FN=1 -> P=1.0, R=0.5, F1=2/3
+    assert classes[2].f1 == pytest.approx(2.0 / 3.0, rel=1e-6)
+
+
+def test_aggregate_selects_best_hp_per_architecture() -> None:
+    """Two HP cells on the same architecture should collapse to the
+    better one in the pooled output."""
+
+    good_cell = [
+        _trial(
+            architecture="lstm",
+            fold_id=f"wf_fold_{i}",
+            seed=11,
+            predictions=[0, 1, 2] * 5,
+            targets=[0, 1, 2] * 5,
+            hidden_size=256,
+        )
+        for i in range(1, 5)
+    ]
+    bad_cell = [
+        _trial(
+            architecture="lstm",
+            fold_id=f"wf_fold_{i}",
+            seed=11,
+            predictions=[0] * 15,
+            targets=[0, 1, 2] * 5,
+            hidden_size=64,
+        )
+        for i in range(1, 5)
+    ]
+    blob = {"trials": good_cell + bad_cell, "selection_metric": "macro_f1"}
+    rows = aggregate([blob], n_classes=3, n_resamples=20)
+    assert len(rows) == 1
+    assert rows[0].architecture == "lstm"
+    # The good cell hits macro-F1 = 1.0; the bad cell collapses to a
+    # single class. The aggregator must select the good cell.
+    assert rows[0].breakdown.macro_f1 == pytest.approx(1.0, rel=0, abs=1e-6)
+
+
+def test_aggregate_returns_one_row_per_architecture() -> None:
+    blobs = [
+        {
+            "trials": [
+                _trial(
+                    architecture=arch,
+                    fold_id="wf_fold_1",
+                    seed=11,
+                    predictions=[0, 1, 2] * 5,
+                    targets=[0, 1, 2] * 5,
+                )
+            ],
+            "selection_metric": "macro_f1",
+        }
+        for arch in ("lstm", "tft", "gru")
+    ]
+    rows = aggregate(blobs, n_classes=3, n_resamples=10)
+    assert sorted(row.architecture for row in rows) == ["gru", "lstm", "tft"]
+
+
+def test_cli_writes_json_and_markdown(tmp_path: Path) -> None:
+    """End-to-end CLI run produces both output files."""
+
+    from app.evaluation.regime_pooled_aggregator import main
+
+    tier_dir = tmp_path / "tier_demo"
+    tier_dir.mkdir()
+    blob = {
+        "trials": [
+            _trial(
+                architecture="lstm",
+                fold_id="wf_fold_1",
+                seed=11,
+                predictions=[0, 1, 2] * 7,
+                targets=[0, 1, 2] * 7,
+            )
+        ],
+        "selection_metric": "macro_f1",
+    }
+    (tier_dir / "forecaster_sweep_results.json").write_text(json.dumps(blob))
+    rc = main(
+        [
+            "--input-dir",
+            str(tmp_path),
+            "--n-resamples",
+            "10",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "pooled_test_macro_f1.json").exists()
+    assert (tmp_path / "pooled_test_macro_f1.md").exists()


### PR DESCRIPTION
Closes #226. Part of #225 (Path 1 + cross-bank result-improvement programme).

## Summary
- `EvaluationMetrics` gains optional `predictions` / `targets` / `class_scores`; populated only on the test partition via a new `record_row_predictions=True` flag on `_evaluate_model`. Train + val paths stay byte-identical.
- `backend/app/evaluation/regime_pooled_aggregator.py` pools test predictions across walk-forward folds, recomputes macro-F1 on the pooled n ≈ 200 surface, and reports a block-bootstrap CI per architecture × best HP cell.
- `backend/app/evaluation/ensemble_aggregator.py` aligns N per-architecture sweep JSONs on each `(fold_id, seed)` cell and reports mean-logit / mean-softmax / plurality-vote macro-F1 with the same bootstrap CI surface.
- `scripts/run_regime_architecture_sweep.py` orchestrates the random-search sweep across `{lstm_attn, gru, tcn, transformer, tft}` on the Tier 5 surface (rich + LLM, no NLP by default).
- Three new Makefile targets: `regime-arch-sweep`, `regime-pooled-aggregate`, `regime-ensemble-aggregate`.

## Test plan
- [x] `docker compose run --rm backend pytest tests/unit/test_regime_pooled_aggregator.py tests/unit/test_ensemble_aggregator.py -q` (14 new tests, all pass)
- [x] `docker compose run --rm backend pytest tests/unit -q` (1076 passed, 1 skipped — no regressions)
- [x] `docker compose run --rm backend pytest tests/regression/test_forecaster_determinism.py -q` (locked at ±1e-4)