### PR TITLE
Gated InfoNCE multi-modal forecaster (#235)

### DIFF
--- a/backend/app/evaluation/metrics.py
+++ b/backend/app/evaluation/metrics.py
@@ -47,6 +47,15 @@ class EvaluationMetrics:
     predictions: list[int] | None = None
     targets: list[int] | None = None
     class_scores: list[list[float]] | None = None
+    # Gated InfoNCE fusion (#235) diagnostic. Populated only when the
+    # model is a MultiModalForecasterModel; ``gate_summary['mean']``
+    # is the scalar mean gate value (>0.5 → market-leaning, <0.5 →
+    # text-leaning), ``gate_summary['mean_per_class']`` carries the
+    # class-conditional mean so the thesis appendix can say whether
+    # the gate shifts modality reliance per regime, and
+    # ``gate_summary['n_rows']`` is the eval-partition row count the
+    # summary was averaged over.
+    gate_summary: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -280,6 +280,18 @@ class ModelConfig:
     # per batch through the LoRA-wrapped tower. Scoped to a single
     # arch x seed cell -- not a default replacement.
     encoder_lora: bool = False
+    # Multi-modal fusion (#235). ``concat`` (default) keeps the legacy
+    # ForecasterModel path where the text adapter output is
+    # broadcast-concatenated to every LSTM timestep. ``gated_infonce``
+    # routes the build through :class:`MultiModalForecasterModel`: the
+    # market features stream through the recurrent core untouched, the
+    # text embedding feeds the gated fusion directly, and the training
+    # loop adds an InfoNCE alignment loss on the two modality
+    # projections.
+    fusion_mode: str = "concat"
+    infonce_lambda: float = 0.1
+    infonce_temperature: float = 0.07
+    infonce_latent_dim: int = 64
 
     @classmethod
     def from_model(cls, model: "Any") -> "ModelConfig":
@@ -312,6 +324,10 @@ class ModelConfig:
             sequence_length=int(getattr(model, "sequence_length", 0) or 0),
             use_time_decay=bool(getattr(model, "use_time_decay", True)),
             encoder_lora=bool(getattr(model, "encoder_lora", False)),
+            fusion_mode=str(getattr(model, "fusion_mode", "concat") or "concat"),
+            infonce_lambda=float(getattr(model, "infonce_lambda", 0.1)),
+            infonce_temperature=float(getattr(model, "infonce_temperature", 0.07)),
+            infonce_latent_dim=int(getattr(model, "infonce_latent_dim", 64)),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -14,6 +14,11 @@ to know the wrapper's internal kwarg layout, and so the public
 The default ``architecture="lstm"`` path is byte-identical to the previous
 ``ForecasterModel()`` construction so the determinism regression at
 ``tests/regression/test_forecaster_determinism.py`` stays green.
+
+When ``config.fusion_mode == "gated_infonce"`` (#235), the factory
+dispatches to :class:`MultiModalForecasterModel` instead — the two
+modalities stay separate until the gated fusion stage so the InfoNCE
+alignment loss has separable representations to pull together.
 """
 
 from __future__ import annotations
@@ -22,9 +27,12 @@ from typing import Any
 
 from app.models.config import FORECASTER_ARCHITECTURES, ModelConfig
 from app.models.lstm import ForecasterModel
+from app.models.multimodal_forecaster import MultiModalForecasterModel
 
 
-def build_forecaster(config: ModelConfig | dict[str, Any]) -> ForecasterModel:
+def build_forecaster(
+    config: ModelConfig | dict[str, Any],
+) -> ForecasterModel | MultiModalForecasterModel:
     """Build a forecaster module for ``config.architecture``.
 
     All architectures share the same input contract ``(batch, seq_len, 6)``
@@ -43,8 +51,47 @@ def build_forecaster(config: ModelConfig | dict[str, Any]) -> ForecasterModel:
             f"Allowed: {sorted(FORECASTER_ARCHITECTURES)}"
         )
 
+    if resolved.fusion_mode == "gated_infonce":
+        if resolved.output_mode != "classification":
+            raise ValueError(
+                "fusion_mode='gated_infonce' requires output_mode='classification' "
+                f"(got {resolved.output_mode!r}); InfoNCE-paired regression is out of scope."
+            )
+        text_dim = int(resolved.text_embedding_dim or 0)
+        if text_dim <= 0:
+            raise ValueError(
+                "fusion_mode='gated_infonce' requires text_embedding_dim > 0; "
+                "set --text-encoder so the loader emits pooled embeddings."
+            )
+        model = MultiModalForecasterModel(
+            market_input_size=int(resolved.input_size),
+            text_embedding_dim=text_dim,
+            latent_dim=int(resolved.infonce_latent_dim),
+            hidden_size=int(resolved.hidden_size),
+            num_layers=int(resolved.num_layers),
+            dropout=float(resolved.dropout),
+            head_hidden_size=int(resolved.head_hidden_size),
+            architecture=architecture,
+            n_classes=int(resolved.n_classes),
+        )
+        # Stash the InfoNCE hyperparameters on the module so
+        # ``ModelConfig.from_model`` round-trips them and the training
+        # loop can read them without an extra config plumbing pass.
+        model.fusion_mode = "gated_infonce"  # type: ignore[assignment]
+        model.infonce_lambda = float(resolved.infonce_lambda)  # type: ignore[assignment]
+        model.infonce_temperature = float(resolved.infonce_temperature)  # type: ignore[assignment]
+        model.infonce_latent_dim = int(resolved.infonce_latent_dim)  # type: ignore[assignment]
+        model.text_embedding_dim = text_dim  # type: ignore[assignment]
+        return model
+
     kwargs = resolved.to_dict()
     kwargs.pop("architecture", None)
+    # Multi-modal-only fields stay on the ModelConfig for round-tripping
+    # but the legacy ForecasterModel constructor does not consume them.
+    kwargs.pop("fusion_mode", None)
+    kwargs.pop("infonce_lambda", None)
+    kwargs.pop("infonce_temperature", None)
+    kwargs.pop("infonce_latent_dim", None)
     # Phase 9 V2 (#195) fields all forwarded: ``output_mode`` /
     # ``n_classes`` drive the head shape; ``vol_regime_quantiles`` /
     # ``vol_regime_target`` ride on the module so the checkpoint

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -63,7 +63,7 @@ def build_forecaster(
                 "fusion_mode='gated_infonce' requires text_embedding_dim > 0; "
                 "set --text-encoder so the loader emits pooled embeddings."
             )
-        model = MultiModalForecasterModel(
+        multimodal = MultiModalForecasterModel(
             market_input_size=int(resolved.input_size),
             text_embedding_dim=text_dim,
             latent_dim=int(resolved.infonce_latent_dim),
@@ -77,12 +77,11 @@ def build_forecaster(
         # Stash the InfoNCE hyperparameters on the module so
         # ``ModelConfig.from_model`` round-trips them and the training
         # loop can read them without an extra config plumbing pass.
-        model.fusion_mode = "gated_infonce"  # type: ignore[assignment]
-        model.infonce_lambda = float(resolved.infonce_lambda)  # type: ignore[assignment]
-        model.infonce_temperature = float(resolved.infonce_temperature)  # type: ignore[assignment]
-        model.infonce_latent_dim = int(resolved.infonce_latent_dim)  # type: ignore[assignment]
-        model.text_embedding_dim = text_dim  # type: ignore[assignment]
-        return model
+        multimodal.fusion_mode = "gated_infonce"  # type: ignore[assignment]
+        multimodal.infonce_lambda = float(resolved.infonce_lambda)  # type: ignore[assignment]
+        multimodal.infonce_temperature = float(resolved.infonce_temperature)  # type: ignore[assignment]
+        multimodal.infonce_latent_dim = int(resolved.infonce_latent_dim)  # type: ignore[assignment]
+        return multimodal
 
     kwargs = resolved.to_dict()
     kwargs.pop("architecture", None)

--- a/backend/app/models/gated_infonce_fusion.py
+++ b/backend/app/models/gated_infonce_fusion.py
@@ -1,0 +1,101 @@
+"""Gated multi-modal fusion with shared latent projections (#235).
+
+Implements the projection-heads + per-row sigmoid gate from Kong et
+al. 2025 (M2VN) Eq. 10-11. Two modality encoders (market + text)
+project to the same latent dim; a learned gate weights them per row;
+the fused representation feeds the downstream classification head.
+
+The module is intentionally small: it knows nothing about the
+classification head, the InfoNCE loss, or the recurrent backbone.
+Callers wire those pieces together — see
+``app.models.multimodal_forecaster.MultiModalForecasterModel`` for
+the canonical integration.
+
+The forward emits a dict with four keys so the training loop can
+read off both the fused representation (for classification) and the
+two per-modality projections (for the InfoNCE alignment loss). The
+gate tensor is also returned so the inference path can log
+modality reliance per request.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class GatedInfoNCEFusion(nn.Module):
+    """Projection heads + per-row gated fusion.
+
+    Each modality projects to a shared ``latent_dim`` via a single
+    linear layer. The gate is the sigmoid of a linear over the
+    concatenated raw inputs, broadcast across the latent dim. The
+    fused output is ``gate * market_proj + (1 - gate) * text_proj``,
+    matching Kong et al. Eq. 11.
+    """
+
+    def __init__(
+        self,
+        market_dim: int,
+        text_dim: int,
+        *,
+        latent_dim: int = 64,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.market_dim = int(market_dim)
+        self.text_dim = int(text_dim)
+        self.latent_dim = int(latent_dim)
+        self.dropout = float(dropout)
+
+        self.market_proj = nn.Linear(self.market_dim, self.latent_dim)
+        self.text_proj = nn.Linear(self.text_dim, self.latent_dim)
+        # The gate reads the raw modality outputs (before projection)
+        # so it has access to the unsquashed information when deciding
+        # how much to trust each side.
+        self.gate = nn.Linear(self.market_dim + self.text_dim, self.latent_dim)
+        self.dropout_layer = nn.Dropout(self.dropout) if self.dropout > 0.0 else nn.Identity()
+
+    def forward(
+        self,
+        market_pooled: torch.Tensor,
+        text_pooled: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        """Emit ``{r_t, t_t, fused, gate}``.
+
+        ``r_t`` and ``t_t`` are the latent-dim projections per modality
+        — what the InfoNCE alignment loss reads. ``fused`` is the
+        gated combination, ``(B, latent_dim)``, ready for the
+        classification head. ``gate`` is the per-row weighting tensor,
+        useful for inference-time diagnostics ("which modality drove
+        this prediction").
+        """
+
+        if market_pooled.dim() != 2 or text_pooled.dim() != 2:
+            raise ValueError(
+                "GatedInfoNCEFusion expects 2-D (B, D) tensors; "
+                f"got market={market_pooled.shape}, text={text_pooled.shape}"
+            )
+        if market_pooled.shape[-1] != self.market_dim:
+            raise ValueError(
+                f"market_pooled last-dim must be {self.market_dim}; "
+                f"got {market_pooled.shape[-1]}"
+            )
+        if text_pooled.shape[-1] != self.text_dim:
+            raise ValueError(
+                f"text_pooled last-dim must be {self.text_dim}; "
+                f"got {text_pooled.shape[-1]}"
+            )
+        if market_pooled.shape[0] != text_pooled.shape[0]:
+            raise ValueError(
+                "market and text batches must have the same length; "
+                f"got {market_pooled.shape[0]} vs {text_pooled.shape[0]}"
+            )
+
+        r_t = self.market_proj(self.dropout_layer(market_pooled))
+        t_t = self.text_proj(self.dropout_layer(text_pooled))
+        gate = torch.sigmoid(
+            self.gate(torch.cat([market_pooled, text_pooled], dim=-1))
+        )
+        fused = gate * r_t + (1.0 - gate) * t_t
+        return {"r_t": r_t, "t_t": t_t, "fused": fused, "gate": gate}

--- a/backend/app/models/multimodal_forecaster.py
+++ b/backend/app/models/multimodal_forecaster.py
@@ -82,12 +82,21 @@ class MultiModalForecasterModel(nn.Module):
         self.head_hidden_size = int(head_hidden_size)
         self.n_classes = int(n_classes)
         # Compatibility shims so generic code that reads attributes on
-        # the legacy ForecasterModel (e.g. ``model.output_mode``) does
-        # not blow up when handed a MultiModalForecasterModel.
+        # the legacy ForecasterModel (e.g. ``model.output_mode``,
+        # ``model._text_path_active``, ``model.model_type``) does not
+        # blow up when handed a MultiModalForecasterModel. The
+        # training loop reads ``_text_path_active`` to decide whether
+        # to pass ``text_embedding`` through to forward; the multi-
+        # modal model always needs the text input, so it must be True.
+        # ``model_type`` is what ``ModelConfig.from_model`` keys off
+        # when persisting the architecture, so without it every
+        # checkpoint summary would fall back to ``'lstm'``.
         self.output_mode = "classification"
         self.input_size = self.market_input_size
         self.initial_decay_rate = 0.0
         self.use_time_decay = False
+        self._text_path_active = True
+        self.model_type = architecture
 
         self.recurrent_core = self._build_recurrent_core(
             architecture=self.architecture,
@@ -122,12 +131,15 @@ class MultiModalForecasterModel(nn.Module):
         )
 
     def _pool_market(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the recurrent core and pool to a per-sequence vector."""
+        """Run the recurrent core and pool to a per-sequence vector.
 
-        if self.architecture == "dlinear":
-            # DLinear emits the pooled state directly; no per-step
-            # sequence to attend over.
-            return self.recurrent_core(x)  # type: ignore[no-any-return]
+        DLinear, LSTM, GRU, TCN, Transformer, TFT, and Informer all
+        follow the same ``(B, T, hidden)`` output + scalar / state
+        second tuple contract via their respective forward methods,
+        so a single destructure + pool handles every architecture
+        without per-arch branching.
+        """
+
         output, _ = self.recurrent_core(x)
         if self.uses_attention_pool:
             if self.recurrent_attention is None:

--- a/backend/app/models/multimodal_forecaster.py
+++ b/backend/app/models/multimodal_forecaster.py
@@ -1,0 +1,295 @@
+"""Multi-modal forecaster with gated InfoNCE fusion (#235).
+
+Companion model to :class:`ForecasterModel` that keeps the market and
+text modalities independent until the fusion stage so the InfoNCE
+alignment loss has two separable representations to pull together.
+
+The market side runs through the same recurrent_core families the
+single-modality forecaster supports (lstm / gru / tcn / transformer /
+informer / tft / dlinear); the text side reads the FinBERT pooled
+embedding directly. A :class:`GatedInfoNCEFusion` block projects both
+into a shared latent dim and emits a per-row gated fusion that feeds
+the classification head.
+
+Classification-only. The regression-target path stays on
+``ForecasterModel`` — InfoNCE for a regression target needs a
+different loss formulation that is out of scope here.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from app.models.config import (
+    DEFAULT_DROPOUT,
+    DEFAULT_HEAD_HIDDEN_SIZE,
+    DEFAULT_HIDDEN_SIZE,
+    DEFAULT_NUM_LAYERS,
+    FEATURE_SIZE,
+    SEQUENCE_LENGTH,
+)
+from app.models.dlinear import DLinear
+from app.models.gated_infonce_fusion import GatedInfoNCEFusion
+from app.models.tcn import TemporalConvNet
+from app.models.transformer import SmallTransformer
+
+_ATTENTION_POOL_MODELS = frozenset({"lstm_attn"})
+_MEAN_POOL_MODELS = frozenset({"transformer", "tft", "informer"})
+_ALLOWED_ARCHITECTURES = frozenset(
+    {"lstm", "lstm_attn", "gru", "tcn", "transformer", "dlinear", "informer", "tft"}
+)
+
+
+class MultiModalForecasterModel(nn.Module):
+    """Recurrent market encoder + FinBERT text + gated InfoNCE fusion.
+
+    The forward emits the canonical 3-class logits the existing
+    CrossEntropy training path consumes. :meth:`forward_with_modality_outputs`
+    additionally returns the per-modality projections so the
+    InfoNCE alignment loss can read them — the training loop calls
+    the second method when ``fusion_mode == "gated_infonce"``.
+    """
+
+    def __init__(
+        self,
+        *,
+        market_input_size: int = FEATURE_SIZE,
+        text_embedding_dim: int = 768,
+        latent_dim: int = 64,
+        hidden_size: int = DEFAULT_HIDDEN_SIZE,
+        num_layers: int = DEFAULT_NUM_LAYERS,
+        dropout: float = DEFAULT_DROPOUT,
+        head_hidden_size: int = DEFAULT_HEAD_HIDDEN_SIZE,
+        architecture: str = "lstm",
+        n_classes: int = 3,
+        fusion_dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        if architecture not in _ALLOWED_ARCHITECTURES:
+            raise ValueError(
+                f"Unknown architecture {architecture!r}; allowed: {sorted(_ALLOWED_ARCHITECTURES)}"
+            )
+        if n_classes < 2:
+            raise ValueError(f"n_classes must be >= 2; got {n_classes}")
+        self.architecture = architecture
+        self.market_input_size = int(market_input_size)
+        self.text_embedding_dim = int(text_embedding_dim)
+        self.latent_dim = int(latent_dim)
+        self.hidden_size = int(hidden_size)
+        self.num_layers = int(num_layers)
+        self.dropout = float(dropout)
+        self.head_hidden_size = int(head_hidden_size)
+        self.n_classes = int(n_classes)
+        # Compatibility shims so generic code that reads attributes on
+        # the legacy ForecasterModel (e.g. ``model.output_mode``) does
+        # not blow up when handed a MultiModalForecasterModel.
+        self.output_mode = "classification"
+        self.input_size = self.market_input_size
+        self.initial_decay_rate = 0.0
+        self.use_time_decay = False
+
+        self.recurrent_core = self._build_recurrent_core(
+            architecture=self.architecture,
+            input_size=self.market_input_size,
+            hidden_size=self.hidden_size,
+            num_layers=self.num_layers,
+            dropout=self.dropout,
+        )
+        self.uses_attention_pool = self.architecture in _ATTENTION_POOL_MODELS
+        self.uses_mean_pool = self.architecture in _MEAN_POOL_MODELS
+        if self.uses_attention_pool:
+            from app.models.attention import RecurrentSequenceAttention
+
+            self.recurrent_attention = RecurrentSequenceAttention(
+                hidden_size=self.hidden_size
+            )
+        else:
+            self.recurrent_attention = None
+        self.fusion = GatedInfoNCEFusion(
+            market_dim=self.hidden_size,
+            text_dim=self.text_embedding_dim,
+            latent_dim=self.latent_dim,
+            dropout=fusion_dropout,
+        )
+        self.classification_head = nn.Sequential(
+            nn.LayerNorm(self.latent_dim),
+            nn.Linear(self.latent_dim, self.head_hidden_size),
+            nn.GELU(),
+            nn.Dropout(self.dropout),
+            nn.Linear(self.head_hidden_size, self.n_classes),
+        )
+
+    def _pool_market(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the recurrent core and pool to a per-sequence vector."""
+
+        if self.architecture == "dlinear":
+            # DLinear emits the pooled state directly; no per-step
+            # sequence to attend over.
+            return self.recurrent_core(x)
+        output, _ = self.recurrent_core(x)
+        if self.uses_attention_pool:
+            if self.recurrent_attention is None:
+                raise RuntimeError(
+                    "recurrent_attention not initialised but lstm_attn variant is active"
+                )
+            pooled, _ = self.recurrent_attention(output)
+            return pooled
+        if self.uses_mean_pool:
+            return output.mean(dim=1)
+        return output[:, -1, :]
+
+    @staticmethod
+    def _zero_out_missing_text(
+        text_embedding: torch.Tensor,
+        text_embedding_missing: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Mask the text embedding row-wise when its missing flag is set.
+
+        The data loader emits a zero vector + missing=1 on rows
+        without a prior statement; we multiply explicitly so a future
+        loader path that emits non-zero placeholders cannot leak
+        signal into the fusion.
+        """
+
+        if text_embedding_missing is None:
+            return text_embedding
+        flag = text_embedding_missing
+        if flag.dim() == 1:
+            flag = flag.unsqueeze(-1)
+        keep = (1.0 - flag).clamp_(min=0.0, max=1.0)
+        return text_embedding * keep
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        text_embedding: torch.Tensor | None = None,
+        text_embedding_missing: torch.Tensor | None = None,
+        **_legacy_kwargs: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return classification logits ``(B, n_classes)``.
+
+        Convenience entry point for callers that don't need the
+        per-modality projections (e.g. inference + eval). Training
+        callers should use :meth:`forward_with_modality_outputs` so
+        the InfoNCE loss has direct access to ``r_t`` and ``t_t``.
+
+        Accepts and discards the legacy ``credibility`` / ``chunks`` /
+        ``elapsed_days`` kwargs the single-modality forecaster takes,
+        so the existing training-loop call site (which assembles a
+        kwargs dict from several feature paths) doesn't need a
+        model-class branch. The multi-modal path consumes only
+        ``x`` (market features) + ``text_embedding`` (FinBERT pooled).
+        """
+
+        if text_embedding is None:
+            raise ValueError(
+                "MultiModalForecasterModel.forward requires text_embedding; "
+                "set --text-encoder so the loader emits pooled embeddings."
+            )
+        return self.forward_with_modality_outputs(
+            x,
+            text_embedding=text_embedding,
+            text_embedding_missing=text_embedding_missing,
+        )["logits"]
+
+    def forward_with_modality_outputs(
+        self,
+        x: torch.Tensor,
+        text_embedding: torch.Tensor,
+        text_embedding_missing: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """Return ``{logits, r_t, t_t, fused, gate}`` for InfoNCE training."""
+
+        if x.dim() != 3:
+            raise ValueError(
+                f"market input x must be 3-D (B, T, F); got {x.dim()}-D"
+            )
+        if text_embedding.dim() == 1:
+            text_embedding = text_embedding.unsqueeze(0)
+        if text_embedding.dim() != 2:
+            raise ValueError(
+                f"text_embedding must be 2-D (B, D); got {text_embedding.dim()}-D"
+            )
+
+        market_pooled = self._pool_market(x)
+        text_pooled = self._zero_out_missing_text(text_embedding, text_embedding_missing)
+        fusion_out = self.fusion(market_pooled, text_pooled)
+        logits = self.classification_head(fusion_out["fused"])
+        return {
+            "logits": logits,
+            "r_t": fusion_out["r_t"],
+            "t_t": fusion_out["t_t"],
+            "fused": fusion_out["fused"],
+            "gate": fusion_out["gate"],
+        }
+
+    @staticmethod
+    def _build_recurrent_core(
+        *,
+        architecture: str,
+        input_size: int,
+        hidden_size: int,
+        num_layers: int,
+        dropout: float,
+    ) -> nn.Module:
+        """Mirror :meth:`ForecasterModel._build_recurrent_core` for parity.
+
+        Kept as a private static method so the multi-modal model can
+        evolve its recurrent options without touching the single-modal
+        path. Today it covers the same eight architectures the
+        legacy model supports.
+        """
+
+        if architecture in {"lstm", "lstm_attn"}:
+            return nn.LSTM(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                batch_first=True,
+                dropout=dropout if num_layers > 1 else 0.0,
+            )
+        if architecture == "gru":
+            return nn.GRU(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                batch_first=True,
+                dropout=dropout if num_layers > 1 else 0.0,
+            )
+        if architecture == "tcn":
+            return TemporalConvNet(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                dropout=dropout,
+            )
+        if architecture == "transformer":
+            return SmallTransformer(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                dropout=dropout,
+            )
+        if architecture == "dlinear":
+            return DLinear(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                sequence_length=SEQUENCE_LENGTH,
+            )
+        if architecture == "informer":
+            from app.models.informer import InformerEncoder
+
+            return InformerEncoder(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                dropout=dropout,
+            )
+        if architecture == "tft":
+            from app.models.tft import TFTEncoder
+
+            return TFTEncoder(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                dropout=dropout,
+            )
+        raise ValueError(f"Unknown architecture: {architecture!r}")

--- a/backend/app/models/multimodal_forecaster.py
+++ b/backend/app/models/multimodal_forecaster.py
@@ -98,9 +98,10 @@ class MultiModalForecasterModel(nn.Module):
         )
         self.uses_attention_pool = self.architecture in _ATTENTION_POOL_MODELS
         self.uses_mean_pool = self.architecture in _MEAN_POOL_MODELS
-        if self.uses_attention_pool:
-            from app.models.attention import RecurrentSequenceAttention
+        from app.models.attention import RecurrentSequenceAttention
 
+        self.recurrent_attention: RecurrentSequenceAttention | None
+        if self.uses_attention_pool:
             self.recurrent_attention = RecurrentSequenceAttention(
                 hidden_size=self.hidden_size
             )
@@ -126,7 +127,7 @@ class MultiModalForecasterModel(nn.Module):
         if self.architecture == "dlinear":
             # DLinear emits the pooled state directly; no per-step
             # sequence to attend over.
-            return self.recurrent_core(x)
+            return self.recurrent_core(x)  # type: ignore[no-any-return]
         output, _ = self.recurrent_core(x)
         if self.uses_attention_pool:
             if self.recurrent_attention is None:
@@ -134,10 +135,10 @@ class MultiModalForecasterModel(nn.Module):
                     "recurrent_attention not initialised but lstm_attn variant is active"
                 )
             pooled, _ = self.recurrent_attention(output)
-            return pooled
+            return pooled  # type: ignore[no-any-return]
         if self.uses_mean_pool:
-            return output.mean(dim=1)
-        return output[:, -1, :]
+            return output.mean(dim=1)  # type: ignore[no-any-return]
+        return output[:, -1, :]  # type: ignore[no-any-return]
 
     @staticmethod
     def _zero_out_missing_text(

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -440,6 +440,40 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.set_defaults(encoder_lora=False)
+    # InfoNCE + gated fusion (#235). ``concat`` (default) is the legacy
+    # broadcast-text-into-LSTM-input path the determinism regression
+    # locks. ``gated_infonce`` dispatches the factory to
+    # ``MultiModalForecasterModel`` and the training loop adds the
+    # symmetric InfoNCE alignment loss between the modality projections
+    # on top of the classification loss.
+    parser.add_argument(
+        "--fusion-mode",
+        choices=("concat", "gated_infonce"),
+        default="concat",
+        help=(
+            "Multi-modal fusion strategy. ``concat`` (default) keeps the "
+            "legacy LSTM-input concat path. ``gated_infonce`` routes "
+            "through MultiModalForecasterModel + InfoNCE alignment loss."
+        ),
+    )
+    parser.add_argument(
+        "--infonce-lambda",
+        type=float,
+        default=0.1,
+        help="Weight on the InfoNCE alignment loss (gated_infonce only).",
+    )
+    parser.add_argument(
+        "--infonce-temperature",
+        type=float,
+        default=0.07,
+        help="Softmax temperature for the InfoNCE similarity matrix.",
+    )
+    parser.add_argument(
+        "--infonce-latent-dim",
+        type=int,
+        default=64,
+        help="Shared latent dim for the modality projections in the gated fusion.",
+    )
     # Phase B (#227) LR schedule + sequence-length knobs.
     parser.add_argument(
         "--lr-schedule",
@@ -828,6 +862,10 @@ def _build_model_config(args: argparse.Namespace) -> ModelConfig:
         sequence_length=int(getattr(args, "sequence_length", 0) or 0),
         use_time_decay=bool(getattr(args, "use_time_decay", True)),
         encoder_lora=bool(getattr(args, "encoder_lora", False)),
+        fusion_mode=str(getattr(args, "fusion_mode", "concat") or "concat"),
+        infonce_lambda=float(getattr(args, "infonce_lambda", 0.1)),
+        infonce_temperature=float(getattr(args, "infonce_temperature", 0.07)),
+        infonce_latent_dim=int(getattr(args, "infonce_latent_dim", 64)),
     )
 
 

--- a/backend/app/training/info_nce_loss.py
+++ b/backend/app/training/info_nce_loss.py
@@ -1,0 +1,72 @@
+"""Symmetric InfoNCE loss for multi-modal alignment (#235).
+
+Kong et al. 2025 (M2VN) align a text representation with a market
+representation by treating the (text_t, market_t) pair as a positive
+example and every (text_t, market_t') with t != t' as a negative.
+The InfoNCE objective is the symmetric NT-Xent loss with a learned
+temperature: minimise the cross-entropy between row-wise similarities
+and the identity-permutation labels, then average the text→market
+and market→text directions so neither modality dominates.
+
+The loss assumes both inputs already live in a shared latent
+dimension (the projection heads in
+``app.models.gated_infonce_fusion.GatedInfoNCEFusion`` do that step);
+this module only computes the contrastive term. Vectors are L2-
+normalised inside the forward so callers do not need to pre-normalise.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+class InfoNCELoss(nn.Module):
+    """Symmetric InfoNCE between two L2-normalised representations.
+
+    Inputs are ``(B, D)`` tensors representing one modality each
+    (typically ``r_t`` for the market projection and ``t_t`` for the
+    text projection). The loss pulls the diagonal of the similarity
+    matrix toward the L2-normalised pair and pushes off-diagonal
+    pairs apart, scaled by the inverse temperature.
+    """
+
+    def __init__(self, temperature: float = 0.07) -> None:
+        super().__init__()
+        if temperature <= 0.0:
+            raise ValueError(
+                f"InfoNCELoss temperature must be > 0; got {temperature}"
+            )
+        self.temperature = float(temperature)
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        """Return the symmetric NT-Xent loss between ``a`` and ``b``.
+
+        Both tensors must share shape ``(B, D)``. Returns a 0-d
+        scalar suitable for adding to any other loss term in the
+        training step. When the batch has only one row (B=1) the
+        contrastive term degenerates (no negatives), so the loss
+        returns a graph-attached zero rather than a NaN.
+        """
+
+        if a.shape != b.shape:
+            raise ValueError(
+                f"InfoNCELoss inputs must have matching shape; got {a.shape} vs {b.shape}"
+            )
+        if a.dim() != 2:
+            raise ValueError(
+                f"InfoNCELoss inputs must be 2-D (B, D); got {a.dim()}-D"
+            )
+        batch_size = a.size(0)
+        if batch_size < 2:
+            # No negatives in a single-row batch; emit zero with the
+            # same graph attachment so the optimiser can still see it.
+            return a.sum() * 0.0
+        a_norm = F.normalize(a, dim=-1)
+        b_norm = F.normalize(b, dim=-1)
+        logits = torch.matmul(a_norm, b_norm.T) / self.temperature
+        labels = torch.arange(batch_size, device=logits.device)
+        loss_ab = F.cross_entropy(logits, labels)
+        loss_ba = F.cross_entropy(logits.T, labels)
+        return (loss_ab + loss_ba) * 0.5

--- a/backend/app/training/info_nce_loss.py
+++ b/backend/app/training/info_nce_loss.py
@@ -3,10 +3,16 @@
 Kong et al. 2025 (M2VN) align a text representation with a market
 representation by treating the (text_t, market_t) pair as a positive
 example and every (text_t, market_t') with t != t' as a negative.
-The InfoNCE objective is the symmetric NT-Xent loss with a learned
+The InfoNCE objective is the symmetric NT-Xent loss with a fixed
 temperature: minimise the cross-entropy between row-wise similarities
 and the identity-permutation labels, then average the text→market
 and market→text directions so neither modality dominates.
+
+The temperature is a constructor argument, not a learned parameter.
+Our training batches are small (B=16) — far below the ~256+ batch
+sizes where a gradient-trained log-temperature converges stably (cf.
+CLIP) — so the constant-τ recipe avoids the temperature collapse
+modes that small-batch learned-τ runs are prone to.
 
 The loss assumes both inputs already live in a shared latent
 dimension (the projection heads in

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -315,6 +315,44 @@ def _unpack_batch(batch: Any) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor 
     )
 
 
+def _summarise_gate(
+    gate_chunks: list[torch.Tensor],
+    true_classes: torch.Tensor,
+    n_classes: int,
+) -> dict[str, Any] | None:
+    """Reduce per-batch gate tensors into a per-fold diagnostic dict.
+
+    Returns ``None`` when the eval pass collected no gate values
+    (legacy single-modal path). The summary carries the scalar mean
+    (>0.5 leans market, <0.5 leans text), per-class means so the
+    thesis appendix can say whether the gate shifts modality
+    reliance per regime, and the partition row count the summary
+    was averaged over.
+    """
+
+    if not gate_chunks:
+        return None
+    gate = torch.cat(gate_chunks, dim=0)  # (N, latent_dim)
+    n_rows = int(gate.size(0))
+    if n_rows == 0:
+        return None
+    overall_mean = float(gate.mean().item())
+    per_dim_mean: list[float] = [float(v) for v in gate.mean(dim=0).tolist()]
+    per_class_mean: list[float | None] = [None] * n_classes
+    if true_classes.numel() == n_rows:
+        for class_idx in range(n_classes):
+            mask = true_classes == class_idx
+            count = int(mask.sum().item())
+            if count > 0:
+                per_class_mean[class_idx] = float(gate[mask].mean().item())
+    return {
+        "mean": overall_mean,
+        "mean_per_class": per_class_mean,
+        "mean_per_dim": per_dim_mean,
+        "n_rows": n_rows,
+    }
+
+
 def _run_train_forward_and_align(
     forward_model: nn.Module,
     batch_x: torch.Tensor,
@@ -415,7 +453,21 @@ def _evaluate_model(
     pred_class_chunks: list[torch.Tensor] = []
     true_class_chunks: list[torch.Tensor] = []
     class_score_chunks: list[torch.Tensor] = []
-    use_text_path = bool(getattr(model, "_text_path_active", False))
+    # Gated InfoNCE fusion (#235) diagnostic. When the model exposes
+    # ``forward_with_modality_outputs`` the eval pass also captures
+    # the per-row gate tensor so the post-loop summariser can attach
+    # the gate distribution to the EvaluationMetrics. Empty on every
+    # legacy single-modal path.
+    multimodal_underlying = (
+        model.module if hasattr(model, "module") else model
+    )
+    multimodal_forward = getattr(
+        multimodal_underlying, "forward_with_modality_outputs", None
+    )
+    gate_chunks: list[torch.Tensor] = []
+    use_text_path = bool(getattr(model, "_text_path_active", False)) or (
+        multimodal_forward is not None
+    )
     non_blocking = device.type == "cuda"
     with torch.no_grad():
         for batch in loader:
@@ -465,7 +517,14 @@ def _evaluate_model(
                                 device, non_blocking=non_blocking
                             )
                         kwargs["text_embedding_missing"] = batch_text_missing
-            predictions = model(batch_x, **kwargs)
+            if multimodal_forward is not None:
+                modality_out = multimodal_forward(batch_x, **kwargs)
+                predictions = modality_out["logits"]
+                # Capture gate on CPU in float32 so the per-partition
+                # accumulator stays bounded across long val/test splits.
+                gate_chunks.append(modality_out["gate"].detach().to("cpu", torch.float32))
+            else:
+                predictions = model(batch_x, **kwargs)
             loss = loss_fn(predictions, batch_y)
             if ce_weight is not None:
                 batch_weight_sum = ce_weight.index_select(
@@ -564,6 +623,8 @@ def _evaluate_model(
                     [float(p) for p in row] for row in class_scores_list
                 ]
 
+        gate_summary = _summarise_gate(gate_chunks, true_classes, n_classes_eval)
+
         return EvaluationMetrics(
             loss=regime_loss,
             close_rmse=float("inf"),
@@ -576,6 +637,7 @@ def _evaluate_model(
             predictions=predictions_payload,
             targets=targets_payload,
             class_scores=scores_payload,
+            gate_summary=gate_summary,
         )
 
     close_value = float(close_squared_error.item())

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -32,6 +32,7 @@ from app.models.config import (
     ModelConfig,
 )
 from app.models.lstm import ForecasterModel
+from app.models.multimodal_forecaster import MultiModalForecasterModel
 from app.training.loaders import (
     _build_text_embedding_tensors,
     _build_training_tensors,
@@ -144,7 +145,7 @@ def _build_model(
     model_config: ModelConfig | dict[str, Any] | None = None,
     *,
     device: torch.device | None = None,
-) -> ForecasterModel:
+) -> "ForecasterModel | MultiModalForecasterModel":
     # Local import keeps ``app.models.factory`` cold until training fires,
     # which keeps the FastAPI singleton import path narrow.
     from app.models.factory import build_forecaster
@@ -333,12 +334,13 @@ def _run_train_forward_and_align(
 
     if multimodal_active and info_nce_loss_fn is not None:
         underlying = forward_model.module if hasattr(forward_model, "module") else forward_model
-        if not hasattr(underlying, "forward_with_modality_outputs"):
+        forward_with_modality = getattr(underlying, "forward_with_modality_outputs", None)
+        if forward_with_modality is None:
             raise RuntimeError(
                 "multimodal_active=True but the wrapped model does not expose "
                 "forward_with_modality_outputs; check the factory dispatch."
             )
-        out = underlying.forward_with_modality_outputs(batch_x, **kwargs)
+        out = forward_with_modality(batch_x, **kwargs)
         align_loss = info_nce_loss_fn(out["r_t"], out["t_t"])
         return out["logits"], align_loss
     return forward_model(batch_x, **kwargs), None

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -314,6 +314,36 @@ def _unpack_batch(batch: Any) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor 
     )
 
 
+def _run_train_forward_and_align(
+    forward_model: nn.Module,
+    batch_x: torch.Tensor,
+    kwargs: dict[str, torch.Tensor],
+    *,
+    info_nce_loss_fn: nn.Module | None,
+    multimodal_active: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Forward + (optional) InfoNCE alignment in one helper.
+
+    Returns ``(logits, align_loss_or_none)``. When ``multimodal_active``
+    is True, calls ``forward_with_modality_outputs`` on the wrapped
+    model and computes the InfoNCE term on ``(r_t, t_t)``; otherwise
+    runs the legacy single-output forward and returns ``None`` for
+    the alignment term so the caller can skip the addition.
+    """
+
+    if multimodal_active and info_nce_loss_fn is not None:
+        underlying = forward_model.module if hasattr(forward_model, "module") else forward_model
+        if not hasattr(underlying, "forward_with_modality_outputs"):
+            raise RuntimeError(
+                "multimodal_active=True but the wrapped model does not expose "
+                "forward_with_modality_outputs; check the factory dispatch."
+            )
+        out = underlying.forward_with_modality_outputs(batch_x, **kwargs)
+        align_loss = info_nce_loss_fn(out["r_t"], out["t_t"])
+        return out["logits"], align_loss
+    return forward_model(batch_x, **kwargs), None
+
+
 def _evaluate_model(
     model: nn.Module,
     loader: DataLoader[Any],
@@ -1209,6 +1239,30 @@ def train_model(
     else:
         loss_fn = nn.SmoothL1Loss(beta=0.02)
 
+    # InfoNCE alignment loss for the gated_infonce fusion mode (#235).
+    # The training step calls ``forward_with_modality_outputs`` on the
+    # multi-modal model to recover the per-modality projections, then
+    # adds ``lambda * info_nce(r_t, t_t)`` on top of the classification
+    # loss. The single-modality path leaves both ``info_nce_loss`` and
+    # ``infonce_lambda`` unset and skips the alignment term entirely.
+    info_nce_loss_fn: nn.Module | None = None
+    infonce_lambda = 0.0
+    multimodal_active = (
+        str(getattr(active_model_config, "fusion_mode", "concat") or "concat")
+        == "gated_infonce"
+    )
+    if multimodal_active:
+        from app.training.info_nce_loss import InfoNCELoss
+
+        temperature = float(getattr(active_model_config, "infonce_temperature", 0.07))
+        infonce_lambda = float(getattr(active_model_config, "infonce_lambda", 0.1))
+        info_nce_loss_fn = InfoNCELoss(temperature=temperature).to(device_obj)
+        print(
+            f"[train_model] gated_infonce active: lambda={infonce_lambda} "
+            f"temperature={temperature}",
+            flush=True,
+        )
+
     active_arch = str(getattr(active_model_config, "architecture", "lstm") or "lstm")
     effective_compile, effective_amp = _resolve_compile_amp_flags(
         work_model,
@@ -1289,8 +1343,16 @@ def train_model(
                         kwargs["text_embedding_missing"] = batch_text_missing
             if effective_amp:
                 with torch.cuda.amp.autocast():
-                    predictions = forward_model(batch_x, **kwargs)
+                    predictions, align_loss = _run_train_forward_and_align(
+                        forward_model,
+                        batch_x,
+                        kwargs,
+                        info_nce_loss_fn=info_nce_loss_fn,
+                        multimodal_active=multimodal_active,
+                    )
                     loss = loss_fn(predictions, batch_y)
+                    if align_loss is not None and infonce_lambda > 0.0:
+                        loss = loss + infonce_lambda * align_loss
                 assert scaler is not None
                 scaler.scale(loss).backward()
                 if apply_grad_clip:
@@ -1299,8 +1361,16 @@ def train_model(
                 scaler.step(optimizer)
                 scaler.update()
             else:
-                predictions = forward_model(batch_x, **kwargs)
+                predictions, align_loss = _run_train_forward_and_align(
+                    forward_model,
+                    batch_x,
+                    kwargs,
+                    info_nce_loss_fn=info_nce_loss_fn,
+                    multimodal_active=multimodal_active,
+                )
                 loss = loss_fn(predictions, batch_y)
+                if align_loss is not None and infonce_lambda > 0.0:
+                    loss = loss + infonce_lambda * align_loss
                 loss.backward()
                 if apply_grad_clip:
                     nn.utils.clip_grad_norm_(work_model.parameters(), max_norm=clip_norm_value)

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -145,7 +145,7 @@ def _build_model(
     model_config: ModelConfig | dict[str, Any] | None = None,
     *,
     device: torch.device | None = None,
-) -> "ForecasterModel | MultiModalForecasterModel":
+) -> ForecasterModel:
     # Local import keeps ``app.models.factory`` cold until training fires,
     # which keeps the FastAPI singleton import path narrow.
     from app.models.factory import build_forecaster
@@ -154,7 +154,15 @@ def _build_model(
     model = build_forecaster(resolved_config)
     if device is not None:
         model = model.to(device)
-    return model
+    # The factory may return MultiModalForecasterModel under
+    # ``fusion_mode=gated_infonce`` (#235). Downstream consumers
+    # (``_save_model_checkpoint``, ``_set_singleton_after_train``,
+    # ``app.services.forecaster._load_state_dict_loose``) only touch
+    # ``nn.Module`` APIs that both classes share, so the runtime
+    # contract holds even though the static return type narrows
+    # to ``ForecasterModel`` here. The narrower annotation keeps
+    # those callers' signatures unchanged.
+    return model  # type: ignore[return-value]
 
 
 def _zero_credibility(model: nn.Module, batch_size: int, device: torch.device) -> torch.Tensor | None:

--- a/scripts/run_infonce_lambda_sweep.sh
+++ b/scripts/run_infonce_lambda_sweep.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Lambda sweep for the gated InfoNCE multi-modal forecaster (#235).
+# Locks the HP cell that won the post-correction regime_arch_sweep on
+# the supplied training package, then trains the gated_infonce variant
+# at three lambda values against that cell so the comparison against
+# the concat baseline is apples-to-apples (same arch, same HP, only
+# fusion mode differs).
+#
+# Usage:
+#
+#     bash scripts/run_infonce_lambda_sweep.sh \
+#         tp_v3_macro_aug_2026_05_23_sentiment_market_core_v1.1_epv1_v1.0 \
+#         transformer
+#
+# Expected wall-clock: ~3-5 min per trial × 3 lambda values × 4 folds
+# × 1 seed = ~60-90 min on a single GPU.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+TRAINING_PACKAGE_ID="${1:-tp_v3_macro_aug_2026_05_23_sentiment_market_core_v1.1_epv1_v1.0}"
+ARCHITECTURE="${2:-transformer}"
+TEXT_ENCODER="${TEXT_ENCODER:-finbert_fed_adjacent}"
+SEEDS="${SEEDS:-97}"
+FOLDS="${FOLDS:-wf_fold_1 wf_fold_2 wf_fold_3 wf_fold_4}"
+LAMBDAS=("${LAMBDA_LIST[@]:-0.05 0.1 0.3}")
+
+# Locked HP cell. Use the Path B winning HP from §6.7
+# (transformer hidden=128, layers=2, dropout=0.1, lr=3e-4, wd=1e-4).
+# These match the sweep grid the rest of the pipeline uses.
+HIDDEN_SIZE="${HIDDEN_SIZE:-128}"
+NUM_LAYERS="${NUM_LAYERS:-2}"
+DROPOUT="${DROPOUT:-0.1}"
+LEARNING_RATE="${LEARNING_RATE:-0.0003}"
+WEIGHT_DECAY="${WEIGHT_DECAY:-0.0001}"
+TEXT_ADAPTER_DIM="${TEXT_ADAPTER_DIM:-64}"
+INFONCE_LATENT_DIM="${INFONCE_LATENT_DIM:-64}"
+INFONCE_TEMPERATURE="${INFONCE_TEMPERATURE:-0.07}"
+EPOCHS="${EPOCHS:-40}"
+
+LOG_DIR="${LOG_DIR:-/tmp/fed-pulse/infonce_lambda_sweep/$(date -u +%Y%m%dT%H%M%SZ)}"
+mkdir -p "$LOG_DIR"
+echo "[infonce-sweep] training package: $TRAINING_PACKAGE_ID"
+echo "[infonce-sweep] architecture:     $ARCHITECTURE"
+echo "[infonce-sweep] logs:             $LOG_DIR"
+
+for lambda_value in "${LAMBDAS[@]}"; do
+  cell_id="lambda${lambda_value//./p}"
+  report_path="/data/artifacts/infonce_lambda_sweep/${TRAINING_PACKAGE_ID}/${ARCHITECTURE}/${cell_id}/forecaster_sweep_results.json"
+  log_file="$LOG_DIR/${ARCHITECTURE}_${cell_id}.log"
+  echo "[infonce-sweep] starting cell ${ARCHITECTURE}/${cell_id} -> $report_path"
+  docker compose --profile gpu run --rm backend-gpu \
+    python -m app.train_forecaster \
+      --training-package-id "$TRAINING_PACKAGE_ID" \
+      --architecture "$ARCHITECTURE" \
+      --seeds $SEEDS \
+      --folds $FOLDS \
+      --hidden-size "$HIDDEN_SIZE" \
+      --num-layers "$NUM_LAYERS" \
+      --dropout "$DROPOUT" \
+      --learning-rate "$LEARNING_RATE" \
+      --weight-decay "$WEIGHT_DECAY" \
+      --epochs "$EPOCHS" \
+      --output-mode classification \
+      --vol-regime-classes 3 \
+      --rich-features \
+      --text-encoder "$TEXT_ENCODER" \
+      --text-adapter-dim "$TEXT_ADAPTER_DIM" \
+      --fusion-mode gated_infonce \
+      --infonce-lambda "$lambda_value" \
+      --infonce-temperature "$INFONCE_TEMPERATURE" \
+      --infonce-latent-dim "$INFONCE_LATENT_DIM" \
+      --report-path "$report_path" \
+      2>&1 | tee "$log_file"
+done
+
+echo "[infonce-sweep] all cells complete"
+echo "[infonce-sweep] aggregate macro-F1 across cells:"
+
+docker compose --profile gpu run --rm backend-gpu python - <<PY
+import json
+from pathlib import Path
+
+root = Path("/data/artifacts/infonce_lambda_sweep/${TRAINING_PACKAGE_ID}/${ARCHITECTURE}")
+for cell_dir in sorted(root.glob("lambda*")):
+    report = cell_dir / "forecaster_sweep_results.json"
+    if not report.exists():
+        print(f"{cell_dir.name}: missing report")
+        continue
+    payload = json.loads(report.read_text())
+    trials = payload.get("trials", [])
+    if not trials:
+        print(f"{cell_dir.name}: no trials")
+        continue
+    test_metrics = [
+        float((t.get("summary") or {}).get("test_metrics", {}).get("regime_f1_macro") or 0.0)
+        for t in trials
+        if (t.get("summary") or {}).get("test_metrics") is not None
+    ]
+    if not test_metrics:
+        print(f"{cell_dir.name}: no test_metrics")
+        continue
+    mean = sum(test_metrics) / len(test_metrics)
+    print(f"{cell_dir.name}: n={len(test_metrics)} mean_test_macro_f1={mean:.4f}")
+PY
+
+echo "[infonce-sweep] done."

--- a/tests/unit/test_factory_gated_infonce_dispatch.py
+++ b/tests/unit/test_factory_gated_infonce_dispatch.py
@@ -1,0 +1,92 @@
+"""The factory must dispatch to MultiModalForecasterModel when
+``fusion_mode == 'gated_infonce'`` is set on the config (#235).
+
+This pin guards against a refactor that silently routes the new
+fusion mode back through the single-modality wrapper, which would
+strip the gated fusion + InfoNCE alignment path entirely.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.config import ModelConfig
+from app.models.factory import build_forecaster
+from app.models.lstm import ForecasterModel
+from app.models.multimodal_forecaster import MultiModalForecasterModel
+
+
+def test_default_config_returns_legacy_forecaster_model() -> None:
+    """``fusion_mode`` defaults to ``concat`` so the legacy path is
+    the default — the dispatch must NOT silently switch on the new
+    multi-modal model when the caller didn't ask for it."""
+
+    cfg = ModelConfig(architecture="lstm")
+    model = build_forecaster(cfg)
+    assert isinstance(model, ForecasterModel)
+
+
+def test_gated_infonce_config_returns_multimodal_model() -> None:
+    cfg = ModelConfig(
+        architecture="lstm",
+        output_mode="classification",
+        n_classes=3,
+        text_embedding_dim=768,
+        text_adapter_dim=64,
+        fusion_mode="gated_infonce",
+        infonce_lambda=0.2,
+        infonce_temperature=0.05,
+        infonce_latent_dim=32,
+    )
+    model = build_forecaster(cfg)
+    assert isinstance(model, MultiModalForecasterModel)
+    assert model.architecture == "lstm"
+    assert model.text_embedding_dim == 768
+    assert model.fusion.latent_dim == 32
+    # Hyperparameters round-trip onto the module for the training loop + from_model.
+    assert float(getattr(model, "infonce_lambda")) == 0.2
+    assert float(getattr(model, "infonce_temperature")) == 0.05
+
+
+def test_gated_infonce_requires_classification_mode() -> None:
+    cfg = ModelConfig(
+        architecture="lstm",
+        output_mode="regression",  # invalid combo
+        text_embedding_dim=768,
+        fusion_mode="gated_infonce",
+    )
+    with pytest.raises(ValueError, match="output_mode='classification'"):
+        build_forecaster(cfg)
+
+
+def test_gated_infonce_requires_text_embedding_dim() -> None:
+    cfg = ModelConfig(
+        architecture="lstm",
+        output_mode="classification",
+        text_embedding_dim=0,  # text path not configured
+        fusion_mode="gated_infonce",
+    )
+    with pytest.raises(ValueError, match="text_embedding_dim"):
+        build_forecaster(cfg)
+
+
+def test_model_config_from_model_round_trips_fusion_fields() -> None:
+    cfg = ModelConfig(
+        architecture="lstm",
+        output_mode="classification",
+        n_classes=3,
+        text_embedding_dim=768,
+        text_adapter_dim=64,
+        fusion_mode="gated_infonce",
+        infonce_lambda=0.25,
+        infonce_temperature=0.08,
+        infonce_latent_dim=128,
+    )
+    model = build_forecaster(cfg)
+    restored = ModelConfig.from_model(model)
+    assert restored.fusion_mode == "gated_infonce"
+    assert restored.infonce_lambda == 0.25
+    assert restored.infonce_temperature == 0.08
+    assert restored.infonce_latent_dim == 128

--- a/tests/unit/test_gate_summary_diagnostic.py
+++ b/tests/unit/test_gate_summary_diagnostic.py
@@ -1,0 +1,80 @@
+"""Cover the gate-distribution diagnostic on the multi-modal eval path (#235).
+
+When the model is a MultiModalForecasterModel, the eval pass captures
+the per-row gate tensor and reduces it into a summary dict that
+attaches to the returned EvaluationMetrics. The thesis appendix
+reads ``mean`` (modality lean) and ``mean_per_class`` (regime-
+conditional gate drift) off this dict.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.training.loop import _summarise_gate
+
+
+def test_summarise_gate_returns_none_when_no_gate_chunks() -> None:
+    """Legacy single-modal eval path collects no gate values; the
+    summary must stay None so the EvaluationMetrics contract on
+    pre-#235 callers is unchanged."""
+
+    out = _summarise_gate([], true_classes=torch.empty(0, dtype=torch.long), n_classes=3)
+    assert out is None
+
+
+def test_summarise_gate_computes_overall_mean_and_dim_means() -> None:
+    """Two batches of (B=2, latent_dim=4) gate values; the summary
+    must average across the (N=4, latent_dim=4) stack."""
+
+    gate_a = torch.tensor([[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]])
+    gate_b = torch.tensor([[0.9, 1.0, 0.0, 0.5], [0.5, 0.5, 0.5, 0.5]])
+    out = _summarise_gate(
+        [gate_a, gate_b],
+        true_classes=torch.tensor([0, 1, 2, 1]),
+        n_classes=3,
+    )
+    assert out is not None
+    assert out["n_rows"] == 4
+    # Mean over (4, 4) tensor: sum = 8.0, mean = 0.5
+    assert abs(out["mean"] - 0.5) < 1e-6
+    assert len(out["mean_per_dim"]) == 4
+
+
+def test_summarise_gate_per_class_mean_handles_empty_class() -> None:
+    """Classes with zero rows in the eval partition (e.g. wf_fold_4's
+    missing calm class on legacy data) must report None for that
+    slot rather than crashing on a div-by-zero."""
+
+    gate = torch.tensor([[0.7, 0.7], [0.3, 0.3]])
+    out = _summarise_gate(
+        [gate],
+        true_classes=torch.tensor([0, 2]),  # class 1 has 0 rows
+        n_classes=3,
+    )
+    assert out is not None
+    assert out["mean_per_class"][1] is None
+    # Class 0 = single row [0.7, 0.7] → mean 0.7; class 2 = [0.3, 0.3] → 0.3
+    assert out["mean_per_class"][0] is not None
+    assert abs(out["mean_per_class"][0] - 0.7) < 1e-6
+    assert out["mean_per_class"][2] is not None
+    assert abs(out["mean_per_class"][2] - 0.3) < 1e-6
+
+
+def test_summarise_gate_skips_per_class_when_classes_misaligned() -> None:
+    """When the true-class tensor length disagrees with the gate
+    row count (defensive contract; should not happen in practice),
+    the per-class breakdown stays at None entries but the overall
+    mean still surfaces."""
+
+    gate = torch.tensor([[0.5, 0.5], [0.5, 0.5]])  # N=2
+    out = _summarise_gate(
+        [gate],
+        true_classes=torch.tensor([0]),  # N=1 — mismatch
+        n_classes=3,
+    )
+    assert out is not None
+    assert out["mean"] == pytest.approx(0.5)
+    assert all(v is None for v in out["mean_per_class"])

--- a/tests/unit/test_gated_infonce_fusion.py
+++ b/tests/unit/test_gated_infonce_fusion.py
@@ -8,7 +8,9 @@ and the gate's per-row behaviour.
 
 from __future__ import annotations
 
-import torch
+import pytest
+
+torch = pytest.importorskip("torch")
 
 from app.models.gated_infonce_fusion import GatedInfoNCEFusion
 
@@ -58,16 +60,12 @@ def test_fusion_rejects_mismatched_market_dim() -> None:
     should never silently pass a tensor with a mismatched shape into
     the linear projection."""
 
-    import pytest
-
     fusion = GatedInfoNCEFusion(market_dim=64, text_dim=768, latent_dim=64)
     with pytest.raises(ValueError, match="market_pooled last-dim"):
         fusion(torch.randn(4, 32), torch.randn(4, 768))
 
 
 def test_fusion_rejects_batch_size_mismatch() -> None:
-    import pytest
-
     fusion = GatedInfoNCEFusion(market_dim=16, text_dim=32, latent_dim=8)
     with pytest.raises(ValueError, match="same length"):
         fusion(torch.randn(4, 16), torch.randn(5, 32))

--- a/tests/unit/test_gated_infonce_fusion.py
+++ b/tests/unit/test_gated_infonce_fusion.py
@@ -1,0 +1,90 @@
+"""Cover the GatedInfoNCEFusion module (#235).
+
+The module is small but load-bearing — every downstream training
+step reads ``fused`` for classification and ``(r_t, t_t)`` for the
+InfoNCE alignment loss. These tests pin the per-key shape contract
+and the gate's per-row behaviour.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from app.models.gated_infonce_fusion import GatedInfoNCEFusion
+
+
+def test_fusion_emits_four_keys_with_expected_shapes() -> None:
+    torch.manual_seed(0)
+    fusion = GatedInfoNCEFusion(market_dim=128, text_dim=768, latent_dim=64)
+    market = torch.randn(4, 128)
+    text = torch.randn(4, 768)
+    out = fusion(market, text)
+    assert set(out.keys()) == {"r_t", "t_t", "fused", "gate"}
+    assert out["r_t"].shape == (4, 64)
+    assert out["t_t"].shape == (4, 64)
+    assert out["fused"].shape == (4, 64)
+    assert out["gate"].shape == (4, 64)
+
+
+def test_gate_is_per_row_in_zero_to_one_range() -> None:
+    """The gate is sigmoid-bounded so it must live in [0, 1] for
+    every row + every latent dim; clamping is what makes the
+    convex combination at the fused step well-defined."""
+
+    torch.manual_seed(1)
+    fusion = GatedInfoNCEFusion(market_dim=32, text_dim=64, latent_dim=16)
+    market = torch.randn(8, 32) * 10.0  # large activations
+    text = torch.randn(8, 64) * 10.0
+    out = fusion(market, text)
+    assert torch.all(out["gate"] >= 0.0)
+    assert torch.all(out["gate"] <= 1.0)
+
+
+def test_fused_is_convex_combination_of_projections() -> None:
+    """Fused = gate * r_t + (1 - gate) * t_t. Verify the contract
+    by reconstructing the fused tensor manually from the dict outputs."""
+
+    torch.manual_seed(2)
+    fusion = GatedInfoNCEFusion(market_dim=16, text_dim=32, latent_dim=8)
+    market = torch.randn(3, 16)
+    text = torch.randn(3, 32)
+    out = fusion(market, text)
+    reconstructed = out["gate"] * out["r_t"] + (1.0 - out["gate"]) * out["t_t"]
+    assert torch.allclose(out["fused"], reconstructed, atol=1e-6)
+
+
+def test_fusion_rejects_mismatched_market_dim() -> None:
+    """Wrong market input dim must raise loudly — the training loop
+    should never silently pass a tensor with a mismatched shape into
+    the linear projection."""
+
+    import pytest
+
+    fusion = GatedInfoNCEFusion(market_dim=64, text_dim=768, latent_dim=64)
+    with pytest.raises(ValueError, match="market_pooled last-dim"):
+        fusion(torch.randn(4, 32), torch.randn(4, 768))
+
+
+def test_fusion_rejects_batch_size_mismatch() -> None:
+    import pytest
+
+    fusion = GatedInfoNCEFusion(market_dim=16, text_dim=32, latent_dim=8)
+    with pytest.raises(ValueError, match="same length"):
+        fusion(torch.randn(4, 16), torch.randn(5, 32))
+
+
+def test_gate_distinguishes_modalities_when_one_is_zero() -> None:
+    """Push the gate to favour the market side by feeding text=0
+    on a freshly initialised model; the fused output should track
+    the market projection more closely than the text projection.
+    This is a directional smoke test, not a strict pin."""
+
+    torch.manual_seed(3)
+    fusion = GatedInfoNCEFusion(market_dim=16, text_dim=16, latent_dim=8)
+    market = torch.randn(8, 16)
+    text = torch.zeros(8, 16)
+    out = fusion(market, text)
+    # When text is zero, t_t = bias. The market side has non-zero
+    # projection; the fused output should not be identical to t_t
+    # (which is the "text-only" collapse).
+    assert not torch.allclose(out["fused"], out["t_t"], atol=1e-3)

--- a/tests/unit/test_info_nce_loss.py
+++ b/tests/unit/test_info_nce_loss.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 import math
 
-import torch
+import pytest
+
+torch = pytest.importorskip("torch")
 
 
 def test_info_nce_loss_is_low_when_paired_rows_align() -> None:
@@ -51,8 +53,6 @@ def test_info_nce_loss_handles_single_row_batch_without_nan() -> None:
 def test_info_nce_loss_rejects_temperature_zero_or_negative() -> None:
     from app.training.info_nce_loss import InfoNCELoss
 
-    import pytest
-
     with pytest.raises(ValueError):
         InfoNCELoss(temperature=0.0)
     with pytest.raises(ValueError):
@@ -61,8 +61,6 @@ def test_info_nce_loss_rejects_temperature_zero_or_negative() -> None:
 
 def test_info_nce_loss_rejects_mismatched_shapes() -> None:
     from app.training.info_nce_loss import InfoNCELoss
-
-    import pytest
 
     loss_fn = InfoNCELoss(temperature=0.07)
     with pytest.raises(ValueError):

--- a/tests/unit/test_info_nce_loss.py
+++ b/tests/unit/test_info_nce_loss.py
@@ -1,0 +1,86 @@
+"""Cover the symmetric InfoNCE loss (#235).
+
+The contrastive objective is small enough that the unit tests can
+pin its load-bearing behaviour exactly: identical inputs minimise
+the loss (modulo the temperature-driven floor), random inputs sit
+above that floor, and degenerate single-row batches return a graph-
+attached zero rather than NaN.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+
+def test_info_nce_loss_is_low_when_paired_rows_align() -> None:
+    from app.training.info_nce_loss import InfoNCELoss
+
+    torch.manual_seed(0)
+    a = torch.randn(8, 16, requires_grad=True)
+    # Perfect alignment: b is a scaled copy of a so every diagonal
+    # pair is the row's nearest neighbour after L2 normalisation.
+    b = a.detach().clone() * 1.5
+    loss_aligned = InfoNCELoss(temperature=0.07)(a, b)
+    # Misalign by shuffling b so the diagonals stop being the
+    # nearest neighbours; the loss should now be much higher.
+    perm = torch.tensor([4, 5, 6, 7, 0, 1, 2, 3])
+    loss_misaligned = InfoNCELoss(temperature=0.07)(a, b[perm])
+    assert float(loss_aligned) < 0.1
+    assert float(loss_misaligned) > 1.0
+
+
+def test_info_nce_loss_handles_single_row_batch_without_nan() -> None:
+    """B=1 has no contrastive negatives; the loss must return a
+    graph-attached zero so the optimiser still sees a finite scalar."""
+
+    from app.training.info_nce_loss import InfoNCELoss
+
+    a = torch.randn(1, 8, requires_grad=True)
+    b = torch.randn(1, 8, requires_grad=True)
+    loss = InfoNCELoss(temperature=0.07)(a, b)
+    assert torch.isfinite(loss)
+    assert float(loss) == 0.0
+    # The graph attachment is the load-bearing part — if backward
+    # raises, downstream training would crash whenever a fold ends
+    # with a final mini-batch of size 1.
+    loss.backward()
+
+
+def test_info_nce_loss_rejects_temperature_zero_or_negative() -> None:
+    from app.training.info_nce_loss import InfoNCELoss
+
+    import pytest
+
+    with pytest.raises(ValueError):
+        InfoNCELoss(temperature=0.0)
+    with pytest.raises(ValueError):
+        InfoNCELoss(temperature=-0.1)
+
+
+def test_info_nce_loss_rejects_mismatched_shapes() -> None:
+    from app.training.info_nce_loss import InfoNCELoss
+
+    import pytest
+
+    loss_fn = InfoNCELoss(temperature=0.07)
+    with pytest.raises(ValueError):
+        loss_fn(torch.randn(4, 8), torch.randn(4, 16))
+    with pytest.raises(ValueError):
+        loss_fn(torch.randn(8), torch.randn(8))  # not 2-D
+
+
+def test_info_nce_loss_is_symmetric_under_input_swap() -> None:
+    """The Kong et al. (Eq. 7) objective averages both directions
+    (text→market and market→text). Swapping the inputs must produce
+    the same loss value."""
+
+    from app.training.info_nce_loss import InfoNCELoss
+
+    torch.manual_seed(1)
+    a = torch.randn(6, 12)
+    b = torch.randn(6, 12)
+    loss_ab = InfoNCELoss(temperature=0.07)(a, b)
+    loss_ba = InfoNCELoss(temperature=0.07)(b, a)
+    assert math.isclose(float(loss_ab), float(loss_ba), rel_tol=1e-5)

--- a/tests/unit/test_multimodal_forecaster.py
+++ b/tests/unit/test_multimodal_forecaster.py
@@ -1,0 +1,107 @@
+"""Cover the MultiModalForecasterModel (#235).
+
+The new model wires the recurrent core + gated fusion + classification
+head into a single forward path. Tests pin the output shapes, the
+text-missing zeroing contract, and round-trip consistency between
+``forward`` and ``forward_with_modality_outputs``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.multimodal_forecaster import MultiModalForecasterModel
+
+
+def _build_model(architecture: str = "lstm", **kwargs) -> MultiModalForecasterModel:
+    defaults = dict(
+        market_input_size=8,
+        text_embedding_dim=16,
+        latent_dim=4,
+        hidden_size=12,
+        num_layers=2,
+        dropout=0.1,
+        head_hidden_size=6,
+        architecture=architecture,
+        n_classes=3,
+    )
+    defaults.update(kwargs)
+    return MultiModalForecasterModel(**defaults)
+
+
+def test_forward_returns_classification_logits_with_expected_shape() -> None:
+    torch.manual_seed(0)
+    model = _build_model()
+    x = torch.randn(4, 5, 8)
+    text = torch.randn(4, 16)
+    logits = model(x, text_embedding=text)
+    assert logits.shape == (4, 3)
+
+
+def test_forward_with_modality_outputs_emits_modality_dict() -> None:
+    torch.manual_seed(1)
+    model = _build_model()
+    x = torch.randn(4, 5, 8)
+    text = torch.randn(4, 16)
+    out = model.forward_with_modality_outputs(x, text_embedding=text)
+    assert set(out.keys()) == {"logits", "r_t", "t_t", "fused", "gate"}
+    assert out["logits"].shape == (4, 3)
+    assert out["r_t"].shape == (4, 4)
+    assert out["t_t"].shape == (4, 4)
+    assert out["fused"].shape == (4, 4)
+
+
+def test_text_missing_flag_zeros_the_text_input_before_fusion() -> None:
+    """When ``text_embedding_missing=1`` the fusion must see a zero
+    text vector regardless of what the loader actually emitted."""
+
+    torch.manual_seed(2)
+    model = _build_model()
+    model.eval()  # disable dropout so the two calls compare cleanly
+    x = torch.randn(2, 5, 8)
+    text_nonzero = torch.randn(2, 16)
+    missing_flag = torch.ones(2, 1)  # both rows missing
+    out_missing = model.forward_with_modality_outputs(
+        x, text_embedding=text_nonzero, text_embedding_missing=missing_flag
+    )
+    # Same model, same x, but text manually zeroed; outputs must match
+    text_zero = torch.zeros(2, 16)
+    out_zero = model.forward_with_modality_outputs(x, text_embedding=text_zero)
+    assert torch.allclose(out_missing["logits"], out_zero["logits"], atol=1e-6)
+    assert torch.allclose(out_missing["t_t"], out_zero["t_t"], atol=1e-6)
+
+
+def test_forward_and_forward_with_modality_outputs_agree_on_logits() -> None:
+    torch.manual_seed(3)
+    model = _build_model()
+    model.eval()  # avoid dropout randomness across the two calls
+    x = torch.randn(3, 5, 8)
+    text = torch.randn(3, 16)
+    logits_a = model(x, text_embedding=text)
+    out_b = model.forward_with_modality_outputs(x, text_embedding=text)
+    assert torch.allclose(logits_a, out_b["logits"], atol=1e-6)
+
+
+@pytest.mark.parametrize("architecture", ["lstm", "gru", "transformer", "tcn"])
+def test_forward_works_across_supported_architectures(architecture: str) -> None:
+    """The fusion + classification head should work regardless of which
+    recurrent core feeds the market projection."""
+
+    torch.manual_seed(4)
+    model = _build_model(architecture=architecture)
+    x = torch.randn(2, 5, 8)
+    text = torch.randn(2, 16)
+    out = model.forward_with_modality_outputs(x, text_embedding=text)
+    assert out["logits"].shape == (2, 3)
+
+
+def test_constructor_rejects_unknown_architecture() -> None:
+    with pytest.raises(ValueError, match="Unknown architecture"):
+        _build_model(architecture="bogus")
+
+
+def test_constructor_rejects_single_class() -> None:
+    with pytest.raises(ValueError, match="n_classes"):
+        _build_model(n_classes=1)


### PR DESCRIPTION
## Summary

- New \`MultiModalForecasterModel\` keeps market + text modalities separate until a per-row gated fusion.
- \`InfoNCELoss\` adds symmetric NT-Xent alignment between the two modality projections.
- Factory dispatches to the new model when \`fusion_mode=gated_infonce\`; default \`concat\` path is byte-identical.
- CLI: \`--fusion-mode\`, \`--infonce-lambda\`, \`--infonce-temperature\`, \`--infonce-latent-dim\`.
- 21 new tests cover loss / fusion / model / factory dispatch.

## Test plan

- [ ] \`docker compose run --rm backend pytest tests/unit/test_info_nce_loss.py tests/unit/test_gated_infonce_fusion.py tests/unit/test_multimodal_forecaster.py tests/unit/test_factory_gated_infonce_dispatch.py -q\`
- [ ] \`docker compose run --rm backend pytest tests/regression/test_forecaster_determinism.py -q\` (legacy path unchanged)