### PR TITLE
Walk-forward embargo gap (Round 0, closes #238)

### DIFF
--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -606,6 +606,22 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--embargo-days",
+        type=int,
+        default=20,
+        help=(
+            "Purge buffer between adjacent walk-forward partitions "
+            "(López de Prado, Advances in Financial ML, ch. 7). Drops "
+            "val rows whose event date sits within this many calendar "
+            "days of the fold's train_end, and test rows within this "
+            "many days of val_end. The default 20 covers a 10-day "
+            "forward target while leaving headroom; the strict no-overlap "
+            "threshold for SEQUENCE_LENGTH=20 + 10d horizon is 30 days. "
+            "Pass 0 to opt out (reproduces the pre-2026-05-23 leaky "
+            "baseline). Honoured on the walk-forward path only."
+        ),
+    )
+    parser.add_argument(
         "--target-mode",
         choices=("event_study", "realized_return"),
         default="event_study",
@@ -1995,6 +2011,7 @@ def main() -> int:
                     text_adapter_dim=int(args.text_adapter_dim),
                     text_pool_lambda_inv_days=float(args.text_pool_lambda_inv_days),
                     use_text_embeddings=bool(args.use_text_embeddings),
+                    embargo_days=int(args.embargo_days),
                 )
                 walk_forward_splits[fold_id] = split
                 print(
@@ -2031,6 +2048,9 @@ def main() -> int:
                 text_adapter_dim=int(args.text_adapter_dim),
                 text_pool_lambda_inv_days=float(args.text_pool_lambda_inv_days),
                 use_text_embeddings=bool(args.use_text_embeddings),
+                # Single-fold uses split_tag, not manifest dates -- embargo
+                # passes through but the loader will no-op on this path.
+                embargo_days=int(args.embargo_days),
             )
             walk_forward_splits = {"_single_fold": split}
             print(

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -1498,6 +1498,7 @@ def load_walk_forward_split(
     text_pool_lambda_inv_days: float = DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS,
     use_text_embeddings: bool = True,
     text_embedding_cache_dir: Path | str | None = None,
+    embargo_days: int = 0,
 ) -> WalkForwardSplit:
     """Return the (train, val, test) sequence partitions for one fold.
 
@@ -1522,6 +1523,24 @@ def load_walk_forward_split(
     consumed by the training loop for early stopping. Both paths
     preserve the prior-bars + rich-feature + text-embedding attachment
     logic; only the partition step changes.
+
+    ``embargo_days`` inserts a purged buffer between adjacent partitions
+    (López de Prado, *Advances in Financial ML*, ch. 7). With a
+    10-bar forward target and a ``SEQUENCE_LENGTH``-bar input window,
+    consecutive event rows can share bars across the train/val
+    boundary: train_event_T's 10-day forward target spans bars
+    [T+1, T+10] and val_event_V's input window spans bars
+    [V - SEQUENCE_LENGTH + 1, V], so the two windows overlap whenever
+    V - T <= SEQUENCE_LENGTH + 10 - 1 calendar bars. Setting
+    ``embargo_days`` drops val rows whose event date sits within
+    ``embargo_days`` calendar days of the fold's ``train_end``, and
+    test rows within ``embargo_days`` of ``val_end``. The function
+    default is ``0`` (back-compat); ``app.train_forecaster`` and
+    other production callers pass a non-zero value via their
+    ``--embargo-days`` CLI flag. ``embargo_days`` is currently honoured
+    only on the multi-fold walk-forward path (single-fold partitions
+    are split-tag-driven and have no manifest dates to anchor the
+    embargo against).
 
     Raises ``ValueError`` when the chosen partition produces an empty
     test list: a sweep that silently runs on no held-out events is the
@@ -1582,6 +1601,7 @@ def load_walk_forward_split(
                 continue
     else:
         protocol = "walk-forward"
+        train_end_str = fold_window.get("train_end", "")
         val_start = fold_window.get("val_start", "")
         val_end = fold_window.get("val_end", "")
         test_start = fold_window.get("test_start", "")
@@ -1591,6 +1611,20 @@ def load_walk_forward_split(
                 f"fold {fold_id!r} manifest entry missing one of "
                 "val_start/val_end/test_start/test_end"
             )
+        embargo_active = int(embargo_days) > 0
+        if embargo_active and not train_end_str:
+            raise ValueError(
+                f"fold {fold_id!r} manifest entry is missing ``train_end``; "
+                "cannot apply a non-zero embargo without an anchored "
+                "train-boundary date"
+            )
+        train_end_dt = (
+            datetime.date.fromisoformat(train_end_str) if embargo_active else None
+        )
+        val_end_dt = (
+            datetime.date.fromisoformat(val_end) if embargo_active else None
+        )
+        embargo = datetime.timedelta(days=int(embargo_days))
         for sequence, _text_hash, event_date_str in items:
             # Expanding-window contract: any event chronologically
             # before the val window belongs to the training partition,
@@ -1599,9 +1633,21 @@ def load_walk_forward_split(
                 train.append(sequence)
                 train_dates.append(event_date_str)
             elif val_start <= event_date_str <= val_end:
+                if embargo_active and train_end_dt is not None:
+                    ed = datetime.date.fromisoformat(event_date_str)
+                    if (ed - train_end_dt) < embargo:
+                        # Purged: too close to train_end. Drops the
+                        # row to break the train-target / val-input
+                        # bar-window overlap; see docstring for the
+                        # exact arithmetic.
+                        continue
                 val.append(sequence)
                 val_dates.append(event_date_str)
             elif test_start <= event_date_str <= test_end:
+                if embargo_active and val_end_dt is not None:
+                    ed = datetime.date.fromisoformat(event_date_str)
+                    if (ed - val_end_dt) < embargo:
+                        continue
                 test.append(sequence)
                 test_dates.append(event_date_str)
             else:

--- a/tests/unit/test_training_package_loader.py
+++ b/tests/unit/test_training_package_loader.py
@@ -1463,3 +1463,182 @@ def test_walk_forward_split_back_compat_wrapper_emits_deprecation(
     # Synthesised realized_date was the same date as event_date in the
     # fixture, so the appended target frame uses each event's own date.
     assert target_dates == ["2020-01-15", "2020-02-15"]
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward embargo tests
+#
+# The walk-forward path builds (train, val, test) partitions off the
+# fold manifest's chronological boundaries. A 10-day forward target
+# combined with a SEQUENCE_LENGTH=20 input window can leak bars across
+# the train/val boundary when two events sit close in calendar time
+# (a FOMC statement and its release of the minutes, for instance).
+# The ``embargo_days`` parameter drops val rows whose event date is
+# within N calendar days of ``train_end`` and test rows within N days
+# of ``val_end``. The tests below pin the embargo arithmetic so the
+# leakage fix cannot silently regress.
+# ---------------------------------------------------------------------------
+
+
+_EMBARGO_PACKAGE_ID = "tp_unit_walk_forward_embargo_v0"
+
+
+@pytest.fixture
+def walk_forward_embargo_package_dir(tmp_path: Path, monkeypatch) -> Path:
+    """Materialise a package with deliberately close train/val/test events.
+
+    The fold's ``train_end`` sits at 2020-01-31. Val window spans
+    February; one val event sits 5 days after train_end (inside any
+    embargo > 5), a second sits 25 days after. Test window spans
+    March, mirroring the same 5-vs-25-day split around ``val_end``
+    (2020-02-29). With this layout, embargo_days=10 drops one val and
+    one test row; embargo_days=20 still drops one of each; embargo_days
+    >=30 wipes the test partition and the loader raises.
+    """
+
+    package_dir = tmp_path / "processed" / _EMBARGO_PACKAGE_ID
+    package_dir.mkdir(parents=True)
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+
+    events = [
+        _wf_event_row(event_date="2020-01-05", text_hash="hash_t1", base_close=4400.0),
+        _wf_event_row(event_date="2020-01-25", text_hash="hash_t2", base_close=4410.0),
+        _wf_event_row(event_date="2020-02-05", text_hash="hash_v_near", base_close=4420.0),
+        _wf_event_row(event_date="2020-02-25", text_hash="hash_v_far", base_close=4425.0),
+        _wf_event_row(event_date="2020-03-05", text_hash="hash_te_near", base_close=4430.0),
+        _wf_event_row(event_date="2020-03-25", text_hash="hash_te_far", base_close=4435.0),
+    ]
+    pd.DataFrame(events).to_parquet(package_dir / "events.parquet", index=False)
+
+    splits = [
+        {"text_hash": "hash_t1", "split_tag": "train"},
+        {"text_hash": "hash_t2", "split_tag": "train"},
+        {"text_hash": "hash_v_near", "split_tag": "val"},
+        {"text_hash": "hash_v_far", "split_tag": "val"},
+        {"text_hash": "hash_te_near", "split_tag": "test"},
+        {"text_hash": "hash_te_far", "split_tag": "test"},
+    ]
+    pd.DataFrame(splits).to_parquet(
+        package_dir / "splits_train_val_test.parquet", index=False
+    )
+
+    manifest = {
+        "evaluation_protocol": "evaluation_protocol_v1",
+        "folds": [
+            {
+                "fold_id": "wf_fold_1",
+                "train_start": "2020-01-01",
+                "train_end": "2020-01-31",
+                "val_start": "2020-02-01",
+                "val_end": "2020-02-29",
+                "test_start": "2020-03-01",
+                "test_end": "2020-03-31",
+            },
+        ],
+    }
+    (package_dir / "fold_manifest_expanding_walk_forward.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+    return package_dir
+
+
+def test_walk_forward_embargo_zero_preserves_all_partitions(
+    walk_forward_embargo_package_dir: Path,
+) -> None:
+    """``embargo_days=0`` reproduces the pre-fix leaky baseline."""
+
+    split = loaders.load_walk_forward_split(
+        _EMBARGO_PACKAGE_ID,
+        fold_id="wf_fold_1",
+        rich_features=False,
+        embargo_days=0,
+    )
+    assert split.train_event_dates == ["2020-01-05", "2020-01-25"]
+    assert split.val_event_dates == ["2020-02-05", "2020-02-25"]
+    assert split.test_event_dates == ["2020-03-05", "2020-03-25"]
+
+
+def test_walk_forward_embargo_default_drops_near_boundary_rows(
+    walk_forward_embargo_package_dir: Path,
+) -> None:
+    """``embargo_days=20`` drops val rows within 20 days of train_end,
+    and test rows within 20 days of val_end."""
+
+    split = loaders.load_walk_forward_split(
+        _EMBARGO_PACKAGE_ID,
+        fold_id="wf_fold_1",
+        rich_features=False,
+        embargo_days=20,
+    )
+    # train_end=2020-01-31. Val event 2020-02-05 is 5 days away
+    # (< 20) -> dropped; val event 2020-02-25 is 25 days away -> kept.
+    assert split.val_event_dates == ["2020-02-25"]
+    # val_end=2020-02-29. Test event 2020-03-05 is 5 days away -> dropped;
+    # test event 2020-03-25 is 25 days away -> kept.
+    assert split.test_event_dates == ["2020-03-25"]
+    # Train partition is unaffected; embargo only purges val and test.
+    assert split.train_event_dates == ["2020-01-05", "2020-01-25"]
+
+
+def test_walk_forward_embargo_strict_threshold_empties_test_partition(
+    walk_forward_embargo_package_dir: Path,
+) -> None:
+    """A 30-day embargo drops both test events; loader must refuse to
+    silently train on a no-held-out-events partition."""
+
+    with pytest.raises(ValueError, match="empty test partition"):
+        loaders.load_walk_forward_split(
+            _EMBARGO_PACKAGE_ID,
+            fold_id="wf_fold_1",
+            rich_features=False,
+            embargo_days=30,
+        )
+
+
+def test_walk_forward_embargo_requires_train_end_in_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Non-zero embargo against a manifest missing ``train_end`` must
+    raise loudly rather than silently degrade to zero embargo."""
+
+    package_id = "tp_unit_embargo_missing_train_end"
+    package_dir = tmp_path / "processed" / package_id
+    package_dir.mkdir(parents=True)
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+
+    events = [
+        _wf_event_row(event_date="2020-01-15", text_hash="hash_t", base_close=4400.0),
+        _wf_event_row(event_date="2020-02-15", text_hash="hash_v", base_close=4410.0),
+        _wf_event_row(event_date="2020-03-15", text_hash="hash_te", base_close=4420.0),
+    ]
+    pd.DataFrame(events).to_parquet(package_dir / "events.parquet", index=False)
+    pd.DataFrame(
+        [
+            {"text_hash": "hash_t", "split_tag": "train"},
+            {"text_hash": "hash_v", "split_tag": "val"},
+            {"text_hash": "hash_te", "split_tag": "test"},
+        ]
+    ).to_parquet(package_dir / "splits_train_val_test.parquet", index=False)
+
+    manifest = {
+        "folds": [
+            {
+                "fold_id": "wf_fold_1",
+                # train_end deliberately omitted to exercise the
+                # non-zero embargo guard.
+                "train_start": "2020-01-01",
+                "val_start": "2020-02-01",
+                "val_end": "2020-02-29",
+                "test_start": "2020-03-01",
+                "test_end": "2020-03-31",
+            }
+        ],
+    }
+    (package_dir / "fold_manifest_expanding_walk_forward.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="train_end"):
+        loaders.load_walk_forward_split(
+            package_id, fold_id="wf_fold_1", embargo_days=20, rich_features=False
+        )


### PR DESCRIPTION
## Summary

- Walk-forward folds had zero gap between train_end / val_start / val_end / test_start
- The `forward_realized_vol_10d` target spans bars T+1..T+10; the SEQUENCE_LENGTH=20 input window pulls bars V-19..V, so train-target windows leaked into val-input windows whenever consecutive event dates sat under ~30 trading days apart
- Adds `embargo_days` kwarg to `load_walk_forward_split` (function default 0 for back-compat at the API level)
- Production callers pick up the leak fix via the new `--embargo-days` CLI flag, default 20
- Single-fold path is unchanged (no manifest dates to anchor the embargo against)

## Test plan

- [ ] `pytest tests/unit/test_training_package_loader.py -q`
- [ ] `pytest tests/regression/test_forecaster_determinism.py -q`

Closes #238. Parent: #237.
