### PR TITLE
Cross-bank multi-axis supervision + bis_xbank DAPT substrate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -518,6 +518,17 @@ finbert-bis-only-pretrain:
 		SUBSTRATE=bis \
 		PRETRAIN_OUT_NAME=finbert_bis_only
 
+# DAPT substrate extension: BIS speeches + 5 cross-bank gtfintechlab corpora
+# (ECB / BoJ / BoE / BoC / RBA) reformatted as consecutive-sentence NSP pairs.
+# Same hyperparameters as the headline finbert-fed-adjacent-pretrain run; only
+# the substrate changes. Output checkpoint registers under
+# ``finbert_fed_adjacent_xbank_dapt`` in models/registry.yaml after the first
+# GPU run lands and the embedding cache builder self-pins the revision.
+finbert-fed-adjacent-xbank-dapt-pretrain:
+	$(MAKE) finbert-fed-adjacent-pretrain \
+		SUBSTRATE=bis_xbank \
+		PRETRAIN_OUT_NAME=finbert_fed_adjacent_xbank_dapt
+
 finbert-fed-adjacent-pretrain-smoke:
 	docker compose run --rm backend \
 		python -m app.data.continued_pretraining \

--- a/backend/app/data/continued_pretraining.py
+++ b/backend/app/data/continued_pretraining.py
@@ -89,9 +89,9 @@ _GTFINTECHLAB_XBANK_REVISIONS: dict[str, str] = {
 # ``_GTFINTECHLAB_XBANK_REVISIONS`` would otherwise silently fall back
 # to fetching HF Hub HEAD, breaking the reproducibility invariant the
 # DAPT manifest relies on.
-assert set(dataset_id for _, dataset_id in _GTFINTECHLAB_XBANK_DATASETS) == set(
-    _GTFINTECHLAB_XBANK_REVISIONS.keys()
-), (
+assert {
+    dataset_id for _, dataset_id in _GTFINTECHLAB_XBANK_DATASETS
+} == set(_GTFINTECHLAB_XBANK_REVISIONS.keys()), (
     "_GTFINTECHLAB_XBANK_DATASETS and _GTFINTECHLAB_XBANK_REVISIONS must "
     "list the same dataset ids; missing pin or stale entry detected."
 )

--- a/backend/app/data/continued_pretraining.py
+++ b/backend/app/data/continued_pretraining.py
@@ -502,7 +502,7 @@ def _collect_pairs(args: argparse.Namespace) -> list[dict[str, Any]]:
             local_pairs = local_pairs[: args.max_rows]
         pairs.extend(local_pairs)
 
-    if args.substrate in {"bis", "both", "bis_xbank"}:
+    if args.substrate in {"bis", "both"}:
         if args.substrate == "both" and args.max_rows:
             remaining = max(0, args.max_rows - len(pairs))
             bis_cap = remaining

--- a/backend/app/data/continued_pretraining.py
+++ b/backend/app/data/continued_pretraining.py
@@ -13,6 +13,16 @@ larger and within range of FinBERT's original pretraining substrate.
 The legacy local JSON corpus is preserved as an optional auxiliary substrate
 via ``--auxiliary-local-dir`` for ablation studies; pass ``--substrate local``
 to use it as the sole substrate (reproduces the pre-Sprint-1B behaviour).
+
+Substrate options:
+- ``bis``   – BIS speeches only (default headline substrate).
+- ``local`` – legacy 44-doc Fed-adjacent JSON corpus.
+- ``fomc``  – strict FOMC statements + minutes only (Round 3 / #242 ablation).
+- ``both``  – local + BIS combined.
+- ``bis_xbank`` – BIS speeches + cross-bank gtfintechlab corpora (ECB / BoJ /
+  BoE / BoC / RBA) reformatted as consecutive-sentence NSP pairs. Gives the
+  encoder exposure to non-Fed monetary-policy language without changing the
+  downstream fine-tune target.
 """
 
 from __future__ import annotations
@@ -51,7 +61,26 @@ DEFAULT_FOMC_CORPUS_FILES: tuple[str, ...] = (
     "fomc_statements.json",
     "fomc_minutes.json",
 )
-_VALID_SUBSTRATES = ("bis", "local", "fomc", "both")
+# Cross-bank gtfintechlab datasets reused for the bis_xbank substrate. The
+# (bank_key, hf_dataset_id) pairs and SHA pins mirror the supervised loader in
+# ``app.data.ingest_sources`` — keep the two lists in sync if you ever add a
+# sixth bank. Revisions captured 2026-05-15.
+_GTFINTECHLAB_XBANK_DATASETS: tuple[tuple[str, str], ...] = (
+    ("european_central_bank", "gtfintechlab/european_central_bank"),
+    ("bank_of_japan", "gtfintechlab/bank_of_japan"),
+    ("bank_of_england", "gtfintechlab/bank_of_england"),
+    ("bank_of_canada", "gtfintechlab/bank_of_canada"),
+    ("reserve_bank_of_australia", "gtfintechlab/reserve_bank_of_australia"),
+)
+_GTFINTECHLAB_XBANK_REVISIONS: dict[str, str] = {
+    "gtfintechlab/european_central_bank": "867cee85784ce569826e0104797b6e017205867b",
+    "gtfintechlab/bank_of_japan": "1885e21cf1c33c4aea19a824ba40eac886c7a122",
+    "gtfintechlab/bank_of_england": "de1123cf9d747dbb3e0c2224467f501692d5a310",
+    "gtfintechlab/bank_of_canada": "ab15ea2271bfa3208874a5517afc439640fd9200",
+    "gtfintechlab/reserve_bank_of_australia": "7a91206b56f2841b2586e409feade2518284894b",
+}
+
+_VALID_SUBSTRATES = ("bis", "local", "fomc", "both", "bis_xbank")
 
 
 def _iter_local_pairs(data_dir: Path, files: Iterable[str]) -> list[dict[str, Any]]:
@@ -117,6 +146,78 @@ def _bis_pair_stream(
             continue
         yield {"sequenceA": a, "sequenceB": b, "next_sentence_label": int(row.get("next_sentence_label") or 0)}
         seen += 1
+
+
+def _iter_gtfintechlab_xbank_pairs() -> list[dict[str, Any]]:
+    """Stream the 5 cross-bank gtfintechlab corpora as NSP-style sentence pairs.
+
+    Each dataset (ECB / BoJ / BoE / BoC / RBA) ships ~3,000 single-sentence rows
+    annotated with stance / time / certainty axes. For DAPT we ignore the
+    labels and use only the raw ``sentences`` field, pairing rows
+    ``[2k, 2k+1]`` within the same ``(config, split)`` bucket so each emitted
+    record looks like the BIS stream output: two distinct sentence strings plus
+    a ``next_sentence_label``. Label is fixed at 0 (BIS convention: 0 = "is
+    next"); the assumption is loose since gtfintechlab rows aren't guaranteed
+    consecutive in any original document, but it keeps the schema uniform and
+    the trainer doesn't differentiate per-row.
+
+    Revisions are pinned via ``_GTFINTECHLAB_XBANK_REVISIONS`` so HF Hub pushes
+    can't rotate row indices mid-run; the same SHAs are mirrored from
+    ``app.data.ingest_sources._DATASET_REVISIONS``.
+    """
+    from datasets import (  # type: ignore
+        get_dataset_config_names,
+        get_dataset_split_names,
+        load_dataset,
+    )
+
+    pairs: list[dict[str, Any]] = []
+    for _bank_key, dataset_id in _GTFINTECHLAB_XBANK_DATASETS:
+        revision = _GTFINTECHLAB_XBANK_REVISIONS.get(dataset_id)
+        kwargs: dict[str, Any] = {}
+        if revision:
+            kwargs["revision"] = revision
+        configs = list(get_dataset_config_names(dataset_id, **kwargs))
+        if not configs:
+            configs = [None]  # default config
+        for config in configs:
+            split_kwargs = dict(kwargs)
+            try:
+                splits = (
+                    list(get_dataset_split_names(dataset_id, config, **split_kwargs))
+                    if config is not None
+                    else list(get_dataset_split_names(dataset_id, **split_kwargs))
+                )
+            except Exception:
+                splits = ["train"]
+            for split in splits:
+                load_kwargs: dict[str, Any] = {"split": split}
+                if revision:
+                    load_kwargs["revision"] = revision
+                if config is not None:
+                    ds = load_dataset(dataset_id, config, **load_kwargs)
+                else:
+                    ds = load_dataset(dataset_id, **load_kwargs)
+                buffer: list[str] = []
+                for row in ds:
+                    if not isinstance(row, dict):
+                        continue
+                    sentence = (row.get("sentences") or "").strip()
+                    if not sentence:
+                        continue
+                    buffer.append(sentence)
+                    if len(buffer) == 2:
+                        a, b = buffer
+                        if a != b:
+                            pairs.append(
+                                {
+                                    "sequenceA": a,
+                                    "sequenceB": b,
+                                    "next_sentence_label": 0,
+                                }
+                            )
+                        buffer = []
+    return pairs
 
 
 def run_mlm(
@@ -285,7 +386,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=(
             "bis (default; samchain/BIS_speeches_97_23_MLM), local (legacy "
             "Fed-adjacent JSON corpus), fomc (strict FOMC-only — minutes + "
-            "statements; Round 3 / #242 ablation), or both (local + BIS)."
+            "statements; Round 3 / #242 ablation), both (local + BIS), or "
+            "bis_xbank (BIS + 5 cross-bank gtfintechlab corpora paired as NSP)."
         ),
     )
     parser.add_argument(
@@ -352,6 +454,47 @@ def _collect_pairs(args: argparse.Namespace) -> list[dict[str, Any]]:
         pairs.extend(fomc_pairs)
         return pairs
 
+    if args.substrate == "bis_xbank":
+        # BIS + cross-bank (ECB / BoJ / BoE / BoC / RBA) substrate. Cross-bank
+        # pairs (small, finite ~7,500) load first so the BIS firehose can't
+        # silently empty the xbank slice under --max-rows, mirroring the
+        # local-first convention of --substrate both. FOMC and the broader
+        # local Fed-adjacent JSON corpus are deliberately excluded — the
+        # downstream fine-tune target stays FOMC, so adding FOMC text here
+        # would leak the target into pretraining.
+        xbank_pairs = _iter_gtfintechlab_xbank_pairs()
+        if args.max_rows and len(xbank_pairs) > args.max_rows:
+            xbank_pairs = xbank_pairs[: args.max_rows]
+        pairs.extend(xbank_pairs)
+
+        # --max-rows == 0 means unlimited for both halves; non-zero caps BIS
+        # at whatever capacity remains after the (already-clamped) xbank slice.
+        if args.max_rows:
+            remaining = max(0, args.max_rows - len(pairs))
+            bis_cap = remaining
+            should_load_bis = remaining > 0
+            if not should_load_bis:
+                import warnings as _warnings
+
+                _warnings.warn(
+                    f"--substrate bis_xbank --max-rows {args.max_rows} was reached "
+                    f"by cross-bank ({len(pairs)} pairs); BIS substrate dropped. "
+                    "Raise --max-rows or use --substrate bis to override.",
+                    stacklevel=2,
+                )
+        else:
+            bis_cap = 0  # _bis_pair_stream treats 0 as "no cap".
+            should_load_bis = True
+        if should_load_bis:
+            bis_iter = _bis_pair_stream(
+                args.bis_dataset_id,
+                args.bis_dataset_revision,
+                streaming=args.streaming,
+                max_rows=bis_cap,
+            )
+            pairs.extend(list(bis_iter))
+        return pairs
+
     if args.substrate in {"local", "both"}:
         local_dir = Path(args.auxiliary_local_dir) if args.auxiliary_local_dir else Path(args.data_dir)
         local_pairs = _iter_local_pairs(local_dir, args.corpus_files)
@@ -359,7 +502,7 @@ def _collect_pairs(args: argparse.Namespace) -> list[dict[str, Any]]:
             local_pairs = local_pairs[: args.max_rows]
         pairs.extend(local_pairs)
 
-    if args.substrate in {"bis", "both"}:
+    if args.substrate in {"bis", "both", "bis_xbank"}:
         if args.substrate == "both" and args.max_rows:
             remaining = max(0, args.max_rows - len(pairs))
             bis_cap = remaining
@@ -418,7 +561,7 @@ def main(argv: list[str] | None = None) -> int:
 
     resolved_revision = (
         _resolve_dataset_sha(args.bis_dataset_id, args.bis_dataset_revision)
-        if args.substrate in {"bis", "both"}
+        if args.substrate in {"bis", "both", "bis_xbank"}
         else None
     )
 
@@ -459,7 +602,7 @@ def main(argv: list[str] | None = None) -> int:
             "bis_dataset_revision_requested": args.bis_dataset_revision,
             "bis_dataset_revision_resolved": resolved_revision,
         },
-        inputs=[args.bis_dataset_id] if args.substrate in {"bis", "both"} else [],
+        inputs=[args.bis_dataset_id] if args.substrate in {"bis", "both", "bis_xbank"} else [],
         extra={"num_examples": result["num_examples"]},
     )
     print(f"[mlm] checkpoint at {result['checkpoint_path']}")

--- a/backend/app/data/continued_pretraining.py
+++ b/backend/app/data/continued_pretraining.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -37,6 +38,8 @@ from typing import Any, Iterable
 from app.config import DATA_DIR
 from app.models.registry import revision_for
 from app.training.manifest import write_run_manifest
+
+_logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_CHECKPOINT = "ProsusAI/finbert"
 DEFAULT_OUT_NAME = "finbert_fed_adjacent"
@@ -79,6 +82,19 @@ _GTFINTECHLAB_XBANK_REVISIONS: dict[str, str] = {
     "gtfintechlab/bank_of_canada": "ab15ea2271bfa3208874a5517afc439640fd9200",
     "gtfintechlab/reserve_bank_of_australia": "7a91206b56f2841b2586e409feade2518284894b",
 }
+
+# Enforce that every cross-bank dataset id has a pinned SHA at import
+# time. A future edit that adds a sixth bank to
+# ``_GTFINTECHLAB_XBANK_DATASETS`` without an entry in
+# ``_GTFINTECHLAB_XBANK_REVISIONS`` would otherwise silently fall back
+# to fetching HF Hub HEAD, breaking the reproducibility invariant the
+# DAPT manifest relies on.
+assert set(dataset_id for _, dataset_id in _GTFINTECHLAB_XBANK_DATASETS) == set(
+    _GTFINTECHLAB_XBANK_REVISIONS.keys()
+), (
+    "_GTFINTECHLAB_XBANK_DATASETS and _GTFINTECHLAB_XBANK_REVISIONS must "
+    "list the same dataset ids; missing pin or stale entry detected."
+)
 
 _VALID_SUBSTRATES = ("bis", "local", "fomc", "both", "bis_xbank")
 
@@ -173,10 +189,12 @@ def _iter_gtfintechlab_xbank_pairs() -> list[dict[str, Any]]:
 
     pairs: list[dict[str, Any]] = []
     for _bank_key, dataset_id in _GTFINTECHLAB_XBANK_DATASETS:
-        revision = _GTFINTECHLAB_XBANK_REVISIONS.get(dataset_id)
-        kwargs: dict[str, Any] = {}
-        if revision:
-            kwargs["revision"] = revision
+        # Indexing (not ``.get``) so a missing pin raises ``KeyError`` at
+        # the call site instead of silently degrading to HF Hub HEAD —
+        # the same reproducibility guard the import-time assertion
+        # enforces, restated here for the dynamic dispatch path.
+        revision = _GTFINTECHLAB_XBANK_REVISIONS[dataset_id]
+        kwargs: dict[str, Any] = {"revision": revision}
         configs = list(get_dataset_config_names(dataset_id, **kwargs))
         if not configs:
             configs = [None]  # default config
@@ -191,14 +209,13 @@ def _iter_gtfintechlab_xbank_pairs() -> list[dict[str, Any]]:
             except Exception:
                 splits = ["train"]
             for split in splits:
-                load_kwargs: dict[str, Any] = {"split": split}
-                if revision:
-                    load_kwargs["revision"] = revision
+                load_kwargs: dict[str, Any] = {"split": split, "revision": revision}
                 if config is not None:
                     ds = load_dataset(dataset_id, config, **load_kwargs)
                 else:
                     ds = load_dataset(dataset_id, **load_kwargs)
                 buffer: list[str] = []
+                trailing_dropped = 0
                 for row in ds:
                     if not isinstance(row, dict):
                         continue
@@ -216,7 +233,31 @@ def _iter_gtfintechlab_xbank_pairs() -> list[dict[str, Any]]:
                                     "next_sentence_label": 0,
                                 }
                             )
-                        buffer = []
+                            buffer = []
+                        else:
+                            # Degenerate duplicate: drop ``a`` only; keep
+                            # ``b`` as the candidate first-of-pair for
+                            # the next iteration. Previously the buffer
+                            # was reset to ``[]``, silently discarding
+                            # ``b`` alongside the duplicate ``a`` and
+                            # losing a sentence that could have
+                            # legitimately paired with the next row.
+                            buffer = [b]
+                if buffer:
+                    # An odd number of non-empty sentences in this
+                    # ``(config, split)`` bucket leaves the last
+                    # sentence with no partner. We surface the count in
+                    # the logs so reproducibility audits can reconcile
+                    # the pair total against the row total.
+                    trailing_dropped += len(buffer)
+                if trailing_dropped:
+                    _logger.info(
+                        "xbank_trailing_dropped dataset_id=%s config=%s split=%s n=%d",
+                        dataset_id,
+                        config,
+                        split,
+                        trailing_dropped,
+                    )
     return pairs
 
 

--- a/backend/app/data/continued_pretraining.py
+++ b/backend/app/data/continued_pretraining.py
@@ -585,24 +585,38 @@ def main(argv: list[str] | None = None) -> int:
         objective=args.objective,
     )
     (run_dir / "metrics.json").write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+    # Mirror the BIS-revision capture for the cross-bank corpora so a
+    # bis_xbank run records every HF dataset id + pinned SHA that fed it.
+    # Pulled from the module constant rather than re-querying the Hub:
+    # the SHAs are pinned for reproducibility, so a fresh resolve would
+    # only introduce drift risk.
+    hyperparameters: dict[str, Any] = {
+        "base_checkpoint": args.base_checkpoint,
+        "epochs": args.epochs,
+        "learning_rate": args.learning_rate,
+        "batch_size": args.batch_size,
+        "block_size": args.block_size,
+        "objective": args.objective,
+        "substrate": args.substrate,
+        "bis_dataset_id": args.bis_dataset_id,
+        "bis_dataset_revision_requested": args.bis_dataset_revision,
+        "bis_dataset_revision_resolved": resolved_revision,
+    }
+    inputs: list[str] = (
+        [args.bis_dataset_id] if args.substrate in {"bis", "both", "bis_xbank"} else []
+    )
+    if args.substrate == "bis_xbank":
+        hyperparameters["xbank_dataset_revisions"] = dict(_GTFINTECHLAB_XBANK_REVISIONS)
+        inputs.extend(dataset_id for _bank_key, dataset_id in _GTFINTECHLAB_XBANK_DATASETS)
+
     write_run_manifest(
         run_dir,
         run_id=f"{args.checkpoint_name}_{run_token}_s{args.seed}",
         version_ids={"model_version": args.checkpoint_name},
         seeds=[args.seed],
-        hyperparameters={
-            "base_checkpoint": args.base_checkpoint,
-            "epochs": args.epochs,
-            "learning_rate": args.learning_rate,
-            "batch_size": args.batch_size,
-            "block_size": args.block_size,
-            "objective": args.objective,
-            "substrate": args.substrate,
-            "bis_dataset_id": args.bis_dataset_id,
-            "bis_dataset_revision_requested": args.bis_dataset_revision,
-            "bis_dataset_revision_resolved": resolved_revision,
-        },
-        inputs=[args.bis_dataset_id] if args.substrate in {"bis", "both", "bis_xbank"} else [],
+        hyperparameters=hyperparameters,
+        inputs=inputs,
         extra={"num_examples": result["num_examples"]},
     )
     print(f"[mlm] checkpoint at {result['checkpoint_path']}")

--- a/backend/app/data/label_schemas.py
+++ b/backend/app/data/label_schemas.py
@@ -53,3 +53,24 @@ def load_schema(path: Path | None = None) -> dict[str, Any]:
 def sample_weight_for(provenance: str) -> float:
     weights = (load_schema().get("provenance") or {}).get("sample_weights") or {}
     return float(weights.get(provenance, 0.0))
+
+
+def auxiliary_axis_weight_for(provenance: str) -> float:
+    """Inclusion weight for auxiliary (non-stance) axes per provenance bucket.
+
+    ``sample_weight_for`` is the strict-FOMC gate on the stance head: it
+    returns 0.0 for ``peer_reviewed_cross_bank`` rows so they never
+    contribute to FOMC stance supervision. The auxiliary axes
+    (certainty / topic / factor / time) do not carry the same
+    FOMC-distribution concern — the cross-bank corpora are useful
+    encoder-side signal for those axes. This helper returns 1.0 for
+    ``peer_reviewed_cross_bank`` so the encoder fine-tune can route
+    those rows through the auxiliary heads even when their stance is
+    masked, and otherwise falls back to the provenance-keyed sample
+    weight so non-cross-bank buckets behave identically to the
+    existing gate.
+    """
+
+    if provenance == "peer_reviewed_cross_bank":
+        return 1.0
+    return sample_weight_for(provenance)

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -64,13 +64,22 @@ class _AxisRow:
     without per-axis branching. ``source`` carries the originating
     corpus (e.g. ``"gtfintechlab/federal_reserve_system"``,
     ``"events_parquet"``) so the eval pass can slice per-bank metrics
-    (D from the 2026-05-24 plan).
+    (D from the 2026-05-24 plan). ``provenance`` mirrors the
+    registry's provenance bucket (e.g. ``"peer_reviewed"``,
+    ``"peer_reviewed_cross_bank"``) so the cross-bank supervision flag
+    can scope its mask + weight rewrites without re-deriving the
+    bucket from ``source``. ``stance_sample_weight`` is a per-row
+    multiplier on the stance branch's loss; it stays 1.0 for every
+    FOMC row and is scaled down for cross-bank rows under the
+    ``weighted`` arm of ``--cross-bank-supervision``.
     """
 
     text: str
     targets: dict[str, float | int] = field(default_factory=dict)
     masks: dict[str, bool] = field(default_factory=dict)
     source: str = ""
+    provenance: str = ""
+    stance_sample_weight: float = 1.0
 
 
 def _set_all_seeds(seed: int) -> None:
@@ -189,8 +198,22 @@ def _load_supervised_rows(events_parquet: Path) -> list[_AxisRow]:
         if not any(masks.values()):
             continue
         source = str(record.get("source") or "events_parquet")
+        # ``events.parquet`` does not carry ``provenance`` directly —
+        # the event builder collapses by (source, event_date, kind),
+        # dropping the per-row provenance column. Cross-bank rows do
+        # not reach this path today, so a constant "" is correct: the
+        # cross-bank supervision flag is a no-op for events_parquet
+        # by design and the per-axis sanity log will record zero
+        # cross-bank rows on this corpus.
         rows.append(
-            _AxisRow(text=text, targets=targets, masks=masks, source=source)
+            _AxisRow(
+                text=text,
+                targets=targets,
+                masks=masks,
+                source=source,
+                provenance="",
+                stance_sample_weight=1.0,
+            )
         )
     return rows
 
@@ -211,7 +234,12 @@ _GTFINTECHLAB_DATASET_IDS: tuple[str, ...] = (
 
 
 def _gtfintechlab_row_to_axis_row(
-    item: dict[str, Any], *, source: str = "gtfintechlab"
+    item: dict[str, Any],
+    *,
+    source: str = "gtfintechlab",
+    provenance: str = "",
+    cross_bank_mode: str = "off",
+    cross_bank_stance_weight: float = 1.0,
 ) -> _AxisRow | None:
     """Map a single gtfintechlab sentence-level row to ``_AxisRow``.
 
@@ -223,6 +251,12 @@ def _gtfintechlab_row_to_axis_row(
     canonical value) are kept but their stance mask stays False so
     the loss does not train on them — they still contribute
     certainty supervision when that axis is populated.
+
+    ``cross_bank_mode`` rewrites the per-row stance mask + weight for
+    rows whose ``provenance == "peer_reviewed_cross_bank"`` (see
+    ``--cross-bank-supervision`` on the CLI). The rewrite happens
+    here, at row materialisation, so every downstream layer reads the
+    corrected mask without further special-casing.
     """
 
     text = str(item.get("sentences") or "").strip()
@@ -259,9 +293,31 @@ def _gtfintechlab_row_to_axis_row(
     # loss contributes nothing for them. The branches still emit
     # predictions at inference, which the frontend can choose to
     # render as low-confidence.
+    stance_sample_weight = 1.0
+    if provenance == "peer_reviewed_cross_bank":
+        if cross_bank_mode == "stance_masked":
+            # Substitute-not-complement guard: drop the stance label
+            # so the head does not fit the cross-bank stance
+            # distribution. Other axes keep their natural per-row
+            # masks so the encoder still trains on the auxiliary
+            # signal.
+            masks["stance"] = False
+        elif cross_bank_mode == "weighted":
+            # Diagnostic A/B: keep the stance mask so the head sees
+            # the cross-bank labels, but scale the row's contribution
+            # to the stance loss down so it does not dominate the
+            # FOMC distribution.
+            stance_sample_weight = float(cross_bank_stance_weight)
     if not any(masks.values()):
         return None
-    return _AxisRow(text=text, targets=targets, masks=masks, source=source)
+    return _AxisRow(
+        text=text,
+        targets=targets,
+        masks=masks,
+        source=source,
+        provenance=provenance,
+        stance_sample_weight=stance_sample_weight,
+    )
 
 
 def _gtfintechlab_datasets_module() -> Any:
@@ -297,6 +353,9 @@ def _gtfintechlab_split_rows(
     config: str,
     split: str,
     revision: str,
+    provenance: str = "",
+    cross_bank_mode: str = "off",
+    cross_bank_stance_weight: float = 1.0,
 ) -> list[_AxisRow]:
     """Materialise one ``(dataset, config, split)`` triple's rows.
 
@@ -317,14 +376,26 @@ def _gtfintechlab_split_rows(
         return []
     out: list[_AxisRow] = []
     for record in ds:
-        row = _gtfintechlab_row_to_axis_row(dict(record), source=dataset_id)
+        row = _gtfintechlab_row_to_axis_row(
+            dict(record),
+            source=dataset_id,
+            provenance=provenance,
+            cross_bank_mode=cross_bank_mode,
+            cross_bank_stance_weight=cross_bank_stance_weight,
+        )
         if row is not None:
             out.append(row)
     return out
 
 
 def _gtfintechlab_dataset_rows(
-    hf_mod: Any, *, dataset_id: str, revision: str
+    hf_mod: Any,
+    *,
+    dataset_id: str,
+    revision: str,
+    provenance: str = "",
+    cross_bank_mode: str = "off",
+    cross_bank_stance_weight: float = 1.0,
 ) -> list[_AxisRow]:
     """Walk every (config, split) under one gtfintechlab dataset."""
 
@@ -354,12 +425,37 @@ def _gtfintechlab_dataset_rows(
                     config=config,
                     split=split,
                     revision=revision,
+                    provenance=provenance,
+                    cross_bank_mode=cross_bank_mode,
+                    cross_bank_stance_weight=cross_bank_stance_weight,
                 )
             )
     return rows
 
 
-def _load_gtfintechlab_rows(*, fed_only: bool = False) -> list[_AxisRow]:
+def _provenance_for_gtfintechlab_dataset(dataset_id: str) -> str:
+    """Bucket each gtfintechlab dataset into the registry's provenance vocab.
+
+    The FOMC dataset is part of the supervised pool (``peer_reviewed``,
+    sample_weight 1.0). The other five central-bank datasets enter
+    the cross-bank generalisation pool (``peer_reviewed_cross_bank``,
+    sample_weight 0.0). This mirrors the same bucketing
+    ``ingest_sources._iter_gtfintechlab_cross_bank_records`` writes
+    onto the registry so the trainer's view of provenance stays in
+    sync with the registry view.
+    """
+
+    if dataset_id == _GTFINTECHLAB_DATASET_IDS[0]:
+        return "peer_reviewed"
+    return "peer_reviewed_cross_bank"
+
+
+def _load_gtfintechlab_rows(
+    *,
+    fed_only: bool = False,
+    cross_bank_mode: str = "off",
+    cross_bank_stance_weight: float = 1.0,
+) -> list[_AxisRow]:
     """Pull supervised sentence-level rows from the gtfintechlab HF datasets.
 
     Iterates every (config, split) under each dataset to materialise
@@ -367,6 +463,17 @@ def _load_gtfintechlab_rows(*, fed_only: bool = False) -> list[_AxisRow]:
     With ``fed_only=True`` the loader restricts to the
     ``federal_reserve_system`` subset (~3 000 rows) for FOMC-specific
     fine-tuning at the cost of a smaller, more imbalanced training pool.
+
+    ``cross_bank_mode`` controls how rows from the five non-FOMC
+    central-bank datasets (provenance ``peer_reviewed_cross_bank``)
+    enter the supervised pool. ``off`` (default) drops them entirely
+    — the loader walks the FOMC dataset only, reproducing the
+    strict-FOMC training pool byte-identically. ``stance_masked``
+    admits them with their stance mask forced to False so the head
+    only fits the FOMC stance distribution while the encoder still
+    sees the cross-bank text. ``weighted`` admits them with the
+    natural stance label and downscales their stance loss
+    contribution by ``cross_bank_stance_weight``.
     """
 
     hf_mod = _gtfintechlab_datasets_module()
@@ -377,7 +484,10 @@ def _load_gtfintechlab_rows(*, fed_only: bool = False) -> list[_AxisRow]:
     # training side stays aligned with the ingestion side.
     from app.data.ingest_sources import _dataset_revision
 
-    dataset_ids = _GTFINTECHLAB_DATASET_IDS[:1] if fed_only else _GTFINTECHLAB_DATASET_IDS
+    if fed_only or cross_bank_mode == "off":
+        dataset_ids = _GTFINTECHLAB_DATASET_IDS[:1]
+    else:
+        dataset_ids = _GTFINTECHLAB_DATASET_IDS
     rows: list[_AxisRow] = []
     for dataset_id in dataset_ids:
         revision = _dataset_revision(dataset_id)
@@ -386,13 +496,22 @@ def _load_gtfintechlab_rows(*, fed_only: bool = False) -> list[_AxisRow]:
                 "gtfintechlab_revision_missing dataset=%s (skipping)", dataset_id
             )
             continue
+        provenance = _provenance_for_gtfintechlab_dataset(dataset_id)
         rows.extend(
             _gtfintechlab_dataset_rows(
-                hf_mod, dataset_id=dataset_id, revision=revision
+                hf_mod,
+                dataset_id=dataset_id,
+                revision=revision,
+                provenance=provenance,
+                cross_bank_mode=cross_bank_mode,
+                cross_bank_stance_weight=cross_bank_stance_weight,
             )
         )
     _logger.info(
-        "loaded_gtfintechlab_rows total=%d fed_only=%s", len(rows), fed_only
+        "loaded_gtfintechlab_rows total=%d fed_only=%s cross_bank_mode=%s",
+        len(rows),
+        fed_only,
+        cross_bank_mode,
     )
     return rows
 
@@ -468,6 +587,16 @@ class _MultiAxisDataset(Dataset):
             # pass can compute per-bank macro-F1 without re-loading
             # the original rows. Collated as a list of strings.
             "source": row.source,
+            # Provenance bucket from the registry (e.g.
+            # ``peer_reviewed``, ``peer_reviewed_cross_bank``). Used
+            # by the first-epoch sanity log to split per-axis row
+            # counts by corpus origin.
+            "provenance": row.provenance,
+            # Per-row multiplier on the stance branch's loss. Stays
+            # 1.0 for FOMC rows; the ``weighted`` cross-bank arm
+            # scales cross-bank rows down so they do not dominate
+            # the FOMC stance distribution.
+            "stance_sample_weight": float(row.stance_sample_weight),
         }
 
 
@@ -499,12 +628,52 @@ def _collate(batch: list[dict[str, Any]]) -> dict[str, Any]:
     out["mask_topic"] = torch.tensor(
         [item["mask_topic"] for item in batch], dtype=torch.bool
     )
-    # ``source`` is a per-row str the per-bank eval reads; the rest of
-    # the batch is torch.Tensor. The mixed-type return signature is
+    # ``source`` and ``provenance`` are per-row strings (the per-bank
+    # eval and the first-epoch sanity log read them); the rest of the
+    # batch is torch.Tensor. The mixed-type return signature is
     # documented on _collate's annotation so the type hint matches
-    # the actual payload.
+    # the actual payload. ``stance_sample_weight`` is a per-row
+    # float32 vector consumed by the training loop when the
+    # ``weighted`` cross-bank arm is active; FOMC rows stay at 1.0.
     out["source"] = [str(item.get("source", "")) for item in batch]
+    out["provenance"] = [str(item.get("provenance", "")) for item in batch]
+    out["stance_sample_weight"] = torch.tensor(
+        [float(item.get("stance_sample_weight", 1.0)) for item in batch],
+        dtype=torch.float32,
+    )
     return out
+
+
+def _log_per_axis_provenance_breakdown(rows: list[_AxisRow]) -> None:
+    """One-shot sanity log of per-axis training-row counts by provenance.
+
+    Emitted once at the start of training so any regression that
+    leaks cross-bank rows into the stance head shows up as a
+    non-zero ``from_cross_bank`` column on the stance line. The log
+    matches the project's existing ``key=value key=value`` info-log
+    style so downstream parsers (and the wiki's training-summary
+    extractor) stay uniform.
+    """
+
+    axis_names: tuple[str, ...] = ("stance", "factor", "certainty", "topic")
+    for axis_name in axis_names:
+        from_fomc = 0
+        from_cross_bank = 0
+        for row in rows:
+            if not row.masks.get(axis_name, False):
+                continue
+            if row.provenance == "peer_reviewed_cross_bank":
+                from_cross_bank += 1
+            else:
+                from_fomc += 1
+        total = from_fomc + from_cross_bank
+        _logger.info(
+            "axis=%s rows_total=%d from_FOMC=%d from_cross_bank=%d",
+            axis_name,
+            total,
+            from_fomc,
+            from_cross_bank,
+        )
 
 
 def _train_one_epoch(
@@ -535,7 +704,16 @@ def _train_one_epoch(
             "certainty_mask": batch["mask_certainty"].to(device),
             "topic_mask": batch["mask_topic"].to(device),
         }
-        total, breakdown = loss_fn(logits, targets, masks)
+        stance_weight = batch.get("stance_sample_weight")
+        if stance_weight is not None:
+            stance_weight = stance_weight.to(device)
+        total, breakdown = _compute_weighted_total_loss(
+            loss_fn=loss_fn,
+            logits=logits,
+            targets=targets,
+            masks=masks,
+            stance_sample_weight=stance_weight,
+        )
         total.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
@@ -549,6 +727,57 @@ def _train_one_epoch(
     for axis_name, total in sum_axis.items():
         out[f"loss_{axis_name}"] = total / n_batches
     return out
+
+
+def _compute_weighted_total_loss(
+    *,
+    loss_fn: MultiTaskLoss,
+    logits: dict[str, torch.Tensor],
+    targets: dict[str, torch.Tensor],
+    masks: dict[str, torch.Tensor],
+    stance_sample_weight: torch.Tensor | None,
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """Apply per-row stance weighting on top of the masked multi-task loss.
+
+    The default ``MultiTaskLoss`` path is preserved when no per-row
+    weight vector is supplied OR when every weight is 1.0 (the only
+    state the FOMC-only pool ever produces). When the ``weighted``
+    arm of ``--cross-bank-supervision`` produces non-unit weights,
+    the stance branch is recomputed as a per-row weighted CE so
+    cross-bank rows scale their contribution down by
+    ``--cross-bank-stance-weight`` without changing any other axis.
+    The breakdown dict mirrors the standard ``MultiTaskLoss`` output
+    so the training-loop logger keeps the same per-axis trajectory.
+    """
+
+    total, breakdown = loss_fn(logits, targets, masks)
+    if stance_sample_weight is None:
+        return total, breakdown
+    if torch.all(stance_sample_weight == 1.0):
+        return total, breakdown
+    stance_mask = masks["stance_mask"]
+    if stance_mask.numel() == 0 or not stance_mask.any():
+        return total, breakdown
+    active_logits = logits["stance"][stance_mask]
+    active_target = targets["stance"][stance_mask]
+    active_weight = stance_sample_weight[stance_mask]
+    weight_buf = loss_fn.get_buffer("_stance_weight")
+    class_weight = weight_buf if weight_buf.numel() > 0 else None
+    per_row = torch.nn.functional.cross_entropy(
+        active_logits, active_target, weight=class_weight, reduction="none"
+    )
+    weight_total = active_weight.sum()
+    if float(weight_total.item()) <= 0.0:
+        return total, breakdown
+    stance_loss_weighted = (per_row * active_weight).sum() / weight_total
+    new_total = (
+        total
+        - loss_fn.lambda_stance * breakdown["stance"]
+        + loss_fn.lambda_stance * stance_loss_weighted
+    )
+    new_breakdown = dict(breakdown)
+    new_breakdown["stance"] = stance_loss_weighted.detach()
+    return new_total, new_breakdown
 
 
 @torch.no_grad()
@@ -719,6 +948,15 @@ def _save_checkpoint(
             "gtfintechlab_fed_only": bool(
                 getattr(args, "gtfintechlab_fed_only", False)
             ),
+            # Bundle A.1: record the cross-bank arm + weight so a
+            # checkpoint trained under ``stance_masked`` cannot be
+            # confused with one trained under ``weighted`` on disk.
+            "cross_bank_supervision": str(
+                getattr(args, "cross_bank_supervision", "off")
+            ),
+            "cross_bank_stance_weight": float(
+                getattr(args, "cross_bank_stance_weight", 0.25)
+            ),
         },
         "saved_at_utc": datetime.now(timezone.utc).isoformat(),
     }
@@ -732,7 +970,11 @@ def main(argv: list[str] | None = None) -> int:
     _set_all_seeds(args.seed)
 
     if args.data_source == "gtfintechlab_hf":
-        rows = _load_gtfintechlab_rows(fed_only=args.gtfintechlab_fed_only)
+        rows = _load_gtfintechlab_rows(
+            fed_only=args.gtfintechlab_fed_only,
+            cross_bank_mode=args.cross_bank_supervision,
+            cross_bank_stance_weight=args.cross_bank_stance_weight,
+        )
         if not rows:
             raise SystemExit(
                 "gtfintechlab loader returned zero rows; check network access + "
@@ -821,6 +1063,8 @@ def main(argv: list[str] | None = None) -> int:
         ],
         lr=args.learning_rate,
     )
+
+    _log_per_axis_provenance_breakdown(train_rows)
 
     best_val_loss = float("inf")
     best_metrics: dict[str, float] = {}
@@ -952,6 +1196,43 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--lambda-factor", type=float, default=0.3)
     parser.add_argument("--lambda-certainty", type=float, default=0.3)
     parser.add_argument("--lambda-topic", type=float, default=0.3)
+    # Bundle A.1: cross-bank auxiliary supervision flag on the
+    # text-encoder fine-tune. ``off`` (default) keeps the strict
+    # FOMC stance pool — cross-bank rows are excluded so the
+    # current FOMC headline reproduces byte-identically.
+    # ``stance_masked`` admits cross-bank rows but forces their
+    # stance mask to False so the head only fits the FOMC stance
+    # distribution while the encoder still trains on the
+    # cross-bank text + auxiliary (certainty / topic / factor /
+    # time) supervision. ``weighted`` admits them with the natural
+    # stance label and downscales their stance contribution by
+    # ``--cross-bank-stance-weight`` so the head can be A/B-tested
+    # against the masked arm to re-litigate the Phase C
+    # substitute-vs-complement prior (#231).
+    parser.add_argument(
+        "--cross-bank-supervision",
+        choices=("off", "stance_masked", "weighted"),
+        default="off",
+        help=(
+            "Cross-bank (peer_reviewed_cross_bank) row handling on the "
+            "encoder fine-tune. ``off`` (default) excludes them; "
+            "``stance_masked`` admits them with stance masked out so the "
+            "head stays on the FOMC stance distribution; ``weighted`` "
+            "admits them with their stance contribution scaled by "
+            "``--cross-bank-stance-weight``."
+        ),
+    )
+    parser.add_argument(
+        "--cross-bank-stance-weight",
+        type=float,
+        default=0.25,
+        help=(
+            "Per-row multiplier on the stance loss for cross-bank rows "
+            "under ``--cross-bank-supervision weighted``. FOMC rows stay "
+            "at 1.0; cross-bank rows scale down so they do not dominate "
+            "the FOMC distribution."
+        ),
+    )
     return parser.parse_args(argv)
 
 

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -346,7 +346,7 @@ def _gtfintechlab_datasets_module() -> Any:
     )
 
 
-def _gtfintechlab_split_rows(
+def _gtfintechlab_split_rows(  # noqa: PLR0913 — keyword-only HF load coords plus cross-bank context; grouping would obscure call sites.
     hf_mod: Any,
     *,
     dataset_id: str,
@@ -388,7 +388,7 @@ def _gtfintechlab_split_rows(
     return out
 
 
-def _gtfintechlab_dataset_rows(
+def _gtfintechlab_dataset_rows(  # noqa: PLR0913 — same cross-bank context as _gtfintechlab_split_rows; grouping into a dataclass would obscure call sites.
     hf_mod: Any,
     *,
     dataset_id: str,

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -979,6 +979,19 @@ def _save_checkpoint(
             "cross_bank_stance_weight": float(
                 getattr(args, "cross_bank_stance_weight", 0.25)
             ),
+            # When ``--gtfintechlab-fed-only`` is combined with a
+            # non-``off`` cross-bank arm, ``main()`` warns and the
+            # loader restricts to FOMC — so the run did NOT actually
+            # use cross-bank supervision regardless of what was
+            # requested. Surface the resolved effective mode alongside
+            # the raw request so the checkpoint provenance is honest:
+            # the raw field traces what the operator asked for, the
+            # effective field traces what the run actually did.
+            "effective_cross_bank_supervision": (
+                "off"
+                if bool(getattr(args, "gtfintechlab_fed_only", False))
+                else str(getattr(args, "cross_bank_supervision", "off"))
+            ),
         },
         "saved_at_utc": datetime.now(timezone.utc).isoformat(),
     }

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -653,11 +653,19 @@ def _log_per_axis_provenance_breakdown(rows: list[_AxisRow]) -> None:
     matches the project's existing ``key=value key=value`` info-log
     style so downstream parsers (and the wiki's training-summary
     extractor) stay uniform.
+
+    The non-cross-bank bucket is named ``from_other`` (not
+    ``from_FOMC``) so a future provenance (e.g. ``scraped_cross_bank``
+    or an events_parquet row carrying provenance="") that is neither
+    FOMC nor the recognised cross-bank tag does not silently inflate
+    the FOMC counter. Today the supervised pool is dominated by FOMC
+    rows under the ``peer_reviewed`` tag, but the bucket name should
+    not encode that as a permanent assumption.
     """
 
     axis_names: tuple[str, ...] = ("stance", "factor", "certainty", "topic")
     for axis_name in axis_names:
-        from_fomc = 0
+        from_other = 0
         from_cross_bank = 0
         for row in rows:
             if not row.masks.get(axis_name, False):
@@ -665,13 +673,13 @@ def _log_per_axis_provenance_breakdown(rows: list[_AxisRow]) -> None:
             if row.provenance == "peer_reviewed_cross_bank":
                 from_cross_bank += 1
             else:
-                from_fomc += 1
-        total = from_fomc + from_cross_bank
+                from_other += 1
+        total = from_other + from_cross_bank
         _logger.info(
-            "axis=%s rows_total=%d from_FOMC=%d from_cross_bank=%d",
+            "axis=%s rows_total=%d from_other=%d from_cross_bank=%d",
             axis_name,
             total,
-            from_fomc,
+            from_other,
             from_cross_bank,
         )
 
@@ -958,6 +966,23 @@ def main(argv: list[str] | None = None) -> int:
     _set_all_seeds(args.seed)
 
     if args.data_source == "gtfintechlab_hf":
+        # Conflict warning: ``--gtfintechlab-fed-only`` restricts the
+        # loader to the FOMC dataset, which leaves the cross-bank
+        # supervision arm with zero rows to act on — the run log would
+        # otherwise advertise ``cross_bank_mode=stance_masked`` /
+        # ``weighted`` while silently doing nothing. Fed-only wins by
+        # design (it's the explicit FOMC-restriction switch); the
+        # warning lets the caller resolve the conflict on their next
+        # run instead of being misled by the cross-bank flag's
+        # appearance in the args.
+        if args.gtfintechlab_fed_only and args.cross_bank_supervision != "off":
+            _logger.warning(
+                "cross_bank_supervision_noop "
+                "--gtfintechlab-fed-only=True --cross-bank-supervision=%s "
+                "fed-only restricts the loader to the FOMC dataset so the "
+                "cross-bank arm has no rows to act on; fed-only wins.",
+                args.cross_bank_supervision,
+            )
         rows = _load_gtfintechlab_rows(
             fed_only=args.gtfintechlab_fed_only,
             cross_bank_mode=args.cross_bank_supervision,

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -861,12 +861,29 @@ def _evaluate_per_bank(
     return out
 
 
+@torch.no_grad()
 def _evaluate(
     model: TextMultiAxisClassifier,
     loader: DataLoader,
     loss_fn: MultiTaskLoss,
     device: torch.device,
 ) -> dict[str, float]:
+    """Eval loop that mirrors the train loop's loss formula exactly.
+
+    The decorator suppresses autograd graph construction for the whole
+    forward + loss pass (``model.eval()`` only flips dropout/BN, it does
+    NOT disable autograd) — without it, the per-batch forward retained a
+    computation graph that was never backpropagated, ballooning memory.
+
+    The per-row ``stance_sample_weight`` from the batch is threaded into
+    ``loss_fn`` so the val loss tracks the same objective the optimizer
+    is minimizing on the train side. Otherwise (under
+    ``--cross-bank-supervision=weighted``) the train path runs weighted
+    CE on stance while the val path runs plain unweighted CE, and
+    best-checkpoint selection by ``val_loss`` picks against the wrong
+    objective.
+    """
+
     model.eval()
     sum_total = 0.0
     sum_axis = {"stance": 0.0, "factor": 0.0, "certainty": 0.0, "topic": 0.0}
@@ -889,7 +906,16 @@ def _evaluate(
             "certainty_mask": batch["mask_certainty"].to(device),
             "topic_mask": batch["mask_topic"].to(device),
         }
-        total, breakdown = loss_fn(logits, targets, masks)
+        stance_weight = batch.get("stance_sample_weight")
+        if stance_weight is not None:
+            stance_weight = stance_weight.to(device)
+        total, breakdown = _compute_weighted_total_loss(
+            loss_fn=loss_fn,
+            logits=logits,
+            targets=targets,
+            masks=masks,
+            stance_sample_weight=stance_weight,
+        )
         sum_total += float(total.item())
         for axis_name in sum_axis:
             sum_axis[axis_name] += float(breakdown[axis_name].item())

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -737,47 +737,35 @@ def _compute_weighted_total_loss(
     masks: dict[str, torch.Tensor],
     stance_sample_weight: torch.Tensor | None,
 ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
-    """Apply per-row stance weighting on top of the masked multi-task loss.
+    """Forward through ``MultiTaskLoss`` with the per-row stance weight.
 
-    The default ``MultiTaskLoss`` path is preserved when no per-row
-    weight vector is supplied OR when every weight is 1.0 (the only
-    state the FOMC-only pool ever produces). When the ``weighted``
-    arm of ``--cross-bank-supervision`` produces non-unit weights,
-    the stance branch is recomputed as a per-row weighted CE so
-    cross-bank rows scale their contribution down by
-    ``--cross-bank-stance-weight`` without changing any other axis.
-    The breakdown dict mirrors the standard ``MultiTaskLoss`` output
-    so the training-loop logger keeps the same per-axis trajectory.
+    ``MultiTaskLoss.forward`` takes an optional ``stance_sample_weight``
+    kwarg that turns the stance branch into a weighted-mean CE; the
+    factor / certainty / topic branches are unchanged. Passing the
+    vector straight through keeps every gradient path on the loss
+    side, so the helper here is a thin call-site adapter: when the
+    batch carries no weights, or every weight is exactly 1.0 (the
+    only state the FOMC-only pool ever produces), we call the loss
+    without the kwarg so the numerics reproduce the prior path
+    byte-identically.
+
+    Note on correctness: an earlier draft of this helper computed the
+    weighted stance loss outside the loss and then subtracted
+    ``breakdown["stance"]`` (a detached scalar) from the original
+    ``total``. That left the original stance gradient path through
+    ``logits["stance"]`` accumulated alongside the new weighted path
+    — a silent double-count. The current path delegates the swap to
+    ``MultiTaskLoss`` itself so there is exactly one stance loss term
+    in the computation graph.
     """
 
-    total, breakdown = loss_fn(logits, targets, masks)
     if stance_sample_weight is None:
-        return total, breakdown
+        return loss_fn(logits, targets, masks)
     if torch.all(stance_sample_weight == 1.0):
-        return total, breakdown
-    stance_mask = masks["stance_mask"]
-    if stance_mask.numel() == 0 or not stance_mask.any():
-        return total, breakdown
-    active_logits = logits["stance"][stance_mask]
-    active_target = targets["stance"][stance_mask]
-    active_weight = stance_sample_weight[stance_mask]
-    weight_buf = loss_fn.get_buffer("_stance_weight")
-    class_weight = weight_buf if weight_buf.numel() > 0 else None
-    per_row = torch.nn.functional.cross_entropy(
-        active_logits, active_target, weight=class_weight, reduction="none"
+        return loss_fn(logits, targets, masks)
+    return loss_fn(
+        logits, targets, masks, stance_sample_weight=stance_sample_weight
     )
-    weight_total = active_weight.sum()
-    if float(weight_total.item()) <= 0.0:
-        return total, breakdown
-    stance_loss_weighted = (per_row * active_weight).sum() / weight_total
-    new_total = (
-        total
-        - loss_fn.lambda_stance * breakdown["stance"]
-        + loss_fn.lambda_stance * stance_loss_weighted
-    )
-    new_breakdown = dict(breakdown)
-    new_breakdown["stance"] = stance_loss_weighted.detach()
-    return new_total, new_breakdown
 
 
 @torch.no_grad()

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -166,3 +166,20 @@ encoders:
       stance head); the remaining four seeds are kept on disk under
       ``finetune_batch_20260519T190604Z/finbert_fed_adjacent_s{29,47,71,97}``
       for reproducibility but the embedding cache builds against s11.
+
+  finbert_fed_adjacent_xbank_dapt:
+    repo: local/finbert-fed-adjacent-xbank-dapt
+    revision: ""
+    gated: false
+    task: masked_lm
+    description: |
+      DAPT substrate-extension sibling of ``finbert_fed_adjacent``. Same
+      MLM+NSP recipe, but the pretraining substrate adds the 5 cross-bank
+      gtfintechlab corpora (ECB / BoJ / BoE / BoC / RBA, ~15k sentences
+      reformatted as ~7.5k consecutive NSP pairs) on top of the BIS
+      speeches firehose — pure pretrain extension, no FOMC / local
+      Fed-adjacent JSON, so the downstream fine-tune target is unchanged
+      and there is no target leakage. Produced by
+      ``make finbert-fed-adjacent-xbank-dapt-pretrain``. Revision stays
+      empty until the first GPU run lands a checkpoint; same unpinned-
+      local guard as ``finbert_fomc_only`` applies.

--- a/backend/app/training/loss.py
+++ b/backend/app/training/loss.py
@@ -94,6 +94,8 @@ class MultiTaskLoss(nn.Module):
         logits: dict[str, torch.Tensor],
         targets: dict[str, torch.Tensor],
         masks: dict[str, torch.Tensor],
+        *,
+        stance_sample_weight: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Return ``(total_loss, per_axis_breakdown)``.
 
@@ -101,6 +103,17 @@ class MultiTaskLoss(nn.Module):
         keyed by axis name so the training-loop logger can record per-
         axis loss trajectories. Axes whose mask is all-False contribute
         zero loss to the total and emit a zero-valued breakdown entry.
+
+        ``stance_sample_weight`` is an optional per-row float vector
+        with the same length as the batch. When supplied, the stance
+        branch becomes a weighted-mean CE where each masked-in row's
+        contribution is scaled by its weight. When ``None`` (the
+        default), the stance loss is the unweighted masked mean — the
+        path every existing call site reaches today. The cross-bank
+        supervision arm (``--cross-bank-supervision weighted``) is the
+        only caller that passes a non-None vector; FOMC-only training
+        runs leave it as ``None`` and reproduce the prior numerics
+        byte-identically.
         """
 
         device = logits["stance"].device
@@ -111,6 +124,7 @@ class MultiTaskLoss(nn.Module):
             targets["stance"],
             masks["stance_mask"],
             weight=self._stance_weight_or_none(),
+            sample_weight=stance_sample_weight,
         )
         factor_loss = self._masked_regression_loss(
             logits["factor"],
@@ -152,6 +166,7 @@ class MultiTaskLoss(nn.Module):
         mask: torch.Tensor,
         *,
         weight: torch.Tensor | None,
+        sample_weight: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Mean CE loss over masked rows; zero when no rows are masked.
 
@@ -161,13 +176,34 @@ class MultiTaskLoss(nn.Module):
         Returns a graph-attached zero (``logits.sum() * 0``) when no
         rows survive so the optimiser still sees a tensor on the
         same device with the same gradient connectivity.
+
+        ``sample_weight`` (optional per-row float vector, same length
+        as ``mask``) scales each masked-in row's CE contribution. The
+        return is a weighted mean: ``sum(w_i * ce_i) / sum(w_i)`` over
+        masked-in rows. When the total weight collapses to zero (an
+        all-cross-bank batch under ``weighted`` with weight=0.0), the
+        result is the same graph-attached zero used for the empty-mask
+        case so backward stays well-defined and contributes no
+        gradient through the stance head.
         """
 
         if mask.numel() == 0 or not mask.any():
             return logits.sum() * 0.0
         active_logits = logits[mask]
         active_target = target[mask]
-        return F.cross_entropy(active_logits, active_target, weight=weight)
+        if sample_weight is None:
+            return F.cross_entropy(active_logits, active_target, weight=weight)
+        active_sample_weight = sample_weight[mask]
+        per_row = F.cross_entropy(
+            active_logits, active_target, weight=weight, reduction="none"
+        )
+        weight_total = active_sample_weight.sum()
+        # ``> 0`` keeps the zero-weight collapse on the same graph-
+        # attached zero path the empty-mask branch uses; otherwise the
+        # ``/ weight_total`` divisor would produce NaN gradients.
+        if float(weight_total.detach().item()) <= 0.0:
+            return logits.sum() * 0.0
+        return (per_row * active_sample_weight).sum() / weight_total
 
     def _masked_regression_loss(
         self,

--- a/tests/unit/test_continued_pretraining.py
+++ b/tests/unit/test_continued_pretraining.py
@@ -300,3 +300,167 @@ def test_parse_args_objective_validates_choices() -> None:
     assert args.objective == "mlm"
     with pytest.raises(SystemExit):
         cpt._parse_args(["--objective", "nonsense"])
+
+
+def test_bis_xbank_substrate_is_registered() -> None:
+    """The bis_xbank substrate must show up in the valid-choices tuple
+    so the CLI accepts ``--substrate bis_xbank`` without an argparse error."""
+    assert "bis_xbank" in cpt._VALID_SUBSTRATES
+
+
+def _install_fake_gtfintechlab(monkeypatch, sentences_per_dataset: dict[str, list[str]]) -> None:
+    """Stub the datasets module's load_dataset + config/split helpers used by
+    ``_iter_gtfintechlab_xbank_pairs``.
+
+    ``sentences_per_dataset`` keys are HF dataset ids; values are the flat list
+    of sentence strings that should be returned (single config / single split).
+    """
+    fake = types.SimpleNamespace()
+    fake.get_dataset_config_names = lambda dataset_id, revision=None: ["default"]
+    fake.get_dataset_split_names = lambda dataset_id, config, revision=None: ["train"]
+
+    def _load(dataset_id, config=None, split=None, revision=None, **kw):
+        sents = sentences_per_dataset.get(dataset_id, [])
+        return [{"sentences": s} for s in sents]
+
+    fake.load_dataset = _load
+    monkeypatch.setitem(sys.modules, "datasets", fake)
+
+
+def test_iter_gtfintechlab_xbank_pairs_shape(monkeypatch) -> None:
+    """The xbank pair iterator must return pair dicts with the same keys as
+    ``_iter_fomc_pairs`` / ``_bis_pair_stream`` so the trainer stays uniform."""
+    sentences = {
+        "gtfintechlab/european_central_bank": ["ECB s1.", "ECB s2.", "ECB s3.", "ECB s4."],
+        "gtfintechlab/bank_of_japan": ["BoJ s1.", "BoJ s2."],
+        "gtfintechlab/bank_of_england": ["BoE s1.", "BoE s2."],
+        "gtfintechlab/bank_of_canada": ["BoC s1.", "BoC s2."],
+        "gtfintechlab/reserve_bank_of_australia": ["RBA s1.", "RBA s2."],
+    }
+    _install_fake_gtfintechlab(monkeypatch, sentences)
+
+    pairs = cpt._iter_gtfintechlab_xbank_pairs()
+    assert isinstance(pairs, list)
+    assert len(pairs) > 0
+    for p in pairs:
+        assert set(p.keys()) >= {"sequenceA", "sequenceB", "next_sentence_label"}
+        assert isinstance(p["sequenceA"], str) and p["sequenceA"]
+        assert isinstance(p["sequenceB"], str) and p["sequenceB"]
+        # Pairs must be two distinct sentences, not degenerate copies.
+        assert p["sequenceA"] != p["sequenceB"]
+        assert isinstance(p["next_sentence_label"], int)
+
+
+def test_iter_gtfintechlab_xbank_pairs_covers_all_five_banks(monkeypatch) -> None:
+    """Every one of the 5 cross-bank datasets must contribute pairs — no silent
+    drop of a single bank."""
+    sentences = {
+        "gtfintechlab/european_central_bank": ["ECB a.", "ECB b."],
+        "gtfintechlab/bank_of_japan": ["BoJ a.", "BoJ b."],
+        "gtfintechlab/bank_of_england": ["BoE a.", "BoE b."],
+        "gtfintechlab/bank_of_canada": ["BoC a.", "BoC b."],
+        "gtfintechlab/reserve_bank_of_australia": ["RBA a.", "RBA b."],
+    }
+    _install_fake_gtfintechlab(monkeypatch, sentences)
+    pairs = cpt._iter_gtfintechlab_xbank_pairs()
+    joined = " | ".join(p["sequenceA"] + " " + p["sequenceB"] for p in pairs)
+    for marker in ("ECB", "BoJ", "BoE", "BoC", "RBA"):
+        assert marker in joined, f"{marker} contribution missing from xbank pair stream"
+
+
+def test_iter_gtfintechlab_xbank_pairs_scale_floor() -> None:
+    """The live HF datasets yield 5 x ~3,000 sentences; even after consecutive
+    pairing we should clear 5,000 pairs. Skip when ``datasets`` package or
+    network is unavailable (CI runs in offline-only mode)."""
+    pytest.importorskip("datasets")
+    try:
+        pairs = cpt._iter_gtfintechlab_xbank_pairs()
+    except Exception as exc:  # pragma: no cover — networkless CI
+        pytest.skip(f"HF cross-bank load failed: {exc}")
+    assert len(pairs) >= 5000, (
+        f"expected >= 5000 xbank pairs across the 5 banks, got {len(pairs)}"
+    )
+
+
+def test_collect_pairs_substrate_bis_xbank_combines_bis_and_xbank(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """``--substrate bis_xbank`` must combine BIS + cross-bank pairs and
+    exclude FOMC / local Fed-adjacent JSONs."""
+    _install_fake_datasets(
+        monkeypatch,
+        [
+            {"sequenceA": "BIS A1", "sequenceB": "BIS B1", "next_sentence_label": 0},
+            {"sequenceA": "BIS A2", "sequenceB": "BIS B2", "next_sentence_label": 1},
+        ],
+    )
+    # The fake xbank iterator replaces the real HF loader to keep the test
+    # offline. Returns a couple of clearly-tagged pairs we can assert on.
+    monkeypatch.setattr(
+        cpt,
+        "_iter_gtfintechlab_xbank_pairs",
+        lambda: [
+            {"sequenceA": "XBANK A1", "sequenceB": "XBANK B1", "next_sentence_label": 0},
+            {"sequenceA": "XBANK A2", "sequenceB": "XBANK B2", "next_sentence_label": 0},
+        ],
+    )
+    # Decoy local + FOMC files that must NOT be loaded under bis_xbank.
+    (tmp_path / "chair_speeches.json").write_text(
+        json.dumps([{"text": "Decoy local speech."}]),
+        encoding="utf-8",
+    )
+    (tmp_path / "fomc_statements.json").write_text(
+        json.dumps([{"text": "Decoy FOMC statement."}]),
+        encoding="utf-8",
+    )
+    args = cpt._parse_args(
+        [
+            "--substrate",
+            "bis_xbank",
+            "--data-dir",
+            str(tmp_path),
+        ]
+    )
+    pairs = cpt._collect_pairs(args)
+    bodies_a = [p["sequenceA"] for p in pairs]
+    assert "BIS A1" in bodies_a and "BIS A2" in bodies_a
+    assert "XBANK A1" in bodies_a and "XBANK A2" in bodies_a
+    # Decoys excluded.
+    assert "Decoy local speech." not in bodies_a
+    assert "Decoy FOMC statement." not in bodies_a
+
+
+def test_collect_pairs_substrate_bis_xbank_respects_max_rows(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Under ``--substrate bis_xbank --max-rows N``, xbank loads first (small,
+    finite) and BIS fills the remainder — mirroring the local/both convention
+    so the xbank contribution is never silently emptied."""
+    _install_fake_datasets(
+        monkeypatch,
+        [{"sequenceA": f"BIS A{i}", "sequenceB": "B", "next_sentence_label": 0} for i in range(10)],
+    )
+    monkeypatch.setattr(
+        cpt,
+        "_iter_gtfintechlab_xbank_pairs",
+        lambda: [
+            {"sequenceA": "XBANK A1", "sequenceB": "XBANK B1", "next_sentence_label": 0},
+            {"sequenceA": "XBANK A2", "sequenceB": "XBANK B2", "next_sentence_label": 0},
+        ],
+    )
+    args = cpt._parse_args(
+        [
+            "--substrate",
+            "bis_xbank",
+            "--data-dir",
+            str(tmp_path),
+            "--max-rows",
+            "5",
+        ]
+    )
+    pairs = cpt._collect_pairs(args)
+    assert len(pairs) == 5
+    # First two come from xbank, remaining 3 from BIS.
+    assert pairs[0]["sequenceA"].startswith("XBANK")
+    assert pairs[1]["sequenceA"].startswith("XBANK")
+    assert pairs[2]["sequenceA"].startswith("BIS")

--- a/tests/unit/test_continued_pretraining.py
+++ b/tests/unit/test_continued_pretraining.py
@@ -368,6 +368,115 @@ def test_iter_gtfintechlab_xbank_pairs_covers_all_five_banks(monkeypatch) -> Non
         assert marker in joined, f"{marker} contribution missing from xbank pair stream"
 
 
+def test_iter_gtfintechlab_xbank_pairs_dedup_preserves_b(monkeypatch) -> None:
+    """When the pairing buffer contains a degenerate (a == b) duplicate,
+    only ``a`` should be dropped — ``b`` must roll forward as the
+    candidate first-of-pair so it can legitimately pair with the next
+    sentence. The pre-fix code reset the buffer to ``[]`` and silently
+    discarded ``b`` alongside ``a``.
+
+    Sequence: ["X", "X", "Y"]. The first two collapse into the
+    degenerate (X, X) — drop the first X, keep the second X as buffer.
+    Pair (X, Y) then emits a single pair.
+    """
+    sentences = {
+        # All five datasets must be present (the iterator walks the full
+        # _GTFINTECHLAB_XBANK_DATASETS tuple) but only the first carries
+        # the dedup-relevant fixture.
+        "gtfintechlab/european_central_bank": ["X", "X", "Y"],
+        "gtfintechlab/bank_of_japan": [],
+        "gtfintechlab/bank_of_england": [],
+        "gtfintechlab/bank_of_canada": [],
+        "gtfintechlab/reserve_bank_of_australia": [],
+    }
+    _install_fake_gtfintechlab(monkeypatch, sentences)
+    pairs = cpt._iter_gtfintechlab_xbank_pairs()
+    # Exactly one pair (X, Y) — not zero (pre-fix would have dropped
+    # the second X with the dedup-reset) and not two (would happen if
+    # the dedup somehow emitted (X, X) anyway).
+    assert pairs == [
+        {"sequenceA": "X", "sequenceB": "Y", "next_sentence_label": 0}
+    ]
+
+
+def test_iter_gtfintechlab_xbank_pairs_dedup_does_not_double_count_b(
+    monkeypatch,
+) -> None:
+    """Edge case: when ``b == c`` (the next sentence after a dedup also
+    equals ``b``), the loop must emit ONE pair, not two — the rolled-
+    forward ``b`` should dedup-cancel against ``c`` rather than
+    silently fire (b, c) as a degenerate pair.
+
+    Sequence: ["X", "X", "X", "Y"]. Step 1: (X, X) → drop first X,
+    buffer = [X]. Step 2: append X → (X, X) again → drop, buffer =
+    [X]. Step 3: append Y → (X, Y) emit. Exactly one pair.
+    """
+    sentences = {
+        "gtfintechlab/european_central_bank": ["X", "X", "X", "Y"],
+        "gtfintechlab/bank_of_japan": [],
+        "gtfintechlab/bank_of_england": [],
+        "gtfintechlab/bank_of_canada": [],
+        "gtfintechlab/reserve_bank_of_australia": [],
+    }
+    _install_fake_gtfintechlab(monkeypatch, sentences)
+    pairs = cpt._iter_gtfintechlab_xbank_pairs()
+    assert pairs == [
+        {"sequenceA": "X", "sequenceB": "Y", "next_sentence_label": 0}
+    ]
+
+
+def test_iter_gtfintechlab_xbank_pairs_logs_trailing_odd_sentence(
+    monkeypatch, caplog
+) -> None:
+    """A bucket with an odd number of non-empty sentences leaves the
+    last sentence unpaired. The iterator must log how many trailing
+    sentences were dropped per (config, split) bucket so
+    reproducibility audits can reconcile pair counts against row
+    counts."""
+    sentences = {
+        # 3 sentences in this dataset → 1 pair emitted, 1 trailing.
+        "gtfintechlab/european_central_bank": ["A", "B", "C"],
+        "gtfintechlab/bank_of_japan": [],
+        "gtfintechlab/bank_of_england": [],
+        "gtfintechlab/bank_of_canada": [],
+        "gtfintechlab/reserve_bank_of_australia": [],
+    }
+    _install_fake_gtfintechlab(monkeypatch, sentences)
+    caplog.set_level("INFO", logger="app.data.continued_pretraining")
+    pairs = cpt._iter_gtfintechlab_xbank_pairs()
+    assert pairs == [
+        {"sequenceA": "A", "sequenceB": "B", "next_sentence_label": 0}
+    ]
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "xbank_trailing_dropped" in messages
+    assert "dataset_id=gtfintechlab/european_central_bank" in messages
+    assert "n=1" in messages
+
+
+def test_iter_gtfintechlab_xbank_pairs_raises_on_missing_revision(
+    monkeypatch,
+) -> None:
+    """If a future edit adds a bank to ``_GTFINTECHLAB_XBANK_DATASETS``
+    without a corresponding entry in ``_GTFINTECHLAB_XBANK_REVISIONS``,
+    the iterator must raise loudly — silently degrading to HF Hub HEAD
+    would break the reproducibility invariant. Simulate by removing
+    one pin and asserting ``KeyError``."""
+    sentences = {
+        "gtfintechlab/european_central_bank": ["A", "B"],
+        "gtfintechlab/bank_of_japan": ["C", "D"],
+        "gtfintechlab/bank_of_england": ["E", "F"],
+        "gtfintechlab/bank_of_canada": ["G", "H"],
+        "gtfintechlab/reserve_bank_of_australia": ["I", "J"],
+    }
+    _install_fake_gtfintechlab(monkeypatch, sentences)
+    # Drop the BoJ pin so the iterator's first BoJ lookup fails.
+    patched = dict(cpt._GTFINTECHLAB_XBANK_REVISIONS)
+    patched.pop("gtfintechlab/bank_of_japan")
+    monkeypatch.setattr(cpt, "_GTFINTECHLAB_XBANK_REVISIONS", patched)
+    with pytest.raises(KeyError, match="bank_of_japan"):
+        cpt._iter_gtfintechlab_xbank_pairs()
+
+
 def test_iter_gtfintechlab_xbank_pairs_scale_floor() -> None:
     """The live HF datasets yield 5 x ~3,000 sentences; even after consecutive
     pairing we should clear 5,000 pairs. Skip when ``datasets`` package or

--- a/tests/unit/test_continued_pretraining.py
+++ b/tests/unit/test_continued_pretraining.py
@@ -464,3 +464,87 @@ def test_collect_pairs_substrate_bis_xbank_respects_max_rows(
     assert pairs[0]["sequenceA"].startswith("XBANK")
     assert pairs[1]["sequenceA"].startswith("XBANK")
     assert pairs[2]["sequenceA"].startswith("BIS")
+
+
+def test_main_bis_xbank_manifest_records_xbank_dataset_revisions(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Reproducibility: a --substrate bis_xbank run must record every
+    cross-bank dataset id + pinned SHA in the manifest, alongside the BIS
+    entry. Otherwise a future re-run can't reconstruct the exact text mix.
+    """
+    _install_fake_datasets(
+        monkeypatch,
+        [{"sequenceA": "BIS A1", "sequenceB": "BIS B1", "next_sentence_label": 0}],
+    )
+    monkeypatch.setattr(
+        cpt,
+        "_iter_gtfintechlab_xbank_pairs",
+        lambda: [
+            {"sequenceA": "XBANK A1", "sequenceB": "XBANK B1", "next_sentence_label": 0}
+        ],
+    )
+    # Keep the manifest writer offline + skip the real MLM training run.
+    monkeypatch.setattr(cpt, "_resolve_dataset_sha", lambda dataset_id, revision: revision)
+
+    def _fake_run_mlm(**kwargs):
+        out_dir = kwargs["output_dir"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "checkpoint").mkdir(parents=True, exist_ok=True)
+        return {
+            "base_checkpoint": kwargs["base_checkpoint"],
+            "base_revision": None,
+            "epochs": kwargs["epochs"],
+            "learning_rate": kwargs["learning_rate"],
+            "batch_size": kwargs["batch_size"],
+            "block_size": kwargs["block_size"],
+            "objective": kwargs["objective"],
+            "train_runtime_s": 0.0,
+            "train_loss": 0.0,
+            "num_examples": len(kwargs["pair_records"]),
+            "checkpoint_path": str(out_dir / "checkpoint"),
+        }
+
+    monkeypatch.setattr(cpt, "run_mlm", _fake_run_mlm)
+
+    rc = cpt.main(
+        [
+            "--substrate",
+            "bis_xbank",
+            "--artifact-root",
+            str(tmp_path),
+            "--data-dir",
+            str(tmp_path),
+            "--bis-dataset-revision",
+            "deadbeef",
+        ]
+    )
+    assert rc == 0
+
+    # Locate the run dir under the temp artifact root.
+    run_dirs = [p for p in tmp_path.iterdir() if p.is_dir()]
+    assert len(run_dirs) == 1, f"expected single run dir, got {run_dirs}"
+    manifest_path = run_dirs[0] / "run_manifest.json"
+    assert manifest_path.exists(), "manifest was not written"
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    expected_xbank_ids = {
+        "gtfintechlab/european_central_bank",
+        "gtfintechlab/bank_of_japan",
+        "gtfintechlab/bank_of_england",
+        "gtfintechlab/bank_of_canada",
+        "gtfintechlab/reserve_bank_of_australia",
+    }
+
+    # The 5 xbank ids + the BIS id should all be referenced under
+    # hyperparameters.xbank_dataset_revisions (5 ids -> 5 pinned SHAs).
+    recorded = manifest["hyperparameters"]["xbank_dataset_revisions"]
+    assert set(recorded.keys()) == expected_xbank_ids
+    for dataset_id, sha in recorded.items():
+        assert sha == cpt._GTFINTECHLAB_XBANK_REVISIONS[dataset_id]
+        # Pinned SHAs are 40-char lowercase hex; guard against accidental nulls.
+        assert isinstance(sha, str) and len(sha) == 40
+
+    # BIS entry is unaffected: id + requested + resolved still in place.
+    assert manifest["hyperparameters"]["bis_dataset_id"] == cpt.DEFAULT_BIS_DATASET_ID
+    assert manifest["hyperparameters"]["bis_dataset_revision_resolved"] == "deadbeef"

--- a/tests/unit/test_continued_pretraining.py
+++ b/tests/unit/test_continued_pretraining.py
@@ -316,8 +316,8 @@ def _install_fake_gtfintechlab(monkeypatch, sentences_per_dataset: dict[str, lis
     of sentence strings that should be returned (single config / single split).
     """
     fake = types.SimpleNamespace()
-    fake.get_dataset_config_names = lambda dataset_id, revision=None: ["default"]
-    fake.get_dataset_split_names = lambda dataset_id, config, revision=None: ["train"]
+    fake.get_dataset_config_names = lambda dataset_id, revision=None, **kw: ["default"]
+    fake.get_dataset_split_names = lambda dataset_id, config, revision=None, **kw: ["train"]
 
     def _load(dataset_id, config=None, split=None, revision=None, **kw):
         sents = sentences_per_dataset.get(dataset_id, [])

--- a/tests/unit/test_label_schemas.py
+++ b/tests/unit/test_label_schemas.py
@@ -9,6 +9,7 @@ from app.data.label_schemas import (  # noqa: E402
     MultiAxisLabel,
     Stance,
     Topic,
+    auxiliary_axis_weight_for,
     load_schema,
     sample_weight_for,
 )
@@ -29,6 +30,29 @@ def test_sample_weights_table_matches_provenance() -> None:
     assert sample_weight_for("peer_reviewed_cross_bank") == 0.0
     assert sample_weight_for("scraped") == 0.0
     assert sample_weight_for("unknown-bucket") == 0.0
+
+
+def test_auxiliary_axis_weight_admits_cross_bank() -> None:
+    # ``peer_reviewed_cross_bank`` is the only provenance whose
+    # auxiliary-axis weight diverges from ``sample_weight_for`` — the
+    # encoder fine-tune routes these rows through the non-stance heads
+    # while keeping them off the FOMC stance distribution.
+    assert auxiliary_axis_weight_for("peer_reviewed_cross_bank") == 1.0
+
+
+def test_auxiliary_axis_weight_falls_back_to_sample_weight() -> None:
+    # Every non-cross-bank bucket should match ``sample_weight_for``
+    # exactly so the helper stays a strict superset and downstream
+    # callers can pick either without changing the FOMC pool.
+    for provenance in (
+        "peer_reviewed",
+        "kaggle",
+        "scraped",
+        "unknown-bucket",
+    ):
+        assert auxiliary_axis_weight_for(provenance) == sample_weight_for(
+            provenance
+        )
 
 
 def test_multi_axis_label_stance_only() -> None:

--- a/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
+++ b/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
@@ -17,9 +17,11 @@ torch = pytest.importorskip("torch")
 from app.data.train_text_multi_axis_classifier import (  # noqa: E402
     _AxisRow,
     _collate,
+    _compute_weighted_total_loss,
     _gtfintechlab_row_to_axis_row,
     _log_per_axis_provenance_breakdown,
 )
+from app.training.loss import MultiTaskLoss  # noqa: E402
 
 
 def _gtf_row(
@@ -225,3 +227,252 @@ def test_per_axis_provenance_log_splits_by_corpus(
         "axis=certainty rows_total=4 from_FOMC=2 from_cross_bank=2"
         in messages
     )
+
+
+# --- Gradient-path tests for _compute_weighted_total_loss --------------
+#
+# These guard against the double-gradient regression that the
+# pre-fix helper produced: it subtracted ``breakdown["stance"]`` (a
+# detached scalar) from ``total`` and added the new weighted stance
+# loss. That subtraction does NOT remove the original
+# graph-attached stance loss path, so ``total.backward()``
+# accumulated stance gradients from BOTH the unweighted and the
+# weighted CE — a silent double-count. The current helper delegates
+# to ``MultiTaskLoss.forward(..., stance_sample_weight=...)`` so
+# there is exactly one stance loss term in the graph. The first
+# test pins the analytical gradient; the others pin the corner
+# cases (zero-weight collapse, FOMC-only byte-identity, and
+# non-stance axis isolation).
+#
+# All four tests fail on the pre-fix code (confirmed by stashing
+# the fix and re-running them).
+
+
+def _make_two_row_two_class_logits(
+    *, target_classes: tuple[int, int], stance_logits: list[list[float]]
+) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+    """Tiny 2-row, 2-class fixture with stance + factor + certainty + topic.
+
+    Only the stance axis is exercised by the gradient assertions; the
+    other axes carry False masks so they contribute graph-attached
+    zeros (matching the MultiTaskLoss empty-mask contract). The
+    factor / certainty / topic tensors are still ``requires_grad``
+    so the loss can graph-attach a zero through them — the gradient
+    on those tensors must be zero everywhere when their masks are
+    all-False.
+    """
+
+    stance = torch.tensor(stance_logits, dtype=torch.float32, requires_grad=True)
+    factor = torch.zeros(2, dtype=torch.float32, requires_grad=True)
+    certainty = torch.zeros(2, 3, dtype=torch.float32, requires_grad=True)
+    topic = torch.zeros(2, 4, dtype=torch.float32, requires_grad=True)
+    logits = {
+        "stance": stance,
+        "factor": factor,
+        "certainty": certainty,
+        "topic": topic,
+    }
+    targets = {
+        "stance": torch.tensor(list(target_classes), dtype=torch.long),
+        "factor": torch.zeros(2, dtype=torch.float32),
+        "certainty": torch.zeros(2, dtype=torch.long),
+        "topic": torch.zeros(2, dtype=torch.long),
+    }
+    masks = {
+        "stance_mask": torch.tensor([True, True], dtype=torch.bool),
+        "factor_mask": torch.tensor([False, False], dtype=torch.bool),
+        "certainty_mask": torch.tensor([False, False], dtype=torch.bool),
+        "topic_mask": torch.tensor([False, False], dtype=torch.bool),
+    }
+    return logits, targets, masks
+
+
+def test_weighted_stance_gradient_matches_analytical_2row_2class() -> None:
+    """Gradient on stance logits under ``weighted`` arm matches the
+    closed-form weighted CE gradient.
+
+    Setup: 2 rows, 2 classes, no class weights, per-row weights
+    ``[1.0, 0.25]``, lambda_stance=1.0 (so the stance branch is the
+    full total loss). Stance logits chosen so softmax is exact and
+    easy to write down. The expected gradient on row i is
+    ``(w_i / sum(w)) * (softmax_i - onehot(target_i))``.
+    """
+
+    # Row 0 logits [2.0, 0.0] with target=0 → softmax ≈
+    # [e^2/(e^2+1), 1/(e^2+1)] ≈ [0.8807970, 0.1192030].
+    # Row 1 logits [0.0, 1.0] with target=1 → softmax ≈
+    # [1/(1+e), e/(1+e)] ≈ [0.2689414, 0.7310586].
+    logits, targets, masks = _make_two_row_two_class_logits(
+        target_classes=(0, 1),
+        stance_logits=[[2.0, 0.0], [0.0, 1.0]],
+    )
+    loss_fn = MultiTaskLoss(lambda_stance=1.0, lambda_factor=0.0,
+                            lambda_certainty=0.0, lambda_topic=0.0)
+    weights = torch.tensor([1.0, 0.25], dtype=torch.float32)
+
+    total, _ = _compute_weighted_total_loss(
+        loss_fn=loss_fn,
+        logits=logits,
+        targets=targets,
+        masks=masks,
+        stance_sample_weight=weights,
+    )
+    total.backward()
+
+    # Closed-form expected gradient.
+    softmax = torch.softmax(
+        torch.tensor([[2.0, 0.0], [0.0, 1.0]], dtype=torch.float32), dim=-1
+    )
+    onehot = torch.tensor([[1.0, 0.0], [0.0, 1.0]], dtype=torch.float32)
+    weight_total = weights.sum()
+    expected = (weights.unsqueeze(-1) / weight_total) * (softmax - onehot)
+
+    assert logits["stance"].grad is not None
+    torch.testing.assert_close(
+        logits["stance"].grad, expected, rtol=1e-6, atol=1e-6
+    )
+
+
+def test_all_zero_weight_batch_emits_zero_stance_gradient() -> None:
+    """When every cross-bank row has stance_sample_weight=0.0 and no
+    FOMC rows are in the batch, the stance loss must contribute
+    exactly zero gradient through ``logits["stance"]`` — backward
+    must still succeed (no NaN, no error) because the loss returns a
+    graph-attached zero from ``logits.sum() * 0.0``."""
+
+    logits, targets, masks = _make_two_row_two_class_logits(
+        target_classes=(0, 1),
+        stance_logits=[[2.0, 0.0], [0.0, 1.0]],
+    )
+    loss_fn = MultiTaskLoss(lambda_stance=1.0, lambda_factor=0.0,
+                            lambda_certainty=0.0, lambda_topic=0.0)
+    weights = torch.zeros(2, dtype=torch.float32)
+
+    total, _ = _compute_weighted_total_loss(
+        loss_fn=loss_fn,
+        logits=logits,
+        targets=targets,
+        masks=masks,
+        stance_sample_weight=weights,
+    )
+    total.backward()
+
+    assert logits["stance"].grad is not None
+    assert torch.equal(
+        logits["stance"].grad,
+        torch.zeros_like(logits["stance"].grad),
+    )
+    # And the total itself is exactly zero (the only contributing
+    # axis was masked-out by the zero weight).
+    assert float(total.detach().item()) == 0.0
+
+
+def test_fomc_only_batch_byte_identical_to_unweighted_loss() -> None:
+    """With all rows FOMC (provenance != cross-bank) and weights all
+    1.0, ``_compute_weighted_total_loss`` must return a tensor
+    numerically equal to ``MultiTaskLoss(logits, targets, masks)[0]``
+    — the FOMC-only training run must reproduce the prior numerics
+    byte-for-byte so the strict-FOMC headline does not drift."""
+
+    logits_a, targets_a, masks_a = _make_two_row_two_class_logits(
+        target_classes=(0, 1),
+        stance_logits=[[2.0, 0.0], [0.0, 1.0]],
+    )
+    logits_b, targets_b, masks_b = _make_two_row_two_class_logits(
+        target_classes=(0, 1),
+        stance_logits=[[2.0, 0.0], [0.0, 1.0]],
+    )
+    loss_fn = MultiTaskLoss(lambda_stance=1.0, lambda_factor=0.3,
+                            lambda_certainty=0.3, lambda_topic=0.3)
+    weights = torch.ones(2, dtype=torch.float32)
+
+    weighted_total, _ = _compute_weighted_total_loss(
+        loss_fn=loss_fn,
+        logits=logits_a,
+        targets=targets_a,
+        masks=masks_a,
+        stance_sample_weight=weights,
+    )
+    plain_total, _ = loss_fn(logits_b, targets_b, masks_b)
+
+    torch.testing.assert_close(
+        weighted_total, plain_total, rtol=0.0, atol=0.0
+    )
+
+
+def test_weighted_arm_leaves_other_axis_gradients_unchanged() -> None:
+    """The cross-bank ``weighted`` arm scales only the stance branch.
+    Gradients on logits["factor"], logits["certainty"], and
+    logits["topic"] must be identical to the gradients produced by
+    the ``off`` baseline (i.e. ``MultiTaskLoss`` called without any
+    per-row weight). Tested with a populated mask on each non-stance
+    axis so the comparison is non-trivial."""
+
+    def _seeded_batch(seed: int) -> tuple[
+        dict[str, torch.Tensor],
+        dict[str, torch.Tensor],
+        dict[str, torch.Tensor],
+    ]:
+        torch.manual_seed(seed)
+        stance = torch.randn(3, 3, requires_grad=True)
+        factor = torch.randn(3, requires_grad=True)
+        certainty = torch.randn(3, 3, requires_grad=True)
+        topic = torch.randn(3, 4, requires_grad=True)
+        return (
+            {
+                "stance": stance,
+                "factor": factor,
+                "certainty": certainty,
+                "topic": topic,
+            },
+            {
+                "stance": torch.tensor([0, 1, 2], dtype=torch.long),
+                "factor": torch.tensor([0.1, -0.4, 0.7], dtype=torch.float32),
+                "certainty": torch.tensor([0, 2, 1], dtype=torch.long),
+                "topic": torch.tensor([1, 3, 0], dtype=torch.long),
+            },
+            {
+                "stance_mask": torch.tensor([True, True, True], dtype=torch.bool),
+                "factor_mask": torch.tensor([True, True, True], dtype=torch.bool),
+                "certainty_mask": torch.tensor(
+                    [True, True, True], dtype=torch.bool
+                ),
+                "topic_mask": torch.tensor([True, True, True], dtype=torch.bool),
+            },
+        )
+
+    loss_fn = MultiTaskLoss(lambda_stance=1.0, lambda_factor=0.3,
+                            lambda_certainty=0.3, lambda_topic=0.3)
+
+    # Weighted (cross-bank arm with non-unit weights).
+    logits_w, targets_w, masks_w = _seeded_batch(seed=17)
+    weights = torch.tensor([0.25, 0.25, 0.25], dtype=torch.float32)
+    total_w, _ = _compute_weighted_total_loss(
+        loss_fn=loss_fn,
+        logits=logits_w,
+        targets=targets_w,
+        masks=masks_w,
+        stance_sample_weight=weights,
+    )
+    total_w.backward()
+
+    # Baseline (``off`` — same seeded inputs, no per-row weight).
+    logits_o, targets_o, masks_o = _seeded_batch(seed=17)
+    total_o, _ = _compute_weighted_total_loss(
+        loss_fn=loss_fn,
+        logits=logits_o,
+        targets=targets_o,
+        masks=masks_o,
+        stance_sample_weight=None,
+    )
+    total_o.backward()
+
+    for axis in ("factor", "certainty", "topic"):
+        assert logits_w[axis].grad is not None
+        assert logits_o[axis].grad is not None
+        torch.testing.assert_close(
+            logits_w[axis].grad,
+            logits_o[axis].grad,
+            rtol=1e-6,
+            atol=1e-6,
+        )

--- a/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
+++ b/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
@@ -1,0 +1,227 @@
+"""Bundle A.1: cross-bank supervision gate on the multi-axis trainer.
+
+Pins the per-row mask + weight rewrites that
+``train_text_multi_axis_classifier._gtfintechlab_row_to_axis_row``
+applies under each arm of ``--cross-bank-supervision``. The collate
+contract surfaces the rewrites end-to-end so any downstream layer
+(loss, sanity log, eval) reads the corrected mask without further
+special-casing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.data.train_text_multi_axis_classifier import (  # noqa: E402
+    _AxisRow,
+    _collate,
+    _gtfintechlab_row_to_axis_row,
+    _log_per_axis_provenance_breakdown,
+)
+
+
+def _gtf_row(
+    *,
+    stance: str = "hawkish",
+    certain: str = "certain",
+    text: str = "Inflation expectations remain anchored.",
+) -> dict[str, object]:
+    """Minimal HF gtfintechlab record fixture for the row mapper."""
+
+    return {
+        "sentences": text,
+        "stance_label": stance,
+        "certain_label": certain,
+        "time_label": "",
+        "year": 2024,
+    }
+
+
+class _FakeTokenizer:
+    """Tiny tokenizer stand-in so ``__getitem__`` runs without HF."""
+
+    def __call__(
+        self,
+        text: str,
+        *,
+        max_length: int,
+        padding: str,
+        truncation: bool,
+        return_tensors: str,
+    ) -> dict[str, "torch.Tensor"]:
+        ids = torch.zeros(1, max_length, dtype=torch.long)
+        mask = torch.ones(1, max_length, dtype=torch.long)
+        return {"input_ids": ids, "attention_mask": mask}
+
+
+def _axis_row_from_gtf(
+    *,
+    provenance: str,
+    mode: str,
+    stance_weight: float = 1.0,
+    stance: str = "hawkish",
+) -> _AxisRow:
+    row = _gtfintechlab_row_to_axis_row(
+        _gtf_row(stance=stance),
+        source="gtfintechlab/bank_of_japan",
+        provenance=provenance,
+        cross_bank_mode=mode,
+        cross_bank_stance_weight=stance_weight,
+    )
+    assert row is not None
+    return row
+
+
+def test_off_mode_keeps_fomc_row_masks_intact() -> None:
+    """``off`` is a no-op for FOMC rows: stance stays masked-in at
+    weight 1.0 and the other axes follow their natural per-row mask."""
+
+    fomc = _axis_row_from_gtf(provenance="peer_reviewed", mode="off")
+    assert fomc.masks["stance"] is True
+    assert fomc.masks["certainty"] is True
+    assert fomc.stance_sample_weight == 1.0
+
+
+def test_stance_masked_mode_drops_stance_for_cross_bank_only() -> None:
+    """The ``stance_masked`` arm rewrites the per-row stance mask
+    to False for every ``peer_reviewed_cross_bank`` row and leaves
+    the other axis masks intact. FOMC rows are untouched."""
+
+    cross_bank = _axis_row_from_gtf(
+        provenance="peer_reviewed_cross_bank", mode="stance_masked"
+    )
+    fomc = _axis_row_from_gtf(provenance="peer_reviewed", mode="stance_masked")
+
+    assert cross_bank.masks["stance"] is False
+    assert cross_bank.masks["certainty"] is True
+    assert cross_bank.stance_sample_weight == 1.0
+
+    assert fomc.masks["stance"] is True
+    assert fomc.masks["certainty"] is True
+    assert fomc.stance_sample_weight == 1.0
+
+
+def test_weighted_mode_scales_only_stance_for_cross_bank() -> None:
+    """The ``weighted`` arm leaves every mask intact and scales the
+    cross-bank rows' stance weight by ``cross_bank_stance_weight``.
+    Other axes (certainty, factor, topic) are NOT scaled — the
+    weight rides on the stance branch alone."""
+
+    cross_bank = _axis_row_from_gtf(
+        provenance="peer_reviewed_cross_bank",
+        mode="weighted",
+        stance_weight=0.25,
+    )
+    fomc = _axis_row_from_gtf(
+        provenance="peer_reviewed", mode="weighted", stance_weight=0.25
+    )
+
+    assert cross_bank.masks["stance"] is True
+    assert cross_bank.masks["certainty"] is True
+    assert cross_bank.stance_sample_weight == pytest.approx(0.25)
+
+    # FOMC rows are not in the cross-bank bucket, so the weight stays
+    # at 1.0 even when the arm is ``weighted``.
+    assert fomc.masks["stance"] is True
+    assert fomc.stance_sample_weight == 1.0
+
+
+def test_collate_emits_per_row_stance_weight_under_weighted_arm() -> None:
+    """End-to-end: the collate output surfaces a per-row stance
+    sample-weight tensor scaled by 0.25 for cross-bank rows. The
+    stance mask is all-True so the head still sees the cross-bank
+    stance labels — this is the diagnostic A/B for the
+    substitute-vs-complement prior."""
+
+    cross_bank = _axis_row_from_gtf(
+        provenance="peer_reviewed_cross_bank",
+        mode="weighted",
+        stance_weight=0.25,
+    )
+    fomc = _axis_row_from_gtf(provenance="peer_reviewed", mode="weighted")
+    rows = [fomc, cross_bank, cross_bank, fomc]
+
+    tokenizer = _FakeTokenizer()
+    from app.data.train_text_multi_axis_classifier import _MultiAxisDataset
+
+    ds = _MultiAxisDataset(rows, tokenizer, max_length=8)
+    batch = _collate([ds[i] for i in range(len(rows))])
+
+    assert torch.equal(
+        batch["mask_stance"], torch.tensor([True, True, True, True])
+    )
+    assert torch.allclose(
+        batch["stance_sample_weight"],
+        torch.tensor([1.0, 0.25, 0.25, 1.0], dtype=torch.float32),
+    )
+    assert batch["provenance"] == [
+        "peer_reviewed",
+        "peer_reviewed_cross_bank",
+        "peer_reviewed_cross_bank",
+        "peer_reviewed",
+    ]
+
+
+def test_collate_masks_stance_for_cross_bank_under_stance_masked_arm() -> None:
+    """Companion end-to-end check for the ``stance_masked`` arm: the
+    cross-bank rows arrive in the batch with stance False (so the
+    masked loss skips them on stance) while their certainty mask
+    stays True (so the encoder still trains on the auxiliary axis)."""
+
+    cross_bank = _axis_row_from_gtf(
+        provenance="peer_reviewed_cross_bank", mode="stance_masked"
+    )
+    fomc = _axis_row_from_gtf(provenance="peer_reviewed", mode="stance_masked")
+    rows = [cross_bank, fomc, cross_bank]
+
+    from app.data.train_text_multi_axis_classifier import _MultiAxisDataset
+
+    ds = _MultiAxisDataset(rows, _FakeTokenizer(), max_length=8)
+    batch = _collate([ds[i] for i in range(len(rows))])
+
+    assert torch.equal(
+        batch["mask_stance"], torch.tensor([False, True, False])
+    )
+    # All other axes stay aligned with the per-row natural mask.
+    assert torch.equal(
+        batch["mask_certainty"], torch.tensor([True, True, True])
+    )
+    assert torch.allclose(
+        batch["stance_sample_weight"],
+        torch.tensor([1.0, 1.0, 1.0], dtype=torch.float32),
+    )
+
+
+def test_per_axis_provenance_log_splits_by_corpus(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The first-epoch sanity log must split per-axis counts by
+    provenance bucket so any regression that leaks cross-bank rows
+    into the FOMC stance head shows up as a non-zero
+    ``from_cross_bank`` column on the ``stance`` line. The
+    ``stance_masked`` rewrite makes ``from_cross_bank`` on stance
+    zero by construction even when the cross-bank rows are admitted
+    into the pool."""
+
+    rows = [
+        _axis_row_from_gtf(provenance="peer_reviewed", mode="stance_masked"),
+        _axis_row_from_gtf(provenance="peer_reviewed", mode="stance_masked"),
+        _axis_row_from_gtf(
+            provenance="peer_reviewed_cross_bank", mode="stance_masked"
+        ),
+        _axis_row_from_gtf(
+            provenance="peer_reviewed_cross_bank", mode="stance_masked"
+        ),
+    ]
+    caplog.set_level("INFO", logger="app.data.train_text_multi_axis_classifier")
+    _log_per_axis_provenance_breakdown(rows)
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert (
+        "axis=stance rows_total=2 from_FOMC=2 from_cross_bank=0" in messages
+    )
+    assert (
+        "axis=certainty rows_total=4 from_FOMC=2 from_cross_bank=2"
+        in messages
+    )

--- a/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
+++ b/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
@@ -18,6 +18,7 @@ from app.data.train_text_multi_axis_classifier import (  # noqa: E402
     _AxisRow,
     _collate,
     _compute_weighted_total_loss,
+    _evaluate,
     _gtfintechlab_row_to_axis_row,
     _log_per_axis_provenance_breakdown,
 )
@@ -493,3 +494,214 @@ def test_weighted_arm_leaves_other_axis_gradients_unchanged() -> None:
             rtol=1e-6,
             atol=1e-6,
         )
+
+
+# --- _evaluate train/val parity --------------------------------------
+#
+# Pins that ``_evaluate`` threads ``stance_sample_weight`` through to
+# ``loss_fn`` so the val loss tracks the same objective the optimizer
+# minimizes on the train side. Without the thread-through, the train
+# arm runs weighted CE on stance while the val arm runs unweighted CE
+# under ``--cross-bank-supervision=weighted`` — and best-checkpoint
+# selection by val_loss picks against the wrong objective.
+
+
+class _ConstantLogitsModel(torch.nn.Module):
+    """Stand-in module whose ``forward`` returns a fixed logits dict.
+
+    The trainer only reads ``model(input_ids, attention_mask)`` so a
+    constant-output model is enough to exercise the loss + weight path
+    without the real encoder. The dummy ``_param`` keeps optimizer.step
+    happy in the train-arm tests (no real parameter update happens
+    since the logits don't depend on it)."""
+
+    def __init__(self, logits: dict[str, "torch.Tensor"]) -> None:
+        super().__init__()
+        self._logits = logits
+        self._param = torch.nn.Parameter(torch.zeros(1, dtype=torch.float32))
+
+    def forward(
+        self, input_ids: "torch.Tensor", attention_mask: "torch.Tensor"
+    ) -> dict[str, "torch.Tensor"]:
+        # Re-emit the cached logits each call. ``_evaluate`` is called
+        # under ``torch.no_grad()`` so any graph attachment via
+        # ``self._param`` would be a no-op on the val side anyway.
+        return {k: v.clone() for k, v in self._logits.items()}
+
+
+def _two_row_batch(weights: list[float]) -> dict[str, "torch.Tensor"]:
+    """Build a 2-row collated batch with the given per-row stance weights."""
+
+    return {
+        "input_ids": torch.zeros(2, 4, dtype=torch.long),
+        "attention_mask": torch.ones(2, 4, dtype=torch.long),
+        "target_stance": torch.tensor([0, 1], dtype=torch.long),
+        "target_factor": torch.zeros(2, dtype=torch.float32),
+        "target_certainty": torch.zeros(2, dtype=torch.long),
+        "target_topic": torch.zeros(2, dtype=torch.long),
+        "mask_stance": torch.tensor([True, True], dtype=torch.bool),
+        "mask_factor": torch.tensor([False, False], dtype=torch.bool),
+        "mask_certainty": torch.tensor([False, False], dtype=torch.bool),
+        "mask_topic": torch.tensor([False, False], dtype=torch.bool),
+        "stance_sample_weight": torch.tensor(weights, dtype=torch.float32),
+        "source": ["fomc", "fomc"],
+        "provenance": ["peer_reviewed", "peer_reviewed"],
+    }
+
+
+def test_evaluate_threads_stance_sample_weight_through_loss() -> None:
+    """Train and val arms must produce the same loss on the same toy
+    batch when the same per-row weights are applied. Pre-fix, the val
+    arm ignored ``stance_sample_weight`` and ran unweighted CE — the
+    two losses diverged under the ``weighted`` arm. This test fails
+    on the old code (sees the unweighted/weighted gap) and passes on
+    the fixed code.
+
+    Uses non-uniform weights ``[1.0, 0.25]`` so the weighted vs plain
+    mean produce different numerics (uniform weights collapse to the
+    plain mean and would mask the bug).
+    """
+
+    # Deterministic logits chosen so the two rows have meaningfully
+    # different per-row CE — non-uniform weighting then yields a
+    # detectably different total from the plain mean.
+    stance_logits = torch.tensor(
+        [[2.0, 0.0, -1.0], [0.0, 1.0, 0.5]], dtype=torch.float32
+    )
+    factor_logits = torch.zeros(2, dtype=torch.float32)
+    certainty_logits = torch.zeros(2, 3, dtype=torch.float32)
+    topic_logits = torch.zeros(2, 4, dtype=torch.float32)
+    logits = {
+        "stance": stance_logits,
+        "factor": factor_logits,
+        "certainty": certainty_logits,
+        "topic": topic_logits,
+    }
+    model = _ConstantLogitsModel(logits)
+    loss_fn = MultiTaskLoss(
+        lambda_stance=1.0,
+        lambda_factor=0.0,
+        lambda_certainty=0.0,
+        lambda_topic=0.0,
+    )
+
+    batch = _two_row_batch([1.0, 0.25])
+
+    class _OneShotLoader:
+        def __init__(self, batch: dict[str, "torch.Tensor"]) -> None:
+            self._batch = batch
+
+        def __iter__(self):
+            return iter([self._batch])
+
+    # Eval loss with the per-row stance weight threaded through.
+    val_metrics_weighted = _evaluate(
+        model, _OneShotLoader(batch), loss_fn, torch.device("cpu")
+    )
+
+    # Train-side reference: ``_compute_weighted_total_loss`` is the
+    # train arm's loss-computation helper. Calling it directly on the
+    # same batch + same stance weight produces the loss the optimizer
+    # actually minimizes. Eval must match.
+    targets = {
+        "stance": batch["target_stance"],
+        "factor": batch["target_factor"],
+        "certainty": batch["target_certainty"],
+        "topic": batch["target_topic"],
+    }
+    masks = {
+        "stance_mask": batch["mask_stance"],
+        "factor_mask": batch["mask_factor"],
+        "certainty_mask": batch["mask_certainty"],
+        "topic_mask": batch["mask_topic"],
+    }
+    train_total, _ = _compute_weighted_total_loss(
+        loss_fn=loss_fn,
+        logits=logits,
+        targets=targets,
+        masks=masks,
+        stance_sample_weight=batch["stance_sample_weight"],
+    )
+
+    assert val_metrics_weighted["loss"] == pytest.approx(
+        float(train_total.detach().item()), rel=0.0, abs=1e-6
+    )
+
+    # And the val_loss under the non-uniform weight differs from the
+    # val_loss the pre-fix path would have produced (plain unweighted
+    # CE). The gap pins that the kwarg actually rode through to the
+    # loss formula.
+    plain_total, _ = loss_fn(logits, targets, masks)
+    assert val_metrics_weighted["loss"] != pytest.approx(
+        float(plain_total.detach().item()), abs=1e-6
+    )
+
+
+def test_evaluate_runs_under_no_grad() -> None:
+    """``_evaluate`` must not retain a computation graph on the
+    forward pass — ``model.eval()`` flips dropout/BN but does NOT
+    disable autograd. The model logits inside the eval forward must
+    have ``requires_grad=False`` because the ``@torch.no_grad()``
+    decorator suppresses graph construction. We capture the logits
+    via a side-effect list and assert their grad state."""
+
+    seen_requires_grad: list[bool] = []
+    leaf = torch.nn.Parameter(torch.tensor(1.0))
+
+    class _GraphAttachingModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.leaf = leaf
+
+        def forward(
+            self,
+            input_ids: "torch.Tensor",
+            attention_mask: "torch.Tensor",
+        ) -> dict[str, "torch.Tensor"]:
+            # Multiply by the leaf so the output WOULD attach to a
+            # grad graph in autograd-enabled mode. Under
+            # ``@torch.no_grad()`` the multiplication still produces
+            # a tensor but with ``requires_grad=False``.
+            scale = self.leaf
+            stance = torch.zeros(2, 3) * scale
+            seen_requires_grad.append(bool(stance.requires_grad))
+            return {
+                "stance": stance,
+                "factor": torch.zeros(2) * scale,
+                "certainty": torch.zeros(2, 3) * scale,
+                "topic": torch.zeros(2, 4) * scale,
+            }
+
+    loss_fn = MultiTaskLoss(
+        lambda_stance=1.0,
+        lambda_factor=0.0,
+        lambda_certainty=0.0,
+        lambda_topic=0.0,
+    )
+
+    class _OneShotLoader:
+        def __init__(self, batch: dict[str, "torch.Tensor"]) -> None:
+            self._batch = batch
+
+        def __iter__(self):
+            return iter([self._batch])
+
+    batch = _two_row_batch([1.0, 1.0])
+    metrics = _evaluate(
+        _GraphAttachingModel(),
+        _OneShotLoader(batch),
+        loss_fn,
+        torch.device("cpu"),
+    )
+    # Eval forward observed the logits as detached — autograd graph
+    # construction was suppressed by ``@torch.no_grad()``. Without
+    # the decorator, multiplying ``torch.zeros(...) * leaf`` (where
+    # ``leaf.requires_grad=True``) would produce a graph-attached
+    # tensor with ``requires_grad=True``.
+    assert seen_requires_grad == [False]
+    assert "loss" in metrics
+    # Logits are all zero → softmax is uniform across 3 classes →
+    # CE = ln(3) ≈ 1.0986. Sanity-check the formula matches.
+    import math
+
+    assert metrics["loss"] == pytest.approx(math.log(3.0), abs=1e-5)

--- a/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
+++ b/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
@@ -104,6 +104,21 @@ def test_stance_masked_mode_drops_stance_for_cross_bank_only() -> None:
     assert fomc.masks["certainty"] is True
     assert fomc.stance_sample_weight == 1.0
 
+    # Pin the natural per-row factor / topic masks on a cross-bank
+    # row. The gtfintechlab schema does not carry factor or topic
+    # labels (the trainer maps only stance + certainty + time), so
+    # the natural masks are False here. Any future change that
+    # leaks a cross-bank stance label onto the factor or topic
+    # mask under ``stance_masked`` would flip these — the regression
+    # would show up as the assertion firing.
+    assert cross_bank.masks["factor"] is False
+    assert cross_bank.masks["topic"] is False
+    # FOMC rows under ``stance_masked`` follow the same natural
+    # per-row factor / topic masks the gtfintechlab schema produces;
+    # ``stance_masked`` rewrites are scoped to cross-bank rows only.
+    assert fomc.masks["factor"] is False
+    assert fomc.masks["topic"] is False
+
 
 def test_weighted_mode_scales_only_stance_for_cross_bank() -> None:
     """The ``weighted`` arm leaves every mask intact and scales the
@@ -205,7 +220,9 @@ def test_per_axis_provenance_log_splits_by_corpus(
     ``from_cross_bank`` column on the ``stance`` line. The
     ``stance_masked`` rewrite makes ``from_cross_bank`` on stance
     zero by construction even when the cross-bank rows are admitted
-    into the pool."""
+    into the pool. The non-cross-bank bucket is named ``from_other``
+    so a future provenance that is neither FOMC nor the recognised
+    cross-bank tag does not silently inflate the counter."""
 
     rows = [
         _axis_row_from_gtf(provenance="peer_reviewed", mode="stance_masked"),
@@ -221,10 +238,10 @@ def test_per_axis_provenance_log_splits_by_corpus(
     _log_per_axis_provenance_breakdown(rows)
     messages = "\n".join(record.getMessage() for record in caplog.records)
     assert (
-        "axis=stance rows_total=2 from_FOMC=2 from_cross_bank=0" in messages
+        "axis=stance rows_total=2 from_other=2 from_cross_bank=0" in messages
     )
     assert (
-        "axis=certainty rows_total=4 from_FOMC=2 from_cross_bank=2"
+        "axis=certainty rows_total=4 from_other=2 from_cross_bank=2"
         in messages
     )
 

--- a/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
+++ b/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
@@ -705,3 +705,103 @@ def test_evaluate_runs_under_no_grad() -> None:
     import math
 
     assert metrics["loss"] == pytest.approx(math.log(3.0), abs=1e-5)
+
+
+# --- Checkpoint provenance: effective_cross_bank_supervision ---------
+#
+# When ``--gtfintechlab-fed-only`` is combined with a non-``off``
+# cross-bank arm, the loader silently restricts to FOMC. The
+# checkpoint payload must record this resolution honestly:
+# ``effective_cross_bank_supervision`` is ``"off"`` regardless of the
+# requested arm. The raw ``cross_bank_supervision`` field stays so
+# operators can trace what they originally asked for.
+
+
+class _StubMultiAxisModel(torch.nn.Module):
+    """Bare-minimum stand-in for ``TextMultiAxisClassifier`` so the
+    checkpoint payload test can exercise ``_save_checkpoint`` without
+    pulling a real encoder off HF Hub.
+
+    Only the two surfaces ``_save_checkpoint`` touches are implemented:
+    ``state_dict`` (inherited from ``nn.Module``) and ``metadata()``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._param = torch.nn.Parameter(torch.zeros(1, dtype=torch.float32))
+
+    def metadata(self) -> dict[str, object]:
+        return {"encoder_alias": "stub", "encoder_revision": "stub"}
+
+
+def _checkpoint_args(*, fed_only: bool, supervision: str) -> "argparse.Namespace":
+    import argparse
+
+    return argparse.Namespace(
+        training_package_id="dummy",
+        encoder_alias="finbert",
+        epochs=1,
+        seed=0,
+        learning_rate=1e-5,
+        batch_size=2,
+        val_fraction=0.1,
+        max_length=8,
+        data_source="gtfintechlab_hf",
+        gtfintechlab_fed_only=fed_only,
+        cross_bank_supervision=supervision,
+        cross_bank_stance_weight=0.25,
+    )
+
+
+def test_checkpoint_payload_records_effective_cross_bank_under_fed_only(
+    tmp_path,
+) -> None:
+    """The checkpoint payload must surface
+    ``effective_cross_bank_supervision="off"`` when fed_only is True,
+    even if the operator asked for ``weighted`` — and must keep the
+    raw request alongside for traceability."""
+
+    from app.data.train_text_multi_axis_classifier import _save_checkpoint
+
+    args = _checkpoint_args(fed_only=True, supervision="weighted")
+    ckpt_path = tmp_path / "ckpt.pt"
+    _save_checkpoint(
+        _StubMultiAxisModel(),
+        path=ckpt_path,
+        metrics={"val_loss": 0.0},
+        args=args,
+        class_weights={},
+    )
+    payload = torch.load(ckpt_path, weights_only=False)
+    ta = payload["training_args"]
+    # Raw request is preserved for traceability.
+    assert ta["cross_bank_supervision"] == "weighted"
+    # Effective field reflects what the run actually did — under
+    # fed_only the cross-bank pool is empty so the arm reduces to off.
+    assert ta["effective_cross_bank_supervision"] == "off"
+    assert ta["gtfintechlab_fed_only"] is True
+
+
+def test_checkpoint_payload_effective_matches_raw_when_not_fed_only(
+    tmp_path,
+) -> None:
+    """When fed_only is False, the effective field mirrors the raw
+    request — operator asked for ``weighted``, the run ran
+    ``weighted``."""
+
+    from app.data.train_text_multi_axis_classifier import _save_checkpoint
+
+    args = _checkpoint_args(fed_only=False, supervision="weighted")
+    ckpt_path = tmp_path / "ckpt.pt"
+    _save_checkpoint(
+        _StubMultiAxisModel(),
+        path=ckpt_path,
+        metrics={"val_loss": 0.0},
+        args=args,
+        class_weights={},
+    )
+    payload = torch.load(ckpt_path, weights_only=False)
+    ta = payload["training_args"]
+    assert ta["cross_bank_supervision"] == "weighted"
+    assert ta["effective_cross_bank_supervision"] == "weighted"
+    assert ta["gtfintechlab_fed_only"] is False


### PR DESCRIPTION
## Summary

- Add `--cross-bank-supervision off|stance_masked|weighted` flag to multi-axis text trainer
- `stance_masked` arm: cross-bank rows train on certainty/factor/topic only, stance masked
- `weighted` arm: per-row stance loss scaling via new `MultiTaskLoss.stance_sample_weight` kwarg
- New `bis_xbank` DAPT substrate mixing BIS speeches with 5 cross-bank corpora as NSP pairs
- Register `finbert_fed_adjacent_xbank_dapt` encoder alias + Makefile pretrain target
- Manifest records xbank dataset SHAs alongside the BIS revision

Behaviour note: in mode `off` (default) the gtfintechlab loader now restricts to FOMC only. Prior default silently loaded all six banks without stance protection in the multi-axis trainer — a pre-existing silent bias the new gate closes.

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_continued_pretraining.py tests/unit/test_label_schemas.py tests/unit/test_cross_bank_supervision_flag.py tests/unit/test_train_text_multi_axis_cross_bank_gate.py -q\`
- 1-seed × 4-fold forecaster smoke with the new encoder once Bundle A.2 (GPU) lands the cache
- DAPT smoke: \`make finbert-fed-adjacent-xbank-dapt-pretrain\` once Bundle A.4 kicks off

Sweep result rows for the wiki §6.6 result-improvement table land on this PR before merge.