### PR TITLE
Class-weight ablation (Round 2c, closes #234)

### DIFF
--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -663,6 +663,20 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.set_defaults(use_amp=True)
+    parser.add_argument(
+        "--no-class-weights",
+        dest="use_class_weights",
+        action="store_false",
+        help=(
+            "Skip the A1 (#206) per-fold inverse-frequency class "
+            "weighting in classification mode. Default off-flag is on, "
+            "so ``CrossEntropyLoss(weight=…)`` fires with weights fit "
+            "on the train slice. Round 2c (#234) ablation toggles this "
+            "to measure whether the weighting actually shifts macro-F1 "
+            "now that PR #233 fixed the val-loss arithmetic."
+        ),
+    )
+    parser.set_defaults(use_class_weights=True)
     args = parser.parse_args()
     # Emit DeprecationWarning when the legacy --validation-split alias is
     # used. argparse silently maps it onto validation_fraction, so callers
@@ -1185,6 +1199,7 @@ def _run_single_training(
     grad_clip_norm: float = 0.0,
     use_compile: bool = True,
     use_amp: bool = True,
+    use_class_weights: bool = True,
 ) -> TrainingRunSummary:
     # Three input paths, in precedence order:
     #
@@ -1224,6 +1239,7 @@ def _run_single_training(
             use_compile=use_compile,
             use_amp=use_amp,
             lr_schedule=lr_schedule_choice,
+            use_class_weights=use_class_weights,
         )
     elif sequence_groups:
         result = _train_model_with_groups(
@@ -1246,6 +1262,7 @@ def _run_single_training(
             use_compile=use_compile,
             use_amp=use_amp,
             lr_schedule=lr_schedule_choice,
+            use_class_weights=use_class_weights,
         )
     else:
         result = train_model(
@@ -1268,6 +1285,7 @@ def _run_single_training(
             use_compile=use_compile,
             use_amp=use_amp,
             lr_schedule=lr_schedule_choice,
+            use_class_weights=use_class_weights,
         )
     return result.summary
 
@@ -1293,6 +1311,7 @@ def _train_model_with_groups(
     use_compile: bool = True,
     use_amp: bool = True,
     lr_schedule: str = "plateau",
+    use_class_weights: bool = True,
 ) -> Any:
     """Invoke ``train_model`` against pre-loaded sequence groups.
 
@@ -1324,6 +1343,7 @@ def _train_model_with_groups(
         use_compile=use_compile,
         use_amp=use_amp,
         lr_schedule=lr_schedule,
+        use_class_weights=use_class_weights,
     )
 
 
@@ -1361,6 +1381,7 @@ def _worker_run_cell(payload: dict[str, Any]) -> dict[str, Any]:
         grad_clip_norm=float(payload.get("grad_clip_norm", 0.0)),
         use_compile=bool(payload.get("use_compile", True)),
         use_amp=bool(payload.get("use_amp", True)),
+        use_class_weights=bool(payload.get("use_class_weights", True)),
     )
     return {
         "trial_index": int(payload["trial_index"]),
@@ -1410,6 +1431,7 @@ def _build_worker_payload(
         "grad_clip_norm": float(getattr(args, "grad_clip_norm", 0.0)),
         "use_compile": bool(getattr(args, "use_compile", True)),
         "use_amp": bool(getattr(args, "use_amp", True)),
+        "use_class_weights": bool(getattr(args, "use_class_weights", True)),
     }
 
 
@@ -1597,6 +1619,7 @@ def _run_sweep(
                     grad_clip_norm=float(getattr(args, "grad_clip_norm", 0.0)),
                     use_compile=bool(getattr(args, "use_compile", True)),
                     use_amp=bool(getattr(args, "use_amp", True)),
+                    use_class_weights=bool(getattr(args, "use_class_weights", True)),
                 )
             record: dict[str, Any] = {
                 "trial_index": int(trial_index),
@@ -1760,6 +1783,7 @@ def _run_sweep(
                 grad_clip_norm=float(getattr(args, "grad_clip_norm", 0.0)),
                 use_compile=bool(getattr(args, "use_compile", True)),
                 use_amp=bool(getattr(args, "use_amp", True)),
+                use_class_weights=bool(getattr(args, "use_class_weights", True)),
             )
             summaries.append(summary)
             record = {
@@ -1857,6 +1881,7 @@ def _run_sweep(
         grad_clip_norm=float(getattr(args, "grad_clip_norm", 0.0)),
         use_compile=bool(getattr(args, "use_compile", True)),
         use_amp=bool(getattr(args, "use_amp", True)),
+        use_class_weights=bool(getattr(args, "use_class_weights", True)),
     )
     for trial in trial_records:
         trial["selected"] = trial["trial_index"] == best_trial_index
@@ -2146,6 +2171,7 @@ def main() -> int:
         grad_clip_norm=float(getattr(args, "grad_clip_norm", 0.0)),
         use_compile=bool(getattr(args, "use_compile", True)),
         use_amp=bool(getattr(args, "use_amp", True)),
+        use_class_weights=bool(getattr(args, "use_class_weights", True)),
     )
     metrics = summary.metrics
     if metrics is not None:

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -639,6 +639,7 @@ def train_model(
     use_compile: bool = True,
     use_amp: bool = True,
     lr_schedule: str = "plateau",
+    use_class_weights: bool = True,
 ) -> TrainingResult:
     if seed is not None:
         enable_deterministic_mode(seed)
@@ -701,11 +702,18 @@ def train_model(
             # of least resistance is no longer "predict the majority
             # prior". Train-only fit; val + test see the same weights
             # but only at loss computation, not in their own slices.
-            fitted_class_weights = fit_class_weights(
-                train_forward_vols,
-                fitted_quantiles,
-                n_classes=n_classes_active,
-            )
+            # Round 2c (#234) ablation: ``use_class_weights=False``
+            # skips the fit and leaves the weight tuple empty, so the
+            # downstream ``CrossEntropyLoss(weight=None)`` path runs
+            # for direct A1-on-vs-A1-off comparison.
+            if use_class_weights:
+                fitted_class_weights = fit_class_weights(
+                    train_forward_vols,
+                    fitted_quantiles,
+                    n_classes=n_classes_active,
+                )
+            else:
+                fitted_class_weights = ()
         else:
             fitted_quantiles = ()
             fitted_class_weights = ()

--- a/tests/unit/test_class_weight_ablation.py
+++ b/tests/unit/test_class_weight_ablation.py
@@ -14,8 +14,6 @@ stable knob to flip in re-runs.
 
 from __future__ import annotations
 
-import inspect
-import textwrap
 from pathlib import Path
 
 import pytest
@@ -49,26 +47,28 @@ def test_train_model_accepts_use_class_weights_kwarg() -> None:
 
 def test_class_weight_off_path_emits_empty_tuple() -> None:
     """When ``use_class_weights=False`` the loop must short-circuit to
-    an empty weight tuple rather than fitting and silently zeroing them."""
+    an empty weight tuple rather than fitting and silently zeroing them.
+
+    Asserted at the token level to stay stable under arbitrary
+    surrounding-indentation changes; the contract is the ``if/else``
+    pair around ``fit_class_weights`` plus the empty tuple in the off
+    branch."""
 
     source = _read(_LOOP_PATH)
-    # The else-branch under the use_class_weights guard sets the
-    # fitted_class_weights tuple to () so CrossEntropyLoss(weight=None)
-    # runs and the train-side reduction stays standard mean.
-    expected = textwrap.dedent(
-        """\
-        if use_class_weights:
-                    fitted_class_weights = fit_class_weights(
-                        train_forward_vols,
-                        fitted_quantiles,
-                        n_classes=n_classes_active,
-                    )
-                else:
-                    fitted_class_weights = ()
-        """
-    ).strip()
-    assert expected in source, (
-        "use_class_weights=False path does not zero the fitted class weights"
+    assert "if use_class_weights:" in source
+    assert "fitted_class_weights = ()" in source
+    # Order matters: the empty-tuple assignment must follow the guard,
+    # and the fit call must live inside the ``if`` block before it.
+    guard_idx = source.index("if use_class_weights:")
+    fit_call_idx = source.index(
+        "fitted_class_weights = fit_class_weights(", guard_idx
+    )
+    off_assign_idx = source.index(
+        "fitted_class_weights = ()", fit_call_idx
+    )
+    assert guard_idx < fit_call_idx < off_assign_idx, (
+        "use_class_weights guard / fit_class_weights call / empty-tuple "
+        "assignment are not in the expected order"
     )
 
 

--- a/tests/unit/test_class_weight_ablation.py
+++ b/tests/unit/test_class_weight_ablation.py
@@ -1,0 +1,105 @@
+"""Round 2c (#234) ablation: ``--no-class-weights`` skips the A1 fit.
+
+The intent of the per-fold inverse-frequency class weighting in
+``app.training.loop.train_model`` is to compensate for vol-regime
+support imbalance on the train slice. With the PR #233 weighted-CE
+val-loss fix in place, the next question is whether the weighting
+itself still moves macro-F1 — the train slice is roughly balanced by
+quantile-cutoff construction, so the weights may be a near no-op.
+
+The tests below pin the toggle semantics (default on, opt-out via
+``--no-class-weights``) at the source level so the ablation has a
+stable knob to flip in re-runs.
+"""
+
+from __future__ import annotations
+
+import inspect
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+_LOOP_PATH = Path(__file__).resolve().parents[2] / "backend" / "app" / "training" / "loop.py"
+_TRAIN_FORECASTER_PATH = (
+    Path(__file__).resolve().parents[2] / "backend" / "app" / "train_forecaster.py"
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_train_model_accepts_use_class_weights_kwarg() -> None:
+    """The signature must carry ``use_class_weights`` so the CLI flag
+    has a place to land."""
+
+    source = _read(_LOOP_PATH)
+    # Two surface guards:
+    #  1. The signature line has the kwarg with a default of True.
+    assert "use_class_weights: bool = True" in source, (
+        "train_model is missing the use_class_weights kwarg (default True)"
+    )
+    #  2. The fit_class_weights call is guarded behind the flag.
+    assert "if use_class_weights:" in source, (
+        "fit_class_weights call is not guarded by the use_class_weights flag"
+    )
+
+
+def test_class_weight_off_path_emits_empty_tuple() -> None:
+    """When ``use_class_weights=False`` the loop must short-circuit to
+    an empty weight tuple rather than fitting and silently zeroing them."""
+
+    source = _read(_LOOP_PATH)
+    # The else-branch under the use_class_weights guard sets the
+    # fitted_class_weights tuple to () so CrossEntropyLoss(weight=None)
+    # runs and the train-side reduction stays standard mean.
+    expected = textwrap.dedent(
+        """\
+        if use_class_weights:
+                    fitted_class_weights = fit_class_weights(
+                        train_forward_vols,
+                        fitted_quantiles,
+                        n_classes=n_classes_active,
+                    )
+                else:
+                    fitted_class_weights = ()
+        """
+    ).strip()
+    assert expected in source, (
+        "use_class_weights=False path does not zero the fitted class weights"
+    )
+
+
+def test_train_forecaster_exposes_no_class_weights_cli_flag() -> None:
+    """The CLI must expose ``--no-class-weights`` so the ablation can be
+    driven from the sweep harness without code edits."""
+
+    source = _read(_TRAIN_FORECASTER_PATH)
+    assert "\"--no-class-weights\"" in source, "missing --no-class-weights CLI flag"
+    assert "dest=\"use_class_weights\"" in source, (
+        "--no-class-weights does not write into args.use_class_weights"
+    )
+    assert "parser.set_defaults(use_class_weights=True)" in source, (
+        "default for --no-class-weights is not 'class weights on'"
+    )
+
+
+def test_run_single_training_threads_use_class_weights() -> None:
+    """The flag must be threaded through ``_run_single_training`` so the
+    worker payload + every call site forwards the user's choice."""
+
+    source = _read(_TRAIN_FORECASTER_PATH)
+    # Function signature carries the kwarg with default True (back-compat).
+    assert "use_class_weights: bool = True" in source
+    # Each train_model call inside _run_single_training forwards the flag.
+    occurrences = source.count("use_class_weights=use_class_weights")
+    assert occurrences >= 4, (
+        "use_class_weights is not forwarded into every train_model call site "
+        f"(found {occurrences}, expected >= 4)"
+    )
+    # Worker payload passes the flag through to subprocesses.
+    assert "\"use_class_weights\": bool(getattr(args, \"use_class_weights\", True))" in source, (
+        "worker payload does not carry use_class_weights"
+    )


### PR DESCRIPTION
## Summary

- New `use_class_weights` kwarg on `train_model`, default `True` (back-compat)
- Guards the A1 per-fold `fit_class_weights` call; `False` path emits empty weight tuple
- New `--no-class-weights` CLI flag on `train_forecaster` (default on)
- Threaded through `_run_single_training`, `_train_model_with_groups`, and the multiprocessing worker payload
- Source-level tests pin the toggle semantics so the off-path can be exercised in a sweep without code edits

## Test plan

- [ ] `pytest tests/unit/test_class_weight_ablation.py -q`
- [ ] `pytest tests/regression/test_forecaster_determinism.py -q` (regression-mode lock; class weights only apply to classification)

Closes #234. Parent: #237.
