### PR TITLE
Add 65% coverage gate to CI pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
         env:
           PYTHONPATH: backend
         run: |
-          pytest tests/unit tests/properties tests/contract tests/regression -q --maxfail=5
+          pytest tests/unit tests/properties tests/contract tests/regression \
+            -q --maxfail=5 \
+            --cov=app --cov-report=term --cov-fail-under=65
 
   frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Chunk of #196 and #222. Coverage threshold gate so a regression below the project floor surfaces in CI instead of weeks later.

## Summary

- `.github/workflows/ci.yml` pytest job now runs with `--cov=app --cov-report=term --cov-fail-under=65`
- 65% matches the audit floor at commit 99fe881 (measured 70%); easy to ratchet up in a follow-up once the four 84-85% modules clear 90%

## Test plan

- [ ] CI pytest job passes on this PR with the new coverage gate