### PR TITLE
Round 3 corpus ablation: pretrain targets + registry placeholders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,6 +468,24 @@ finbert-fed-adjacent-pretrain-bert-control:
 		PRETRAIN_OUT_NAME=bert_base_fed_adjacent \
 		$(if $(SUBSTRATE),SUBSTRATE=$(SUBSTRATE),)
 
+# Round 3 (#242) corpus ablation: strict FOMC-only continued-pretrain.
+# Loads only fomc_statements.json + fomc_minutes.json (~48 docs, ~240k
+# tokens), bypassing BIS entirely. Pair with finbert-bis-only-pretrain
+# for the 3-way ablation against the legacy mixed substrate.
+finbert-fomc-only-pretrain:
+	$(MAKE) finbert-fed-adjacent-pretrain \
+		SUBSTRATE=fomc \
+		PRETRAIN_OUT_NAME=finbert_fomc_only
+
+# Round 3 (#242) corpus ablation: strict BIS-only continued-pretrain.
+# Drops the legacy local Fed-adjacent JSON corpus so the encoder learns
+# only from samchain/BIS_speeches_97_23_MLM. Pair with the FOMC-only
+# variant above to compare narrow-but-on-target against broad-but-mixed.
+finbert-bis-only-pretrain:
+	$(MAKE) finbert-fed-adjacent-pretrain \
+		SUBSTRATE=bis \
+		PRETRAIN_OUT_NAME=finbert_bis_only
+
 finbert-fed-adjacent-pretrain-smoke:
 	docker compose run --rm backend \
 		python -m app.data.continued_pretraining \

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -123,6 +123,33 @@ encoders:
       bake-off pairs the two checkpoints so we can isolate the contribution of
       the FinBERT prior versus the BIS substrate alone.
 
+  finbert_fomc_only:
+    repo: local/finbert-fomc-only
+    revision: ""
+    gated: false
+    task: masked_lm
+    description: |
+      Round 3 (#242) corpus-ablation sibling of ``finbert_fed_adjacent``.
+      Continued-pretrained on FOMC statements + minutes ONLY (~48 docs,
+      ~240k tokens), bypassing BIS speeches and the broader Fed-adjacent
+      JSON corpus. Produced by ``make finbert-fomc-only-pretrain``. The
+      revision stays empty until the first GPU run lands a checkpoint;
+      ``encoder_ref`` treats this as "unpinned local" and the bake-off
+      CLI will refuse to load it until the path + revision are filled in.
+
+  finbert_bis_only:
+    repo: local/finbert-bis-only
+    revision: ""
+    gated: false
+    task: masked_lm
+    description: |
+      Round 3 (#242) corpus-ablation sibling of ``finbert_fed_adjacent``.
+      Continued-pretrained on samchain/BIS_speeches_97_23_MLM ONLY,
+      dropping the legacy local Fed-adjacent auxiliary JSONs. Produced
+      by ``make finbert-bis-only-pretrain``. Revision empty until the
+      first GPU run lands a checkpoint; same unpinned-local guard as
+      ``finbert_fomc_only`` applies.
+
   finbert_fed_adjacent_xbank:
     repo: /data/artifacts/phase3/finetune_batch_20260519T190604Z/finbert_fed_adjacent_s11/hf_checkpoints
     revision: "20260519T190604Z_s11"

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -60,3 +60,26 @@ def test_registry_path_resolves_relative_to_module() -> None:
     assert MODEL_REGISTRY_PATH.name == "registry.yaml"
     assert MODEL_REGISTRY_PATH.exists()
     assert isinstance(MODEL_REGISTRY_PATH, Path)
+
+
+def test_round3_corpus_ablation_placeholders_are_registered_but_unpinned() -> None:
+    """The Round 3 (#242) FOMC-only and BIS-only encoders ship as
+    placeholders so the bake-off CLI knows the aliases exist; the empty
+    revision keeps ``encoder_ref`` flagging them as 'unpinned local'
+    until the first GPU run fills in a real checkpoint path."""
+
+    from app.models.registry import encoder_ref, is_pinned, load_registry
+
+    load_registry.cache_clear()
+    for alias in ("finbert_fomc_only", "finbert_bis_only"):
+        ref = encoder_ref(alias)
+        assert ref is not None, f"{alias!r} missing from registry"
+        assert ref.repo.startswith("local/"), (
+            f"{alias!r} should advertise a local path until pretraining lands"
+        )
+        assert ref.revision == "", (
+            f"{alias!r} revision should be empty until first pretrain run pins it"
+        )
+        assert not is_pinned(alias), (
+            f"is_pinned should be False for the placeholder alias {alias!r}"
+        )


### PR DESCRIPTION
## Summary

Round 3 corpus-ablation admin follow-up. PR #250 wired the `--substrate fomc` argument into the pretrainer; this PR adds the operator surface to actually drive the 3-way comparison.

- `make finbert-fomc-only-pretrain` — wraps the recipe with `SUBSTRATE=fomc` + `PRETRAIN_OUT_NAME=finbert_fomc_only`
- `make finbert-bis-only-pretrain` — locks the legacy substrate to BIS only
- Two placeholder registry aliases (`finbert_fomc_only`, `finbert_bis_only`) with empty revision; bake-off treats them as unpinned-local until the first GPU run pins a checkpoint
- New test fails loudly if a future PR forgets to update the revision when promoting the placeholder

## Test plan

- [ ] `pytest tests/unit/test_model_registry.py -q`
- [ ] `make finbert-fomc-only-pretrain` (smoke, no GPU; verify the flag fan-out reaches `continued_pretraining.py`)

Parent: #237. No issue closure — feeds the eventual Round 3 GPU runs.
