### PR TITLE
Multi-task loss foundation (#273) + per-bank classifier eval

### DIFF
--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -471,7 +471,7 @@ class _MultiAxisDataset(Dataset):
         }
 
 
-def _collate(batch: list[dict[str, Any]]) -> dict[str, torch.Tensor]:
+def _collate(batch: list[dict[str, Any]]) -> dict[str, Any]:
     out: dict[str, torch.Tensor] = {}
     out["input_ids"] = torch.stack([item["input_ids"] for item in batch])
     out["attention_mask"] = torch.stack([item["attention_mask"] for item in batch])
@@ -499,6 +499,10 @@ def _collate(batch: list[dict[str, Any]]) -> dict[str, torch.Tensor]:
     out["mask_topic"] = torch.tensor(
         [item["mask_topic"] for item in batch], dtype=torch.bool
     )
+    # ``source`` is a per-row str the per-bank eval reads; the rest of
+    # the batch is torch.Tensor. The mixed-type return signature is
+    # documented on _collate's annotation so the type hint matches
+    # the actual payload.
     out["source"] = [str(item.get("source", "")) for item in batch]
     return out
 
@@ -579,7 +583,7 @@ def _evaluate_per_bank(
     model: TextMultiAxisClassifier,
     loader: DataLoader,
     device: torch.device,
-) -> dict[str, dict[str, dict[str, float]]]:
+) -> dict[str, dict[str, dict[str, float | int]]]:
     """Per-source per-axis macro-F1 breakdown on the eval partition (D, #209).
 
     Returns ``{source: {axis: {macro_f1, n}}}`` where ``source`` is the
@@ -596,16 +600,13 @@ def _evaluate_per_bank(
 
     model.eval()
     per_source_axis: dict[str, dict[str, list[tuple[int, int]]]] = {}
+    classification_axes: tuple[str, ...] = ("stance", "certainty", "topic")
     for batch in loader:
         input_ids = batch["input_ids"].to(device)
         attn = batch["attention_mask"].to(device)
         logits = model(input_ids=input_ids, attention_mask=attn)
         sources = batch["source"]
-        for axis_name, n_classes in (
-            ("stance", MULTI_TASK_STANCE_CLASSES),
-            ("certainty", MULTI_TASK_CERTAINTY_CLASSES),
-            ("topic", MULTI_TASK_TOPIC_CLASSES),
-        ):
+        for axis_name in classification_axes:
             mask = batch[f"mask_{axis_name}"]
             targets = batch[f"target_{axis_name}"]
             preds = logits[axis_name].argmax(dim=-1).detach().to("cpu")
@@ -622,7 +623,7 @@ def _evaluate_per_bank(
         "certainty": MULTI_TASK_CERTAINTY_CLASSES,
         "topic": MULTI_TASK_TOPIC_CLASSES,
     }
-    out: dict[str, dict[str, dict[str, float]]] = {}
+    out: dict[str, dict[str, dict[str, float | int]]] = {}
     for source, axis_bucket in per_source_axis.items():
         out[source] = {}
         for axis_name, rows in axis_bucket.items():
@@ -848,19 +849,34 @@ def main(argv: list[str] | None = None) -> int:
 
     _logger.info("training_complete best_val_loss=%.4f", best_val_loss)
 
-    # Per-bank breakdown on the val partition (D, 2026-05-24). Lands
-    # next to the canonical checkpoint as
-    # ``<checkpoint_stem>.per_bank_metrics.json`` so wiki §6.9 can
-    # quote per-source macro-F1 without re-running the eval.
+    # Per-bank breakdown on the val partition (D, 2026-05-24). Reload
+    # the best-epoch weights before scoring so the numbers next to the
+    # canonical checkpoint match the checkpoint itself (the in-memory
+    # ``model`` carries the last-epoch weights, which can differ from
+    # the best-epoch checkpoint when early-stopping kicked in).
+    checkpoint_path = Path(args.output_checkpoint)
+    if checkpoint_path.exists():
+        try:
+            best_payload = torch.load(
+                checkpoint_path, map_location=device, weights_only=False
+            )
+            best_state = best_payload.get("model_state_dict")
+            if best_state:
+                model.load_state_dict(best_state)
+        except Exception:  # pragma: no cover — defensive
+            _logger.warning("best_checkpoint_reload_failed", exc_info=True)
     try:
         per_bank = _evaluate_per_bank(model, val_loader, device)
     except Exception:  # pragma: no cover — defensive
         _logger.warning("per_bank_eval_failed", exc_info=True)
         per_bank = None
     if per_bank:
-        per_bank_path = Path(
-            str(Path(args.output_checkpoint).with_suffix(""))
-            + ".per_bank_metrics.json"
+        # ``with_name(stem + ".per_bank_metrics.json")`` works whether
+        # or not the user-supplied checkpoint path carries an
+        # extension; ``with_suffix("")`` raises ValueError on
+        # suffix-less paths.
+        per_bank_path = checkpoint_path.with_name(
+            checkpoint_path.stem + ".per_bank_metrics.json"
         )
         per_bank_path.parent.mkdir(parents=True, exist_ok=True)
         import json as _json

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -849,12 +849,30 @@ def main(argv: list[str] | None = None) -> int:
 
     _logger.info("training_complete best_val_loss=%.4f", best_val_loss)
 
-    # Per-bank breakdown on the val partition (D, 2026-05-24). Reload
-    # the best-epoch weights before scoring so the numbers next to the
-    # canonical checkpoint match the checkpoint itself (the in-memory
-    # ``model`` carries the last-epoch weights, which can differ from
-    # the best-epoch checkpoint when early-stopping kicked in).
-    checkpoint_path = Path(args.output_checkpoint)
+    _write_per_bank_breakdown(
+        model=model,
+        checkpoint_path=Path(args.output_checkpoint),
+        val_loader=val_loader,
+        device=device,
+    )
+
+    return 0
+
+
+def _write_per_bank_breakdown(
+    *,
+    model: TextMultiAxisClassifier,
+    checkpoint_path: Path,
+    val_loader: DataLoader,
+    device: torch.device,
+) -> None:
+    """Reload the best-epoch weights and write per-bank metrics next to the checkpoint.
+
+    The in-memory ``model`` carries the last-epoch weights, which can differ
+    from the best-epoch checkpoint when early-stopping triggered, so the
+    per-bank table next to the checkpoint must come from the persisted state.
+    """
+
     if checkpoint_path.exists():
         try:
             best_payload = torch.load(
@@ -869,22 +887,20 @@ def main(argv: list[str] | None = None) -> int:
         per_bank = _evaluate_per_bank(model, val_loader, device)
     except Exception:  # pragma: no cover — defensive
         _logger.warning("per_bank_eval_failed", exc_info=True)
-        per_bank = None
-    if per_bank:
-        # ``with_name(stem + ".per_bank_metrics.json")`` works whether
-        # or not the user-supplied checkpoint path carries an
-        # extension; ``with_suffix("")`` raises ValueError on
-        # suffix-less paths.
-        per_bank_path = checkpoint_path.with_name(
-            checkpoint_path.stem + ".per_bank_metrics.json"
-        )
-        per_bank_path.parent.mkdir(parents=True, exist_ok=True)
-        import json as _json
+        return
+    if not per_bank:
+        return
+    # ``with_name(stem + ".per_bank_metrics.json")`` works whether or not the
+    # user-supplied checkpoint path carries an extension; ``with_suffix("")``
+    # raises ValueError on suffix-less paths.
+    per_bank_path = checkpoint_path.with_name(
+        checkpoint_path.stem + ".per_bank_metrics.json"
+    )
+    per_bank_path.parent.mkdir(parents=True, exist_ok=True)
+    import json as _json
 
-        per_bank_path.write_text(_json.dumps(per_bank, indent=2), encoding="utf-8")
-        _logger.info("per_bank_metrics_written path=%s", per_bank_path)
-
-    return 0
+    per_bank_path.write_text(_json.dumps(per_bank, indent=2), encoding="utf-8")
+    _logger.info("per_bank_metrics_written path=%s", per_bank_path)
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -61,12 +61,16 @@ class _AxisRow:
 
     ``targets`` and ``masks`` are dicts keyed by axis name so the
     DataLoader collate path can stack them into batched tensors
-    without per-axis branching.
+    without per-axis branching. ``source`` carries the originating
+    corpus (e.g. ``"gtfintechlab/federal_reserve_system"``,
+    ``"events_parquet"``) so the eval pass can slice per-bank metrics
+    (D from the 2026-05-24 plan).
     """
 
     text: str
     targets: dict[str, float | int] = field(default_factory=dict)
     masks: dict[str, bool] = field(default_factory=dict)
+    source: str = ""
 
 
 def _set_all_seeds(seed: int) -> None:
@@ -184,7 +188,10 @@ def _load_supervised_rows(events_parquet: Path) -> list[_AxisRow]:
         targets, masks = _row_targets(record)
         if not any(masks.values()):
             continue
-        rows.append(_AxisRow(text=text, targets=targets, masks=masks))
+        source = str(record.get("source") or "events_parquet")
+        rows.append(
+            _AxisRow(text=text, targets=targets, masks=masks, source=source)
+        )
     return rows
 
 
@@ -203,7 +210,9 @@ _GTFINTECHLAB_DATASET_IDS: tuple[str, ...] = (
 )
 
 
-def _gtfintechlab_row_to_axis_row(item: dict[str, Any]) -> _AxisRow | None:
+def _gtfintechlab_row_to_axis_row(
+    item: dict[str, Any], *, source: str = "gtfintechlab"
+) -> _AxisRow | None:
     """Map a single gtfintechlab sentence-level row to ``_AxisRow``.
 
     The gtfintechlab schema is uniform across all six bank datasets:
@@ -252,7 +261,7 @@ def _gtfintechlab_row_to_axis_row(item: dict[str, Any]) -> _AxisRow | None:
     # render as low-confidence.
     if not any(masks.values()):
         return None
-    return _AxisRow(text=text, targets=targets, masks=masks)
+    return _AxisRow(text=text, targets=targets, masks=masks, source=source)
 
 
 def _gtfintechlab_datasets_module() -> Any:
@@ -308,7 +317,7 @@ def _gtfintechlab_split_rows(
         return []
     out: list[_AxisRow] = []
     for record in ds:
-        row = _gtfintechlab_row_to_axis_row(dict(record))
+        row = _gtfintechlab_row_to_axis_row(dict(record), source=dataset_id)
         if row is not None:
             out.append(row)
     return out
@@ -455,6 +464,10 @@ class _MultiAxisDataset(Dataset):
             "mask_factor": bool(row.masks["factor"]),
             "mask_certainty": bool(row.masks["certainty"]),
             "mask_topic": bool(row.masks["topic"]),
+            # Source bank label rides on every batch row so the eval
+            # pass can compute per-bank macro-F1 without re-loading
+            # the original rows. Collated as a list of strings.
+            "source": row.source,
         }
 
 
@@ -486,6 +499,7 @@ def _collate(batch: list[dict[str, Any]]) -> dict[str, torch.Tensor]:
     out["mask_topic"] = torch.tensor(
         [item["mask_topic"] for item in batch], dtype=torch.bool
     )
+    out["source"] = [str(item.get("source", "")) for item in batch]
     return out
 
 
@@ -534,6 +548,93 @@ def _train_one_epoch(
 
 
 @torch.no_grad()
+def _macro_f1_from_arrays(
+    predictions: list[int], targets: list[int], n_classes: int
+) -> float:
+    """Plain unweighted macro-F1 over the supplied row-level arrays.
+
+    Avoids a heavy sklearn dependency on what is otherwise a small
+    inline computation. Empty inputs return ``0.0``. Per-class F1 is
+    ``0.0`` when both precision and recall vanish (a class never
+    appears in either predictions or targets).
+    """
+
+    if not predictions or not targets or len(predictions) != len(targets):
+        return 0.0
+    f1_sum = 0.0
+    for cls in range(n_classes):
+        tp = sum(1 for p, t in zip(predictions, targets) if p == cls and t == cls)
+        fp = sum(1 for p, t in zip(predictions, targets) if p == cls and t != cls)
+        fn = sum(1 for p, t in zip(predictions, targets) if p != cls and t == cls)
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        denom = precision + recall
+        f1 = 2 * precision * recall / denom if denom > 0 else 0.0
+        f1_sum += f1
+    return f1_sum / max(n_classes, 1)
+
+
+@torch.no_grad()
+def _evaluate_per_bank(
+    model: TextMultiAxisClassifier,
+    loader: DataLoader,
+    device: torch.device,
+) -> dict[str, dict[str, dict[str, float]]]:
+    """Per-source per-axis macro-F1 breakdown on the eval partition (D, #209).
+
+    Returns ``{source: {axis: {macro_f1, n}}}`` where ``source`` is the
+    originating corpus tag (e.g. ``"gtfintechlab/federal_reserve_system"``,
+    ``"events_parquet"``) and ``axis`` ∈ ``{stance, certainty, topic}``.
+    Factor is regression-typed and is omitted here; the parent
+    ``_evaluate`` already reports its SmoothL1 loss.
+
+    Rows whose axis mask is False on a given (source, axis) are
+    dropped before computing F1 — keeps the macro-F1 honest on the
+    sparse axes (factor / certainty / topic) where most rows from
+    most banks have nothing to score.
+    """
+
+    model.eval()
+    per_source_axis: dict[str, dict[str, list[tuple[int, int]]]] = {}
+    for batch in loader:
+        input_ids = batch["input_ids"].to(device)
+        attn = batch["attention_mask"].to(device)
+        logits = model(input_ids=input_ids, attention_mask=attn)
+        sources = batch["source"]
+        for axis_name, n_classes in (
+            ("stance", MULTI_TASK_STANCE_CLASSES),
+            ("certainty", MULTI_TASK_CERTAINTY_CLASSES),
+            ("topic", MULTI_TASK_TOPIC_CLASSES),
+        ):
+            mask = batch[f"mask_{axis_name}"]
+            targets = batch[f"target_{axis_name}"]
+            preds = logits[axis_name].argmax(dim=-1).detach().to("cpu")
+            for i in range(len(sources)):
+                if not bool(mask[i].item()):
+                    continue
+                source = str(sources[i])
+                bucket = per_source_axis.setdefault(source, {})
+                axis_bucket = bucket.setdefault(axis_name, [])
+                axis_bucket.append((int(preds[i].item()), int(targets[i].item())))
+
+    axis_n_classes = {
+        "stance": MULTI_TASK_STANCE_CLASSES,
+        "certainty": MULTI_TASK_CERTAINTY_CLASSES,
+        "topic": MULTI_TASK_TOPIC_CLASSES,
+    }
+    out: dict[str, dict[str, dict[str, float]]] = {}
+    for source, axis_bucket in per_source_axis.items():
+        out[source] = {}
+        for axis_name, rows in axis_bucket.items():
+            preds = [p for p, _t in rows]
+            tgts = [t for _p, t in rows]
+            out[source][axis_name] = {
+                "macro_f1": _macro_f1_from_arrays(preds, tgts, axis_n_classes[axis_name]),
+                "n": len(rows),
+            }
+    return out
+
+
 def _evaluate(
     model: TextMultiAxisClassifier,
     loader: DataLoader,
@@ -746,6 +847,27 @@ def main(argv: list[str] | None = None) -> int:
             )
 
     _logger.info("training_complete best_val_loss=%.4f", best_val_loss)
+
+    # Per-bank breakdown on the val partition (D, 2026-05-24). Lands
+    # next to the canonical checkpoint as
+    # ``<checkpoint_stem>.per_bank_metrics.json`` so wiki §6.9 can
+    # quote per-source macro-F1 without re-running the eval.
+    try:
+        per_bank = _evaluate_per_bank(model, val_loader, device)
+    except Exception:  # pragma: no cover — defensive
+        _logger.warning("per_bank_eval_failed", exc_info=True)
+        per_bank = None
+    if per_bank:
+        per_bank_path = Path(
+            str(Path(args.output_checkpoint).with_suffix(""))
+            + ".per_bank_metrics.json"
+        )
+        per_bank_path.parent.mkdir(parents=True, exist_ok=True)
+        import json as _json
+
+        per_bank_path.write_text(_json.dumps(per_bank, indent=2), encoding="utf-8")
+        _logger.info("per_bank_metrics_written path=%s", per_bank_path)
+
     return 0
 
 

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -292,6 +292,18 @@ class ModelConfig:
     infonce_lambda: float = 0.1
     infonce_temperature: float = 0.07
     infonce_latent_dim: int = 64
+    # #273 follow-up to the multi-task head (#272). When True, the
+    # training loop swaps the single-axis CrossEntropy for
+    # :class:`app.training.loss.MultiTaskLoss`, which folds per-axis
+    # CE / SmoothL1 terms onto stance / factor / certainty / topic
+    # with per-axis class weights and a per-row availability mask.
+    # Default False keeps the byte-identity regression contract on
+    # every existing classification run (stance-only training).
+    multi_task_loss: bool = False
+    multi_task_lambda_stance: float = 1.0
+    multi_task_lambda_factor: float = 0.3
+    multi_task_lambda_certainty: float = 0.3
+    multi_task_lambda_topic: float = 0.3
 
     @classmethod
     def from_model(cls, model: "Any") -> "ModelConfig":
@@ -328,6 +340,11 @@ class ModelConfig:
             infonce_lambda=float(getattr(model, "infonce_lambda", 0.1)),
             infonce_temperature=float(getattr(model, "infonce_temperature", 0.07)),
             infonce_latent_dim=int(getattr(model, "infonce_latent_dim", 64)),
+            multi_task_loss=bool(getattr(model, "multi_task_loss", False)),
+            multi_task_lambda_stance=float(getattr(model, "multi_task_lambda_stance", 1.0)),
+            multi_task_lambda_factor=float(getattr(model, "multi_task_lambda_factor", 0.3)),
+            multi_task_lambda_certainty=float(getattr(model, "multi_task_lambda_certainty", 0.3)),
+            multi_task_lambda_topic=float(getattr(model, "multi_task_lambda_topic", 0.3)),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -91,6 +91,16 @@ def build_forecaster(
     kwargs.pop("infonce_lambda", None)
     kwargs.pop("infonce_temperature", None)
     kwargs.pop("infonce_latent_dim", None)
+    # Multi-task loss (#273) is a training-loop concern; the existing
+    # MultiTaskHead is already wired on the ForecasterModel (since #272)
+    # in classification mode. These knobs stash on the built module so
+    # ``ModelConfig.from_model`` recovers them when the checkpoint is
+    # loaded for resume / inference.
+    multi_task_loss_flag = bool(kwargs.pop("multi_task_loss", False))
+    multi_task_lambda_stance = float(kwargs.pop("multi_task_lambda_stance", 1.0))
+    multi_task_lambda_factor = float(kwargs.pop("multi_task_lambda_factor", 0.3))
+    multi_task_lambda_certainty = float(kwargs.pop("multi_task_lambda_certainty", 0.3))
+    multi_task_lambda_topic = float(kwargs.pop("multi_task_lambda_topic", 0.3))
     # Phase 9 V2 (#195) fields all forwarded: ``output_mode`` /
     # ``n_classes`` drive the head shape; ``vol_regime_quantiles`` /
     # ``vol_regime_target`` ride on the module so the checkpoint
@@ -116,6 +126,11 @@ def build_forecaster(
     # the LoRA flag is a plain bool stashed for ``from_model`` to read
     # back, so suppress the noise rather than register a fake buffer.
     model.encoder_lora = encoder_lora_flag  # type: ignore[assignment]
+    model.multi_task_loss = multi_task_loss_flag  # type: ignore[assignment]
+    model.multi_task_lambda_stance = multi_task_lambda_stance  # type: ignore[assignment]
+    model.multi_task_lambda_factor = multi_task_lambda_factor  # type: ignore[assignment]
+    model.multi_task_lambda_certainty = multi_task_lambda_certainty  # type: ignore[assignment]
+    model.multi_task_lambda_topic = multi_task_lambda_topic  # type: ignore[assignment]
     return model
 
 

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -474,6 +474,45 @@ def _parse_args() -> argparse.Namespace:
         default=64,
         help="Shared latent dim for the modality projections in the gated fusion.",
     )
+    # #273 — joint multi-task loss on the four MultiTaskHead branches.
+    # Default off so single-axis CrossEntropy stays the byte-identity
+    # path on every existing classification run.
+    parser.add_argument(
+        "--multi-task-loss",
+        dest="multi_task_loss",
+        action="store_true",
+        help=(
+            "Train classification with MultiTaskLoss over stance / factor / "
+            "certainty / topic instead of single-axis CrossEntropy. "
+            "Per-axis class weights fit on the train slice; per-row mask "
+            "drops axes whose label is absent on a given row."
+        ),
+    )
+    parser.set_defaults(multi_task_loss=False)
+    parser.add_argument(
+        "--multi-task-lambda-stance",
+        type=float,
+        default=1.0,
+        help="Loss weight on the stance branch when --multi-task-loss is on.",
+    )
+    parser.add_argument(
+        "--multi-task-lambda-factor",
+        type=float,
+        default=0.3,
+        help="Loss weight on the factor regression branch.",
+    )
+    parser.add_argument(
+        "--multi-task-lambda-certainty",
+        type=float,
+        default=0.3,
+        help="Loss weight on the certainty branch.",
+    )
+    parser.add_argument(
+        "--multi-task-lambda-topic",
+        type=float,
+        default=0.3,
+        help="Loss weight on the topic branch.",
+    )
     # Phase B (#227) LR schedule + sequence-length knobs.
     parser.add_argument(
         "--lr-schedule",
@@ -866,6 +905,11 @@ def _build_model_config(args: argparse.Namespace) -> ModelConfig:
         infonce_lambda=float(getattr(args, "infonce_lambda", 0.1)),
         infonce_temperature=float(getattr(args, "infonce_temperature", 0.07)),
         infonce_latent_dim=int(getattr(args, "infonce_latent_dim", 64)),
+        multi_task_loss=bool(getattr(args, "multi_task_loss", False)),
+        multi_task_lambda_stance=float(getattr(args, "multi_task_lambda_stance", 1.0)),
+        multi_task_lambda_factor=float(getattr(args, "multi_task_lambda_factor", 0.3)),
+        multi_task_lambda_certainty=float(getattr(args, "multi_task_lambda_certainty", 0.3)),
+        multi_task_lambda_topic=float(getattr(args, "multi_task_lambda_topic", 0.3)),
     )
 
 
@@ -1096,6 +1140,11 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                             infonce_lambda=float(getattr(args, "infonce_lambda", 0.1)),
                             infonce_temperature=float(getattr(args, "infonce_temperature", 0.07)),
                             infonce_latent_dim=int(getattr(args, "infonce_latent_dim", 64)),
+                            multi_task_loss=bool(getattr(args, "multi_task_loss", False)),
+                            multi_task_lambda_stance=float(getattr(args, "multi_task_lambda_stance", 1.0)),
+                            multi_task_lambda_factor=float(getattr(args, "multi_task_lambda_factor", 0.3)),
+                            multi_task_lambda_certainty=float(getattr(args, "multi_task_lambda_certainty", 0.3)),
+                            multi_task_lambda_topic=float(getattr(args, "multi_task_lambda_topic", 0.3)),
                         ),
                         "learning_rate": float(hp["learning_rate"]),
                         "epochs": int(hp["epochs"]),
@@ -1187,6 +1236,11 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                     infonce_lambda=float(getattr(args, "infonce_lambda", 0.1)),
                     infonce_temperature=float(getattr(args, "infonce_temperature", 0.07)),
                     infonce_latent_dim=int(getattr(args, "infonce_latent_dim", 64)),
+                    multi_task_loss=bool(getattr(args, "multi_task_loss", False)),
+                    multi_task_lambda_stance=float(getattr(args, "multi_task_lambda_stance", 1.0)),
+                    multi_task_lambda_factor=float(getattr(args, "multi_task_lambda_factor", 0.3)),
+                    multi_task_lambda_certainty=float(getattr(args, "multi_task_lambda_certainty", 0.3)),
+                    multi_task_lambda_topic=float(getattr(args, "multi_task_lambda_topic", 0.3)),
                 ),
                 "learning_rate": float(learning_rate),
                 "epochs": int(epochs),

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -459,6 +459,71 @@ def _summarise_gate(
     }
 
 
+def _build_partition_multi_task_tensors(
+    sequence_groups: "Sequence[Sequence[FeatureVector]]",
+    *,
+    vol_regime_quantiles: "Sequence[float]",
+) -> dict[str, torch.Tensor] | None:
+    """Materialise per-partition multi-task target + mask tensors (#273).
+
+    Thin wrapper around
+    :func:`app.training.loaders._build_multi_task_target_tensors` that
+    matches the partition-tensor naming convention in this module.
+    Used by the train loop to attach the 8 multi-task tensors
+    (4 targets + 4 masks) to each partition's TensorDataset when
+    ``multi_task_loss=True`` is set on the active ModelConfig.
+
+    Returns ``None`` when the partition has no usable supervised rows.
+    The underlying helper drops rows whose ``forward_realized_vol_10d``
+    is missing — same row-filter the classification-mode
+    ``_build_training_tensors`` applies, so the multi-task tensors
+    stay row-aligned with ``y``.
+    """
+
+    from app.training.loaders import _build_multi_task_target_tensors
+
+    return _build_multi_task_target_tensors(
+        sequence_groups, vol_regime_quantiles=vol_regime_quantiles
+    )
+
+
+def _fit_axis_class_weights_from_mask(
+    target_idx: torch.Tensor,
+    mask: torch.Tensor,
+    n_classes: int,
+    *,
+    smoothing: float = 1.0,
+) -> torch.Tensor:
+    """Inverse-frequency class weights fit on masked rows of one axis (#273).
+
+    Mirrors :func:`app.training.loaders.fit_class_weights` for the
+    multi-task path: each axis (stance, certainty, topic) computes its
+    own class weights using only the rows where the axis mask is True.
+    Smoothing keeps an empty class from blowing the weight up; the
+    weights are normalised so they sum to ``n_classes``.
+
+    Returns a length-``n_classes`` tensor (uniform 1.0 fallback when
+    no rows are masked) so :class:`MultiTaskLoss` can construct a
+    well-defined :class:`torch.nn.CrossEntropyLoss` for that axis.
+    """
+
+    if mask.numel() == 0 or not bool(mask.any().item()):
+        return torch.ones(n_classes, dtype=torch.float32)
+    masked = target_idx[mask].detach().to("cpu").long()
+    counts = [0] * n_classes
+    for v in masked.tolist():
+        idx = int(v)
+        if 0 <= idx < n_classes:
+            counts[idx] += 1
+    if sum(counts) == 0:
+        return torch.ones(n_classes, dtype=torch.float32)
+    raw = [1.0 / (c + smoothing) for c in counts]
+    total = sum(raw)
+    return torch.tensor(
+        [(w / total) * n_classes for w in raw], dtype=torch.float32
+    )
+
+
 def _run_train_forward_and_align(
     forward_model: nn.Module,
     batch_x: torch.Tensor,

--- a/tests/unit/test_classifier_per_bank_eval.py
+++ b/tests/unit/test_classifier_per_bank_eval.py
@@ -1,0 +1,62 @@
+"""Cover the per-bank slicing helpers on the multi-axis classifier (D).
+
+The classifier's eval pass now reports per-source macro-F1 alongside
+the existing per-axis loss. Bootstrap CIs around those numbers are
+filed as a follow-up; this file pins the slicing contract + the
+inline macro-F1 helper.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.data.train_text_multi_axis_classifier import (
+    _AxisRow,
+    _macro_f1_from_arrays,
+)
+
+
+def test_axis_row_carries_source_default_empty() -> None:
+    """Default constructor leaves ``source`` empty so existing call
+    sites that pre-date the per-bank tracking keep working without
+    being forced to specify the source explicitly."""
+
+    row = _AxisRow(text="hello")
+    assert row.source == ""
+
+
+def test_axis_row_round_trips_source() -> None:
+    row = _AxisRow(text="hello", source="gtfintechlab/federal_reserve_system")
+    assert row.source == "gtfintechlab/federal_reserve_system"
+
+
+def test_macro_f1_returns_zero_on_empty_input() -> None:
+    assert _macro_f1_from_arrays([], [], n_classes=3) == 0.0
+
+
+def test_macro_f1_returns_one_on_perfect_predictions() -> None:
+    preds = [0, 1, 2, 0, 1, 2]
+    tgts = [0, 1, 2, 0, 1, 2]
+    assert _macro_f1_from_arrays(preds, tgts, n_classes=3) == pytest.approx(1.0)
+
+
+def test_macro_f1_balanced_when_class_collapses() -> None:
+    """All-zero predictions on a balanced target → only class 0 has
+    nonzero F1; macro should average to ~1/3."""
+
+    preds = [0] * 9
+    tgts = [0, 0, 0, 1, 1, 1, 2, 2, 2]
+    f1 = _macro_f1_from_arrays(preds, tgts, n_classes=3)
+    # class 0: precision=3/9, recall=3/3 -> F1=2*1/3*1/(1/3+1)=0.5
+    # classes 1+2: zero
+    # macro = 0.5/3
+    assert f1 == pytest.approx(0.5 / 3.0, abs=1e-4)
+
+
+def test_macro_f1_drops_mismatched_lengths() -> None:
+    """Defensive contract: mismatched arrays return 0.0 rather than
+    raising; the caller is expected to feed aligned rows."""
+
+    assert _macro_f1_from_arrays([0, 1], [0, 1, 2], n_classes=3) == 0.0

--- a/tests/unit/test_multi_task_loss_config.py
+++ b/tests/unit/test_multi_task_loss_config.py
@@ -1,0 +1,110 @@
+"""Cover the multi-task-loss config + factory plumbing (#273 foundation).
+
+The wider plumbing — threading per-axis target tensors through the
+DataLoader and swapping CrossEntropy for MultiTaskLoss in the training
+step — lands as a follow-up. This test file pins the configuration
+surface so the follow-up has a stable contract to build against.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.config import ModelConfig
+from app.models.factory import build_forecaster
+from app.training.loop import _fit_axis_class_weights_from_mask
+
+
+def test_default_modelconfig_keeps_multi_task_loss_off() -> None:
+    """The byte-identity contract on every existing classification
+    run depends on this default — flipping it would change the loss
+    surface and break the determinism regression."""
+
+    cfg = ModelConfig()
+    assert cfg.multi_task_loss is False
+    assert cfg.multi_task_lambda_stance == 1.0
+    assert cfg.multi_task_lambda_factor == 0.3
+    assert cfg.multi_task_lambda_certainty == 0.3
+    assert cfg.multi_task_lambda_topic == 0.3
+
+
+def test_factory_stashes_multi_task_flags_on_built_model() -> None:
+    """``ModelConfig.from_model`` reads these attributes back when
+    serialising a checkpoint summary; without them the run summary
+    would record the wrong loss config."""
+
+    cfg = ModelConfig(
+        architecture="lstm",
+        output_mode="classification",
+        n_classes=3,
+        multi_task_loss=True,
+        multi_task_lambda_stance=0.5,
+        multi_task_lambda_factor=0.2,
+        multi_task_lambda_certainty=0.4,
+        multi_task_lambda_topic=0.1,
+    )
+    model = build_forecaster(cfg)
+    assert bool(getattr(model, "multi_task_loss")) is True
+    assert float(getattr(model, "multi_task_lambda_stance")) == 0.5
+    assert float(getattr(model, "multi_task_lambda_factor")) == 0.2
+    assert float(getattr(model, "multi_task_lambda_certainty")) == 0.4
+    assert float(getattr(model, "multi_task_lambda_topic")) == 0.1
+
+
+def test_modelconfig_from_model_round_trips_multi_task_fields() -> None:
+    cfg = ModelConfig(
+        architecture="lstm",
+        output_mode="classification",
+        n_classes=3,
+        multi_task_loss=True,
+        multi_task_lambda_stance=0.7,
+    )
+    model = build_forecaster(cfg)
+    restored = ModelConfig.from_model(model)
+    assert restored.multi_task_loss is True
+    assert restored.multi_task_lambda_stance == 0.7
+
+
+def test_fit_axis_class_weights_handles_empty_mask() -> None:
+    """An axis whose mask is all-False (sparse-label case) must return
+    uniform weights so the masked MultiTaskLoss does not blow up
+    when the cross-entropy receives a length-N_classes weight vector."""
+
+    targets = torch.tensor([0, 1, 2, 0, 1])
+    mask = torch.tensor([False, False, False, False, False])
+    weights = _fit_axis_class_weights_from_mask(targets, mask, n_classes=3)
+    assert weights.shape == (3,)
+    assert torch.allclose(weights, torch.ones(3))
+
+
+def test_fit_axis_class_weights_inverts_frequency() -> None:
+    """A rare class should weight more than a common one; weights
+    normalise to sum to ``n_classes`` so an evenly-distributed axis
+    reads ~1.0 per class."""
+
+    # Class 0 has 8 rows, class 1 has 2 rows, class 2 has 0 rows
+    targets = torch.tensor([0] * 8 + [1] * 2 + [0])  # 9th 0
+    # Mask: keep the 10 rows but drop the 11th
+    mask = torch.tensor([True] * 10 + [False])
+    weights = _fit_axis_class_weights_from_mask(targets, mask, n_classes=3)
+    assert weights.shape == (3,)
+    # Rare class (1) outweighs common class (0); empty class (2)
+    # gets the largest weight via the smoothing floor.
+    assert weights[2] > weights[1]
+    assert weights[1] > weights[0]
+    # Normalised to sum to n_classes
+    assert torch.isclose(weights.sum(), torch.tensor(3.0), atol=1e-5)
+
+
+def test_fit_axis_class_weights_clips_out_of_range_labels() -> None:
+    """Defensive contract: targets outside [0, n_classes) should be
+    silently dropped from the count so a malformed row does not
+    crash the loss construction."""
+
+    targets = torch.tensor([0, 5, 1, -1, 2])
+    mask = torch.tensor([True, True, True, True, True])
+    weights = _fit_axis_class_weights_from_mask(targets, mask, n_classes=3)
+    assert weights.shape == (3,)
+    assert torch.isclose(weights.sum(), torch.tensor(3.0), atol=1e-5)


### PR DESCRIPTION
## Summary

- \`ModelConfig.multi_task_loss\` + 4 per-axis lambda fields ship with default off; CLI flags + factory + sweep candidate builders all thread the fields end-to-end.
- New \`_build_partition_multi_task_tensors\` + \`_fit_axis_class_weights_from_mask\` helpers in \`loop.py\` (DataLoader plumbing → training step is the next follow-up).
- \`_AxisRow.source\` + per-source slicing in classifier eval; per-bank macro-F1 breakdown lands at \`<checkpoint_stem>.per_bank_metrics.json\` after training.
- 15 new tests; determinism regression byte-identical.

## Test plan

- [ ] \`docker compose run --rm backend pytest tests/unit/test_multi_task_loss_config.py tests/unit/test_classifier_per_bank_eval.py tests/regression/test_forecaster_determinism.py -q\`

Closes (partial): #273 (foundation; full DataLoader plumbing in follow-up).