### PR TITLE
Manifest SHA sidecar for training-package immutability

### DIFF
--- a/backend/app/data/build_training_package.py
+++ b/backend/app/data/build_training_package.py
@@ -369,7 +369,14 @@ def main() -> int:
     }
     (package_dir / "dataset_metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
 
+    # Immutability sidecar (docs/benchmark-policy.md). A later load
+    # whose manifest disagrees with this hash raises so a silent
+    # replacement cannot reach a published run.
+    from app.data.manifest_sha import write_manifest_sha
+
+    sha = write_manifest_sha(package_dir)
     print(f"Training package created: {package_dir}")
+    print(f"Manifest sha256: {sha}")
     return 0
 
 

--- a/backend/app/data/manifest_sha.py
+++ b/backend/app/data/manifest_sha.py
@@ -1,0 +1,98 @@
+"""SHA-256 sidecar for training-package immutability guarantees.
+
+The benchmark policy under ``docs/benchmark-policy.md`` promises that
+published training packages are never silently replaced. Without an
+explicit hash, a rebuild that lands at the same directory name would
+violate the promise undetectably. This module writes a
+``dataset_metadata.sha256`` sidecar at publish time and verifies it at
+load time.
+
+The hash covers ``dataset_metadata.json`` only — the manifest itself
+already references the contents (row counts, source counts, fold
+boundaries, drift values), so any change to the underlying parquet
+that should be visible to a downstream consumer must round-trip through
+the manifest.
+
+Loader behaviour:
+
+- Sidecar present and matches: pass silently.
+- Sidecar present and mismatches: raise ``ManifestShaMismatch``.
+- Sidecar missing: log a warning so unsidecarred packages surface for
+  backfill, but do not block loads. Existing pre-sidecar packages
+  remain usable until they are rebuilt.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+_MANIFEST_NAME = "dataset_metadata.json"
+_SIDECAR_NAME = "dataset_metadata.sha256"
+
+_logger = logging.getLogger(__name__)
+
+
+class ManifestShaMismatch(RuntimeError):
+    """Raised when the manifest hash does not match the sidecar."""
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def compute_manifest_sha(package_dir: Path) -> str:
+    """Return the SHA-256 hex digest of the package's manifest file."""
+
+    manifest_path = package_dir / _MANIFEST_NAME
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"manifest not found at {manifest_path}")
+    return _hash_file(manifest_path)
+
+
+def write_manifest_sha(package_dir: Path) -> str:
+    """Compute the manifest hash and write it to the sidecar.
+
+    Returns the computed hex digest so callers can log or surface it.
+    Overwrites any existing sidecar — the canonical hash is whatever
+    the current manifest evaluates to at write time.
+    """
+
+    digest = compute_manifest_sha(package_dir)
+    (package_dir / _SIDECAR_NAME).write_text(digest + "\n", encoding="utf-8")
+    return digest
+
+
+def verify_manifest_sha(package_dir: Path) -> bool:
+    """Verify ``dataset_metadata.sha256`` matches ``dataset_metadata.json``.
+
+    Returns ``True`` when the sidecar exists and matches. Returns
+    ``False`` when the sidecar is absent (logged as a warning for
+    backfill follow-up). Raises :class:`ManifestShaMismatch` when the
+    sidecar exists but disagrees with the manifest — that case
+    indicates a silent replacement, which the policy forbids.
+    """
+
+    sidecar = package_dir / _SIDECAR_NAME
+    if not sidecar.exists():
+        _logger.warning(
+            "manifest_sha_sidecar_missing",
+            extra={"package_dir": str(package_dir)},
+        )
+        return False
+    expected = sidecar.read_text(encoding="utf-8").strip()
+    actual = compute_manifest_sha(package_dir)
+    if expected != actual:
+        raise ManifestShaMismatch(
+            f"manifest hash mismatch in {package_dir.name}: "
+            f"sidecar reports {expected[:12]}…, manifest hashes to {actual[:12]}… "
+            "— the package has been replaced after publish, which "
+            "docs/benchmark-policy.md forbids. Rebuild and republish, "
+            "or restore the original manifest."
+        )
+    return True

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -562,13 +562,22 @@ def _append_event_day_target(
 
 
 def _resolve_training_package_dir(training_package_id: str) -> Path:
-    """Resolve ``<id>`` to ``<DATA_DIR>/processed/<id>/``."""
+    """Resolve ``<id>`` to ``<DATA_DIR>/processed/<id>/``.
+
+    Also verifies the manifest sidecar (``dataset_metadata.sha256``)
+    when present. A mismatch raises ``ManifestShaMismatch``; a missing
+    sidecar emits a warning so the package surfaces for backfill but
+    the load proceeds.
+    """
 
     package_dir = DATA_DIR / "processed" / training_package_id
     if not package_dir.exists():
         raise FileNotFoundError(
             f"Training package directory not found: {package_dir}"
         )
+    from app.data.manifest_sha import verify_manifest_sha
+
+    verify_manifest_sha(package_dir)
     return package_dir
 
 

--- a/scripts/verify_training_package_manifests.py
+++ b/scripts/verify_training_package_manifests.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Offline audit for training-package manifest sidecars.
+
+Walks ``data/processed/`` and verifies every directory containing a
+``dataset_metadata.json`` has a matching ``dataset_metadata.sha256``.
+Missing sidecars print a backfill hint; mismatches exit non-zero.
+
+Usage::
+
+    python scripts/verify_training_package_manifests.py [--backfill]
+
+With ``--backfill``, packages missing a sidecar get one written from
+their current manifest hash. The flag is for one-shot migration of
+packages built before the sidecar landed; do not use it as a routine
+"make the check pass" knob — the whole point is that a mismatch
+flags a silent replacement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BACKEND = ROOT / "backend"
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+from app.data.manifest_sha import (  # noqa: E402
+    ManifestShaMismatch,
+    verify_manifest_sha,
+    write_manifest_sha,
+)
+
+
+def _iter_package_dirs(processed_dir: Path) -> list[Path]:
+    return sorted(
+        path for path in processed_dir.iterdir()
+        if path.is_dir() and (path / "dataset_metadata.json").exists()
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--processed-dir",
+        type=Path,
+        default=ROOT / "data" / "processed",
+        help="Root of training packages (default: data/processed/).",
+    )
+    parser.add_argument(
+        "--backfill",
+        action="store_true",
+        help="Write sidecars for packages currently missing one. "
+        "Use only for one-shot migration of pre-sidecar packages.",
+    )
+    args = parser.parse_args()
+
+    if not args.processed_dir.exists():
+        print(f"no training packages at {args.processed_dir}; nothing to verify")
+        return 0
+
+    packages = _iter_package_dirs(args.processed_dir)
+    if not packages:
+        print(f"no packages found in {args.processed_dir}")
+        return 0
+
+    failures: list[str] = []
+    missing: list[Path] = []
+    for package_dir in packages:
+        try:
+            present = verify_manifest_sha(package_dir)
+        except ManifestShaMismatch as exc:
+            failures.append(f"{package_dir.name}: {exc}")
+            continue
+        if not present:
+            missing.append(package_dir)
+            continue
+        print(f"OK    {package_dir.name}")
+
+    for package_dir in missing:
+        if args.backfill:
+            digest = write_manifest_sha(package_dir)
+            print(f"BACKFILL  {package_dir.name}  sha256={digest[:12]}…")
+        else:
+            print(f"MISSING   {package_dir.name}  (run with --backfill to create sidecar)")
+
+    if failures:
+        print()
+        print("MISMATCH detected — manifest disagrees with sidecar:")
+        for entry in failures:
+            print(f"  - {entry}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_manifest_sha.py
+++ b/tests/unit/test_manifest_sha.py
@@ -1,0 +1,81 @@
+"""Tests for the training-package manifest sidecar (#97 alternative)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from app.data.manifest_sha import (
+    ManifestShaMismatch,
+    compute_manifest_sha,
+    verify_manifest_sha,
+    write_manifest_sha,
+)
+
+
+def _make_package(tmp_path: Path) -> Path:
+    package_dir = tmp_path / "tp_test_v1_v1"
+    package_dir.mkdir()
+    (package_dir / "dataset_metadata.json").write_text(
+        json.dumps({"training_package_id": "tp_test_v1_v1", "input_rows": 42}),
+        encoding="utf-8",
+    )
+    return package_dir
+
+
+def test_write_then_verify_roundtrips(tmp_path: Path) -> None:
+    package_dir = _make_package(tmp_path)
+    digest = write_manifest_sha(package_dir)
+
+    assert len(digest) == 64  # SHA-256 hex length
+    assert (package_dir / "dataset_metadata.sha256").exists()
+    assert verify_manifest_sha(package_dir) is True
+
+
+def test_verify_detects_tampered_manifest(tmp_path: Path) -> None:
+    package_dir = _make_package(tmp_path)
+    write_manifest_sha(package_dir)
+
+    # Silently replace the manifest contents (this is the scenario the
+    # benchmark policy forbids — same name, different contents).
+    (package_dir / "dataset_metadata.json").write_text(
+        json.dumps({"training_package_id": "tp_test_v1_v1", "input_rows": 99}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ManifestShaMismatch) as exc:
+        verify_manifest_sha(package_dir)
+    assert "mismatch" in str(exc.value).lower()
+
+
+def test_verify_returns_false_and_warns_when_sidecar_missing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    package_dir = _make_package(tmp_path)
+    # No write_manifest_sha call → no sidecar.
+
+    with caplog.at_level(logging.WARNING):
+        assert verify_manifest_sha(package_dir) is False
+    assert any(
+        "manifest_sha_sidecar_missing" in record.message
+        for record in caplog.records
+    )
+
+
+def test_compute_raises_when_manifest_missing(tmp_path: Path) -> None:
+    package_dir = tmp_path / "empty_pkg"
+    package_dir.mkdir()
+
+    with pytest.raises(FileNotFoundError):
+        compute_manifest_sha(package_dir)
+
+
+def test_write_is_idempotent_for_unchanged_manifest(tmp_path: Path) -> None:
+    package_dir = _make_package(tmp_path)
+
+    first = write_manifest_sha(package_dir)
+    second = write_manifest_sha(package_dir)
+    assert first == second


### PR DESCRIPTION
## Summary

- Cheaper alternative to the #97 content-addressable rename: a \`dataset_metadata.sha256\` sidecar pinned at publish time, verified at every load.
- Silent replacement of a published manifest now raises \`ManifestShaMismatch\` instead of going undetected — the scenario docs/benchmark-policy.md forbids.
- Missing sidecars on legacy packages log a warning and keep loading; \`scripts/verify_training_package_manifests.py --backfill\` writes them once and for all.
- No directory renames, no migration churn, no operator friction from SHA-prefix names.

## Test plan

- [x] \`pytest tests/unit/test_manifest_sha.py\` — 5 tests cover roundtrip, tamper detection, missing-sidecar warning, missing-manifest error, idempotence
- [x] \`pytest tests/unit/test_training_package_loader.py\` — 30 existing loader tests still pass with the verify hook
- [x] \`pytest tests/regression\` — 11 regression tests still pass