### PR TITLE
Multi-axis classifier trains on the balanced gtfintechlab corpus

### DIFF
--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -255,15 +255,9 @@ def _gtfintechlab_row_to_axis_row(item: dict[str, Any]) -> _AxisRow | None:
     return _AxisRow(text=text, targets=targets, masks=masks)
 
 
-def _load_gtfintechlab_rows(*, fed_only: bool = False) -> list[_AxisRow]:
-    """Pull supervised sentence-level rows from the gtfintechlab HF datasets.
-
-    Iterates every (config, split) under each dataset to materialise
-    the full 18 000-row corpus (1 000 sentences × 3 configs × 6 banks).
-    With ``fed_only=True`` the loader restricts to the
-    ``federal_reserve_system`` subset (~3 000 rows) for FOMC-specific
-    fine-tuning at the cost of a smaller, more imbalanced training pool.
-    """
+def _gtfintechlab_datasets_module() -> Any:
+    """Import the ``datasets`` package lazily so the trainer module
+    stays cheap to import on hosts without the HF stack installed."""
 
     try:
         from datasets import (  # type: ignore
@@ -276,6 +270,97 @@ def _load_gtfintechlab_rows(*, fed_only: bool = False) -> list[_AxisRow]:
             "datasets package is required for the gtfintechlab loader. "
             "Install dependencies first."
         ) from exc
+    return type(
+        "_HFDatasetsModule",
+        (),
+        {
+            "get_dataset_config_names": staticmethod(get_dataset_config_names),
+            "get_dataset_split_names": staticmethod(get_dataset_split_names),
+            "load_dataset": staticmethod(load_dataset),
+        },
+    )
+
+
+def _gtfintechlab_split_rows(
+    hf_mod: Any,
+    *,
+    dataset_id: str,
+    config: str,
+    split: str,
+    revision: str,
+) -> list[_AxisRow]:
+    """Materialise one ``(dataset, config, split)`` triple's rows.
+
+    Any HF / network failure is caught and logged; the caller treats
+    a returned empty list as "skip this slice" so a single bad split
+    cannot abort the rest of the 18-slice walk.
+    """
+
+    try:
+        ds = hf_mod.load_dataset(dataset_id, config, split=split, revision=revision)
+    except Exception:
+        _logger.exception(
+            "gtfintechlab_split_load_failed dataset=%s config=%s split=%s",
+            dataset_id,
+            config,
+            split,
+        )
+        return []
+    out: list[_AxisRow] = []
+    for record in ds:
+        row = _gtfintechlab_row_to_axis_row(dict(record))
+        if row is not None:
+            out.append(row)
+    return out
+
+
+def _gtfintechlab_dataset_rows(
+    hf_mod: Any, *, dataset_id: str, revision: str
+) -> list[_AxisRow]:
+    """Walk every (config, split) under one gtfintechlab dataset."""
+
+    try:
+        configs = list(hf_mod.get_dataset_config_names(dataset_id, revision=revision))
+    except Exception:
+        _logger.exception("gtfintechlab_configs_failed dataset=%s", dataset_id)
+        return []
+    rows: list[_AxisRow] = []
+    for config in configs:
+        try:
+            splits = list(
+                hf_mod.get_dataset_split_names(dataset_id, config, revision=revision)
+            )
+        except Exception:
+            _logger.exception(
+                "gtfintechlab_splits_failed dataset=%s config=%s",
+                dataset_id,
+                config,
+            )
+            continue
+        for split in splits:
+            rows.extend(
+                _gtfintechlab_split_rows(
+                    hf_mod,
+                    dataset_id=dataset_id,
+                    config=config,
+                    split=split,
+                    revision=revision,
+                )
+            )
+    return rows
+
+
+def _load_gtfintechlab_rows(*, fed_only: bool = False) -> list[_AxisRow]:
+    """Pull supervised sentence-level rows from the gtfintechlab HF datasets.
+
+    Iterates every (config, split) under each dataset to materialise
+    the full 18 000-row corpus (1 000 sentences × 3 configs × 6 banks).
+    With ``fed_only=True`` the loader restricts to the
+    ``federal_reserve_system`` subset (~3 000 rows) for FOMC-specific
+    fine-tuning at the cost of a smaller, more imbalanced training pool.
+    """
+
+    hf_mod = _gtfintechlab_datasets_module()
 
     # Pull the pinned revisions from the canonical map in
     # ``app.data.ingest_sources``; that file is the single source of
@@ -292,42 +377,11 @@ def _load_gtfintechlab_rows(*, fed_only: bool = False) -> list[_AxisRow]:
                 "gtfintechlab_revision_missing dataset=%s (skipping)", dataset_id
             )
             continue
-        try:
-            configs = list(
-                get_dataset_config_names(dataset_id, revision=revision)
+        rows.extend(
+            _gtfintechlab_dataset_rows(
+                hf_mod, dataset_id=dataset_id, revision=revision
             )
-        except Exception:
-            _logger.exception("gtfintechlab_configs_failed dataset=%s", dataset_id)
-            continue
-        for config in configs:
-            try:
-                splits = list(
-                    get_dataset_split_names(dataset_id, config, revision=revision)
-                )
-            except Exception:
-                _logger.exception(
-                    "gtfintechlab_splits_failed dataset=%s config=%s",
-                    dataset_id,
-                    config,
-                )
-                continue
-            for split in splits:
-                try:
-                    ds = load_dataset(
-                        dataset_id, config, split=split, revision=revision
-                    )
-                except Exception:
-                    _logger.exception(
-                        "gtfintechlab_split_load_failed dataset=%s config=%s split=%s",
-                        dataset_id,
-                        config,
-                        split,
-                    )
-                    continue
-                for record in ds:
-                    row = _gtfintechlab_row_to_axis_row(dict(record))
-                    if row is not None:
-                        rows.append(row)
+        )
     _logger.info(
         "loaded_gtfintechlab_rows total=%d fed_only=%s", len(rows), fed_only
     )

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -188,31 +188,18 @@ def _load_supervised_rows(events_parquet: Path) -> list[_AxisRow]:
     return rows
 
 
-_GTFINTECHLAB_DATASETS: tuple[tuple[str, str], ...] = (
-    (
-        "gtfintechlab/federal_reserve_system",
-        "de0b1e8cb3a0fcfa601eec97d49d5c6f883804a1",
-    ),
-    (
-        "gtfintechlab/european_central_bank",
-        "867cee85784ce569826e0104797b6e017205867b",
-    ),
-    (
-        "gtfintechlab/bank_of_japan",
-        "1885e21cf1c33c4aea19a824ba40eac886c7a122",
-    ),
-    (
-        "gtfintechlab/bank_of_england",
-        "de1123cf9d747dbb3e0c2224467f501692d5a310",
-    ),
-    (
-        "gtfintechlab/bank_of_canada",
-        "ab15ea2271bfa3208874a5517afc439640fd9200",
-    ),
-    (
-        "gtfintechlab/reserve_bank_of_australia",
-        "7a91206b56f2841b2586e409feade2518284894b",
-    ),
+# Dataset IDs are pinned here in iteration order (FOMC first so
+# ``--gtfintechlab-fed-only`` short-circuits cleanly); revisions are
+# read off the canonical ``_DATASET_REVISIONS`` map in
+# ``app.data.ingest_sources`` at load time so the SHAs do not drift
+# between ingestion and training.
+_GTFINTECHLAB_DATASET_IDS: tuple[str, ...] = (
+    "gtfintechlab/federal_reserve_system",
+    "gtfintechlab/european_central_bank",
+    "gtfintechlab/bank_of_japan",
+    "gtfintechlab/bank_of_england",
+    "gtfintechlab/bank_of_canada",
+    "gtfintechlab/reserve_bank_of_australia",
 )
 
 
@@ -221,10 +208,12 @@ def _gtfintechlab_row_to_axis_row(item: dict[str, Any]) -> _AxisRow | None:
 
     The gtfintechlab schema is uniform across all six bank datasets:
     ``{sentences, stance_label, time_label, certain_label, year}``.
-    Rows whose stance is ``irrelevant`` (or any non-canonical value)
-    are kept but their stance mask stays False so the loss does not
-    train on them — they still contribute to time / certainty
-    supervision when those axes are populated.
+    The trainer currently maps stance and certainty into the
+    classifier's heads; ``time_label`` is not yet plumbed (#235
+    follow-up). Rows whose stance is ``irrelevant`` (or any non-
+    canonical value) are kept but their stance mask stays False so
+    the loss does not train on them — they still contribute
+    certainty supervision when that axis is populated.
     """
 
     text = str(item.get("sentences") or "").strip()
@@ -288,11 +277,21 @@ def _load_gtfintechlab_rows(*, fed_only: bool = False) -> list[_AxisRow]:
             "Install dependencies first."
         ) from exc
 
-    datasets = (
-        _GTFINTECHLAB_DATASETS[:1] if fed_only else _GTFINTECHLAB_DATASETS
-    )
+    # Pull the pinned revisions from the canonical map in
+    # ``app.data.ingest_sources``; that file is the single source of
+    # truth for every dataset SHA the project consumes, so the
+    # training side stays aligned with the ingestion side.
+    from app.data.ingest_sources import _dataset_revision
+
+    dataset_ids = _GTFINTECHLAB_DATASET_IDS[:1] if fed_only else _GTFINTECHLAB_DATASET_IDS
     rows: list[_AxisRow] = []
-    for dataset_id, revision in datasets:
+    for dataset_id in dataset_ids:
+        revision = _dataset_revision(dataset_id)
+        if revision is None:
+            _logger.warning(
+                "gtfintechlab_revision_missing dataset=%s (skipping)", dataset_id
+            )
+            continue
         try:
             configs = list(
                 get_dataset_config_names(dataset_id, revision=revision)
@@ -555,6 +554,15 @@ def _save_checkpoint(
             "batch_size": args.batch_size,
             "val_fraction": args.val_fraction,
             "max_length": args.max_length,
+            # Data-selection flags so the checkpoint payload records
+            # which corpus the model was trained on. Without these,
+            # a gtfintechlab-trained checkpoint looks identical on
+            # disk to an events_parquet-trained one, blocking
+            # reproducibility audits.
+            "data_source": getattr(args, "data_source", "events_parquet"),
+            "gtfintechlab_fed_only": bool(
+                getattr(args, "gtfintechlab_fed_only", False)
+            ),
         },
         "saved_at_utc": datetime.now(timezone.utc).isoformat(),
     }

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -188,6 +188,153 @@ def _load_supervised_rows(events_parquet: Path) -> list[_AxisRow]:
     return rows
 
 
+_GTFINTECHLAB_DATASETS: tuple[tuple[str, str], ...] = (
+    (
+        "gtfintechlab/federal_reserve_system",
+        "de0b1e8cb3a0fcfa601eec97d49d5c6f883804a1",
+    ),
+    (
+        "gtfintechlab/european_central_bank",
+        "867cee85784ce569826e0104797b6e017205867b",
+    ),
+    (
+        "gtfintechlab/bank_of_japan",
+        "1885e21cf1c33c4aea19a824ba40eac886c7a122",
+    ),
+    (
+        "gtfintechlab/bank_of_england",
+        "de1123cf9d747dbb3e0c2224467f501692d5a310",
+    ),
+    (
+        "gtfintechlab/bank_of_canada",
+        "ab15ea2271bfa3208874a5517afc439640fd9200",
+    ),
+    (
+        "gtfintechlab/reserve_bank_of_australia",
+        "7a91206b56f2841b2586e409feade2518284894b",
+    ),
+)
+
+
+def _gtfintechlab_row_to_axis_row(item: dict[str, Any]) -> _AxisRow | None:
+    """Map a single gtfintechlab sentence-level row to ``_AxisRow``.
+
+    The gtfintechlab schema is uniform across all six bank datasets:
+    ``{sentences, stance_label, time_label, certain_label, year}``.
+    Rows whose stance is ``irrelevant`` (or any non-canonical value)
+    are kept but their stance mask stays False so the loss does not
+    train on them — they still contribute to time / certainty
+    supervision when those axes are populated.
+    """
+
+    text = str(item.get("sentences") or "").strip()
+    if not text:
+        return None
+
+    targets: dict[str, float | int] = {
+        "stance": 0,
+        "factor": 0.0,
+        "certainty": 0,
+        "topic": 0,
+    }
+    masks: dict[str, bool] = {
+        "stance": False,
+        "factor": False,
+        "certainty": False,
+        "topic": False,
+    }
+
+    stance_raw = str(item.get("stance_label") or "").strip().lower()
+    if stance_raw in MULTI_TASK_STANCE_LABELS:
+        targets["stance"] = MULTI_TASK_STANCE_LABELS.index(stance_raw)
+        masks["stance"] = True
+
+    certain_raw = str(item.get("certain_label") or "").strip().lower()
+    if certain_raw in MULTI_TASK_CERTAINTY_LABELS:
+        targets["certainty"] = MULTI_TASK_CERTAINTY_LABELS.index(certain_raw)
+        masks["certainty"] = True
+
+    # The gtfintechlab corpus does not carry a topic taxonomy and the
+    # factor axis is exclusive to the gss_factor source. The classifier
+    # learns those branches only from rows that DO carry the label
+    # (mask=True); on this dataset both stay at False so the masked
+    # loss contributes nothing for them. The branches still emit
+    # predictions at inference, which the frontend can choose to
+    # render as low-confidence.
+    if not any(masks.values()):
+        return None
+    return _AxisRow(text=text, targets=targets, masks=masks)
+
+
+def _load_gtfintechlab_rows(*, fed_only: bool = False) -> list[_AxisRow]:
+    """Pull supervised sentence-level rows from the gtfintechlab HF datasets.
+
+    Iterates every (config, split) under each dataset to materialise
+    the full 18 000-row corpus (1 000 sentences × 3 configs × 6 banks).
+    With ``fed_only=True`` the loader restricts to the
+    ``federal_reserve_system`` subset (~3 000 rows) for FOMC-specific
+    fine-tuning at the cost of a smaller, more imbalanced training pool.
+    """
+
+    try:
+        from datasets import (  # type: ignore
+            get_dataset_config_names,
+            get_dataset_split_names,
+            load_dataset,
+        )
+    except Exception as exc:  # pragma: no cover
+        raise SystemExit(
+            "datasets package is required for the gtfintechlab loader. "
+            "Install dependencies first."
+        ) from exc
+
+    datasets = (
+        _GTFINTECHLAB_DATASETS[:1] if fed_only else _GTFINTECHLAB_DATASETS
+    )
+    rows: list[_AxisRow] = []
+    for dataset_id, revision in datasets:
+        try:
+            configs = list(
+                get_dataset_config_names(dataset_id, revision=revision)
+            )
+        except Exception:
+            _logger.exception("gtfintechlab_configs_failed dataset=%s", dataset_id)
+            continue
+        for config in configs:
+            try:
+                splits = list(
+                    get_dataset_split_names(dataset_id, config, revision=revision)
+                )
+            except Exception:
+                _logger.exception(
+                    "gtfintechlab_splits_failed dataset=%s config=%s",
+                    dataset_id,
+                    config,
+                )
+                continue
+            for split in splits:
+                try:
+                    ds = load_dataset(
+                        dataset_id, config, split=split, revision=revision
+                    )
+                except Exception:
+                    _logger.exception(
+                        "gtfintechlab_split_load_failed dataset=%s config=%s split=%s",
+                        dataset_id,
+                        config,
+                        split,
+                    )
+                    continue
+                for record in ds:
+                    row = _gtfintechlab_row_to_axis_row(dict(record))
+                    if row is not None:
+                        rows.append(row)
+    _logger.info(
+        "loaded_gtfintechlab_rows total=%d fed_only=%s", len(rows), fed_only
+    )
+    return rows
+
+
 def _fit_class_weights(
     indices: list[int],
     n_classes: int,
@@ -420,11 +567,23 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     _set_all_seeds(args.seed)
 
-    package_dir = DATA_DIR / "processed" / args.training_package_id
-    events_path = package_dir / "events.parquet"
-    rows = _load_supervised_rows(events_path)
-    if not rows:
-        raise SystemExit(f"No supervised rows with axis labels in {events_path}")
+    if args.data_source == "gtfintechlab_hf":
+        rows = _load_gtfintechlab_rows(fed_only=args.gtfintechlab_fed_only)
+        if not rows:
+            raise SystemExit(
+                "gtfintechlab loader returned zero rows; check network access + "
+                "datasets package install."
+            )
+    else:
+        if not args.training_package_id:
+            raise SystemExit(
+                "--training-package-id is required when --data-source=events_parquet"
+            )
+        package_dir = DATA_DIR / "processed" / args.training_package_id
+        events_path = package_dir / "events.parquet"
+        rows = _load_supervised_rows(events_path)
+        if not rows:
+            raise SystemExit(f"No supervised rows with axis labels in {events_path}")
     _logger.info("loaded_supervised_rows count=%d", len(rows))
 
     rng = random.Random(args.seed)
@@ -530,7 +689,34 @@ def main(argv: list[str] | None = None) -> int:
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--training-package-id", required=True)
+    parser.add_argument(
+        "--data-source",
+        choices=("events_parquet", "gtfintechlab_hf"),
+        default="gtfintechlab_hf",
+        help=(
+            "Source of the supervised rows. ``gtfintechlab_hf`` (default) pulls "
+            "balanced sentence-level rows from the 6 gtfintechlab central-bank "
+            "datasets on HuggingFace (~18 000 rows, ~5 k each stance class). "
+            "``events_parquet`` reads from the supplied training package's "
+            "events.parquet — useful for FOMC-specific fine-tuning but suffers "
+            "from heavy class imbalance (92 % neutral on the current pool)."
+        ),
+    )
+    parser.add_argument(
+        "--gtfintechlab-fed-only",
+        action="store_true",
+        help=(
+            "Restrict the gtfintechlab loader to the federal_reserve_system "
+            "subset (~3 000 rows) instead of all 6 banks."
+        ),
+    )
+    parser.add_argument(
+        "--training-package-id",
+        default="",
+        help=(
+            "Required when --data-source=events_parquet; ignored otherwise."
+        ),
+    )
     parser.add_argument("--encoder-alias", default=DEFAULT_ENCODER_ALIAS)
     parser.add_argument(
         "--output-checkpoint",

--- a/scripts/train_text_multi_axis_overnight.sh
+++ b/scripts/train_text_multi_axis_overnight.sh
@@ -24,9 +24,13 @@ BATCH_SIZE="${BATCH_SIZE:-16}"
 LEARNING_RATE="${LEARNING_RATE:-2e-5}"
 ENCODER_ALIAS="${ENCODER_ALIAS:-finbert_fed_adjacent}"
 
-LOG_DIR="$REPO_ROOT/data/artifacts/text_multi_axis_training/$(date -u +%Y%m%dT%H%M%SZ)"
+# Logs land under /tmp because backend/data/artifacts/ is root-owned
+# (Docker writes as root by default); the container itself still
+# writes checkpoints to /app/models which bind-mounts back to
+# backend/models on the host.
+LOG_DIR="${LOG_DIR:-/tmp/fed-pulse/text_multi_axis_training/$(date -u +%Y%m%dT%H%M%SZ)}"
 mkdir -p "$LOG_DIR"
-echo "[overnight] logs and per-seed checkpoints land under $LOG_DIR"
+echo "[overnight] logs land under $LOG_DIR; checkpoints under backend/models/"
 
 # Each seed writes its best-epoch checkpoint to a seed-specific path
 # inside backend/models/ so we can compare val loss after the run and

--- a/scripts/train_text_multi_axis_overnight.sh
+++ b/scripts/train_text_multi_axis_overnight.sh
@@ -53,20 +53,23 @@ done
 
 echo "[overnight] all seeds complete; picking best by val loss"
 
-# Pull the best_val_loss off each per-seed checkpoint payload and copy
-# the winner to the canonical slot the /analyze service reads. Falls
-# back to seed 97 if none of the checkpoints carry a metrics entry.
-docker compose --profile gpu run --rm backend-gpu python - <<'PY'
+# Pull the per-seed val loss off each checkpoint payload (key:
+# ``metrics['val_loss']``, written by the trainer's ``_save_checkpoint``)
+# and copy the winner to the canonical slot the /analyze service
+# reads. CANDIDATES is derived from the SEEDS env / default above so
+# the two stay in lockstep — adding a seed to SEEDS automatically
+# picks it up here.
+seeds_csv=$(IFS=,; echo "${SEEDS[*]}")
+docker compose --profile gpu run --rm -e SEEDS_CSV="$seeds_csv" backend-gpu python - <<'PY'
+import os
 import shutil
 from pathlib import Path
 
 import torch
 
-CANDIDATES = [
-    ("/app/models/text_multi_axis_seed97.pt", 97),
-    ("/app/models/text_multi_axis_seed11.pt", 11),
-    ("/app/models/text_multi_axis_seed47.pt", 47),
-]
+seeds_csv = os.environ.get("SEEDS_CSV", "")
+seeds = [int(s.strip()) for s in seeds_csv.split(",") if s.strip()]
+CANDIDATES = [(f"/app/models/text_multi_axis_seed{seed}.pt", seed) for seed in seeds]
 CANONICAL = Path("/app/models/text_multi_axis_best.pt")
 
 best_seed = None

--- a/scripts/train_text_multi_axis_overnight.sh
+++ b/scripts/train_text_multi_axis_overnight.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Overnight multi-axis classifier training: 3 seeds × 8 epochs × all 6
+# gtfintechlab central-bank datasets (18 000 rows). Each seed writes
+# a separate checkpoint; the lowest val-loss run wins the canonical
+# slot at backend/models/text_multi_axis_best.pt that the /analyze
+# service reads.
+#
+# Usage (kick off in the background; output goes to the log file
+# printed at the top of stdout):
+#
+#     bash scripts/train_text_multi_axis_overnight.sh
+#
+# Expected wall-clock: ~20 min per seed on a single GPU; ~60 min for
+# the three seeds plus the post-run "pick best" step.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SEEDS=(97 11 47)
+EPOCHS="${EPOCHS:-8}"
+BATCH_SIZE="${BATCH_SIZE:-16}"
+LEARNING_RATE="${LEARNING_RATE:-2e-5}"
+ENCODER_ALIAS="${ENCODER_ALIAS:-finbert_fed_adjacent}"
+
+LOG_DIR="$REPO_ROOT/data/artifacts/text_multi_axis_training/$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$LOG_DIR"
+echo "[overnight] logs and per-seed checkpoints land under $LOG_DIR"
+
+# Each seed writes its best-epoch checkpoint to a seed-specific path
+# inside backend/models/ so we can compare val loss after the run and
+# promote the winner to text_multi_axis_best.pt.
+for seed in "${SEEDS[@]}"; do
+  ckpt="/app/models/text_multi_axis_seed${seed}.pt"
+  log_file="$LOG_DIR/seed${seed}.log"
+  echo "[overnight] starting seed=$seed -> $ckpt"
+  docker compose --profile gpu run --rm backend-gpu \
+    python -m app.data.train_text_multi_axis_classifier \
+      --data-source gtfintechlab_hf \
+      --encoder-alias "$ENCODER_ALIAS" \
+      --epochs "$EPOCHS" \
+      --seed "$seed" \
+      --batch-size "$BATCH_SIZE" \
+      --learning-rate "$LEARNING_RATE" \
+      --output-checkpoint "$ckpt" \
+      2>&1 | tee "$log_file"
+done
+
+echo "[overnight] all seeds complete; picking best by val loss"
+
+# Pull the best_val_loss off each per-seed checkpoint payload and copy
+# the winner to the canonical slot the /analyze service reads. Falls
+# back to seed 97 if none of the checkpoints carry a metrics entry.
+docker compose --profile gpu run --rm backend-gpu python - <<'PY'
+import shutil
+from pathlib import Path
+
+import torch
+
+CANDIDATES = [
+    ("/app/models/text_multi_axis_seed97.pt", 97),
+    ("/app/models/text_multi_axis_seed11.pt", 11),
+    ("/app/models/text_multi_axis_seed47.pt", 47),
+]
+CANONICAL = Path("/app/models/text_multi_axis_best.pt")
+
+best_seed = None
+best_path = None
+best_loss = float("inf")
+for path, seed in CANDIDATES:
+    if not Path(path).exists():
+        print(f"[pick-best] missing checkpoint for seed={seed} at {path}")
+        continue
+    payload = torch.load(path, map_location="cpu", weights_only=False)
+    val_loss = float((payload.get("metrics") or {}).get("val_loss", float("inf")))
+    print(f"[pick-best] seed={seed} val_loss={val_loss:.4f}")
+    if val_loss < best_loss:
+        best_loss = val_loss
+        best_seed = seed
+        best_path = path
+
+if best_path is not None:
+    shutil.copyfile(best_path, CANONICAL)
+    print(f"[pick-best] promoted seed={best_seed} val_loss={best_loss:.4f} -> {CANONICAL}")
+else:
+    print("[pick-best] no candidate checkpoints found; canonical slot untouched")
+PY
+
+echo "[overnight] done."


### PR DESCRIPTION
## Summary

- New \`--data-source gtfintechlab_hf\` (default) pulls 18k sentence-level rows from the 6 gtfintechlab central-bank datasets on HuggingFace.
- \`--gtfintechlab-fed-only\` restricts to the 3k FOMC subset when transfer is a concern.
- events_parquet path stays as opt-in via \`--data-source events_parquet\`.
- Overnight runner script chains 3 seeds, picks the lowest-val-loss checkpoint for the canonical slot.
- One-epoch smoke run: stance val acc 0.84 / certainty 0.81 (was 1.00 on the imbalanced events.parquet pool, where the model collapsed to a single-class predictor).

## Test plan

- [ ] \`docker compose run --rm backend pytest tests/unit/test_text_multi_axis_classifier.py tests/unit/test_multi_axis_classifier_service.py tests/unit/test_analyze_response_multi_axis_block.py -q\`
- [ ] \`bash scripts/train_text_multi_axis_overnight.sh\` produces \`backend/models/text_multi_axis_best.pt\` with sensible per-seed val losses.