### PR TITLE
Encoder LoRA + in-loop FinBERT path (Round 5, closes #244)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,18 @@ regime-arch-sweep:
 		$(if $(NLP_TEXT_ENCODER),--text-encoder "$(NLP_TEXT_ENCODER)",) \
 		--report-root /data/artifacts/regime_arch_sweep
 
+# Round 5 (#244) LoRA + in-loop FinBERT ceiling probe. Reads the
+# best architecture + HP cell from the post-correction
+# regime_arch_sweep, then trains one cell (seed 97 x 4 folds) with
+# the encoder pulled into the loop and wrapped in PEFT LoRA.
+# Output lands at data/artifacts/encoder_lora_ceiling_probe/<pkg>/.
+lora-ceiling-probe:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	docker compose --profile "$(FORECASTER_COMPOSE_PROFILE)" run --rm "$(FORECASTER_COMPOSE_SERVICE)" \
+		python scripts/run_lora_ceiling_probe.py \
+		--training-package-id "$(TRAINING_PACKAGE_ID)" \
+		$(if $(LORA_ARCHITECTURE),--architecture "$(LORA_ARCHITECTURE)",)
+
 # GARCH(1,1) classical-finance reference baseline. Fits per fold on
 # SPX log-returns up to train_end, forecasts 10-day forward conditional
 # vol, bins via train-slice quantile cutoffs, reports pooled macro-F1

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -241,6 +241,16 @@ class ModelConfig:
     # the post-embargo baseline. Default ``True`` preserves the legacy
     # forward path byte-identical.
     use_time_decay: bool = True
+    # Round 5 (#244) LoRA ceiling probe. ``False`` (default) reads
+    # pooled text embeddings from the parquet cache -- the static path
+    # the rest of the pipeline depends on. ``True`` pulls the encoder
+    # named by ``text_encoder`` into ``train_model``, wraps it with
+    # PEFT LoRA, and runs the forward per batch so the regime loss
+    # flows gradients into the encoder. Per-event raw text is loaded
+    # from events.parquet at load time, tokenised once, then re-encoded
+    # per batch through the LoRA-wrapped tower. Scoped to a single
+    # arch x seed cell -- not a default replacement.
+    encoder_lora: bool = False
 
     @classmethod
     def from_model(cls, model: "Any") -> "ModelConfig":
@@ -272,6 +282,7 @@ class ModelConfig:
             lr_schedule=str(getattr(model, "lr_schedule", "plateau") or "plateau"),
             sequence_length=int(getattr(model, "sequence_length", 0) or 0),
             use_time_decay=bool(getattr(model, "use_time_decay", True)),
+            encoder_lora=bool(getattr(model, "encoder_lora", False)),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -471,6 +482,15 @@ class FeatureVector:
     # ``TextEmbeddingAdapter`` so the scalar slice stays at 35 dims.
     text_embedding_pooled: list[float] = field(default_factory=list)
     text_embedding_missing: float = 1.0
+    # Round 5 (#244) LoRA path raw text. Populated by the loader on the
+    # target-row bar of each sequence only when ``encoder_lora=True`` is
+    # threaded into the package-loading call. The other 20 lookback
+    # bars in the sequence carry the default empty string; the
+    # tokeniser in the LoRA training step reads from
+    # ``sequence[-1].raw_text`` so memory does not duplicate the text
+    # across the prior-window. Stays empty on every static-cache path
+    # so the legacy embedding pipeline is byte-identical.
+    raw_text: str = ""
 
     @classmethod
     def from_market_state(

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -55,6 +55,13 @@ def build_forecaster(config: ModelConfig | dict[str, Any]) -> ForecasterModel:
     # construction (the training loop reads them from the config).
     kwargs.pop("lr_schedule", None)
     kwargs.pop("sequence_length", None)
+    # Round 5 (#244) LoRA toggle is a training-loop concern; the
+    # ``ForecasterModel`` consumes its text input from a per-batch
+    # tensor regardless of whether the encoder ran statically (parquet
+    # cache) or per-batch (LoRA-wrapped tower). Strip the flag here so
+    # ModelConfig can persist it onto the checkpoint without forcing
+    # the model constructor to know about it.
+    kwargs.pop("encoder_lora", None)
     return ForecasterModel(model_type=architecture, **kwargs)
 
 

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -424,6 +424,22 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.set_defaults(use_time_decay=True)
+    parser.add_argument(
+        "--encoder-lora",
+        dest="encoder_lora",
+        action="store_true",
+        help=(
+            "Round 5 (#244) ceiling probe: pull the configured "
+            "``--text-encoder`` checkpoint into the training loop, "
+            "wrap with PEFT LoRA (r=8, alpha=16, dropout=0.1, target "
+            "modules {query, value}), and run the forward per batch "
+            "so the regime loss flows gradients into the encoder. "
+            "Default off keeps the parquet-cached embedding path. "
+            "Only supported on the walk-forward path with a registered "
+            "encoder alias (revision must be pinned)."
+        ),
+    )
+    parser.set_defaults(encoder_lora=False)
     # Phase B (#227) LR schedule + sequence-length knobs.
     parser.add_argument(
         "--lr-schedule",
@@ -811,6 +827,7 @@ def _build_model_config(args: argparse.Namespace) -> ModelConfig:
         lr_schedule=str(getattr(args, "lr_schedule", "plateau") or "plateau"),
         sequence_length=int(getattr(args, "sequence_length", 0) or 0),
         use_time_decay=bool(getattr(args, "use_time_decay", True)),
+        encoder_lora=bool(getattr(args, "encoder_lora", False)),
     )
 
 
@@ -1036,6 +1053,7 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                             output_mode=str(getattr(args, "output_mode", "regression") or "regression"),
                             n_classes=int(getattr(args, "vol_regime_classes", 3) or 3),
                             use_time_decay=bool(getattr(args, "use_time_decay", True)),
+                            encoder_lora=bool(getattr(args, "encoder_lora", False)),
                         ),
                         "learning_rate": float(hp["learning_rate"]),
                         "epochs": int(hp["epochs"]),
@@ -1122,6 +1140,7 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                     lr_schedule=str(lr_schedule),
                     sequence_length=int(sequence_length),
                     use_time_decay=bool(getattr(args, "use_time_decay", True)),
+                    encoder_lora=bool(getattr(args, "encoder_lora", False)),
                 ),
                 "learning_rate": float(learning_rate),
                 "epochs": int(epochs),

--- a/backend/app/training/encoder_lora.py
+++ b/backend/app/training/encoder_lora.py
@@ -92,14 +92,14 @@ def build_lora_encoder(
     """
 
     try:
-        from transformers import AutoModel, AutoTokenizer  # type: ignore
+        from transformers import AutoModel, AutoTokenizer
     except ImportError as exc:  # pragma: no cover - defensive
         raise ImportError(
             "transformers is required for the encoder_lora path; "
             "install via the backend pyproject.toml dependency block."
         ) from exc
     try:
-        from peft import LoraConfig, get_peft_model  # type: ignore
+        from peft import LoraConfig, get_peft_model
     except ImportError as exc:  # pragma: no cover - defensive
         raise ImportError(
             "peft is required for the encoder_lora path; "

--- a/backend/app/training/encoder_lora.py
+++ b/backend/app/training/encoder_lora.py
@@ -1,0 +1,236 @@
+"""LoRA-wrapped encoder helpers for the Round 5 (#244) ceiling probe.
+
+The static text-embedding path (PR #176 onward) reads pre-computed
+pooled vectors from a parquet cache. The encoder weights stay frozen
+throughout training, so the regime-loss gradient never flows back into
+the language model. Round 5 hypothesises that joint training -- letting
+the regime loss update a small LoRA adapter on top of FinBERT (or
+whichever encoder is configured) -- lifts the macro-F1 ceiling. This
+module wires the encoder + LoRA wrapper + per-batch forward path that
+``app.training.loop.train_model`` calls into when
+``ModelConfig.encoder_lora`` is on.
+
+Scope: one architecture x one seed x four folds x one trial. Not a
+default replacement for the static cache.
+
+Dependencies (``transformers``, ``peft``) are imported lazily inside
+the helpers so the module imports cleanly on environments without the
+LoRA stack -- the static-cache path stays runnable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Sequence
+
+import torch
+from torch import nn
+
+if TYPE_CHECKING:
+    from app.models.config import FeatureVector
+
+
+# Token-window cap for the LoRA-wrapped encoder. FinBERT / BERT-base /
+# DeBERTa-v3-base all share the same 512-position limit; 256 covers a
+# typical FOMC statement (≤ 250 tokens after WordPiece) while keeping
+# the per-batch forward memory inside the RTX 4080 budget. Override at
+# call time if a longer-context encoder lands.
+DEFAULT_LORA_MAX_TOKENS = 256
+
+# LoRA hyperparameters fixed for the ceiling probe. Chosen to mirror
+# the PEFT defaults for BERT-family encoders (Hu et al. 2021):
+# ``r=8`` keeps the adapter small (~0.3% of FinBERT's 110M params),
+# ``alpha=16`` is the textbook 2x rank ratio, and the dropout matches
+# the standard ``LoraConfig`` recommendation. ``target_modules`` picks
+# the query + value projections in every attention layer -- the LoRA
+# paper's lowest-cost variant that still recovers most of the lift
+# over a frozen encoder.
+DEFAULT_LORA_R = 8
+DEFAULT_LORA_ALPHA = 16
+DEFAULT_LORA_DROPOUT = 0.1
+DEFAULT_LORA_TARGET_MODULES: tuple[str, ...] = ("query", "value")
+
+
+@dataclass(frozen=True)
+class LoraEncoderBundle:
+    """Container for the wrapped encoder + its tokenizer.
+
+    The training loop holds one instance for the lifetime of a single
+    sweep cell; the per-batch forward path uses ``encoder`` and
+    ``tokenizer`` directly. ``out_dim`` is the encoder's hidden size
+    (768 for FinBERT, 1024 for BGE-large, etc.) so the downstream
+    text-adapter projection picks the correct ``text_embedding_dim``.
+    """
+
+    encoder: nn.Module
+    tokenizer: Any
+    out_dim: int
+    encoder_alias: str
+
+
+def build_lora_encoder(
+    encoder_alias: str,
+    *,
+    r: int = DEFAULT_LORA_R,
+    lora_alpha: int = DEFAULT_LORA_ALPHA,
+    lora_dropout: float = DEFAULT_LORA_DROPOUT,
+    target_modules: Sequence[str] = DEFAULT_LORA_TARGET_MODULES,
+) -> LoraEncoderBundle:
+    """Load the encoder named by ``encoder_alias`` and wrap it with PEFT LoRA.
+
+    Reads the checkpoint path + revision from
+    ``app.models.registry``. The base encoder is frozen end-to-end;
+    only the LoRA adapter parameters (``r * (in_dim + out_dim)`` per
+    target module) train. Returns the wrapped model + the matching
+    tokenizer + the encoder's hidden size so callers can size the
+    downstream adapter dim correctly.
+
+    Raises ``ValueError`` when the encoder alias is not registered or
+    its revision is empty (unpinned-local placeholder). Raises
+    ``ImportError`` (with a clear remediation hint) when ``transformers``
+    or ``peft`` is missing.
+    """
+
+    try:
+        from transformers import AutoModel, AutoTokenizer  # type: ignore
+    except ImportError as exc:  # pragma: no cover - defensive
+        raise ImportError(
+            "transformers is required for the encoder_lora path; "
+            "install via the backend pyproject.toml dependency block."
+        ) from exc
+    try:
+        from peft import LoraConfig, get_peft_model  # type: ignore
+    except ImportError as exc:  # pragma: no cover - defensive
+        raise ImportError(
+            "peft is required for the encoder_lora path; "
+            "install ``peft>=0.10`` via the backend pyproject.toml."
+        ) from exc
+
+    from app.models.registry import encoder_ref
+
+    ref = encoder_ref(encoder_alias)
+    if ref is None:
+        raise ValueError(
+            f"encoder alias {encoder_alias!r} is not registered in "
+            "models/registry.yaml"
+        )
+    if not ref.revision:
+        raise ValueError(
+            f"encoder alias {encoder_alias!r} is unpinned (empty revision); "
+            "the LoRA path refuses to train against an unpinned checkpoint "
+            "so the ceiling-probe number can be traced back to a specific "
+            "encoder build"
+        )
+
+    tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)
+    base_encoder = AutoModel.from_pretrained(ref.repo, revision=ref.revision)
+    base_encoder.requires_grad_(False)
+
+    lora_config = LoraConfig(
+        r=int(r),
+        lora_alpha=int(lora_alpha),
+        lora_dropout=float(lora_dropout),
+        target_modules=list(target_modules),
+        bias="none",
+    )
+    wrapped = get_peft_model(base_encoder, lora_config)
+    out_dim = int(getattr(base_encoder.config, "hidden_size", 0))
+    if out_dim <= 0:
+        raise RuntimeError(
+            f"encoder {encoder_alias!r} did not expose ``hidden_size`` on "
+            "its config -- cannot size the downstream text-adapter dim"
+        )
+    return LoraEncoderBundle(
+        encoder=wrapped,
+        tokenizer=tokenizer,
+        out_dim=out_dim,
+        encoder_alias=encoder_alias,
+    )
+
+
+def tokenize_sequence_texts(
+    sequences: Sequence[Sequence["FeatureVector"]],
+    tokenizer: Any,
+    *,
+    max_tokens: int = DEFAULT_LORA_MAX_TOKENS,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Tokenise each sequence's target-row text into a (N, T) tensor pair.
+
+    For each sequence group, reads ``sequence[-1].raw_text`` (the
+    target-row bar populated by
+    ``app.training.loaders._load_package_sequences_with_metadata``
+    when ``encoder_lora=True`` is threaded through). Sequences whose
+    target-row carries an empty string fall back to the empty-string
+    encoding so the encoder forward still produces a deterministic
+    zero-context vector for them; the resulting attention_mask is
+    all-zero, which mean-pooling collapses to a zero output, matching
+    the "missing flag" semantics of the static-cache path.
+
+    Returns ``(input_ids, attention_mask)`` torch tensors with dtype
+    ``int64`` and shape ``(len(sequences), max_tokens)``.
+    """
+
+    texts: list[str] = []
+    for sequence in sequences:
+        if not sequence:
+            texts.append("")
+            continue
+        target_text = str(getattr(sequence[-1], "raw_text", "") or "").strip()
+        texts.append(target_text)
+
+    encoded = tokenizer(
+        texts,
+        padding="max_length",
+        truncation=True,
+        max_length=int(max_tokens),
+        return_tensors="pt",
+        return_attention_mask=True,
+    )
+    input_ids = encoded["input_ids"].to(dtype=torch.long)
+    attention_mask = encoded["attention_mask"].to(dtype=torch.long)
+    # Zero out attention mask on rows whose text is empty so the
+    # downstream mean-pool collapses to a zero vector.
+    for i, text in enumerate(texts):
+        if not text:
+            attention_mask[i].zero_()
+    return input_ids, attention_mask
+
+
+def encode_batch_pooled(
+    bundle: LoraEncoderBundle,
+    input_ids: torch.Tensor,
+    attention_mask: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the LoRA-wrapped encoder over one batch and mean-pool tokens.
+
+    Returns ``(pooled, missing_flag)`` where ``pooled`` has shape
+    ``(B, out_dim)`` and ``missing_flag`` has shape ``(B, 1)`` and is
+    ``1.0`` for rows whose attention mask is all-zero (the empty-text
+    sentinel from ``tokenize_sequence_texts``). The pair matches the
+    ``(text_embedding, text_embedding_missing)`` contract that
+    ``ForecasterModel.forward`` consumes, so the LoRA branch in
+    ``train_model`` can substitute it directly for the static-cache
+    tensors emitted by ``_build_text_embedding_tensors``.
+
+    Gradients flow through ``pooled`` back into the LoRA adapter
+    parameters (the base encoder weights are frozen by
+    ``build_lora_encoder``) so the regime loss updates the adapter
+    end-to-end. ``missing_flag`` carries no gradient by construction
+    -- it is a derived signal, not a learnable parameter.
+    """
+
+    encoder_outputs = bundle.encoder(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        return_dict=True,
+    )
+    hidden_states = encoder_outputs.last_hidden_state
+    mask_expanded = attention_mask.to(dtype=hidden_states.dtype).unsqueeze(-1)
+    masked_hidden = hidden_states * mask_expanded
+    token_counts = mask_expanded.sum(dim=1).clamp_min(1.0)
+    pooled = masked_hidden.sum(dim=1) / token_counts
+    # Missing flag: 1.0 when no tokens attended (empty-text sentinel),
+    # 0.0 otherwise. Detached so no spurious gradient flows.
+    row_token_sum = attention_mask.sum(dim=1)
+    missing_flag = (row_token_sum == 0).to(dtype=pooled.dtype).unsqueeze(-1).detach()
+    return pooled, missing_flag

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -1245,6 +1245,7 @@ def _load_package_sequences_with_metadata(
     text_pool_lambda_inv_days: float = DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS,
     use_text_embeddings: bool = True,
     text_embedding_cache_dir: Path | str | None = None,
+    encoder_lora: bool = False,
 ) -> list[tuple[list[FeatureVector], str, str]]:
     """Materialise every event in a training package as a sequence triple.
 
@@ -1478,6 +1479,19 @@ def _load_package_sequences_with_metadata(
             for vector in vectors:
                 vector.text_embedding_pooled = list(pooled_list)
                 vector.text_embedding_missing = missing_flag
+        if encoder_lora:
+            # Round 5 (#244) per-event raw text for in-loop LoRA
+            # tokenisation. Only the target-row bar (last in the
+            # sequence after ``_append_event_day_target``) carries the
+            # text -- the lookback bars do not need it since the
+            # tokeniser reads ``sequence[-1].raw_text`` per sequence.
+            # The text comes from the event's own ``text`` column,
+            # not from the prior-4 statement pool, so the LoRA path
+            # learns gradients w.r.t. the event's actual content
+            # (statement / minutes / press conference / scrape).
+            row_text = str(row.get("text", "") or "").strip()
+            if vectors:
+                vectors[-1].raw_text = row_text
         results.append((vectors, row_text_hash, event_date_str[:10]))
     return results
 
@@ -1499,6 +1513,7 @@ def load_walk_forward_split(
     use_text_embeddings: bool = True,
     text_embedding_cache_dir: Path | str | None = None,
     embargo_days: int = 0,
+    encoder_lora: bool = False,
 ) -> WalkForwardSplit:
     """Return the (train, val, test) sequence partitions for one fold.
 
@@ -1572,6 +1587,7 @@ def load_walk_forward_split(
         text_pool_lambda_inv_days=text_pool_lambda_inv_days,
         use_text_embeddings=use_text_embeddings,
         text_embedding_cache_dir=text_embedding_cache_dir,
+        encoder_lora=encoder_lora,
     )
 
     train: list[list[FeatureVector]] = []

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -1416,9 +1416,9 @@ def train_model(
             # is absent (which only happens on a ``encoder_lora=False``
             # run, so the branch never fires).
             try:
-                from peft import get_peft_model_state_dict  # type: ignore
+                from peft import get_peft_model_state_dict
             except ImportError:  # pragma: no cover - defensive
-                get_peft_model_state_dict = None  # type: ignore[assignment]
+                get_peft_model_state_dict = None
             if get_peft_model_state_dict is not None:
                 adapter_path = Path(str(checkpoint_target) + ".lora_adapter.pt")
                 adapter_state = get_peft_model_state_dict(encoder_lora_bundle.encoder)

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -1406,6 +1406,30 @@ def train_model(
             close_scale=close_scale,
             rich_feature_scaler=rich_feature_scaler,
         )
+        if encoder_lora_bundle is not None:
+            # Round 5 (#244) sidecar: write only the LoRA adapter state
+            # (not the base encoder weights) so a future audit / resume
+            # path can rebuild the wrapped encoder by re-loading the
+            # registry-pinned base + the adapter delta. ``peft`` exposes
+            # ``get_peft_model_state_dict`` for this exact use; the
+            # lazy import keeps the helper module agnostic when peft
+            # is absent (which only happens on a ``encoder_lora=False``
+            # run, so the branch never fires).
+            try:
+                from peft import get_peft_model_state_dict  # type: ignore
+            except ImportError:  # pragma: no cover - defensive
+                get_peft_model_state_dict = None  # type: ignore[assignment]
+            if get_peft_model_state_dict is not None:
+                adapter_path = Path(str(checkpoint_target) + ".lora_adapter.pt")
+                adapter_state = get_peft_model_state_dict(encoder_lora_bundle.encoder)
+                torch.save(
+                    {
+                        "encoder_alias": encoder_lora_bundle.encoder_alias,
+                        "out_dim": encoder_lora_bundle.out_dim,
+                        "adapter_state": adapter_state,
+                    },
+                    adapter_path,
+                )
         # Lazy-import the services facade so subsequent inference picks up the
         # freshly trained weights without a process restart. Doing this at the
         # module top would create a circular (services.forecaster -> training.loop -> services.forecaster).

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -285,6 +285,7 @@ def _evaluate_model(
     credibility_buffer: torch.Tensor | None = None,
     *,
     record_row_predictions: bool = False,
+    encoder_lora_bundle: Any = None,
 ) -> EvaluationMetrics:
     """Evaluate ``model`` on ``loader`` and return aggregate metrics.
 
@@ -304,6 +305,8 @@ def _evaluate_model(
     """
 
     model.eval()
+    if encoder_lora_bundle is not None:
+        encoder_lora_bundle.encoder.eval()
     is_classification = str(getattr(model, "output_mode", "regression")) == "classification"
     total_loss_sum = torch.zeros((), dtype=torch.float64, device=device)
     total_items = torch.zeros((), dtype=torch.int64, device=device)
@@ -363,13 +366,36 @@ def _evaluate_model(
             if batch_text is not None and use_text_path:
                 if batch_text.device != device:
                     batch_text = batch_text.to(device, non_blocking=non_blocking)
-                kwargs["text_embedding"] = batch_text
-                if batch_text_missing is not None:
-                    if batch_text_missing.device != device:
+                if encoder_lora_bundle is not None:
+                    # Round 5 (#244): batch_text + batch_text_missing
+                    # carry (input_ids, attention_mask) in LoRA mode.
+                    # Run the LoRA-wrapped encoder over the tokens to
+                    # materialise the pooled embedding the downstream
+                    # text-adapter projection consumes. ``no_grad`` is
+                    # active in this eval helper; train-loop forward
+                    # has the same logic without the grad guard.
+                    from app.training.encoder_lora import encode_batch_pooled
+
+                    if batch_text_missing is not None and batch_text_missing.device != device:
                         batch_text_missing = batch_text_missing.to(
                             device, non_blocking=non_blocking
                         )
-                    kwargs["text_embedding_missing"] = batch_text_missing
+                    pooled, lora_missing = encode_batch_pooled(
+                        encoder_lora_bundle,
+                        batch_text,
+                        batch_text_missing if batch_text_missing is not None
+                        else torch.ones_like(batch_text, dtype=torch.long),
+                    )
+                    kwargs["text_embedding"] = pooled
+                    kwargs["text_embedding_missing"] = lora_missing
+                else:
+                    kwargs["text_embedding"] = batch_text
+                    if batch_text_missing is not None:
+                        if batch_text_missing.device != device:
+                            batch_text_missing = batch_text_missing.to(
+                                device, non_blocking=non_blocking
+                            )
+                        kwargs["text_embedding_missing"] = batch_text_missing
             predictions = model(batch_x, **kwargs)
             loss = loss_fn(predictions, batch_y)
             if ce_weight is not None:
@@ -523,6 +549,8 @@ def _build_partition_tensors(
     close_scale: float | None = None,
     output_mode: str = "regression",
     vol_regime_quantiles: Sequence[float] = (),
+    lora_bundle: Any = None,
+    lora_max_tokens: int = 0,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -543,6 +571,14 @@ def _build_partition_tensors(
     has a null ``forward_realized_vol_10d`` are dropped from BOTH the
     x/y tensors and the text-embedding tensors so the row alignment
     invariant holds.
+
+    Round 5 (#244) LoRA branch: when ``lora_bundle`` is supplied (a
+    :class:`app.training.encoder_lora.LoraEncoderBundle`), the last
+    two return slots carry ``(input_ids, attention_mask)`` long
+    tensors (shape ``(N, lora_max_tokens)``) instead of the
+    pooled-embedding pair. The train step detects LoRA mode by
+    inspecting the dtype + running the bundle's encoder over the
+    tokens per batch to materialise gradient-tracked pooled vectors.
     """
 
     if output_mode == "classification":
@@ -584,6 +620,20 @@ def _build_partition_tensors(
             "_build_partition_tensors produced an empty partition; "
             "every walk-forward fold must carry at least one event."
         )
+    if lora_bundle is not None:
+        # Round 5 (#244): tokenise each sequence's target-row text once
+        # and return (input_ids, attention_mask) in the text slots.
+        # The training step runs the LoRA-wrapped encoder over these
+        # tokens per batch to compute a gradient-tracked pooled vector.
+        from app.training.encoder_lora import tokenize_sequence_texts
+
+        max_tokens = int(lora_max_tokens) if int(lora_max_tokens) > 0 else 256
+        input_ids, attention_mask = tokenize_sequence_texts(
+            active_groups,
+            lora_bundle.tokenizer,
+            max_tokens=max_tokens,
+        )
+        return x, y, scale, input_ids, attention_mask
     text_emb, text_missing, _ = _build_text_embedding_tensors(
         active_groups, fallback_in_dim=fallback_text_in_dim
     )
@@ -717,6 +767,24 @@ def train_model(
         else:
             fitted_quantiles = ()
             fitted_class_weights = ()
+        # Round 5 (#244) LoRA bundle. Built ONCE before any partition
+        # tensor materialisation so the tokeniser is shared across
+        # train / val / test. When ``encoder_lora`` is off (default)
+        # the bundle stays ``None`` and the static-cache path runs.
+        encoder_lora_active = bool(
+            getattr(active_model_config, "encoder_lora", False)
+        )
+        encoder_lora_bundle: Any = None
+        if encoder_lora_active:
+            from app.training.encoder_lora import build_lora_encoder
+
+            if not text_encoder or str(text_encoder) == "none":
+                raise ValueError(
+                    "encoder_lora=True requires text_encoder to be set to a "
+                    "registered alias (got 'none' / empty)"
+                )
+            encoder_lora_bundle = build_lora_encoder(str(text_encoder))
+            encoder_lora_bundle.encoder.to(device_obj)
         # Fit the close-scale on the training partition only; never on
         # the val or test rows. The walk-forward protocol forbids
         # fitting any scaler over held-out events.
@@ -726,6 +794,7 @@ def train_model(
             close_scale=None,
             output_mode=active_output_mode,
             vol_regime_quantiles=fitted_quantiles,
+            lora_bundle=encoder_lora_bundle,
         )
         # Fit the rich-feature RobustScaler on the TRAIN tensor only;
         # no-op for legacy 6-feature tensors so the regression contract
@@ -740,6 +809,7 @@ def train_model(
             close_scale=close_scale,
             output_mode=active_output_mode,
             vol_regime_quantiles=fitted_quantiles,
+            lora_bundle=encoder_lora_bundle,
         )
         val_x = apply_rich_feature_scaler_tensor(val_x, rich_feature_scaler)
         test_x, test_y, _test_scale, test_text_emb, test_text_missing = _build_partition_tensors(
@@ -748,10 +818,22 @@ def train_model(
             close_scale=close_scale,
             output_mode=active_output_mode,
             vol_regime_quantiles=fitted_quantiles,
+            lora_bundle=encoder_lora_bundle,
         )
         test_x = apply_rich_feature_scaler_tensor(test_x, rich_feature_scaler)
         sequence_groups_for_summary = train_groups + val_groups + test_groups
     else:
+        # Legacy single-list path: no LoRA support. encoder_lora must
+        # be off in this branch -- the per-batch encoder forward needs
+        # the walk-forward partition tensor builder to emit token
+        # tensors, which the legacy path bypasses entirely.
+        encoder_lora_bundle = None
+        if bool(getattr(active_model_config, "encoder_lora", False)):
+            raise ValueError(
+                "encoder_lora=True is only supported on the walk-forward "
+                "training-package path; the legacy single-list ``data_dir`` "
+                "branch does not produce the token tensors LoRA needs"
+            )
         if sequence_groups is not None:
             active_sequence_groups: list[list[FeatureVector]] = [list(group) for group in sequence_groups]
         else:
@@ -969,10 +1051,30 @@ def train_model(
     # does not perturb the byte-identity regression contract on the
     # legacy regression path.
     wd_value = float(weight_decay)
+    # Round 5 (#244): build a unified param iterator that yields both
+    # the forecaster's parameters AND (when LoRA is on) the encoder
+    # adapter parameters. The base encoder is frozen by
+    # ``build_lora_encoder``, so the ``requires_grad`` filter below
+    # picks up exactly the adapter layers without the rest of the
+    # encoder leaking in.
+    def _trainable_named_parameters() -> Any:
+        seen: set[int] = set()
+        for name, param in work_model.named_parameters():
+            if id(param) in seen:
+                continue
+            seen.add(id(param))
+            yield f"forecaster.{name}", param
+        if encoder_lora_bundle is not None:
+            for name, param in encoder_lora_bundle.encoder.named_parameters():
+                if id(param) in seen:
+                    continue
+                seen.add(id(param))
+                yield f"encoder_lora.{name}", param
+
     if wd_value > 0.0:
         decay_params: list[torch.nn.Parameter] = []
         no_decay_params: list[torch.nn.Parameter] = []
-        for name, param in work_model.named_parameters():
+        for name, param in _trainable_named_parameters():
             if not param.requires_grad:
                 continue
             # Skip biases, layer-norm / batch-norm weights+biases, and
@@ -993,7 +1095,7 @@ def train_model(
         )
     else:
         optimizer = torch.optim.AdamW(
-            work_model.parameters(),
+            [param for _name, param in _trainable_named_parameters() if param.requires_grad],
             lr=learning_rate,
             weight_decay=0.0,
         )
@@ -1092,6 +1194,8 @@ def train_model(
 
     for epoch_index in range(epochs):
         work_model.train()
+        if encoder_lora_bundle is not None:
+            encoder_lora_bundle.encoder.train()
         for batch in train_loader:
             batch_x, batch_y, batch_text, batch_text_missing = _unpack_batch(batch)
             # Tensors are already on the target device; the .to() calls
@@ -1105,9 +1209,26 @@ def train_model(
             if credibility is not None:
                 kwargs["credibility"] = credibility
             if batch_text is not None and use_text_path:
-                kwargs["text_embedding"] = batch_text
-                if batch_text_missing is not None:
-                    kwargs["text_embedding_missing"] = batch_text_missing
+                if encoder_lora_bundle is not None:
+                    # Round 5 (#244): convert batch tokens to pooled
+                    # embedding via the LoRA-wrapped encoder so the
+                    # regime loss backpropagates into the adapter.
+                    from app.training.encoder_lora import encode_batch_pooled
+
+                    attention_mask_tensor = (
+                        batch_text_missing
+                        if batch_text_missing is not None
+                        else torch.ones_like(batch_text, dtype=torch.long)
+                    )
+                    pooled, lora_missing = encode_batch_pooled(
+                        encoder_lora_bundle, batch_text, attention_mask_tensor
+                    )
+                    kwargs["text_embedding"] = pooled
+                    kwargs["text_embedding_missing"] = lora_missing
+                else:
+                    kwargs["text_embedding"] = batch_text
+                    if batch_text_missing is not None:
+                        kwargs["text_embedding_missing"] = batch_text_missing
             if effective_amp:
                 with torch.cuda.amp.autocast():
                     predictions = forward_model(batch_x, **kwargs)
@@ -1138,6 +1259,7 @@ def train_model(
             device_obj,
             loss_fn,
             credibility_buffer=val_credibility_buffer,
+            encoder_lora_bundle=encoder_lora_bundle,
         )
         if schedule_steps_per_epoch is None:
             scheduler.step(eval_metrics.loss)
@@ -1201,6 +1323,7 @@ def train_model(
         device_obj,
         loss_fn,
         credibility_buffer=train_credibility_buffer,
+        encoder_lora_bundle=encoder_lora_bundle,
     )
 
     # Final-state held-out test evaluation. On the walk-forward path
@@ -1227,6 +1350,7 @@ def train_model(
             loss_fn,
             credibility_buffer=test_credibility_buffer,
             record_row_predictions=True,
+            encoder_lora_bundle=encoder_lora_bundle,
         )
     else:
         test_metrics = best_val_metrics

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "langsmith>=0.1.0",
   "scikit-learn",
   "arch>=6.3",
+  "peft>=0.10",
   "pypdf>=5.0.0",
   "pdfplumber>=0.11.0",
   "python-docx>=1.1.0",

--- a/scripts/run_lora_ceiling_probe.py
+++ b/scripts/run_lora_ceiling_probe.py
@@ -1,0 +1,301 @@
+"""Round 5 (#244) ceiling-probe orchestrator.
+
+Resolves the best-arch from the latest ``regime_arch_sweep`` aggregator
+output for a given training package, then invokes
+``app.train_forecaster`` with ``--encoder-lora`` on that architecture
+for seed 97 across all four walk-forward folds. The result lands as a
+single sweep JSON under
+``data/artifacts/encoder_lora_ceiling_probe/<package>/`` so the
+follow-up pooled-CI aggregator can produce the macro-F1 number that
+feeds the §6.6 LoRA-vs-static-cache row.
+
+Why a wrapper: the ceiling probe needs (a) the right architecture
+pulled from the post-correction sweep, not the pre-correction §6.6
+table, and (b) a tight HP cell that matches Round 1's best so the
+delta isolates the encoder-LoRA lift rather than mixing in HP-grid
+variation. The wrapper reads both off the existing aggregator JSON
+and refuses to run if Round 1's results are absent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+_DEFAULT_PACKAGE_ID = "tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0"
+_DEFAULT_ARCH_SWEEP_ROOT = Path("data/artifacts/regime_arch_sweep")
+_DEFAULT_OUTPUT_ROOT = Path("data/artifacts/encoder_lora_ceiling_probe")
+_DEFAULT_SEED = 97
+_DEFAULT_FOLDS: tuple[str, ...] = (
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+)
+_DEFAULT_TEXT_ENCODER = "finbert_fed_adjacent"
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Resolve Round 1's best architecture from the post-correction "
+            "regime_arch_sweep results and invoke train_forecaster with "
+            "--encoder-lora for the Round 5 ceiling-probe cell."
+        )
+    )
+    parser.add_argument(
+        "--training-package-id",
+        default=_DEFAULT_PACKAGE_ID,
+    )
+    parser.add_argument(
+        "--arch-sweep-root",
+        type=Path,
+        default=_DEFAULT_ARCH_SWEEP_ROOT,
+        help="Parent of <package_id>/<architecture>/forecaster_sweep_results.json",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=_DEFAULT_OUTPUT_ROOT,
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=_DEFAULT_SEED,
+        help="Single seed. Default 97 matches the ceiling-probe scope.",
+    )
+    parser.add_argument(
+        "--folds",
+        nargs="+",
+        default=list(_DEFAULT_FOLDS),
+    )
+    parser.add_argument(
+        "--text-encoder",
+        default=_DEFAULT_TEXT_ENCODER,
+        help="Encoder alias (must be pinned in models/registry.yaml).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=16,
+        help=(
+            "Smaller-than-default batch size to keep the LoRA forward "
+            "inside the RTX 4080 16GB envelope -- the encoder forward "
+            "memory dominates the recurrent core memory."
+        ),
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=40,
+    )
+    parser.add_argument(
+        "--architecture",
+        default=None,
+        help=(
+            "Override the auto-resolved best architecture. Useful when "
+            "the post-correction sweep has not finished yet or you want "
+            "to probe a specific arch."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the resolved CLI without executing it.",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_best_architecture(
+    arch_sweep_dir: Path,
+) -> tuple[str, dict[str, Any]]:
+    """Pick the best architecture by pooled macro-F1 across the
+    per-architecture sweep JSONs. Reads ``<arch>/forecaster_sweep_results.json``
+    for each subdirectory, picks the trial with the highest
+    ``test_metrics.classification_breakdown.macro_f1``, and returns
+    ``(arch_name, best_trial_record)``."""
+
+    candidates: list[tuple[str, float, dict[str, Any]]] = []
+    if not arch_sweep_dir.exists():
+        raise FileNotFoundError(
+            f"arch sweep directory not found: {arch_sweep_dir}; run "
+            "``make regime-arch-sweep`` first"
+        )
+    for arch_dir in sorted(arch_sweep_dir.iterdir()):
+        if not arch_dir.is_dir():
+            continue
+        results_path = arch_dir / "forecaster_sweep_results.json"
+        if not results_path.exists():
+            continue
+        payload = json.loads(results_path.read_text(encoding="utf-8"))
+        trials = payload.get("trials") if isinstance(payload, dict) else None
+        if not isinstance(trials, list):
+            continue
+        best_macro = -1.0
+        best_record: dict[str, Any] | None = None
+        for trial in trials:
+            if not isinstance(trial, dict):
+                continue
+            summary = trial.get("summary") if isinstance(trial.get("summary"), dict) else trial
+            test_metrics = summary.get("test_metrics") if isinstance(summary, dict) else None
+            if not isinstance(test_metrics, dict):
+                continue
+            breakdown = test_metrics.get("classification_breakdown")
+            macro = None
+            if isinstance(breakdown, dict):
+                macro = breakdown.get("macro_f1")
+            if not isinstance(macro, (int, float)):
+                continue
+            macro_value = float(macro)
+            if macro_value > best_macro:
+                best_macro = macro_value
+                best_record = trial
+        if best_record is not None:
+            candidates.append((arch_dir.name, best_macro, best_record))
+
+    if not candidates:
+        raise RuntimeError(
+            f"no per-architecture sweep results with a usable macro-F1 "
+            f"in {arch_sweep_dir}; the pooled aggregator must have run "
+            "first or the sweep produced no classification trials"
+        )
+    candidates.sort(key=lambda row: row[1], reverse=True)
+    best_arch_name, best_macro_f1, best_trial = candidates[0]
+    print(
+        f"[lora_ceiling_probe] best architecture from "
+        f"{arch_sweep_dir.name}: {best_arch_name} (macro_f1={best_macro_f1:.4f})"
+    )
+    return best_arch_name, best_trial
+
+
+def _trial_hp_cell(trial: dict[str, Any]) -> dict[str, Any]:
+    """Extract the HP cell that produced the best macro-F1 -- the
+    LoRA probe re-uses this cell so the delta isolates the LoRA lift
+    rather than mixing in HP search variance."""
+
+    candidate = trial.get("candidate") if isinstance(trial.get("candidate"), dict) else {}
+    summary = trial.get("summary") if isinstance(trial.get("summary"), dict) else trial
+    model_config = summary.get("model_config") if isinstance(summary, dict) else None
+    cell: dict[str, Any] = {}
+    if isinstance(candidate, dict):
+        cell.update(candidate)
+    if isinstance(model_config, dict):
+        for key in (
+            "hidden_size",
+            "num_layers",
+            "dropout",
+            "head_hidden_size",
+        ):
+            if key in model_config:
+                cell.setdefault(key, model_config[key])
+    return cell
+
+
+def _build_train_forecaster_cmd(
+    *,
+    args: argparse.Namespace,
+    architecture: str,
+    hp_cell: dict[str, Any],
+    report_path: Path,
+) -> list[str]:
+    hidden_size = int(hp_cell.get("hidden_size", 64))
+    num_layers = int(hp_cell.get("num_layers", 2))
+    dropout = float(hp_cell.get("dropout", 0.2))
+    learning_rate = float(hp_cell.get("learning_rate", 1e-3))
+    weight_decay = float(hp_cell.get("weight_decay", 1e-4))
+    text_adapter_dim = int(hp_cell.get("text_adapter_dim", 64))
+    return [
+        sys.executable,
+        "-m",
+        "app.train_forecaster",
+        "--training-package-id",
+        args.training_package_id,
+        "--sweep",
+        "--architectures",
+        architecture,
+        "--seeds",
+        str(int(args.seed)),
+        "--folds",
+        *list(args.folds),
+        "--hidden-sizes",
+        str(hidden_size),
+        "--num-layers-grid",
+        str(num_layers),
+        "--dropouts",
+        str(dropout),
+        "--learning-rates",
+        str(learning_rate),
+        "--weight-decays",
+        str(weight_decay),
+        "--text-adapter-dims",
+        str(text_adapter_dim),
+        "--batch-size",
+        str(int(args.batch_size)),
+        "--epochs",
+        str(int(args.epochs)),
+        "--output-mode",
+        "classification",
+        "--vol-regime-classes",
+        "3",
+        "--rich-features",
+        "--use-llm-features",
+        "--text-encoder",
+        str(args.text_encoder),
+        "--encoder-lora",
+        "--report-path",
+        str(report_path),
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    arch_sweep_dir = args.arch_sweep_root / args.training_package_id
+
+    if args.architecture:
+        architecture = str(args.architecture)
+        # Manual override: pull the best HP cell from whatever subset
+        # of the sweep is available so the probe still re-uses a
+        # measured cell rather than guessing.
+        trial: dict[str, Any] = {}
+        per_arch = arch_sweep_dir / architecture / "forecaster_sweep_results.json"
+        if per_arch.exists():
+            _, trial = _resolve_best_architecture(arch_sweep_dir / architecture)
+    else:
+        architecture, trial = _resolve_best_architecture(arch_sweep_dir)
+    hp_cell = _trial_hp_cell(trial)
+
+    output_dir = args.output_root / args.training_package_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "forecaster_sweep_results.json"
+
+    cmd = _build_train_forecaster_cmd(
+        args=args,
+        architecture=architecture,
+        hp_cell=hp_cell,
+        report_path=report_path,
+    )
+    print(f"[lora_ceiling_probe] cmd: {shlex.join(cmd)}", flush=True)
+    if args.dry_run:
+        return 0
+
+    env = os.environ.copy()
+    result = subprocess.run(cmd, env=env)
+    if result.returncode != 0:
+        print(
+            f"[lora_ceiling_probe] exited with status {result.returncode}",
+            file=sys.stderr,
+        )
+        return result.returncode
+    print(f"[lora_ceiling_probe] sweep report at {report_path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_encoder_lora_wiring.py
+++ b/tests/unit/test_encoder_lora_wiring.py
@@ -1,0 +1,131 @@
+"""Round 5 (#244) source-level tests for the LoRA + in-loop FinBERT path.
+
+The full LoRA training run needs ``peft`` + ``transformers`` + a GPU
+and is too expensive for CI. These tests cover the wiring around the
+LoRA path: the config field exists with the right default, the
+``--encoder-lora`` CLI flag flows into the candidate ``ModelConfig``
+construction, the factory drops the field before reaching
+``ForecasterModel`` (which does not consume it), and the
+``encoder_lora.py`` helper module exposes the documented surface.
+The byte-identity guarantee for ``encoder_lora=False`` rides on the
+existing determinism regression at
+``tests/regression/test_forecaster_determinism.py`` (its synthetic
+vectors carry no ``raw_text`` and the static-cache path runs
+unchanged).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel_path: str) -> str:
+    return (_REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def test_model_config_carries_encoder_lora_field() -> None:
+    """``ModelConfig.encoder_lora`` must be a real field with default
+    ``False`` so existing checkpoints deserialise into the legacy
+    static-cache path."""
+
+    source = _read("backend/app/models/config.py")
+    assert "encoder_lora: bool = False" in source, (
+        "ModelConfig is missing the encoder_lora field (default False)"
+    )
+    assert "encoder_lora=bool(getattr(model, \"encoder_lora\", False))" in source, (
+        "ModelConfig.from_model does not round-trip encoder_lora"
+    )
+
+
+def test_feature_vector_carries_raw_text_field() -> None:
+    """``FeatureVector.raw_text`` is populated by the loader on the
+    target-row bar of each sequence when ``encoder_lora=True``. The
+    LoRA tokeniser reads ``sequence[-1].raw_text`` per group."""
+
+    source = _read("backend/app/models/config.py")
+    assert "raw_text: str = \"\"" in source, (
+        "FeatureVector is missing the raw_text field (default empty)"
+    )
+
+
+def test_factory_pops_encoder_lora_before_forecaster_model() -> None:
+    """``ForecasterModel`` does not accept ``encoder_lora`` as a kwarg
+    -- the factory strips it before constructing the model. Without
+    this guard, every walk-forward run on ``encoder_lora`` propagating
+    through ModelConfig.to_dict() crashes immediately."""
+
+    source = _read("backend/app/models/factory.py")
+    assert "kwargs.pop(\"encoder_lora\", None)" in source, (
+        "factory does not pop encoder_lora before ForecasterModel(**kwargs)"
+    )
+
+
+def test_train_forecaster_exposes_encoder_lora_cli_flag() -> None:
+    """The CLI must expose ``--encoder-lora`` so the ceiling probe can
+    be driven from a wrapper script."""
+
+    source = _read("backend/app/train_forecaster.py")
+    assert "\"--encoder-lora\"" in source
+    assert "dest=\"encoder_lora\"" in source
+    assert "parser.set_defaults(encoder_lora=False)" in source
+
+
+def test_train_forecaster_threads_encoder_lora_into_model_config() -> None:
+    """``encoder_lora`` rides on ``ModelConfig`` so the checkpoint
+    persists it. The CLI flag must reach every ``ModelConfig(...)``
+    construction site so the sweep + single-run paths honour it."""
+
+    source = _read("backend/app/train_forecaster.py")
+    occurrences = source.count(
+        "encoder_lora=bool(getattr(args, \"encoder_lora\", False))"
+    )
+    assert occurrences >= 3, (
+        "encoder_lora is not threaded into every ModelConfig construction "
+        f"site (found {occurrences}, expected >= 3)"
+    )
+
+
+def test_loaders_thread_encoder_lora_into_metadata_pass() -> None:
+    """The loader must accept ``encoder_lora`` and populate
+    ``vector.raw_text`` on the target-row bar when the flag is set."""
+
+    source = _read("backend/app/training/loaders.py")
+    assert "encoder_lora: bool = False" in source
+    assert "vectors[-1].raw_text = row_text" in source, (
+        "loader does not populate raw_text on the target-row bar"
+    )
+
+
+def test_encoder_lora_module_exposes_documented_surface() -> None:
+    """The helper module exports ``build_lora_encoder``,
+    ``tokenize_sequence_texts``, ``encode_batch_pooled``, and the
+    ``LoraEncoderBundle`` container. Each is called from
+    ``train_model`` -- a rename in the helper without a corresponding
+    update in the loop would break the LoRA training path silently."""
+
+    source = _read("backend/app/training/encoder_lora.py")
+    for symbol in (
+        "def build_lora_encoder(",
+        "def tokenize_sequence_texts(",
+        "def encode_batch_pooled(",
+        "class LoraEncoderBundle",
+    ):
+        assert symbol in source, f"encoder_lora module missing symbol: {symbol}"
+
+
+def test_train_model_builds_lora_bundle_only_when_active() -> None:
+    """``train_model`` builds the LoRA bundle once before the partition
+    tensors and threads it everywhere. When ``encoder_lora`` is off
+    the bundle stays ``None`` and the static-cache path runs."""
+
+    source = _read("backend/app/training/loop.py")
+    assert "encoder_lora_active = bool(" in source
+    assert "encoder_lora_bundle: Any = None" in source
+    assert "build_lora_encoder(str(text_encoder))" in source
+    # Bundle is threaded into all three partition builders + every
+    # _evaluate_model call site.
+    assert source.count("lora_bundle=encoder_lora_bundle") >= 3
+    assert source.count("encoder_lora_bundle=encoder_lora_bundle") >= 3


### PR DESCRIPTION
## Summary

Pulls the configured text encoder into the training loop, wraps it with PEFT LoRA, and runs the encoder forward per batch so the regime loss can update the adapter. Static-cache path stays byte-identical when `encoder_lora=False` (default).

- New `ModelConfig.encoder_lora` field and `FeatureVector.raw_text` field; `peft>=0.10` added to dependencies
- New `backend/app/training/encoder_lora.py` exposes `build_lora_encoder`, `tokenize_sequence_texts`, `encode_batch_pooled`
- Loader populates `raw_text` on the target-row bar when `encoder_lora=True`
- `_build_partition_tensors` returns `(input_ids, attention_mask)` instead of `(text_emb, text_missing)` when given a bundle
- `train_model` builds the bundle once, threads it into `_evaluate_model` and the train step; the optimiser includes adapter parameters with the same bias / LayerNorm weight-decay exemption as the forecaster
- `factory.py` drops `encoder_lora` before `ForecasterModel(**kwargs)` so the field rides only on the training-loop side
- Adapter sidecar checkpoint at `<checkpoint>.lora_adapter.pt` carries the encoder alias and the PEFT adapter state
- `scripts/run_lora_ceiling_probe.py` + `make lora-ceiling-probe` wrap one seed × four folds against the architecture chosen by the latest sweep

## Test plan

- [ ] `pytest tests/unit/test_encoder_lora_wiring.py -q`
- [ ] `pytest tests/regression/test_forecaster_determinism.py -q`
- [ ] `make lora-ceiling-probe TRAINING_PACKAGE_ID=tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0`

Closes #244.