### PR TITLE
VIX term structure + yield-curve slope features (Path B Chunk 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,11 +34,12 @@ VOYAGE_API_KEY=
 # https://console.anthropic.com/settings/keys.
 ANTHROPIC_API_KEY=
 
-# Alpha Vantage API key used as the fallback historical-bar source when
-# yfinance rate-limits or returns thin coverage on cross-asset symbols
-# (VIX term-structure series, T-bill yields, credit-spread proxies).
-# Free tier covers 25 requests / day; that is enough for the one-shot
-# event-dataset rebuild after a feature surface change. Get a key at
+# Alpha Vantage API key, consumed by
+# `backend/app/data/alphavantage_spx.py` for the intraday SPX backfill
+# the post-correction programme uses as ground truth for the
+# announcement-window magnitude target (Round 6 trigger surface).
+# Free tier covers 25 requests / day; the intraday backfill stays
+# under that limit on a single-asset pull. Get a key at
 # https://www.alphavantage.co/support/#api-key. The legacy alias
 # ALPHAVANTAGE_API_KEY (no underscore) is also read.
 ALPHA_VANTAGE_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,15 @@ VOYAGE_API_KEY=
 # https://console.anthropic.com/settings/keys.
 ANTHROPIC_API_KEY=
 
+# Alpha Vantage API key used as the fallback historical-bar source when
+# yfinance rate-limits or returns thin coverage on cross-asset symbols
+# (VIX term-structure series, T-bill yields, credit-spread proxies).
+# Free tier covers 25 requests / day; that is enough for the one-shot
+# event-dataset rebuild after a feature surface change. Get a key at
+# https://www.alphavantage.co/support/#api-key. The legacy alias
+# ALPHAVANTAGE_API_KEY (no underscore) is also read.
+ALPHA_VANTAGE_API_KEY=
+
 # Optional runtime overrides; defaults work for the standard docker setup.
 # FED_PULSE_DATA_DIR=/data
 # FED_PULSE_MODEL_CHECKPOINT_DIR=/app/models

--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -173,6 +173,15 @@ CROSS_ASSET_SYMBOLS: tuple[tuple[str, str], ...] = (
     ("DX-Y.NYB", "dxy_close"),
     ("^TNX", "tnx_close"),
     ("GC=F", "gold_close"),
+    # Chunk 1 of Path B (#239 / Round 1 follow-up): VIX term structure
+    # + short-end yield. ``^VIX3M`` is the 3-month CBOE volatility
+    # index; the ratio against the 30-day ^VIX is the textbook
+    # vol-regime warning signal (backwardation = stressed). ``^IRX``
+    # is the 13-week T-bill yield (×100); combined with ^TNX it pins
+    # the 10Y–3M yield-curve slope, which the vol-forecasting
+    # literature consistently uses as a regime predictor.
+    ("^VIX3M", "vix3m_close"),
+    ("^IRX", "irx_close"),
 )
 MARKET_MODEL_WINDOW_DAYS = 252
 VOL_WINDOW_DAYS = 10
@@ -321,6 +330,16 @@ class _PriorBar:
     dxy_close: float = 0.0
     tnx_close: float = 0.0
     gold_close: float = 0.0
+    # Path B Chunk 1: VIX term structure + short-end yield. Raw closes
+    # for the new series; the per-bar emission below computes the two
+    # derived slopes (``vix_term_slope``, ``yield_curve_slope_10y_3m``)
+    # so the model sees both the levels and the stationary spreads.
+    # Series with no observation default to 0.0 — same back-compat
+    # contract as the original four cross-asset axes.
+    vix3m_close: float = 0.0
+    irx_close: float = 0.0
+    vix_term_slope: float = 0.0
+    yield_curve_slope_10y_3m: float = 0.0
 
 
 @dataclass
@@ -758,6 +777,24 @@ def _build_prior_window(
             if cross_asset_lookup is not None
             else {}
         )
+        vix_close_val = float(cross_asset_row.get("vix_close", 0.0))
+        tnx_close_val = float(cross_asset_row.get("tnx_close", 0.0))
+        vix3m_close_val = float(cross_asset_row.get("vix3m_close", 0.0))
+        irx_close_val = float(cross_asset_row.get("irx_close", 0.0))
+        # Derived slopes. Both go to 0.0 when either input is missing
+        # (the join-day default) so the rich-feature block stays
+        # numerically clean on pre-2002 bars where VIX3M does not exist
+        # and the loader's per-fold scaler does not see NaN.
+        vix_term_slope_val = (
+            math.log(vix3m_close_val / vix_close_val)
+            if vix3m_close_val > 0.0 and vix_close_val > 0.0
+            else 0.0
+        )
+        yield_curve_slope_val = (
+            tnx_close_val - irx_close_val
+            if tnx_close_val > 0.0 and irx_close_val > 0.0
+            else 0.0
+        )
         bars.append(
             _PriorBar(
                 date=bar_date,
@@ -767,10 +804,14 @@ def _build_prior_window(
                 cum_return_20d=cum_return,
                 vol_20d=extra_vols.get(20, 0.0),
                 vol_60d=extra_vols.get(60, 0.0),
-                vix_close=float(cross_asset_row.get("vix_close", 0.0)),
+                vix_close=vix_close_val,
                 dxy_close=float(cross_asset_row.get("dxy_close", 0.0)),
-                tnx_close=float(cross_asset_row.get("tnx_close", 0.0)),
+                tnx_close=tnx_close_val,
                 gold_close=float(cross_asset_row.get("gold_close", 0.0)),
+                vix3m_close=vix3m_close_val,
+                irx_close=irx_close_val,
+                vix_term_slope=vix_term_slope_val,
+                yield_curve_slope_10y_3m=yield_curve_slope_val,
             )
         )
     # Enforce no look-ahead: last prior bar must be < as_of
@@ -1122,6 +1163,10 @@ def _prior_window_sha(bars: Sequence[_PriorBar]) -> str:
                     f"{b.dxy_close:.6f}",
                     f"{b.tnx_close:.6f}",
                     f"{b.gold_close:.6f}",
+                    f"{b.vix3m_close:.6f}",
+                    f"{b.irx_close:.6f}",
+                    f"{b.vix_term_slope:.6f}",
+                    f"{b.yield_curve_slope_10y_3m:.6f}",
                 ]
             )
         )
@@ -1142,6 +1187,10 @@ def _bars_to_json(bars: Sequence[_PriorBar]) -> str:
             "dxy_close": round(b.dxy_close, 6),
             "tnx_close": round(b.tnx_close, 6),
             "gold_close": round(b.gold_close, 6),
+            "vix3m_close": round(b.vix3m_close, 6),
+            "irx_close": round(b.irx_close, 6),
+            "vix_term_slope": round(b.vix_term_slope, 6),
+            "yield_curve_slope_10y_3m": round(b.yield_curve_slope_10y_3m, 6),
         }
         for b in bars
     ]

--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -785,6 +785,14 @@ def _build_prior_window(
         # (the join-day default) so the rich-feature block stays
         # numerically clean on pre-2002 bars where VIX3M does not exist
         # and the loader's per-fold scaler does not see NaN.
+        #
+        # Unit contract: ^TNX and ^IRX both come from Yahoo Finance and
+        # both are quoted as percent yields on the same scale (e.g.
+        # TNX ~= 4.20 means 4.20% on the 10Y, IRX ~= 5.10 means 5.10%
+        # on the 13-week T-bill). The subtraction is therefore the
+        # 10Y-3M slope in percentage points; an inversion shows up as
+        # a negative number. VIX3M / VIX is a unitless ratio so the
+        # log-slope is also unitless.
         vix_term_slope_val = (
             math.log(vix3m_close_val / vix_close_val)
             if vix3m_close_val > 0.0 and vix_close_val > 0.0

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -115,12 +115,14 @@ RICH_REALIZED_VOL_SLICE = slice(
     RICH_MULTI_AXIS_SLICE.stop,
     RICH_MULTI_AXIS_SLICE.stop + RICH_REALIZED_VOL_DIM,
 )
-# A3 (#208) cross-asset slice (positions [37:41]).
+# A3 (#208) cross-asset slice (positions [37:45] after Path B Chunk 1:
+# VIX, DXY, TNX, gold, VIX3M, IRX, vix_term_slope, yield_curve_slope_10y_3m).
 RICH_CROSS_ASSET_SLICE = slice(
     RICH_REALIZED_VOL_SLICE.stop,
     RICH_REALIZED_VOL_SLICE.stop + RICH_CROSS_ASSET_DIM,
 )
-# B1 (#212) LLM-as-features slice (positions [41:76] one-hot + 76 flag).
+# B1 (#212) LLM-as-features slice (positions [45:80] one-hot + 80 flag
+# after Path B Chunk 1 widened cross-asset by 4).
 RICH_LLM_FEATURE_SLICE = slice(
     RICH_CROSS_ASSET_SLICE.stop,
     RICH_CROSS_ASSET_SLICE.stop + RICH_LLM_FEATURE_DIM,

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -62,7 +62,15 @@ RICH_REALIZED_VOL_DIM = 2
 # gold). Each is a single float per bar. VIX is the market's own
 # forward-vol forecast; the others capture risk-on/risk-off (DXY),
 # the rates-pricing layer (TNX), and flight-to-safety (gold).
-RICH_CROSS_ASSET_DIM = 4
+# Path B Chunk 1 (#239 follow-up): widened from 4 (VIX, DXY, TNX, gold)
+# to 8 by adding the 3M VIX term-structure series, the 13-week T-bill
+# yield, plus two derived stationary slopes (VIX term slope, 10Y-3M
+# yield-curve slope). These are the macro features the vol-forecasting
+# literature consistently relies on; the raw levels alone were not
+# sufficient. Bumps RICH_FEATURE_SIZE by 4 (the four new dims); old
+# checkpoints carrying the pre-widen size become incompatible and the
+# next sweep refits both the model and the per-fold RobustScaler.
+RICH_CROSS_ASSET_DIM = 8
 # B1 (#212) LLM-as-features one-hot block. 10 catalogue features with
 # {4, 4, 5, 4, 4, 4, 2, 2, 3, 3} levels = 35 one-hot dimensions plus
 # one ``llm_features_missing`` flag for events where the extraction
@@ -455,6 +463,14 @@ class FeatureVector:
     dxy_close: float = 0.0
     tnx_close: float = 0.0
     gold_close: float = 0.0
+    # Path B Chunk 1: VIX term structure + short-end yield + the two
+    # derived stationary slopes. Same back-compat contract as the
+    # original four — missing fields on pre-widen events.parquet
+    # default to 0.0 in the loader.
+    vix3m_close: float = 0.0
+    irx_close: float = 0.0
+    vix_term_slope: float = 0.0
+    yield_curve_slope_10y_3m: float = 0.0
     # B1 (#212) LLM-as-features one-hot block. 35-dim list mirroring
     # the catalogue order; each per-feature slot is a one-hot over the
     # feature's allowed levels. Default ``None`` keeps the regression /
@@ -578,6 +594,10 @@ class FeatureVector:
             float(self.dxy_close),
             float(self.tnx_close),
             float(self.gold_close),
+            float(self.vix3m_close),
+            float(self.irx_close),
+            float(self.vix_term_slope),
+            float(self.yield_curve_slope_10y_3m),
         ]
         # B1 (#212) LLM-as-features block. When ``llm_features`` is
         # ``None`` (legacy path or extraction not yet attached) the

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -427,6 +427,13 @@ def _bars_to_feature_vectors(
         dxy_close_value = float(bar.get("dxy_close", 0.0))
         tnx_close_value = float(bar.get("tnx_close", 0.0))
         gold_close_value = float(bar.get("gold_close", 0.0))
+        # Path B Chunk 1 (vol-regime macro features). Missing keys on
+        # pre-widen events.parquet default to 0.0 — same back-compat
+        # contract as the A3 cross-asset bundle.
+        vix3m_close_value = float(bar.get("vix3m_close", 0.0))
+        irx_close_value = float(bar.get("irx_close", 0.0))
+        vix_term_slope_value = float(bar.get("vix_term_slope", 0.0))
+        yield_curve_slope_value = float(bar.get("yield_curve_slope_10y_3m", 0.0))
         elapsed_time = float((bar_date - event_date).days)
         fv = FeatureVector.from_market_state(
             date=date_value,
@@ -443,6 +450,10 @@ def _bars_to_feature_vectors(
         fv.dxy_close = dxy_close_value
         fv.tnx_close = tnx_close_value
         fv.gold_close = gold_close_value
+        fv.vix3m_close = vix3m_close_value
+        fv.irx_close = irx_close_value
+        fv.vix_term_slope = vix_term_slope_value
+        fv.yield_curve_slope_10y_3m = yield_curve_slope_value
         vectors.append(fv)
         previous_close = close_value
         previous_volatility = volatility_value

--- a/tests/unit/test_event_dataset_builder_macro_slopes.py
+++ b/tests/unit/test_event_dataset_builder_macro_slopes.py
@@ -1,7 +1,7 @@
 """Path B Chunk 1: VIX term slope + yield-curve slope per-bar emission.
 
 The slopes are computed in
-:func:`app.data.event_dataset_builder.build_prior_window` from the
+:func:`app.data.event_dataset_builder._build_prior_window` from the
 joined cross-asset row. These tests pin the formula and the
 zero-default behaviour on missing inputs without exercising the full
 yfinance fetch path.

--- a/tests/unit/test_event_dataset_builder_macro_slopes.py
+++ b/tests/unit/test_event_dataset_builder_macro_slopes.py
@@ -1,0 +1,108 @@
+"""Path B Chunk 1: VIX term slope + yield-curve slope per-bar emission.
+
+The slopes are computed in
+:func:`app.data.event_dataset_builder.build_prior_window` from the
+joined cross-asset row. These tests pin the formula and the
+zero-default behaviour on missing inputs without exercising the full
+yfinance fetch path.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+
+import pytest
+
+
+def _make_series(n: int = 30):
+    from app.data.event_dataset_builder import _CloseSeries
+
+    start = dt.date(2023, 1, 1)
+    return _CloseSeries(
+        dates=[start + dt.timedelta(days=i) for i in range(n)],
+        close=[100.0 + i * 0.5 for i in range(n)],
+        volume=[1_000_000.0] * n,
+    )
+
+
+def _cross_asset_lookup_constant(
+    vix: float, vix3m: float, tnx: float, irx: float
+) -> dict[dt.date, dict[str, float]]:
+    """Same cross-asset row for every date, so derived slopes are constant."""
+
+    base = _make_series().dates
+    row = {
+        "vix_close": vix,
+        "vix3m_close": vix3m,
+        "tnx_close": tnx,
+        "irx_close": irx,
+    }
+    return {d: row for d in base}
+
+
+def test_vix_term_slope_is_log_ratio_when_both_inputs_present() -> None:
+    from app.data import event_dataset_builder as edb
+
+    series = _make_series()
+    lookup = _cross_asset_lookup_constant(vix=18.0, vix3m=20.0, tnx=4.2, irx=5.1)
+    bars = edb._build_prior_window(
+        series, as_of=series.dates[-1] + dt.timedelta(days=1), window_days=5,
+        cross_asset_lookup=lookup,
+    )
+    assert bars and bars[0].vix_term_slope == pytest.approx(math.log(20.0 / 18.0))
+
+
+def test_yield_curve_slope_is_tnx_minus_irx() -> None:
+    from app.data import event_dataset_builder as edb
+
+    series = _make_series()
+    lookup = _cross_asset_lookup_constant(vix=18.0, vix3m=20.0, tnx=4.2, irx=5.1)
+    bars = edb._build_prior_window(
+        series, as_of=series.dates[-1] + dt.timedelta(days=1), window_days=5,
+        cross_asset_lookup=lookup,
+    )
+    assert bars and bars[0].yield_curve_slope_10y_3m == pytest.approx(4.2 - 5.1)
+
+
+def test_slopes_zero_when_inputs_missing() -> None:
+    """Missing cross-asset inputs (pre-2002 VIX3M, holiday rows) must
+    produce 0.0 slopes — never NaN, never raise — so the rich-feature
+    block stays clean for the loader's per-fold scaler."""
+
+    from app.data import event_dataset_builder as edb
+
+    series = _make_series()
+    # Lookup with vix3m = 0.0 simulates a pre-VIX3M date.
+    lookup = _cross_asset_lookup_constant(vix=18.0, vix3m=0.0, tnx=0.0, irx=0.0)
+    bars = edb._build_prior_window(
+        series, as_of=series.dates[-1] + dt.timedelta(days=1), window_days=5,
+        cross_asset_lookup=lookup,
+    )
+    assert bars
+    bar = bars[0]
+    assert bar.vix_term_slope == 0.0
+    assert bar.yield_curve_slope_10y_3m == 0.0
+
+
+def test_slopes_emitted_in_bars_to_json() -> None:
+    """The JSON payload that lands in ``prior_bars_json`` must carry
+    both raw closes and derived slopes so the loader can read them back
+    without joining the cross-asset lookup again."""
+
+    from app.data import event_dataset_builder as edb
+
+    series = _make_series()
+    lookup = _cross_asset_lookup_constant(vix=18.0, vix3m=20.0, tnx=4.2, irx=5.1)
+    bars = edb._build_prior_window(
+        series, as_of=series.dates[-1] + dt.timedelta(days=1), window_days=5,
+        cross_asset_lookup=lookup,
+    )
+    blob = edb._bars_to_json(bars)
+    for key in (
+        "vix3m_close",
+        "irx_close",
+        "vix_term_slope",
+        "yield_curve_slope_10y_3m",
+    ):
+        assert key in blob, f"prior-bars JSON missing key {key!r}"

--- a/tests/unit/test_feature_vector_as_rich_list.py
+++ b/tests/unit/test_feature_vector_as_rich_list.py
@@ -94,8 +94,9 @@ def test_realized_vol_slice_default_is_zero() -> None:
 
 
 def test_cross_asset_slice_emits_at_documented_positions() -> None:
-    """A3 (#208) cross-asset close levels land at positions [37:41]
-    in the order VIX, DXY, TNX, gold."""
+    """Cross-asset close levels + Chunk 1 (VIX term structure + 10Y-3M
+    yield slope) land at positions [37:45] in the order VIX, DXY, TNX,
+    gold, VIX3M, IRX, vix_term_slope, yield_curve_slope_10y_3m."""
 
     from app.models.config import RICH_CROSS_ASSET_SLICE
 
@@ -104,17 +105,30 @@ def test_cross_asset_slice_emits_at_documented_positions() -> None:
         dxy_close=104.5,
         tnx_close=4.21,
         gold_close=1942.0,
+        vix3m_close=23.7,
+        irx_close=5.15,
+        vix_term_slope=0.061,
+        yield_curve_slope_10y_3m=-0.94,
     )
-    assert fv.as_rich_list()[RICH_CROSS_ASSET_SLICE] == [22.3, 104.5, 4.21, 1942.0]
+    assert fv.as_rich_list()[RICH_CROSS_ASSET_SLICE] == [
+        22.3,
+        104.5,
+        4.21,
+        1942.0,
+        23.7,
+        5.15,
+        0.061,
+        -0.94,
+    ]
 
 
 def test_cross_asset_slice_default_is_zero() -> None:
-    """Legacy / pre-A3 FeatureVectors carry 0.0 across all 4 axes."""
+    """Legacy / pre-Chunk-1 FeatureVectors carry 0.0 across all 8 axes."""
 
     from app.models.config import RICH_CROSS_ASSET_SLICE
 
     fv = _base_vector()
-    assert fv.as_rich_list()[RICH_CROSS_ASSET_SLICE] == [0.0, 0.0, 0.0, 0.0]
+    assert fv.as_rich_list()[RICH_CROSS_ASSET_SLICE] == [0.0] * 8
 
 
 def test_llm_features_slice_default_is_missing_flag_one() -> None:


### PR DESCRIPTION
## Summary

Widens the rich-feature cross-asset family from 4 raw closes to 8: adds **VIX3M** and **IRX** raw series, plus two **derived stationary slopes** the vol-forecasting literature uses directly — \`log(VIX3M / VIX)\` as the backwardation signal and \`TNX - IRX\` as the 10Y-3M yield-curve slope.

- \`event_dataset_builder.CROSS_ASSET_SYMBOLS\` gains \`^VIX3M\` and \`^IRX\`; the per-bar emission computes the slopes with a zero-default contract on missing inputs (pre-2002 VIX3M dates, holidays) so the rich block stays NaN-free.
- \`RICH_CROSS_ASSET_DIM\` goes from 4 → 8. \`FeatureVector\` carries the four new fields; \`as_rich_list\` extends the cross-asset block from \`[37:41]\` to \`[37:45]\`. \`RICH_FEATURE_SIZE\` grows by 4 (77 → 81). Old checkpoints become incompatible — next sweep refits both the model and the per-fold RobustScaler.
- \`.env.example\` adds \`ALPHA_VANTAGE_API_KEY\` for the historical-bar fallback when yfinance rate-limits.

Closes Chunk 1 of the Path B programme (lift from 0.4707 → target ~0.51). Next chunks: Round 5 LoRA on GRU + the new feature surface; then optional encoder bake-off v2.

## Test plan

- [x] \`pytest tests/unit/test_event_dataset_builder_macro_slopes.py\` — 4 cases pinning the log-ratio + difference formulas, zero-default branch, JSON payload
- [x] \`pytest tests/unit/test_rich_feature_scaler.py tests/unit/test_training_package_loader.py tests/unit/test_event_dataset_builder.py tests/regression/test_forecaster_determinism.py\` — 73 existing tests still pass with the widened rich-feature size
- [ ] CI pytest + typecheck green
- [ ] Manual: dataset rebuild via \`make data-prep\` pulls VIX3M / IRX without yfinance errors