### PR TITLE
Text-only tier (Round 2b, closes #241)

### DIFF
--- a/scripts/run_regime_baseline_tiers.py
+++ b/scripts/run_regime_baseline_tiers.py
@@ -112,6 +112,21 @@ def _tier_args(
     """Return the tier-specific flag overlay on top of the common args."""
 
     common = _build_common_args(args)
+    if tier == "tier0_text_only":
+        # Unimodal text-only row: NLP embeddings alone, no market features.
+        # Pairs with tier1 (market-only) to bracket the multimodal tiers
+        # — if a multimodal tier does not clear max(tier0, tier1), it has
+        # not earned its complexity.
+        return [
+            *common,
+            "--no-rich-features",
+            "--text-encoder",
+            args.nlp_text_encoder,
+            "--text-adapter-dims",
+            *[str(d) for d in args.text_adapter_dims],
+            "--report-path",
+            str(report_path),
+        ]
     if tier == "tier1_market_only":
         return [
             *common,
@@ -259,6 +274,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--tiers",
         nargs="+",
         choices=(
+            "tier0_text_only",
             "tier1_market_only",
             "tier2_market_rich",
             "tier3_market_rich_nlp",
@@ -268,6 +284,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "tier7_market_rich_nlp_xbank_llm",
         ),
         default=(
+            "tier0_text_only",
             "tier1_market_only",
             "tier2_market_rich",
             "tier3_market_rich_nlp",
@@ -276,7 +293,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "tier6_market_rich_nlp_xbank",
             "tier7_market_rich_nlp_xbank_llm",
         ),
-        help="Subset of tiers to run. Default: all seven.",
+        help="Subset of tiers to run. Default: all eight.",
     )
     parser.add_argument(
         "--dry-run",

--- a/tests/unit/test_regime_baseline_tiers.py
+++ b/tests/unit/test_regime_baseline_tiers.py
@@ -37,6 +37,7 @@ def test_parses_required_package_id(harness_module) -> None:
     assert args.folds == ["wf_fold_1", "wf_fold_2", "wf_fold_3", "wf_fold_4"]
     assert args.vol_regime_classes == 3
     assert args.tiers == (
+        "tier0_text_only",
         "tier1_market_only",
         "tier2_market_rich",
         "tier3_market_rich_nlp",
@@ -55,6 +56,27 @@ def test_rejects_missing_package_id(harness_module) -> None:
 # ---------------------------------------------------------------------------
 # Per-tier argument overlays
 # ---------------------------------------------------------------------------
+
+
+def test_tier0_text_only_drops_rich_features_and_keeps_encoder(
+    harness_module, tmp_path
+) -> None:
+    """Tier 0 is the unimodal text-only row: NLP embeddings alone, no
+    market features. Pairs with tier 1 to bracket the multimodal tiers."""
+
+    args = harness_module._parse_args(
+        ["--training-package-id", "pkg", "--nlp-text-encoder", "finbert_fed_adjacent"]
+    )
+    cmd = harness_module._tier_args(
+        "tier0_text_only", args, tmp_path / "tier0.json"
+    )
+    assert "--no-rich-features" in cmd
+    assert "--rich-features" not in cmd
+    assert cmd[cmd.index("--text-encoder") + 1] == "finbert_fed_adjacent"
+    # Text adapter dims forwarded so the encoder projection is exercised.
+    assert "--text-adapter-dims" in cmd
+    # LLM features explicitly off — tier 0 is *only* text.
+    assert "--use-llm-features" not in cmd
 
 
 def test_tier1_disables_rich_and_text(harness_module, tmp_path) -> None:
@@ -189,6 +211,7 @@ def test_dry_run_prints_commands_for_each_tier(harness_module, tmp_path, capsys)
     )
     assert rc == 0
     captured = capsys.readouterr().out
+    assert "tier0_text_only" in captured
     assert "tier1_market_only" in captured
     assert "tier2_market_rich" in captured
     assert "tier3_market_rich_nlp" in captured
@@ -197,7 +220,7 @@ def test_dry_run_prints_commands_for_each_tier(harness_module, tmp_path, capsys)
     assert "tier6_market_rich_nlp_xbank" in captured
     assert "tier7_market_rich_nlp_xbank_llm" in captured
     # Each per-tier line records the cmd that would have run.
-    assert captured.count("[regime_tiers] cmd:") == 7
+    assert captured.count("[regime_tiers] cmd:") == 8
 
 
 def test_dry_run_can_restrict_tier_subset(harness_module, tmp_path, capsys) -> None:


### PR DESCRIPTION
## Summary

- New `tier0_text_only` row: `--no-rich-features --text-encoder finbert_fed_adjacent`
- Brackets the multimodal tiers against the unimodal text source
- Default tier list now eight tiers; `--tiers` flag restricts subsets
- Tests cover the new dispatch path and the eight-tier dry-run count

## Test plan

- [ ] `pytest tests/unit/test_regime_baseline_tiers.py -q`
- [ ] `python scripts/run_regime_baseline_tiers.py --training-package-id <pkg> --tiers tier0_text_only --dry-run`

Closes #241. Parent: #237.
