### PR TITLE
Retire AnalyzeForm forecast-mode selector + polling state (#265 phase 1)

### DIFF
--- a/frontend/components/analyze/AnalyzeForm.tsx
+++ b/frontend/components/analyze/AnalyzeForm.tsx
@@ -13,7 +13,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { HORIZON_OPTIONS, SYMBOL_OPTIONS } from "@/lib/analyze/constants";
-import type { AnalyzeRequest, ForecastMode, Horizon } from "@/lib/analyze/types";
+import type { AnalyzeRequest, Horizon } from "@/lib/analyze/types";
 
 interface AnalyzeFormProps {
   value: AnalyzeRequest;
@@ -22,18 +22,8 @@ interface AnalyzeFormProps {
   loading: boolean;
 }
 
-const MODE_OPTIONS: Array<{ value: ForecastMode; label: string; description: string }> = [
-  { value: "fast", label: "Fast", description: "Checkpoint inference, low latency." },
-  { value: "quick_train", label: "Quick Train", description: "Short bounded adaptation before inference." },
-  { value: "real_train", label: "Real Train", description: "Async 252-day fine-tune, polled to completion." },
-];
-
 export function AnalyzeForm({ value, onChange, onSubmit, loading }: AnalyzeFormProps) {
-  const submitLabel = loading
-    ? value.forecast_mode === "real_train"
-      ? "Running Real Train…"
-      : "Running analysis…"
-    : "Analyze";
+  const submitLabel = loading ? "Running analysis…" : "Analyze";
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -57,7 +47,7 @@ export function AnalyzeForm({ value, onChange, onSubmit, loading }: AnalyzeFormP
             onChange={(text) => patch({ text })}
           />
 
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <div className="grid gap-4 md:grid-cols-3">
             <div className="space-y-2">
               <Label htmlFor="date">Document date</Label>
               <Input
@@ -83,28 +73,6 @@ export function AnalyzeForm({ value, onChange, onSubmit, loading }: AnalyzeFormP
                   ))}
                 </SelectContent>
               </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="mode">Forecast mode</Label>
-              <Select
-                value={value.forecast_mode}
-                onValueChange={(next) => patch({ forecast_mode: next as ForecastMode })}
-              >
-                <SelectTrigger id="mode">
-                  <SelectValue placeholder="Mode" />
-                </SelectTrigger>
-                <SelectContent>
-                  {MODE_OPTIONS.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-muted-foreground">
-                {MODE_OPTIONS.find((m) => m.value === value.forecast_mode)?.description}
-              </p>
             </div>
 
             <div className="space-y-2">
@@ -147,9 +115,6 @@ export function AnalyzeForm({ value, onChange, onSubmit, loading }: AnalyzeFormP
             <Button type="submit" disabled={loading}>
               {submitLabel}
             </Button>
-            <p className="text-xs text-muted-foreground">
-              Real Train returns a job id and polls every {2}s.
-            </p>
           </div>
         </form>
       </CardContent>

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -22,30 +22,12 @@ export function resolveApiBaseUrl(): string {
   return raw;
 }
 
-export type AnalyzeResponse =
-  | { mode: "result"; result: AnalyzeResult }
-  | { mode: "queued"; job: TrainJobState };
-
 export async function postAnalyze(
   baseUrl: string,
   request: AnalyzeRequest
-): Promise<AnalyzeResponse> {
+): Promise<AnalyzeResult> {
   const response = await axios.post(`${baseUrl}/analyze`, request);
-  const data = response.data || {};
-  if (request.forecast_mode === "real_train") {
-    const jobId = (data as { job_id?: string }).job_id;
-    if (!jobId) throw new Error("Real Train did not return a job id.");
-    return {
-      mode: "queued",
-      job: {
-        job_id: jobId,
-        status: (data as { status?: TrainJobState["status"] }).status || "queued",
-        message: (data as { message?: string }).message || "Real Train queued.",
-        error: null,
-      },
-    };
-  }
-  return { mode: "result", result: data as AnalyzeResult };
+  return (response.data || {}) as AnalyzeResult;
 }
 
 export async function fetchTrainJob(baseUrl: string, jobId: string): Promise<TrainJobState> {

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -6,7 +6,10 @@ export interface AnalyzeRequest {
   text: string;
   date: string;
   symbol: SymbolValue;
-  forecast_mode: ForecastMode;
+  // forecast_mode is retired from the frontend (#265). Field is optional
+  // so older history rows still type-check; new requests omit it and the
+  // backend defaults to "fast".
+  forecast_mode?: ForecastMode;
   horizon: Horizon;
   include_realized: boolean;
   include_xai?: boolean;

--- a/frontend/pages/analyze.tsx
+++ b/frontend/pages/analyze.tsx
@@ -9,25 +9,20 @@ import { ErrorBadges } from "@/components/analyze/ErrorBadges";
 import { ForecastChart } from "@/components/analyze/ForecastChart";
 import { MarketContext } from "@/components/analyze/MarketContext";
 import { PredictionCards } from "@/components/analyze/PredictionCards";
-import { RealTrainStatus } from "@/components/analyze/RealTrainStatus";
 import { SentimentCard } from "@/components/analyze/SentimentCard";
 import { WatchlistChips } from "@/components/analyze/WatchlistChips";
 import { Header } from "@/components/shell/header";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { fetchTrainJob, postAnalyze, resolveApiBaseUrl } from "@/lib/analyze/api";
-import {
-  DEFAULT_TEXT,
-  REAL_TRAIN_POLL_INTERVAL_MS,
-  REAL_TRAIN_POLL_MAX,
-} from "@/lib/analyze/constants";
+import { postAnalyze, resolveApiBaseUrl } from "@/lib/analyze/api";
+import { DEFAULT_TEXT } from "@/lib/analyze/constants";
 import {
   buildCloseSeries,
   buildVolatilitySeries,
   computeErrorMetrics,
 } from "@/lib/analyze/derive";
 import { bandLabel } from "@/lib/analyze/format";
-import type { AnalyzeRequest, AnalyzeResult, TrainJobState } from "@/lib/analyze/types";
+import type { AnalyzeRequest, AnalyzeResult } from "@/lib/analyze/types";
 
 // Lazy-load fixture-driven panels so the fixture module never ships to the
 // default analyze bundle. Only loaded when the toggle is on or when the API
@@ -42,32 +37,16 @@ function defaultRequest(): AnalyzeRequest {
     text: DEFAULT_TEXT,
     date: new Date().toISOString().slice(0, 10),
     symbol: "^GSPC",
-    forecast_mode: "fast",
     horizon: "3d",
     include_realized: false,
     include_xai: true,
   };
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function trainJobMessage(state: TrainJobState): string {
-  if (state.message) return state.message;
-  if (state.status === "running") {
-    return "Real Train running on 252-day history…";
-  }
-  if (state.status === "queued") return "Real Train queued…";
-  if (state.status === "succeeded") return "Real Train completed. Rendering results.";
-  return "";
-}
-
 export default function AnalyzePage() {
   const router = useRouter();
   const [request, setRequest] = React.useState<AnalyzeRequest>(defaultRequest);
   const [result, setResult] = React.useState<AnalyzeResult | null>(null);
-  const [trainJob, setTrainJob] = React.useState<TrainJobState | null>(null);
   const [loading, setLoading] = React.useState(false);
   const [previewV2, setPreviewV2] = React.useState(false);
   const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
@@ -110,33 +89,10 @@ export default function AnalyzePage() {
 
   const handleSubmit = async () => {
     setLoading(true);
-    setTrainJob(null);
     try {
-      const response = await postAnalyze(apiBaseUrl, request);
-      if (response.mode === "result") {
-        setResult(response.result);
-        toast.success("Forecast ready");
-        return;
-      }
-
-      setResult(null);
-      setTrainJob(response.job);
-      toast.info("Real Train queued — polling for completion");
-
-      for (let i = 0; i < REAL_TRAIN_POLL_MAX; i += 1) {
-        await sleep(REAL_TRAIN_POLL_INTERVAL_MS);
-        const next = await fetchTrainJob(apiBaseUrl, response.job.job_id);
-        setTrainJob({ ...next, message: trainJobMessage(next) });
-        if (next.status === "succeeded") {
-          setResult(next.result ?? null);
-          toast.success("Real Train completed");
-          return;
-        }
-        if (next.status === "failed") {
-          throw new Error(next.error || "Real Train job failed.");
-        }
-      }
-      throw new Error("Real Train timed out while waiting for completion.");
+      const result = await postAnalyze(apiBaseUrl, request);
+      setResult(result);
+      toast.success("Forecast ready");
     } catch (err) {
       setResult(null);
       const message =
@@ -197,7 +153,6 @@ export default function AnalyzePage() {
             onSelect={(symbol) => setRequest((value) => ({ ...value, symbol }))}
           />
 
-          {trainJob ? <RealTrainStatus job={trainJob} /> : null}
 
           {loading && !result ? (
             <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/frontend/tests/components/analyze/AnalyzeForm.test.tsx
+++ b/frontend/tests/components/analyze/AnalyzeForm.test.tsx
@@ -9,7 +9,6 @@ function baseRequest(): AnalyzeRequest {
     text: "Recent indicators…",
     date: "2024-09-18",
     symbol: "^GSPC",
-    forecast_mode: "fast",
     horizon: "3d",
     include_realized: false,
   };
@@ -43,15 +42,15 @@ describe("AnalyzeForm", () => {
     expect(onSubmit).toHaveBeenCalled();
   });
 
-  it("shows real-train submit label while loading", () => {
+  it("disables the submit button while loading", () => {
     render(
       <AnalyzeForm
-        value={{ ...baseRequest(), forecast_mode: "real_train" }}
+        value={baseRequest()}
         onChange={vi.fn()}
         onSubmit={vi.fn()}
         loading
       />
     );
-    expect(screen.getByRole("button", { name: /running real train/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /running analysis/i })).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary

Frontend stops offering the deprecated \`quick_train\` / \`real_train\` modes. The analyze page now runs a synchronous \`fast\`-mode request and renders the result inline — no queued state, no polling loop, no RealTrainStatus card.

- \`AnalyzeForm\`: mode selector removed; form is now date + asset + horizon on a 3-column grid.
- \`analyze.tsx\`: trainJob state + polling loop + RealTrainStatus render gone; \`postAnalyze\` returns \`AnalyzeResult\` directly.
- \`lib/analyze/api.ts\`: \`AnalyzeResponse\` union collapsed to a flat \`AnalyzeResult\`. \`fetchTrainJob\` stays for the \`/training\` and \`/training/[id]\` pages until their cleanup lands in the next phase.
- \`lib/analyze/types.ts\`: \`forecast_mode\` becomes optional on \`AnalyzeRequest\` so HistoryDetail rows that carry the field still type-check.

Tracks #265. Phase 2 (backend schema, /train-jobs endpoints, /training pages, worker) ships in a follow-up.

## Test plan

- [x] \`npm run type-check\` — clean (the pre-existing @react-pdf/renderer error on dev is unrelated)
- [x] \`npm test tests/components/analyze/AnalyzeForm.test.tsx\` — 4 tests, all pass after dropping the real-train submit-label test
- [ ] \`make dev-cpu\` — manual smoke on the form + analyze page