### PR TITLE
Save multi-axis trainer encoder as HF directory per run

### DIFF
--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -53,6 +53,7 @@ _logger = logging.getLogger(__name__)
 
 DEFAULT_CHECKPOINT_PATH = MODEL_CHECKPOINT_DIR / "text_multi_axis_best.pt"
 DEFAULT_ENCODER_ALIAS = "finbert_fed_adjacent"
+DEFAULT_ARTIFACT_ROOT = DATA_DIR / "artifacts" / "text_multi_axis"
 
 
 @dataclass
@@ -938,6 +939,29 @@ def _evaluate(
     return out
 
 
+def _save_hf_encoder_directory(
+    model: TextMultiAxisClassifier,
+    tokenizer: Any,
+    checkpoint_dir: Path,
+) -> None:
+    """Persist the encoder backbone + tokenizer as a HF-format directory.
+
+    Saves ONLY the encoder backbone (``model.encoder``), not the
+    ``TextMultiAxisClassifier`` wrapper — the registry consumes the
+    bare HF encoder via ``AutoModel.from_pretrained`` and the
+    multi-task head is irrelevant to downstream callers
+    (embedding-cache builder, forecaster). The resulting directory
+    follows the same convention as
+    ``app.data.finetune_pilot``'s ``hf_checkpoints/`` so future
+    tooling can find HF dirs the same way regardless of which trainer
+    produced them.
+    """
+
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    model.encoder.save_pretrained(str(checkpoint_dir))
+    tokenizer.save_pretrained(str(checkpoint_dir))
+
+
 def _save_checkpoint(
     model: TextMultiAxisClassifier,
     *,
@@ -1118,6 +1142,15 @@ def main(argv: list[str] | None = None) -> int:
 
     _log_per_axis_provenance_breakdown(train_rows)
 
+    # Per-run HF artifact directory. The singleton .pt at
+    # ``args.output_checkpoint`` stays the inference-service contract;
+    # this directory carries the encoder backbone + tokenizer in HF
+    # format so the registry, embedding-cache builder, and forecaster
+    # can consume the fine-tuned encoder via ``AutoModel.from_pretrained``.
+    run_token = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    artifact_dir = Path(args.artifact_root) / f"text_multi_axis_{run_token}"
+    hf_checkpoint_dir = artifact_dir / "hf_checkpoints"
+
     best_val_loss = float("inf")
     best_metrics: dict[str, float] = {}
     for epoch in range(args.epochs):
@@ -1142,6 +1175,8 @@ def main(argv: list[str] | None = None) -> int:
                 args=args,
                 class_weights=class_weights,
             )
+            _save_hf_encoder_directory(model, tokenizer, hf_checkpoint_dir)
+            print(f"[multi_axis] hf checkpoint saved to {hf_checkpoint_dir}")
 
     _logger.info("training_complete best_val_loss=%.4f", best_val_loss)
 
@@ -1234,6 +1269,18 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--output-checkpoint",
         default=str(DEFAULT_CHECKPOINT_PATH),
         help="Destination .pt path for the best-epoch checkpoint.",
+    )
+    parser.add_argument(
+        "--artifact-root",
+        default=str(DEFAULT_ARTIFACT_ROOT),
+        help=(
+            "Root directory for per-run HF-format encoder artifacts. Each "
+            "run writes to ``{artifact_root}/text_multi_axis_{run_token}/"
+            "hf_checkpoints/`` so the encoder backbone + tokenizer can be "
+            "consumed by ``AutoModel.from_pretrained`` (registry, embedding "
+            "cache, forecaster). Independent of the singleton .pt at "
+            "``--output-checkpoint`` which the inference service reads."
+        ),
     )
     parser.add_argument("--seed", type=int, default=97)
     parser.add_argument("--epochs", type=int, default=4)

--- a/tests/unit/test_train_text_multi_axis_classifier.py
+++ b/tests/unit/test_train_text_multi_axis_classifier.py
@@ -1,0 +1,186 @@
+"""Bundle A.1.5: per-run HF-format encoder save on the multi-axis trainer.
+
+Pins that the trainer's best-checkpoint save path emits a HF
+directory containing the encoder backbone (NOT the
+``TextMultiAxisClassifier`` wrapper) plus the tokenizer, so the
+registry / embedding-cache builder / forecaster can load it via
+``AutoModel.from_pretrained`` regardless of which trainer produced
+it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.data.train_text_multi_axis_classifier import (  # noqa: E402
+    _save_hf_encoder_directory,
+)
+
+
+class _RecordingEncoder(torch.nn.Module):
+    """Minimal stand-in for a HF encoder backbone.
+
+    ``save_pretrained`` is the only surface ``_save_hf_encoder_directory``
+    touches on the encoder; the recording variant writes a sentinel
+    ``config.json`` and ``model.safetensors`` so the artifact directory
+    looks like a real HF checkpoint to downstream callers (and to the
+    standard-files assertion below). The recording also pins WHICH
+    object got ``save_pretrained`` called on it, which the trainer's
+    main-path test uses to assert the encoder backbone was saved
+    rather than the ``TextMultiAxisClassifier`` wrapper.
+    """
+
+    save_calls: list[str]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._param = torch.nn.Parameter(torch.zeros(1, dtype=torch.float32))
+        self.save_calls = []
+
+    def save_pretrained(self, directory: str) -> None:
+        path = Path(directory)
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "config.json").write_text("{}", encoding="utf-8")
+        (path / "model.safetensors").write_bytes(b"\x00")
+        self.save_calls.append(str(path))
+
+
+class _RecordingTokenizer:
+    """Tokenizer stand-in with the same ``save_pretrained`` contract."""
+
+    save_calls: list[str]
+
+    def __init__(self) -> None:
+        self.save_calls = []
+
+    def save_pretrained(self, directory: str) -> None:
+        path = Path(directory)
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+        self.save_calls.append(str(path))
+
+
+class _ClassifierWithEncoder(torch.nn.Module):
+    """Mimics the ``TextMultiAxisClassifier.encoder`` attribute layout.
+
+    The helper under test reads ``model.encoder.save_pretrained`` —
+    NOT ``model.save_pretrained`` — so the head weights stay out of
+    the HF directory the registry consumes.
+    """
+
+    def __init__(self, encoder: torch.nn.Module) -> None:
+        super().__init__()
+        self.encoder = encoder
+        # A dummy "head" parameter so any accidental save of the whole
+        # wrapper would be detectable in the resulting state_dict.
+        self.head = torch.nn.Linear(1, 1)
+
+    def save_pretrained(self, directory: str) -> None:  # pragma: no cover
+        # Wrapper-level save MUST NOT be called by
+        # ``_save_hf_encoder_directory``. The body raises so any
+        # regression that swaps ``model.encoder.save_pretrained`` for
+        # ``model.save_pretrained`` fails the test loudly.
+        raise AssertionError(
+            "TextMultiAxisClassifier.save_pretrained called — the HF "
+            "save path must save only the encoder backbone."
+        )
+
+
+def test_save_hf_encoder_directory_writes_standard_hf_files(
+    tmp_path: Path,
+) -> None:
+    """The helper writes a directory containing the standard HF files
+    the registry's ``AutoModel.from_pretrained`` / ``AutoTokenizer``
+    pair expects."""
+
+    encoder = _RecordingEncoder()
+    tokenizer = _RecordingTokenizer()
+    model = _ClassifierWithEncoder(encoder)
+    checkpoint_dir = tmp_path / "hf_checkpoints"
+
+    _save_hf_encoder_directory(model, tokenizer, checkpoint_dir)
+
+    assert checkpoint_dir.is_dir()
+    files = {p.name for p in checkpoint_dir.iterdir()}
+    # Encoder side: config + one of the two HF weight conventions.
+    assert "config.json" in files
+    assert "model.safetensors" in files or "pytorch_model.bin" in files
+    # Tokenizer side: at least one of the standard tokenizer files.
+    assert "tokenizer.json" in files or "tokenizer_config.json" in files
+
+
+def test_save_hf_encoder_directory_saves_encoder_backbone_not_wrapper(
+    tmp_path: Path,
+) -> None:
+    """The helper must call ``save_pretrained`` on the encoder backbone,
+    not on the ``TextMultiAxisClassifier`` wrapper — otherwise the
+    multi-task head would land in the HF directory and the registry's
+    ``AutoModel.from_pretrained`` would either fail or silently load
+    a head-contaminated state dict.
+
+    The wrapper's ``save_pretrained`` raises on call, so any regression
+    that swaps the receiver flips this test from green to red.
+    """
+
+    encoder = _RecordingEncoder()
+    tokenizer = _RecordingTokenizer()
+    model = _ClassifierWithEncoder(encoder)
+    checkpoint_dir = tmp_path / "hf_checkpoints"
+
+    _save_hf_encoder_directory(model, tokenizer, checkpoint_dir)
+
+    # The encoder backbone (NOT the wrapper) received the save call.
+    assert encoder.save_calls == [str(checkpoint_dir)]
+    # And the tokenizer was saved to the same directory.
+    assert tokenizer.save_calls == [str(checkpoint_dir)]
+
+
+def test_save_hf_encoder_directory_creates_parent_directories(
+    tmp_path: Path,
+) -> None:
+    """The helper must ``mkdir(parents=True, exist_ok=True)`` so a
+    caller can pass a nested artifact path without pre-creating the
+    intermediate directories (the trainer's main path builds
+    ``{artifact_root}/text_multi_axis_{run_token}/hf_checkpoints/``
+    in one shot)."""
+
+    encoder = _RecordingEncoder()
+    tokenizer = _RecordingTokenizer()
+    model = _ClassifierWithEncoder(encoder)
+    checkpoint_dir = tmp_path / "artifacts" / "text_multi_axis_2026XYZ" / "hf_checkpoints"
+
+    _save_hf_encoder_directory(model, tokenizer, checkpoint_dir)
+
+    assert checkpoint_dir.is_dir()
+
+
+def test_default_artifact_root_lives_under_data_dir() -> None:
+    """The default artifact root mirrors ``finetune_pilot``'s convention
+    of writing under ``DATA_DIR / "artifacts" / "<trainer-tag>"`` so
+    future tooling can find HF dirs the same way regardless of which
+    trainer produced them."""
+
+    from app.config import DATA_DIR
+    from app.data.train_text_multi_axis_classifier import DEFAULT_ARTIFACT_ROOT
+
+    assert DEFAULT_ARTIFACT_ROOT == DATA_DIR / "artifacts" / "text_multi_axis"
+
+
+def test_artifact_root_cli_flag_is_overridable() -> None:
+    """The ``--artifact-root`` flag must be parseable and override the
+    default — needed for CI / job-runner contexts that write to a
+    sandboxed artifact directory."""
+
+    from app.data.train_text_multi_axis_classifier import _parse_args
+
+    args = _parse_args(
+        [
+            "--artifact-root",
+            "/tmp/custom_artifact_root",
+        ]
+    )
+    assert args.artifact_root == "/tmp/custom_artifact_root"


### PR DESCRIPTION
## Summary

- Add `--artifact-root` flag to `train_text_multi_axis_classifier.py` (defaults to `data/artifacts/text_multi_axis`)
- On best-epoch save, also write encoder backbone + tokenizer as a HF directory at `{artifact_root}/text_multi_axis_{run_token}/hf_checkpoints/`
- Singleton `.pt` envelope at `backend/models/text_multi_axis_best.pt` (inference contract) kept

Unblocks Bundle A.2 GPU ops: the new HF directories can be registered in `backend/app/models/registry.yaml` and consumed by the forecaster's embedding cache. Mirrors the `finetune_pilot.py:334-365` pattern.

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_train_text_multi_axis_classifier.py tests/unit/test_train_text_multi_axis_cross_bank_gate.py tests/unit/test_label_schemas.py -q\`