### PR TITLE
Pin base-image digests on backend + frontend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0
 
 WORKDIR /app
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
 
 WORKDIR /app
 


### PR DESCRIPTION
Half of #98 — the digest-pin half. The multi-stage refactor stays deferred to a follow-up because it changes the build mechanics and warrants a full image-rebuild validation cycle.

## Summary

- `backend/Dockerfile` and `frontend/Dockerfile` now pin their base images by sha256 digest instead of floating `python:3.11-slim` and `node:20-alpine` tags
- Dependabot's docker-registry channel keeps emitting digest-bump PRs on schedule; the explicit pin is the reproducibility floor between those updates

## Test plan

- [ ] `docker compose build backend frontend` (smoke; verify the digests resolve)