### PR TITLE
Strict-forward 10-day realised-vol target convention

### DIFF
--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -954,16 +954,30 @@ def _volatility_shift(
     *,
     window: int = VOL_WINDOW_DAYS,
 ) -> float | None:
+    """Post-event vol minus pre-event vol around an as-of bar.
+
+    Both windows are computed from log returns with sample std (ddof=1).
+    The pre-window covers returns on days ``t-window .. t-1`` (strictly
+    before the event) and the post-window covers returns on days
+    ``t+1 .. t+window`` (strictly after the event), where ``t`` is the
+    first bar on or after ``as_of``. ``close[t]`` participates only as
+    the denominator of the post-window's first return, never as a
+    numerator, so the announcement-day close-to-close move does not
+    enter either window. Matches the strict-forward convention used by
+    ``_forward_realized_vol``.
+    """
+
     base_idx = series.index_strictly_before(as_of)
     if base_idx < window:
         return None
     on_or_after = series.index_on_or_after(as_of)
-    if on_or_after + window > len(series):
+    if on_or_after + window >= len(series):
         return None
     pre_closes = series.close[base_idx - window : base_idx + 1]
     pre_rets = _log_returns(pre_closes)
-    post_closes = series.close[on_or_after - 1 : on_or_after + window]
-    # post_closes spans (t-1, t, t+1, ..., t+window-1) -> window returns
+    post_closes = series.close[on_or_after : on_or_after + window + 1]
+    # post_closes spans (t, t+1, ..., t+window) -> window strict-forward
+    # returns log(close[t+1]/close[t]) ... log(close[t+window]/close[t+window-1]).
     post_rets = _log_returns(post_closes)
     if len(pre_rets) < 2 or len(post_rets) < 2:
         return None
@@ -982,7 +996,7 @@ def _forward_realized_vol(
     *,
     window: int = 10,
 ) -> float | None:
-    """Realised volatility of log returns over the next ``window`` trading days.
+    """Realised volatility of log returns over the *strictly* next ``window`` trading days.
 
     Target for the Phase 9 V2 vol-regime classifier (#195). 10 trading
     days is the default to keep the window clean of the FOMC blackout
@@ -990,19 +1004,34 @@ def _forward_realized_vol(
     ``None`` when the event sits within ``window`` days of the end of
     the price series (no forward window available).
 
-    Computed as ``std(log_return(close[t:t+window]))`` with sample std
-    (ddof=1). The first log-return uses ``close[t]`` -- i.e. the close
-    on the event date -- as the denominator so the window does NOT
-    include the as-of bar itself.
+    Computed as ``std(log_return(close[t+1 .. t+window]))`` with sample
+    std (ddof=1), where ``t`` is the index of the event bar (first close
+    on or after ``as_of``). The returns produced are
+    ``log(close[t+1]/close[t])`` through
+    ``log(close[t+window]/close[t+window-1])`` — strictly post-event.
+    ``close[t]`` participates only as the denominator of the first
+    return, never as a numerator, so the announcement-day close-to-close
+    move (``log(close[t]/close[t-1])``) does not enter the target. This
+    keeps the target disjoint from any feature derived from ``close[t]``
+    (notably ``FeatureVector.market_close`` at the as-of bar) and the
+    classification contract clean of look-ahead.
+
+    A previous convention used the slice
+    ``close[t-1 .. t+window-1]``, which folded
+    ``log(close[t]/close[t-1])`` (the announcement-day reaction) into
+    the target as the first return. That created a mechanical overlap
+    with the day-``t`` close feature on the input side. The current
+    slice ``close[t .. t+window]`` is the strict-forward replacement.
     """
 
     on_or_after = series.index_on_or_after(as_of)
-    if on_or_after + window > len(series):
+    # Need ``window`` strictly-forward returns: indices
+    # ``on_or_after, on_or_after+1, ..., on_or_after+window`` must
+    # all be in range, so ``on_or_after + window`` must be a valid
+    # index (i.e. ``< len(series)``).
+    if on_or_after + window >= len(series):
         return None
-    # close[on_or_after-1] is the bar immediately before the event;
-    # close[on_or_after:on_or_after+window] is the t+1..t+window window.
-    # log returns of (t, t+1, ..., t+window) give ``window`` values.
-    closes = series.close[on_or_after - 1 : on_or_after + window]
+    closes = series.close[on_or_after : on_or_after + window + 1]
     rets = _log_returns(closes)
     if len(rets) < 2:
         return None

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -147,7 +147,17 @@ Required columns (full schema in module docstring):
     strictly before `as_of_ts`.
   - `direction_t1d` — sign of the t+1d realized return (-1, 0, +1).
 - `volatility_shift` — post-event 10d realized vol minus pre-event 10d
-  realized vol (log returns; sample std).
+  realized vol (log returns; sample std). Both windows are strict-flank:
+  the pre-window covers returns on days `t-10..t-1` and the post-window
+  covers returns on days `t+1..t+10`, where `t` is the first trading bar
+  on or after the event. `close[t]` participates only as the denominator
+  of the post-window's first return, never as a numerator, so the
+  announcement-day close-to-close move does not enter either flank.
+- `forward_realized_vol_10d` — strict-forward 10-day realised vol over
+  `t+1..t+10`, sample std of log returns (ddof=1). This is the target
+  column for the Phase 9 V2 vol-regime classifier (#195). Per-fold
+  quantile cutoffs map this continuous value to a 3-class label at
+  training time (train-slice fit only; never on val / test).
 - `concurrent_macro_release` — boolean. True when a major US macro
   release (CPI, NFP, ISM) falls within ±2 trading days. Flagged only;
   no event is dropped on this basis. The calendar is loaded from

--- a/tests/unit/test_forward_realized_vol_strict_forward.py
+++ b/tests/unit/test_forward_realized_vol_strict_forward.py
@@ -1,0 +1,150 @@
+"""Pin the strict-forward window for `_forward_realized_vol` + `_volatility_shift`.
+
+Both helpers used to include the announcement-day close-to-close return
+as the first bar of their post-event window. The strict-forward
+convention (matching the textbook definition of ``RV_{t+1:t+window}``)
+restricts the window to bars strictly after the event so the target /
+post-event feature stays disjoint from any input feature derived from
+``close[t]``. These tests pin the slicing so a future refactor cannot
+silently regress to the deprecated convention.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import math
+
+import pytest
+
+from app.data import event_dataset_builder as edb
+
+
+def _series_with_constructed_returns(closes: list[float]) -> edb._CloseSeries:
+    """Build a `_CloseSeries` whose dates are dense trading days starting 2025-01-02."""
+
+    base = _dt.date(2025, 1, 2)
+    dates: list[_dt.date] = []
+    cursor = base
+    while len(dates) < len(closes):
+        if cursor.weekday() < 5:  # Mon-Fri
+            dates.append(cursor)
+        cursor += _dt.timedelta(days=1)
+    return edb._CloseSeries(
+        dates=dates,
+        close=[float(c) for c in closes],
+        volume=[0.0] * len(closes),
+    )
+
+
+def test_forward_realized_vol_excludes_announcement_day_return() -> None:
+    """The first log return in the target window must be `log(close[t+1]/close[t])`.
+
+    Constructed so the announcement-day return is huge (close jumps 100 → 200, a
+    log-return of +0.693) and every strictly-forward return is zero (constant
+    close at 200). Under the strict-forward convention the std collapses to 0;
+    under the deprecated convention it would be the std of one 0.693 plus nine
+    zeros (~0.219).
+    """
+
+    # Layout:
+    #   idx:  0   1   2   3   4   5   6   7   8   9   10   11
+    #   day: t-1   t  t+1 t+2 ...                          t+10
+    # Choose enough bars before t so `_volatility_shift`'s pre-window works
+    # in the sibling test below.
+    pre_bars = 30
+    closes = (
+        [100.0] * pre_bars              # bars before t
+        + [200.0]                       # close at t (announcement-day jump)
+        + [200.0] * 11                  # close at t+1 .. t+10 + 1 spare
+    )
+    series = _series_with_constructed_returns(closes)
+    as_of = series.dates[pre_bars]      # t = bar at index pre_bars
+    rv = edb._forward_realized_vol(series, as_of, window=10)
+    assert rv is not None
+    # 10 returns, all equal to 0 (constant closes 200, 200, ..., 200)
+    # std of zeros is 0.0
+    assert rv == pytest.approx(0.0, abs=1e-12), (
+        f"Strict-forward RV should be 0 when post-event closes are flat; "
+        f"got {rv}. A non-zero value means the announcement-day return is "
+        "leaking into the target window."
+    )
+
+
+def test_forward_realized_vol_first_return_uses_close_t_as_denominator() -> None:
+    """`log(close[t+1] / close[t])` should be the first return.
+
+    Constructed so day-t close is 100, day-t+1 close is 110 (+9.5 % log
+    return), all subsequent closes are 110 (zero returns). The standard
+    deviation across the 10 returns of (ln(1.1), 0, 0, ..., 0) has a
+    known closed form we can pin.
+    """
+
+    pre_bars = 30
+    closes = [100.0] * pre_bars + [100.0, 110.0] + [110.0] * 10
+    series = _series_with_constructed_returns(closes)
+    as_of = series.dates[pre_bars]
+    rv = edb._forward_realized_vol(series, as_of, window=10)
+    assert rv is not None
+
+    rets = [math.log(110.0 / 100.0)] + [0.0] * 9
+    n = len(rets)
+    mean = sum(rets) / n
+    expected = math.sqrt(sum((v - mean) ** 2 for v in rets) / (n - 1))
+    assert rv == pytest.approx(expected, abs=1e-12)
+
+
+def test_forward_realized_vol_returns_none_at_end_of_series() -> None:
+    """A bar within ``window`` days of the end has no full forward window."""
+
+    pre_bars = 30
+    # Only 5 strictly-forward bars available after `t`; window=10 -> None.
+    closes = [100.0] * pre_bars + [100.0] * 5
+    series = _series_with_constructed_returns(closes)
+    as_of = series.dates[pre_bars]
+    assert edb._forward_realized_vol(series, as_of, window=10) is None
+
+
+def test_forward_realized_vol_accepts_exactly_window_forward_bars() -> None:
+    """A bar with exactly ``window`` strictly-forward bars must NOT return None.
+
+    Strict-forward needs ``window`` returns, which needs ``window+1`` closes
+    starting from ``close[t]``. A series with ``t`` at index ``N - window - 1``
+    has exactly that many bars and should produce a finite value.
+    """
+
+    pre_bars = 30
+    window = 10
+    closes = [100.0] * pre_bars + [100.0] + [101.0] * window
+    series = _series_with_constructed_returns(closes)
+    as_of = series.dates[pre_bars]
+    rv = edb._forward_realized_vol(series, as_of, window=window)
+    assert rv is not None
+    assert math.isfinite(rv)
+
+
+def test_volatility_shift_excludes_announcement_day_return() -> None:
+    """The post-window in `_volatility_shift` must be strict-forward too.
+
+    Construct a series where the announcement day jumps but the pre and
+    post windows are both flat. Under strict-forward the shift is exactly
+    ``std(post) - std(pre) = 0 - 0 = 0``; under the deprecated
+    convention the post window would include the day-t jump and produce
+    a positive shift.
+    """
+
+    window = edb.VOL_WINDOW_DAYS
+    pre_bars = window + 5  # plenty of room before t
+    closes = (
+        [100.0] * pre_bars
+        + [200.0]                       # close at t (announcement-day jump)
+        + [200.0] * (window + 1)        # flat post-event
+    )
+    series = _series_with_constructed_returns(closes)
+    as_of = series.dates[pre_bars]
+    shift = edb._volatility_shift(series, as_of, window=window)
+    assert shift is not None
+    assert shift == pytest.approx(0.0, abs=1e-12), (
+        f"Strict-forward vol shift should be 0 when both flanks are flat; "
+        f"got {shift}. A non-zero value means the announcement-day return "
+        "is leaking into the post-event window."
+    )

--- a/tests/unit/test_forward_realized_vol_strict_forward.py
+++ b/tests/unit/test_forward_realized_vol_strict_forward.py
@@ -97,7 +97,8 @@ def test_forward_realized_vol_returns_none_at_end_of_series() -> None:
     """A bar within ``window`` days of the end has no full forward window."""
 
     pre_bars = 30
-    # Only 5 strictly-forward bars available after `t`; window=10 -> None.
+    # ``t`` lands at index ``pre_bars``; only 4 strictly-forward bars exist
+    # after it (indices pre_bars+1 .. pre_bars+4). window=10 -> guard fires.
     closes = [100.0] * pre_bars + [100.0] * 5
     series = _series_with_constructed_returns(closes)
     as_of = series.dates[pre_bars]


### PR DESCRIPTION
## Summary

- `_forward_realized_vol` + `_volatility_shift` use the strict-forward slice `close[t .. t+window]`; first return is now `log(close[t+1]/close[t])`, not `log(close[t]/close[t-1])`.
- Removes the mechanical overlap between the target's first return and `FeatureVector.market_close` at the as-of bar (`close[t]` participates only as a denominator, never as a numerator).
- Boundary guard tightens to `on_or_after + window >= len(series)` so the strict-forward slice always has `window + 1` valid closes.
- Five new tests in `test_forward_realized_vol_strict_forward.py` pin the convention so a future refactor cannot regress.
- Wiki §6.7 grows a "Target convention correction" subsection; ADR 0014 captures the design decisions.
- New training package ID convention: `tp_v3_macro_aug_2026_05_24_fwd_strict_v1.0`. The deprecated package stays on disk to reproduce the historical 0.5225 number.
- Path B 0.5225 stays in §6.7 as historical record under the deprecated convention; new canonical headline lands once the Transformer best-HP cell re-runs against the strict-forward package.

## Test plan

- `docker compose run --rm backend pytest tests/unit/test_forward_realized_vol_strict_forward.py -q`
- `docker compose run --rm backend pytest tests/unit/test_event_dataset_builder.py tests/unit/test_event_dataset_builder_macro_release.py tests/unit/test_event_dataset_builder_axis_labels.py tests/unit/test_event_dataset_builder_macro_slopes.py tests/unit/test_event_dataset_builder_credibility.py -q`