### PR TITLE
Time-decay ablation (Round 4, closes #243)

### DIFF
--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -233,6 +233,14 @@ class ModelConfig:
     # The CLI surfaces this as ``--sequence-length`` for the capacity
     # push at hidden=512 / seq=60.
     sequence_length: int = 0
+    # Round 4 (#243) elapsed-time decay toggle. ``True`` keeps the
+    # ``TimeDecayAttention`` path (the advisor-mandated mechanism that
+    # multiplies the sentiment channel by ``exp(-lambda * |elapsed|)``);
+    # ``False`` swaps it for a no-op pass-through so the ablation can
+    # measure whether the mechanism actually earns its complexity on
+    # the post-embargo baseline. Default ``True`` preserves the legacy
+    # forward path byte-identical.
+    use_time_decay: bool = True
 
     @classmethod
     def from_model(cls, model: "Any") -> "ModelConfig":
@@ -263,6 +271,7 @@ class ModelConfig:
             ),
             lr_schedule=str(getattr(model, "lr_schedule", "plateau") or "plateau"),
             sequence_length=int(getattr(model, "sequence_length", 0) or 0),
+            use_time_decay=bool(getattr(model, "use_time_decay", True)),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -410,6 +410,20 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.set_defaults(use_text_embeddings=True)
+    parser.add_argument(
+        "--no-time-decay",
+        dest="use_time_decay",
+        action="store_false",
+        help=(
+            "Disable the elapsed-time decay path "
+            "(``TimeDecayAttention``). Default off-flag is on, so the "
+            "decay multiplies the sentiment channel by "
+            "``exp(-lambda * |elapsed|)``. Round 4 (#243) ablation "
+            "flips this to measure whether the mechanism still earns "
+            "its complexity on the post-embargo baseline."
+        ),
+    )
+    parser.set_defaults(use_time_decay=True)
     # Phase B (#227) LR schedule + sequence-length knobs.
     parser.add_argument(
         "--lr-schedule",
@@ -766,6 +780,7 @@ def _build_model_config(args: argparse.Namespace) -> ModelConfig:
         n_classes=n_classes,
         lr_schedule=str(getattr(args, "lr_schedule", "plateau") or "plateau"),
         sequence_length=int(getattr(args, "sequence_length", 0) or 0),
+        use_time_decay=bool(getattr(args, "use_time_decay", True)),
     )
 
 
@@ -990,6 +1005,7 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                             text_adapter_dim=text_adapter_dim,
                             output_mode=str(getattr(args, "output_mode", "regression") or "regression"),
                             n_classes=int(getattr(args, "vol_regime_classes", 3) or 3),
+                            use_time_decay=bool(getattr(args, "use_time_decay", True)),
                         ),
                         "learning_rate": float(hp["learning_rate"]),
                         "epochs": int(hp["epochs"]),
@@ -1075,6 +1091,7 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                     n_classes=int(getattr(args, "vol_regime_classes", 3) or 3),
                     lr_schedule=str(lr_schedule),
                     sequence_length=int(sequence_length),
+                    use_time_decay=bool(getattr(args, "use_time_decay", True)),
                 ),
                 "learning_rate": float(learning_rate),
                 "epochs": int(epochs),

--- a/tests/unit/test_time_decay_ablation.py
+++ b/tests/unit/test_time_decay_ablation.py
@@ -1,0 +1,87 @@
+"""Round 4 (#243) ablation: ``--no-time-decay`` short-circuits the
+``TimeDecayAttention`` path.
+
+The advisor mandated the elapsed-time decay mechanism but it has never
+been measured against a clean post-embargo baseline; the existing
+``use_time_decay`` kwarg on ``ForecasterModel`` is plumbed but has no
+end-to-end CLI surface. This test pins the CLI + config wiring so the
+ablation can be flipped from a sweep harness without code edits.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+_TRAIN_FORECASTER_PATH = (
+    Path(__file__).resolve().parents[2] / "backend" / "app" / "train_forecaster.py"
+)
+_CONFIG_PATH = (
+    Path(__file__).resolve().parents[2] / "backend" / "app" / "models" / "config.py"
+)
+_LSTM_PATH = (
+    Path(__file__).resolve().parents[2] / "backend" / "app" / "models" / "lstm.py"
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_model_config_carries_use_time_decay_field() -> None:
+    """``ModelConfig.use_time_decay`` must be a real field with default
+    ``True`` so existing checkpoints deserialise into the legacy
+    time-decay-on forward path."""
+
+    source = _read(_CONFIG_PATH)
+    assert "use_time_decay: bool = True" in source, (
+        "ModelConfig is missing the use_time_decay field (default True)"
+    )
+    # ``from_model`` must round-trip the field from the constructed module.
+    assert "use_time_decay=bool(getattr(model, \"use_time_decay\", True))" in source, (
+        "ModelConfig.from_model does not round-trip use_time_decay"
+    )
+
+
+def test_forecaster_model_still_owns_the_time_decay_kwarg() -> None:
+    """``ForecasterModel`` already accepts ``use_time_decay`` (predates
+    this round). Pin the kwarg + guarded forward-path branch so the
+    plumbed config field actually does something."""
+
+    source = _read(_LSTM_PATH)
+    assert "use_time_decay: bool = True" in source
+    assert "self.use_time_decay = bool(use_time_decay)" in source
+    assert "if self.use_time_decay:" in source
+
+
+def test_train_forecaster_exposes_no_time_decay_flag() -> None:
+    """The CLI must expose ``--no-time-decay`` so the ablation flips
+    from the sweep harness without source edits."""
+
+    source = _read(_TRAIN_FORECASTER_PATH)
+    assert "\"--no-time-decay\"" in source, "missing --no-time-decay CLI flag"
+    assert "dest=\"use_time_decay\"" in source, (
+        "--no-time-decay does not write into args.use_time_decay"
+    )
+    assert "parser.set_defaults(use_time_decay=True)" in source, (
+        "default for --no-time-decay is not 'time decay on'"
+    )
+
+
+def test_model_config_construction_threads_use_time_decay() -> None:
+    """Every ``ModelConfig(`` construction site in train_forecaster must
+    thread ``use_time_decay`` so the sweep + single-run paths honour
+    the CLI flag."""
+
+    source = _read(_TRAIN_FORECASTER_PATH)
+    # Three construction sites: _build_model_config, the random-search
+    # candidate builder, and the exhaustive candidate builder.
+    occurrences = source.count(
+        "use_time_decay=bool(getattr(args, \"use_time_decay\", True))"
+    )
+    assert occurrences >= 3, (
+        "use_time_decay is not threaded into every ModelConfig construction "
+        f"site (found {occurrences}, expected >= 3)"
+    )


### PR DESCRIPTION
## Summary

- New `use_time_decay` field on `ModelConfig`, default `True` (back-compat round-trip)
- `ForecasterModel.use_time_decay` kwarg now driven from the config field via the factory
- New `--no-time-decay` CLI flag (default on) flips the ablation without source edits
- Threaded through `_build_model_config` and both candidate-builder paths in the sweep harness
- Source-level tests pin CLI surface + config field + model kwarg

## Test plan

- [ ] `pytest tests/unit/test_time_decay_ablation.py -q`
- [ ] `python -m app.train_forecaster --training-package-id <pkg> --no-time-decay --list-data` (dry-run flag parse)

Closes #243. Parent: #237.
