### PR TITLE
FinBERT FOMC-only substrate (Round 3, closes #242)

### DIFF
--- a/backend/app/data/continued_pretraining.py
+++ b/backend/app/data/continued_pretraining.py
@@ -41,7 +41,17 @@ DEFAULT_LOCAL_CORPUS_FILES: tuple[str, ...] = (
     "beige_book.json",
     "regional_research.json",
 )
-_VALID_SUBSTRATES = ("bis", "local", "both")
+# Round 3 (#242) strict FOMC-only substrate: minutes + statements only.
+# Strips the BIS / Fed-adjacent broader text from the pretraining mix so
+# the ablation row can measure whether the broader substrate actually
+# helps downstream macro-F1 versus a smaller-but-strictly-on-target pool.
+# ~48 documents / ~240k tokens after chunking; expect underperformance
+# vs BIS-only but the row anchors the lower bound.
+DEFAULT_FOMC_CORPUS_FILES: tuple[str, ...] = (
+    "fomc_statements.json",
+    "fomc_minutes.json",
+)
+_VALID_SUBSTRATES = ("bis", "local", "fomc", "both")
 
 
 def _iter_local_pairs(data_dir: Path, files: Iterable[str]) -> list[dict[str, Any]]:
@@ -66,6 +76,20 @@ def _iter_local_pairs(data_dir: Path, files: Iterable[str]) -> list[dict[str, An
                 # NSP label is fixed at 0 so the model treats it as non-paired.
                 pairs.append({"sequenceA": text, "sequenceB": "", "next_sentence_label": 0})
     return pairs
+
+
+def _iter_fomc_pairs(data_dir: Path) -> list[dict[str, Any]]:
+    """Build NSP pairs from the on-disk FOMC statements + minutes JSON.
+
+    The strict FOMC-only substrate strips every non-FOMC document from
+    the pretraining mix so the ablation row can isolate whether the
+    BIS / Fed-adjacent broader corpus actually helps downstream
+    classification. The same degenerate-pair convention as
+    ``_iter_local_pairs`` is used so the downstream chunker + collator
+    paths stay identical.
+    """
+
+    return _iter_local_pairs(data_dir, DEFAULT_FOMC_CORPUS_FILES)
 
 
 def _bis_pair_stream(
@@ -258,7 +282,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--substrate",
         choices=_VALID_SUBSTRATES,
         default="bis",
-        help="bis (default; samchain/BIS_speeches_97_23_MLM), local (legacy JSON corpus), or both.",
+        help=(
+            "bis (default; samchain/BIS_speeches_97_23_MLM), local (legacy "
+            "Fed-adjacent JSON corpus), fomc (strict FOMC-only — minutes + "
+            "statements; Round 3 / #242 ablation), or both (local + BIS)."
+        ),
     )
     parser.add_argument(
         "--bis-dataset-id",
@@ -311,6 +339,18 @@ def _collect_pairs(args: argparse.Namespace) -> list[dict[str, Any]]:
     from --substrate bis.
     """
     pairs: list[dict[str, Any]] = []
+
+    if args.substrate == "fomc":
+        # Strict FOMC-only mode (Round 3 / #242 ablation). Reads only
+        # ``fomc_statements.json`` + ``fomc_minutes.json``; bypasses BIS
+        # and the broader local corpus entirely. ``--max-rows`` clamps
+        # the resulting pool (same as the legacy local branch).
+        fomc_dir = Path(args.auxiliary_local_dir) if args.auxiliary_local_dir else Path(args.data_dir)
+        fomc_pairs = _iter_fomc_pairs(fomc_dir)
+        if args.max_rows and len(fomc_pairs) > args.max_rows:
+            fomc_pairs = fomc_pairs[: args.max_rows]
+        pairs.extend(fomc_pairs)
+        return pairs
 
     if args.substrate in {"local", "both"}:
         local_dir = Path(args.auxiliary_local_dir) if args.auxiliary_local_dir else Path(args.data_dir)

--- a/tests/unit/test_continued_pretraining.py
+++ b/tests/unit/test_continued_pretraining.py
@@ -76,6 +76,95 @@ def test_bis_pair_stream_filters_empty_and_respects_max_rows(monkeypatch) -> Non
     assert rows[2]["sequenceB"] == ""
 
 
+def test_iter_fomc_pairs_reads_only_minutes_and_statements(tmp_path: Path) -> None:
+    """The strict FOMC-only substrate must read only ``fomc_minutes.json``
+    and ``fomc_statements.json`` even when other JSON files sit alongside."""
+
+    (tmp_path / "fomc_minutes.json").write_text(
+        json.dumps([{"text": "Minutes paragraph."}]),
+        encoding="utf-8",
+    )
+    (tmp_path / "fomc_statements.json").write_text(
+        json.dumps([{"text": "Statement paragraph."}]),
+        encoding="utf-8",
+    )
+    # Decoys: these must NOT be picked up by the strict substrate.
+    (tmp_path / "chair_speeches.json").write_text(
+        json.dumps([{"text": "Decoy speech."}]),
+        encoding="utf-8",
+    )
+    (tmp_path / "beige_book.json").write_text(
+        json.dumps([{"text": "Decoy beige book."}]),
+        encoding="utf-8",
+    )
+
+    pairs = cpt._iter_fomc_pairs(tmp_path)
+    assert len(pairs) == 2
+    bodies = {p["sequenceA"] for p in pairs}
+    assert bodies == {"Minutes paragraph.", "Statement paragraph."}
+    # Decoys must not have made it in.
+    assert "Decoy speech." not in bodies
+    assert "Decoy beige book." not in bodies
+
+
+def test_collect_pairs_substrate_fomc_strips_bis_and_local(tmp_path: Path) -> None:
+    """``--substrate fomc`` is strict: no BIS network call, no broader
+    local corpus, only the two FOMC JSON files."""
+
+    (tmp_path / "fomc_statements.json").write_text(
+        json.dumps([{"text": "FOMC statement body."}]),
+        encoding="utf-8",
+    )
+    (tmp_path / "fomc_minutes.json").write_text(
+        json.dumps([{"text": "FOMC minutes body."}]),
+        encoding="utf-8",
+    )
+    # Even though chair_speeches is in --corpus-files (legacy default),
+    # the fomc substrate must skip it.
+    (tmp_path / "chair_speeches.json").write_text(
+        json.dumps([{"text": "Decoy chair speech."}]),
+        encoding="utf-8",
+    )
+    args = cpt._parse_args(
+        [
+            "--substrate",
+            "fomc",
+            "--data-dir",
+            str(tmp_path),
+        ]
+    )
+    pairs = cpt._collect_pairs(args)
+    bodies = {p["sequenceA"] for p in pairs}
+    assert bodies == {"FOMC statement body.", "FOMC minutes body."}
+    assert "Decoy chair speech." not in bodies
+
+
+def test_collect_pairs_substrate_fomc_respects_max_rows(tmp_path: Path) -> None:
+    """``--max-rows`` clamps the strict FOMC pool just like the local
+    substrate does."""
+
+    (tmp_path / "fomc_minutes.json").write_text(
+        json.dumps([{"text": f"Minutes {i}."} for i in range(5)]),
+        encoding="utf-8",
+    )
+    (tmp_path / "fomc_statements.json").write_text(
+        json.dumps([{"text": f"Stmt {i}."} for i in range(5)]),
+        encoding="utf-8",
+    )
+    args = cpt._parse_args(
+        [
+            "--substrate",
+            "fomc",
+            "--data-dir",
+            str(tmp_path),
+            "--max-rows",
+            "3",
+        ]
+    )
+    pairs = cpt._collect_pairs(args)
+    assert len(pairs) == 3
+
+
 def test_collect_pairs_substrate_local(monkeypatch, tmp_path: Path) -> None:
     (tmp_path / "chair_speeches.json").write_text(
         json.dumps([{"text": "Local speech text."}]),


### PR DESCRIPTION
## Summary

- New `--substrate fomc` mode in `continued_pretraining.py` reads only `fomc_statements.json` + `fomc_minutes.json`
- Bypasses BIS download and the broader Fed-adjacent local corpus entirely
- Strict-FOMC corpus is ~48 docs / ~240k tokens vs BIS's 909k pairs / ~365M tokens — measures whether broader substrate actually helps
- `--max-rows` clamps the FOMC pool same as the legacy local branch
- Unit tests cover decoy stripping, BIS bypass, max-rows clamp

## Test plan

- [ ] `pytest tests/unit/test_continued_pretraining.py -q`
- [ ] `python -m app.data.continued_pretraining --substrate fomc --data-dir data --max-rows 5` (smoke; no GPU needed)

Follow-up (separate PR, GPU run): pretrain three encoders (`finbert_fomc_only`, `finbert_bis_only`, current `finbert_fed_adjacent_full`) and re-cache embeddings for the bake-off.

Closes #242. Parent: #237.
