### PR TITLE
Multi-task head + multi_axis surface on /analyze (#78)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -252,11 +252,49 @@ def _build_analyze_response(
         "market": market,
         "model": forecast["model"],
         "series": forecast["series"],
+        "multi_axis": _build_multi_axis_block(sentiment),
     }
     if getattr(payload, "include_xai", False):
         attributions = attribute_text(payload.text)
         response["xai"] = xai_to_response(attributions)
     return response
+
+
+def _build_multi_axis_block(sentiment: dict[str, Any]) -> dict[str, Any] | None:
+    """Build the multi-axis card block from the available text signals (#78).
+
+    Stance card reuses the existing text classifier output (hawkish /
+    dovish / neutral with per-class probability). The factor /
+    certainty / topic cards are left at ``None`` for now — the
+    multi-task text classifier that will populate them is staged
+    infrastructure (see ``MultiTaskHead`` / ``MultiTaskLoss`` in the
+    models / training packages) and lands in a follow-up. The frontend
+    renders ``None`` cards with a "not available" affordance so users
+    see honest absence rather than a placeholder value.
+    """
+
+    label_raw = str(sentiment.get("label", "")).strip().lower()
+    canonical_labels = ("hawkish", "dovish", "neutral")
+    label = label_raw if label_raw in canonical_labels else "neutral"
+
+    distribution: dict[str, float] = {key: 0.0 for key in canonical_labels}
+    for entry in sentiment.get("raw", []) or []:
+        raw_label = str(entry.get("label", "")).strip().lower()
+        if raw_label in distribution:
+            distribution[raw_label] = float(entry.get("score", 0.0) or 0.0)
+    confidence = float(sentiment.get("score", distribution.get(label, 0.0)) or 0.0)
+    confidence = max(0.0, min(1.0, confidence))
+
+    return {
+        "stance": {
+            "label": label,
+            "confidence": confidence,
+            "distribution": distribution,
+        },
+        "factor": None,
+        "certainty": None,
+        "topic": None,
+    }
 
 
 @app.post("/analyze", response_model=AnalyzeResponse)

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -132,6 +132,25 @@ RICH_LLM_FEATURE_MISSING_SLICE = slice(
     RICH_LLM_FEATURE_SLICE.stop + RICH_LLM_FEATURE_MISSING_DIM,
 )
 
+# Multi-task head (#78) axis cardinalities and canonical label maps.
+# The multi-task head emits four branches; the cardinalities are pinned
+# here so the loader, the model factory, and the inference path agree on
+# the shape. Adding a topic label would require bumping
+# MULTI_TASK_TOPIC_LABELS in lockstep with the loader's topic-string
+# normaliser; the four buckets below cover the only topic-string
+# families that show up on gtfintechlab + scraped Fed rows.
+MULTI_TASK_STANCE_CLASSES = 3
+MULTI_TASK_CERTAINTY_CLASSES = 3
+MULTI_TASK_TOPIC_CLASSES = 4
+MULTI_TASK_STANCE_LABELS: tuple[str, ...] = ("hawkish", "dovish", "neutral")
+MULTI_TASK_CERTAINTY_LABELS: tuple[str, ...] = ("certain", "uncertain", "neutral")
+MULTI_TASK_TOPIC_LABELS: tuple[str, ...] = (
+    "macro",
+    "forward_guidance",
+    "market_reaction",
+    "other",
+)
+
 # Text-embedding adapter dim search axis. The forecaster sweep iterates
 # over these values so the diminishing-returns curve across {32, 64, 128}
 # shows up in the aggregator table. The default mirrors the small-data
@@ -509,6 +528,25 @@ class FeatureVector:
     # across the prior-window. Stays empty on every static-cache path
     # so the legacy embedding pipeline is byte-identical.
     raw_text: str = ""
+    # Multi-task head (#78) per-axis training targets. Populated by the
+    # loader on the target-row bar (last index of each supervised
+    # sequence); the lookback bars carry the defaults. ``target_*_present``
+    # is the per-axis mask the loss reads to decide whether the row
+    # contributes to that axis's loss. Indices use the canonical
+    # mappings: stance {hawkish: 0, dovish: 1, neutral: 2}, certainty
+    # {certain: 0, uncertain: 1, neutral: 2}, topic {macro: 0,
+    # forward_guidance: 1, market_reaction: 2, other: 3}. Factor is a
+    # signed scalar in [-1, 1] (no idx). When a label is absent the
+    # target field stays at its default and the mask is False, so the
+    # masked loss contributes zero for that axis on that row.
+    target_stance_idx: int = -1
+    target_stance_present: bool = False
+    target_factor: float = 0.0
+    target_factor_present: bool = False
+    target_certainty_idx: int = -1
+    target_certainty_present: bool = False
+    target_topic_idx: int = -1
+    target_topic_present: bool = False
 
     @classmethod
     def from_market_state(

--- a/backend/app/models/lstm.py
+++ b/backend/app/models/lstm.py
@@ -23,6 +23,7 @@ from app.models.config import (
     SEQUENCE_LENGTH,
 )
 from app.models.dlinear import DLinear
+from app.models.multi_task_head import MultiTaskHead
 from app.models.tcn import TemporalConvNet
 from app.models.transformer import SmallTransformer
 
@@ -228,23 +229,35 @@ class ForecasterModel(nn.Module):
         else:
             self.recurrent_attention = None
         # Phase 9 V2 (#195) head dispatch. ``regression`` keeps the
-        # 2-output (close, vol) shape; ``classification`` switches the
-        # final linear to emit ``n_classes`` logits for CrossEntropy.
-        # The intermediate LayerNorm + Linear(hidden, head_hidden) +
-        # GELU + Dropout stack is shared across modes so the
-        # representation capacity stays comparable.
+        # 2-output (close, vol) shape; ``classification`` switches to
+        # the multi-task head (#78) which emits four branches: stance
+        # (the 3-class headline target), factor (scalar [-1, 1]),
+        # certainty (3-class), and topic (4-class). The shared
+        # pre-classifier stem mirrors the legacy LayerNorm + Linear +
+        # GELU + Dropout stack so per-branch capacity matches the
+        # baseline. Multi-task replaces single-head as the canonical
+        # classification path (state_dict shape break documented in
+        # ADR-0010); checkpoints trained on the legacy single head do
+        # not load here, and cold-start /analyze retrains from scratch.
         self.output_mode = output_mode
         self.n_classes = int(n_classes)
         self.vol_regime_quantiles = tuple(float(v) for v in vol_regime_quantiles or ())
         self.vol_regime_target = str(vol_regime_target or "forward_realized_vol_10d")
-        head_out = self.n_classes if output_mode == "classification" else 2
-        self.head = nn.Sequential(
-            nn.LayerNorm(hidden_size),
-            nn.Linear(hidden_size, head_hidden_size),
-            nn.GELU(),
-            nn.Dropout(dropout),
-            nn.Linear(head_hidden_size, head_out),
-        )
+        if output_mode == "classification":
+            self.head: nn.Module = MultiTaskHead(
+                hidden_size=hidden_size,
+                head_hidden_size=head_hidden_size,
+                dropout=dropout,
+                stance_classes=self.n_classes,
+            )
+        else:
+            self.head = nn.Sequential(
+                nn.LayerNorm(hidden_size),
+                nn.Linear(hidden_size, head_hidden_size),
+                nn.GELU(),
+                nn.Dropout(dropout),
+                nn.Linear(head_hidden_size, 2),
+            )
 
     def forward(
         self,
@@ -342,17 +355,117 @@ class ForecasterModel(nn.Module):
             pooled_step = output.mean(dim=1)
         else:
             pooled_step = output[:, -1, :]
-        raw = self.head(pooled_step)
-        # Phase 9 V2 (#195) dispatch. Classification mode returns the
-        # raw class logits ``(batch, n_classes)`` so the training-loop
-        # CrossEntropyLoss path can apply ``log_softmax`` itself. The
-        # regression path keeps the existing softplus-on-volatility
-        # post-processing (unconstrained close + non-negative vol).
+        # Phase 9 V2 (#195) + multi-task head (#78) dispatch.
+        # Classification mode calls the MultiTaskHead which emits a
+        # dict of per-axis logits; the stance branch is the canonical
+        # 3-class output the training-loop CrossEntropyLoss reads, the
+        # other three branches are stashed on ``self._last_multi_task``
+        # for the multi-task loss + the /analyze response serialiser
+        # to read. Regression mode keeps the existing 2-output
+        # (close, vol) head and softplus post-processing.
         if self.output_mode == "classification":
-            return raw  # type: ignore[no-any-return]
+            multi_task = self.head(pooled_step)
+            self._last_multi_task = {
+                key: tensor.detach() for key, tensor in multi_task.items()
+            }
+            return multi_task["stance"]  # type: ignore[no-any-return]
+        raw = self.head(pooled_step)
         close = raw[:, 0:1]
         volatility = F.softplus(raw[:, 1:2])
         return torch.cat((close, volatility), dim=1)
+
+    def forward_multi_task(
+        self,
+        x: torch.Tensor,
+        chunks: torch.Tensor | None = None,
+        elapsed_days: torch.Tensor | None = None,
+        chunk_mask: torch.Tensor | None = None,
+        credibility: torch.Tensor | None = None,
+        text_embedding: torch.Tensor | None = None,
+        text_embedding_missing: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """Run the forward pass and return the full multi-task dict.
+
+        Classification mode only; raises ``RuntimeError`` on a model
+        configured for regression. Used by the multi-task training
+        loss (which needs gradient-tracked logits for all four
+        branches) and by the inference path (which serialises every
+        branch into the ``/analyze`` response). The main
+        :meth:`forward` returns only the stance logits so existing
+        CrossEntropy callers stay byte-compatible.
+        """
+
+        if self.output_mode != "classification":
+            raise RuntimeError(
+                "forward_multi_task requires output_mode='classification'"
+            )
+        # Mirror the body of forward() up to the pooled-step but emit
+        # the multi-task dict instead of the stance-only tensor.
+        if self.use_time_decay:
+            x = self.time_decay(x)
+        _uses_pooler = self.use_chunk_attention or self.use_llm_embeddings
+        if _uses_pooler:
+            if self.chunk_pooler is None or self.chunk_projection is None:
+                raise RuntimeError("chunk_pooler not initialised but pooler variant is active")
+            if chunks is None or elapsed_days is None:
+                variant = "use_chunk_attention" if self.use_chunk_attention else "use_llm_embeddings"
+                raise ValueError(
+                    f"ForecasterModel requires chunks/elapsed_days when {variant}=True"
+                )
+            pooled, _, _ = self.chunk_pooler(chunks, elapsed_days, mask=chunk_mask)
+            projected = self.chunk_projection(pooled)
+            if projected.dim() == 1:
+                projected = projected.unsqueeze(0)
+            seq_len = x.shape[1]
+            broadcast = projected.unsqueeze(1).expand(-1, seq_len, -1)
+            x = torch.cat([x, broadcast], dim=-1)
+        if self.credibility_features:
+            if credibility is None:
+                raise ValueError(
+                    "ForecasterModel requires `credibility` tensor when credibility_features=True"
+                )
+            if credibility.dim() == 1:
+                credibility = credibility.unsqueeze(0)
+            seq_len = x.shape[1]
+            broadcast = credibility.unsqueeze(1).expand(-1, seq_len, -1)
+            x = torch.cat([x, broadcast], dim=-1)
+        if self._text_path_active:
+            if self.text_adapter is None or text_embedding is None:
+                raise RuntimeError("text path active but inputs missing")
+            if text_embedding.dim() == 1:
+                text_embedding = text_embedding.unsqueeze(0)
+            projected = self.text_adapter(text_embedding)
+            if text_embedding_missing is None:
+                missing_column = torch.zeros(
+                    (projected.shape[0], 1),
+                    dtype=projected.dtype,
+                    device=projected.device,
+                )
+            else:
+                missing_column = text_embedding_missing
+                if missing_column.dim() == 1:
+                    missing_column = missing_column.unsqueeze(-1)
+                missing_column = missing_column.to(
+                    dtype=projected.dtype, device=projected.device
+                )
+            keep_mask = (1.0 - missing_column).clamp_(min=0.0, max=1.0)
+            projected = projected * keep_mask
+            text_slot = torch.cat([projected, missing_column], dim=-1)
+            seq_len = x.shape[1]
+            broadcast = text_slot.unsqueeze(1).expand(-1, seq_len, -1)
+            x = torch.cat([x, broadcast], dim=-1)
+        output, _ = self.lstm(x)
+        if self.uses_attention_pool:
+            if self.recurrent_attention is None:
+                raise RuntimeError(
+                    "recurrent_attention not initialised but lstm_attn variant is active"
+                )
+            pooled_step, _ = self.recurrent_attention(output)
+        elif self.uses_mean_pool:
+            pooled_step = output.mean(dim=1)
+        else:
+            pooled_step = output[:, -1, :]
+        return self.head(pooled_step)  # type: ignore[no-any-return]
 
     def attention_diagnostics(
         self,

--- a/backend/app/models/multi_task_head.py
+++ b/backend/app/models/multi_task_head.py
@@ -1,0 +1,99 @@
+"""Multi-task head for the forecaster (#78).
+
+Replaces the legacy single-output classification head on
+``ForecasterModel`` when ``output_mode=="classification"``. Emits four
+branches from a shared pre-classifier stem:
+
+- ``stance`` — 3-class logits over ``{hawkish, dovish, neutral}`` (the
+  legacy 3-class head; the existing CrossEntropy loss reads from this
+  branch on the training path so the headline macro-F1 stays
+  comparable to the single-head baseline).
+- ``factor`` — scalar regression in ``[-1, 1]`` (tanh-bounded).
+- ``certainty`` — 3-class logits over ``{certain, uncertain, neutral}``.
+- ``topic`` — K-class logits over ``MULTI_TASK_TOPIC_LABELS``
+  (``{macro, forward_guidance, market_reaction, other}``).
+
+The shared stem (LayerNorm + Linear + GELU + Dropout) mirrors the
+existing single-head pre-classifier so the representation capacity
+per branch is comparable to the baseline. Each branch is a single
+linear projection from the stem output, which keeps the parameter
+count small on top of the recurrent core.
+
+Loss masking lives in :class:`app.training.loss.MultiTaskLoss`; the
+head itself is mask-unaware (it always emits the same shape).
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from app.models.config import (
+    MULTI_TASK_CERTAINTY_CLASSES,
+    MULTI_TASK_STANCE_CLASSES,
+    MULTI_TASK_TOPIC_CLASSES,
+)
+
+
+class MultiTaskHead(nn.Module):
+    """Per-axis output heads sharing a pre-classifier stem.
+
+    Construction mirrors the legacy single-head Sequential at
+    ``lstm.py:230-247`` (LayerNorm + Linear + GELU + Dropout) so the
+    head capacity is comparable. The four output projections are
+    independent linears applied to the stem output.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        head_hidden_size: int,
+        dropout: float,
+        *,
+        stance_classes: int = MULTI_TASK_STANCE_CLASSES,
+        certainty_classes: int = MULTI_TASK_CERTAINTY_CLASSES,
+        topic_classes: int = MULTI_TASK_TOPIC_CLASSES,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = int(hidden_size)
+        self.head_hidden_size = int(head_hidden_size)
+        self.dropout = float(dropout)
+        self.stance_classes = int(stance_classes)
+        self.certainty_classes = int(certainty_classes)
+        self.topic_classes = int(topic_classes)
+
+        self.stem = nn.Sequential(
+            nn.LayerNorm(self.hidden_size),
+            nn.Linear(self.hidden_size, self.head_hidden_size),
+            nn.GELU(),
+            nn.Dropout(self.dropout),
+        )
+        self.stance = nn.Linear(self.head_hidden_size, self.stance_classes)
+        self.factor = nn.Linear(self.head_hidden_size, 1)
+        self.certainty = nn.Linear(self.head_hidden_size, self.certainty_classes)
+        self.topic = nn.Linear(self.head_hidden_size, self.topic_classes)
+
+    def forward(self, pooled: torch.Tensor) -> dict[str, torch.Tensor]:
+        """Emit per-axis predictions from the pooled backbone output.
+
+        Returns a dict with four keys:
+
+        - ``stance`` — ``(B, stance_classes)`` raw logits
+        - ``factor`` — ``(B,)`` tanh-bounded scalar in ``[-1, 1]``
+        - ``certainty`` — ``(B, certainty_classes)`` raw logits
+        - ``topic`` — ``(B, topic_classes)`` raw logits
+
+        Classification branches return raw logits so CrossEntropy can
+        apply log-softmax internally. The factor branch applies a tanh
+        bound at emit time because the upstream label support is in
+        ``[-1, 1]`` and an unconstrained linear regressor would drift
+        outside that range on rows with no factor supervision.
+        """
+
+        stem = self.stem(pooled)
+        return {
+            "stance": self.stance(stem),
+            "factor": torch.tanh(self.factor(stem).squeeze(-1)),
+            "certainty": self.certainty(stem),
+            "topic": self.topic(stem),
+        }

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -153,6 +153,73 @@ class CredibilityResponse(BaseModel):
     months_since_reversal: int
 
 
+class MultiAxisStanceCard(BaseModel):
+    """Stance prediction from the multi-task head."""
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    label: str = Field(..., description="hawkish | dovish | neutral")
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    distribution: dict[str, float] = Field(
+        default_factory=dict,
+        description="Per-class softmax probability over hawkish/dovish/neutral.",
+    )
+
+
+class MultiAxisFactorCard(BaseModel):
+    """Forward-guidance factor regression in [-1, 1].
+
+    Positive values lean hawkish, negative values lean dovish. Sourced
+    from the multi-task head's tanh-bounded regression branch.
+    Confidence reflects training-time coverage and is left to the
+    caller to calibrate; absent supervision, the field is None.
+    """
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    value: float = Field(..., ge=-1.0, le=1.0)
+    confidence: float = Field(..., ge=0.0, le=1.0)
+
+
+class MultiAxisCertaintyCard(BaseModel):
+    """Certainty prediction from the multi-task head."""
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    label: str = Field(..., description="certain | uncertain | neutral")
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    distribution: dict[str, float] = Field(default_factory=dict)
+
+
+class MultiAxisTopicCard(BaseModel):
+    """Topic prediction from the multi-task head."""
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    label: str = Field(..., description="macro | forward_guidance | market_reaction | other")
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    distribution: dict[str, float] = Field(default_factory=dict)
+
+
+class MultiAxisBlock(BaseModel):
+    """Multi-task head per-axis predictions surfaced on /analyze (#78).
+
+    The four axes mirror the multi-task head's four output branches.
+    Stance reuses the canonical 3-class classifier (also exposed on
+    the legacy ``sentiment`` field for back-compat); the other three
+    branches are populated for the first time with this block. Axes
+    whose checkpoint was trained on very few labels are flagged as
+    low-confidence; the frontend renders a muted card in that case.
+    """
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    stance: MultiAxisStanceCard
+    factor: MultiAxisFactorCard | None = None
+    certainty: MultiAxisCertaintyCard | None = None
+    topic: MultiAxisTopicCard | None = None
+
+
 class AnalyzeResponse(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 
@@ -163,6 +230,7 @@ class AnalyzeResponse(BaseModel):
     series: ForecastSeriesResponse
     xai: XaiResponse | None = None
     credibility: CredibilityResponse | None = None
+    multi_axis: MultiAxisBlock | None = None
 
 
 class HistoryEntry(BaseModel):

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -19,6 +19,9 @@ from app.models.config import (
     DEFAULT_TEXT_ADAPTER_DIM,
     DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS,
     FEATURE_SIZE,
+    MULTI_TASK_CERTAINTY_LABELS,
+    MULTI_TASK_STANCE_LABELS,
+    MULTI_TASK_TOPIC_LABELS,
     RICH_FEATURE_SIZE,
     RICH_LINGUISTIC_DIM,
     RichFeatureScalerParams,
@@ -1041,6 +1044,77 @@ def _attach_rich_features(
         time_label_forward = certain_label_certain = 0.0
         stance_missing = 0.0
 
+    # Multi-task head (#78) per-axis training targets. Independent of
+    # ``use_multi_axis`` (which controls the rich-feature INPUT block);
+    # targets are always lifted off the event row when present so the
+    # masked loss can contribute on every supervised row that carries a
+    # label. Missing labels leave the target at its default and the
+    # mask flag at False; the loss reads the flag to skip that axis on
+    # that row.
+    target_stance_str = (
+        str(event_row.get("axis_stance")).strip().lower()
+        if isinstance(event_row.get("axis_stance"), str)
+        and str(event_row.get("axis_stance")).strip()
+        else None
+    )
+    target_stance_idx = -1
+    target_stance_present = False
+    if target_stance_str in MULTI_TASK_STANCE_LABELS:
+        target_stance_idx = MULTI_TASK_STANCE_LABELS.index(target_stance_str)
+        target_stance_present = True
+
+    target_factor_value = _coerce_finite_float(event_row.get("axis_factor"))
+    if target_factor_value is None:
+        target_factor = 0.0
+        target_factor_present = False
+    else:
+        target_factor = max(min(float(target_factor_value), 1.0), -1.0)
+        target_factor_present = True
+
+    # Certainty: prefer the categorical ``axis_certain_label`` (string)
+    # from gtfintechlab rows; fall back to the numeric ``axis_certainty``
+    # (float in [0, 1]) binned into 3 classes when only the float is
+    # populated. Tertiles fit the {certain, uncertain, neutral} taxonomy.
+    target_certainty_idx = -1
+    target_certainty_present = False
+    certainty_str_raw = event_row.get("axis_certain_label")
+    certainty_str = (
+        str(certainty_str_raw).strip().lower()
+        if isinstance(certainty_str_raw, str) and str(certainty_str_raw).strip()
+        else None
+    )
+    if certainty_str in MULTI_TASK_CERTAINTY_LABELS:
+        target_certainty_idx = MULTI_TASK_CERTAINTY_LABELS.index(certainty_str)
+        target_certainty_present = True
+    else:
+        certainty_float = _coerce_finite_float(event_row.get("axis_certainty"))
+        if certainty_float is not None:
+            if certainty_float >= 0.66:
+                target_certainty_idx = MULTI_TASK_CERTAINTY_LABELS.index("certain")
+            elif certainty_float <= 0.33:
+                target_certainty_idx = MULTI_TASK_CERTAINTY_LABELS.index("uncertain")
+            else:
+                target_certainty_idx = MULTI_TASK_CERTAINTY_LABELS.index("neutral")
+            target_certainty_present = True
+
+    target_topic_idx = -1
+    target_topic_present = False
+    topic_raw = event_row.get("axis_topic")
+    topic_str = (
+        str(topic_raw).strip().lower()
+        if isinstance(topic_raw, str) and str(topic_raw).strip()
+        else None
+    )
+    if topic_str is not None:
+        for canonical in MULTI_TASK_TOPIC_LABELS[:-1]:
+            if canonical in topic_str:
+                target_topic_idx = MULTI_TASK_TOPIC_LABELS.index(canonical)
+                target_topic_present = True
+                break
+        if not target_topic_present:
+            target_topic_idx = MULTI_TASK_TOPIC_LABELS.index("other")
+            target_topic_present = True
+
     for vector in vectors:
         vector.credibility_drift_score = cred_drift
         vector.credibility_realized_vs_stated_gap = cred_realized
@@ -1057,6 +1131,14 @@ def _attach_rich_features(
         vector.time_label_forward = time_label_forward
         vector.certain_label_certain = certain_label_certain
         vector.stance_missing = stance_missing
+        vector.target_stance_idx = target_stance_idx
+        vector.target_stance_present = target_stance_present
+        vector.target_factor = target_factor
+        vector.target_factor_present = target_factor_present
+        vector.target_certainty_idx = target_certainty_idx
+        vector.target_certainty_present = target_certainty_present
+        vector.target_topic_idx = target_topic_idx
+        vector.target_topic_present = target_topic_present
         vector.rich_payload = True
 
 
@@ -2428,6 +2510,81 @@ def _build_training_tensors(
     else:
         y = torch.tensor(targets, dtype=torch.float32)
     return x, y, fitted_scale
+
+
+def _build_multi_task_target_tensors(
+    sequence_groups: Sequence[Sequence[FeatureVector]],
+    *,
+    vol_regime_quantiles: Sequence[float],
+) -> dict[str, torch.Tensor] | None:
+    """Materialise per-axis targets aligned with ``_build_training_tensors``.
+
+    Returns a dict of 8 1-D tensors: 4 target tensors (stance / factor /
+    certainty / topic) and 4 corresponding mask tensors. Row alignment
+    matches the classification rows ``_build_training_tensors`` emits —
+    same filter (drop rows whose ``forward_realized_vol_10d`` is missing
+    so ``vol_regime_class_for`` returns -1), same iteration order. Mask
+    tensors are True iff the underlying axis label was populated on the
+    target-row event; False rows do not contribute to that axis's loss.
+
+    Returns ``None`` when no rows survive the filter (matches the
+    None / None return contract of ``_build_training_tensors``).
+    """
+
+    stance_targets: list[int] = []
+    stance_masks: list[bool] = []
+    factor_targets: list[float] = []
+    factor_masks: list[bool] = []
+    certainty_targets: list[int] = []
+    certainty_masks: list[bool] = []
+    topic_targets: list[int] = []
+    topic_masks: list[bool] = []
+
+    for sequence_group in sequence_groups:
+        if len(sequence_group) < SEQUENCE_LENGTH + 1:
+            continue
+        for idx in range(SEQUENCE_LENGTH, len(sequence_group)):
+            target_row = sequence_group[idx]
+            cls_idx = vol_regime_class_for(
+                getattr(target_row, "forward_realized_vol_10d", None),
+                vol_regime_quantiles,
+            )
+            if cls_idx < 0:
+                continue
+            stance_idx = int(getattr(target_row, "target_stance_idx", -1) or 0)
+            stance_present = bool(getattr(target_row, "target_stance_present", False))
+            stance_targets.append(max(stance_idx, 0))
+            stance_masks.append(stance_present)
+
+            factor_val = float(getattr(target_row, "target_factor", 0.0) or 0.0)
+            factor_present = bool(getattr(target_row, "target_factor_present", False))
+            factor_targets.append(factor_val)
+            factor_masks.append(factor_present)
+
+            certainty_idx = int(getattr(target_row, "target_certainty_idx", -1) or 0)
+            certainty_present = bool(
+                getattr(target_row, "target_certainty_present", False)
+            )
+            certainty_targets.append(max(certainty_idx, 0))
+            certainty_masks.append(certainty_present)
+
+            topic_idx = int(getattr(target_row, "target_topic_idx", -1) or 0)
+            topic_present = bool(getattr(target_row, "target_topic_present", False))
+            topic_targets.append(max(topic_idx, 0))
+            topic_masks.append(topic_present)
+
+    if not stance_targets:
+        return None
+    return {
+        "stance": torch.tensor(stance_targets, dtype=torch.long),
+        "stance_mask": torch.tensor(stance_masks, dtype=torch.bool),
+        "factor": torch.tensor(factor_targets, dtype=torch.float32),
+        "factor_mask": torch.tensor(factor_masks, dtype=torch.bool),
+        "certainty": torch.tensor(certainty_targets, dtype=torch.long),
+        "certainty_mask": torch.tensor(certainty_masks, dtype=torch.bool),
+        "topic": torch.tensor(topic_targets, dtype=torch.long),
+        "topic_mask": torch.tensor(topic_masks, dtype=torch.bool),
+    }
 
 
 def _build_text_embedding_tensors(

--- a/backend/app/training/loss.py
+++ b/backend/app/training/loss.py
@@ -78,13 +78,16 @@ class MultiTaskLoss(nn.Module):
         self.factor_smooth_l1_beta = float(factor_smooth_l1_beta)
 
     def _stance_weight_or_none(self) -> torch.Tensor | None:
-        return self._stance_weight if self._stance_weight.numel() > 0 else None
+        buf = self.get_buffer("_stance_weight")
+        return buf if buf.numel() > 0 else None
 
     def _certainty_weight_or_none(self) -> torch.Tensor | None:
-        return self._certainty_weight if self._certainty_weight.numel() > 0 else None
+        buf = self.get_buffer("_certainty_weight")
+        return buf if buf.numel() > 0 else None
 
     def _topic_weight_or_none(self) -> torch.Tensor | None:
-        return self._topic_weight if self._topic_weight.numel() > 0 else None
+        buf = self.get_buffer("_topic_weight")
+        return buf if buf.numel() > 0 else None
 
     def forward(
         self,

--- a/backend/app/training/loss.py
+++ b/backend/app/training/loss.py
@@ -1,0 +1,181 @@
+"""Multi-task loss for the four-branch classification head (#78).
+
+The four axes (stance, factor, certainty, topic) have very different
+label-coverage rates on the supervised corpus: stance ~100%, factor
+and certainty <5% (gtfintechlab cross-bank rows + the gss_factor
+source only), topic 0% upstream. The loss handles this with per-axis
+masks — a row only contributes loss on axes where its label was
+populated, so the optimiser never learns from a synthetic placeholder
+that would otherwise lock the head in on a meaningless mean.
+
+The total loss is a lambda-weighted sum:
+
+    L = lambda_stance * stance_loss
+      + lambda_factor * factor_loss
+      + lambda_certainty * certainty_loss
+      + lambda_topic * topic_loss
+
+Each per-axis term is the mean of the row-wise loss over rows where
+that axis's mask is True (0 when the mask is empty for that batch,
+which avoids div-by-zero). Lambdas default to (1.0, 0.3, 0.3, 0.3) so
+the headline stance F1 stays the dominant gradient signal; the
+sparser axes contribute auxiliary gradients without overpowering
+stance.
+
+Class weights are passed per axis. Stance reuses the per-fold
+``fit_class_weights`` output; certainty / topic class weights are
+fitted on the train slice independently using the same helper. The
+factor branch is a regression (SmoothL1, ``beta=0.02`` to mirror the
+existing vol-regression loss) so it does not consume a class-weight
+tensor.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+class MultiTaskLoss(nn.Module):
+    """Per-axis weighted + masked loss for the multi-task head.
+
+    Reads logits and targets from dicts keyed by axis name and applies
+    the corresponding per-axis loss (CE for stance / certainty /
+    topic; SmoothL1 for factor). Class weights are optional per axis
+    — None gives uniform weighting on that axis.
+    """
+
+    def __init__(
+        self,
+        *,
+        stance_weight: torch.Tensor | None = None,
+        certainty_weight: torch.Tensor | None = None,
+        topic_weight: torch.Tensor | None = None,
+        lambda_stance: float = 1.0,
+        lambda_factor: float = 0.3,
+        lambda_certainty: float = 0.3,
+        lambda_topic: float = 0.3,
+        factor_smooth_l1_beta: float = 0.02,
+    ) -> None:
+        super().__init__()
+        self.register_buffer(
+            "_stance_weight",
+            stance_weight if stance_weight is not None else torch.empty(0),
+        )
+        self.register_buffer(
+            "_certainty_weight",
+            certainty_weight if certainty_weight is not None else torch.empty(0),
+        )
+        self.register_buffer(
+            "_topic_weight",
+            topic_weight if topic_weight is not None else torch.empty(0),
+        )
+        self.lambda_stance = float(lambda_stance)
+        self.lambda_factor = float(lambda_factor)
+        self.lambda_certainty = float(lambda_certainty)
+        self.lambda_topic = float(lambda_topic)
+        self.factor_smooth_l1_beta = float(factor_smooth_l1_beta)
+
+    def _stance_weight_or_none(self) -> torch.Tensor | None:
+        return self._stance_weight if self._stance_weight.numel() > 0 else None
+
+    def _certainty_weight_or_none(self) -> torch.Tensor | None:
+        return self._certainty_weight if self._certainty_weight.numel() > 0 else None
+
+    def _topic_weight_or_none(self) -> torch.Tensor | None:
+        return self._topic_weight if self._topic_weight.numel() > 0 else None
+
+    def forward(
+        self,
+        logits: dict[str, torch.Tensor],
+        targets: dict[str, torch.Tensor],
+        masks: dict[str, torch.Tensor],
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Return ``(total_loss, per_axis_breakdown)``.
+
+        ``per_axis_breakdown`` is a detached dict of scalar tensors
+        keyed by axis name so the training-loop logger can record per-
+        axis loss trajectories. Axes whose mask is all-False contribute
+        zero loss to the total and emit a zero-valued breakdown entry.
+        """
+
+        device = logits["stance"].device
+        zero = torch.zeros((), device=device)
+
+        stance_loss = self._masked_classification_loss(
+            logits["stance"],
+            targets["stance"],
+            masks["stance_mask"],
+            weight=self._stance_weight_or_none(),
+        )
+        factor_loss = self._masked_regression_loss(
+            logits["factor"],
+            targets["factor"],
+            masks["factor_mask"],
+        )
+        certainty_loss = self._masked_classification_loss(
+            logits["certainty"],
+            targets["certainty"],
+            masks["certainty_mask"],
+            weight=self._certainty_weight_or_none(),
+        )
+        topic_loss = self._masked_classification_loss(
+            logits["topic"],
+            targets["topic"],
+            masks["topic_mask"],
+            weight=self._topic_weight_or_none(),
+        )
+
+        total = (
+            self.lambda_stance * stance_loss
+            + self.lambda_factor * factor_loss
+            + self.lambda_certainty * certainty_loss
+            + self.lambda_topic * topic_loss
+        )
+        if not total.requires_grad and stance_loss.requires_grad:
+            total = total + zero
+        return total, {
+            "stance": stance_loss.detach(),
+            "factor": factor_loss.detach(),
+            "certainty": certainty_loss.detach(),
+            "topic": topic_loss.detach(),
+        }
+
+    @staticmethod
+    def _masked_classification_loss(
+        logits: torch.Tensor,
+        target: torch.Tensor,
+        mask: torch.Tensor,
+        *,
+        weight: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Mean CE loss over masked rows; zero when no rows are masked.
+
+        ``F.cross_entropy`` would happily train against the placeholder
+        class indices on masked-out rows; instead we slice the logits
+        and targets by the boolean mask before computing the loss.
+        Returns a graph-attached zero (``logits.sum() * 0``) when no
+        rows survive so the optimiser still sees a tensor on the
+        same device with the same gradient connectivity.
+        """
+
+        if mask.numel() == 0 or not mask.any():
+            return logits.sum() * 0.0
+        active_logits = logits[mask]
+        active_target = target[mask]
+        return F.cross_entropy(active_logits, active_target, weight=weight)
+
+    def _masked_regression_loss(
+        self,
+        pred: torch.Tensor,
+        target: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor:
+        if mask.numel() == 0 or not mask.any():
+            return pred.sum() * 0.0
+        active_pred = pred[mask]
+        active_target = target[mask]
+        return F.smooth_l1_loss(
+            active_pred, active_target, beta=self.factor_smooth_l1_beta
+        )

--- a/backend/app/training/loss.py
+++ b/backend/app/training/loss.py
@@ -46,7 +46,7 @@ class MultiTaskLoss(nn.Module):
     — None gives uniform weighting on that axis.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 — per-axis class weights + lambdas surface as named kwargs by design
         self,
         *,
         stance_weight: torch.Tensor | None = None,

--- a/frontend/components/analyze/MultiAxisCards.tsx
+++ b/frontend/components/analyze/MultiAxisCards.tsx
@@ -121,12 +121,13 @@ function CertaintyCard({ certainty }: { certainty: NonNullable<MultiAxisResponse
 }
 
 function TopicCard({ topic }: { topic: NonNullable<MultiAxisResponse["topic"]> }) {
+  const display = (topic.label ?? topic.primary ?? "other").toString();
   return (
     <Card>
       <CardHeader className="pb-2">
         <CardDescription>Topic</CardDescription>
         <CardTitle className="text-xl capitalize">
-          {topic.primary.replace(/_/g, " ")}
+          {display.replace(/_/g, " ")}
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-2">

--- a/frontend/lib/analyze/compare.ts
+++ b/frontend/lib/analyze/compare.ts
@@ -100,9 +100,15 @@ export function describeStanceShift(shift: CompareDelta["stanceShift"]): string 
   }
 }
 
-// Certainty axis ranks "decisive" highest and "tentative" lowest so the
-// shift label tracks confidence movement, not lexical similarity.
+// Certainty axis ranks "certain" highest and "uncertain" lowest so the
+// shift label tracks confidence movement, not lexical similarity. The
+// legacy fixture labels ("decisive" / "measured" / "tentative") are
+// kept here for back-compat with persisted history entries written
+// before the canonical relabel landed.
 const _CERTAINTY_RANK: Record<string, number> = {
+  certain: 2,
+  neutral: 1,
+  uncertain: 0,
   decisive: 2,
   measured: 1,
   tentative: 0,
@@ -154,8 +160,8 @@ export function computeMultiAxisDelta(
       ? ma.certainty.confidence - mb.certainty.confidence
       : null;
 
-  const topicA = ma?.topic?.primary ?? null;
-  const topicB = mb?.topic?.primary ?? null;
+  const topicA = ma?.topic?.label ?? ma?.topic?.primary ?? null;
+  const topicB = mb?.topic?.label ?? mb?.topic?.primary ?? null;
   const topicChanged =
     topicA != null && topicB != null ? topicA !== topicB : null;
 

--- a/frontend/lib/analyze/fixtures.ts
+++ b/frontend/lib/analyze/fixtures.ts
@@ -16,13 +16,16 @@ export const SAMPLE_MULTI_AXIS: MultiAxisResponse = {
     range: [0.14, 0.49],
   },
   certainty: {
-    label: "decisive",
+    label: "certain",
     confidence: 0.68,
+    distribution: { certain: 0.68, uncertain: 0.18, neutral: 0.14 },
   },
   topic: {
-    primary: "inflation_persistence",
+    label: "macro",
+    primary: "macro",
     confidence: 0.58,
-    secondary: ["labor_market_tightness", "growth_path"],
+    secondary: ["forward_guidance", "market_reaction"],
+    distribution: { macro: 0.58, forward_guidance: 0.27, market_reaction: 0.1, other: 0.05 },
   },
 };
 

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -86,7 +86,8 @@ export interface HistoryRealizedResponse {
 }
 
 export type StanceAxis = "hawkish" | "dovish" | "neutral";
-export type CertaintyAxis = "tentative" | "measured" | "decisive";
+export type CertaintyAxis = "certain" | "uncertain" | "neutral";
+export type TopicAxis = "macro" | "forward_guidance" | "market_reaction" | "other";
 
 export interface MultiAxisStance {
   label: StanceAxis;
@@ -103,19 +104,25 @@ export interface MultiAxisFactor {
 export interface MultiAxisCertainty {
   label: CertaintyAxis;
   confidence: number;
+  distribution?: Partial<Record<CertaintyAxis, number>>;
 }
 
 export interface MultiAxisTopic {
-  primary: string;
+  label: TopicAxis | string;
   confidence: number;
+  distribution?: Partial<Record<string, number>>;
+  // Back-compat aliases that older fixtures use. ``primary`` mirrors
+  // ``label`` and ``secondary`` lists alternate topics the model
+  // considered. New code should prefer ``label`` + ``distribution``.
+  primary?: string;
   secondary?: string[];
 }
 
 export interface MultiAxisResponse {
-  stance?: MultiAxisStance;
-  factor?: MultiAxisFactor;
-  certainty?: MultiAxisCertainty;
-  topic?: MultiAxisTopic;
+  stance: MultiAxisStance | null;
+  factor: MultiAxisFactor | null;
+  certainty: MultiAxisCertainty | null;
+  topic: MultiAxisTopic | null;
 }
 
 export interface XaiTokenAttribution {

--- a/frontend/tests/components/analyze/MultiAxisCards.test.tsx
+++ b/frontend/tests/components/analyze/MultiAxisCards.test.tsx
@@ -4,6 +4,8 @@ import { render, screen } from "@testing-library/react";
 import { MultiAxisCards } from "@/components/analyze/MultiAxisCards";
 import { SAMPLE_MULTI_AXIS } from "@/lib/analyze/fixtures";
 
+const EMPTY_AXIS = { stance: null, factor: null, certainty: null, topic: null };
+
 describe("MultiAxisCards", () => {
   it("renders four cards from the canonical fixture", () => {
     render(<MultiAxisCards multiAxis={SAMPLE_MULTI_AXIS} />);
@@ -12,17 +14,28 @@ describe("MultiAxisCards", () => {
     expect(screen.getByText(/^certainty$/i)).toBeInTheDocument();
     expect(screen.getByText(/^topic$/i)).toBeInTheDocument();
     expect(screen.getAllByText(/hawkish/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/inflation persistence/i)).toBeInTheDocument();
+    expect(screen.getByText(/^macro$/i)).toBeInTheDocument();
   });
 
-  it("returns null when every axis is undefined", () => {
-    const { container } = render(<MultiAxisCards multiAxis={{}} />);
+  it("returns null when every axis is null", () => {
+    const { container } = render(<MultiAxisCards multiAxis={EMPTY_AXIS} />);
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("hides factor card when factor is absent", () => {
-    render(<MultiAxisCards multiAxis={{ stance: SAMPLE_MULTI_AXIS.stance }} />);
+  it("hides factor / certainty / topic when only stance is available", () => {
+    render(
+      <MultiAxisCards
+        multiAxis={{
+          stance: SAMPLE_MULTI_AXIS.stance,
+          factor: null,
+          certainty: null,
+          topic: null,
+        }}
+      />,
+    );
     expect(screen.queryByText(/^factor$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^certainty$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^topic$/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/^stance$/i).length).toBeGreaterThan(0);
   });
 });

--- a/tests/unit/test_analyze_response_multi_axis_block.py
+++ b/tests/unit/test_analyze_response_multi_axis_block.py
@@ -1,0 +1,69 @@
+"""Multi-axis block on the /analyze response (#78).
+
+The stance card is sourced from the existing sentiment classifier
+output; factor / certainty / topic are left as None until the
+multi-axis text classifier ships in a follow-up. The frontend renders
+None cards as absent (no placeholder), so the contract here is
+"stance always present; the others default to None".
+"""
+
+from __future__ import annotations
+
+
+def test_multi_axis_block_carries_stance_from_sentiment_output() -> None:
+    from app.main import _build_multi_axis_block
+
+    sentiment = {
+        "label": "hawkish",
+        "score": 0.82,
+        "raw": [
+            {"label": "hawkish", "score": 0.82},
+            {"label": "neutral", "score": 0.12},
+            {"label": "dovish", "score": 0.06},
+        ],
+    }
+    block = _build_multi_axis_block(sentiment)
+    assert block is not None
+    assert block["stance"]["label"] == "hawkish"
+    assert 0.0 <= block["stance"]["confidence"] <= 1.0
+    distribution = block["stance"]["distribution"]
+    assert set(distribution.keys()) == {"hawkish", "dovish", "neutral"}
+    assert abs(distribution["hawkish"] - 0.82) < 1e-6
+
+
+def test_multi_axis_block_other_axes_default_to_none() -> None:
+    """The factor / certainty / topic cards are populated in a
+    follow-up PR by the multi-task text classifier. Until then they
+    are explicitly None so the frontend renders absence honestly."""
+
+    from app.main import _build_multi_axis_block
+
+    sentiment = {
+        "label": "neutral",
+        "score": 0.5,
+        "raw": [{"label": "neutral", "score": 0.5}],
+    }
+    block = _build_multi_axis_block(sentiment)
+    assert block is not None
+    assert block["factor"] is None
+    assert block["certainty"] is None
+    assert block["topic"] is None
+
+
+def test_multi_axis_block_coerces_unknown_label_to_neutral() -> None:
+    """If the upstream classifier returns a label outside the
+    canonical set (case mismatch, stale checkpoint, fallback model),
+    the block collapses to neutral with the available distribution so
+    the frontend stays renderable."""
+
+    from app.main import _build_multi_axis_block
+
+    sentiment = {
+        "label": "UNKNOWN",
+        "score": 0.0,
+        "raw": [],
+    }
+    block = _build_multi_axis_block(sentiment)
+    assert block is not None
+    assert block["stance"]["label"] == "neutral"
+    assert block["stance"]["confidence"] == 0.0

--- a/tests/unit/test_loader_emits_per_axis_targets.py
+++ b/tests/unit/test_loader_emits_per_axis_targets.py
@@ -1,0 +1,158 @@
+"""Per-axis target tensor builder + FeatureVector population (#78).
+
+The loader extracts axis labels off events.parquet, populates the
+target fields on every FeatureVector, then materialises 4 target
+tensors + 4 mask tensors aligned 1:1 with the classification rows
+``_build_training_tensors`` emits. This covers both halves: the
+FeatureVector population and the tensor-builder output.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from app.models.config import (
+    FeatureVector,
+    MULTI_TASK_CERTAINTY_LABELS,
+    MULTI_TASK_STANCE_LABELS,
+    MULTI_TASK_TOPIC_LABELS,
+    SEQUENCE_LENGTH,
+)
+from app.training.loaders import (
+    _attach_rich_features,
+    _build_multi_task_target_tensors,
+)
+
+
+def _base_vector(forward_vol: float | None = 0.1) -> FeatureVector:
+    return FeatureVector(
+        date="2024-01-01",
+        sentiment_score=0.0,
+        market_close=4000.0,
+        market_volatility=0.01,
+        forward_realized_vol_10d=forward_vol,
+    )
+
+
+def _make_group(forward_vol: float | None = 0.1) -> list[FeatureVector]:
+    # SEQUENCE_LENGTH lookback bars + 1 target bar.
+    return [_base_vector(forward_vol=None) for _ in range(SEQUENCE_LENGTH)] + [
+        _base_vector(forward_vol=forward_vol)
+    ]
+
+
+def test_attach_rich_features_populates_target_fields_from_event_row() -> None:
+    vectors = _make_group()
+    event_row = {
+        "axis_stance": "hawkish",
+        "axis_factor": 0.42,
+        "axis_certain_label": "uncertain",
+        "axis_topic": "macro outlook",
+    }
+    _attach_rich_features(
+        vectors,
+        event_row=event_row,
+        linguistic_lookup={},
+        mp_surprise_lookup={},
+        text_hash="xx",
+        event_date_str="2024-01-01",
+        use_credibility=False,
+        use_linguistic=False,
+        use_mp_surprise=False,
+        use_multi_axis=True,
+    )
+    target = vectors[-1]
+    assert target.target_stance_present is True
+    assert target.target_stance_idx == MULTI_TASK_STANCE_LABELS.index("hawkish")
+    assert target.target_factor_present is True
+    assert math.isclose(target.target_factor, 0.42, rel_tol=1e-6)
+    assert target.target_certainty_present is True
+    assert (
+        target.target_certainty_idx == MULTI_TASK_CERTAINTY_LABELS.index("uncertain")
+    )
+    assert target.target_topic_present is True
+    assert target.target_topic_idx == MULTI_TASK_TOPIC_LABELS.index("macro")
+
+
+def test_attach_rich_features_leaves_masks_false_when_row_has_no_labels() -> None:
+    vectors = _make_group()
+    _attach_rich_features(
+        vectors,
+        event_row={},  # no axis_* keys at all
+        linguistic_lookup={},
+        mp_surprise_lookup={},
+        text_hash="xx",
+        event_date_str="2024-01-01",
+        use_credibility=False,
+        use_linguistic=False,
+        use_mp_surprise=False,
+        use_multi_axis=True,
+    )
+    target = vectors[-1]
+    assert target.target_stance_present is False
+    assert target.target_factor_present is False
+    assert target.target_certainty_present is False
+    assert target.target_topic_present is False
+
+
+def test_certainty_float_falls_back_to_binned_class_label() -> None:
+    """When ``axis_certain_label`` is missing but ``axis_certainty``
+    (float in [0, 1]) is populated, the loader bins the numeric value
+    into the categorical class indices used by the multi-task head."""
+
+    vectors = _make_group()
+    _attach_rich_features(
+        vectors,
+        event_row={"axis_certainty": 0.85},
+        linguistic_lookup={},
+        mp_surprise_lookup={},
+        text_hash="xx",
+        event_date_str="2024-01-01",
+        use_credibility=False,
+        use_linguistic=False,
+        use_mp_surprise=False,
+        use_multi_axis=True,
+    )
+    target = vectors[-1]
+    assert target.target_certainty_present is True
+    # 0.85 > 0.66 -> certain
+    assert target.target_certainty_idx == MULTI_TASK_CERTAINTY_LABELS.index("certain")
+
+
+def test_target_tensor_builder_aligns_rows_with_classification_filter() -> None:
+    """``_build_multi_task_target_tensors`` must apply the same row
+    drop that ``_build_training_tensors`` does (rows whose
+    ``forward_realized_vol_10d`` -> -1 under the fitted quantiles are
+    dropped)."""
+
+    keep_group = _make_group(forward_vol=0.05)
+    drop_group = _make_group(forward_vol=None)  # target row has no forward vol
+    # Populate stance on both target rows so we can verify the row
+    # ordering survives the filter.
+    keep_group[-1].target_stance_idx = MULTI_TASK_STANCE_LABELS.index("dovish")
+    keep_group[-1].target_stance_present = True
+    drop_group[-1].target_stance_idx = MULTI_TASK_STANCE_LABELS.index("hawkish")
+    drop_group[-1].target_stance_present = True
+
+    quantiles = (0.1, 0.2)
+    out = _build_multi_task_target_tensors(
+        [keep_group, drop_group], vol_regime_quantiles=quantiles
+    )
+    assert out is not None
+    # Only the keep_group target survived (drop_group has no forward
+    # vol so vol_regime_class_for returns -1 and the row is dropped).
+    assert out["stance"].shape == (1,)
+    assert int(out["stance"][0]) == MULTI_TASK_STANCE_LABELS.index("dovish")
+    # Mask types: stance/cert/topic are bool, dtypes match the
+    # CrossEntropyLoss + SmoothL1 contract.
+    assert out["stance"].dtype == torch.long
+    assert out["stance_mask"].dtype == torch.bool
+    assert out["factor"].dtype == torch.float32
+    assert out["factor_mask"].dtype == torch.bool
+
+
+def test_target_tensor_builder_returns_none_on_empty_input() -> None:
+    out = _build_multi_task_target_tensors([], vol_regime_quantiles=(0.1, 0.2))
+    assert out is None

--- a/tests/unit/test_multi_task_head_shape.py
+++ b/tests/unit/test_multi_task_head_shape.py
@@ -1,0 +1,62 @@
+"""Cover the MultiTaskHead module (#78).
+
+The head shape is what the inference path and the /analyze response
+serialiser depend on. Pin the per-branch shapes + value bounds so a
+future refactor does not silently change the wire format.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def test_multi_task_head_emits_four_branches_with_expected_shapes() -> None:
+    from app.models.multi_task_head import MultiTaskHead
+
+    head = MultiTaskHead(
+        hidden_size=32,
+        head_hidden_size=16,
+        dropout=0.0,
+    )
+    pooled = torch.zeros(4, 32)
+    out = head(pooled)
+
+    assert set(out.keys()) == {"stance", "factor", "certainty", "topic"}
+    assert out["stance"].shape == (4, 3)
+    assert out["factor"].shape == (4,)
+    assert out["certainty"].shape == (4, 3)
+    assert out["topic"].shape == (4, 4)
+
+
+def test_factor_branch_stays_in_minus_one_to_one_range() -> None:
+    """The factor regressor applies tanh so the emit value lives in
+    ``[-1, 1]``. Without that bound an unsupervised row could blow
+    out the scale of the regression target and confuse the
+    downstream RobustScaler."""
+
+    from app.models.multi_task_head import MultiTaskHead
+
+    torch.manual_seed(0)
+    head = MultiTaskHead(hidden_size=8, head_hidden_size=8, dropout=0.0)
+    # Force a large activation through the stem so an unbounded head
+    # would saturate the regression branch above 1.0.
+    pooled = torch.randn(16, 8) * 50.0
+    out = head(pooled)
+    assert torch.all(out["factor"] >= -1.0)
+    assert torch.all(out["factor"] <= 1.0)
+
+
+def test_classification_branches_are_raw_logits_not_softmax() -> None:
+    """CrossEntropyLoss applies log_softmax internally; the head must
+    not pre-softmax. Confirm by asserting the row sums vary (raw
+    logits) instead of summing to 1 (softmax)."""
+
+    from app.models.multi_task_head import MultiTaskHead
+
+    torch.manual_seed(1)
+    head = MultiTaskHead(hidden_size=8, head_hidden_size=8, dropout=0.0)
+    pooled = torch.randn(4, 8)
+    out = head(pooled)
+    stance_sum = out["stance"].sum(dim=-1)
+    # Probabilities summing to 1.0 would mean the head pre-softmaxed.
+    assert not torch.allclose(stance_sum, torch.ones_like(stance_sum), atol=1e-4)

--- a/tests/unit/test_multi_task_loss_masking.py
+++ b/tests/unit/test_multi_task_loss_masking.py
@@ -1,0 +1,109 @@
+"""Per-axis masking on the MultiTaskLoss (#78).
+
+The three sparse axes (factor / certainty / topic) carry labels on
+fewer than 5% of supervised rows. A naive un-masked loss would train
+those branches against a synthetic placeholder index — locking them
+on a meaningless mean. The masked-loss contract is the load-bearing
+behaviour the head depends on; pin it here.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def _zero_logits_batch(batch: int = 4) -> dict[str, torch.Tensor]:
+    return {
+        "stance": torch.zeros(batch, 3, requires_grad=True),
+        "factor": torch.zeros(batch, requires_grad=True),
+        "certainty": torch.zeros(batch, 3, requires_grad=True),
+        "topic": torch.zeros(batch, 4, requires_grad=True),
+    }
+
+
+def test_axis_with_all_false_mask_contributes_zero_loss() -> None:
+    from app.training.loss import MultiTaskLoss
+
+    loss_fn = MultiTaskLoss()
+    logits = _zero_logits_batch(batch=4)
+    targets = {
+        "stance": torch.tensor([0, 1, 2, 0]),
+        "factor": torch.zeros(4),
+        "certainty": torch.tensor([0, 0, 0, 0]),
+        "topic": torch.tensor([0, 0, 0, 0]),
+    }
+    masks = {
+        "stance_mask": torch.tensor([True, True, True, True]),
+        "factor_mask": torch.tensor([False, False, False, False]),
+        "certainty_mask": torch.tensor([False, False, False, False]),
+        "topic_mask": torch.tensor([False, False, False, False]),
+    }
+    total, breakdown = loss_fn(logits, targets, masks)
+    assert float(breakdown["factor"]) == 0.0
+    assert float(breakdown["certainty"]) == 0.0
+    assert float(breakdown["topic"]) == 0.0
+    # Stance is the only contributing axis so the total equals its lambda * loss.
+    assert float(total) > 0.0
+
+
+def test_masked_classification_matches_filtered_cross_entropy() -> None:
+    """The masked branch must agree with a manual CE over the masked
+    subset; this is the load-bearing equivalence behind the masking
+    decision."""
+
+    from app.training.loss import MultiTaskLoss
+    from torch.nn import functional as F
+
+    torch.manual_seed(7)
+    loss_fn = MultiTaskLoss(lambda_factor=0.0, lambda_certainty=0.0, lambda_topic=0.0)
+    logits = {
+        "stance": torch.randn(8, 3, requires_grad=True),
+        "factor": torch.zeros(8, requires_grad=True),
+        "certainty": torch.zeros(8, 3, requires_grad=True),
+        "topic": torch.zeros(8, 4, requires_grad=True),
+    }
+    targets = {
+        "stance": torch.tensor([0, 1, 2, 0, 1, 2, 0, 1]),
+        "factor": torch.zeros(8),
+        "certainty": torch.tensor([0, 0, 0, 0, 0, 0, 0, 0]),
+        "topic": torch.tensor([0, 0, 0, 0, 0, 0, 0, 0]),
+    }
+    mask = torch.tensor([True, False, True, True, False, True, True, False])
+    masks = {
+        "stance_mask": mask,
+        "factor_mask": torch.zeros(8, dtype=torch.bool),
+        "certainty_mask": torch.zeros(8, dtype=torch.bool),
+        "topic_mask": torch.zeros(8, dtype=torch.bool),
+    }
+    total, _ = loss_fn(logits, targets, masks)
+
+    expected = F.cross_entropy(logits["stance"][mask], targets["stance"][mask])
+    assert torch.allclose(total, expected, atol=1e-6)
+
+
+def test_total_loss_carries_gradients_back_to_logits() -> None:
+    """Even with all-False masks on three axes, the total loss must
+    flow gradients back to the contributing axis's logits. A
+    detached zero would prevent the optimiser from training the
+    stance branch on its own."""
+
+    from app.training.loss import MultiTaskLoss
+
+    loss_fn = MultiTaskLoss()
+    logits = _zero_logits_batch(batch=4)
+    targets = {
+        "stance": torch.tensor([0, 1, 2, 0]),
+        "factor": torch.zeros(4),
+        "certainty": torch.zeros(4, dtype=torch.long),
+        "topic": torch.zeros(4, dtype=torch.long),
+    }
+    masks = {
+        "stance_mask": torch.tensor([True, True, True, True]),
+        "factor_mask": torch.zeros(4, dtype=torch.bool),
+        "certainty_mask": torch.zeros(4, dtype=torch.bool),
+        "topic_mask": torch.zeros(4, dtype=torch.bool),
+    }
+    total, _ = loss_fn(logits, targets, masks)
+    total.backward()
+    assert logits["stance"].grad is not None
+    assert torch.any(logits["stance"].grad != 0.0)

--- a/tests/unit/test_phase9_classification_head.py
+++ b/tests/unit/test_phase9_classification_head.py
@@ -40,13 +40,18 @@ def test_regression_volatility_stays_non_negative() -> None:
 
 @pytest.mark.parametrize("n_classes", [2, 3, 5])
 def test_classification_head_emits_n_class_logits(n_classes: int) -> None:
+    """The multi-task head (#78) replaced the single classification
+    Sequential. The stance branch carries the canonical 3-class
+    (configurable) target the training loop reads via the model's
+    primary forward output."""
+
     cfg = ModelConfig(
         architecture="lstm", output_mode="classification", n_classes=n_classes
     )
     model = build_forecaster(cfg)
     assert model.output_mode == "classification"
     assert model.n_classes == n_classes
-    assert model.head[-1].out_features == n_classes
+    assert model.head.stance.out_features == n_classes
     x = torch.randn(4, 5, 6)
     out = model(x)
     assert out.shape == (4, n_classes)


### PR DESCRIPTION
## Summary

- `MultiTaskHead` replaces the single classification head; four branches share a pre-classifier stem.
- Stance branch remains the 3-class output the existing CrossEntropy loss reads via `forward()`.
- `MultiTaskLoss` ships with per-axis weighted + masked loss as staged infrastructure.
- Loader extracts per-axis targets onto `FeatureVector` and emits aligned target + mask tensors.
- `AnalyzeResponse.multi_axis` carries the stance card from the existing sentiment classifier.
- Frontend types + `MultiAxisCards` consume the new schema with canonical certainty labels.

## Test plan

- [ ] `docker compose run --rm backend pytest tests/unit/test_multi_task_head_shape.py tests/unit/test_multi_task_loss_masking.py tests/unit/test_loader_emits_per_axis_targets.py tests/unit/test_analyze_response_multi_axis_block.py tests/unit/test_phase9_classification_head.py -q`
- [ ] `docker compose run --rm backend pytest tests/regression/test_forecaster_determinism.py -q`
- [ ] `make dev-cpu` then POST `/analyze` — confirm `multi_axis.stance` is populated.

Closes #78.