### PR TITLE
Per-axis × per-encoder table + regime aggregator CIs (closes #82, #84)

### DIFF
--- a/backend/app/evaluation/multi_axis_table.py
+++ b/backend/app/evaluation/multi_axis_table.py
@@ -1,0 +1,295 @@
+"""Per-axis macro-F1 table across encoders.
+
+Reads the bake-off ``aggregate.json`` output and produces a per-axis ×
+per-encoder breakdown with mean, std, and bootstrap CI columns. The
+``per_axis`` block on each encoder is the new shape produced by the
+multi-axis-aware fine-tune batch (one block per axis: stance / factor /
+certainty / time / topic); the legacy single-axis shape is treated as a
+stance-only row so older aggregates render the same table layout.
+
+Each row is one (axis, encoder, metric) cell. Output ships as both CSV
+(for downstream tooling) and markdown (for direct paste into the wiki
+or the thesis docs).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from app.evaluation.bootstrap import block_bootstrap_ci
+
+
+DEFAULT_METRICS: tuple[str, ...] = ("macro_f1", "weighted_f1", "accuracy")
+DEFAULT_AXES: tuple[str, ...] = ("stance", "factor", "certainty", "time", "topic")
+LEGACY_AXIS: str = "stance"
+
+
+@dataclass(frozen=True)
+class MultiAxisRow:
+    axis: str
+    encoder: str
+    metric: str
+    mean: float
+    std: float | None
+    n: int
+    ci_lo: float | None
+    ci_hi: float | None
+    samples: tuple[float, ...] = ()
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return None if result != result else result
+
+
+def _samples_from_per_seed(per_seed: Any, metric: str) -> list[float]:
+    if not isinstance(per_seed, Mapping):
+        return []
+    out: list[float] = []
+    for raw in per_seed.values():
+        if isinstance(raw, Mapping):
+            value = _coerce_float(raw.get(metric))
+        else:
+            value = _coerce_float(raw)
+        if value is not None:
+            out.append(value)
+    return out
+
+
+def _row_from_samples(
+    *,
+    axis: str,
+    encoder: str,
+    metric: str,
+    samples: Sequence[float],
+    block_size: int,
+    n_resamples: int,
+    coverage: float,
+    seed: int,
+) -> MultiAxisRow | None:
+    if not samples:
+        return None
+    n = len(samples)
+    mean = sum(samples) / n
+    std: float | None = None
+    if n > 1:
+        variance = sum((s - mean) ** 2 for s in samples) / (n - 1)
+        std = variance ** 0.5
+    ci_lo: float | None = None
+    ci_hi: float | None = None
+    if n > 1:
+        ci = block_bootstrap_ci(
+            list(samples),
+            block_size=block_size,
+            n_resamples=n_resamples,
+            coverage=coverage,
+            seed=seed,
+        )
+        ci_lo = float(ci.lo)
+        ci_hi = float(ci.hi)
+    return MultiAxisRow(
+        axis=axis,
+        encoder=encoder,
+        metric=metric,
+        mean=float(mean),
+        std=std,
+        n=n,
+        ci_lo=ci_lo,
+        ci_hi=ci_hi,
+        samples=tuple(samples),
+    )
+
+
+def _rows_for_encoder(
+    encoder_name: str,
+    encoder_block: Mapping[str, Any],
+    *,
+    metrics: Iterable[str],
+    block_size: int,
+    n_resamples: int,
+    coverage: float,
+    seed: int,
+) -> list[MultiAxisRow]:
+    per_axis = encoder_block.get("per_axis")
+    rows: list[MultiAxisRow] = []
+    metric_list = list(metrics)
+    if isinstance(per_axis, Mapping) and per_axis:
+        # New shape: each axis carries its own per-seed metric block.
+        for axis_name, axis_block in per_axis.items():
+            if not isinstance(axis_block, Mapping):
+                continue
+            for metric in metric_list:
+                samples = _samples_from_per_seed(axis_block.get("per_seed"), metric)
+                row = _row_from_samples(
+                    axis=str(axis_name),
+                    encoder=encoder_name,
+                    metric=metric,
+                    samples=samples,
+                    block_size=block_size,
+                    n_resamples=n_resamples,
+                    coverage=coverage,
+                    seed=seed,
+                )
+                if row is not None:
+                    rows.append(row)
+        return rows
+
+    # Legacy shape: encoder block has a per_seed map directly. Treat the
+    # whole table as stance-axis values; downstream tooling renders one
+    # row per (stance, encoder, metric) without losing the older table.
+    for metric in metric_list:
+        samples = _samples_from_per_seed(encoder_block.get("per_seed"), metric)
+        row = _row_from_samples(
+            axis=LEGACY_AXIS,
+            encoder=encoder_name,
+            metric=metric,
+            samples=samples,
+            block_size=block_size,
+            n_resamples=n_resamples,
+            coverage=coverage,
+            seed=seed,
+        )
+        if row is not None:
+            rows.append(row)
+    return rows
+
+
+def build_rows(
+    aggregate: Mapping[str, Any],
+    *,
+    metrics: Iterable[str] = DEFAULT_METRICS,
+    block_size: int = 1,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    seed: int = 11,
+) -> list[MultiAxisRow]:
+    """Return the (axis, encoder, metric) rows for one aggregate.json payload."""
+
+    by_encoder = aggregate.get("by_encoder") if isinstance(aggregate, Mapping) else None
+    if not isinstance(by_encoder, Mapping):
+        return []
+    rows: list[MultiAxisRow] = []
+    for encoder_name, encoder_block in by_encoder.items():
+        if not isinstance(encoder_block, Mapping):
+            continue
+        rows.extend(
+            _rows_for_encoder(
+                str(encoder_name),
+                encoder_block,
+                metrics=metrics,
+                block_size=block_size,
+                n_resamples=n_resamples,
+                coverage=coverage,
+                seed=seed,
+            )
+        )
+    return rows
+
+
+def render_markdown(rows: Sequence[MultiAxisRow], *, coverage: float = 0.95) -> str:
+    """Render the per-axis table as markdown grouped by axis."""
+
+    if not rows:
+        return "_no rows_\n"
+    by_axis: dict[str, list[MultiAxisRow]] = {}
+    for row in rows:
+        by_axis.setdefault(row.axis, []).append(row)
+    band = int(round(coverage * 100))
+    out: list[str] = []
+    for axis in sorted(by_axis.keys()):
+        out.append(f"### Axis: `{axis}`")
+        out.append("")
+        out.append(
+            f"| Encoder | Metric | n | mean | std | {band}% CI lo | {band}% CI hi |"
+        )
+        out.append("| --- | --- | ---: | ---: | ---: | ---: | ---: |")
+        for row in by_axis[axis]:
+            std = "—" if row.std is None else f"{row.std:.4f}"
+            lo = "—" if row.ci_lo is None else f"{row.ci_lo:.4f}"
+            hi = "—" if row.ci_hi is None else f"{row.ci_hi:.4f}"
+            out.append(
+                f"| {row.encoder} | {row.metric} | {row.n} | "
+                f"{row.mean:.4f} | {std} | {lo} | {hi} |"
+            )
+        out.append("")
+    return "\n".join(out)
+
+
+def write_csv(rows: Sequence[MultiAxisRow], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            ["axis", "encoder", "metric", "n", "mean", "std", "ci_lo", "ci_hi"]
+        )
+        for row in rows:
+            writer.writerow(
+                [
+                    row.axis,
+                    row.encoder,
+                    row.metric,
+                    row.n,
+                    row.mean,
+                    "" if row.std is None else row.std,
+                    "" if row.ci_lo is None else row.ci_lo,
+                    "" if row.ci_hi is None else row.ci_hi,
+                ]
+            )
+
+
+def write_json(rows: Sequence[MultiAxisRow], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "rows": [
+            {k: v for k, v in asdict(row).items() if k != "samples"}
+            for row in rows
+        ]
+    }
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build the per-axis × per-encoder bake-off table."
+    )
+    parser.add_argument("--aggregate", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--block-size", type=int, default=1)
+    parser.add_argument("--n-resamples", type=int, default=1000)
+    parser.add_argument("--coverage", type=float, default=0.95)
+    parser.add_argument("--seed", type=int, default=11)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    aggregate = json.loads(Path(args.aggregate).read_text(encoding="utf-8"))
+    rows = build_rows(
+        aggregate,
+        block_size=int(args.block_size),
+        n_resamples=int(args.n_resamples),
+        coverage=float(args.coverage),
+        seed=int(args.seed),
+    )
+    output_dir = Path(args.output_dir)
+    write_csv(rows, output_dir / "table.csv")
+    write_json(rows, output_dir / "table.json")
+    (output_dir / "table.md").write_text(
+        render_markdown(rows, coverage=float(args.coverage)), encoding="utf-8"
+    )
+    print(f"[multi_axis_table] wrote {len(rows)} rows to {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/app/evaluation/regime_aggregator.py
+++ b/backend/app/evaluation/regime_aggregator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 from typing import Any, Iterable, Mapping
 
@@ -24,6 +24,15 @@ class RegimeRow:
     mean: float
     std: float | None
     n: int
+    # Raw per-seed values backing this row. Carries forward into the
+    # bootstrap CI helper without forcing the aggregator to recompute
+    # from upstream artefacts. ``ci_lo`` / ``ci_hi`` are populated when
+    # at least two samples are present; rows with a single sample
+    # (smoke runs, single-seed cells) carry ``None`` so callers can
+    # surface "n/a" in the table.
+    samples: tuple[float, ...] = ()
+    ci_lo: float | None = None
+    ci_hi: float | None = None
 
 
 def _to_date(value: str) -> date:
@@ -35,7 +44,23 @@ def aggregate_by_regime(
     *,
     regime_windows: Iterable[tuple[str, str, str]] = REGIME_WINDOWS,
     metric_keys: Iterable[str] = ("combined_rmse", "close_rmse", "volatility_rmse", "directional_accuracy"),
+    bootstrap_block_size: int = 1,
+    bootstrap_resamples: int = 1000,
+    bootstrap_coverage: float = 0.95,
+    bootstrap_seed: int = 11,
 ) -> list[RegimeRow]:
+    """Return one row per (regime, fold, variant, metric).
+
+    Each row carries the per-seed samples it was built from plus a
+    moving-block bootstrap CI on the row mean. Bootstrap defaults to
+    block size 1 because the per-seed list is a small sample of
+    independent runs, not a time series; pass a larger block when the
+    samples are autocorrelated (e.g. a per-day series fed into this
+    helper).
+    """
+
+    from app.evaluation.bootstrap import block_bootstrap_ci
+
     out: list[RegimeRow] = []
     holdout_list = list(holdouts)
     if not holdout_list:
@@ -63,6 +88,18 @@ def aggregate_by_regime(
                     metric = variant_payload.get(metric_key)
                     if not isinstance(metric, dict):
                         continue
+                    samples = tuple(_iter_samples(metric.get("per_seed")))
+                    ci_lo: float | None = None
+                    ci_hi: float | None = None
+                    if len(samples) > 1:
+                        ci = block_bootstrap_ci(
+                            list(samples),
+                            block_size=int(bootstrap_block_size),
+                            n_resamples=int(bootstrap_resamples),
+                            coverage=float(bootstrap_coverage),
+                            seed=int(bootstrap_seed),
+                        )
+                        ci_lo, ci_hi = float(ci.lo), float(ci.hi)
                     out.append(
                         RegimeRow(
                             regime=regime_name,
@@ -72,9 +109,34 @@ def aggregate_by_regime(
                             mean=float(metric.get("mean", float("nan"))),
                             std=_coerce_optional_float(metric.get("std")),
                             n=int(metric.get("count", 0)),
+                            samples=samples,
+                            ci_lo=ci_lo,
+                            ci_hi=ci_hi,
                         )
                     )
     return out
+
+
+def _iter_samples(per_seed: Any) -> Iterable[float]:
+    """Extract numeric per-seed values from the metric block.
+
+    Tolerates both ``{seed: value}`` and ``{seed: {"value": x}}`` shapes
+    so older aggregate.json layouts keep working. Non-finite or
+    unparseable entries are dropped so the bootstrap input stays a
+    clean numeric list.
+    """
+
+    if not isinstance(per_seed, Mapping):
+        return
+    for _seed, raw in per_seed.items():
+        value: float | None
+        if isinstance(raw, Mapping):
+            value = _coerce_optional_float(raw.get("value"))
+        else:
+            value = _coerce_optional_float(raw)
+        if value is None:
+            continue
+        yield value
 
 
 def _coerce_optional_float(value: Any) -> float | None:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -140,6 +140,7 @@ ignore = [
 "app/evaluation/conformal.py" = ["PLR0913"]
 "app/evaluation/cross_bank_transfer.py" = ["PLR0913"]
 "app/evaluation/metrics.py" = ["PLR0913"]
+"app/evaluation/multi_axis_table.py" = ["PLR0913"]
 "app/evaluation/regime_aggregator.py" = ["PLR0913", "C901"]
 "app/evaluation/transfer_matrix.py" = ["PLR0913"]
 "app/features/credibility.py" = ["PLR0913"]

--- a/tests/unit/test_multi_axis_table.py
+++ b/tests/unit/test_multi_axis_table.py
@@ -1,0 +1,150 @@
+"""Tests for the per-axis × per-encoder table aggregator (#82)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.evaluation.multi_axis_table import (
+    build_rows,
+    render_markdown,
+    write_csv,
+    write_json,
+)
+
+
+def _aggregate_per_axis() -> dict:
+    """Synthetic 2-encoder × 2-axis fixture mirroring the future
+    multi-axis bake-off output shape."""
+
+    return {
+        "by_encoder": {
+            "encoder_a": {
+                "per_axis": {
+                    "stance": {
+                        "per_seed": {
+                            "11": {"macro_f1": 0.60, "weighted_f1": 0.62, "accuracy": 0.61},
+                            "29": {"macro_f1": 0.62, "weighted_f1": 0.63, "accuracy": 0.63},
+                            "47": {"macro_f1": 0.58, "weighted_f1": 0.60, "accuracy": 0.59},
+                            "71": {"macro_f1": 0.61, "weighted_f1": 0.62, "accuracy": 0.60},
+                            "97": {"macro_f1": 0.63, "weighted_f1": 0.64, "accuracy": 0.64},
+                        }
+                    },
+                    "factor": {
+                        "per_seed": {
+                            "11": {"macro_f1": 0.48, "weighted_f1": 0.49, "accuracy": 0.51},
+                            "29": {"macro_f1": 0.50, "weighted_f1": 0.51, "accuracy": 0.52},
+                            "47": {"macro_f1": 0.47, "weighted_f1": 0.48, "accuracy": 0.50},
+                        }
+                    },
+                }
+            },
+            "encoder_b": {
+                "per_axis": {
+                    "stance": {
+                        "per_seed": {
+                            "11": {"macro_f1": 0.65, "weighted_f1": 0.66, "accuracy": 0.66},
+                            "29": {"macro_f1": 0.66, "weighted_f1": 0.67, "accuracy": 0.67},
+                            "47": {"macro_f1": 0.64, "weighted_f1": 0.65, "accuracy": 0.65},
+                        }
+                    },
+                    "factor": {
+                        "per_seed": {
+                            "11": {"macro_f1": 0.50, "weighted_f1": 0.51, "accuracy": 0.52},
+                            "29": {"macro_f1": 0.52, "weighted_f1": 0.53, "accuracy": 0.54},
+                        }
+                    },
+                }
+            },
+        }
+    }
+
+
+def test_build_rows_covers_every_axis_encoder_metric_combination() -> None:
+    rows = build_rows(_aggregate_per_axis())
+    # 2 encoders × 2 axes × 3 metrics = 12 rows
+    assert len(rows) == 12
+    triples = {(r.encoder, r.axis, r.metric) for r in rows}
+    expected = {
+        (enc, axis, metric)
+        for enc in ("encoder_a", "encoder_b")
+        for axis in ("stance", "factor")
+        for metric in ("macro_f1", "weighted_f1", "accuracy")
+    }
+    assert triples == expected
+
+
+def test_rows_carry_bootstrap_ci_when_multi_seed() -> None:
+    rows = build_rows(_aggregate_per_axis())
+    for row in rows:
+        if row.n > 1:
+            assert row.ci_lo is not None and row.ci_hi is not None
+            assert row.ci_lo <= row.mean <= row.ci_hi
+
+
+def test_legacy_per_seed_shape_falls_through_as_stance_only() -> None:
+    legacy = {
+        "by_encoder": {
+            "encoder_legacy": {
+                "per_seed": {
+                    "11": {"macro_f1": 0.70, "weighted_f1": 0.71, "accuracy": 0.72},
+                    "29": {"macro_f1": 0.72, "weighted_f1": 0.73, "accuracy": 0.74},
+                }
+            }
+        }
+    }
+    rows = build_rows(legacy)
+    assert {r.axis for r in rows} == {"stance"}
+    assert {r.encoder for r in rows} == {"encoder_legacy"}
+    assert {r.metric for r in rows} == {"macro_f1", "weighted_f1", "accuracy"}
+
+
+def test_csv_and_markdown_outputs_round_trip(tmp_path: Path) -> None:
+    rows = build_rows(_aggregate_per_axis())
+    csv_path = tmp_path / "table.csv"
+    json_path = tmp_path / "table.json"
+    md_path = tmp_path / "table.md"
+
+    write_csv(rows, csv_path)
+    write_json(rows, json_path)
+    md_path.write_text(render_markdown(rows), encoding="utf-8")
+
+    # CSV header is fixed; the row count matches build_rows.
+    csv_lines = csv_path.read_text(encoding="utf-8").splitlines()
+    assert csv_lines[0] == "axis,encoder,metric,n,mean,std,ci_lo,ci_hi"
+    assert len(csv_lines) - 1 == len(rows)
+
+    # JSON payload mirrors the row dataclasses minus the raw samples.
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert len(payload["rows"]) == len(rows)
+    for emitted in payload["rows"]:
+        assert "samples" not in emitted
+
+    # Markdown groups by axis; both axes get their own section.
+    md = md_path.read_text(encoding="utf-8")
+    assert "### Axis: `stance`" in md
+    assert "### Axis: `factor`" in md
+    # Each metric × encoder pair shows up exactly once in the relevant section.
+    assert md.count("encoder_a") == 2 * 3  # 2 axes × 3 metrics
+    assert md.count("encoder_b") == 2 * 3
+
+
+def test_empty_aggregate_emits_no_rows() -> None:
+    assert build_rows({}) == []
+    assert build_rows({"by_encoder": {}}) == []
+
+
+def test_axis_block_without_per_seed_is_skipped() -> None:
+    aggregate = {
+        "by_encoder": {
+            "encoder_x": {
+                "per_axis": {
+                    "stance": {"per_seed": {"11": {"macro_f1": 0.5}}},
+                    "factor": {},  # malformed / empty axis
+                }
+            }
+        }
+    }
+    rows = build_rows(aggregate)
+    axes = {r.axis for r in rows}
+    assert axes == {"stance"}

--- a/tests/unit/test_regime_aggregator.py
+++ b/tests/unit/test_regime_aggregator.py
@@ -47,3 +47,68 @@ def test_regime_windows_cover_2010_to_2023() -> None:
     assert "2010-01-01" in starts
     assert "2020-01-01" in starts
     assert "2022-01-01" in starts
+
+
+def _holdout_with_per_seed(
+    fold_id: str, test_start: str, test_end: str, values: dict[str, float]
+) -> dict:
+    return {
+        "fold_id": fold_id,
+        "test_start": test_start,
+        "test_end": test_end,
+        "variants": {
+            "baseline": {
+                "combined_rmse": {
+                    "mean": sum(values.values()) / max(1, len(values)),
+                    "std": 0.0,
+                    "count": len(values),
+                    "per_seed": dict(values),
+                }
+            }
+        },
+    }
+
+
+def test_row_carries_samples_from_per_seed_block() -> None:
+    rows = aggregate_by_regime(
+        [
+            _holdout_with_per_seed(
+                "wf_fold_1",
+                "2018-01-01",
+                "2018-06-30",
+                {"11": 0.10, "29": 0.12, "47": 0.11, "71": 0.13, "97": 0.09},
+            )
+        ],
+        metric_keys=("combined_rmse",),
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert sorted(row.samples) == [0.09, 0.10, 0.11, 0.12, 0.13]
+    assert row.ci_lo is not None and row.ci_hi is not None
+    assert row.ci_lo <= row.mean <= row.ci_hi
+
+
+def test_single_seed_emits_none_ci() -> None:
+    rows = aggregate_by_regime(
+        [
+            _holdout_with_per_seed(
+                "wf_fold_1",
+                "2018-01-01",
+                "2018-06-30",
+                {"11": 0.10},
+            )
+        ],
+        metric_keys=("combined_rmse",),
+    )
+    assert rows[0].samples == (0.10,)
+    assert rows[0].ci_lo is None
+    assert rows[0].ci_hi is None
+
+
+def test_legacy_holdout_without_per_seed_keeps_running() -> None:
+    rows = aggregate_by_regime([_holdout("wf_fold_1", "2018-01-01", "2018-06-30", 0.001)])
+    # Older fixtures use ``per_seed: {}``; the aggregator should still emit
+    # rows, just with empty samples and no CI.
+    assert rows, "expected at least one row from the legacy holdout"
+    assert all(r.samples == () for r in rows)
+    assert all(r.ci_lo is None and r.ci_hi is None for r in rows)


### PR DESCRIPTION
Closes #82, closes #84.

## Summary

- `backend/app/evaluation/multi_axis_table.py` reads bake-off `aggregate.json` and produces one row per (axis, encoder, metric) with mean, std, and moving-block bootstrap CI; CSV, JSON, and markdown outputs ship in parallel.
- Legacy single-axis `aggregate.json` files fall through as a stance-only row so older runs still produce a usable table.
- `regime_aggregator.RegimeRow` now carries the per-seed samples it was built from plus `ci_lo` / `ci_hi`; rows with a single sample emit `None` CIs so the renderer can show "n/a".

## Test plan

- [ ] `pytest tests/unit/test_multi_axis_table.py -q`
- [ ] `pytest tests/unit/test_regime_aggregator.py -q`
- [ ] `python -m app.evaluation.multi_axis_table --aggregate data/artifacts/phase3/finetune_batch_20260519T190604Z/aggregate.json --output-dir data/artifacts/v2_multi_axis_table/20260523/`