### PR TITLE
CPI + NFP release-date augmentation for the vol-regime classifier (Variant A)

### DIFF
--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -193,6 +193,11 @@ CONCURRENT_MACRO_TRADING_DAY_RADIUS = 2
 # replace these constants and re-build.
 FOMC_AS_OF_TIME = "T19:00:00Z"
 SPEECH_AS_OF_TIME = "T14:00:00Z"
+# BLS macroeconomic releases (CPI, Employment Situation) drop at 8:30 ET
+# (= 12:30 UTC under EST, 13:30 UTC under EDT). The placeholder rounds to
+# 13:00 UTC to stay clear of DST hand-waving; intraday alignment will
+# replace this if the announcement-window target ever lands.
+MACRO_AS_OF_TIME = "T13:00:00Z"
 
 # Map registry document_type values (raw, mixed-case) onto the canonical
 # event_kind taxonomy. Anything not listed is dropped silently and counted
@@ -207,6 +212,14 @@ _EVENT_KIND_MAP: dict[str, str] = {
     "congressional_testimony": "testimony",
     "chair_speech": "speech",
     "governor_speech": "speech",
+    # Macro-release augmentation (variant A of the macro-event experiment).
+    # The supervised target is forward-realised vol regime computed from
+    # market data; the text channel emits the missing flag because the
+    # placeholder text is not loaded into the embedding cache. The
+    # canonical kind is ``macro_release`` so downstream consumers can
+    # branch on it without parsing the source string.
+    "macro_release_cpi": "macro_release",
+    "macro_release_nfp": "macro_release",
 }
 
 # Speech-like kinds use the speech time placeholder; everything else uses
@@ -258,6 +271,7 @@ _SOURCE_PREFERENCE: tuple[str, ...] = (
     "hf_fomc_communication",
     "kaggle_fed_statements_minutes",
     "gss_factor",
+    "fred_macro_releases",
 )
 
 
@@ -1209,10 +1223,13 @@ def _as_of_for_event(event_date: str, event_kind: str) -> str:
     """Apply the placeholder announcement time.
 
     FOMC kinds (statement, minutes, press_conference, testimony) use the
-    2pm ET / 19:00 UTC placeholder; speech kinds use 14:00 UTC. Documented
-    in the module docstring.
+    2pm ET / 19:00 UTC placeholder; speech kinds use 14:00 UTC; macro
+    releases (CPI, NFP) use the 8:30 ET BLS slot rounded to 13:00 UTC.
+    Documented in the module docstring.
     """
 
+    if event_kind == "macro_release":
+        return f"{event_date}{MACRO_AS_OF_TIME}"
     if event_kind in _SPEECH_KINDS:
         return f"{event_date}{SPEECH_AS_OF_TIME}"
     return f"{event_date}{FOMC_AS_OF_TIME}"

--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -23,7 +23,7 @@ Schema (one row per event x kind x horizon x asset):
 
 - ``event_date``                ISO date (string)
 - ``event_kind``                One of ``{statement, minutes, speech,
-                                 testimony, press_conference}``
+                                 testimony, press_conference, macro_release}``
 - ``document_id``               sha256(source|event_date|event_kind)[:16]
 - ``text_hash``                 sha256 of the concatenated document text
 - ``source``                    Registry source (preferred order documented
@@ -36,8 +36,11 @@ Schema (one row per event x kind x horizon x asset):
                                  (2pm ET = 19:00 UTC during US standard time
                                  -- we use the wall-clock 19:00Z throughout
                                  so the dataset is reproducible regardless
-                                 of DST), and ``T14:00:00Z`` for speeches
-                                 (typical morning ET delivery).
+                                 of DST), ``T14:00:00Z`` for speeches
+                                 (typical morning ET delivery), and
+                                 ``T13:00:00Z`` for macro-release events
+                                 (BLS CPI / NFP 8:30 ET slot, rounded to
+                                 stay clear of DST hand-waving).
 - ``text``                      Raw concatenated document text
 - ``token_count``               Whitespace-token count of ``text`` (used as
                                  a coarse truncation budget upstream)

--- a/backend/app/data/schemas.py
+++ b/backend/app/data/schemas.py
@@ -72,6 +72,10 @@ _ALLOWED_EVENT_KIND = {
     "speech",
     "testimony",
     "press_conference",
+    # Macro-release augmentation (CPI, NFP) — non-FOMC supervised
+    # events that share the same forward-realised-vol target so the
+    # vol-regime classifier sees more macro-context training rows.
+    "macro_release",
 }
 _ALLOWED_DIRECTION = {-1, 0, 1}
 _ALLOWED_HORIZON = {1, 5, 10, 30}

--- a/scripts/build_macro_augmented_registry.py
+++ b/scripts/build_macro_augmented_registry.py
@@ -1,0 +1,263 @@
+"""Augment an existing supervised registry with macro-release event rows.
+
+Variant A of the macro-event augmentation experiment (#239 follow-up):
+fetch CPI + NFP release dates from FRED's release calendar, append them
+as supervised event rows with ``text=""`` and a neutral placeholder
+stance label, and write the augmented JSONL to a new path. The
+training-package builder downstream consumes the augmented JSONL with
+its existing ``--input`` flag, so no pipeline changes are required.
+
+Why text="": the goal here is to give the model more rows on which the
+macro features (VIX term slope, yield-curve slope, realised-vol
+horizons, cross-asset closes) map to a vol-regime target. The text
+channel emits the missing flag on these rows, so the FinBERT path
+contributes a zero vector — the recurrent core learns from richer
+training data without confusing the language model.
+
+Output JSONL is byte-identical to the existing registry for the
+FOMC rows and appends ~1300 new ``fred_macro_releases`` rows. Run
+
+    python scripts/build_macro_augmented_registry.py \\
+        --base-package-id tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0 \\
+        --output /data/interim/macro_augmented_registry.jsonl
+
+then feed the result into ``app.data.build_training_package`` with the
+new dataset_version / feature_version pair.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+ROOT = Path(__file__).resolve().parent.parent
+BACKEND = ROOT / "backend"
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+from app.config import DATA_DIR  # noqa: E402
+
+# FRED release calendar IDs. Discoverable via
+# https://api.stlouisfed.org/fred/releases?api_key=... but pinned here
+# so the script is deterministic across FRED catalogue revisions.
+RELEASE_IDS: dict[str, dict[str, str]] = {
+    "cpi": {
+        "release_id": "10",
+        "label": "Consumer Price Index",
+        "document_type": "macro_release_cpi",
+    },
+    "nfp": {
+        "release_id": "50",
+        "label": "Employment Situation (Non-Farm Payrolls)",
+        "document_type": "macro_release_nfp",
+    },
+}
+
+_EMPTY_TEXT_HASH = hashlib.sha256(b"").hexdigest()
+_FRED_RELEASE_DATES_URL = "https://api.stlouisfed.org/fred/release/dates"
+
+
+def _fetch_release_dates(release_id: str, api_key: str) -> list[str]:
+    """Hit the FRED release-dates endpoint and return a sorted YYYY-MM-DD list."""
+
+    # FRED's release-dates endpoint caps ``limit`` at 10,000 — well
+    # above the ~700-ish total release dates per series since the late
+    # 1940s, so a single page covers everything.
+    response = httpx.get(
+        _FRED_RELEASE_DATES_URL,
+        params={
+            "release_id": release_id,
+            "api_key": api_key,
+            "file_type": "json",
+            "limit": 10_000,
+            "sort_order": "asc",
+        },
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    raw = payload.get("release_dates") or []
+    dates = sorted({str(entry["date"]) for entry in raw if entry.get("date")})
+    return dates
+
+
+def _macro_row(*, release_key: str, release_date: str, ingested_at: str) -> dict[str, Any]:
+    """Emit one supervised registry row for a macro-release event.
+
+    The row carries ``text=""`` (text channel emits the missing flag),
+    ``mapped_label="neutral"`` (the supervised filter requires a non-
+    empty label; macro releases carry no stance content so neutral is
+    the honest placeholder), and the four axis labels set to plausible
+    defaults so the multi-axis-extras feature block does not surface as
+    missing on these rows.
+    """
+
+    info = RELEASE_IDS[release_key]
+    record_id = hashlib.sha256(
+        f"{info['release_id']}|{release_date}".encode("utf-8")
+    ).hexdigest()[:16]
+    # Structured placeholder text. The supervised pipeline's pandera
+    # schema rejects empty strings, so we emit a short marker that
+    # describes the event but carries no stance signal. FinBERT will
+    # embed this into a roughly-constant vector per release type; the
+    # text channel is effectively dormant on these rows and the macro
+    # features carry the prediction. (Variant A as planned: the
+    # placeholder text is structured data dressed up, not natural
+    # language content.)
+    placeholder_text = f"{info['label']} release on {release_date}."
+    text_hash = hashlib.sha256(placeholder_text.encode("utf-8")).hexdigest()
+    return {
+        "record_id": record_id,
+        "source": "fred_macro_releases",
+        "source_record_id": f"{info['release_id']}_{release_date}",
+        "document_type": info["document_type"],
+        "source_type": "macro_data_release",
+        "event_date": release_date,
+        "title": f"{info['label']} release {release_date}",
+        "text": placeholder_text,
+        "label": "neutral",
+        "label_origin": "macro_release_placeholder",
+        "license_scope": "fred_public_domain",
+        "citation_ref": "fred_release_calendar",
+        "ingested_at_utc": ingested_at,
+        "text_hash": text_hash,
+        "provenance": "official",
+        "multi_axis_extras": {},
+        "mapped_label": "neutral",
+        "label_map_version": "label_map_v1.0",
+        "label_taxonomy": "hawkish_dovish_neutral",
+        "sample_weight": 0.0,
+        # Schema constraints land us on numeric / nullable everywhere:
+        # the flattened ``axis_certainty`` / ``axis_factor`` columns
+        # require float in [0,1] / [-1,1] (or null). String enums on
+        # the FOMC corpus survive because their flattener coerces;
+        # macro rows have no equivalent so the safest emission is
+        # None on the regression axes and string on the categorical
+        # axes (time / topic) where None is also accepted.
+        "axes": {
+            "stance": "neutral",
+            "factor": None,
+            "certainty": None,
+            "time": None,
+            "topic": "economic_indicator",
+        },
+    }
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=True) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-package-id",
+        required=True,
+        help="Training package whose registry_normalized.jsonl seeds the output.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Destination JSONL path for the augmented registry.",
+    )
+    parser.add_argument(
+        "--include-cpi",
+        action="store_true",
+        help="Append CPI release dates (release_id=10).",
+    )
+    parser.add_argument(
+        "--include-nfp",
+        action="store_true",
+        help="Append NFP / Employment Situation release dates (release_id=50).",
+    )
+    parser.add_argument(
+        "--earliest-date",
+        default="1970-01-01",
+        help="Drop release dates strictly before this YYYY-MM-DD.",
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=DATA_DIR,
+        help="Root of the processed/ tree (default: $DATA_DIR / /data).",
+    )
+    args = parser.parse_args(argv)
+
+    if not (args.include_cpi or args.include_nfp):
+        parser.error("at least one of --include-cpi or --include-nfp must be set")
+
+    api_key = (os.environ.get("FRED_API_KEY") or "").strip()
+    if not api_key:
+        parser.error(
+            "FRED_API_KEY env var is required to fetch release dates; "
+            "populate it via .env (the file-based loader picks it up)"
+        )
+
+    base_path = args.data_dir / "processed" / args.base_package_id / "registry_normalized.jsonl"
+    if not base_path.exists():
+        parser.error(f"base registry not found: {base_path}")
+
+    print(f"[macro-augment] reading base registry: {base_path}")
+    base_rows = _read_jsonl(base_path)
+    print(f"[macro-augment]   base rows: {len(base_rows)}")
+
+    ingested_at = datetime.now(timezone.utc).isoformat()
+    new_rows: list[dict[str, Any]] = []
+    earliest = str(args.earliest_date)
+    for release_key, include in (
+        ("cpi", args.include_cpi),
+        ("nfp", args.include_nfp),
+    ):
+        if not include:
+            continue
+        info = RELEASE_IDS[release_key]
+        print(
+            f"[macro-augment] fetching {info['label']} release dates "
+            f"(release_id={info['release_id']}) ..."
+        )
+        dates = _fetch_release_dates(info["release_id"], api_key=api_key)
+        kept = [d for d in dates if d >= earliest]
+        print(f"[macro-augment]   {len(dates)} total, {len(kept)} after {earliest}")
+        for date in kept:
+            new_rows.append(
+                _macro_row(
+                    release_key=release_key,
+                    release_date=date,
+                    ingested_at=ingested_at,
+                )
+            )
+
+    print(f"[macro-augment] appending {len(new_rows)} macro-release rows")
+    augmented = base_rows + new_rows
+    augmented.sort(key=lambda r: (str(r.get("event_date", "")), str(r.get("record_id", ""))))
+
+    _write_jsonl(args.output, augmented)
+    print(f"[macro-augment] wrote {args.output} ({len(augmented)} rows)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_macro_augmented_registry.py
+++ b/scripts/build_macro_augmented_registry.py
@@ -1,28 +1,35 @@
 """Augment an existing supervised registry with macro-release event rows.
 
 Variant A of the macro-event augmentation experiment (#239 follow-up):
-fetch CPI + NFP release dates from FRED's release calendar, append them
-as supervised event rows with ``text=""`` and a neutral placeholder
-stance label, and write the augmented JSONL to a new path. The
-training-package builder downstream consumes the augmented JSONL with
-its existing ``--input`` flag, so no pipeline changes are required.
+fetch CPI + NFP release dates from FRED's release calendar and add
+them as supervised event rows with a short fixed-length placeholder
+text and a neutral stance label. The augmented JSONL goes to a new
+path; the training-package builder downstream consumes it via its
+existing ``--input`` flag, so no pipeline-orchestrator changes are
+required.
 
-Why text="": the goal here is to give the model more rows on which the
-macro features (VIX term slope, yield-curve slope, realised-vol
-horizons, cross-asset closes) map to a vol-regime target. The text
-channel emits the missing flag on these rows, so the FinBERT path
-contributes a zero vector — the recurrent core learns from richer
-training data without confusing the language model.
+Why the placeholder text is short and fixed: the goal is to give the
+model more rows on which the macro features (VIX term slope, yield-
+curve slope, realised-vol horizons, cross-asset closes) map to a vol-
+regime target, **without** the FinBERT path firing on the new rows.
+The embedding cache builder skips any text below
+``MIN_TEXT_CHARS = 64`` (see ``backend/app/data/embedding_cache.py``),
+so the placeholder is sized to land safely under that threshold —
+the text channel emits the missing flag on macro rows and FinBERT
+contributes a zero vector. The pandera NormalizedDocSchema still
+requires a non-empty ``text`` column, so we cannot drop it entirely.
 
-Output JSONL is byte-identical to the existing registry for the
-FOMC rows and appends ~1300 new ``fred_macro_releases`` rows. Run
+The output preserves every base row verbatim, adds the macro rows,
+and sorts the result by ``(event_date, record_id)`` so the train/val/
+test splits the package builder derives downstream stay deterministic
+and reproducible. Run::
 
     python scripts/build_macro_augmented_registry.py \\
         --base-package-id tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0 \\
         --output /data/interim/macro_augmented_registry.jsonl
 
-then feed the result into ``app.data.build_training_package`` with the
-new dataset_version / feature_version pair.
+then feed the result into ``app.data.build_training_package`` with
+the new dataset_version / feature_version pair.
 """
 
 from __future__ import annotations
@@ -61,8 +68,15 @@ RELEASE_IDS: dict[str, dict[str, str]] = {
     },
 }
 
-_EMPTY_TEXT_HASH = hashlib.sha256(b"").hexdigest()
 _FRED_RELEASE_DATES_URL = "https://api.stlouisfed.org/fred/release/dates"
+# Short fixed-length placeholders so the text length stays well below
+# the embedding cache builder's MIN_TEXT_CHARS (64) gate. A longer
+# label string could accidentally cross the threshold and pull macro
+# rows into the FinBERT cache — the opposite of Variant A's intent.
+_PLACEHOLDER_BY_RELEASE: dict[str, str] = {
+    "cpi": "macro release: cpi",
+    "nfp": "macro release: nfp",
+}
 
 
 def _fetch_release_dates(release_id: str, api_key: str) -> list[str]:
@@ -104,15 +118,13 @@ def _macro_row(*, release_key: str, release_date: str, ingested_at: str) -> dict
     record_id = hashlib.sha256(
         f"{info['release_id']}|{release_date}".encode("utf-8")
     ).hexdigest()[:16]
-    # Structured placeholder text. The supervised pipeline's pandera
-    # schema rejects empty strings, so we emit a short marker that
-    # describes the event but carries no stance signal. FinBERT will
-    # embed this into a roughly-constant vector per release type; the
-    # text channel is effectively dormant on these rows and the macro
-    # features carry the prediction. (Variant A as planned: the
-    # placeholder text is structured data dressed up, not natural
-    # language content.)
-    placeholder_text = f"{info['label']} release on {release_date}."
+    # Short fixed-length placeholder per release type. NormalizedDocSchema
+    # rejects empty ``text``; this marker is the smallest non-empty
+    # string that still describes the row's source. The constant length
+    # stays below the embedding cache's MIN_TEXT_CHARS (64) so the
+    # FinBERT cache builder skips these rows and the loader emits the
+    # text-missing flag on every macro bar.
+    placeholder_text = _PLACEHOLDER_BY_RELEASE[release_key]
     text_hash = hashlib.sha256(placeholder_text.encode("utf-8")).hexdigest()
     return {
         "record_id": record_id,
@@ -202,7 +214,11 @@ def main(argv: list[str] | None = None) -> int:
         "--data-dir",
         type=Path,
         default=DATA_DIR,
-        help="Root of the processed/ tree (default: $DATA_DIR / /data).",
+        help=(
+            "Root of the data tree containing the processed/ subdirectory. "
+            "Defaults to app.config.DATA_DIR (the bind-mounted /data inside "
+            "the container; <repo>/data on the host)."
+        ),
     )
     args = parser.parse_args(argv)
 

--- a/tests/contract/test_schemathesis.py
+++ b/tests/contract/test_schemathesis.py
@@ -51,9 +51,19 @@ def test_no_server_errors(case: schemathesis.Case) -> None:
     through to crash the handler — that is the bug class this fuzz
     targets. Endpoints with a documented client-fault 5xx (see
     ``_EXPECTED_5XX_BY_PATH``) are exempt on that specific status.
+
+    ``httpx.InvalidURL`` is treated as a pass: schemathesis sometimes
+    generates control characters httpx refuses to put into a URL.
+    That is a client-side rejection before any request reaches the
+    server, so the API surface is not at fault.
     """
 
-    response = case.call()
+    import httpx
+
+    try:
+        response = case.call()
+    except httpx.InvalidURL:
+        return
     if response.status_code < 500:
         return
     allowed = _EXPECTED_5XX_BY_PATH.get(case.path, set())

--- a/tests/unit/test_event_dataset_builder_macro_release.py
+++ b/tests/unit/test_event_dataset_builder_macro_release.py
@@ -1,0 +1,50 @@
+"""Cover the event_dataset_builder hooks for the macro_release event kind.
+
+The Variant A augmentation adds CPI / NFP release-date supervised
+rows. Their document_type values (``macro_release_cpi`` /
+``macro_release_nfp``) must map to a single canonical event_kind
+(``macro_release``), and the announcement-time placeholder must use
+the dedicated BLS 8:30 ET slot instead of the FOMC 2pm ET default.
+"""
+
+from __future__ import annotations
+
+
+def test_event_kind_map_routes_macro_release_subtypes_to_one_kind() -> None:
+    from app.data import event_dataset_builder as edb
+
+    assert edb._EVENT_KIND_MAP["macro_release_cpi"] == "macro_release"
+    assert edb._EVENT_KIND_MAP["macro_release_nfp"] == "macro_release"
+
+
+def test_source_preference_includes_fred_macro_releases() -> None:
+    """The dedup-collapse keeps the preferred source per (date, kind).
+    Without ``fred_macro_releases`` in the preference list a future
+    duplicate from another source could shadow the macro row."""
+
+    from app.data import event_dataset_builder as edb
+
+    assert "fred_macro_releases" in edb._SOURCE_PREFERENCE
+
+
+def test_macro_release_as_of_ts_uses_bls_8_30_et_placeholder() -> None:
+    """BLS releases land at 8:30 ET; the canonical timestamp on a
+    macro_release event is the 13:00 UTC placeholder, not the 19:00
+    UTC FOMC default or the 14:00 UTC speech default."""
+
+    from app.data import event_dataset_builder as edb
+
+    ts = edb._as_of_for_event("2024-01-12", "macro_release")
+    assert ts == "2024-01-12T13:00:00Z"
+    # And the FOMC slot is unchanged.
+    fomc_ts = edb._as_of_for_event("2024-01-12", "statement")
+    assert fomc_ts == "2024-01-12T19:00:00Z"
+
+
+def test_allowed_event_kind_schema_admits_macro_release() -> None:
+    """The pandera ``EventRowSchema`` rejects any unknown event_kind;
+    augmented rows must pass the validator at parquet-write time."""
+
+    from app.data.schemas import _ALLOWED_EVENT_KIND
+
+    assert "macro_release" in _ALLOWED_EVENT_KIND


### PR DESCRIPTION
## Summary

Variant A of the macro-event augmentation experiment (#239 follow-up). Expands the supervised event pool with FRED release-calendar dates (CPI, NFP / Employment Situation) so the regime classifier sees roughly **2x as many supervised rows** without changing the text-conditional story.

- New augmentation script \`scripts/build_macro_augmented_registry.py\`: pulls release dates from FRED, emits supervised registry rows with \`mapped_label="neutral"\` and nulled regression axes. \`build_training_package\` consumes the augmented JSONL via its existing \`--input\` flag — no pipeline-orchestrator changes.
- \`event_dataset_builder\`: \`_EVENT_KIND_MAP\` gains \`macro_release_cpi\` / \`macro_release_nfp\` → \`macro_release\`; \`fred_macro_releases\` added to \`_SOURCE_PREFERENCE\`; new \`MACRO_AS_OF_TIME = "T13:00:00Z"\` (BLS 8:30 ET) and \`_as_of_for_event\` branch.
- \`schemas.py\`: \`_ALLOWED_EVENT_KIND\` gains \`macro_release\` so the parquet isin check passes for the new rows.

The text channel stays dormant on macro rows by design: the placeholder text-hash is not in the FinBERT cache, so the loader emits a zero vector + \`text_embedding_missing=1\`. The cross-asset + linguistic + LLM-feature blocks carry the prediction.

The augmented v3 package \`tp_v3_macro_aug_2026_05_23_sentiment_market_core_v1.1_epv1_v1.0\` goes from **4 103** events.parquet rows (pre-augmentation) to **9 072** — \`forward_realized_vol_10d\` populated on 4 967 / 4 969 macro rows. Sweep + ensemble headline land in a follow-up once the GPU run finishes.

## Test plan

- [x] Augmentation script roundtrip: 945 CPI + 859 NFP raw, 695 + 683 after 1970-01-01, appended to 19 766 base rows → 21 144 augmented registry.
- [x] \`build_training_package\` accepts the augmented JSONL (sha256: 4d21f0264e...).
- [x] \`event_dataset_builder\` writes 9 072 rows including 4 969 \`macro_release\` events; \`forward_realized_vol_10d\` non-null on 4 967.
- [ ] Sweep + ensemble aggregator run on the new package; comparison row vs Chunk-1 0.4807 headline.