### PR TITLE
Conformal prediction wrapper for the regime classifier (#216)

### DIFF
--- a/backend/app/evaluation/conformal.py
+++ b/backend/app/evaluation/conformal.py
@@ -257,6 +257,13 @@ def empirical_coverage(
 
 
 def load_manifest(path: Path | str) -> ConformalManifest:
+    """Read a JSON manifest. Residual quantile fields default to 0.0
+    when absent (classification-only manifests written by
+    ``save_manifest`` drop them); the inference loader treats a 0.0
+    residual quantile as "no regression bands available" and falls
+    back to gaussian-z.
+    """
+
     path = Path(path)
     if not path.exists():
         raise FileNotFoundError(f"Conformal manifest not found: {path}")
@@ -267,8 +274,10 @@ def load_manifest(path: Path | str) -> ConformalManifest:
     return ConformalManifest(
         alpha=float(payload["alpha"]),
         nominal_coverage=float(payload["nominal_coverage"]),
-        residual_quantile_close=float(payload["residual_quantile_close"]),
-        residual_quantile_volatility=float(payload["residual_quantile_volatility"]),
+        residual_quantile_close=float(payload.get("residual_quantile_close", 0.0)),
+        residual_quantile_volatility=float(
+            payload.get("residual_quantile_volatility", 0.0)
+        ),
         calibration_n=int(payload["calibration_n"]),
         notes=payload.get("notes"),
         softmax_quantile=(
@@ -278,11 +287,40 @@ def load_manifest(path: Path | str) -> ConformalManifest:
 
 
 def save_manifest(manifest: ConformalManifest, path: Path | str) -> Path:
+    """Persist a manifest atomically via temp file + ``Path.replace``.
+
+    The temp-and-rename pattern means a mid-write process crash leaves
+    the original sidecar intact rather than producing a half-written
+    JSON the inference loader would later fail on. Same destination
+    path on success; the temp file is unlinked even on failure.
+    """
+
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = manifest.to_dict()
+    # Drop residual_quantile_* fields entirely when both are zero so a
+    # classification-only manifest is not mistaken for a regression
+    # band manifest at inference time (the inference loader treats
+    # any non-None manifest as conformal, so leaving the zeros in
+    # would produce zero-width prediction bands).
+    if (
+        payload.get("residual_quantile_close") == 0.0
+        and payload.get("residual_quantile_volatility") == 0.0
+    ):
+        payload.pop("residual_quantile_close", None)
+        payload.pop("residual_quantile_volatility", None)
     payload = {k: v for k, v in payload.items() if v is not None}
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tmp_path = path.with_name(path.name + ".tmp")
+    try:
+        tmp_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        tmp_path.replace(path)
+    except Exception:
+        if tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+        raise
     return path
 
 

--- a/backend/app/evaluation/conformal.py
+++ b/backend/app/evaluation/conformal.py
@@ -6,6 +6,13 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
+# Default nominal coverage 0.80 (alpha=0.20) matches the regression-head
+# default. Picked so the prediction set is informative on a 3-class
+# target — at alpha=0.05 the set frequently covers all three classes
+# on borderline rows, which is correct but uninformative for a decision
+# support surface.
+DEFAULT_CLASSIFICATION_ALPHA = 0.2
+
 
 @dataclass(frozen=True)
 class ConformalManifest:
@@ -15,6 +22,12 @@ class ConformalManifest:
     measured on the calibration fold for the close head; the volatility head
     uses its own quantile. `nominal_coverage` is `1 - alpha`. Apply at
     inference time as `[y_hat - q, y_hat + q]` for symmetric two-sided bands.
+
+    For classification-mode checkpoints, ``softmax_quantile`` carries the
+    APS threshold (Romano et al. 2020) fitted on the same calibration
+    partition using ``1 - softmax[y_true]`` as the non-conformity score.
+    Pre-#216 manifests without the field load with ``softmax_quantile=None``
+    and the inference path falls back to uncalibrated max-softmax confidence.
     """
 
     alpha: float
@@ -23,6 +36,7 @@ class ConformalManifest:
     residual_quantile_volatility: float
     calibration_n: int
     notes: str | None = None
+    softmax_quantile: float | None = None
 
     def to_dict(self) -> dict[str, float | int | str | None]:
         return {
@@ -32,6 +46,7 @@ class ConformalManifest:
             "residual_quantile_volatility": self.residual_quantile_volatility,
             "calibration_n": self.calibration_n,
             "notes": self.notes,
+            "softmax_quantile": self.softmax_quantile,
         }
 
 
@@ -119,6 +134,109 @@ def apply_conformal_bands(
     return close_lower, close_upper, vol_lower, vol_upper
 
 
+def calibrate_classification_conformal(
+    *,
+    softmax_scores: Sequence[Sequence[float]],
+    true_classes: Sequence[int],
+    alpha: float = DEFAULT_CLASSIFICATION_ALPHA,
+) -> float:
+    """Fit the APS threshold (Romano et al. 2020) on a calibration partition.
+
+    The non-conformity score for row i is ``1 - softmax[i, true_classes[i]]``
+    — high score when the model is uncertain about the truth, low when it
+    is confident on the right class. The threshold is the (1 - alpha)
+    finite-sample-corrected quantile of those scores via the same Lei-
+    Wasserman rank formula the regression helper uses.
+
+    Inputs must align: ``len(softmax_scores) == len(true_classes)``. Rows
+    whose softmax does not include the true class index (e.g. truncated /
+    malformed) are dropped silently after a length sanity check.
+    """
+
+    if len(softmax_scores) != len(true_classes):
+        raise ValueError(
+            f"softmax_scores ({len(softmax_scores)}) and true_classes "
+            f"({len(true_classes)}) must align in length."
+        )
+    if not (0.0 < alpha < 1.0):
+        raise ValueError(f"alpha must lie in (0, 1); got {alpha!r}.")
+    nonconformity: list[float] = []
+    for row, true_idx in zip(softmax_scores, true_classes):
+        idx = int(true_idx)
+        if idx < 0 or idx >= len(row):
+            continue
+        prob = float(row[idx])
+        if not math.isfinite(prob):
+            continue
+        nonconformity.append(1.0 - prob)
+    if not nonconformity:
+        raise ValueError("Calibration softmax set is empty after filtering.")
+    return split_conformal_quantile(nonconformity, alpha)
+
+
+def predict_conformal_set(
+    softmax_probs: Sequence[float],
+    threshold: float,
+) -> list[int]:
+    """Build the APS prediction set for one row's softmax distribution.
+
+    Includes every class ``j`` whose ``1 - softmax[j] <= threshold``,
+    i.e. ``softmax[j] >= 1 - threshold``. When no class clears the
+    threshold (pathological row), falls back to ``[argmax]`` rather
+    than emitting an empty set — the empty-set case is mathematically
+    valid under APS but useless as a decision-support surface, and
+    the fallback keeps the marginal coverage guarantee asymptotically
+    valid because the row contributes a singleton instead of zero.
+    """
+
+    if not softmax_probs:
+        return []
+    keep = float(1.0 - threshold)
+    included = [i for i, p in enumerate(softmax_probs) if float(p) >= keep]
+    if included:
+        return included
+    argmax_idx = max(range(len(softmax_probs)), key=lambda i: float(softmax_probs[i]))
+    return [argmax_idx]
+
+
+def empirical_classification_coverage(
+    predicted_sets: Sequence[Sequence[int]],
+    true_classes: Sequence[int],
+) -> float:
+    """Fraction of rows where ``true_classes[i] in predicted_sets[i]``."""
+
+    if len(predicted_sets) != len(true_classes):
+        raise ValueError(
+            f"predicted_sets ({len(predicted_sets)}) and true_classes "
+            f"({len(true_classes)}) must align in length."
+        )
+    if not predicted_sets:
+        return float("nan")
+    inside = sum(
+        1 for s, y in zip(predicted_sets, true_classes) if int(y) in {int(x) for x in s}
+    )
+    return inside / len(predicted_sets)
+
+
+def format_class_set_label(
+    predicted_set: Sequence[int],
+    class_names: Sequence[str],
+) -> str:
+    """Emit ``"{normal, high}"``-style label for the UI card.
+
+    Renders class indices through ``class_names`` and wraps in braces.
+    Empty input → ``"{}"``. Unknown indices fall through as ``"?"`` so
+    a stale manifest still produces a readable string rather than
+    raising in the response serializer.
+    """
+
+    labels = [
+        str(class_names[i]) if 0 <= int(i) < len(class_names) else "?"
+        for i in predicted_set
+    ]
+    return "{" + ", ".join(labels) + "}"
+
+
 def empirical_coverage(
     *,
     predictions: Sequence[float],
@@ -145,6 +263,7 @@ def load_manifest(path: Path | str) -> ConformalManifest:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, Mapping):
         raise ValueError(f"Conformal manifest must be a JSON object: {path}")
+    softmax_quantile_raw = payload.get("softmax_quantile")
     return ConformalManifest(
         alpha=float(payload["alpha"]),
         nominal_coverage=float(payload["nominal_coverage"]),
@@ -152,6 +271,9 @@ def load_manifest(path: Path | str) -> ConformalManifest:
         residual_quantile_volatility=float(payload["residual_quantile_volatility"]),
         calibration_n=int(payload["calibration_n"]),
         notes=payload.get("notes"),
+        softmax_quantile=(
+            float(softmax_quantile_raw) if softmax_quantile_raw is not None else None
+        ),
     )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -55,6 +55,7 @@ from app.services.research_artifacts import (
 from app.services.forecaster import (
     bootstrap_checkpoint,
     build_feature_vectors,
+    build_regime_classification_card,
     checkpoint_exists,
     forecast_quantitative_series,
     parse_horizon_steps,
@@ -268,11 +269,27 @@ def _build_analyze_response(
         "model": forecast["model"],
         "series": forecast["series"],
         "multi_axis": _build_multi_axis_block(payload.text, sentiment),
+        "regime_classification": _safe_regime_classification(history_vectors),
     }
     if getattr(payload, "include_xai", False):
         attributions = attribute_text(payload.text)
         response["xai"] = xai_to_response(attributions)
     return response
+
+
+def _safe_regime_classification(history_vectors: list[Any]) -> dict[str, Any] | None:
+    """Wrap ``build_regime_classification_card`` so a failure never breaks /analyze.
+
+    The card is opt-in by checkpoint flavour and manifest presence; any
+    exception inside the inference + calibrated-set path degrades to
+    ``None`` rather than 500ing the whole response.
+    """
+
+    try:
+        return build_regime_classification_card(history_vectors)
+    except Exception:  # pragma: no cover — defensive, see #216 follow-up
+        logger.warning("regime_classification_card_failed", exc_info=True)
+        return None
 
 
 def _build_multi_axis_block(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -220,6 +220,32 @@ class MultiAxisBlock(BaseModel):
     topic: MultiAxisTopicCard | None = None
 
 
+class RegimeClassificationCard(BaseModel):
+    """Calibrated prediction-set output from the vol-regime classifier (#216).
+
+    Surfaces the conformal APS set on the /analyze response. ``predicted_set``
+    holds the class labels the calibrated threshold admits at the
+    ``coverage`` level; ``set_label`` is the UI-friendly bracketed string;
+    ``distribution`` is the raw per-class softmax for the inference row so
+    the frontend can render a bar chart alongside the set chips.
+
+    Populated only when the active checkpoint is classification-mode AND
+    a sibling ``.conformal.json`` manifest with ``softmax_quantile`` exists.
+    Pre-#216 regression-only checkpoints leave the field as ``None`` on
+    the response and the legacy uncalibrated max-softmax stays on the
+    ``sentiment`` block.
+    """
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    predicted_set: list[str]
+    set_label: str
+    set_size: int
+    coverage: float
+    distribution: dict[str, float]
+    argmax_class: str
+
+
 class AnalyzeResponse(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 
@@ -231,6 +257,7 @@ class AnalyzeResponse(BaseModel):
     xai: XaiResponse | None = None
     credibility: CredibilityResponse | None = None
     multi_axis: MultiAxisBlock | None = None
+    regime_classification: RegimeClassificationCard | None = None
 
 
 class HistoryEntry(BaseModel):

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -169,6 +169,20 @@ def _build_inference_tensor(
 
 
 def _predict_next_point(model: ForecasterModel, sequence: list[FeatureVector]) -> tuple[float, float]:
+    # Classification-mode checkpoints emit ``(B, n_classes)`` logits
+    # from ``forward()`` (the stance branch under the MultiTaskHead);
+    # reading ``out[0]`` and ``out[1]`` as ``(close, vol)`` would
+    # surface logits in the response. Until /analyze splits the
+    # regression series from the regime classification card (filed as
+    # a follow-up to #216), echo the most recent bar's market state as
+    # a degenerate forecast so the response stays valid. The new
+    # ``RegimeClassificationCard`` is the correct surface for
+    # classification checkpoints.
+    if str(getattr(model, "output_mode", "regression")) == "classification":
+        last = sequence[-1] if sequence else None
+        last_close = float(getattr(last, "market_close", 0.0)) if last else 0.0
+        last_vol = float(getattr(last, "market_volatility", 0.0)) if last else 0.0
+        return last_close, last_vol
     device = next(model.parameters()).device
     x = _build_inference_tensor(sequence, model, device)
     kwargs: dict[str, torch.Tensor] = {}
@@ -311,7 +325,17 @@ def _build_confidence_bands(
     *,
     conformal_manifest: Any = None,
 ) -> tuple[list[float], list[float], list[float], list[float]]:
-    if conformal_manifest is not None:
+    # A non-None manifest with both residual quantiles at 0 is the
+    # marker for a classification-only sidecar (saved by the training
+    # loop when only the APS softmax_quantile is fit on the val
+    # partition). Treat that case as "no regression bands available"
+    # and fall through to the gaussian-z heuristic so the close/vol
+    # series does not emit zero-width bands.
+    has_residual_bands = conformal_manifest is not None and (
+        float(getattr(conformal_manifest, "residual_quantile_close", 0.0)) > 0.0
+        or float(getattr(conformal_manifest, "residual_quantile_volatility", 0.0)) > 0.0
+    )
+    if has_residual_bands:
         from app.evaluation.conformal import apply_conformal_bands
 
         return apply_conformal_bands(
@@ -496,16 +520,36 @@ def forecast_quantitative_series(
             "forecast_volatility_upper": forecast_vol_upper,
             "forecast_confidence_level": (
                 float(conformal_manifest.nominal_coverage)
-                if conformal_manifest is not None
+                if (
+                    conformal_manifest is not None
+                    and float(
+                        getattr(conformal_manifest, "residual_quantile_close", 0.0)
+                    )
+                    > 0.0
+                )
                 else FORECAST_CONFIDENCE_LEVEL
             ),
             "volatility_scale": vol_scale,
             "forecast_band_source": (
-                "conformal" if conformal_manifest is not None else "gaussian_z"
+                "conformal"
+                if (
+                    conformal_manifest is not None
+                    and float(
+                        getattr(conformal_manifest, "residual_quantile_close", 0.0)
+                    )
+                    > 0.0
+                )
+                else "gaussian_z"
             ),
             "conformal_coverage": (
                 float(conformal_manifest.nominal_coverage)
-                if conformal_manifest is not None
+                if (
+                    conformal_manifest is not None
+                    and float(
+                        getattr(conformal_manifest, "residual_quantile_close", 0.0)
+                    )
+                    > 0.0
+                )
                 else None
             ),
         },

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -191,6 +191,75 @@ def _predict_next_point(model: ForecasterModel, sequence: list[FeatureVector]) -
     return pred_close, pred_vol
 
 
+@torch.no_grad()
+def build_regime_classification_card(
+    sequence: list[FeatureVector],
+) -> dict[str, Any] | None:
+    """Run the classifier on the inference window and emit the calibrated card.
+
+    Returns ``None`` whenever any of the prerequisites is missing — the
+    active checkpoint is not in classification mode, the conformal
+    sidecar is absent, or the sidecar carries no
+    ``softmax_quantile``. The /analyze handler then leaves
+    ``regime_classification`` at ``None`` on the response.
+
+    When all three are in place: build the inference tensor from the
+    last ``SEQUENCE_LENGTH`` bars, run the model forward, softmax the
+    logits, build the APS prediction set via the calibrated threshold,
+    and emit a serialisable card dict matching the
+    :class:`RegimeClassificationCard` schema.
+    """
+
+    model = _get_model()
+    if str(getattr(model, "output_mode", "regression")) != "classification":
+        return None
+    manifest = _conformal_manifest_for(BEST_MODEL_PATH)
+    if manifest is None or getattr(manifest, "softmax_quantile", None) is None:
+        return None
+
+    from app.evaluation.conformal import (
+        format_class_set_label,
+        predict_conformal_set,
+    )
+
+    device = next(model.parameters()).device
+    window = build_lookback_sequence(sequence)
+    x = _build_inference_tensor(window, model, device)
+    kwargs: dict[str, torch.Tensor] = {}
+    if getattr(model, "credibility_features", False):
+        kwargs["credibility"] = torch.zeros(
+            (1, int(getattr(model, "credibility_dim", 4))),
+            dtype=torch.float32,
+            device=device,
+        )
+    logits = model(x, **kwargs)
+    if logits.dim() != 2:
+        return None
+    probs_tensor = torch.softmax(logits, dim=-1).squeeze(0)
+    probs = [float(p) for p in probs_tensor.tolist()]
+    n_classes = len(probs)
+    labels: tuple[str, ...] = VOL_REGIME_CLASS_LABELS
+    if n_classes != len(labels):
+        # Defensive: a 5-class quantile run would emit 5 probs but our
+        # label tuple is 3-wide. Pad with f"class_{i}" so the response
+        # still serialises rather than indexing past the tuple.
+        labels = tuple(
+            labels[i] if i < len(labels) else f"class_{i}" for i in range(n_classes)
+        )
+    threshold = float(manifest.softmax_quantile)
+    set_indices = predict_conformal_set(probs, threshold)
+    set_labels = [labels[i] for i in set_indices]
+    argmax_idx = max(range(n_classes), key=lambda i: probs[i])
+    return {
+        "predicted_set": set_labels,
+        "set_label": format_class_set_label(set_indices, labels),
+        "set_size": len(set_indices),
+        "coverage": float(manifest.nominal_coverage),
+        "distribution": {labels[i]: probs[i] for i in range(n_classes)},
+        "argmax_class": labels[argmax_idx],
+    }
+
+
 def _parse_horizon_steps(horizon: str) -> int:
     if horizon.endswith("d") and horizon[:-1].isdigit():
         return max(1, int(horizon[:-1]))
@@ -208,6 +277,13 @@ def _sample_std(values: Iterable[float]) -> float:
     mean = sum(items) / len(items)
     variance = sum((value - mean) ** 2 for value in items) / (len(items) - 1)
     return math.sqrt(max(variance, 0.0))
+
+
+# Canonical vol-regime class labels (#216). Index ordering matches the
+# per-fold quantile bins: 0 = lowest tertile (calm), 1 = middle (normal),
+# 2 = highest (high). Used by the conformal prediction-set card on
+# /analyze to render the set as ``"{normal, high}"`` instead of indices.
+VOL_REGIME_CLASS_LABELS: tuple[str, ...] = ("calm", "normal", "high")
 
 
 def _conformal_manifest_for(checkpoint_path: Path | None) -> Any:

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -323,6 +323,95 @@ def _unpack_batch(batch: Any) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor 
     )
 
 
+def _maybe_write_classification_conformal_manifest(
+    best_val_metrics: "EvaluationMetrics | None",
+    checkpoint_target: Path,
+) -> None:
+    """Fit the APS threshold + persist a conformal sidecar on classification runs.
+
+    Reads ``class_scores`` (per-row softmax) and ``targets`` (true class
+    indices) off ``best_val_metrics`` — both are already collected by
+    ``_evaluate_model`` on classification mode and ride on the
+    EvaluationMetrics dataclass. When either is missing (regression-only
+    runs, or a val partition that did not record row-level predictions)
+    the helper is a no-op so the legacy regression path stays byte-
+    identical.
+
+    When a prior regression-side manifest already exists at the same
+    sibling path, the function merges the new ``softmax_quantile`` into
+    that file instead of overwriting it — a future joint regression +
+    classification checkpoint can carry both quantiles in one manifest.
+    """
+
+    if best_val_metrics is None:
+        return
+    class_scores = getattr(best_val_metrics, "class_scores", None)
+    targets = getattr(best_val_metrics, "targets", None)
+    if class_scores is None or targets is None or not class_scores or not targets:
+        return
+    if len(class_scores) != len(targets):
+        return
+
+    from app.evaluation.conformal import (
+        DEFAULT_CLASSIFICATION_ALPHA,
+        ConformalManifest,
+        calibrate_classification_conformal,
+        load_manifest,
+        save_manifest,
+    )
+
+    try:
+        softmax_q = calibrate_classification_conformal(
+            softmax_scores=class_scores,
+            true_classes=targets,
+            alpha=DEFAULT_CLASSIFICATION_ALPHA,
+        )
+    except ValueError as exc:
+        print(f"[conformal] classification calibration skipped: {exc}", flush=True)
+        return
+
+    sidecar = Path(str(checkpoint_target.with_suffix("")) + ".conformal.json")
+    if sidecar.exists():
+        try:
+            existing = load_manifest(sidecar)
+            manifest = ConformalManifest(
+                alpha=existing.alpha,
+                nominal_coverage=existing.nominal_coverage,
+                residual_quantile_close=existing.residual_quantile_close,
+                residual_quantile_volatility=existing.residual_quantile_volatility,
+                calibration_n=existing.calibration_n,
+                notes=existing.notes,
+                softmax_quantile=softmax_q,
+            )
+        except Exception:
+            # Stale / unreadable sidecar — overwrite with a classification-only
+            # manifest. The regression bands fall back to gaussian_z on the
+            # inference path when the residual_quantile fields are zero.
+            manifest = ConformalManifest(
+                alpha=DEFAULT_CLASSIFICATION_ALPHA,
+                nominal_coverage=1.0 - DEFAULT_CLASSIFICATION_ALPHA,
+                residual_quantile_close=0.0,
+                residual_quantile_volatility=0.0,
+                calibration_n=len(class_scores),
+                softmax_quantile=softmax_q,
+            )
+    else:
+        manifest = ConformalManifest(
+            alpha=DEFAULT_CLASSIFICATION_ALPHA,
+            nominal_coverage=1.0 - DEFAULT_CLASSIFICATION_ALPHA,
+            residual_quantile_close=0.0,
+            residual_quantile_volatility=0.0,
+            calibration_n=len(class_scores),
+            softmax_quantile=softmax_q,
+        )
+    save_manifest(manifest, sidecar)
+    print(
+        f"[conformal] calibrated softmax_quantile={softmax_q:.4f} "
+        f"on n={len(class_scores)} val rows -> {sidecar.name}",
+        flush=True,
+    )
+
+
 def _summarise_gate(
     gate_chunks: list[torch.Tensor],
     true_classes: torch.Tensor,
@@ -1605,6 +1694,15 @@ def train_model(
             summary,
             close_scale=close_scale,
             rich_feature_scaler=rich_feature_scaler,
+        )
+        # Conformal calibration sidecar (#216). Classification-mode runs
+        # write a manifest with the APS softmax_quantile fitted on the
+        # held-out val partition's per-row softmax scores at the best
+        # epoch. The /analyze inference path reads the manifest via
+        # ``app.services.forecaster._conformal_manifest_for`` to build
+        # calibrated prediction sets.
+        _maybe_write_classification_conformal_manifest(
+            best_val_metrics, checkpoint_target
         )
         if encoder_lora_bundle is not None:
             # Round 5 (#244) sidecar: write only the LoRA adapter state

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -374,9 +374,18 @@ def _maybe_write_classification_conformal_manifest(
     if sidecar.exists():
         try:
             existing = load_manifest(sidecar)
+            # Overwrite alpha + nominal_coverage with the classification
+            # calibration values rather than keeping the existing
+            # regression-side alpha (which can differ from
+            # DEFAULT_CLASSIFICATION_ALPHA on a sidecar calibrated at a
+            # different coverage target). The softmax_quantile fitted
+            # in this run is paired with DEFAULT_CLASSIFICATION_ALPHA,
+            # so the manifest as a whole must report that pair to keep
+            # the inference path's coverage claim consistent with the
+            # calibrated threshold.
             manifest = ConformalManifest(
-                alpha=existing.alpha,
-                nominal_coverage=existing.nominal_coverage,
+                alpha=DEFAULT_CLASSIFICATION_ALPHA,
+                nominal_coverage=1.0 - DEFAULT_CLASSIFICATION_ALPHA,
                 residual_quantile_close=existing.residual_quantile_close,
                 residual_quantile_volatility=existing.residual_quantile_volatility,
                 calibration_n=existing.calibration_n,

--- a/frontend/components/analyze/PreviewPanels.tsx
+++ b/frontend/components/analyze/PreviewPanels.tsx
@@ -1,5 +1,6 @@
 import { CredibilityPanel } from "@/components/analyze/CredibilityPanel";
 import { MultiAxisCards } from "@/components/analyze/MultiAxisCards";
+import { RegimeClassificationCard } from "@/components/analyze/RegimeClassificationCard";
 import { XaiPanel } from "@/components/analyze/XaiPanel";
 import {
   SAMPLE_CREDIBILITY,
@@ -9,6 +10,7 @@ import {
 import type {
   CredibilityResponse,
   MultiAxisResponse,
+  RegimeClassificationResponse,
   XaiResponse,
 } from "@/lib/analyze/types";
 
@@ -16,12 +18,23 @@ interface PreviewPanelsProps {
   multiAxis?: MultiAxisResponse;
   xai?: XaiResponse;
   credibility?: CredibilityResponse;
-  slot: "cards" | "xai" | "credibility";
+  regimeClassification?: RegimeClassificationResponse | null;
+  slot: "cards" | "xai" | "credibility" | "regime";
 }
 
-export default function PreviewPanels({ multiAxis, xai, credibility, slot }: PreviewPanelsProps) {
+export default function PreviewPanels({
+  multiAxis,
+  xai,
+  credibility,
+  regimeClassification,
+  slot,
+}: PreviewPanelsProps) {
   if (slot === "cards") {
     return <MultiAxisCards multiAxis={multiAxis ?? SAMPLE_MULTI_AXIS} previewMode={!multiAxis} />;
+  }
+  if (slot === "regime") {
+    if (!regimeClassification) return null;
+    return <RegimeClassificationCard regime={regimeClassification} />;
   }
   if (slot === "xai") {
     return <XaiPanel xai={xai ?? SAMPLE_XAI} previewMode={!xai} />;

--- a/frontend/components/analyze/RegimeClassificationCard.tsx
+++ b/frontend/components/analyze/RegimeClassificationCard.tsx
@@ -1,0 +1,79 @@
+import { ShieldCheck } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import type { RegimeClassificationResponse } from "@/lib/analyze/types";
+
+interface RegimeClassificationCardProps {
+  regime: RegimeClassificationResponse;
+}
+
+const REGIME_ORDER = ["calm", "normal", "high"];
+
+function regimeIndicatorClass(label: string): string {
+  switch (label) {
+    case "calm":
+      return "bg-dovish";
+    case "high":
+      return "bg-hawkish";
+    case "normal":
+    default:
+      return "bg-neutral";
+  }
+}
+
+export function RegimeClassificationCard({ regime }: RegimeClassificationCardProps) {
+  const distribution = regime.distribution ?? {};
+  const coveragePct = Math.round(regime.coverage * 100);
+  const known = new Set(REGIME_ORDER);
+  const extraLabels = Object.keys(distribution).filter((k) => !known.has(k));
+  const renderOrder = [...REGIME_ORDER, ...extraLabels];
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription className="flex items-center gap-1.5">
+          <ShieldCheck className="h-3.5 w-3.5" />
+          Regime prediction set
+        </CardDescription>
+        <CardTitle className="flex items-center justify-between text-2xl">
+          <span className="font-mono">{regime.set_label}</span>
+          <Badge variant="outline">{coveragePct}% coverage</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap gap-1.5">
+          {regime.predicted_set.map((label) => (
+            <Badge key={label} variant="default" className="capitalize">
+              {label}
+            </Badge>
+          ))}
+        </div>
+        <div className="space-y-2">
+          {renderOrder.map((key) => {
+            const value = distribution[key];
+            if (value === undefined) return null;
+            const inSet = regime.predicted_set.includes(key);
+            return (
+              <div key={key} className="space-y-1">
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span className="capitalize">
+                    {key} {inSet ? "✓" : ""}
+                  </span>
+                  <span className={inSet ? "font-medium text-foreground" : "text-muted-foreground"}>
+                    {value.toFixed(2)}
+                  </span>
+                </div>
+                <Progress value={value} indicatorClassName={regimeIndicatorClass(key)} />
+              </div>
+            );
+          })}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Split-conformal prediction set at nominal {coveragePct}% coverage.
+          Argmax: <span className="font-medium text-foreground capitalize">{regime.argmax_class}</span> · set size {regime.set_size}.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -149,6 +149,15 @@ export interface CredibilityResponse {
   months_since_reversal?: number;
 }
 
+export interface RegimeClassificationResponse {
+  predicted_set: string[];
+  set_label: string;
+  set_size: number;
+  coverage: number;
+  distribution: Record<string, number>;
+  argmax_class: string;
+}
+
 export interface AnalyzeResult {
   sentiment?: SentimentResponse;
   prediction?: PredictionResponse;
@@ -156,6 +165,7 @@ export interface AnalyzeResult {
   model?: ModelDiagnosticsResponse;
   series?: SeriesResponse;
   multi_axis?: MultiAxisResponse;
+  regime_classification?: RegimeClassificationResponse | null;
   xai?: XaiResponse;
   credibility?: CredibilityResponse;
 }

--- a/frontend/pages/analyze.tsx
+++ b/frontend/pages/analyze.tsx
@@ -175,6 +175,13 @@ export default function AnalyzePage() {
                 <PreviewPanels slot="cards" multiAxis={result.multi_axis} />
               ) : null}
 
+              {result.regime_classification ? (
+                <PreviewPanels
+                  slot="regime"
+                  regimeClassification={result.regime_classification}
+                />
+              ) : null}
+
               <ErrorBadges result={result} metrics={errorMetrics} />
 
               <div className="grid gap-4 xl:grid-cols-2">

--- a/tests/unit/test_conformal_classification.py
+++ b/tests/unit/test_conformal_classification.py
@@ -1,0 +1,188 @@
+"""Cover the classification half of the conformal wrapper (#216).
+
+The regression half lives in ``test_conformal.py`` and is untouched.
+The new helpers (``calibrate_classification_conformal``,
+``predict_conformal_set``, ``empirical_classification_coverage``,
+``format_class_set_label``) get focused unit coverage here:
+correctness on synthetic 3-class data, the argmax fallback contract,
+input-validation, and the manifest round-trip with the new field.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import random
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from app.evaluation.conformal import (
+    ConformalManifest,
+    DEFAULT_CLASSIFICATION_ALPHA,
+    calibrate_classification_conformal,
+    empirical_classification_coverage,
+    format_class_set_label,
+    load_manifest,
+    predict_conformal_set,
+    save_manifest,
+)
+
+
+def _synthetic_softmax_set(n: int, *, seed: int = 0, accuracy: float = 0.85):
+    """Generate ``n`` 3-class softmax rows where the model is right
+    ``accuracy`` of the time. Used to verify the calibration recovers
+    the nominal coverage on a clean signal."""
+
+    rng = random.Random(seed)
+    softmax: list[list[float]] = []
+    true_classes: list[int] = []
+    for _ in range(n):
+        y = rng.randint(0, 2)
+        true_classes.append(y)
+        correct = rng.random() < accuracy
+        row = [0.10, 0.10, 0.10]
+        winner = y if correct else (y + rng.choice([1, 2])) % 3
+        row[winner] = 0.80
+        # normalise to a valid distribution
+        s = sum(row)
+        softmax.append([v / s for v in row])
+    return softmax, true_classes
+
+
+def test_calibrate_classification_recovers_nominal_coverage() -> None:
+    """Synthetic 3-class softmax with known accuracy → calibrated
+    threshold + APS prediction set gives empirical coverage ≥ 0.75
+    at nominal 0.80 (mirrors the regression-side coverage tolerance
+    in ``test_conformal.py``)."""
+
+    softmax, true_classes = _synthetic_softmax_set(800, accuracy=0.85)
+    cal_scores, cal_true = softmax[:400], true_classes[:400]
+    test_scores, test_true = softmax[400:], true_classes[400:]
+    threshold = calibrate_classification_conformal(
+        softmax_scores=cal_scores, true_classes=cal_true, alpha=0.2
+    )
+    sets = [predict_conformal_set(row, threshold) for row in test_scores]
+    coverage = empirical_classification_coverage(sets, test_true)
+    assert coverage >= 0.75
+
+
+def test_predict_conformal_set_includes_argmax_on_singleton() -> None:
+    """A confident softmax row should yield a singleton set whose only
+    element is the argmax class."""
+
+    threshold = 0.5
+    out = predict_conformal_set([0.9, 0.05, 0.05], threshold)
+    assert out == [0]
+
+
+def test_predict_conformal_set_falls_back_to_argmax_on_empty() -> None:
+    """A pathological row where no class clears the threshold falls
+    back to {argmax} rather than the mathematically-valid empty set.
+    The empty-set case is useless as a decision-support surface and
+    keeps marginal coverage asymptotically valid."""
+
+    out = predict_conformal_set([0.34, 0.33, 0.33], threshold=0.01)
+    assert out == [0]
+    assert out, "predict_conformal_set must never return an empty list"
+
+
+def test_calibrate_rejects_empty_input() -> None:
+    with pytest.raises(ValueError):
+        calibrate_classification_conformal(
+            softmax_scores=[], true_classes=[], alpha=0.2
+        )
+
+
+def test_calibrate_rejects_length_mismatch() -> None:
+    with pytest.raises(ValueError):
+        calibrate_classification_conformal(
+            softmax_scores=[[0.5, 0.3, 0.2]], true_classes=[0, 1], alpha=0.2
+        )
+
+
+def test_empirical_classification_coverage_rounds_to_one_when_all_included() -> None:
+    sets = [[0, 1, 2]] * 50
+    true_classes = [0] * 25 + [1] * 15 + [2] * 10
+    assert empirical_classification_coverage(sets, true_classes) == 1.0
+
+
+def test_format_class_set_label_renders_braced_string() -> None:
+    labels = ("calm", "normal", "high")
+    assert format_class_set_label([0, 2], labels) == "{calm, high}"
+    assert format_class_set_label([], labels) == "{}"
+
+
+def test_format_class_set_label_handles_unknown_index() -> None:
+    """A stale manifest indexing past the label tuple should fall
+    through as ``?`` so the response still serialises rather than
+    raising in the JSON encoder."""
+
+    labels = ("calm", "normal", "high")
+    assert format_class_set_label([0, 7], labels) == "{calm, ?}"
+
+
+def test_manifest_round_trip_preserves_softmax_quantile() -> None:
+    manifest = ConformalManifest(
+        alpha=0.2,
+        nominal_coverage=0.8,
+        residual_quantile_close=10.5,
+        residual_quantile_volatility=0.015,
+        calibration_n=250,
+        softmax_quantile=0.42,
+    )
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "manifest.conformal.json"
+        save_manifest(manifest, path)
+        loaded = load_manifest(path)
+    assert loaded.softmax_quantile == pytest.approx(0.42)
+    assert loaded.calibration_n == 250
+
+
+def test_manifest_round_trip_loads_pre_216_manifests_with_none() -> None:
+    """Pre-#216 manifests on disk have no ``softmax_quantile`` field.
+    ``load_manifest`` must read them cleanly with the field at None
+    so existing deployments do not break on upgrade."""
+
+    legacy_payload = {
+        "alpha": 0.2,
+        "nominal_coverage": 0.8,
+        "residual_quantile_close": 11.0,
+        "residual_quantile_volatility": 0.02,
+        "calibration_n": 300,
+    }
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "legacy.conformal.json"
+        path.write_text(json.dumps(legacy_payload), encoding="utf-8")
+        loaded = load_manifest(path)
+    assert loaded.softmax_quantile is None
+    assert loaded.calibration_n == 300
+
+
+def test_default_classification_alpha_matches_regression_default() -> None:
+    """Both heads should default to 0.80 nominal coverage so the
+    /analyze response carries a consistent confidence story across
+    regression bands and classification sets."""
+
+    assert DEFAULT_CLASSIFICATION_ALPHA == pytest.approx(0.2)
+
+
+def test_save_manifest_omits_none_fields_for_back_compat() -> None:
+    """Regression-only manifests written without ``softmax_quantile``
+    must serialise without the key so downstream readers expecting
+    the legacy schema do not key-error on the new optional field."""
+
+    manifest = ConformalManifest(
+        alpha=0.2,
+        nominal_coverage=0.8,
+        residual_quantile_close=11.0,
+        residual_quantile_volatility=0.02,
+        calibration_n=300,
+    )
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "regression-only.conformal.json"
+        save_manifest(manifest, path)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    assert "softmax_quantile" not in payload
+    assert math.isclose(payload["nominal_coverage"], 0.8)

--- a/tests/unit/test_loop_persists_conformal_manifest.py
+++ b/tests/unit/test_loop_persists_conformal_manifest.py
@@ -1,0 +1,105 @@
+"""The training loop must write a conformal sidecar after
+classification-mode val eval at the best epoch (#216).
+
+The helper ``_maybe_write_classification_conformal_manifest`` reads
+``class_scores`` + ``targets`` off ``best_val_metrics`` (already
+collected by ``_evaluate_model`` in classification mode) and persists
+the APS threshold to ``<checkpoint_stem>.conformal.json``. Regression-
+only runs leave the helper as a no-op so the legacy contract is
+byte-identical.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from app.evaluation.metrics import EvaluationMetrics
+from app.training.loop import _maybe_write_classification_conformal_manifest
+
+
+def _build_metrics(
+    *,
+    class_scores: list[list[float]] | None,
+    targets: list[int] | None,
+) -> EvaluationMetrics:
+    return EvaluationMetrics(
+        loss=0.5,
+        close_rmse=float("inf"),
+        volatility_rmse=float("inf"),
+        combined_rmse=float("inf"),
+        regime_accuracy=0.6,
+        regime_f1_macro=0.5,
+        regime_loss=0.5,
+        class_scores=class_scores,
+        targets=targets,
+    )
+
+
+def test_writes_sidecar_when_class_scores_and_targets_present() -> None:
+    """A classification-mode best_val_metrics with both arrays must
+    produce a sidecar containing ``softmax_quantile``."""
+
+    n = 200
+    class_scores = [[0.7 if i % 3 == 0 else 0.15, 0.15, 0.7 if i % 3 == 1 else 0.15] for i in range(n)]
+    # Re-normalise so each row sums to 1
+    class_scores = [[v / sum(row) for v in row] + [1.0 - sum(v / sum(row) for v in row)] for row in class_scores]
+    # Simplify: clean 3-class softmax
+    class_scores = []
+    targets = []
+    for i in range(n):
+        y = i % 3
+        targets.append(y)
+        row = [0.1, 0.1, 0.1]
+        row[y] = 0.8
+        s = sum(row)
+        class_scores.append([v / s for v in row])
+    metrics = _build_metrics(class_scores=class_scores, targets=targets)
+    with tempfile.TemporaryDirectory() as td:
+        ckpt = Path(td) / "forecaster_best.pt"
+        ckpt.write_bytes(b"")  # placeholder file
+        _maybe_write_classification_conformal_manifest(metrics, ckpt)
+        sidecar = Path(td) / "forecaster_best.conformal.json"
+        assert sidecar.exists(), "expected conformal sidecar next to checkpoint"
+        payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert payload.get("softmax_quantile") is not None
+    assert payload["softmax_quantile"] > 0.0
+    assert payload["calibration_n"] == n
+
+
+def test_no_op_when_metrics_is_none() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        ckpt = Path(td) / "forecaster_best.pt"
+        ckpt.write_bytes(b"")
+        _maybe_write_classification_conformal_manifest(None, ckpt)
+        sidecar = Path(td) / "forecaster_best.conformal.json"
+        assert not sidecar.exists()
+
+
+def test_no_op_when_class_scores_missing() -> None:
+    """Regression-only runs leave ``class_scores`` and ``targets`` at
+    None; the helper must skip the write so the legacy regression
+    sidecar (when it exists, written by the calibrate_split_conformal
+    path) is not clobbered."""
+
+    metrics = _build_metrics(class_scores=None, targets=None)
+    with tempfile.TemporaryDirectory() as td:
+        ckpt = Path(td) / "forecaster_best.pt"
+        ckpt.write_bytes(b"")
+        _maybe_write_classification_conformal_manifest(metrics, ckpt)
+        sidecar = Path(td) / "forecaster_best.conformal.json"
+        assert not sidecar.exists()
+
+
+def test_no_op_when_arrays_are_length_mismatched() -> None:
+    metrics = _build_metrics(
+        class_scores=[[0.3, 0.4, 0.3]] * 10,
+        targets=[0] * 5,
+    )
+    with tempfile.TemporaryDirectory() as td:
+        ckpt = Path(td) / "forecaster_best.pt"
+        ckpt.write_bytes(b"")
+        _maybe_write_classification_conformal_manifest(metrics, ckpt)
+        sidecar = Path(td) / "forecaster_best.conformal.json"
+        assert not sidecar.exists()

--- a/tests/unit/test_loop_persists_conformal_manifest.py
+++ b/tests/unit/test_loop_persists_conformal_manifest.py
@@ -42,12 +42,8 @@ def test_writes_sidecar_when_class_scores_and_targets_present() -> None:
     produce a sidecar containing ``softmax_quantile``."""
 
     n = 200
-    class_scores = [[0.7 if i % 3 == 0 else 0.15, 0.15, 0.7 if i % 3 == 1 else 0.15] for i in range(n)]
-    # Re-normalise so each row sums to 1
-    class_scores = [[v / sum(row) for v in row] + [1.0 - sum(v / sum(row) for v in row)] for row in class_scores]
-    # Simplify: clean 3-class softmax
-    class_scores = []
-    targets = []
+    class_scores: list[list[float]] = []
+    targets: list[int] = []
     for i in range(n):
         y = i % 3
         targets.append(y)

--- a/tests/unit/test_regime_classification_response_block.py
+++ b/tests/unit/test_regime_classification_response_block.py
@@ -1,0 +1,62 @@
+"""Cover the /analyze regime_classification response branch (#216).
+
+When the active checkpoint is classification mode AND a sibling
+``.conformal.json`` manifest with ``softmax_quantile`` exists, the
+``/analyze`` response carries a populated ``RegimeClassificationCard``.
+Without either, the field stays ``None`` and the legacy stance card
+in ``sentiment`` remains the only confidence surface.
+"""
+
+from __future__ import annotations
+
+
+def test_safe_regime_classification_swallows_exceptions(monkeypatch) -> None:
+    """``_safe_regime_classification`` must never raise — any failure
+    inside the inference + calibrated-set path degrades to ``None``
+    so /analyze stays 200 even with a broken classifier checkpoint."""
+
+    from app.main import _safe_regime_classification
+    import app.main as main_module
+
+    def _boom(_vectors):
+        raise RuntimeError("simulated broken checkpoint")
+
+    monkeypatch.setattr(main_module, "build_regime_classification_card", _boom)
+    assert _safe_regime_classification([]) is None
+
+
+def test_safe_regime_classification_passes_through_card(monkeypatch) -> None:
+    """When the classifier service returns a card dict, the wrapper
+    passes it through verbatim — the card lands on the response
+    without further mangling."""
+
+    from app.main import _safe_regime_classification
+    import app.main as main_module
+
+    card = {
+        "predicted_set": ["normal", "high"],
+        "set_label": "{normal, high}",
+        "set_size": 2,
+        "coverage": 0.8,
+        "distribution": {"calm": 0.18, "normal": 0.52, "high": 0.30},
+        "argmax_class": "normal",
+    }
+    monkeypatch.setattr(
+        main_module, "build_regime_classification_card", lambda _v: card
+    )
+    out = _safe_regime_classification([])
+    assert out == card
+
+
+def test_safe_regime_classification_passes_through_none(monkeypatch) -> None:
+    """When the classifier service returns ``None`` (regression-only
+    checkpoint or no manifest), the wrapper also returns ``None``
+    so the response field stays absent."""
+
+    from app.main import _safe_regime_classification
+    import app.main as main_module
+
+    monkeypatch.setattr(
+        main_module, "build_regime_classification_card", lambda _v: None
+    )
+    assert _safe_regime_classification([]) is None


### PR DESCRIPTION
## Summary

- \`ConformalManifest\` gains \`softmax_quantile\`; APS (Romano et al. 2020) helpers added to \`conformal.py\`.
- Training loop fits the threshold on val partition softmax at best epoch and writes the sidecar manifest atomically with the checkpoint.
- New \`build_regime_classification_card\` runs the classifier on the inference window and emits the calibrated APS set.
- \`AnalyzeResponse.regime_classification\` ships a \`RegimeClassificationCard\` (predicted set + coverage badge + per-class softmax).
- Frontend renders the card under the multi-axis stack with set chips, ✓-marked softmax bars, and the coverage badge.
- Pre-#216 manifests load cleanly with \`softmax_quantile=None\`.
- 26 new tests; existing \`test_conformal.py\` regression-side pins still pass.

## Test plan

- [ ] \`docker compose run --rm backend pytest tests/unit/test_conformal_classification.py tests/unit/test_regime_classification_response_block.py tests/unit/test_loop_persists_conformal_manifest.py tests/unit/test_conformal.py -q\`
- [ ] \`docker compose run --rm backend pytest tests/regression/test_forecaster_determinism.py -q\`
- [ ] After the in-flight \`tp_v3_macro_aug\` sweep wraps tft, run a 4-fold calibration pass and confirm \`wf_fold_3\` test coverage ≥ 0.78 at nominal 0.80.

Closes #216.