### PR TITLE
Text multi-axis classifier populates all 4 /analyze cards

### DIFF
--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -90,6 +90,56 @@ def _coerce_float(value: Any) -> float | None:
     return out
 
 
+def _stance_target(row: dict[str, Any]) -> tuple[int, bool]:
+    raw = row.get("axis_stance")
+    if isinstance(raw, str) and raw.strip().lower() in MULTI_TASK_STANCE_LABELS:
+        return MULTI_TASK_STANCE_LABELS.index(raw.strip().lower()), True
+    return 0, False
+
+
+def _factor_target(row: dict[str, Any]) -> tuple[float, bool]:
+    value = _coerce_float(row.get("axis_factor"))
+    if value is None:
+        return 0.0, False
+    return max(min(value, 1.0), -1.0), True
+
+
+def _certainty_target(row: dict[str, Any]) -> tuple[int, bool]:
+    raw = row.get("axis_certain_label")
+    if isinstance(raw, str) and raw.strip().lower() in MULTI_TASK_CERTAINTY_LABELS:
+        return MULTI_TASK_CERTAINTY_LABELS.index(raw.strip().lower()), True
+    float_val = _coerce_float(row.get("axis_certainty"))
+    if float_val is None:
+        return 0, False
+    if float_val >= 0.66:
+        return MULTI_TASK_CERTAINTY_LABELS.index("certain"), True
+    if float_val <= 0.33:
+        return MULTI_TASK_CERTAINTY_LABELS.index("uncertain"), True
+    return MULTI_TASK_CERTAINTY_LABELS.index("neutral"), True
+
+
+# Explicit aliases for upstream topic values that do not contain a
+# canonical substring. "economic_indicator" comes off the macro-release
+# augmentation (CPI / NFP rows) and is the macro topic by construction.
+_TOPIC_ALIASES: dict[str, str] = {
+    "economic_indicator": "macro",
+    "rate_decision": "forward_guidance",
+}
+
+
+def _topic_target(row: dict[str, Any]) -> tuple[int, bool]:
+    raw = row.get("axis_topic")
+    if not isinstance(raw, str) or not raw.strip():
+        return 0, False
+    topic_str = raw.strip().lower()
+    if topic_str in _TOPIC_ALIASES:
+        return MULTI_TASK_TOPIC_LABELS.index(_TOPIC_ALIASES[topic_str]), True
+    for canonical in MULTI_TASK_TOPIC_LABELS[:-1]:
+        if canonical in topic_str:
+            return MULTI_TASK_TOPIC_LABELS.index(canonical), True
+    return MULTI_TASK_TOPIC_LABELS.index("other"), True
+
+
 def _row_targets(row: dict[str, Any]) -> tuple[dict[str, float | int], dict[str, bool]]:
     """Map one events.parquet row to per-axis targets + masks.
 
@@ -98,69 +148,24 @@ def _row_targets(row: dict[str, Any]) -> tuple[dict[str, float | int], dict[str,
     consumes the same canonical label mappings the forecaster does.
     """
 
-    targets: dict[str, float | int] = {
-        "stance": 0,
-        "factor": 0.0,
-        "certainty": 0,
-        "topic": 0,
-    }
-    masks: dict[str, bool] = {
-        "stance": False,
-        "factor": False,
-        "certainty": False,
-        "topic": False,
-    }
-
-    stance_raw = row.get("axis_stance")
-    if isinstance(stance_raw, str) and stance_raw.strip().lower() in MULTI_TASK_STANCE_LABELS:
-        targets["stance"] = MULTI_TASK_STANCE_LABELS.index(stance_raw.strip().lower())
-        masks["stance"] = True
-
-    factor_val = _coerce_float(row.get("axis_factor"))
-    if factor_val is not None:
-        targets["factor"] = max(min(factor_val, 1.0), -1.0)
-        masks["factor"] = True
-
-    cert_raw = row.get("axis_certain_label")
-    if isinstance(cert_raw, str) and cert_raw.strip().lower() in MULTI_TASK_CERTAINTY_LABELS:
-        targets["certainty"] = MULTI_TASK_CERTAINTY_LABELS.index(cert_raw.strip().lower())
-        masks["certainty"] = True
-    else:
-        cert_float = _coerce_float(row.get("axis_certainty"))
-        if cert_float is not None:
-            if cert_float >= 0.66:
-                targets["certainty"] = MULTI_TASK_CERTAINTY_LABELS.index("certain")
-            elif cert_float <= 0.33:
-                targets["certainty"] = MULTI_TASK_CERTAINTY_LABELS.index("uncertain")
-            else:
-                targets["certainty"] = MULTI_TASK_CERTAINTY_LABELS.index("neutral")
-            masks["certainty"] = True
-
-    topic_raw = row.get("axis_topic")
-    if isinstance(topic_raw, str) and topic_raw.strip():
-        topic_str = topic_raw.strip().lower()
-        # Explicit aliases for upstream values that do not contain a
-        # canonical substring. "economic_indicator" comes off the
-        # macro-release augmentation (CPI / NFP rows) and is the
-        # macro topic by construction.
-        topic_aliases = {
-            "economic_indicator": "macro",
-            "rate_decision": "forward_guidance",
-        }
-        if topic_str in topic_aliases:
-            targets["topic"] = MULTI_TASK_TOPIC_LABELS.index(topic_aliases[topic_str])
-            masks["topic"] = True
-        else:
-            for canonical in MULTI_TASK_TOPIC_LABELS[:-1]:
-                if canonical in topic_str:
-                    targets["topic"] = MULTI_TASK_TOPIC_LABELS.index(canonical)
-                    masks["topic"] = True
-                    break
-            if not masks["topic"]:
-                targets["topic"] = MULTI_TASK_TOPIC_LABELS.index("other")
-                masks["topic"] = True
-
-    return targets, masks
+    stance_idx, stance_present = _stance_target(row)
+    factor_value, factor_present = _factor_target(row)
+    certainty_idx, certainty_present = _certainty_target(row)
+    topic_idx, topic_present = _topic_target(row)
+    return (
+        {
+            "stance": stance_idx,
+            "factor": factor_value,
+            "certainty": certainty_idx,
+            "topic": topic_idx,
+        },
+        {
+            "stance": stance_present,
+            "factor": factor_present,
+            "certainty": certainty_present,
+            "topic": topic_present,
+        },
+    )
 
 
 def _load_supervised_rows(events_parquet: Path) -> list[_AxisRow]:

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -1,0 +1,552 @@
+"""Train the text-only multi-axis classifier (#78 follow-up).
+
+Pulls the supervised rows out of events.parquet, derives per-axis
+targets + masks using the same axis-label normalisation the training
+loader uses, then fine-tunes a transformer encoder + MultiTaskHead
+end-to-end against the per-axis weighted + masked loss.
+
+Output is a single checkpoint at
+``backend/models/text_multi_axis_best.pt`` (the path the inference
+service singleton at ``app.services.multi_axis_classifier`` reads on
+cold start). The checkpoint envelope records the encoder alias +
+revision, the head config, the per-axis class weights fitted on the
+train slice, and the best-epoch val metrics so a future run can
+inspect provenance without re-running the trainer.
+
+Usage::
+
+    python -m app.data.train_text_multi_axis_classifier \\
+        --training-package-id tp_v3_macro_aug_2026_05_23_sentiment_market_core_v1.1_epv1_v1.0 \\
+        --encoder-alias finbert_fed_adjacent \\
+        --epochs 4 --seed 97
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import random
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, Dataset
+
+from app.config import DATA_DIR, MODEL_CHECKPOINT_DIR
+from app.models.config import (
+    MULTI_TASK_CERTAINTY_CLASSES,
+    MULTI_TASK_CERTAINTY_LABELS,
+    MULTI_TASK_STANCE_CLASSES,
+    MULTI_TASK_STANCE_LABELS,
+    MULTI_TASK_TOPIC_CLASSES,
+    MULTI_TASK_TOPIC_LABELS,
+)
+from app.models.text_multi_axis_classifier import TextMultiAxisClassifier
+from app.training.loss import MultiTaskLoss
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_CHECKPOINT_PATH = MODEL_CHECKPOINT_DIR / "text_multi_axis_best.pt"
+DEFAULT_ENCODER_ALIAS = "finbert_fed_adjacent"
+
+
+@dataclass
+class _AxisRow:
+    """One supervised row passed to the classifier.
+
+    ``targets`` and ``masks`` are dicts keyed by axis name so the
+    DataLoader collate path can stack them into batched tensors
+    without per-axis branching.
+    """
+
+    text: str
+    targets: dict[str, float | int] = field(default_factory=dict)
+    masks: dict[str, bool] = field(default_factory=dict)
+
+
+def _set_all_seeds(seed: int) -> None:
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    if out != out:  # NaN
+        return None
+    return out
+
+
+def _row_targets(row: dict[str, Any]) -> tuple[dict[str, float | int], dict[str, bool]]:
+    """Map one events.parquet row to per-axis targets + masks.
+
+    Mirrors the extraction in
+    ``app.training.loaders._attach_rich_features`` so the classifier
+    consumes the same canonical label mappings the forecaster does.
+    """
+
+    targets: dict[str, float | int] = {
+        "stance": 0,
+        "factor": 0.0,
+        "certainty": 0,
+        "topic": 0,
+    }
+    masks: dict[str, bool] = {
+        "stance": False,
+        "factor": False,
+        "certainty": False,
+        "topic": False,
+    }
+
+    stance_raw = row.get("axis_stance")
+    if isinstance(stance_raw, str) and stance_raw.strip().lower() in MULTI_TASK_STANCE_LABELS:
+        targets["stance"] = MULTI_TASK_STANCE_LABELS.index(stance_raw.strip().lower())
+        masks["stance"] = True
+
+    factor_val = _coerce_float(row.get("axis_factor"))
+    if factor_val is not None:
+        targets["factor"] = max(min(factor_val, 1.0), -1.0)
+        masks["factor"] = True
+
+    cert_raw = row.get("axis_certain_label")
+    if isinstance(cert_raw, str) and cert_raw.strip().lower() in MULTI_TASK_CERTAINTY_LABELS:
+        targets["certainty"] = MULTI_TASK_CERTAINTY_LABELS.index(cert_raw.strip().lower())
+        masks["certainty"] = True
+    else:
+        cert_float = _coerce_float(row.get("axis_certainty"))
+        if cert_float is not None:
+            if cert_float >= 0.66:
+                targets["certainty"] = MULTI_TASK_CERTAINTY_LABELS.index("certain")
+            elif cert_float <= 0.33:
+                targets["certainty"] = MULTI_TASK_CERTAINTY_LABELS.index("uncertain")
+            else:
+                targets["certainty"] = MULTI_TASK_CERTAINTY_LABELS.index("neutral")
+            masks["certainty"] = True
+
+    topic_raw = row.get("axis_topic")
+    if isinstance(topic_raw, str) and topic_raw.strip():
+        topic_str = topic_raw.strip().lower()
+        # Explicit aliases for upstream values that do not contain a
+        # canonical substring. "economic_indicator" comes off the
+        # macro-release augmentation (CPI / NFP rows) and is the
+        # macro topic by construction.
+        topic_aliases = {
+            "economic_indicator": "macro",
+            "rate_decision": "forward_guidance",
+        }
+        if topic_str in topic_aliases:
+            targets["topic"] = MULTI_TASK_TOPIC_LABELS.index(topic_aliases[topic_str])
+            masks["topic"] = True
+        else:
+            for canonical in MULTI_TASK_TOPIC_LABELS[:-1]:
+                if canonical in topic_str:
+                    targets["topic"] = MULTI_TASK_TOPIC_LABELS.index(canonical)
+                    masks["topic"] = True
+                    break
+            if not masks["topic"]:
+                targets["topic"] = MULTI_TASK_TOPIC_LABELS.index("other")
+                masks["topic"] = True
+
+    return targets, masks
+
+
+def _load_supervised_rows(events_parquet: Path) -> list[_AxisRow]:
+    """Read events.parquet and keep rows with ≥1 axis label populated."""
+
+    import pandas as pd
+
+    if not events_parquet.exists():
+        raise SystemExit(f"events.parquet not found at {events_parquet}")
+    frame = pd.read_parquet(events_parquet)
+    rows: list[_AxisRow] = []
+    for record in frame.to_dict(orient="records"):
+        text = str(record.get("text") or "").strip()
+        if not text:
+            continue
+        targets, masks = _row_targets(record)
+        if not any(masks.values()):
+            continue
+        rows.append(_AxisRow(text=text, targets=targets, masks=masks))
+    return rows
+
+
+def _fit_class_weights(
+    indices: list[int],
+    n_classes: int,
+    *,
+    smoothing: float = 1.0,
+) -> torch.Tensor:
+    """Inverse-frequency weights normalised to sum to ``n_classes``.
+
+    Mirrors :func:`app.training.loaders.fit_class_weights`; the classifier
+    fits one weight tensor per axis on its masked rows.
+    """
+
+    counts = [0] * n_classes
+    for idx in indices:
+        if 0 <= idx < n_classes:
+            counts[idx] += 1
+    if sum(counts) == 0:
+        return torch.ones(n_classes, dtype=torch.float32)
+    raw = [1.0 / (c + smoothing) for c in counts]
+    total = sum(raw)
+    return torch.tensor(
+        [(w / total) * n_classes for w in raw], dtype=torch.float32
+    )
+
+
+def _build_axis_class_weights(rows: list[_AxisRow]) -> dict[str, torch.Tensor]:
+    """Per-axis class weights fitted only on rows where the axis is masked True."""
+
+    stance_indices = [int(r.targets["stance"]) for r in rows if r.masks["stance"]]
+    certainty_indices = [int(r.targets["certainty"]) for r in rows if r.masks["certainty"]]
+    topic_indices = [int(r.targets["topic"]) for r in rows if r.masks["topic"]]
+    return {
+        "stance": _fit_class_weights(stance_indices, MULTI_TASK_STANCE_CLASSES),
+        "certainty": _fit_class_weights(certainty_indices, MULTI_TASK_CERTAINTY_CLASSES),
+        "topic": _fit_class_weights(topic_indices, MULTI_TASK_TOPIC_CLASSES),
+    }
+
+
+class _MultiAxisDataset(Dataset):
+    def __init__(self, rows: list[_AxisRow], tokenizer: Any, max_length: int = 256) -> None:
+        self.rows = rows
+        self.tokenizer = tokenizer
+        self.max_length = int(max_length)
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        row = self.rows[idx]
+        encoded = self.tokenizer(
+            row.text,
+            max_length=self.max_length,
+            padding="max_length",
+            truncation=True,
+            return_tensors="pt",
+        )
+        return {
+            "input_ids": encoded["input_ids"].squeeze(0),
+            "attention_mask": encoded["attention_mask"].squeeze(0),
+            "target_stance": int(row.targets["stance"]),
+            "target_factor": float(row.targets["factor"]),
+            "target_certainty": int(row.targets["certainty"]),
+            "target_topic": int(row.targets["topic"]),
+            "mask_stance": bool(row.masks["stance"]),
+            "mask_factor": bool(row.masks["factor"]),
+            "mask_certainty": bool(row.masks["certainty"]),
+            "mask_topic": bool(row.masks["topic"]),
+        }
+
+
+def _collate(batch: list[dict[str, Any]]) -> dict[str, torch.Tensor]:
+    out: dict[str, torch.Tensor] = {}
+    out["input_ids"] = torch.stack([item["input_ids"] for item in batch])
+    out["attention_mask"] = torch.stack([item["attention_mask"] for item in batch])
+    out["target_stance"] = torch.tensor(
+        [item["target_stance"] for item in batch], dtype=torch.long
+    )
+    out["target_factor"] = torch.tensor(
+        [item["target_factor"] for item in batch], dtype=torch.float32
+    )
+    out["target_certainty"] = torch.tensor(
+        [item["target_certainty"] for item in batch], dtype=torch.long
+    )
+    out["target_topic"] = torch.tensor(
+        [item["target_topic"] for item in batch], dtype=torch.long
+    )
+    out["mask_stance"] = torch.tensor(
+        [item["mask_stance"] for item in batch], dtype=torch.bool
+    )
+    out["mask_factor"] = torch.tensor(
+        [item["mask_factor"] for item in batch], dtype=torch.bool
+    )
+    out["mask_certainty"] = torch.tensor(
+        [item["mask_certainty"] for item in batch], dtype=torch.bool
+    )
+    out["mask_topic"] = torch.tensor(
+        [item["mask_topic"] for item in batch], dtype=torch.bool
+    )
+    return out
+
+
+def _train_one_epoch(
+    model: TextMultiAxisClassifier,
+    loader: DataLoader,
+    loss_fn: MultiTaskLoss,
+    optimizer: torch.optim.Optimizer,
+    device: torch.device,
+) -> dict[str, float]:
+    model.train()
+    sum_total = 0.0
+    sum_axis = {"stance": 0.0, "factor": 0.0, "certainty": 0.0, "topic": 0.0}
+    n_batches = 0
+    for batch in loader:
+        optimizer.zero_grad(set_to_none=True)
+        input_ids = batch["input_ids"].to(device)
+        attn = batch["attention_mask"].to(device)
+        logits = model(input_ids=input_ids, attention_mask=attn)
+        targets = {
+            "stance": batch["target_stance"].to(device),
+            "factor": batch["target_factor"].to(device),
+            "certainty": batch["target_certainty"].to(device),
+            "topic": batch["target_topic"].to(device),
+        }
+        masks = {
+            "stance_mask": batch["mask_stance"].to(device),
+            "factor_mask": batch["mask_factor"].to(device),
+            "certainty_mask": batch["mask_certainty"].to(device),
+            "topic_mask": batch["mask_topic"].to(device),
+        }
+        total, breakdown = loss_fn(logits, targets, masks)
+        total.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        optimizer.step()
+        sum_total += float(total.detach().item())
+        for axis_name in sum_axis:
+            sum_axis[axis_name] += float(breakdown[axis_name].item())
+        n_batches += 1
+    if n_batches == 0:
+        return {"loss": 0.0}
+    out = {"loss": sum_total / n_batches}
+    for axis_name, total in sum_axis.items():
+        out[f"loss_{axis_name}"] = total / n_batches
+    return out
+
+
+@torch.no_grad()
+def _evaluate(
+    model: TextMultiAxisClassifier,
+    loader: DataLoader,
+    loss_fn: MultiTaskLoss,
+    device: torch.device,
+) -> dict[str, float]:
+    model.eval()
+    sum_total = 0.0
+    sum_axis = {"stance": 0.0, "factor": 0.0, "certainty": 0.0, "topic": 0.0}
+    correct_axis = {"stance": 0, "certainty": 0, "topic": 0}
+    seen_axis = {"stance": 0, "certainty": 0, "topic": 0}
+    n_batches = 0
+    for batch in loader:
+        input_ids = batch["input_ids"].to(device)
+        attn = batch["attention_mask"].to(device)
+        logits = model(input_ids=input_ids, attention_mask=attn)
+        targets = {
+            "stance": batch["target_stance"].to(device),
+            "factor": batch["target_factor"].to(device),
+            "certainty": batch["target_certainty"].to(device),
+            "topic": batch["target_topic"].to(device),
+        }
+        masks = {
+            "stance_mask": batch["mask_stance"].to(device),
+            "factor_mask": batch["mask_factor"].to(device),
+            "certainty_mask": batch["mask_certainty"].to(device),
+            "topic_mask": batch["mask_topic"].to(device),
+        }
+        total, breakdown = loss_fn(logits, targets, masks)
+        sum_total += float(total.item())
+        for axis_name in sum_axis:
+            sum_axis[axis_name] += float(breakdown[axis_name].item())
+        n_batches += 1
+        for axis_name in ("stance", "certainty", "topic"):
+            mask = masks[f"{axis_name}_mask"]
+            if mask.any():
+                pred = logits[axis_name][mask].argmax(dim=-1)
+                tgt = targets[axis_name][mask]
+                correct_axis[axis_name] += int((pred == tgt).sum().item())
+                seen_axis[axis_name] += int(mask.sum().item())
+    if n_batches == 0:
+        return {"loss": 0.0}
+    out = {"loss": sum_total / n_batches}
+    for axis_name, total in sum_axis.items():
+        out[f"loss_{axis_name}"] = total / n_batches
+    for axis_name in ("stance", "certainty", "topic"):
+        if seen_axis[axis_name] > 0:
+            out[f"acc_{axis_name}"] = correct_axis[axis_name] / seen_axis[axis_name]
+    return out
+
+
+def _save_checkpoint(
+    model: TextMultiAxisClassifier,
+    *,
+    path: Path,
+    metrics: dict[str, float],
+    args: argparse.Namespace,
+    class_weights: dict[str, torch.Tensor],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "model_state_dict": model.state_dict(),
+        "metadata": model.metadata(),
+        "metrics": metrics,
+        "class_weights": {k: v.tolist() for k, v in class_weights.items()},
+        "training_args": {
+            "training_package_id": args.training_package_id,
+            "encoder_alias": args.encoder_alias,
+            "epochs": args.epochs,
+            "seed": args.seed,
+            "learning_rate": args.learning_rate,
+            "batch_size": args.batch_size,
+            "val_fraction": args.val_fraction,
+            "max_length": args.max_length,
+        },
+        "saved_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    torch.save(payload, path)
+    _logger.info("checkpoint_written path=%s", path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    args = _parse_args(argv)
+    _set_all_seeds(args.seed)
+
+    package_dir = DATA_DIR / "processed" / args.training_package_id
+    events_path = package_dir / "events.parquet"
+    rows = _load_supervised_rows(events_path)
+    if not rows:
+        raise SystemExit(f"No supervised rows with axis labels in {events_path}")
+    _logger.info("loaded_supervised_rows count=%d", len(rows))
+
+    rng = random.Random(args.seed)
+    rng.shuffle(rows)
+    val_size = max(1, int(len(rows) * args.val_fraction))
+    train_rows = rows[val_size:]
+    val_rows = rows[:val_size]
+    _logger.info(
+        "split rows total=%d train=%d val=%d",
+        len(rows),
+        len(train_rows),
+        len(val_rows),
+    )
+
+    class_weights = _build_axis_class_weights(train_rows)
+
+    from transformers import AutoTokenizer
+
+    from app.models.registry import encoder_ref
+
+    ref = encoder_ref(args.encoder_alias)
+    if ref is None or not ref.revision:
+        raise SystemExit(
+            f"Encoder alias {args.encoder_alias!r} is unpinned in registry.yaml; "
+            "add a revision before training."
+        )
+    tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = TextMultiAxisClassifier.from_encoder_alias(
+        encoder_alias=args.encoder_alias,
+        head_hidden_size=args.head_hidden_size,
+        dropout=args.dropout,
+    )
+    model.to(device)
+
+    loss_fn = MultiTaskLoss(
+        stance_weight=class_weights["stance"].to(device),
+        certainty_weight=class_weights["certainty"].to(device),
+        topic_weight=class_weights["topic"].to(device),
+        lambda_stance=args.lambda_stance,
+        lambda_factor=args.lambda_factor,
+        lambda_certainty=args.lambda_certainty,
+        lambda_topic=args.lambda_topic,
+    ).to(device)
+
+    train_ds = _MultiAxisDataset(train_rows, tokenizer, max_length=args.max_length)
+    val_ds = _MultiAxisDataset(val_rows, tokenizer, max_length=args.max_length)
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=args.batch_size,
+        shuffle=True,
+        collate_fn=_collate,
+        num_workers=0,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=args.batch_size,
+        shuffle=False,
+        collate_fn=_collate,
+        num_workers=0,
+    )
+
+    no_decay = {"bias", "LayerNorm.weight"}
+    decay_params = [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)]
+    no_decay_params = [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)]
+    optimizer = torch.optim.AdamW(
+        [
+            {"params": decay_params, "weight_decay": args.weight_decay},
+            {"params": no_decay_params, "weight_decay": 0.0},
+        ],
+        lr=args.learning_rate,
+    )
+
+    best_val_loss = float("inf")
+    best_metrics: dict[str, float] = {}
+    for epoch in range(args.epochs):
+        train_metrics = _train_one_epoch(model, train_loader, loss_fn, optimizer, device)
+        val_metrics = _evaluate(model, val_loader, loss_fn, device)
+        _logger.info(
+            "epoch=%d train_loss=%.4f val_loss=%.4f val_acc_stance=%.3f val_acc_certainty=%.3f val_acc_topic=%.3f",
+            epoch,
+            train_metrics["loss"],
+            val_metrics["loss"],
+            val_metrics.get("acc_stance", float("nan")),
+            val_metrics.get("acc_certainty", float("nan")),
+            val_metrics.get("acc_topic", float("nan")),
+        )
+        if val_metrics["loss"] < best_val_loss:
+            best_val_loss = val_metrics["loss"]
+            best_metrics = {**train_metrics, **{f"val_{k}": v for k, v in val_metrics.items()}}
+            _save_checkpoint(
+                model,
+                path=Path(args.output_checkpoint),
+                metrics=best_metrics,
+                args=args,
+                class_weights=class_weights,
+            )
+
+    _logger.info("training_complete best_val_loss=%.4f", best_val_loss)
+    return 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--training-package-id", required=True)
+    parser.add_argument("--encoder-alias", default=DEFAULT_ENCODER_ALIAS)
+    parser.add_argument(
+        "--output-checkpoint",
+        default=str(DEFAULT_CHECKPOINT_PATH),
+        help="Destination .pt path for the best-epoch checkpoint.",
+    )
+    parser.add_argument("--seed", type=int, default=97)
+    parser.add_argument("--epochs", type=int, default=4)
+    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument("--learning-rate", type=float, default=2e-5)
+    parser.add_argument("--weight-decay", type=float, default=0.01)
+    parser.add_argument("--max-length", type=int, default=256)
+    parser.add_argument("--val-fraction", type=float, default=0.15)
+    parser.add_argument("--head-hidden-size", type=int, default=128)
+    parser.add_argument("--dropout", type=float, default=0.1)
+    parser.add_argument("--lambda-stance", type=float, default=1.0)
+    parser.add_argument("--lambda-factor", type=float, default=0.3)
+    parser.add_argument("--lambda-certainty", type=float, default=0.3)
+    parser.add_argument("--lambda-topic", type=float, default=0.3)
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -87,6 +87,21 @@ async def _lifespan(app: FastAPI):
         warmup_classifier()
     except Exception:  # pragma: no cover — never let model warmup block startup
         get_logger("fed_pulse").warning("classifier_warmup_failed", exc_info=True)
+    # Pre-load the multi-axis classifier when a checkpoint is present.
+    # The service returns None on missing / malformed checkpoints, so
+    # this is a no-op until the trainer ships a real model.
+    try:
+        from app.services.multi_axis_classifier import (
+            checkpoint_exists as multi_axis_checkpoint_exists,
+            get_classifier as get_multi_axis_classifier,
+        )
+
+        if multi_axis_checkpoint_exists():
+            get_multi_axis_classifier()
+    except Exception:  # pragma: no cover — never let warmup block startup
+        get_logger("fed_pulse").warning(
+            "multi_axis_classifier_warmup_failed", exc_info=True
+        )
     get_logger("fed_pulse").info("startup", service="fomc-api")
     try:
         yield
@@ -252,7 +267,7 @@ def _build_analyze_response(
         "market": market,
         "model": forecast["model"],
         "series": forecast["series"],
-        "multi_axis": _build_multi_axis_block(sentiment),
+        "multi_axis": _build_multi_axis_block(payload.text, sentiment),
     }
     if getattr(payload, "include_xai", False):
         attributions = attribute_text(payload.text)
@@ -260,18 +275,39 @@ def _build_analyze_response(
     return response
 
 
-def _build_multi_axis_block(sentiment: dict[str, Any]) -> dict[str, Any] | None:
+def _build_multi_axis_block(
+    text: str, sentiment: dict[str, Any]
+) -> dict[str, Any] | None:
     """Build the multi-axis card block from the available text signals (#78).
 
-    Stance card reuses the existing text classifier output (hawkish /
-    dovish / neutral with per-class probability). The factor /
-    certainty / topic cards are left at ``None`` for now — the
-    multi-task text classifier that will populate them is staged
-    infrastructure (see ``MultiTaskHead`` / ``MultiTaskLoss`` in the
-    models / training packages) and lands in a follow-up. The frontend
-    renders ``None`` cards with a "not available" affordance so users
-    see honest absence rather than a placeholder value.
+    Two paths:
+
+    1. **Trained multi-axis classifier present.** Run the
+       ``TextMultiAxisClassifier`` checkpoint via
+       ``app.services.multi_axis_classifier.score_text``; populate all
+       four cards (stance / factor / certainty / topic) from the
+       per-axis predictions.
+
+    2. **No checkpoint.** Fall back to populating the stance card from
+       the existing sentiment classifier output and leave the other
+       three axes at ``None``. The frontend renders ``None`` cards as
+       absent so the user sees honest absence rather than a
+       placeholder value.
     """
+
+    try:
+        from app.services.multi_axis_classifier import score_text as multi_axis_score
+    except Exception:  # pragma: no cover — import-time failures fall through
+        multi_axis_score = None  # type: ignore[assignment]
+
+    if multi_axis_score is not None:
+        try:
+            classifier_block = multi_axis_score(text)
+        except Exception:  # pragma: no cover — never let the classifier crash /analyze
+            logger.warning("multi_axis_classifier_failed", exc_info=True)
+            classifier_block = None
+        if classifier_block is not None:
+            return classifier_block
 
     label_raw = str(sentiment.get("label", "")).strip().lower()
     canonical_labels = ("hawkish", "dovish", "neutral")

--- a/backend/app/models/text_multi_axis_classifier.py
+++ b/backend/app/models/text_multi_axis_classifier.py
@@ -1,0 +1,151 @@
+"""Text-only multi-axis classifier for the /analyze surface (#78 follow-up).
+
+Wraps a pre-trained transformer encoder (default: finbert_fed_adjacent,
+the project's continued-pretrained FinBERT on BIS speeches) with the
+multi-task head shipped in #272. Emits per-axis predictions on stance,
+factor, certainty, and topic from a single input text.
+
+The classifier is trained on the supervised rows in events.parquet
+that carry axis labels (primarily the gtfintechlab cross-bank rows
+for stance / certainty / topic plus the gss_factor rows for factor),
+not on the volatility-regime target the time-series forecaster uses.
+This is a parallel model to the forecaster, not a replacement.
+
+The encoder pools the [CLS] token from the last hidden state into a
+single vector per text; the MultiTaskHead emits four branches from
+that pooled representation. The shared encoder is fine-tuned end-to-
+end during training; at inference the model is frozen behind the
+service singleton at backend/app/services/multi_axis_classifier.py.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from torch import nn
+
+from app.models.multi_task_head import MultiTaskHead
+from app.models.config import (
+    MULTI_TASK_CERTAINTY_CLASSES,
+    MULTI_TASK_STANCE_CLASSES,
+    MULTI_TASK_TOPIC_CLASSES,
+)
+
+
+class TextMultiAxisClassifier(nn.Module):
+    """Pre-trained transformer encoder + MultiTaskHead.
+
+    Constructed via :meth:`from_encoder_alias` which resolves the
+    encoder from the registry (pinned repo + revision) so every
+    training + inference run loads the same weights deterministically.
+    """
+
+    def __init__(
+        self,
+        encoder: nn.Module,
+        *,
+        hidden_size: int,
+        head_hidden_size: int = 128,
+        dropout: float = 0.1,
+        stance_classes: int = MULTI_TASK_STANCE_CLASSES,
+        certainty_classes: int = MULTI_TASK_CERTAINTY_CLASSES,
+        topic_classes: int = MULTI_TASK_TOPIC_CLASSES,
+        encoder_alias: str = "",
+        encoder_revision: str = "",
+    ) -> None:
+        super().__init__()
+        self.encoder = encoder
+        self.hidden_size = int(hidden_size)
+        self.head = MultiTaskHead(
+            hidden_size=self.hidden_size,
+            head_hidden_size=head_hidden_size,
+            dropout=dropout,
+            stance_classes=stance_classes,
+            certainty_classes=certainty_classes,
+            topic_classes=topic_classes,
+        )
+        # Surface the encoder provenance on the module so the
+        # checkpoint payload can persist the exact alias + revision
+        # the training run consumed.
+        self.encoder_alias = str(encoder_alias)
+        self.encoder_revision = str(encoder_revision)
+
+    @classmethod
+    def from_encoder_alias(
+        cls,
+        encoder_alias: str = "finbert_fed_adjacent",
+        *,
+        head_hidden_size: int = 128,
+        dropout: float = 0.1,
+    ) -> "TextMultiAxisClassifier":
+        """Build the classifier with the encoder resolved from the registry.
+
+        Loads the encoder via ``AutoModel.from_pretrained`` using the
+        pinned revision. Refuses unpinned aliases — every checkpoint
+        the multi-axis classifier consumes must round-trip through a
+        recorded revision so reproducibility is non-negotiable.
+        """
+
+        from transformers import AutoModel
+
+        from app.models.registry import encoder_ref
+
+        ref = encoder_ref(encoder_alias)
+        if ref is None:
+            raise ValueError(
+                f"Encoder alias {encoder_alias!r} is not in models/registry.yaml. "
+                "Add it before constructing the classifier."
+            )
+        if not ref.revision:
+            raise ValueError(
+                f"Encoder alias {encoder_alias!r} has an empty revision in the "
+                "registry. Multi-axis classifier training refuses unpinned "
+                "encoders to keep checkpoint provenance unambiguous."
+            )
+        encoder = AutoModel.from_pretrained(ref.repo, revision=ref.revision)
+        hidden_size = int(getattr(encoder.config, "hidden_size", 0))
+        if hidden_size <= 0:
+            raise ValueError(
+                f"Encoder {encoder_alias!r} reported hidden_size={hidden_size}; "
+                "expected a positive integer from the transformer config."
+            )
+        return cls(
+            encoder,
+            hidden_size=hidden_size,
+            head_hidden_size=head_hidden_size,
+            dropout=dropout,
+            encoder_alias=encoder_alias,
+            encoder_revision=ref.revision,
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """Emit per-axis predictions for a batch of tokenised inputs.
+
+        Uses the [CLS] token pooling convention. Returns the same
+        dict shape MultiTaskHead emits: ``{stance, factor, certainty, topic}``.
+        """
+
+        outputs = self.encoder(input_ids=input_ids, attention_mask=attention_mask)
+        # Last hidden state shape: (B, T, H). [CLS] is at position 0
+        # for the BERT / FinBERT family the classifier targets.
+        pooled = outputs.last_hidden_state[:, 0, :]
+        return self.head(pooled)
+
+    def metadata(self) -> dict[str, Any]:
+        """Round-trippable provenance for checkpoint payloads."""
+
+        return {
+            "encoder_alias": self.encoder_alias,
+            "encoder_revision": self.encoder_revision,
+            "hidden_size": self.hidden_size,
+            "head_hidden_size": self.head.head_hidden_size,
+            "dropout": self.head.dropout,
+            "stance_classes": self.head.stance_classes,
+            "certainty_classes": self.head.certainty_classes,
+            "topic_classes": self.head.topic_classes,
+        }

--- a/backend/app/models/text_multi_axis_classifier.py
+++ b/backend/app/models/text_multi_axis_classifier.py
@@ -134,7 +134,7 @@ class TextMultiAxisClassifier(nn.Module):
         # Last hidden state shape: (B, T, H). [CLS] is at position 0
         # for the BERT / FinBERT family the classifier targets.
         pooled = outputs.last_hidden_state[:, 0, :]
-        return self.head(pooled)
+        return self.head(pooled)  # type: ignore[no-any-return]
 
     def metadata(self) -> dict[str, Any]:
         """Round-trippable provenance for checkpoint payloads."""

--- a/backend/app/services/multi_axis_classifier.py
+++ b/backend/app/services/multi_axis_classifier.py
@@ -1,0 +1,233 @@
+"""Multi-axis text classifier inference service (#78 follow-up).
+
+Wraps the trained ``TextMultiAxisClassifier`` checkpoint behind a
+thread-safe singleton so the FastAPI handler at ``/analyze`` can
+emit per-axis predictions without paying the cold-start cost on
+every request. Mirrors the pattern in
+``app.services.text_encoder.get_classifier``.
+
+The classifier is treated as optional: if no checkpoint exists at
+the configured path the service returns ``None`` for every prediction
+and the /analyze handler falls back to populating only the stance
+card from the legacy sentiment classifier. Cold-start training is
+NOT triggered automatically — the classifier consumes a fixed
+supervised corpus (events.parquet) and is trained out-of-band via
+``python -m app.data.train_text_multi_axis_classifier``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from app.config import MODEL_CHECKPOINT_DIR
+from app.models.config import (
+    MULTI_TASK_CERTAINTY_LABELS,
+    MULTI_TASK_STANCE_LABELS,
+    MULTI_TASK_TOPIC_LABELS,
+)
+from app.models.text_multi_axis_classifier import TextMultiAxisClassifier
+
+DEFAULT_CHECKPOINT_PATH = MODEL_CHECKPOINT_DIR / "text_multi_axis_best.pt"
+DEFAULT_MAX_LENGTH = 256
+
+_logger = logging.getLogger(__name__)
+_state: "_ClassifierState | None" = None
+_state_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class _ClassifierState:
+    model: TextMultiAxisClassifier
+    tokenizer: Any
+    device: torch.device
+    max_length: int
+
+
+def _resolve_checkpoint_path() -> Path:
+    override = (os.environ.get("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT") or "").strip()
+    if override:
+        return Path(override)
+    return DEFAULT_CHECKPOINT_PATH
+
+
+def checkpoint_exists() -> bool:
+    """Best-effort probe used by /analyze to decide whether to invoke the classifier."""
+
+    return _resolve_checkpoint_path().exists()
+
+
+def _load_state() -> _ClassifierState | None:
+    """Build the singleton from the checkpoint payload.
+
+    Returns ``None`` when the checkpoint is missing — the caller then
+    routes /analyze through the legacy stance-only path without
+    raising. Any other failure (missing transformers, malformed
+    payload) is logged and also returns ``None`` so a broken
+    classifier never blocks the rest of the analyze flow.
+    """
+
+    path = _resolve_checkpoint_path()
+    if not path.exists():
+        return None
+    try:
+        payload = torch.load(path, map_location="cpu", weights_only=False)
+    except Exception:
+        _logger.warning("multi_axis_checkpoint_load_failed path=%s", path, exc_info=True)
+        return None
+
+    metadata = payload.get("metadata") or {}
+    encoder_alias = str(metadata.get("encoder_alias") or "finbert_fed_adjacent")
+    head_hidden_size = int(metadata.get("head_hidden_size") or 128)
+    dropout = float(metadata.get("dropout") or 0.1)
+
+    try:
+        from transformers import AutoTokenizer
+
+        from app.models.registry import encoder_ref
+
+        ref = encoder_ref(encoder_alias)
+        if ref is None or not ref.revision:
+            raise ValueError(
+                f"Encoder alias {encoder_alias!r} is unpinned in registry.yaml"
+            )
+        tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)
+        model = TextMultiAxisClassifier.from_encoder_alias(
+            encoder_alias=encoder_alias,
+            head_hidden_size=head_hidden_size,
+            dropout=dropout,
+        )
+        state_dict = payload.get("model_state_dict") or {}
+        missing, unexpected = model.load_state_dict(state_dict, strict=False)
+        if missing or unexpected:
+            _logger.warning(
+                "multi_axis_checkpoint_partial_load missing=%d unexpected=%d",
+                len(missing),
+                len(unexpected),
+            )
+    except Exception:
+        _logger.warning(
+            "multi_axis_classifier_build_failed path=%s", path, exc_info=True
+        )
+        return None
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    model.eval()
+    max_length = int(
+        (payload.get("training_args") or {}).get("max_length") or DEFAULT_MAX_LENGTH
+    )
+    return _ClassifierState(
+        model=model, tokenizer=tokenizer, device=device, max_length=max_length
+    )
+
+
+def get_classifier() -> _ClassifierState | None:
+    """Return the lazily-loaded classifier singleton (or None when absent).
+
+    Thread-safe: callers that race on first use see one load. Subsequent
+    callers read the cached state without acquiring the lock.
+    """
+
+    global _state
+    if _state is not None:
+        return _state
+    with _state_lock:
+        if _state is None:
+            _state = _load_state()
+        return _state
+
+
+def reset_classifier() -> None:
+    """Drop the singleton so the next call rebuilds (test hook + post-train refresh)."""
+
+    global _state
+    with _state_lock:
+        _state = None
+
+
+@torch.no_grad()
+def score_text(text: str) -> dict[str, Any] | None:
+    """Run the classifier on ``text`` and return the per-axis prediction block.
+
+    Returns ``None`` when no checkpoint is loaded. The output shape
+    matches the ``MultiAxisBlock`` Pydantic schema in
+    ``app.schemas`` — keys for stance / factor / certainty / topic
+    each carrying ``label``, ``confidence``, and (where applicable)
+    a per-class distribution.
+    """
+
+    state = get_classifier()
+    if state is None:
+        return None
+    text = (text or "").strip()
+    if not text:
+        return None
+    encoded = state.tokenizer(
+        text,
+        max_length=state.max_length,
+        padding="max_length",
+        truncation=True,
+        return_tensors="pt",
+    )
+    input_ids = encoded["input_ids"].to(state.device)
+    attention_mask = encoded["attention_mask"].to(state.device)
+    logits = state.model(input_ids=input_ids, attention_mask=attention_mask)
+
+    stance_probs = torch.softmax(logits["stance"], dim=-1)[0]
+    stance_idx = int(stance_probs.argmax().item())
+    stance_label = MULTI_TASK_STANCE_LABELS[stance_idx]
+    stance_dist = {
+        MULTI_TASK_STANCE_LABELS[i]: float(stance_probs[i].item())
+        for i in range(len(MULTI_TASK_STANCE_LABELS))
+    }
+
+    factor_value = float(logits["factor"][0].item())
+
+    certainty_probs = torch.softmax(logits["certainty"], dim=-1)[0]
+    certainty_idx = int(certainty_probs.argmax().item())
+    certainty_label = MULTI_TASK_CERTAINTY_LABELS[certainty_idx]
+    certainty_dist = {
+        MULTI_TASK_CERTAINTY_LABELS[i]: float(certainty_probs[i].item())
+        for i in range(len(MULTI_TASK_CERTAINTY_LABELS))
+    }
+
+    topic_probs = torch.softmax(logits["topic"], dim=-1)[0]
+    topic_idx = int(topic_probs.argmax().item())
+    topic_label = MULTI_TASK_TOPIC_LABELS[topic_idx]
+    topic_dist = {
+        MULTI_TASK_TOPIC_LABELS[i]: float(topic_probs[i].item())
+        for i in range(len(MULTI_TASK_TOPIC_LABELS))
+    }
+
+    return {
+        "stance": {
+            "label": stance_label,
+            "confidence": float(stance_probs[stance_idx].item()),
+            "distribution": stance_dist,
+        },
+        "factor": {
+            "value": max(-1.0, min(1.0, factor_value)),
+            # Factor regression confidence is not a probability; for now
+            # we emit the absolute value as a proxy ("how far from
+            # neutral") and the frontend renders it as the bar
+            # magnitude. Calibration is a follow-up.
+            "confidence": min(1.0, abs(factor_value)),
+        },
+        "certainty": {
+            "label": certainty_label,
+            "confidence": float(certainty_probs[certainty_idx].item()),
+            "distribution": certainty_dist,
+        },
+        "topic": {
+            "label": topic_label,
+            "confidence": float(topic_probs[topic_idx].item()),
+            "distribution": topic_dist,
+        },
+    }

--- a/tests/unit/test_analyze_response_multi_axis_block.py
+++ b/tests/unit/test_analyze_response_multi_axis_block.py
@@ -1,18 +1,30 @@
 """Multi-axis block on the /analyze response (#78).
 
-The stance card is sourced from the existing sentiment classifier
-output; factor / certainty / topic are left as None until the
-multi-axis text classifier ships in a follow-up. The frontend renders
-None cards as absent (no placeholder), so the contract here is
-"stance always present; the others default to None".
+Two paths the builder routes between:
+
+- ``TextMultiAxisClassifier`` checkpoint present → all four cards
+  populated from the classifier service.
+- No checkpoint → stance card sourced from the existing sentiment
+  classifier output; factor / certainty / topic stay None.
+
+The frontend renders None cards as absent (no placeholder), so the
+contract is "stance always present; the others fill when the
+classifier ships a checkpoint".
 """
 
 from __future__ import annotations
 
 
-def test_multi_axis_block_carries_stance_from_sentiment_output() -> None:
-    from app.main import _build_multi_axis_block
+def test_multi_axis_block_falls_back_to_sentiment_when_classifier_absent(
+    monkeypatch,
+) -> None:
+    """Without a trained classifier checkpoint, stance comes from the
+    existing sentiment output and the other three axes default to None."""
 
+    from app.main import _build_multi_axis_block
+    from app.services import multi_axis_classifier as svc
+
+    monkeypatch.setattr(svc, "score_text", lambda _text: None)
     sentiment = {
         "label": "hawkish",
         "score": 0.82,
@@ -22,48 +34,69 @@ def test_multi_axis_block_carries_stance_from_sentiment_output() -> None:
             {"label": "dovish", "score": 0.06},
         ],
     }
-    block = _build_multi_axis_block(sentiment)
+    block = _build_multi_axis_block("text body", sentiment)
     assert block is not None
     assert block["stance"]["label"] == "hawkish"
     assert 0.0 <= block["stance"]["confidence"] <= 1.0
     distribution = block["stance"]["distribution"]
     assert set(distribution.keys()) == {"hawkish", "dovish", "neutral"}
     assert abs(distribution["hawkish"] - 0.82) < 1e-6
-
-
-def test_multi_axis_block_other_axes_default_to_none() -> None:
-    """The factor / certainty / topic cards are populated in a
-    follow-up PR by the multi-task text classifier. Until then they
-    are explicitly None so the frontend renders absence honestly."""
-
-    from app.main import _build_multi_axis_block
-
-    sentiment = {
-        "label": "neutral",
-        "score": 0.5,
-        "raw": [{"label": "neutral", "score": 0.5}],
-    }
-    block = _build_multi_axis_block(sentiment)
-    assert block is not None
     assert block["factor"] is None
     assert block["certainty"] is None
     assert block["topic"] is None
 
 
-def test_multi_axis_block_coerces_unknown_label_to_neutral() -> None:
-    """If the upstream classifier returns a label outside the
-    canonical set (case mismatch, stale checkpoint, fallback model),
-    the block collapses to neutral with the available distribution so
-    the frontend stays renderable."""
+def test_multi_axis_block_uses_classifier_when_checkpoint_loaded(monkeypatch) -> None:
+    """When the classifier returns a populated block, the /analyze
+    response surfaces it verbatim (all four cards with real values)."""
 
     from app.main import _build_multi_axis_block
+    from app.services import multi_axis_classifier as svc
 
+    classifier_block = {
+        "stance": {
+            "label": "dovish",
+            "confidence": 0.71,
+            "distribution": {"hawkish": 0.12, "dovish": 0.71, "neutral": 0.17},
+        },
+        "factor": {"value": -0.42, "confidence": 0.42},
+        "certainty": {
+            "label": "uncertain",
+            "confidence": 0.65,
+            "distribution": {"certain": 0.18, "uncertain": 0.65, "neutral": 0.17},
+        },
+        "topic": {
+            "label": "forward_guidance",
+            "confidence": 0.58,
+            "distribution": {
+                "macro": 0.20,
+                "forward_guidance": 0.58,
+                "market_reaction": 0.12,
+                "other": 0.10,
+            },
+        },
+    }
+    monkeypatch.setattr(svc, "score_text", lambda _text: classifier_block)
+    sentiment = {"label": "hawkish", "score": 0.5, "raw": []}
+    block = _build_multi_axis_block("text body", sentiment)
+    assert block == classifier_block
+
+
+def test_multi_axis_block_coerces_unknown_label_to_neutral(monkeypatch) -> None:
+    """If the upstream sentiment classifier returns a label outside the
+    canonical set (case mismatch, stale checkpoint, fallback model),
+    the fallback path collapses to neutral with the available distribution."""
+
+    from app.main import _build_multi_axis_block
+    from app.services import multi_axis_classifier as svc
+
+    monkeypatch.setattr(svc, "score_text", lambda _text: None)
     sentiment = {
         "label": "UNKNOWN",
         "score": 0.0,
         "raw": [],
     }
-    block = _build_multi_axis_block(sentiment)
+    block = _build_multi_axis_block("text body", sentiment)
     assert block is not None
     assert block["stance"]["label"] == "neutral"
     assert block["stance"]["confidence"] == 0.0

--- a/tests/unit/test_multi_axis_classifier_service.py
+++ b/tests/unit/test_multi_axis_classifier_service.py
@@ -1,0 +1,86 @@
+"""Inference service for the multi-axis text classifier (#78 follow-up).
+
+The service is intentionally opt-in: when no checkpoint exists at
+the configured path, ``score_text`` returns ``None`` and the
+/analyze handler falls back to populating the stance card from the
+legacy sentiment classifier. The tests pin both halves of that
+contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.services import multi_axis_classifier as svc
+
+
+def test_score_text_returns_none_when_checkpoint_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Pointing the service at a nonexistent path must NOT raise. The
+    /analyze handler relies on a graceful ``None`` so it can route
+    around an absent classifier."""
+
+    svc.reset_classifier()
+    missing = tmp_path / "no_such_checkpoint.pt"
+    monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(missing))
+    assert svc.checkpoint_exists() is False
+    assert svc.score_text("any text") is None
+
+
+def test_checkpoint_exists_returns_true_when_file_present(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The path probe is a stat-only check; it does NOT validate the
+    checkpoint contents."""
+
+    svc.reset_classifier()
+    present = tmp_path / "present.pt"
+    present.write_bytes(b"\x00" * 4)
+    monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(present))
+    assert svc.checkpoint_exists() is True
+
+
+def test_score_text_returns_none_on_malformed_checkpoint(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A corrupted / non-torch checkpoint at the configured path
+    must degrade gracefully to ``None`` rather than crashing the
+    /analyze handler."""
+
+    svc.reset_classifier()
+    corrupt = tmp_path / "corrupt.pt"
+    corrupt.write_bytes(b"not a torch checkpoint")
+    monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(corrupt))
+    assert svc.score_text("any text") is None
+
+
+def test_reset_classifier_clears_singleton(monkeypatch, tmp_path: Path) -> None:
+    """``reset_classifier`` is the post-train hook the trainer calls
+    to force the next /analyze request to rebuild the singleton from
+    a fresh checkpoint."""
+
+    svc.reset_classifier()
+    missing = tmp_path / "still_missing.pt"
+    monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(missing))
+    # Prime the singleton with a None result.
+    assert svc.get_classifier() is None
+    # Reset must clear the cached None so a future load can rebuild.
+    svc.reset_classifier()
+    # Without the reset the second call would short-circuit on the
+    # cached None; with it we hit the load path again.
+    assert svc.get_classifier() is None
+
+
+def test_score_text_skips_empty_input(monkeypatch, tmp_path: Path) -> None:
+    """Empty / whitespace-only text must not invoke the model — the
+    cards stay empty rather than the classifier hallucinating a
+    label from an empty input window."""
+
+    svc.reset_classifier()
+    missing = tmp_path / "no_checkpoint.pt"
+    monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(missing))
+    assert svc.score_text("") is None
+    assert svc.score_text("   ") is None

--- a/tests/unit/test_text_multi_axis_classifier.py
+++ b/tests/unit/test_text_multi_axis_classifier.py
@@ -1,0 +1,102 @@
+"""Cover the TextMultiAxisClassifier module (#78 follow-up).
+
+The classifier wires a transformer encoder onto the MultiTaskHead.
+Tests use a tiny BERT-config stub so the suite runs in seconds
+without pulling FinBERT weights from disk.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from app.models.text_multi_axis_classifier import TextMultiAxisClassifier
+
+
+class _StubEncoder(nn.Module):
+    """Minimal stand-in for a HF transformer encoder.
+
+    Returns a namespace-like object exposing ``last_hidden_state`` so
+    the classifier's ``[CLS]`` pooling step works without pulling the
+    real FinBERT weights into the test process.
+    """
+
+    def __init__(self, hidden_size: int = 16, vocab_size: int = 30) -> None:
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, hidden_size)
+
+    def forward(self, input_ids: torch.Tensor, attention_mask=None):
+        hidden = self.embed(input_ids)
+
+        class _Out:
+            pass
+
+        out = _Out()
+        out.last_hidden_state = hidden
+        return out
+
+
+def test_classifier_emits_four_axis_dict_from_stub_encoder() -> None:
+    torch.manual_seed(0)
+    encoder = _StubEncoder(hidden_size=16, vocab_size=30)
+    model = TextMultiAxisClassifier(
+        encoder,
+        hidden_size=16,
+        head_hidden_size=8,
+        dropout=0.0,
+        encoder_alias="stub",
+        encoder_revision="rev",
+    )
+    input_ids = torch.randint(0, 30, (2, 12))
+    attention_mask = torch.ones_like(input_ids)
+    out = model(input_ids=input_ids, attention_mask=attention_mask)
+    assert set(out.keys()) == {"stance", "factor", "certainty", "topic"}
+    assert out["stance"].shape == (2, 3)
+    assert out["factor"].shape == (2,)
+    assert out["certainty"].shape == (2, 3)
+    assert out["topic"].shape == (2, 4)
+
+
+def test_metadata_round_trips_encoder_provenance() -> None:
+    """The classifier records the encoder alias + revision so a
+    checkpoint payload can re-resolve the same weights on load."""
+
+    encoder = _StubEncoder(hidden_size=8, vocab_size=20)
+    model = TextMultiAxisClassifier(
+        encoder,
+        hidden_size=8,
+        head_hidden_size=4,
+        dropout=0.1,
+        encoder_alias="alias",
+        encoder_revision="rev123",
+    )
+    meta = model.metadata()
+    assert meta["encoder_alias"] == "alias"
+    assert meta["encoder_revision"] == "rev123"
+    assert meta["hidden_size"] == 8
+    assert meta["head_hidden_size"] == 4
+    assert meta["stance_classes"] == 3
+
+
+def test_factor_branch_stays_in_minus_one_to_one_range() -> None:
+    """Tanh bound on the factor head — same contract as the shared
+    MultiTaskHead unit test, exercised here through the classifier
+    wrapper so a future refactor that bypasses the head is caught."""
+
+    torch.manual_seed(1)
+    encoder = _StubEncoder(hidden_size=16, vocab_size=30)
+    model = TextMultiAxisClassifier(
+        encoder,
+        hidden_size=16,
+        head_hidden_size=8,
+        dropout=0.0,
+    )
+    # Push activations through with extreme weights to provoke
+    # saturation; without tanh the factor branch could exceed 1.
+    with torch.no_grad():
+        model.head.factor.weight.fill_(10.0)
+        model.head.factor.bias.fill_(10.0)
+    input_ids = torch.randint(0, 30, (4, 8))
+    out = model(input_ids=input_ids, attention_mask=torch.ones_like(input_ids))
+    assert torch.all(out["factor"] >= -1.0)
+    assert torch.all(out["factor"] <= 1.0)


### PR DESCRIPTION
## Summary

- `TextMultiAxisClassifier` wraps FinBERT-FedAdjacent + the shipped `MultiTaskHead`.
- New training entrypoint fine-tunes the classifier on `events.parquet` with `MultiTaskLoss`.
- Service singleton loads the checkpoint lazily; returns `None` when absent.
- `_build_multi_axis_block` routes to the classifier first, falls back to sentiment.
- FastAPI lifespan warms the singleton on startup when the checkpoint exists.
- First training run: stance 1.00 / certainty 1.00 / topic 1.00 val accuracy (inflated by class imbalance; see wiki §6.9).

## Test plan

- [ ] `docker compose run --rm backend pytest tests/unit/test_text_multi_axis_classifier.py tests/unit/test_multi_axis_classifier_service.py tests/unit/test_analyze_response_multi_axis_block.py -q`
- [ ] `make dev-gpu` then POST `/analyze` with a FOMC statement — confirm all 4 cards render.