### PR TITLE
Default macro-F1 cell selection on classification sweeps + FOMC-only filter script

### DIFF
--- a/backend/app/evaluation/regime_pooled_aggregator.py
+++ b/backend/app/evaluation/regime_pooled_aggregator.py
@@ -287,6 +287,7 @@ def aggregate(  # noqa: C901, PLR0913
 
     cells: dict[tuple[str, str | None], list[Mapping[str, object]]] = defaultdict(list)
     inferred_metric = "macro_f1"
+    classification_detected = False
     for blob in sweep_jsons:
         trials = blob.get("trials", [])
         metric = blob.get("selection_metric")
@@ -298,6 +299,30 @@ def aggregate(  # noqa: C901, PLR0913
             if not isinstance(trial, Mapping):
                 continue
             cells[_cell_key(trial)].append(trial)
+            # Detect classification mode off the per-trial model_config
+            # so the default selection metric on a classification sweep
+            # is ``macro_f1`` rather than the meaningless ``combined_rmse``
+            # the trainer writes at the top level. Sweep JSONs do not
+            # surface ``output_mode`` at the top so we peek at the first
+            # trial that exposes it.
+            if not classification_detected:
+                summary = _trial_summary(trial)
+                cfg = summary.get("model_config") if isinstance(summary, Mapping) else None
+                if (
+                    isinstance(cfg, Mapping)
+                    and str(cfg.get("output_mode", "")).lower() == "classification"
+                ):
+                    classification_detected = True
+
+    # Classification sweeps' top-level ``selection_metric`` is almost
+    # always ``combined_rmse`` (the trainer writes the same field
+    # regardless of output mode). That metric is undefined under
+    # classification — every trial reports inf for it, so the
+    # per-cell selection collapses to whichever cell pandas iterates
+    # first. Override to macro-F1 once we know the sweep is
+    # classification-typed.
+    if selection_metric is None and classification_detected:
+        inferred_metric = "macro_f1"
 
     selection = selection_metric or inferred_metric
     best_by_arch = _select_best_cell(cells, selection)

--- a/scripts/macro_aug_fomc_only_filter.py
+++ b/scripts/macro_aug_fomc_only_filter.py
@@ -1,0 +1,293 @@
+"""FOMC-only subset re-aggregation of the macro-augmented sweep result.
+
+The macro-augmented arch-sweep evaluates models on a test pool that
+mixes FOMC events and macro-release events (CPI, NFP). The headline
+macro-F1 is the pooled CI over that mixed pool. For an apples-to-
+apples comparison against the Chunk-1 headline (FOMC-only), we need
+to re-pool the same trial predictions filtered to FOMC test rows.
+
+Each test prediction position lines up with an entry in
+``WalkForwardSplit.test_event_dates`` for its trial's fold. Macro
+events live on CPI / NFP release dates; FOMC events live on FOMC
+statement / minutes / press-conference / speech dates. Because the
+two sets of dates almost never overlap on the same calendar day, we
+can classify each test position as macro-vs-FOMC purely by whether
+its event_date is in the FRED release-calendar set.
+
+Output: a markdown table with both pooled-CI numbers (full pool +
+FOMC-only subset) for every architecture in the sweep dir.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+BACKEND = ROOT / "backend"
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+from app.evaluation.bootstrap import block_bootstrap_ci  # noqa: E402
+from app.evaluation.classification_breakdown import (  # noqa: E402
+    compute_classification_breakdown,
+)
+
+
+def _load_fold_test_dates(package_dir: Path, fold_id: str) -> list[str]:
+    """Read the test partition's per-row event_date list for one fold.
+
+    Returns dates in the same order the trainer's
+    ``WalkForwardSplit.test`` partition iterates them — i.e. the order
+    the per-trial predictions arrive in.
+    """
+
+    from app.training.loaders import load_walk_forward_split
+
+    split = load_walk_forward_split(
+        training_package_id=package_dir.name,
+        fold_id=fold_id,
+        rich_features=True,
+    )
+    return list(split.test_event_dates)
+
+
+def _macro_event_dates(registry_jsonl: Path) -> set[str]:
+    """Return the set of event_dates that came from the FRED release
+    calendar (i.e. macro_release rows). Read from the augmented
+    registry directly so we do not depend on the events.parquet
+    survivors."""
+
+    dates: set[str] = set()
+    with registry_jsonl.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            if str(row.get("source", "")) == "fred_macro_releases":
+                date = str(row.get("event_date", ""))[:10]
+                if date:
+                    dates.add(date)
+    return dates
+
+
+def _iter_arch_dirs(sweep_dir: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in sweep_dir.iterdir()
+        if path.is_dir() and (path / "forecaster_sweep_results.json").exists()
+    )
+
+
+def _select_best_hp_cell(payload: dict[str, Any]) -> str:
+    """Replicate the aggregator's per-architecture HP-cell selection:
+    pick the hp_combo_id with the highest pooled macro-F1 across folds
+    + seeds. We use the same selection criterion so the FOMC-only
+    subset evaluates the same cell as the headline."""
+
+    by_cell: dict[Any, list[tuple[int, int]]] = defaultdict(list)
+    for trial in payload.get("trials", []):
+        summary = trial.get("summary", trial)
+        if not isinstance(summary, dict):
+            continue
+        test_metrics = summary.get("test_metrics") or {}
+        preds = test_metrics.get("predictions")
+        targets = test_metrics.get("targets")
+        if not isinstance(preds, list) or not isinstance(targets, list):
+            continue
+        hp = trial.get("hp_combo_id")
+        # Pool by HP cell across folds + seeds for the selection step.
+        by_cell[hp].extend(zip(preds, targets))
+
+    best_cell: Any = None
+    best_macro = -1.0
+    for hp, pairs in by_cell.items():
+        if not pairs:
+            continue
+        preds = [int(p) for p, _ in pairs]
+        targets = [int(t) for _, t in pairs]
+        breakdown = compute_classification_breakdown(preds, targets, n_classes=3)
+        if breakdown.macro_f1 > best_macro:
+            best_macro = breakdown.macro_f1
+            best_cell = hp
+    return best_cell
+
+
+def _aggregate_arch(
+    arch_dir: Path,
+    *,
+    macro_dates: set[str],
+    package_dir: Path,
+) -> dict[str, Any]:
+    payload = json.loads((arch_dir / "forecaster_sweep_results.json").read_text())
+    best_cell = _select_best_hp_cell(payload)
+    fold_dates_cache: dict[str, list[str]] = {}
+
+    pooled_full: list[tuple[int, int]] = []
+    pooled_fomc: list[tuple[int, int]] = []
+    fold_ids_seen: set[str] = set()
+    seeds_seen: set[int] = set()
+
+    for trial in payload.get("trials", []):
+        if trial.get("hp_combo_id") != best_cell:
+            continue
+        summary = trial.get("summary", trial)
+        fold_id = summary.get("fold_id") or trial.get("fold_id")
+        seed = trial.get("seed") or summary.get("seed")
+        test_metrics = summary.get("test_metrics") or {}
+        preds = test_metrics.get("predictions")
+        targets = test_metrics.get("targets")
+        if not (
+            isinstance(preds, list)
+            and isinstance(targets, list)
+            and isinstance(fold_id, str)
+        ):
+            continue
+        if fold_id not in fold_dates_cache:
+            fold_dates_cache[fold_id] = _load_fold_test_dates(package_dir, fold_id)
+        test_dates = fold_dates_cache[fold_id]
+        if len(preds) > len(test_dates):
+            # Should not happen: more predictions than test rows.
+            for p, t in zip(preds, targets):
+                pooled_full.append((int(p), int(t)))
+            continue
+        if len(preds) < len(test_dates):
+            # The trainer drops trailing test rows whose forward
+            # target window is incomplete (10-day forward vol). The
+            # ``test_event_dates`` list mirrors the raw partition; trim
+            # from the END so positions line up with the predictions
+            # the trainer actually emitted.
+            test_dates = test_dates[: len(preds)]
+        for p, t, d in zip(preds, targets, test_dates):
+            pooled_full.append((int(p), int(t)))
+            if str(d)[:10] not in macro_dates:
+                pooled_fomc.append((int(p), int(t)))
+        fold_ids_seen.add(fold_id)
+        if isinstance(seed, int):
+            seeds_seen.add(seed)
+
+    full_breakdown = compute_classification_breakdown(
+        [p for p, _ in pooled_full], [t for _, t in pooled_full], n_classes=3
+    ) if pooled_full else None
+    fomc_breakdown = compute_classification_breakdown(
+        [p for p, _ in pooled_fomc], [t for _, t in pooled_fomc], n_classes=3
+    ) if pooled_fomc else None
+
+    full_ci = (
+        block_bootstrap_ci(
+            [p == t for p, t in pooled_full],  # ignored; we use macro-F1 path below
+            block_size=20,
+            n_resamples=1000,
+        )
+        if pooled_full
+        else None
+    )
+
+    def _ci_macro(pairs: list[tuple[int, int]]) -> dict[str, float] | None:
+        import random
+        if not pairs:
+            return None
+        rng = random.Random(11)
+        n = len(pairs)
+        block_size = 20
+        macros: list[float] = []
+        for _ in range(1000):
+            sample: list[tuple[int, int]] = []
+            while len(sample) < n:
+                start = rng.randrange(0, n)
+                sample.extend(pairs[start:start + block_size])
+            sample = sample[:n]
+            br = compute_classification_breakdown(
+                [p for p, _ in sample], [t for _, t in sample], n_classes=3
+            )
+            macros.append(br.macro_f1)
+        macros.sort()
+        lo = macros[int(0.025 * len(macros))]
+        hi = macros[int(0.975 * len(macros))]
+        return {"lo": lo, "hi": hi}
+
+    full_ci_macro = _ci_macro(pooled_full)
+    fomc_ci_macro = _ci_macro(pooled_fomc)
+
+    return {
+        "arch": arch_dir.name,
+        "best_hp_combo": best_cell,
+        "n_full": len(pooled_full),
+        "n_fomc": len(pooled_fomc),
+        "n_macro": len(pooled_full) - len(pooled_fomc),
+        "seeds": sorted(seeds_seen),
+        "folds": sorted(fold_ids_seen),
+        "macro_f1_full": full_breakdown.macro_f1 if full_breakdown else None,
+        "macro_f1_fomc": fomc_breakdown.macro_f1 if fomc_breakdown else None,
+        "ci_full": full_ci_macro,
+        "ci_fomc": fomc_ci_macro,
+    }
+
+
+def _format_md(rows: list[dict[str, Any]]) -> str:
+    lines: list[str] = []
+    lines.append("# Macro-aug sweep — full pool vs FOMC-only subset macro-F1")
+    lines.append("")
+    lines.append(
+        "Both columns use the same per-architecture best HP cell from the "
+        "macro-augmented sweep (selected by full-pool macro-F1). The "
+        "FOMC-only column re-pools the same trial predictions after "
+        "dropping macro-release rows by event_date."
+    )
+    lines.append("")
+    lines.append("| Arch | n_full | n_fomc | macro-F1 (full) | 95% CI (full) | macro-F1 (FOMC-only) | 95% CI (FOMC-only) |")
+    lines.append("|---|---:|---:|---:|---|---:|---|")
+    for row in rows:
+        full_ci = row.get("ci_full") or {}
+        fomc_ci = row.get("ci_fomc") or {}
+        lines.append(
+            f"| {row['arch']} | {row['n_full']} | {row['n_fomc']} | "
+            f"{row['macro_f1_full']:.4f} | "
+            f"[{full_ci.get('lo', 0.0):.4f}, {full_ci.get('hi', 0.0):.4f}] | "
+            f"{row['macro_f1_fomc']:.4f} | "
+            f"[{fomc_ci.get('lo', 0.0):.4f}, {fomc_ci.get('hi', 0.0):.4f}] |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sweep-dir", type=Path, required=True)
+    parser.add_argument("--registry-jsonl", type=Path, required=True)
+    parser.add_argument("--package-dir", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, default=None)
+    parser.add_argument("--output-md", type=Path, default=None)
+    args = parser.parse_args()
+
+    macro_dates = _macro_event_dates(args.registry_jsonl)
+    print(f"[fomc-only] {len(macro_dates)} macro-release event dates loaded")
+
+    rows: list[dict[str, Any]] = []
+    for arch_dir in _iter_arch_dirs(args.sweep_dir):
+        print(f"[fomc-only] aggregating {arch_dir.name} ...")
+        row = _aggregate_arch(
+            arch_dir, macro_dates=macro_dates, package_dir=args.package_dir
+        )
+        rows.append(row)
+        print(
+            f"  best_hp_combo={row['best_hp_combo']}  "
+            f"n_full={row['n_full']}  n_fomc={row['n_fomc']}  "
+            f"macro_f1_full={row['macro_f1_full']:.4f}  "
+            f"macro_f1_fomc={row['macro_f1_fomc']:.4f}"
+        )
+
+    out_json = args.output_json or args.sweep_dir / "fomc_only_subset_macro_f1.json"
+    out_md = args.output_md or args.sweep_dir / "fomc_only_subset_macro_f1.md"
+    out_json.write_text(json.dumps(rows, indent=2) + "\n", encoding="utf-8")
+    out_md.write_text(_format_md(rows), encoding="utf-8")
+    print(f"[fomc-only] wrote {out_json} + {out_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_regime_pooled_aggregator.py
+++ b/tests/unit/test_regime_pooled_aggregator.py
@@ -240,3 +240,61 @@ def test_cli_writes_json_and_markdown(tmp_path: Path) -> None:
     assert rc == 0
     assert (tmp_path / "pooled_test_macro_f1.json").exists()
     assert (tmp_path / "pooled_test_macro_f1.md").exists()
+
+
+def test_classification_sweep_defaults_to_macro_f1_selection() -> None:
+    """When the sweep JSON's ``selection_metric`` is ``combined_rmse``
+    but the trials carry ``output_mode == "classification"`` on their
+    model_config, the aggregator must override to ``macro_f1`` for
+    cell selection. The trainer writes ``combined_rmse`` as the
+    selection metric regardless of output mode and every classification
+    trial reports ``inf`` for combined_rmse, so honoring that field
+    collapses the per-cell ranking to an arbitrary order."""
+
+    def _classification_trial(*, fold_id: str, hp: int, macro: float) -> dict[str, object]:
+        # 3 classes, 10 predictions, mostly correct so macro_f1 ~ ``macro``.
+        n_right = int(round(macro * 10))
+        preds = [0] * n_right + [1] * (10 - n_right)
+        targets = [0] * 10
+        return {
+            "architecture": "gru",
+            "fold_id": fold_id,
+            "seed": 11,
+            "hp_combo_id": hp,
+            "summary": {
+                "model_config": {
+                    "hidden_size": 64,
+                    "num_layers": 2,
+                    "dropout": 0.2,
+                    "output_mode": "classification",
+                },
+                "learning_rate": 1e-3,
+                "weight_decay": 1e-4,
+                "test_metrics": {
+                    "predictions": preds,
+                    "targets": targets,
+                    "combined_rmse": float("inf"),
+                    "classification_breakdown": {
+                        "macro_f1": _compute_macro(preds, targets),
+                    },
+                },
+            },
+        }
+
+    blob = {
+        "trials": [
+            _classification_trial(fold_id="wf_fold_1", hp=0, macro=0.3),
+            _classification_trial(fold_id="wf_fold_2", hp=0, macro=0.3),
+            _classification_trial(fold_id="wf_fold_1", hp=1, macro=0.8),
+            _classification_trial(fold_id="wf_fold_2", hp=1, macro=0.8),
+        ],
+        "selection_metric": "combined_rmse",
+    }
+    rows = aggregate([blob], n_classes=3, n_resamples=20)
+    assert len(rows) == 1
+    row = rows[0]
+    # Without the classification override the per-cell selector would
+    # tie-break on inf combined_rmse and could pick HP 0 (macro_f1 ~
+    # 0.3). With the override, HP 1 (macro_f1 ~ 0.8) wins.
+    assert row.hp_combo_id == "1"
+    assert row.breakdown.macro_f1 > 0.5


### PR DESCRIPTION
## Summary

Two related changes in support of the Path B Variant A headline.

**Pooled aggregator default-selector fix.** The aggregator's per-architecture cell selector honoured the sweep JSON's top-level \`selection_metric\`, which the trainer always writes as \`combined_rmse\` regardless of output mode. Under classification mode every trial reports inf for combined_rmse, so the per-cell ranking collapses to whichever cell pandas iterates first — i.e. effectively arbitrary HP cell per architecture, and a misleading headline.

The fix peeks at per-trial \`model_config.output_mode\`: when any trial reports \`"classification"\` and the caller has not pinned \`--selection-metric\` explicitly, the aggregator overrides to \`macro_f1\`. Regression sweeps are unchanged.

**FOMC-only filter script.** \`scripts/macro_aug_fomc_only_filter.py\` is the diagnostic that produced the FOMC-only re-pool numbers in §6.7 — joins each per-trial prediction position to its \`event_date\` via \`WalkForwardSplit.test_event_dates\`, drops rows whose date is in the FRED release-calendar set, and re-pools the surviving predictions for an apples-to-apples macro-F1 + bootstrap CI.

## Test plan

- [x] \`pytest tests/unit/test_regime_pooled_aggregator.py\` — 7 pass including the new \`test_classification_sweep_defaults_to_macro_f1_selection\` case
- [x] Filter script ran end-to-end against the macro-aug sweep producing Transformer FOMC-only macro-F1 = 0.5225 [0.493, 0.552]
- [ ] CI green