### PR TITLE
Frontend polish bundle: coverage chip, breakdown surface, batch endpoint, drift chart

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 import io
 import json
 import logging
+import time
 from contextlib import asynccontextmanager
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -14,6 +15,7 @@ from sqlalchemy.orm import Session
 
 from app.config import DATA_DIR
 from app.db import (
+    AnalysisRun,
     delete_run,
     get_engine,
     get_run,
@@ -30,6 +32,7 @@ from app.schemas import (
     ArtifactFile,
     DocumentParseResponse,
     DocumentParseUrlRequest,
+    EvaluationCoverageResponse,
     FomcCalendarResponse,
     HistoryDetail,
     HistoryEntry,
@@ -713,6 +716,80 @@ def get_history_realized_batch(
         except Exception:  # pragma: no cover — partial failures degrade silently
             missing.append(run_id)
     return HistoryRealizedBatchResponse(items=items, missing=missing)
+
+
+# In-memory cache for /evaluation/coverage. Aggregation walks up to
+# ``lookback_runs`` history rows and triggers one yfinance call per row,
+# so refresh latency is on the order of 10-30s in the worst case. A
+# 5-minute TTL keeps the workspace headline chip responsive without
+# pinning a worker on every page load. Cleared by the test fixture.
+_COVERAGE_CACHE_TTL_SECONDS = 5 * 60
+_coverage_cache: dict[str, tuple[float, "EvaluationCoverageResponse"]] = {}
+
+
+def _reset_coverage_cache() -> None:
+    _coverage_cache.clear()
+
+
+@app.get("/evaluation/coverage", response_model=EvaluationCoverageResponse)
+def evaluation_coverage(
+    symbol: str | None = Query(default=None),
+    lookback_runs: int = Query(default=50, ge=1, le=200),
+    session: Session = Depends(get_session),
+) -> EvaluationCoverageResponse:
+    """Aggregate empirical conformal coverage across recent history runs.
+
+    Empirical = fraction of runs where the realized regime label fell
+    inside that run's predicted set. Nominal is the conformal target the
+    active model was calibrated to (read off the most-recent run that
+    carries ``series.forecast_confidence_level``). Rows without a
+    ``regime_classification.predicted_set`` or without a fetchable
+    realized regime are skipped. Results cached for 5 minutes."""
+
+    cache_key = f"{symbol or '*'}:{lookback_runs}"
+    cached = _coverage_cache.get(cache_key)
+    now = time.monotonic()
+    if cached and now - cached[0] < _COVERAGE_CACHE_TTL_SECONDS:
+        return cached[1]
+
+    query = session.query(AnalysisRun).order_by(AnalysisRun.created_at.desc())
+    if symbol:
+        query = query.filter(AnalysisRun.symbol == symbol)
+    rows = query.limit(lookback_runs).all()
+
+    nominal: float | None = None
+    inside = 0
+    sample_size = 0
+    for row in rows:
+        payload = row.payload if isinstance(row.payload, dict) else {}
+        regime = payload.get("regime_classification") or {}
+        predicted_set = regime.get("predicted_set")
+        if not isinstance(predicted_set, list) or not predicted_set:
+            continue
+        if nominal is None:
+            series = payload.get("series") or {}
+            level = series.get("forecast_confidence_level")
+            if isinstance(level, int | float):
+                nominal = float(level)
+        try:
+            realized = _build_realized_payload(row)
+        except Exception:  # pragma: no cover — yfinance failures skip the row
+            continue
+        if realized.realized_regime is None:
+            continue
+        sample_size += 1
+        if realized.realized_regime in predicted_set:
+            inside += 1
+
+    response = EvaluationCoverageResponse(
+        nominal=nominal,
+        empirical=(inside / sample_size) if sample_size else None,
+        sample_size=sample_size,
+        runs_total=len(rows),
+        computed_at=datetime.now(timezone.utc).isoformat(),
+    )
+    _coverage_cache[cache_key] = (now, response)
+    return response
 
 
 @app.get("/fomc/calendar", response_model=FomcCalendarResponse)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -697,7 +697,18 @@ def get_history_realized_batch(
     rows and yfinance failures land under ``missing`` so a single broken
     row does not nuke the table render."""
 
-    id_list = [chunk.strip() for chunk in ids.split(",") if chunk.strip()]
+    # Order-preserving dedupe so a caller passing the same id twice
+    # only triggers one yfinance lookup, and the response order matches
+    # the request order on the way back.
+    seen: set[str] = set()
+    id_list: list[str] = []
+    for chunk in ids.split(","):
+        chunk = chunk.strip()
+        if not chunk or chunk in seen:
+            continue
+        seen.add(chunk)
+        id_list.append(chunk)
+
     if not id_list:
         raise HTTPException(
             status_code=422, detail="ids must contain at least one run id"
@@ -724,9 +735,12 @@ def get_history_realized_batch(
 
 # In-memory cache for /evaluation/coverage. Aggregation walks up to
 # ``lookback_runs`` history rows and triggers one yfinance call per row,
-# so refresh latency is on the order of 10-30s in the worst case. A
-# 5-minute TTL keeps the workspace headline chip responsive without
-# pinning a worker on every page load. Cleared by the test fixture.
+# so cold-cache latency can climb into tens of seconds. The default is
+# tightened to 25 and the hard cap to 100 to keep the workspace
+# headline chip from pinning a worker on first hit; a 5-minute TTL
+# absorbs repeated visits. A persisted realized-regime column on the
+# history row would let us drop the yfinance hop entirely — tracked as
+# the next-step polish item.
 _COVERAGE_CACHE_TTL_SECONDS = 5 * 60
 _coverage_cache: dict[str, tuple[float, "EvaluationCoverageResponse"]] = {}
 
@@ -738,7 +752,7 @@ def _reset_coverage_cache() -> None:
 @app.get("/evaluation/coverage", response_model=EvaluationCoverageResponse)
 def evaluation_coverage(
     symbol: str | None = Query(default=None),
-    lookback_runs: int = Query(default=50, ge=1, le=200),
+    lookback_runs: int = Query(default=25, ge=1, le=100),
     session: Session = Depends(get_session),
 ) -> EvaluationCoverageResponse:
     """Aggregate empirical conformal coverage across recent history runs.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,6 +30,9 @@ from app.schemas import (
     AnalyzeRequest,
     AnalyzeResponse,
     ArtifactFile,
+    ClassificationBreakdownClass,
+    ClassificationBreakdownResponse,
+    ClassificationBreakdownSource,
     DocumentParseResponse,
     DocumentParseUrlRequest,
     EvaluationCoverageResponse,
@@ -54,6 +57,7 @@ from app.services.document_parser import (
     parse_url,
 )
 from app.services.decision_forecast import load_next_fomc_artifacts
+from app.services.classification_breakdown_loader import load_latest as load_classification_breakdown
 from app.services.fomc_calendar import get_calendar
 from app.services.research_artifacts import (
     SECTIONS as RESEARCH_SECTIONS,
@@ -790,6 +794,41 @@ def evaluation_coverage(
     )
     _coverage_cache[cache_key] = (now, response)
     return response
+
+
+@app.get(
+    "/evaluation/classification-breakdown",
+    response_model=ClassificationBreakdownResponse,
+)
+def evaluation_classification_breakdown() -> ClassificationBreakdownResponse:
+    """Surface the freshest classification breakdown written by the
+    regime training scripts under ``data/artifacts/regime_*``. When no
+    qualifying artifact exists the response is ``available=False`` and
+    the /performance dashboard falls back to its client-side
+    aggregation."""
+
+    payload = load_classification_breakdown(DATA_DIR / "artifacts")
+    if payload is None:
+        return ClassificationBreakdownResponse(available=False)
+    return ClassificationBreakdownResponse(
+        available=True,
+        confusion_matrix=payload.confusion_matrix,
+        per_class=[ClassificationBreakdownClass(**row) for row in payload.per_class],
+        macro_f1=payload.macro_f1,
+        macro_precision=payload.macro_precision,
+        macro_recall=payload.macro_recall,
+        macro_roc_auc=payload.macro_roc_auc,
+        macro_pr_auc=payload.macro_pr_auc,
+        weighted_f1=payload.weighted_f1,
+        n_classes=payload.n_classes,
+        class_labels=payload.class_labels,
+        source=ClassificationBreakdownSource(
+            relative_path=payload.source_relative,
+            training_package_id=payload.training_package_id,
+            checkpoint_path=payload.checkpoint_path,
+            modified_at=payload.modified_at,
+        ),
+    )
 
 
 @app.get("/fomc/calendar", response_model=FomcCalendarResponse)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,6 +34,7 @@ from app.schemas import (
     HistoryDetail,
     HistoryEntry,
     HistoryList,
+    HistoryRealizedBatchResponse,
     HistoryRealizedResponse,
     NextFomcForecastResponse,
     ResearchArtifactsResponse,
@@ -645,22 +646,13 @@ def delete_history_run(run_id: str, session: Session = Depends(get_session)) -> 
         raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
 
 
-@app.get("/history/{run_id}/realized", response_model=HistoryRealizedResponse)
-def get_history_run_realized(
-    run_id: str, session: Session = Depends(get_session)
-) -> HistoryRealizedResponse:
-    row = get_run(session, run_id)
-    if row is None:
-        raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+def _build_realized_payload(row) -> HistoryRealizedResponse:
     steps = parse_horizon_steps(row.horizon)
-    try:
-        realized = fetch_realized_forward(
-            target_date=row.document_date,
-            symbol=row.symbol,
-            steps=steps,
-        )
-    except Exception as exc:  # pragma: no cover — yfinance failures bubble as 502
-        raise HTTPException(status_code=502, detail=f"Market lookup failed: {exc}") from exc
+    realized = fetch_realized_forward(
+        target_date=row.document_date,
+        symbol=row.symbol,
+        steps=steps,
+    )
     return HistoryRealizedResponse(
         run_id=row.id,
         symbol=row.symbol,
@@ -673,6 +665,54 @@ def get_history_run_realized(
             float(realized[-1]["volatility_5d"]) if realized else None
         ),
     )
+
+
+@app.get("/history/{run_id}/realized", response_model=HistoryRealizedResponse)
+def get_history_run_realized(
+    run_id: str, session: Session = Depends(get_session)
+) -> HistoryRealizedResponse:
+    row = get_run(session, run_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+    try:
+        return _build_realized_payload(row)
+    except Exception as exc:  # pragma: no cover — yfinance failures bubble as 502
+        raise HTTPException(status_code=502, detail=f"Market lookup failed: {exc}") from exc
+
+
+@app.get("/history-realized", response_model=HistoryRealizedBatchResponse)
+def get_history_realized_batch(
+    ids: str = Query(..., description="Comma-separated run IDs (max 50)"),
+    session: Session = Depends(get_session),
+) -> HistoryRealizedBatchResponse:
+    """Batch the per-row realized fetch the /history list page used to do
+    one row at a time. ``ids`` is the comma-joined run-id list; deleted
+    rows and yfinance failures land under ``missing`` so a single broken
+    row does not nuke the table render."""
+
+    id_list = [chunk.strip() for chunk in ids.split(",") if chunk.strip()]
+    if not id_list:
+        raise HTTPException(
+            status_code=422, detail="ids must contain at least one run id"
+        )
+    if len(id_list) > 50:
+        raise HTTPException(
+            status_code=422,
+            detail=f"ids must contain at most 50 run ids; got {len(id_list)}",
+        )
+
+    items: dict[str, HistoryRealizedResponse] = {}
+    missing: list[str] = []
+    for run_id in id_list:
+        row = get_run(session, run_id)
+        if row is None:
+            missing.append(run_id)
+            continue
+        try:
+            items[run_id] = _build_realized_payload(row)
+        except Exception:  # pragma: no cover — partial failures degrade silently
+            missing.append(run_id)
+    return HistoryRealizedBatchResponse(items=items, missing=missing)
 
 
 @app.get("/fomc/calendar", response_model=FomcCalendarResponse)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -345,6 +345,55 @@ class EvaluationCoverageResponse(BaseModel):
     computed_at: str
 
 
+class ClassificationBreakdownClass(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    class_id: int
+    precision: float
+    recall: float
+    f1: float
+    support: int
+    roc_auc: float | None = None
+    pr_auc: float | None = None
+
+
+class ClassificationBreakdownSource(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    relative_path: str
+    training_package_id: str | None = None
+    checkpoint_path: str | None = None
+    modified_at: str
+
+
+class ClassificationBreakdownResponse(BaseModel):
+    """The richer eval emitted by app/evaluation/classification_breakdown.py.
+
+    Surfaces the freshest ``best_trial.summary.metrics.classification_breakdown``
+    block written under ``data/artifacts/regime_*``. ``available`` is
+    false when no qualifying artifact exists — the UI then falls back to
+    its client-side aggregation across history rows."""
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    available: bool
+    confusion_matrix: list[list[int]] | None = None
+    per_class: list[ClassificationBreakdownClass] | None = None
+    macro_f1: float | None = None
+    macro_precision: float | None = None
+    macro_recall: float | None = None
+    macro_roc_auc: float | None = None
+    macro_pr_auc: float | None = None
+    weighted_f1: float | None = None
+    n_classes: int | None = None
+    # Frontend assumes the canonical {calm, normal, high} ordering for
+    # 3-class regime models. ``class_labels`` is filled when the source
+    # artifact carries it; otherwise the field is None and the UI uses
+    # its defaults.
+    class_labels: list[str] | None = None
+    source: ClassificationBreakdownSource | None = None
+
+
 class SymbolDescriptor(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -327,6 +327,24 @@ class HistoryRealizedBatchResponse(BaseModel):
     missing: list[str]
 
 
+class EvaluationCoverageResponse(BaseModel):
+    """Empirical conformal coverage aggregated across recent history runs.
+
+    ``nominal`` is the conformal target the active model was calibrated
+    to (read off the most-recent run that carries
+    ``series.forecast_confidence_level``). ``empirical`` is the fraction
+    of runs whose realized regime label fell inside the predicted set.
+    Both are None when no qualifying runs exist."""
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    nominal: float | None = None
+    empirical: float | None = None
+    sample_size: int
+    runs_total: int
+    computed_at: str
+
+
 class SymbolDescriptor(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -318,6 +318,15 @@ class HistoryRealizedResponse(BaseModel):
     realized_regime: str | None = None
 
 
+class HistoryRealizedBatchResponse(BaseModel):
+    """Batched realized payloads keyed by run_id. Missing runs (deleted,
+    yfinance failure) come back under ``missing`` so the caller can render
+    a partial result instead of failing the whole page."""
+
+    items: dict[str, HistoryRealizedResponse]
+    missing: list[str]
+
+
 class SymbolDescriptor(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 

--- a/backend/app/services/classification_breakdown_loader.py
+++ b/backend/app/services/classification_breakdown_loader.py
@@ -1,0 +1,180 @@
+"""Surface the freshest ``classification_breakdown`` block from the
+regime sweep artifacts at ``data/artifacts/regime_*``.
+
+Files are emitted by ``app/evaluation/classification_breakdown.py``
+during training; their well-known shape is
+``best_trial.summary.metrics.classification_breakdown``. The loader
+walks every matching JSON, picks the most-recently-modified file that
+actually carries the breakdown, and returns the block plus enough
+provenance for the UI to deep-link back to the source. Missing artifact
+returns a sentinel ``available=False`` payload so the dashboard renders
+its fallback aggregation instead of erroring."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+LOGGER = logging.getLogger(__name__)
+
+# Directories under ``data/artifacts/`` that the regime training scripts
+# write breakdown JSON into. New sweep names should be added here when
+# they ship; missing directories are tolerated.
+_SCAN_PREFIXES: tuple[str, ...] = (
+    "regime_baseline_tiers",
+    "regime_arch_sweep",
+    "regime_arch_sweep_chunk1",
+    "regime_arch_sweep_macro_aug",
+    "regime_capacity_push",
+    "regime_pretrain_sweep",
+    "regime_baseline",
+)
+
+
+@dataclass(frozen=True)
+class BreakdownPayload:
+    confusion_matrix: list[list[int]]
+    per_class: list[dict[str, Any]]
+    macro_f1: float | None
+    macro_precision: float | None
+    macro_recall: float | None
+    macro_roc_auc: float | None
+    macro_pr_auc: float | None
+    weighted_f1: float | None
+    n_classes: int | None
+    class_labels: list[str] | None
+    source_relative: str
+    training_package_id: str | None
+    checkpoint_path: str | None
+    modified_at: str
+
+
+def _iter_candidate_files(artifacts_root: Path) -> Iterable[Path]:
+    for prefix in _SCAN_PREFIXES:
+        root = artifacts_root / prefix
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*.json"):
+            if path.is_file():
+                yield path
+
+
+def _extract_breakdown(payload: Any) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+    best_trial = payload.get("best_trial")
+    if not isinstance(best_trial, dict):
+        return None
+    summary = best_trial.get("summary")
+    if not isinstance(summary, dict):
+        return None
+    metrics = summary.get("metrics")
+    if not isinstance(metrics, dict):
+        return None
+    breakdown = metrics.get("classification_breakdown")
+    if not isinstance(breakdown, dict):
+        return None
+    if not isinstance(breakdown.get("confusion_matrix"), list):
+        return None
+    if not isinstance(breakdown.get("per_class"), list):
+        return None
+    return breakdown
+
+
+def _try_load(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        LOGGER.debug("classification_breakdown skip %s: %s", path, exc)
+        return None
+
+
+def load_latest(artifacts_root: Path) -> BreakdownPayload | None:
+    """Walk the regime sweep directories under ``artifacts_root`` and
+    return the freshest breakdown payload, or None when no artifact
+    carries the expected shape."""
+
+    best: tuple[float, Path, dict[str, Any], dict[str, Any]] | None = None
+    for path in _iter_candidate_files(artifacts_root):
+        payload = _try_load(path)
+        if payload is None:
+            continue
+        breakdown = _extract_breakdown(payload)
+        if breakdown is None:
+            continue
+        mtime = path.stat().st_mtime
+        if best is None or mtime > best[0]:
+            best = (mtime, path, payload, breakdown)
+    if best is None:
+        return None
+
+    mtime, path, payload, breakdown = best
+    relative = str(path.relative_to(artifacts_root))
+    modified_iso = (
+        datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
+    )
+
+    per_class_raw = breakdown.get("per_class") or []
+    per_class: list[dict[str, Any]] = []
+    for entry in per_class_raw:
+        if not isinstance(entry, dict):
+            continue
+        per_class.append(
+            {
+                "class_id": int(entry.get("class_id", 0)),
+                "precision": float(entry.get("precision", 0.0)),
+                "recall": float(entry.get("recall", 0.0)),
+                "f1": float(entry.get("f1", 0.0)),
+                "support": int(entry.get("support", 0)),
+                "roc_auc": _maybe_float(entry.get("roc_auc")),
+                "pr_auc": _maybe_float(entry.get("pr_auc")),
+            }
+        )
+
+    labels = breakdown.get("class_labels")
+    if not (isinstance(labels, list) and all(isinstance(x, str) for x in labels)):
+        labels = None
+
+    return BreakdownPayload(
+        confusion_matrix=[
+            [int(v) for v in row]
+            for row in breakdown.get("confusion_matrix", [])
+            if isinstance(row, list)
+        ],
+        per_class=per_class,
+        macro_f1=_maybe_float(breakdown.get("macro_f1")),
+        macro_precision=_maybe_float(breakdown.get("macro_precision")),
+        macro_recall=_maybe_float(breakdown.get("macro_recall")),
+        macro_roc_auc=_maybe_float(breakdown.get("macro_roc_auc")),
+        macro_pr_auc=_maybe_float(breakdown.get("macro_pr_auc")),
+        weighted_f1=_maybe_float(breakdown.get("weighted_f1")),
+        n_classes=_maybe_int(breakdown.get("n_classes")),
+        class_labels=labels,
+        source_relative=relative,
+        training_package_id=_maybe_str(payload.get("training_package_id")),
+        checkpoint_path=_maybe_str(payload.get("checkpoint_path")),
+        modified_at=modified_iso,
+    )
+
+
+def _maybe_float(value: Any) -> float | None:
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def _maybe_int(value: Any) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return None
+
+
+def _maybe_str(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    return None

--- a/backend/app/services/classification_breakdown_loader.py
+++ b/backend/app/services/classification_breakdown_loader.py
@@ -86,12 +86,25 @@ def _extract_breakdown(payload: Any) -> dict[str, Any] | None:
     return breakdown
 
 
+# Skip very large sweep JSONs (>10MB). The breakdown-bearing artifacts
+# we care about are small per-trial summaries; the multi-megabyte files
+# are full hyperparameter sweep dumps that don't carry the breakdown
+# block at all. Walking them costs hundreds of MB of memory on hosts
+# that have accumulated several sweep runs.
+_MAX_CANDIDATE_BYTES = 10 * 1024 * 1024
+
+
 def _try_load(path: Path) -> dict[str, Any] | None:
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        if path.stat().st_size > _MAX_CANDIDATE_BYTES:
+            return None
+        raw = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as exc:
         LOGGER.debug("classification_breakdown skip %s: %s", path, exc)
         return None
+    if not isinstance(raw, dict):
+        return None
+    return raw
 
 
 def load_latest(artifacts_root: Path) -> BreakdownPayload | None:

--- a/frontend/components/analyze/CredibilityKpis.tsx
+++ b/frontend/components/analyze/CredibilityKpis.tsx
@@ -23,6 +23,28 @@ export function CredibilityKpis({ credibility }: CredibilityKpisProps) {
   const marketGap = credibility.market_implied_gap;
   const monthsSince = credibility.months_since_reversal;
   const marketGapReady = isMarketGapAvailable(marketGap);
+  const driftReady = Math.abs(drift) > 1e-6 || (credibility.drift_trend?.length ?? 0) > 1;
+  const allFlat =
+    !driftReady &&
+    realizedGap == null &&
+    !marketGapReady &&
+    monthsSince == null;
+
+  if (allFlat) {
+    return (
+      <div className="rounded-md border border-dashed border-border bg-muted/20 p-4 text-xs text-muted-foreground">
+        <p className="mb-1 text-[10px] uppercase tracking-wide text-foreground">
+          Credibility features unpopulated
+        </p>
+        <p>
+          The credibility module ran but every signal is at its placeholder value. Needs the
+          prior four FOMC statements + the DFF history under <code className="rounded bg-muted px-1">data/external/fred/</code>
+          {" "}to compute drift, realized-vs-stated gap, and months-since-reversal. The
+          market-implied gap stays N/A until the SEP / OIS curve scrapers ship.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">

--- a/frontend/components/analyze/CredibilityPanel.tsx
+++ b/frontend/components/analyze/CredibilityPanel.tsx
@@ -42,14 +42,14 @@ function MiniTrend({ trend }: { trend: number[] }) {
   );
 }
 
-function gapTone(value?: number): "hawkish" | "dovish" | "neutral" {
+function gapTone(value?: number | null): "hawkish" | "dovish" | "neutral" {
   if (value == null) return "neutral";
   if (value > 0.05) return "hawkish";
   if (value < -0.05) return "dovish";
   return "neutral";
 }
 
-function formatGap(value?: number): string {
+function formatGap(value?: number | null): string {
   if (value == null) return "—";
   return `${value >= 0 ? "+" : ""}${value.toFixed(2)}`;
 }

--- a/frontend/components/analyze/MultiAxisInterpretation.tsx
+++ b/frontend/components/analyze/MultiAxisInterpretation.tsx
@@ -117,6 +117,26 @@ export function MultiAxisInterpretation({
   const stanceHistory = history?.stance;
   const factorHistory = history?.factor;
   const certaintyHistory = history?.certainty;
+  const allAxesNull =
+    !multiAxis.stance && !multiAxis.factor && !multiAxis.certainty && !multiAxis.topic;
+
+  if (allAxesNull) {
+    return (
+      <div className="rounded-md border border-dashed border-border bg-muted/20 p-4 text-xs text-muted-foreground sm:col-span-2">
+        <p className="mb-1 text-[10px] uppercase tracking-wide text-foreground">
+          Multi-axis classifier returned no axis labels
+        </p>
+        <p>
+          The classifier ran but every head returned null. The most common cause is a missing
+          checkpoint at <code className="rounded bg-muted px-1">backend/models/multi_axis_classifier.pt</code>
+          {" "}or a passage shorter than the encoder context window. Train and deploy the
+          checkpoint, or paste a longer FOMC statement to populate stance, factor, certainty,
+          and topic.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="grid gap-3 sm:grid-cols-2">
       {multiAxis.stance ? <StanceTile stance={multiAxis.stance} history={stanceHistory} /> : null}

--- a/frontend/components/analyze/RegimeHeadline.tsx
+++ b/frontend/components/analyze/RegimeHeadline.tsx
@@ -123,11 +123,11 @@ export function RegimeHeadline({
             ) : null}
           </div>
         </div>
-        <CardTitle className="flex flex-wrap items-end gap-4">
-          <span className="numeric text-5xl font-semibold capitalize tracking-tight">
+        <CardTitle className="flex flex-wrap items-end gap-3 sm:gap-4">
+          <span className="numeric text-4xl font-semibold capitalize tracking-tight sm:text-5xl">
             {regime.argmax_class}
           </span>
-          <span className="numeric text-base text-muted-foreground">
+          <span className="numeric text-sm text-muted-foreground sm:text-base">
             argmax · {(argmaxProb * 100).toFixed(1)}%
           </span>
           <div className="flex flex-wrap items-center gap-1.5">

--- a/frontend/components/analyze/RegimeHeadline.tsx
+++ b/frontend/components/analyze/RegimeHeadline.tsx
@@ -17,6 +17,13 @@ interface RegimeHeadlineProps {
   history?: Array<{ documentDate: string; argmax: string | null; realized?: string | null }>;
   symbol?: string;
   documentDate?: string;
+  // Empirical conformal coverage across recent history (fraction in
+  // [0,1]). When provided alongside the run-level nominal coverage,
+  // the headline renders a "Nominal X% · Empirical Y%" chip so the
+  // calibration claim on the spine card is audited rather than
+  // asserted. Null/undefined hides the chip.
+  empiricalCoverage?: number | null;
+  empiricalCoverageSampleSize?: number | null;
 }
 
 function regimeBarClass(label: Regime): string {
@@ -51,9 +58,20 @@ export function RegimeHeadline({
   history,
   symbol,
   documentDate,
+  empiricalCoverage,
+  empiricalCoverageSampleSize,
 }: RegimeHeadlineProps) {
   const distribution = regime.distribution ?? {};
   const coveragePct = Math.round(regime.coverage * 100);
+  const hasEmpirical =
+    typeof empiricalCoverage === "number" &&
+    !Number.isNaN(empiricalCoverage) &&
+    (empiricalCoverageSampleSize ?? 0) > 0;
+  const empiricalPct = hasEmpirical
+    ? Math.round((empiricalCoverage as number) * 100)
+    : null;
+  const coverageDeltaPct = hasEmpirical && empiricalPct !== null ? empiricalPct - coveragePct : 0;
+  const coverageDriftLarge = Math.abs(coverageDeltaPct) >= 10;
   const knownOrder = new Set<string>(REGIME_ORDER);
   const extraLabels = Object.keys(distribution).filter((k) => !knownOrder.has(k));
   const renderOrder = [...REGIME_ORDER, ...extraLabels];
@@ -81,8 +99,23 @@ export function RegimeHeadline({
               </Badge>
             ) : null}
             <Badge variant="outline" className="numeric text-[10px]">
-              {coveragePct}% coverage · set size {regime.set_size}
+              {hasEmpirical
+                ? `Nominal ${coveragePct}% · Empirical ${empiricalPct}%`
+                : `${coveragePct}% coverage`}
+              {` · set size ${regime.set_size}`}
             </Badge>
+            {hasEmpirical && coverageDriftLarge ? (
+              <Badge
+                variant={coverageDeltaPct < 0 ? "hawkish" : "neutral"}
+                className="text-[10px]"
+                title={`Empirical coverage drifted ${
+                  coverageDeltaPct < 0 ? "below" : "above"
+                } nominal across ${empiricalCoverageSampleSize ?? 0} runs.`}
+              >
+                {coverageDeltaPct > 0 ? "+" : ""}
+                {coverageDeltaPct}pp drift
+              </Badge>
+            ) : null}
             {oodFlag ? (
               <Badge variant="hawkish" className="text-[10px]">
                 <AlertTriangle className="h-3 w-3" /> OOD

--- a/frontend/components/analyze/SentenceStrikeXaiPanel.tsx
+++ b/frontend/components/analyze/SentenceStrikeXaiPanel.tsx
@@ -4,6 +4,7 @@ import { Highlighter, Loader2, RotateCcw } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Sparkline } from "@/components/ui/sparkline";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type {
@@ -184,6 +185,74 @@ export function SentenceStrikeXaiPanel({
   const argmaxDiff = describeArgmaxDiff(baselineResult, currentResult);
   const stanceDelta = stanceConfidenceDelta(baselineResult, currentResult);
 
+  const baselineArgmax = baselineResult?.regime_classification?.argmax_class ?? null;
+  const baselineProb = baselineArgmax
+    ? baselineResult?.regime_classification?.distribution?.[baselineArgmax] ?? null
+    : null;
+  const currentProbForBaselineArgmax = baselineArgmax
+    ? currentResult?.regime_classification?.distribution?.[baselineArgmax] ?? null
+    : null;
+
+  // Cumulative probability for the *baseline argmax* class across every
+  // strike action. Index 0 is the un-struck baseline; subsequent points
+  // each correspond to one toggle. Resets to a single point when the
+  // strike set goes empty (Reset button) or when the baseline run
+  // changes (new analyze submit).
+  const [strikeHistory, setStrikeHistory] = React.useState<number[]>([]);
+  const lastRunIdentityRef = React.useRef<AnalyzeResult | null | undefined>(null);
+
+  React.useEffect(() => {
+    if (!interactive) {
+      // Read-only mode (e.g. /history detail render) — chart is meaningless.
+      if (strikeHistory.length !== 0) setStrikeHistory([]);
+      return;
+    }
+    if (struckSet.size === 0) {
+      if (baselineProb != null) {
+        if (strikeHistory.length !== 1 || strikeHistory[0] !== baselineProb) {
+          setStrikeHistory([baselineProb]);
+        }
+      } else if (strikeHistory.length !== 0) {
+        setStrikeHistory([]);
+      }
+      lastRunIdentityRef.current = currentResult;
+      return;
+    }
+    if (currentResult && currentResult !== lastRunIdentityRef.current) {
+      lastRunIdentityRef.current = currentResult;
+      if (currentProbForBaselineArgmax != null) {
+        setStrikeHistory((prev) => {
+          // Guard against double-append from React strict-mode double-effects.
+          if (
+            prev.length > 0 &&
+            prev[prev.length - 1] === currentProbForBaselineArgmax &&
+            prev.length === struckSet.size + 1
+          ) {
+            return prev;
+          }
+          return [...prev, currentProbForBaselineArgmax];
+        });
+      }
+    }
+  }, [
+    interactive,
+    struckSet.size,
+    baselineProb,
+    currentResult,
+    currentProbForBaselineArgmax,
+    strikeHistory,
+  ]);
+
+  const driftPoints = strikeHistory.length >= 2 ? strikeHistory : null;
+  const driftTone: "up" | "down" | "neutral" =
+    driftPoints && driftPoints.length >= 2
+      ? driftPoints[driftPoints.length - 1] > driftPoints[0]
+        ? "up"
+        : driftPoints[driftPoints.length - 1] < driftPoints[0]
+        ? "down"
+        : "neutral"
+      : "neutral";
+
   const handleToggle = React.useCallback(
     (index: number) => {
       if (!onMaskChange) return;
@@ -253,6 +322,33 @@ export function SentenceStrikeXaiPanel({
             : "Hover any sentence to see the five tokens with the largest attribution. "}
           {xai.method ? `Method: ${xai.method}.` : null}
         </CardDescription>
+        {driftPoints ? (
+          <div className="mt-3 rounded-md border border-border bg-muted/20 px-3 py-2">
+            <div className="flex items-center justify-between text-[10px] uppercase tracking-wide text-muted-foreground">
+              <span>
+                P({baselineArgmax ?? "argmax"}) across {driftPoints.length - 1} strike
+                {driftPoints.length - 1 === 1 ? "" : "s"}
+              </span>
+              <span className="numeric text-foreground">
+                {(driftPoints[0] * 100).toFixed(1)}% →{" "}
+                {(driftPoints[driftPoints.length - 1] * 100).toFixed(1)}%
+              </span>
+            </div>
+            <div className="mt-1.5">
+              <Sparkline
+                values={driftPoints}
+                tone={driftTone}
+                height={32}
+                formatTooltip={(value, label) =>
+                  `${label ?? ""} · ${(value * 100).toFixed(1)}%`
+                }
+                labels={driftPoints.map((_, idx) =>
+                  idx === 0 ? "baseline" : `+${idx} struck`,
+                )}
+              />
+            </div>
+          </div>
+        ) : null}
       </CardHeader>
       <CardContent>
         {isEmpty ? (

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -2,10 +2,13 @@ import axios from "axios";
 import type {
   AnalyzeRequest,
   AnalyzeResult,
+  ClassificationBreakdownResponse,
+  EvaluationCoverageResponse,
   FomcCalendarResponse,
   HistoryDetail,
   HistoryList,
   HistoryQuery,
+  HistoryRealizedBatchResponse,
   HistoryRealizedResponse,
   NextFomcForecastResponse,
   ResearchArtifactsResponse,
@@ -67,6 +70,42 @@ export async function fetchHistoryRealized(
 ): Promise<HistoryRealizedResponse> {
   const response = await axios.get(`${baseUrl}/history/${runId}/realized`, { signal });
   return response.data as HistoryRealizedResponse;
+}
+
+// Batched companion to ``fetchHistoryRealized``. The /history list page
+// used to fan out N parallel per-row requests; this collapses them to
+// one round trip. Deleted runs and yfinance failures land under
+// ``missing`` so a single broken row does not nuke the table render.
+export async function fetchHistoryRealizedBatch(
+  baseUrl: string,
+  runIds: readonly string[],
+  signal?: AbortSignal,
+): Promise<HistoryRealizedBatchResponse> {
+  if (runIds.length === 0) {
+    return { items: {}, missing: [] };
+  }
+  const response = await axios.get(`${baseUrl}/history-realized`, {
+    params: { ids: runIds.join(",") },
+    signal,
+  });
+  return response.data as HistoryRealizedBatchResponse;
+}
+
+export async function fetchEvaluationCoverage(
+  baseUrl: string,
+  params?: { symbol?: string; lookback_runs?: number },
+  signal?: AbortSignal,
+): Promise<EvaluationCoverageResponse> {
+  const response = await axios.get(`${baseUrl}/evaluation/coverage`, { params, signal });
+  return response.data as EvaluationCoverageResponse;
+}
+
+export async function fetchClassificationBreakdown(
+  baseUrl: string,
+  signal?: AbortSignal,
+): Promise<ClassificationBreakdownResponse> {
+  const response = await axios.get(`${baseUrl}/evaluation/classification-breakdown`, { signal });
+  return response.data as ClassificationBreakdownResponse;
 }
 
 // Pair-helper for the /compare page. There is no dedicated backend endpoint;

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -196,9 +196,13 @@ export interface XaiResponse {
 export interface CredibilityResponse {
   drift_score: number;
   drift_trend?: number[];
-  realized_vs_stated_gap?: number;
-  market_implied_gap?: number;
-  months_since_reversal?: number;
+  // Backend emits null when the gap can't be computed yet (missing
+  // realized series, missing DFF cache). The KPI tile reads `== null`
+  // so the runtime path tolerates undefined too — the union here just
+  // makes the type honest about both possibilities.
+  realized_vs_stated_gap?: number | null;
+  market_implied_gap?: number | null;
+  months_since_reversal?: number | null;
 }
 
 export interface RegimeClassificationResponse {

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -92,6 +92,51 @@ export interface HistoryRealizedResponse {
   realized_regime?: string | null;
 }
 
+export interface HistoryRealizedBatchResponse {
+  items: Record<string, HistoryRealizedResponse>;
+  missing: string[];
+}
+
+export interface EvaluationCoverageResponse {
+  nominal: number | null;
+  empirical: number | null;
+  sample_size: number;
+  runs_total: number;
+  computed_at: string;
+}
+
+export interface ClassificationBreakdownClass {
+  class_id: number;
+  precision: number;
+  recall: number;
+  f1: number;
+  support: number;
+  roc_auc?: number | null;
+  pr_auc?: number | null;
+}
+
+export interface ClassificationBreakdownSource {
+  relative_path: string;
+  training_package_id?: string | null;
+  checkpoint_path?: string | null;
+  modified_at: string;
+}
+
+export interface ClassificationBreakdownResponse {
+  available: boolean;
+  confusion_matrix?: number[][] | null;
+  per_class?: ClassificationBreakdownClass[] | null;
+  macro_f1?: number | null;
+  macro_precision?: number | null;
+  macro_recall?: number | null;
+  macro_roc_auc?: number | null;
+  macro_pr_auc?: number | null;
+  weighted_f1?: number | null;
+  n_classes?: number | null;
+  class_labels?: string[] | null;
+  source?: ClassificationBreakdownSource | null;
+}
+
 export type StanceAxis = "hawkish" | "dovish" | "neutral";
 export type CertaintyAxis = "certain" | "uncertain" | "neutral";
 export type TopicAxis = "macro" | "forward_guidance" | "market_reaction" | "other";

--- a/frontend/lib/analyze/useEvaluationCoverage.ts
+++ b/frontend/lib/analyze/useEvaluationCoverage.ts
@@ -15,12 +15,13 @@ interface UseEvaluationCoverageState {
 }
 
 /**
- * Polls /evaluation/coverage so the workspace can surface a "Nominal X% /
- * Empirical Y%" chip alongside the regime headline. Failures are
- * intentionally silent — the chip is informational and the workspace
- * should not flash an error toast when the aggregation has nothing to
- * show yet. Backend caches its own aggregation for 5 minutes; the hook
- * does not poll.
+ * Fetches /evaluation/coverage once per (baseUrl, symbol, lookback)
+ * tuple so the workspace can surface a "Nominal X% / Empirical Y%"
+ * chip alongside the regime headline. Failures are intentionally
+ * silent — the chip is informational and the workspace should not
+ * flash an error toast when the aggregation has nothing to show yet.
+ * Backend already caches its own aggregation for 5 minutes; no polling
+ * here.
  */
 export function useEvaluationCoverage(
   apiBaseUrl: string,

--- a/frontend/lib/analyze/useEvaluationCoverage.ts
+++ b/frontend/lib/analyze/useEvaluationCoverage.ts
@@ -1,0 +1,59 @@
+import * as React from "react";
+
+import { fetchEvaluationCoverage } from "@/lib/analyze/api";
+import type { EvaluationCoverageResponse } from "@/lib/analyze/types";
+
+interface UseEvaluationCoverageOptions {
+  symbol?: string;
+  lookbackRuns?: number;
+}
+
+interface UseEvaluationCoverageState {
+  data: EvaluationCoverageResponse | null;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Polls /evaluation/coverage so the workspace can surface a "Nominal X% /
+ * Empirical Y%" chip alongside the regime headline. Failures are
+ * intentionally silent — the chip is informational and the workspace
+ * should not flash an error toast when the aggregation has nothing to
+ * show yet. Backend caches its own aggregation for 5 minutes; the hook
+ * does not poll.
+ */
+export function useEvaluationCoverage(
+  apiBaseUrl: string,
+  options: UseEvaluationCoverageOptions = {},
+): UseEvaluationCoverageState {
+  const { symbol, lookbackRuns } = options;
+  const [state, setState] = React.useState<UseEvaluationCoverageState>({
+    data: null,
+    loading: true,
+    error: null,
+  });
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+    setState((prev) => ({ ...prev, loading: true }));
+    fetchEvaluationCoverage(
+      apiBaseUrl,
+      { symbol, lookback_runs: lookbackRuns },
+      controller.signal,
+    )
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        setState({ data, loading: false, error: null });
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        const message = err instanceof Error ? err.message : "coverage fetch failed";
+        setState({ data: null, loading: false, error: message });
+      });
+    return () => {
+      controller.abort();
+    };
+  }, [apiBaseUrl, symbol, lookbackRuns]);
+
+  return state;
+}

--- a/frontend/pages/calendar.tsx
+++ b/frontend/pages/calendar.tsx
@@ -87,8 +87,8 @@ export default function CalendarPage() {
         <StatusBar />
         <main id="main-content" tabIndex={-1} className="container space-y-6 py-8 focus:outline-none">
           <div className="space-y-2">
-            <h1 className="text-3xl font-semibold tracking-tight flex items-center gap-2">
-              <CalendarIcon className="h-7 w-7 text-primary" />
+            <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight sm:text-3xl">
+              <CalendarIcon className="h-6 w-6 text-primary sm:h-7 sm:w-7" />
               FOMC calendar
             </h1>
             <p className="max-w-2xl text-muted-foreground">

--- a/frontend/pages/compare.tsx
+++ b/frontend/pages/compare.tsx
@@ -486,7 +486,7 @@ export default function ComparePage() {
         <StatusBar />
         <main id="main-content" tabIndex={-1} className="container space-y-6 py-8 focus:outline-none">
           <div className="space-y-2">
-            <h1 className="text-3xl font-semibold tracking-tight">Compare runs</h1>
+            <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Compare runs</h1>
             <p className="max-w-2xl text-muted-foreground">
               Pick two past analyses and see the stance, prediction, and confidence deltas side by
               side. Selections are sticky in the URL — share the link to send a paired view.

--- a/frontend/pages/history/index.tsx
+++ b/frontend/pages/history/index.tsx
@@ -30,7 +30,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
   deleteHistoryRun,
   fetchHistory,
-  fetchHistoryRealized,
+  fetchHistoryRealizedBatch,
   resolveApiBaseUrl,
 } from "@/lib/analyze/api";
 import { stanceLabel, toStance } from "@/lib/analyze/format";
@@ -90,23 +90,25 @@ export default function HistoryPage() {
         if (signal.aborted) return;
         setItems(result.items.map((row) => ({ ...row, realized_regime: null })));
         setTotal(result.total);
-        // Per-row realized fetches share the same signal so a filter
-        // change cancels them before stale writes hit setItems.
-        result.items.forEach(async (row) => {
-          try {
-            const realized = await fetchHistoryRealized(apiBaseUrl, row.id, signal);
-            if (signal.aborted) return;
-            setItems((prev) =>
-              prev.map((entry) =>
-                entry.id === row.id
-                  ? { ...entry, realized_regime: realized.realized_regime ?? null }
-                  : entry,
-              ),
-            );
-          } catch {
-            // Realized fetch is best-effort; aborted requests land here too.
-          }
-        });
+        // One batched round trip replaces the N per-row fetches the page
+        // used to fan out. Backend caps the batch at 50 ids; the page
+        // limit defaults to 50 so the call fits in one request. Failures
+        // are best-effort — aborted requests and yfinance hiccups leave
+        // the realized column on "pending" rather than nuking the table.
+        const ids = result.items.map((row) => row.id);
+        try {
+          const batch = await fetchHistoryRealizedBatch(apiBaseUrl, ids, signal);
+          if (signal.aborted) return;
+          setItems((prev) =>
+            prev.map((entry) => {
+              const realized = batch.items[entry.id];
+              if (!realized) return entry;
+              return { ...entry, realized_regime: realized.realized_regime ?? null };
+            }),
+          );
+        } catch {
+          // Best-effort: realized column stays "pending" on batch failure.
+        }
       } catch (err) {
         if (!signal.aborted) {
           toast.error((err as Error).message || "Failed to load history.");

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/lib/analyze/api";
 import { DEFAULT_TEXT } from "@/lib/analyze/constants";
 import { toStance } from "@/lib/analyze/format";
+import { useEvaluationCoverage } from "@/lib/analyze/useEvaluationCoverage";
 import type { AnalyzeRequest, AnalyzeResult, HistoryEntry, Horizon } from "@/lib/analyze/types";
 import {
   DEFAULT_HORIZON,
@@ -81,6 +82,7 @@ export default function WorkspacePage() {
   const [loading, setLoading] = React.useState(false);
   const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
   const [historyEntries, setHistoryEntries] = React.useState<RegimeHistoryEntry[]>([]);
+  const coverage = useEvaluationCoverage(apiBaseUrl, { symbol: request.symbol });
 
   // Apply saved workspace prefs (default symbol / horizon) after mount.
   // Doing this in an effect rather than the initial state preserves the
@@ -334,6 +336,8 @@ export default function WorkspacePage() {
                   symbol={request.symbol}
                   documentDate={request.date}
                   history={regimeHistorySpark}
+                  empiricalCoverage={coverage.data?.empirical ?? null}
+                  empiricalCoverageSampleSize={coverage.data?.sample_size ?? null}
                 />
               ) : result.prediction?.close != null ? (
                 <LegacyForecastCard

--- a/frontend/pages/performance.tsx
+++ b/frontend/pages/performance.tsx
@@ -24,8 +24,9 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { KpiTile } from "@/components/ui/kpi-tile";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
+  fetchClassificationBreakdown,
   fetchHistory,
-  fetchHistoryRealized,
+  fetchHistoryRealizedBatch,
   fetchHistoryRun,
   resolveApiBaseUrl,
 } from "@/lib/analyze/api";
@@ -35,7 +36,11 @@ import {
   buildRunRegimeRecord,
   type RunRegimeRecord,
 } from "@/lib/analyze/performance";
-import type { HistoryEntry } from "@/lib/analyze/types";
+import type {
+  ClassificationBreakdownResponse,
+  HistoryEntry,
+  HistoryRealizedBatchResponse,
+} from "@/lib/analyze/types";
 
 const HISTORY_LIMIT = 100;
 
@@ -61,6 +66,7 @@ export default function PerformancePage() {
   const [rows, setRows] = React.useState<RunRegimeRecord[]>([]);
   const [loading, setLoading] = React.useState(true);
   const [totalRuns, setTotalRuns] = React.useState(0);
+  const [breakdown, setBreakdown] = React.useState<ClassificationBreakdownResponse | null>(null);
 
   React.useEffect(() => {
     const controller = new AbortController();
@@ -68,23 +74,37 @@ export default function PerformancePage() {
     setLoading(true);
     (async () => {
       try {
-        const list = await fetchHistory(apiBaseUrl, { limit: HISTORY_LIMIT }, signal);
+        const [list, breakdownResponse] = await Promise.all([
+          fetchHistory(apiBaseUrl, { limit: HISTORY_LIMIT }, signal),
+          fetchClassificationBreakdown(apiBaseUrl, signal).catch(() => null),
+        ]);
         if (signal.aborted) return;
         setTotalRuns(list.total);
-        const records = await Promise.all(
-          list.items.map(async (entry: HistoryEntry) => {
-            const [realized, detail] = await Promise.all([
-              fetchHistoryRealized(apiBaseUrl, entry.id, signal).catch(() => null),
+        setBreakdown(breakdownResponse);
+        // Realized labels fetched in one batched round trip; per-row
+        // history-detail (payload) still needs a fan-out because the
+        // persisted predicted_set list isn't carried on the summary.
+        const ids = list.items.map((entry) => entry.id);
+        const emptyBatch: HistoryRealizedBatchResponse = { items: {}, missing: ids };
+        const [batch, detailResults] = await Promise.all([
+          fetchHistoryRealizedBatch(apiBaseUrl, ids, signal).catch(() => emptyBatch),
+          Promise.all(
+            list.items.map((entry) =>
               fetchHistoryRun(apiBaseUrl, entry.id, signal).catch(() => null),
-            ]);
-            return buildRunRegimeRecord({
-              entry,
-              realized,
-              payload: (detail?.payload || null) as Record<string, unknown> | null,
-            });
-          }),
-        );
-        if (!signal.aborted) setRows(records);
+            ),
+          ),
+        ]);
+        if (signal.aborted) return;
+        const records = list.items.map((entry: HistoryEntry, idx) => {
+          const realized = batch.items[entry.id] ?? null;
+          const detail = detailResults[idx];
+          return buildRunRegimeRecord({
+            entry,
+            realized,
+            payload: (detail?.payload || null) as Record<string, unknown> | null,
+          });
+        });
+        setRows(records);
       } catch (err) {
         if (!signal.aborted) {
           toast.error((err as Error).message || "Failed to load performance data.");
@@ -97,6 +117,11 @@ export default function PerformancePage() {
   }, [apiBaseUrl]);
 
   const aggregate = React.useMemo(() => aggregateRegimePerformance(rows), [rows]);
+  const breakdownAvailable = breakdown?.available === true;
+  const headlineMacroF1 = breakdownAvailable
+    ? breakdown?.macro_f1 ?? null
+    : aggregate.macroF1;
+  const headlineMacroRocAuc = breakdownAvailable ? breakdown?.macro_roc_auc ?? null : null;
 
   const symbolColumns: DataTableColumn<(typeof aggregate.bySymbol)[number]>[] = React.useMemo(
     () => [
@@ -279,21 +304,31 @@ export default function PerformancePage() {
             />
             <KpiTile
               label="Macro-F1"
-              value={<span className="numeric">{formatScore(aggregate.macroF1)}</span>}
+              value={<span className="numeric">{formatScore(headlineMacroF1)}</span>}
               caption={
-                aggregate.macroF1 != null
-                  ? "unweighted mean of per-class F1"
+                breakdownAvailable
+                  ? "from training eval artifact"
+                  : aggregate.macroF1 != null
+                  ? "client aggregation across history"
                   : aggregate.resolved > 0
                   ? "needs resolved runs in every regime class"
                   : "needs resolved runs"
               }
-              tone={aggregate.macroF1 != null && aggregate.macroF1 >= 0.4 ? "up" : "neutral"}
+              tone={headlineMacroF1 != null && headlineMacroF1 >= 0.4 ? "up" : "neutral"}
             />
             <KpiTile
               label="Empirical coverage"
               value={<span className="numeric">{formatPercent(aggregate.empiricalCoverage)}</span>}
               caption="realised regime inside the predicted set"
             />
+            {headlineMacroRocAuc != null ? (
+              <KpiTile
+                label="Macro ROC-AUC"
+                value={<span className="numeric">{formatScore(headlineMacroRocAuc)}</span>}
+                caption="one-vs-rest, training eval"
+                tone={headlineMacroRocAuc >= 0.6 ? "up" : "neutral"}
+              />
+            ) : null}
           </div>
 
           {loading ? (
@@ -318,8 +353,9 @@ export default function PerformancePage() {
                 <CardHeader className="pb-3">
                   <CardTitle className="text-base">Per-class metrics</CardTitle>
                   <CardDescription>
-                    Precision / recall / F1 for each calibrated class. Support is the count of
-                    resolved runs whose realised regime matched the truth row.
+                    {breakdownAvailable
+                      ? "From the training-time classification breakdown — precision, recall, F1, ROC-AUC, PR-AUC."
+                      : "Computed client-side from resolved history runs. Will switch to the training eval artifact when one is published."}
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="p-0">
@@ -331,35 +367,82 @@ export default function PerformancePage() {
                         <th className="px-4 py-2 text-right">Precision</th>
                         <th className="px-4 py-2 text-right">Recall</th>
                         <th className="px-4 py-2 text-right">F1</th>
+                        {breakdownAvailable ? (
+                          <>
+                            <th className="px-4 py-2 text-right">ROC-AUC</th>
+                            <th className="px-4 py-2 text-right">PR-AUC</th>
+                          </>
+                        ) : null}
                       </tr>
                     </thead>
                     <tbody>
-                      {aggregate.perClass.map((entry) => (
-                        <tr key={entry.klass} className="border-b border-border last:border-0">
-                          <td className="px-4 py-2 capitalize">{entry.klass}</td>
-                          <td className="numeric px-4 py-2 text-right">{entry.support}</td>
-                          <td className="numeric px-4 py-2 text-right">
-                            {formatScore(entry.precision)}
-                          </td>
-                          <td className="numeric px-4 py-2 text-right">{formatScore(entry.recall)}</td>
-                          <td className="numeric px-4 py-2 text-right">{formatScore(entry.f1)}</td>
-                        </tr>
-                      ))}
+                      {breakdownAvailable && breakdown?.per_class
+                        ? breakdown.per_class.map((row, idx) => {
+                            const label = breakdown.class_labels?.[row.class_id] ?? REGIME_CLASSES[row.class_id] ?? `class ${row.class_id}`;
+                            return (
+                              <tr key={`${row.class_id}-${idx}`} className="border-b border-border last:border-0">
+                                <td className="px-4 py-2 capitalize">{label}</td>
+                                <td className="numeric px-4 py-2 text-right">{row.support}</td>
+                                <td className="numeric px-4 py-2 text-right">{formatScore(row.precision)}</td>
+                                <td className="numeric px-4 py-2 text-right">{formatScore(row.recall)}</td>
+                                <td className="numeric px-4 py-2 text-right">{formatScore(row.f1)}</td>
+                                <td className="numeric px-4 py-2 text-right">{formatScore(row.roc_auc ?? null)}</td>
+                                <td className="numeric px-4 py-2 text-right">{formatScore(row.pr_auc ?? null)}</td>
+                              </tr>
+                            );
+                          })
+                        : aggregate.perClass.map((entry) => (
+                            <tr key={entry.klass} className="border-b border-border last:border-0">
+                              <td className="px-4 py-2 capitalize">{entry.klass}</td>
+                              <td className="numeric px-4 py-2 text-right">{entry.support}</td>
+                              <td className="numeric px-4 py-2 text-right">{formatScore(entry.precision)}</td>
+                              <td className="numeric px-4 py-2 text-right">{formatScore(entry.recall)}</td>
+                              <td className="numeric px-4 py-2 text-right">{formatScore(entry.f1)}</td>
+                            </tr>
+                          ))}
                     </tbody>
                   </table>
                 </CardContent>
+                {breakdownAvailable && breakdown?.source ? (
+                  <div className="border-t border-border bg-muted/20 px-4 py-2 text-[10px] text-muted-foreground">
+                    Source: {breakdown.source.relative_path}
+                    {breakdown.source.training_package_id
+                      ? ` · ${breakdown.source.training_package_id}`
+                      : ""}
+                    {" · "}
+                    {new Date(breakdown.source.modified_at).toLocaleString(undefined, {
+                      dateStyle: "short",
+                      timeStyle: "short",
+                    })}
+                  </div>
+                ) : null}
               </Card>
 
               <Card>
                 <CardHeader className="pb-3">
                   <CardTitle className="text-base">Confusion matrix</CardTitle>
                   <CardDescription>
-                    Rows are the realised regime, columns are the predicted argmax. Counts are
-                    coloured by row share so misclassifications stand out at a glance.
+                    {breakdownAvailable
+                      ? "From the training-time classification breakdown — rows are the true class, columns the predicted argmax."
+                      : "Computed client-side from resolved runs — rows are realised regime, columns are predicted argmax."}
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
-                  <ConfusionMatrix rows={aggregate.confusion} classes={REGIME_CLASSES} />
+                  {breakdownAvailable && breakdown?.confusion_matrix
+                    ? (() => {
+                        const labels = breakdown.class_labels?.length
+                          ? breakdown.class_labels
+                          : REGIME_CLASSES;
+                        const matrixRows = breakdown.confusion_matrix.map((counts, idx) => ({
+                          truth: labels[idx] ?? `class ${idx}`,
+                          counts: Object.fromEntries(
+                            counts.map((value, j) => [labels[j] ?? `class ${j}`, value]),
+                          ),
+                          total: counts.reduce((acc, n) => acc + n, 0),
+                        }));
+                        return <ConfusionMatrix rows={matrixRows} classes={labels} />;
+                      })()
+                    : <ConfusionMatrix rows={aggregate.confusion} classes={REGIME_CLASSES} />}
                 </CardContent>
               </Card>
 

--- a/frontend/scripts/lighthouse-audit.mjs
+++ b/frontend/scripts/lighthouse-audit.mjs
@@ -26,13 +26,14 @@ const AUDIT_DIR = path.join(FRONTEND_ROOT, "audit");
 const BASE_URL = (process.env.LIGHTHOUSE_BASE_URL || "http://localhost:3000").replace(/\/$/, "");
 
 const ROUTES = [
-  { path: "/analyze", label: "Analyze" },
+  { path: "/", label: "Workspace" },
   { path: "/history", label: "History" },
-  { path: "/decisions", label: "Decisions" },
   { path: "/compare", label: "Compare" },
   { path: "/performance", label: "Performance" },
   { path: "/calendar", label: "FOMC calendar" },
   { path: "/research", label: "Research" },
+  { path: "/settings", label: "Settings" },
+  { path: "/decisions", label: "Decisions" },
   { path: "/training", label: "Training" },
 ];
 

--- a/frontend/tests/components/analyze/EmptyStateReasons.test.tsx
+++ b/frontend/tests/components/analyze/EmptyStateReasons.test.tsx
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render as rtlRender, screen } from "@testing-library/react";
 
 import { CredibilityKpis } from "@/components/analyze/CredibilityKpis";
 import { MultiAxisInterpretation } from "@/components/analyze/MultiAxisInterpretation";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+function render(ui: React.ReactElement) {
+  return rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
+}
 
 describe("Inline 'awaiting checkpoint' reasons", () => {
   it("MultiAxisInterpretation explains why no axes are present when all four are null", () => {

--- a/frontend/tests/components/analyze/EmptyStateReasons.test.tsx
+++ b/frontend/tests/components/analyze/EmptyStateReasons.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { CredibilityKpis } from "@/components/analyze/CredibilityKpis";
+import { MultiAxisInterpretation } from "@/components/analyze/MultiAxisInterpretation";
+
+describe("Inline 'awaiting checkpoint' reasons", () => {
+  it("MultiAxisInterpretation explains why no axes are present when all four are null", () => {
+    render(
+      <MultiAxisInterpretation
+        multiAxis={{ stance: null, factor: null, certainty: null, topic: null }}
+      />,
+    );
+    expect(
+      screen.getByText(/multi-axis classifier returned no axis labels/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/multi_axis_classifier\.pt/)).toBeInTheDocument();
+  });
+
+  it("MultiAxisInterpretation renders the tile grid when at least one axis is present", () => {
+    render(
+      <MultiAxisInterpretation
+        multiAxis={{
+          stance: { label: "hawkish", confidence: 0.7 },
+          factor: null,
+          certainty: null,
+          topic: null,
+        }}
+      />,
+    );
+    expect(
+      screen.queryByText(/multi-axis classifier returned no axis labels/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/stance/i)).toBeInTheDocument();
+  });
+
+  it("CredibilityKpis explains why every value is at its placeholder", () => {
+    render(
+      <CredibilityKpis
+        credibility={{
+          drift_score: 0,
+          drift_trend: [],
+          realized_vs_stated_gap: null,
+          market_implied_gap: 0,
+          months_since_reversal: null,
+        }}
+      />,
+    );
+    expect(screen.getByText(/credibility features unpopulated/i)).toBeInTheDocument();
+    expect(screen.getByText(/data\/external\/fred/)).toBeInTheDocument();
+  });
+
+  it("CredibilityKpis renders the KPI tiles when drift trend has real history", () => {
+    render(
+      <CredibilityKpis
+        credibility={{
+          drift_score: 0.42,
+          drift_trend: [0.3, 0.36, 0.42],
+          realized_vs_stated_gap: 0.12,
+          market_implied_gap: 0,
+          months_since_reversal: 9,
+        }}
+      />,
+    );
+    expect(screen.queryByText(/credibility features unpopulated/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/drift score/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/analyze/RegimeHeadline.test.tsx
+++ b/frontend/tests/components/analyze/RegimeHeadline.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { RegimeHeadline } from "@/components/analyze/RegimeHeadline";
+import type { RegimeClassificationResponse } from "@/lib/analyze/types";
+
+const REGIME: RegimeClassificationResponse = {
+  predicted_set: ["calm", "normal"],
+  set_label: "calm|normal",
+  set_size: 2,
+  coverage: 0.8,
+  distribution: { calm: 0.35, normal: 0.45, high: 0.2 },
+  argmax_class: "normal",
+};
+
+describe("RegimeHeadline coverage chip", () => {
+  it("shows the run-level coverage badge when no empirical figure is provided", () => {
+    render(<RegimeHeadline regime={REGIME} symbol="^GSPC" documentDate="2024-09-18" />);
+    expect(screen.getByText(/80% coverage · set size 2/i)).toBeInTheDocument();
+    expect(screen.queryByText(/empirical/i)).not.toBeInTheDocument();
+  });
+
+  it("merges nominal + empirical into one chip when empirical coverage is available", () => {
+    render(
+      <RegimeHeadline
+        regime={REGIME}
+        symbol="^GSPC"
+        documentDate="2024-09-18"
+        empiricalCoverage={0.76}
+        empiricalCoverageSampleSize={42}
+      />,
+    );
+    expect(screen.getByText(/Nominal 80% · Empirical 76%/i)).toBeInTheDocument();
+  });
+
+  it("renders the drift badge when empirical drops more than 10pp under nominal", () => {
+    render(
+      <RegimeHeadline
+        regime={REGIME}
+        symbol="^GSPC"
+        documentDate="2024-09-18"
+        empiricalCoverage={0.55}
+        empiricalCoverageSampleSize={25}
+      />,
+    );
+    expect(screen.getByText(/-25pp drift/i)).toBeInTheDocument();
+  });
+
+  it("hides empirical when sample size is zero (coverage not yet meaningful)", () => {
+    render(
+      <RegimeHeadline
+        regime={REGIME}
+        symbol="^GSPC"
+        documentDate="2024-09-18"
+        empiricalCoverage={0.5}
+        empiricalCoverageSampleSize={0}
+      />,
+    );
+    expect(screen.queryByText(/empirical/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/80% coverage/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/analyze/SentenceStrikeXaiPanel.test.tsx
+++ b/frontend/tests/components/analyze/SentenceStrikeXaiPanel.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { SentenceStrikeXaiPanel } from "@/components/analyze/SentenceStrikeXaiPanel";
+import type { AnalyzeResult, XaiResponse } from "@/lib/analyze/types";
+
+const XAI: XaiResponse = {
+  sentences: [
+    { text: "First sentence about inflation.", score: 0.6, topTokens: [] },
+    { text: "Second sentence about employment.", score: -0.2, topTokens: [] },
+    { text: "Third sentence about forward guidance.", score: 0.1, topTokens: [] },
+  ],
+  method: "fixture",
+};
+
+function makeResult(argmax: string, probability: number): AnalyzeResult {
+  const distribution: Record<string, number> = {
+    calm: argmax === "calm" ? probability : (1 - probability) / 2,
+    normal: argmax === "normal" ? probability : (1 - probability) / 2,
+    high: argmax === "high" ? probability : (1 - probability) / 2,
+  };
+  return {
+    regime_classification: {
+      predicted_set: [argmax],
+      set_label: argmax,
+      set_size: 1,
+      coverage: 0.8,
+      distribution,
+      argmax_class: argmax,
+    },
+  };
+}
+
+describe("SentenceStrikeXaiPanel cumulative drift chart", () => {
+  it("hides the chart when only the baseline point is on record", () => {
+    const baseline = makeResult("normal", 0.6);
+    render(
+      <SentenceStrikeXaiPanel
+        xai={XAI}
+        struck={new Set()}
+        onMaskChange={() => {}}
+        baselineResult={baseline}
+        currentResult={baseline}
+      />,
+    );
+    expect(screen.queryByText(/baseline/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the chart after a single strike and updates on a second", () => {
+    const baseline = makeResult("normal", 0.6);
+    const afterOne = makeResult("normal", 0.52);
+    const afterTwo = makeResult("normal", 0.41);
+    const onMaskChange = vi.fn();
+
+    const { rerender } = render(
+      <SentenceStrikeXaiPanel
+        xai={XAI}
+        struck={new Set()}
+        onMaskChange={onMaskChange}
+        baselineResult={baseline}
+        currentResult={baseline}
+      />,
+    );
+
+    rerender(
+      <SentenceStrikeXaiPanel
+        xai={XAI}
+        struck={new Set([0])}
+        onMaskChange={onMaskChange}
+        baselineResult={baseline}
+        currentResult={afterOne}
+      />,
+    );
+    expect(screen.getByText(/across 1 strike/i)).toBeInTheDocument();
+    expect(screen.getByText(/60\.0% → 52\.0%/i)).toBeInTheDocument();
+
+    rerender(
+      <SentenceStrikeXaiPanel
+        xai={XAI}
+        struck={new Set([0, 1])}
+        onMaskChange={onMaskChange}
+        baselineResult={baseline}
+        currentResult={afterTwo}
+      />,
+    );
+    expect(screen.getByText(/across 2 strikes/i)).toBeInTheDocument();
+    expect(screen.getByText(/60\.0% → 41\.0%/i)).toBeInTheDocument();
+  });
+
+  it("emits the next mask on click and shows the reset button", () => {
+    const baseline = makeResult("normal", 0.6);
+    const onMaskChange = vi.fn();
+    render(
+      <SentenceStrikeXaiPanel
+        xai={XAI}
+        struck={new Set([0])}
+        onMaskChange={onMaskChange}
+        baselineResult={baseline}
+        currentResult={baseline}
+      />,
+    );
+    const resetBtn = screen.getByRole("button", { name: /reset/i });
+    fireEvent.click(resetBtn);
+    expect(onMaskChange).toHaveBeenCalledWith(new Set());
+  });
+});

--- a/frontend/tests/components/analyze/SentenceStrikeXaiPanel.test.tsx
+++ b/frontend/tests/components/analyze/SentenceStrikeXaiPanel.test.tsx
@@ -1,8 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render as rtlRender, screen, fireEvent } from "@testing-library/react";
 
 import { SentenceStrikeXaiPanel } from "@/components/analyze/SentenceStrikeXaiPanel";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import type { AnalyzeResult, XaiResponse } from "@/lib/analyze/types";
+
+function render(ui: React.ReactElement) {
+  return rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+function rerenderWith(
+  rerender: (ui: React.ReactElement) => void,
+  ui: React.ReactElement,
+) {
+  rerender(<TooltipProvider>{ui}</TooltipProvider>);
+}
 
 const XAI: XaiResponse = {
   sentences: [
@@ -62,7 +74,8 @@ describe("SentenceStrikeXaiPanel cumulative drift chart", () => {
       />,
     );
 
-    rerender(
+    rerenderWith(
+      rerender,
       <SentenceStrikeXaiPanel
         xai={XAI}
         struck={new Set([0])}
@@ -74,7 +87,8 @@ describe("SentenceStrikeXaiPanel cumulative drift chart", () => {
     expect(screen.getByText(/across 1 strike/i)).toBeInTheDocument();
     expect(screen.getByText(/60\.0% → 52\.0%/i)).toBeInTheDocument();
 
-    rerender(
+    rerenderWith(
+      rerender,
       <SentenceStrikeXaiPanel
         xai={XAI}
         struck={new Set([0, 1])}

--- a/frontend/tests/e2e/calendar.spec.ts
+++ b/frontend/tests/e2e/calendar.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("FOMC calendar", () => {
+  test("upcoming-meeting link prefills the workspace date input", async ({ page }) => {
+    await page.goto("/calendar");
+    await expect(page.getByRole("heading", { name: /fomc calendar/i, level: 1 })).toBeVisible();
+
+    // The calendar has a past + upcoming section; pick the first
+    // upcoming meeting's Analyze link so the prefill is a real future
+    // date the workspace can ingest without yfinance lookups.
+    const upcomingLink = page.getByRole("link", { name: /analyze/i }).first();
+    await expect(upcomingLink).toBeVisible({ timeout: 15_000 });
+    const href = await upcomingLink.getAttribute("href");
+    expect(href).toMatch(/\/\?date=\d{4}-\d{2}-\d{2}/);
+
+    await upcomingLink.click();
+    await expect(page).toHaveURL(/\/\?date=/);
+
+    // Workspace date input picks up the meeting date.
+    const dateInput = page.getByLabel(/document date/i);
+    const expected = href?.match(/date=(\d{4}-\d{2}-\d{2})/)?.[1] ?? "";
+    await expect(dateInput).toHaveValue(expected);
+  });
+});

--- a/frontend/tests/e2e/calendar.spec.ts
+++ b/frontend/tests/e2e/calendar.spec.ts
@@ -1,24 +1,25 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("FOMC calendar", () => {
-  test("upcoming-meeting link prefills the workspace date input", async ({ page }) => {
+  test("upcoming-meeting click prefills the workspace date input", async ({ page }) => {
     await page.goto("/calendar");
     await expect(page.getByRole("heading", { name: /fomc calendar/i, level: 1 })).toBeVisible();
 
-    // The calendar has a past + upcoming section; pick the first
-    // upcoming meeting's Analyze link so the prefill is a real future
-    // date the workspace can ingest without yfinance lookups.
-    const upcomingLink = page.getByRole("link", { name: /analyze/i }).first();
-    await expect(upcomingLink).toBeVisible({ timeout: 15_000 });
-    const href = await upcomingLink.getAttribute("href");
-    expect(href).toMatch(/\/\?date=\d{4}-\d{2}-\d{2}/);
+    // The Analyze action is a button (router.push to /analyze?date=…),
+    // not an anchor — selector must match a button, and we capture the
+    // resulting URL after navigation rather than reading an href.
+    const analyzeButton = page.getByRole("button", { name: /^analyze$/i }).first();
+    await expect(analyzeButton).toBeVisible({ timeout: 15_000 });
+    await analyzeButton.click();
 
-    await upcomingLink.click();
-    await expect(page).toHaveURL(/\/\?date=/);
+    // /analyze is a getServerSideProps redirect → final URL lands at
+    // /?date=YYYY-MM-DD&kind=statement.
+    await expect(page).toHaveURL(/\/\?date=\d{4}-\d{2}-\d{2}/);
+    const finalUrl = new URL(page.url());
+    const expectedDate = finalUrl.searchParams.get("date") ?? "";
+    expect(expectedDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 
-    // Workspace date input picks up the meeting date.
     const dateInput = page.getByLabel(/document date/i);
-    const expected = href?.match(/date=(\d{4}-\d{2}-\d{2})/)?.[1] ?? "";
-    await expect(dateInput).toHaveValue(expected);
+    await expect(dateInput).toHaveValue(expectedDate);
   });
 });

--- a/frontend/tests/e2e/compare.spec.ts
+++ b/frontend/tests/e2e/compare.spec.ts
@@ -29,7 +29,11 @@ test.describe("history → compare flow", () => {
     await expect(optionList).toBeVisible({ timeout: 5_000 });
     await optionList.getByRole("option").nth(1).click();
 
-    await expect(page.getByText(/Δ A − B/i)).toBeVisible({ timeout: 30_000 });
-    await expect(page.getByText(/^Regime$/i)).toBeVisible();
+    // The Δ A − B card title appears 3× once both slots are populated
+    // (DeltaSummary + Multi-axis Δ + the table header). Anchor on
+    // .first() to dodge Playwright's strict-mode "more than one element"
+    // guard while still proving the delta surface rendered.
+    await expect(page.getByText(/Δ A − B/i).first()).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(/^Regime$/i).first()).toBeVisible();
   });
 });

--- a/frontend/tests/e2e/compare.spec.ts
+++ b/frontend/tests/e2e/compare.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("history → compare flow", () => {
+  test("Compare to… link prefills one slot and renders the regime delta", async ({ page }) => {
+    test.slow();
+    await page.goto("/history");
+    await expect(page.getByRole("heading", { name: /^history$/i, level: 1 })).toBeVisible();
+
+    // The compare flow needs at least two runs in history. Skip
+    // gracefully when the dev environment has a fresh DB — the rest of
+    // the suite still exercises the page render.
+    const rowCount = await page.locator("table tbody tr").count();
+    test.skip(rowCount < 2, "needs at least two history runs to exercise compare");
+
+    // Each table row carries a "Compare to…" action; the link routes
+    // to /compare with the source id in slot A.
+    const compareLink = page.getByRole("link", { name: /compare to/i }).first();
+    await compareLink.click();
+
+    await expect(page).toHaveURL(/\/compare/);
+    await expect(page.getByRole("heading", { name: /compare runs/i, level: 1 })).toBeVisible();
+
+    // Pick the second-most-recent run for slot B from the slot
+    // selector. The page-level Δ card only renders when both slots are
+    // populated.
+    const slotBSelect = page.getByLabel(/Run B/i);
+    await slotBSelect.click();
+    const optionList = page.getByRole("listbox");
+    await expect(optionList).toBeVisible({ timeout: 5_000 });
+    await optionList.getByRole("option").nth(1).click();
+
+    await expect(page.getByText(/Δ A − B/i)).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(/^Regime$/i)).toBeVisible();
+  });
+});

--- a/frontend/tests/e2e/sentence-strike.spec.ts
+++ b/frontend/tests/e2e/sentence-strike.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("sentence strike counterfactual", () => {
+  test("striking a sentence renders a regime Δ badge and reset restores baseline", async ({
+    page,
+  }) => {
+    test.slow();
+    await page.goto("/");
+
+    // Wait for the initial analyze response so the XAI panel is populated.
+    await page.getByRole("button", { name: /analyze/i }).click();
+    await expect(page.getByText(/vol-regime prediction set/i)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const panelHeading = page.getByRole("heading", { name: /sentence attribution/i });
+    await expect(panelHeading).toBeVisible();
+
+    // Find a clickable sentence (each `<button aria-pressed>` inside the
+    // panel is a strike-toggle). Click the first one and wait for the
+    // counterfactual round trip to land. The panel header gets a "1
+    // struck" badge once the strike set is non-empty.
+    const sentenceButton = page
+      .locator('button[aria-pressed="false"]')
+      .first();
+    await expect(sentenceButton).toBeVisible({ timeout: 5_000 });
+    await sentenceButton.click();
+
+    await expect(page.getByText(/1 struck/i)).toBeVisible({ timeout: 30_000 });
+    // Δ regime badge appears once the second /analyze returns.
+    await expect(page.getByText(/Δ regime/i)).toBeVisible({ timeout: 30_000 });
+
+    const resetButton = page.getByRole("button", { name: /reset/i });
+    await resetButton.click();
+    await expect(page.getByText(/1 struck/i)).not.toBeVisible();
+  });
+});

--- a/frontend/tests/e2e/sentence-strike.spec.ts
+++ b/frontend/tests/e2e/sentence-strike.spec.ts
@@ -16,11 +16,15 @@ test.describe("sentence strike counterfactual", () => {
     const panelHeading = page.getByRole("heading", { name: /sentence attribution/i });
     await expect(panelHeading).toBeVisible();
 
-    // Find a clickable sentence (each `<button aria-pressed>` inside the
-    // panel is a strike-toggle). Click the first one and wait for the
-    // counterfactual round trip to land. The panel header gets a "1
-    // struck" badge once the strike set is non-empty.
-    const sentenceButton = page
+    // Scope strike-toggle lookup to the Sentence Attribution card so
+    // we don't pick up other aria-pressed buttons on the workspace
+    // (WatchlistChips also uses aria-pressed for the active-symbol
+    // chip state).
+    const sentencePanel = page
+      .locator('div')
+      .filter({ has: panelHeading })
+      .first();
+    const sentenceButton = sentencePanel
       .locator('button[aria-pressed="false"]')
       .first();
     await expect(sentenceButton).toBeVisible({ timeout: 5_000 });

--- a/frontend/tests/pages/history.test.tsx
+++ b/frontend/tests/pages/history.test.tsx
@@ -19,30 +19,21 @@ vi.mock("next/head", () => ({
 }));
 
 const fetchHistoryMock = vi.fn();
-const fetchHistoryRealizedMock = vi.fn();
+const fetchHistoryRealizedBatchMock = vi.fn();
 const deleteHistoryRunMock = vi.fn();
 
 vi.mock("@/lib/analyze/api", () => ({
   resolveApiBaseUrl: () => "http://localhost:8000",
   fetchHistory: (...args: unknown[]) => fetchHistoryMock(...args),
-  fetchHistoryRealized: (...args: unknown[]) => fetchHistoryRealizedMock(...args),
+  fetchHistoryRealizedBatch: (...args: unknown[]) => fetchHistoryRealizedBatchMock(...args),
   deleteHistoryRun: (...args: unknown[]) => deleteHistoryRunMock(...args),
 }));
 
 describe("HistoryPage", () => {
   beforeEach(() => {
     fetchHistoryMock.mockReset();
-    fetchHistoryRealizedMock.mockReset();
-    fetchHistoryRealizedMock.mockResolvedValue({
-      run_id: "stub",
-      symbol: "^GSPC",
-      document_date: "2026-01-01",
-      horizon: "10d",
-      timestamps: [],
-      close: [],
-      volatility: [],
-      realized_regime: null,
-    });
+    fetchHistoryRealizedBatchMock.mockReset();
+    fetchHistoryRealizedBatchMock.mockResolvedValue({ items: {}, missing: [] });
     deleteHistoryRunMock.mockReset();
   });
 
@@ -90,5 +81,56 @@ describe("HistoryPage", () => {
     await waitFor(() =>
       expect(screen.getByText(/no runs match these filters/i)).toBeInTheDocument(),
     );
+  });
+
+  it("fires exactly one batched realized request after loading the row list", async () => {
+    fetchHistoryMock.mockResolvedValue({
+      total: 2,
+      limit: 20,
+      offset: 0,
+      items: [
+        {
+          id: "abc",
+          created_at: "2024-09-18T12:00:00Z",
+          symbol: "^GSPC",
+          document_date: "2024-09-18",
+          horizon: "10d",
+          forecast_mode: "fast",
+          stance: "hawkish",
+        },
+        {
+          id: "def",
+          created_at: "2024-11-06T12:00:00Z",
+          symbol: "^NDX",
+          document_date: "2024-11-06",
+          horizon: "10d",
+          forecast_mode: "fast",
+          stance: "dovish",
+        },
+      ],
+    });
+    fetchHistoryRealizedBatchMock.mockResolvedValue({
+      items: {
+        abc: {
+          run_id: "abc",
+          symbol: "^GSPC",
+          document_date: "2024-09-18",
+          horizon: "10d",
+          timestamps: ["2024-09-20"],
+          close: [5050.0],
+          volatility: [0.011],
+          realized_regime: "normal",
+        },
+      },
+      missing: ["def"],
+    });
+
+    const { default: HistoryPage } = await import("@/pages/history");
+    render(<HistoryPage />);
+    await waitFor(() =>
+      expect(fetchHistoryRealizedBatchMock).toHaveBeenCalledTimes(1),
+    );
+    const [, ids] = fetchHistoryRealizedBatchMock.mock.calls[0];
+    expect(ids).toEqual(["abc", "def"]);
   });
 });

--- a/frontend/tests/pages/performance.test.tsx
+++ b/frontend/tests/pages/performance.test.tsx
@@ -205,7 +205,10 @@ describe("PerformancePage", () => {
 
     await waitFor(() => expect(screen.getByText(/macro roc-auc/i)).toBeInTheDocument());
     expect(screen.getByText(/from training eval artifact/i)).toBeInTheDocument();
-    expect(screen.getByText(/training-time classification breakdown/i)).toBeInTheDocument();
+    // The "training-time classification breakdown" phrase appears in
+    // both the per-class table and the confusion matrix descriptions
+    // when the artifact is loaded — assert presence, not uniqueness.
+    expect(screen.getAllByText(/training-time classification breakdown/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/tp_fixture/)).toBeInTheDocument();
   });
 });

--- a/frontend/tests/pages/performance.test.tsx
+++ b/frontend/tests/pages/performance.test.tsx
@@ -19,14 +19,17 @@ vi.mock("next/head", () => ({
 }));
 
 const fetchHistoryMock = vi.fn();
-const fetchHistoryRealizedMock = vi.fn();
+const fetchHistoryRealizedBatchMock = vi.fn();
 const fetchHistoryRunMock = vi.fn();
+const fetchClassificationBreakdownMock = vi.fn();
 
 vi.mock("@/lib/analyze/api", () => ({
   resolveApiBaseUrl: () => "http://localhost:8000",
   fetchHistory: (...args: unknown[]) => fetchHistoryMock(...args),
-  fetchHistoryRealized: (...args: unknown[]) => fetchHistoryRealizedMock(...args),
+  fetchHistoryRealizedBatch: (...args: unknown[]) => fetchHistoryRealizedBatchMock(...args),
   fetchHistoryRun: (...args: unknown[]) => fetchHistoryRunMock(...args),
+  fetchClassificationBreakdown: (...args: unknown[]) =>
+    fetchClassificationBreakdownMock(...args),
 }));
 
 const SAMPLE_ROWS = [
@@ -97,8 +100,11 @@ function detailPayload(runId: string, set: string[]) {
 describe("PerformancePage", () => {
   beforeEach(() => {
     fetchHistoryMock.mockReset();
-    fetchHistoryRealizedMock.mockReset();
+    fetchHistoryRealizedBatchMock.mockReset();
     fetchHistoryRunMock.mockReset();
+    fetchClassificationBreakdownMock.mockReset();
+    fetchClassificationBreakdownMock.mockResolvedValue({ available: false });
+    fetchHistoryRealizedBatchMock.mockResolvedValue({ items: {}, missing: [] });
   });
 
   it("renders empty-state when history is empty", async () => {
@@ -117,9 +123,13 @@ describe("PerformancePage", () => {
       offset: 0,
       items: SAMPLE_ROWS,
     });
-    fetchHistoryRealizedMock
-      .mockResolvedValueOnce(realizedPayload("run-1", "high"))
-      .mockResolvedValueOnce(realizedPayload("run-2", "normal"));
+    fetchHistoryRealizedBatchMock.mockResolvedValue({
+      items: {
+        "run-1": realizedPayload("run-1", "high"),
+        "run-2": realizedPayload("run-2", "normal"),
+      },
+      missing: [],
+    });
     fetchHistoryRunMock
       .mockResolvedValueOnce(detailPayload("run-1", ["high", "normal"]))
       .mockResolvedValueOnce(detailPayload("run-2", ["calm"]));
@@ -128,7 +138,7 @@ describe("PerformancePage", () => {
     render(<PerformancePage />);
 
     await waitFor(() =>
-      expect(fetchHistoryRealizedMock).toHaveBeenCalledTimes(2),
+      expect(fetchHistoryRealizedBatchMock).toHaveBeenCalledTimes(1),
     );
 
     // Several of these labels appear in more than one place (the page
@@ -145,22 +155,57 @@ describe("PerformancePage", () => {
     expect(screen.getByText(/Run-level detail/i)).toBeInTheDocument();
   });
 
-  it("still renders the table when one realized fetch fails", async () => {
+  it("still renders the table when the realized batch fetch fails", async () => {
     fetchHistoryMock.mockResolvedValue({
       total: 1,
       limit: 100,
       offset: 0,
       items: [SAMPLE_ROWS[0]],
     });
-    fetchHistoryRealizedMock.mockRejectedValue(new Error("Market lookup failed"));
+    fetchHistoryRealizedBatchMock.mockRejectedValue(new Error("Market lookup failed"));
     fetchHistoryRunMock.mockResolvedValueOnce(detailPayload("run-1", ["high"]));
 
     const { default: PerformancePage } = await import("@/pages/performance");
     render(<PerformancePage />);
 
     await waitFor(() =>
-      expect(fetchHistoryRealizedMock).toHaveBeenCalledTimes(1),
+      expect(fetchHistoryRealizedBatchMock).toHaveBeenCalledTimes(1),
     );
     expect(await screen.findByText(/Run-level detail/i)).toBeInTheDocument();
+  });
+
+  it("renders ROC-AUC + provenance when the breakdown artifact is available", async () => {
+    fetchHistoryMock.mockResolvedValue({
+      total: 1,
+      limit: 100,
+      offset: 0,
+      items: [SAMPLE_ROWS[0]],
+    });
+    fetchClassificationBreakdownMock.mockResolvedValue({
+      available: true,
+      confusion_matrix: [[5, 1, 0], [0, 4, 2], [1, 0, 3]],
+      per_class: [
+        { class_id: 0, precision: 0.83, recall: 0.83, f1: 0.83, support: 6, roc_auc: 0.91, pr_auc: 0.88 },
+        { class_id: 1, precision: 0.80, recall: 0.67, f1: 0.73, support: 6, roc_auc: 0.85, pr_auc: 0.79 },
+        { class_id: 2, precision: 0.60, recall: 0.75, f1: 0.67, support: 4, roc_auc: 0.78, pr_auc: 0.72 },
+      ],
+      macro_f1: 0.74,
+      macro_roc_auc: 0.85,
+      n_classes: 3,
+      source: {
+        relative_path: "regime_baseline_tiers/tp_fixture/forecaster_sweep_results.json",
+        training_package_id: "tp_fixture",
+        modified_at: "2026-05-25T00:00:00Z",
+      },
+    });
+    fetchHistoryRunMock.mockResolvedValueOnce(detailPayload("run-1", ["high"]));
+
+    const { default: PerformancePage } = await import("@/pages/performance");
+    render(<PerformancePage />);
+
+    await waitFor(() => expect(screen.getByText(/macro roc-auc/i)).toBeInTheDocument());
+    expect(screen.getByText(/from training eval artifact/i)).toBeInTheDocument();
+    expect(screen.getByText(/training-time classification breakdown/i)).toBeInTheDocument();
+    expect(screen.getByText(/tp_fixture/)).toBeInTheDocument();
   });
 });

--- a/tests/unit/test_history_endpoints.py
+++ b/tests/unit/test_history_endpoints.py
@@ -262,6 +262,103 @@ def test_evaluation_coverage_returns_zero_sample_when_no_predicted_set(client):
     assert body["nominal"] is None
 
 
+def _write_breakdown_artifact(root, *, package_id="tp_fixture"):
+    import json
+    from pathlib import Path
+
+    artifact_dir = Path(root) / "artifacts" / "regime_baseline_tiers" / package_id
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "training_package_id": package_id,
+        "checkpoint_path": f"/app/models/forecaster_{package_id}.pt",
+        "best_trial": {
+            "summary": {
+                "metrics": {
+                    "classification_breakdown": {
+                        "confusion_matrix": [[10, 1, 2], [3, 12, 1], [1, 2, 8]],
+                        "per_class": [
+                            {
+                                "class_id": 0,
+                                "precision": 0.71,
+                                "recall": 0.77,
+                                "f1": 0.74,
+                                "support": 13,
+                                "roc_auc": 0.82,
+                                "pr_auc": 0.78,
+                            },
+                            {
+                                "class_id": 1,
+                                "precision": 0.80,
+                                "recall": 0.75,
+                                "f1": 0.77,
+                                "support": 16,
+                                "roc_auc": 0.85,
+                                "pr_auc": 0.80,
+                            },
+                            {
+                                "class_id": 2,
+                                "precision": 0.73,
+                                "recall": 0.73,
+                                "f1": 0.73,
+                                "support": 11,
+                                "roc_auc": 0.80,
+                                "pr_auc": 0.75,
+                            },
+                        ],
+                        "macro_f1": 0.75,
+                        "macro_precision": 0.75,
+                        "macro_recall": 0.75,
+                        "macro_roc_auc": 0.82,
+                        "macro_pr_auc": 0.78,
+                        "weighted_f1": 0.75,
+                        "n_classes": 3,
+                    },
+                },
+            },
+        },
+    }
+    path = artifact_dir / "forecaster_sweep_results.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_evaluation_classification_breakdown_reads_latest_artifact(client, tmp_path, monkeypatch):
+    monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+    _write_breakdown_artifact(tmp_path, package_id="tp_old")
+    # Newer artifact wins on mtime; touch to ensure mtime ordering.
+    import os
+    import time
+
+    time.sleep(0.05)
+    newer = _write_breakdown_artifact(tmp_path, package_id="tp_new")
+    os.utime(newer, None)
+
+    response = client.get("/evaluation/classification-breakdown")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["available"] is True
+    assert body["macro_f1"] == 0.75
+    assert body["n_classes"] == 3
+    assert len(body["per_class"]) == 3
+    assert body["per_class"][0]["class_id"] == 0
+    assert body["confusion_matrix"][0] == [10, 1, 2]
+    assert body["source"]["training_package_id"] == "tp_new"
+    assert body["source"]["relative_path"].endswith(".json")
+
+
+def test_evaluation_classification_breakdown_returns_unavailable_when_missing(
+    client, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+    response = client.get("/evaluation/classification-breakdown")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["available"] is False
+    assert body["macro_f1"] is None
+    assert body["per_class"] is None
+    assert body["source"] is None
+
+
 def test_fomc_calendar_endpoint_returns_past_and_upcoming(client):
     response = client.get("/fomc/calendar", params={"as_of": "2024-09-18"})
     assert response.status_code == 200

--- a/tests/unit/test_history_endpoints.py
+++ b/tests/unit/test_history_endpoints.py
@@ -171,6 +171,97 @@ def test_history_realized_batch_rejects_oversize_id_list(client):
     assert response.status_code == 422
 
 
+def _seed_with_regime(sess, *, predicted_set, document_date="2024-09-18", symbol="^GSPC"):
+    return db_module.persist_analysis_run(
+        sess,
+        payload={
+            "sentiment": {"label": "HAWKISH", "score": 0.7, "raw": []},
+            "prediction": {"close": 5050.0, "volatility": 0.012, "horizon": "10d"},
+            "regime_classification": {
+                "predicted_set": predicted_set,
+                "set_label": "|".join(predicted_set),
+                "set_size": len(predicted_set),
+                "coverage": 0.8,
+                "distribution": {"calm": 0.2, "normal": 0.5, "high": 0.3},
+                "argmax_class": "normal",
+            },
+            "series": {"forecast_confidence_level": 0.8},
+        },
+        request={
+            "text": "Recent indicators…",
+            "date": document_date,
+            "symbol": symbol,
+            "horizon": "10d",
+            "forecast_mode": "fast",
+            "include_realized": False,
+        },
+        response={
+            "sentiment": {"label": "HAWKISH", "score": 0.7, "raw": []},
+            "prediction": {"close": 5050.0, "volatility": 0.012, "horizon": "10d"},
+            "regime_classification": {
+                "predicted_set": predicted_set,
+                "set_label": "|".join(predicted_set),
+                "set_size": len(predicted_set),
+                "coverage": 0.8,
+                "distribution": {"calm": 0.2, "normal": 0.5, "high": 0.3},
+                "argmax_class": "normal",
+            },
+            "series": {"forecast_confidence_level": 0.8},
+            "market": {
+                "symbol": symbol,
+                "requested_date": document_date,
+                "date_used": document_date,
+                "lookback_days": 5,
+                "close": 5000.0,
+                "volatility_5d": 0.011,
+            },
+            "model": {},
+        },
+    )
+
+
+def test_evaluation_coverage_aggregates_hits_and_misses(client, monkeypatch):
+    main_mod._reset_coverage_cache()
+
+    session_iter = db_module.get_session()
+    sess = next(session_iter)
+    try:
+        _seed_with_regime(sess, predicted_set=["calm", "normal"], document_date="2024-09-18")
+        _seed_with_regime(sess, predicted_set=["normal"], document_date="2024-11-06")
+        _seed_with_regime(sess, predicted_set=["high"], document_date="2024-12-18")
+    finally:
+        sess.close()
+
+    monkeypatch.setattr(
+        main_mod, "bucket_realized_regime", lambda *_args, **_kwargs: "normal"
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "fetch_realized_forward",
+        lambda **_: [{"date": "x", "close": 1.0, "volatility_5d": 0.01}],
+    )
+
+    response = client.get("/evaluation/coverage", params={"lookback_runs": 10})
+    assert response.status_code == 200
+    body = response.json()
+    # 3 runs, 2 contain "normal" in their predicted_set → empirical 2/3
+    assert body["sample_size"] == 3
+    assert body["runs_total"] == 3
+    assert body["empirical"] == pytest.approx(2 / 3)
+    assert body["nominal"] == pytest.approx(0.8)
+
+
+def test_evaluation_coverage_returns_zero_sample_when_no_predicted_set(client):
+    main_mod._reset_coverage_cache()
+    response = client.get("/evaluation/coverage")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sample_size"] == 0
+    assert body["runs_total"] == 0
+    assert body["empirical"] is None
+    assert body["nominal"] is None
+
+
 def test_fomc_calendar_endpoint_returns_past_and_upcoming(client):
     response = client.get("/fomc/calendar", params={"as_of": "2024-09-18"})
     assert response.status_code == 200

--- a/tests/unit/test_history_endpoints.py
+++ b/tests/unit/test_history_endpoints.py
@@ -132,6 +132,45 @@ def test_history_realized_endpoint_404_for_missing_run(client):
     assert response.status_code == 404
 
 
+def test_history_realized_batch_returns_items_and_missing(client, monkeypatch):
+    session_iter = db_module.get_session()
+    sess = next(session_iter)
+    try:
+        run_a = _seed(sess, document_date="2024-09-18")
+        run_b = _seed(sess, document_date="2024-11-06", symbol="^NDX")
+    finally:
+        sess.close()
+
+    monkeypatch.setattr(
+        main_mod,
+        "fetch_realized_forward",
+        lambda **_: [
+            {"date": "2024-09-19", "close": 5602.0, "volatility_5d": 0.011},
+        ],
+    )
+
+    response = client.get(
+        "/history-realized",
+        params={"ids": f"{run_a.id},{run_b.id},does-not-exist"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body["items"].keys()) == {run_a.id, run_b.id}
+    assert body["missing"] == ["does-not-exist"]
+    assert body["items"][run_a.id]["timestamps"] == ["2024-09-19"]
+
+
+def test_history_realized_batch_rejects_empty_ids(client):
+    response = client.get("/history-realized", params={"ids": ""})
+    assert response.status_code == 422
+
+
+def test_history_realized_batch_rejects_oversize_id_list(client):
+    too_many = ",".join(f"id-{n}" for n in range(51))
+    response = client.get("/history-realized", params={"ids": too_many})
+    assert response.status_code == 422
+
+
 def test_fomc_calendar_endpoint_returns_past_and_upcoming(client):
     response = client.get("/fomc/calendar", params={"as_of": "2024-09-18"})
     assert response.status_code == 200


### PR DESCRIPTION
## Summary

Backend (3 new endpoints) + frontend polish bundle landing all eight items from the #283 retrospective punch-list.

## Backend

- \`GET /history-realized?ids=…\` batch endpoint replaces the per-row realized fan-out (cap 50, missing rows degrade cleanly)
- \`GET /evaluation/coverage\` aggregates empirical conformal coverage across recent runs; 5-min in-memory cache
- \`GET /evaluation/classification-breakdown\` surfaces the freshest \`classification_breakdown\` block from \`data/artifacts/regime_*\`; \`available=false\` sentinel when no artifact exists

## Frontend

- Empirical-vs-nominal coverage chip on RegimeHeadline with directional drift badge (≥10pp)
- \`/history\` and \`/performance\` consume the batched realized endpoint (N→1 round trip)
- \`/performance\` reads the canonical training breakdown when available (per-class P/R/F1/ROC-AUC/PR-AUC + provenance footer); falls back to client aggregation
- "Awaiting checkpoint" inline reasons on multi-axis + credibility cards when their modules ran but returned placeholders
- Sentence-strike panel renders a cumulative P(argmax) drift sparkline across multi-strike sessions
- 393px mobile pass: headline argmax + Compare h1 + Calendar h1 scale down on sm
- Lighthouse audit routes updated to match the post-pivot information architecture
- 3 new Playwright specs: sentence-strike, compare, calendar

## Test plan

- [ ] \`docker compose run --rm backend pytest tests/unit/test_history_endpoints.py\`
- [ ] \`cd frontend && npm run type-check\`
- [ ] \`cd frontend && npm run test\`