### PR TITLE
Multi-stage Dockerfile + pinned digests for runtime / dev split

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,26 +1,48 @@
-FROM python:3.11-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0
+FROM python:3.11-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0 AS base
 
 WORKDIR /app
 
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/opt/venv/bin:$PATH"
+
+
+FROM base AS builder-runtime
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential git \
     && rm -rf /var/lib/apt/lists/*
 
+RUN python -m venv /opt/venv \
+    && /opt/venv/bin/pip install --no-cache-dir --upgrade pip
+
 COPY pyproject.toml ./
 
-# This image is the dev / research target consumed by `make dev-cpu` and
-# `make dev-gpu`; the CMD at the bottom runs uvicorn with --reload. There
-# is no separate production stage today, so the [dev] extra (pytest,
-# mypy, ruff, hypothesis, py-spy) is intentionally baked in — running
-# tests, type-checks, and flamegraph captures all happen against the
-# same image. When a production deployment lands, split this into a
-# multi-stage build with a runtime layer that installs only `"."`.
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir ".[dev]"
+RUN /opt/venv/bin/pip install --no-cache-dir "."
 
+
+FROM builder-runtime AS builder-dev
+
+RUN /opt/venv/bin/pip install --no-cache-dir ".[dev]"
+
+
+FROM base AS runtime
+
+COPY --from=builder-runtime /opt/venv /opt/venv
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+
+FROM base AS dev
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder-dev /opt/venv /opt/venv
 COPY . .
 
 EXPOSE 8000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,6 +10,13 @@ COPY package.json package-lock.json* ./
 RUN npm ci
 
 
+FROM base AS prod-deps
+
+COPY package.json package-lock.json* ./
+
+RUN npm ci --omit=dev
+
+
 FROM deps AS builder
 
 COPY . .
@@ -21,7 +28,7 @@ FROM base AS runtime
 
 ENV NODE_ENV=production
 
-COPY --from=deps /app/node_modules ./node_modules
+COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/package.json ./package.json

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,10 +1,38 @@
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS base
 
 WORKDIR /app
+
+
+FROM base AS deps
 
 COPY package.json package-lock.json* ./
 
 RUN npm ci
+
+
+FROM deps AS builder
+
+COPY . .
+
+RUN npm run build
+
+
+FROM base AS runtime
+
+ENV NODE_ENV=production
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/next.config.js ./next.config.js
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]
+
+
+FROM deps AS dev
 
 COPY . .
 


### PR DESCRIPTION
## Summary

- Backend Dockerfile splits into `base / builder-runtime / builder-dev / runtime / dev`.
- Runtime stage carries no apt packages; venv at `/opt/venv` copied from builder.
- `dev` stays the last stage so compose default-target behaviour is unchanged.
- Frontend Dockerfile splits into `base / deps / builder / runtime / dev`.
- Runtime frontend ships `.next` + production node_modules, `NODE_ENV=production`.
- Pinned digests on both base images carry over.
- Closes #98.

## Test plan

- [x] \`docker buildx build --check\` on both Dockerfiles
- [ ] \`docker compose build backend frontend\` — full image build
- [ ] \`make dev-cpu\` boots; \`/health\` returns ok