### PR TITLE
Alpha Vantage SPX intraday backfill for fed-info residual (closes #159)

### DIFF
--- a/backend/app/data/alphavantage_spx.py
+++ b/backend/app/data/alphavantage_spx.py
@@ -1,0 +1,480 @@
+"""Alpha Vantage SPX intraday backfill for FOMC announcement windows.
+
+The Cieslak-Vissing-Jorgensen (2021) decomposition uses the SPX return
+in a ±30 minute window around the policy announcement. The free tier of
+FRED carries only daily SPX (FRED-licensed CRSP), so `mp_surprise.py`
+defaults to a same-day close-to-close proxy and stamps the row with
+``fed_info_factor_source = "daily_window_proxy"``.
+
+This module backfills the ±30 minute SPX return from Alpha Vantage's
+free intraday endpoint (SPY as the SPX proxy, since direct
+``^GSPC`` intraday is not available in the free tier). The cache lands
+at ``data/external/alphavantage/spx_intraday_fomc_days.parquet``;
+``mp_surprise.py`` reads it and re-stamps upgraded rows with
+``fed_info_factor_source = "alphavantage_intraday_30min"``.
+
+Rate limits:
+
+- 5 requests/minute, 500/day on the free Alpha Vantage tier
+- one ``TIME_SERIES_INTRADAY`` call covers one calendar month at 1-min
+  resolution (~30 trading days × 390 minutes = ~11,700 rows per call)
+- ~150 FOMC meetings across the 2010-2025 window means ~120 distinct
+  (year, month) cells, well within a one-day budget at 13s spacing
+
+``ALPHA_VANTAGE_API_KEY`` must be set on the environment. Get a free key
+at https://www.alphavantage.co/support/#api-key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import httpx
+
+from app.config import DATA_DIR
+
+
+ALPHA_VANTAGE_BASE_URL = "https://www.alphavantage.co/query"
+DEFAULT_CACHE_DIR = DATA_DIR / "external" / "alphavantage"
+SOURCES_LOCK_NAME = "SOURCES.lock"
+INTRADAY_PARQUET = "spx_intraday_fomc_days.parquet"
+DEFAULT_SYMBOL = "SPY"
+DEFAULT_INTERVAL = "1min"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+# Alpha Vantage free tier is 5 req/min. 13 seconds keeps us safely under
+# even with clock drift; the env var lets paid tiers raise the rate.
+DEFAULT_REQUEST_INTERVAL_SECONDS = 13.0
+# FOMC announcements at 2:00pm ET; the CVJ ±30 min window is 13:30-14:30.
+DEFAULT_ANNOUNCEMENT_TIME = datetime.time(hour=14, minute=0)
+DEFAULT_WINDOW_MINUTES = 30
+
+
+@dataclass(frozen=True)
+class IntradayBar:
+    """One minute bar from Alpha Vantage's TIME_SERIES_INTRADAY."""
+
+    timestamp_et: str  # ISO 8601 in US/Eastern, no tz suffix (matches AV format)
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+@dataclass(frozen=True)
+class FomcWindowReturn:
+    """±30 min SPX-proxy return + raw ``(pre, post)`` close pair."""
+
+    event_date: str
+    pre_close: float
+    post_close: float
+    return_pct: float
+    window_minutes: int
+    symbol: str
+    fetched_at_utc: str
+
+
+def _api_key_from_env() -> str:
+    key = os.environ.get("ALPHA_VANTAGE_API_KEY") or os.environ.get("ALPHAVANTAGE_API_KEY")
+    if not key:
+        raise RuntimeError(
+            "ALPHA_VANTAGE_API_KEY is not set. Get a free key at "
+            "https://www.alphavantage.co/support/#api-key and export it."
+        )
+    return key
+
+
+def _parse_intraday_payload(payload: dict[str, Any]) -> list[IntradayBar]:
+    series_key = next(
+        (k for k in payload if k.startswith("Time Series")),
+        None,
+    )
+    if series_key is None:
+        # Note message: "Thank you for using Alpha Vantage..." indicates a rate-limit hit.
+        if "Note" in payload:
+            raise RuntimeError(f"Alpha Vantage rate limit hit: {payload['Note']}")
+        if "Error Message" in payload:
+            raise RuntimeError(f"Alpha Vantage error: {payload['Error Message']}")
+        raise RuntimeError(f"unexpected Alpha Vantage response shape: keys={list(payload.keys())}")
+    rows = payload[series_key]
+    bars: list[IntradayBar] = []
+    for timestamp_et, fields in rows.items():
+        bars.append(
+            IntradayBar(
+                timestamp_et=str(timestamp_et),
+                open=float(fields["1. open"]),
+                high=float(fields["2. high"]),
+                low=float(fields["3. low"]),
+                close=float(fields["4. close"]),
+                volume=float(fields["5. volume"]),
+            )
+        )
+    # Alpha Vantage returns the series newest-first; flip so chronological
+    # callers can binary-search by timestamp.
+    bars.sort(key=lambda bar: bar.timestamp_et)
+    return bars
+
+
+def fetch_intraday_minute_bars(
+    *,
+    api_key: str,
+    symbol: str = DEFAULT_SYMBOL,
+    interval: str = DEFAULT_INTERVAL,
+    month: str | None = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    client: httpx.Client | None = None,
+) -> list[IntradayBar]:
+    """Hit ``TIME_SERIES_INTRADAY`` for one (symbol, month) pair.
+
+    ``month`` is a ``YYYY-MM`` string (e.g. ``"2024-01"``). When None,
+    Alpha Vantage returns the most recent month available — usually
+    fine for live operations but explicit months are preferred for
+    deterministic backfills.
+    """
+
+    params: dict[str, str] = {
+        "function": "TIME_SERIES_INTRADAY",
+        "symbol": symbol,
+        "interval": interval,
+        "outputsize": "full",
+        "adjusted": "true",
+        "extended_hours": "false",
+        "apikey": api_key,
+        "datatype": "json",
+    }
+    if month is not None:
+        params["month"] = month
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=timeout_seconds)
+    try:
+        response = client.get(ALPHA_VANTAGE_BASE_URL, params=params)
+        response.raise_for_status()
+        payload = response.json()
+    finally:
+        if owns_client:
+            client.close()
+    return _parse_intraday_payload(payload)
+
+
+def _et_naive(date_value: datetime.date, time_value: datetime.time) -> datetime.datetime:
+    """Combine date + time into a naive datetime (no tz suffix).
+
+    Alpha Vantage timestamps come back in US/Eastern WITHOUT a tz
+    suffix; matching that format keeps the timestamp comparison
+    string-based and timezone-agnostic.
+    """
+
+    return datetime.datetime.combine(date_value, time_value)
+
+
+def _isoformat_minute(timestamp: datetime.datetime) -> str:
+    return timestamp.strftime("%Y-%m-%d %H:%M:00")
+
+
+def _bracket_window_returns(
+    bars: Sequence[IntradayBar],
+    event_date: datetime.date,
+    *,
+    announcement_time: datetime.time,
+    window_minutes: int,
+) -> tuple[float, float] | None:
+    """Return ``(pre_close, post_close)`` for the ±window around the
+    announcement, or ``None`` if either side is missing.
+
+    The "pre" close is the last bar at or before
+    ``announcement_time - window_minutes``; the "post" close is the
+    first bar at or after ``announcement_time + window_minutes``.
+    Using closest-bar lookups (not exact equality) tolerates the
+    occasional gap in the Alpha Vantage stream.
+    """
+
+    pre_target = _et_naive(
+        event_date,
+        (
+            datetime.datetime.combine(event_date, announcement_time)
+            - datetime.timedelta(minutes=window_minutes)
+        ).time(),
+    )
+    post_target = _et_naive(
+        event_date,
+        (
+            datetime.datetime.combine(event_date, announcement_time)
+            + datetime.timedelta(minutes=window_minutes)
+        ).time(),
+    )
+    pre_target_iso = _isoformat_minute(pre_target)
+    post_target_iso = _isoformat_minute(post_target)
+
+    pre_close: float | None = None
+    post_close: float | None = None
+    for bar in bars:
+        if bar.timestamp_et[:10] != event_date.isoformat():
+            continue
+        if bar.timestamp_et <= pre_target_iso:
+            pre_close = bar.close
+        if bar.timestamp_et >= post_target_iso and post_close is None:
+            post_close = bar.close
+            break
+    if pre_close is None or post_close is None or pre_close <= 0:
+        return None
+    return (float(pre_close), float(post_close))
+
+
+def compute_window_returns(
+    bars: Sequence[IntradayBar],
+    event_dates: Iterable[datetime.date],
+    *,
+    symbol: str = DEFAULT_SYMBOL,
+    announcement_time: datetime.time = DEFAULT_ANNOUNCEMENT_TIME,
+    window_minutes: int = DEFAULT_WINDOW_MINUTES,
+    fetched_at_utc: str | None = None,
+) -> list[FomcWindowReturn]:
+    fetched_at = fetched_at_utc or datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    out: list[FomcWindowReturn] = []
+    for event_date in event_dates:
+        window = _bracket_window_returns(
+            bars,
+            event_date,
+            announcement_time=announcement_time,
+            window_minutes=window_minutes,
+        )
+        if window is None:
+            continue
+        pre_close, post_close = window
+        out.append(
+            FomcWindowReturn(
+                event_date=event_date.isoformat(),
+                pre_close=pre_close,
+                post_close=post_close,
+                return_pct=(post_close - pre_close) / pre_close,
+                window_minutes=int(window_minutes),
+                symbol=symbol,
+                fetched_at_utc=fetched_at,
+            )
+        )
+    return out
+
+
+def _months_covering(event_dates: Iterable[datetime.date]) -> list[str]:
+    """Return distinct ``YYYY-MM`` strings spanning ``event_dates``.
+
+    One Alpha Vantage call retrieves a whole month, so grouping by
+    month keeps the request count down — the rate-limit budget is the
+    binding constraint, not bandwidth.
+    """
+
+    months = {f"{d.year:04d}-{d.month:02d}" for d in event_dates}
+    return sorted(months)
+
+
+def _write_sources_lock_entry(
+    cache_dir: Path,
+    parquet_path: Path,
+    *,
+    sha256: str,
+    rows: int,
+    months_fetched: Sequence[str],
+) -> None:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = cache_dir / SOURCES_LOCK_NAME
+    payload: dict[str, Any] = {}
+    if lock_path.exists():
+        try:
+            payload = json.loads(lock_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            payload = {}
+    payload[parquet_path.name] = {
+        "sha256": sha256,
+        "rows": int(rows),
+        "months_fetched": list(months_fetched),
+        "fetched_at_utc": datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        ),
+        "source": "alphavantage",
+        "endpoint": "TIME_SERIES_INTRADAY",
+        "symbol": DEFAULT_SYMBOL,
+        "interval": DEFAULT_INTERVAL,
+    }
+    lock_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(65536)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def backfill_fomc_days(
+    *,
+    fomc_dates: Iterable[datetime.date],
+    cache_dir: Path | str = DEFAULT_CACHE_DIR,
+    api_key: str | None = None,
+    request_interval_seconds: float = DEFAULT_REQUEST_INTERVAL_SECONDS,
+    announcement_time: datetime.time = DEFAULT_ANNOUNCEMENT_TIME,
+    window_minutes: int = DEFAULT_WINDOW_MINUTES,
+    symbol: str = DEFAULT_SYMBOL,
+    sleep_fn: Any = time.sleep,
+    client: httpx.Client | None = None,
+) -> Path:
+    """Fetch ±30 min SPY closes for every ``fomc_dates`` entry and persist
+    the resulting per-event returns to a parquet cache.
+
+    The fetch is grouped by ``(year, month)`` so each Alpha Vantage call
+    serves many events. ``sleep_fn`` is parameterised so tests can pass
+    a no-op; the production default is ``time.sleep`` with the safe
+    13-second spacing that stays under the 5/min free-tier ceiling.
+    """
+
+    import pandas as pd
+
+    cache_dir = Path(cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    parquet_path = cache_dir / INTRADAY_PARQUET
+
+    date_list = sorted({d for d in fomc_dates})
+    if not date_list:
+        raise ValueError("backfill_fomc_days called with an empty fomc_dates iterable")
+    months = _months_covering(date_list)
+    resolved_key = api_key or _api_key_from_env()
+
+    rows_by_date: dict[datetime.date, list[FomcWindowReturn]] = {d: [] for d in date_list}
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS)
+    try:
+        for i, month in enumerate(months):
+            if i > 0:
+                sleep_fn(float(request_interval_seconds))
+            bars = fetch_intraday_minute_bars(
+                api_key=resolved_key,
+                symbol=symbol,
+                interval=DEFAULT_INTERVAL,
+                month=month,
+                client=client,
+            )
+            month_dates = [d for d in date_list if f"{d.year:04d}-{d.month:02d}" == month]
+            for window_row in compute_window_returns(
+                bars,
+                month_dates,
+                symbol=symbol,
+                announcement_time=announcement_time,
+                window_minutes=window_minutes,
+            ):
+                rows_by_date[
+                    datetime.date.fromisoformat(window_row.event_date)
+                ].append(window_row)
+    finally:
+        if owns_client:
+            client.close()
+
+    flat: list[dict[str, Any]] = []
+    for event_date in date_list:
+        for window_row in rows_by_date.get(event_date, []):
+            flat.append(
+                {
+                    "event_date": window_row.event_date,
+                    "pre_close": window_row.pre_close,
+                    "post_close": window_row.post_close,
+                    "return_pct": window_row.return_pct,
+                    "window_minutes": window_row.window_minutes,
+                    "symbol": window_row.symbol,
+                    "fetched_at_utc": window_row.fetched_at_utc,
+                }
+            )
+
+    frame = pd.DataFrame(flat)
+    if not frame.empty:
+        frame = frame.sort_values("event_date").reset_index(drop=True)
+    frame.to_parquet(parquet_path, index=False)
+    _write_sources_lock_entry(
+        cache_dir,
+        parquet_path,
+        sha256=_file_sha256(parquet_path),
+        rows=len(frame),
+        months_fetched=months,
+    )
+    print(
+        f"[alphavantage_spx] wrote {len(frame)} window returns to {parquet_path} "
+        f"({len(months)} month(s) fetched, "
+        f"{len(date_list) - len(frame)} event(s) without coverage)"
+    )
+    return parquet_path
+
+
+def load_window_returns(
+    cache_dir: Path | str = DEFAULT_CACHE_DIR,
+) -> dict[str, float]:
+    """Return ``{event_date_iso: return_pct}`` from the intraday cache.
+
+    Missing parquet returns an empty dict so callers can degrade
+    cleanly to the daily-close proxy when the backfill has not run.
+    """
+
+    import pandas as pd
+
+    parquet_path = Path(cache_dir) / INTRADAY_PARQUET
+    if not parquet_path.exists():
+        return {}
+    frame = pd.read_parquet(parquet_path)
+    if frame.empty:
+        return {}
+    return {
+        str(row["event_date"]): float(row["return_pct"])
+        for _, row in frame.iterrows()
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill SPY 1-min closes around each FOMC announcement."
+    )
+    parser.add_argument(
+        "--fomc-dates",
+        nargs="+",
+        required=True,
+        help="One or more YYYY-MM-DD FOMC event dates.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=DEFAULT_CACHE_DIR,
+    )
+    parser.add_argument(
+        "--request-interval-seconds",
+        type=float,
+        default=DEFAULT_REQUEST_INTERVAL_SECONDS,
+    )
+    parser.add_argument("--symbol", default=DEFAULT_SYMBOL)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    fomc_dates = [datetime.date.fromisoformat(s) for s in args.fomc_dates]
+    backfill_fomc_days(
+        fomc_dates=fomc_dates,
+        cache_dir=args.cache_dir,
+        request_interval_seconds=float(args.request_interval_seconds),
+        symbol=str(args.symbol),
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/app/data/alphavantage_spx.py
+++ b/backend/app/data/alphavantage_spx.py
@@ -347,7 +347,7 @@ def backfill_fomc_days(
     cache_dir.mkdir(parents=True, exist_ok=True)
     parquet_path = cache_dir / INTRADAY_PARQUET
 
-    date_list = sorted({d for d in fomc_dates})
+    date_list = sorted(set(fomc_dates))
     if not date_list:
         raise ValueError("backfill_fomc_days called with an empty fomc_dates iterable")
     months = _months_covering(date_list)

--- a/backend/app/data/mp_surprise.py
+++ b/backend/app/data/mp_surprise.py
@@ -837,6 +837,7 @@ def build_mp_surprises(
     fred_responses: Mapping[str, FredSeriesResponse],
     fomc_calendar: Sequence[FomcMeetingRecord] | None = None,
     spx_close_by_date: Mapping[_dt.date, float] | None = None,
+    spx_intraday_returns: Mapping[str, float] | None = None,
     fomc_calendar_path: Path | str | None = None,
     methodology: str = METHODOLOGY_OIS_PROXY,
 ) -> BuildArtifacts:
@@ -979,13 +980,22 @@ def build_mp_surprises(
 
     # ---- Pass 3: fed-info factor regression on SPX returns ----
     spx_lookup = spx_close_by_date or {}
+    intraday_lookup = dict(spx_intraday_returns or {})
     levels_for_fit: list[float] = []
     spx_for_fit: list[float] = []
     spx_returns_per_meeting: dict[_dt.date, tuple[float | None, str]] = {}
     for m in meetings:
         ed = m.meeting_date
         lvl = per_meeting_delta_level[ed]
-        ret, source = _spx_return_on(ed, spx_lookup)
+        # Prefer the Alpha Vantage intraday ±30 min return when the
+        # backfill cache covers the event. Falls through to the daily
+        # close-to-close proxy when intraday is missing.
+        intraday_value = intraday_lookup.get(ed.isoformat())
+        if intraday_value is not None:
+            ret: float | None = float(intraday_value)
+            source = "alphavantage_intraday_30min"
+        else:
+            ret, source = _spx_return_on(ed, spx_lookup)
         spx_returns_per_meeting[ed] = (ret, source)
         if lvl is None or ret is None:
             continue

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -108,6 +108,7 @@ ignore = [
 # current debt surface and a fresh PR is expected to leave the rule
 # active wherever it does not yet appear here.
 "app/audit.py" = ["PLR0913"]
+"app/data/alphavantage_spx.py" = ["PLR0913"]
 "app/data/attention_ablation.py" = ["PLR0913", "C901"]
 "app/data/build_training_package.py" = ["PLR0913", "C901"]
 "app/data/chunk_embedding_retrieval.py" = ["PLR0913", "C901"]

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -257,9 +257,19 @@ One row per FOMC meeting from 2010-01-01 to today, with:
 - `pre_event_curve`, `post_event_curve` — JSON lists of
   `(months_ahead, implied_rate)` at {1, 3, 6, 12, 24}-month points
 - `fed_info_factor` — residual of `mp_surprise_level` regressed on the
-  same-day SPX return (Cieslak-Vissing-Jorgensen 2021-style
-  decomposition; documented `daily_window_proxy` flag because intraday
-  ±30 min SPX data is out of scope)
+  SPX return around each announcement (Cieslak-Vissing-Jorgensen
+  2021-style decomposition). The `fed_info_factor_source` column
+  records which SPX series the row used:
+  - `alphavantage_intraday_30min` — ±30 min SPY return from
+    `app.data.alphavantage_spx`, cache at
+    `data/external/alphavantage/spx_intraday_fomc_days.parquet`. This
+    is the CVJ-faithful measurement when available.
+  - `daily_window_proxy` — close-to-close return over the
+    `[t-1, t+1]` window from the FRED-licensed daily SPX. Used as a
+    fallback when the intraday cache does not cover the event date.
+  - `unavailable` — neither source had coverage; the row stamps
+    `fed_info_factor = None` so it is distinguishable from a real-
+    but-tiny residual.
 - `is_intermeeting` — true for unscheduled / emergency actions
   (2020-03-03 and 2020-03-15 in the bundled calendar)
 - `methodology` — `ois_proxy` (Treasury-yield proxy via DGS1MO /

--- a/tests/unit/test_alphavantage_spx.py
+++ b/tests/unit/test_alphavantage_spx.py
@@ -1,0 +1,196 @@
+"""Tests for the Alpha Vantage SPX intraday backfill module (#159)."""
+
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+pytest.importorskip("pyarrow")
+
+from app.data import alphavantage_spx
+from app.data.alphavantage_spx import (
+    FomcWindowReturn,
+    IntradayBar,
+    _bracket_window_returns,
+    _months_covering,
+    _parse_intraday_payload,
+    compute_window_returns,
+    load_window_returns,
+)
+
+
+def _synth_payload(date_iso: str, bars: list[dict[str, str]]) -> dict[str, Any]:
+    series = {bar["t"]: {
+        "1. open": bar["o"], "2. high": bar["h"], "3. low": bar["l"],
+        "4. close": bar["c"], "5. volume": bar["v"],
+    } for bar in bars}
+    return {
+        "Meta Data": {"1. Information": "test", "2. Symbol": "SPY"},
+        "Time Series (1min)": series,
+    }
+
+
+def test_parse_intraday_payload_sorts_oldest_first() -> None:
+    payload = _synth_payload(
+        "2024-01-31",
+        [
+            {"t": "2024-01-31 14:30:00", "o": "1", "h": "1", "l": "1", "c": "473.5", "v": "100"},
+            {"t": "2024-01-31 13:30:00", "o": "1", "h": "1", "l": "1", "c": "470.0", "v": "100"},
+            {"t": "2024-01-31 14:00:00", "o": "1", "h": "1", "l": "1", "c": "471.2", "v": "100"},
+        ],
+    )
+    bars = _parse_intraday_payload(payload)
+    assert [b.timestamp_et for b in bars] == [
+        "2024-01-31 13:30:00",
+        "2024-01-31 14:00:00",
+        "2024-01-31 14:30:00",
+    ]
+    assert bars[0].close == pytest.approx(470.0)
+
+
+def test_parse_intraday_rejects_rate_limit_note() -> None:
+    with pytest.raises(RuntimeError, match="rate limit"):
+        _parse_intraday_payload(
+            {"Note": "Thank you for using Alpha Vantage! The free tier..."}
+        )
+
+
+def test_parse_intraday_rejects_error_message() -> None:
+    with pytest.raises(RuntimeError, match="Alpha Vantage error"):
+        _parse_intraday_payload({"Error Message": "Invalid API call"})
+
+
+def test_bracket_window_returns_picks_correct_pre_and_post() -> None:
+    bars = [
+        IntradayBar("2024-01-31 13:25:00", 470.0, 470.0, 470.0, 470.0, 0.0),
+        IntradayBar("2024-01-31 13:30:00", 470.5, 470.5, 470.5, 470.5, 0.0),
+        IntradayBar("2024-01-31 13:59:00", 472.0, 472.0, 472.0, 472.0, 0.0),
+        IntradayBar("2024-01-31 14:00:00", 473.0, 473.0, 473.0, 473.0, 0.0),
+        IntradayBar("2024-01-31 14:30:00", 475.0, 475.0, 475.0, 475.0, 0.0),
+        IntradayBar("2024-01-31 14:35:00", 475.5, 475.5, 475.5, 475.5, 0.0),
+    ]
+    result = _bracket_window_returns(
+        bars,
+        datetime.date(2024, 1, 31),
+        announcement_time=datetime.time(14, 0),
+        window_minutes=30,
+    )
+    assert result is not None
+    pre, post = result
+    assert pre == pytest.approx(470.5)
+    assert post == pytest.approx(475.0)
+
+
+def test_bracket_window_returns_missing_side_returns_none() -> None:
+    # Only post-window bars present; pre-window missing.
+    bars = [
+        IntradayBar("2024-01-31 14:30:00", 475.0, 475.0, 475.0, 475.0, 0.0),
+        IntradayBar("2024-01-31 14:35:00", 475.5, 475.5, 475.5, 475.5, 0.0),
+    ]
+    result = _bracket_window_returns(
+        bars,
+        datetime.date(2024, 1, 31),
+        announcement_time=datetime.time(14, 0),
+        window_minutes=30,
+    )
+    assert result is None
+
+
+def test_compute_window_returns_drops_uncovered_dates() -> None:
+    bars = [
+        IntradayBar("2024-01-31 13:30:00", 470.0, 470.0, 470.0, 470.0, 0.0),
+        IntradayBar("2024-01-31 14:30:00", 475.0, 475.0, 475.0, 475.0, 0.0),
+    ]
+    rows = compute_window_returns(
+        bars,
+        [datetime.date(2024, 1, 31), datetime.date(2024, 3, 20)],
+    )
+    assert len(rows) == 1
+    assert rows[0].event_date == "2024-01-31"
+    assert rows[0].return_pct == pytest.approx((475.0 - 470.0) / 470.0)
+
+
+def test_months_covering_dedupes_and_sorts() -> None:
+    months = _months_covering(
+        [
+            datetime.date(2024, 1, 31),
+            datetime.date(2024, 1, 31),
+            datetime.date(2023, 12, 13),
+            datetime.date(2024, 3, 20),
+        ]
+    )
+    assert months == ["2023-12", "2024-01", "2024-03"]
+
+
+def test_backfill_writes_parquet_and_sources_lock(tmp_path, monkeypatch) -> None:
+    """End-to-end smoke: stubbed Alpha Vantage client, two events
+    spanning two months. Cache + lock file land at the expected paths."""
+
+    bars_jan = [
+        IntradayBar("2024-01-31 13:30:00", 470.0, 470.0, 470.0, 470.0, 0.0),
+        IntradayBar("2024-01-31 14:30:00", 472.5, 472.5, 472.5, 472.5, 0.0),
+    ]
+    bars_mar = [
+        IntradayBar("2024-03-20 13:30:00", 510.0, 510.0, 510.0, 510.0, 0.0),
+        IntradayBar("2024-03-20 14:30:00", 513.0, 513.0, 513.0, 513.0, 0.0),
+    ]
+    calls: list[str] = []
+
+    def fake_fetch(*, api_key, symbol, interval, month, client):
+        calls.append(month)
+        return {"2024-01": bars_jan, "2024-03": bars_mar}[month]
+
+    monkeypatch.setattr(alphavantage_spx, "fetch_intraday_minute_bars", fake_fetch)
+    monkeypatch.setenv("ALPHA_VANTAGE_API_KEY", "test-key")
+    sleep_calls: list[float] = []
+
+    parquet_path = alphavantage_spx.backfill_fomc_days(
+        fomc_dates=[datetime.date(2024, 1, 31), datetime.date(2024, 3, 20)],
+        cache_dir=tmp_path,
+        sleep_fn=lambda s: sleep_calls.append(s),
+    )
+    assert parquet_path == tmp_path / "spx_intraday_fomc_days.parquet"
+    assert parquet_path.exists()
+    assert calls == ["2024-01", "2024-03"]
+    # One sleep between two months (the first call does not delay).
+    assert len(sleep_calls) == 1
+
+    frame = pd.read_parquet(parquet_path)
+    assert len(frame) == 2
+    assert set(frame["event_date"]) == {"2024-01-31", "2024-03-20"}
+
+    lock_path = tmp_path / "SOURCES.lock"
+    assert lock_path.exists()
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    entry = lock["spx_intraday_fomc_days.parquet"]
+    assert entry["rows"] == 2
+    assert entry["months_fetched"] == ["2024-01", "2024-03"]
+    assert entry["source"] == "alphavantage"
+
+
+def test_load_window_returns_missing_cache_returns_empty(tmp_path) -> None:
+    assert load_window_returns(tmp_path) == {}
+
+
+def test_load_window_returns_round_trips_through_parquet(tmp_path) -> None:
+    parquet_path = tmp_path / "spx_intraday_fomc_days.parquet"
+    pd.DataFrame(
+        [
+            {
+                "event_date": "2024-01-31",
+                "pre_close": 470.0,
+                "post_close": 472.5,
+                "return_pct": (472.5 - 470.0) / 470.0,
+                "window_minutes": 30,
+                "symbol": "SPY",
+                "fetched_at_utc": "2026-05-23T10:00:00Z",
+            }
+        ]
+    ).to_parquet(parquet_path, index=False)
+    returns = load_window_returns(tmp_path)
+    assert returns == {"2024-01-31": pytest.approx((472.5 - 470.0) / 470.0)}


### PR DESCRIPTION
Closes #159.

## Summary

- `backend/app/data/alphavantage_spx.py` fetches SPY 1-minute closes around each FOMC announcement via Alpha Vantage `TIME_SERIES_INTRADAY`, computes a ±30 min return, and persists the per-event rows to `data/external/alphavantage/spx_intraday_fomc_days.parquet`. A `SOURCES.lock` entry records the sha256, row count, and months fetched.
- 13-second pacing keeps the request rate under the Alpha Vantage free-tier 5/min ceiling; `sleep_fn` is parameterised so tests pass a no-op.
- `mp_surprise.build_mp_surprises` takes a new `spx_intraday_returns` mapping. Rows whose event_date is covered stamp `fed_info_factor_source = "alphavantage_intraday_30min"` and skip the daily proxy. Rows without coverage keep the existing `daily_window_proxy` fallback.
- `docs/data-and-training-contracts.md` documents the three possible `fed_info_factor_source` values.

## Test plan

- [ ] `pytest tests/unit/test_alphavantage_spx.py -q`
- [ ] `ALPHA_VANTAGE_API_KEY=... python -m app.data.alphavantage_spx --fomc-dates 2024-01-31 2024-03-20` (live smoke; consumes 2 requests of the daily 500-request budget)