### PR TITLE
Treat --max-rows=0 as unlimited in continued_pretraining BIS branch

### DIFF
--- a/backend/app/data/continued_pretraining.py
+++ b/backend/app/data/continued_pretraining.py
@@ -544,10 +544,20 @@ def _collect_pairs(args: argparse.Namespace) -> list[dict[str, Any]]:
         pairs.extend(local_pairs)
 
     if args.substrate in {"bis", "both"}:
+        # ``--max-rows == 0`` is the "unlimited" sentinel used by both
+        # ``_bis_pair_stream`` and ``_iter_local_pairs``; only when
+        # ``--substrate both`` is supplied with a positive cap do we need
+        # to compute a remaining BIS budget and emit a drop-warning when
+        # the local slice has already exhausted it. The earlier
+        # ``if bis_cap != 0`` guard misread the sentinel as "skip BIS",
+        # silently emptying ``--substrate bis`` (and the default-cap
+        # ``--substrate both``) runs.
+        should_load_bis = True
         if args.substrate == "both" and args.max_rows:
             remaining = max(0, args.max_rows - len(pairs))
             bis_cap = remaining
             if remaining == 0:
+                should_load_bis = False
                 import warnings as _warnings
 
                 _warnings.warn(
@@ -558,7 +568,7 @@ def _collect_pairs(args: argparse.Namespace) -> list[dict[str, Any]]:
                 )
         else:
             bis_cap = args.max_rows
-        if bis_cap != 0:
+        if should_load_bis:
             bis_iter = _bis_pair_stream(
                 args.bis_dataset_id,
                 args.bis_dataset_revision,

--- a/tests/unit/test_continued_pretraining.py
+++ b/tests/unit/test_continued_pretraining.py
@@ -208,6 +208,65 @@ def test_collect_pairs_substrate_bis_uses_streaming(monkeypatch) -> None:
     assert pairs[0]["sequenceA"] == "BIS A1"
 
 
+def test_collect_pairs_substrate_bis_default_max_rows_loads_all_bis(monkeypatch) -> None:
+    """Regression: ``--substrate bis`` with the default ``--max-rows=0`` (the
+    "unlimited" sentinel) must load every BIS row, not silently skip the
+    substrate. The earlier ``if bis_cap != 0`` guard misread the sentinel
+    as "no rows wanted" and dropped the entire BIS stream, leaving
+    ``main()`` to raise ``No training pairs loaded`` on the default CLI."""
+    _install_fake_datasets(
+        monkeypatch,
+        [
+            {"sequenceA": "BIS A1", "sequenceB": "BIS B1", "next_sentence_label": 0},
+            {"sequenceA": "BIS A2", "sequenceB": "BIS B2", "next_sentence_label": 1},
+            {"sequenceA": "BIS A3", "sequenceB": "BIS B3", "next_sentence_label": 0},
+        ],
+    )
+    args = cpt._parse_args(["--substrate", "bis"])
+    assert args.max_rows == 0  # guards against a future default change
+    pairs = cpt._collect_pairs(args)
+    assert len(pairs) == 3
+    assert [p["sequenceA"] for p in pairs] == ["BIS A1", "BIS A2", "BIS A3"]
+
+
+def test_collect_pairs_substrate_both_default_max_rows_loads_local_and_bis(
+    monkeypatch, tmp_path
+) -> None:
+    """Regression: ``--substrate both`` with the default ``--max-rows=0``
+    (the "unlimited" sentinel) must load BOTH the local corpus and the
+    full BIS stream. The earlier guard fell through to ``bis_cap = 0``
+    and then ``if bis_cap != 0`` silently skipped BIS, making
+    ``--substrate both`` indistinguishable from ``--substrate local``
+    at the default cap."""
+    _install_fake_datasets(
+        monkeypatch,
+        [
+            {"sequenceA": "BIS A1", "sequenceB": "BIS B1", "next_sentence_label": 0},
+            {"sequenceA": "BIS A2", "sequenceB": "BIS B2", "next_sentence_label": 0},
+        ],
+    )
+    (tmp_path / "chair_speeches.json").write_text(
+        json.dumps([{"text": "Local 1."}]),
+        encoding="utf-8",
+    )
+    args = cpt._parse_args(
+        [
+            "--substrate",
+            "both",
+            "--data-dir",
+            str(tmp_path),
+            "--corpus-files",
+            "chair_speeches.json",
+        ]
+    )
+    assert args.max_rows == 0
+    pairs = cpt._collect_pairs(args)
+    # Local loads first (1 pair), BIS contributes the remaining 2 with no cap.
+    assert len(pairs) == 3
+    assert pairs[0]["sequenceA"] == "Local 1."
+    assert {p["sequenceA"] for p in pairs[1:]} == {"BIS A1", "BIS A2"}
+
+
 def test_collect_pairs_substrate_both_loads_local_first_then_bis_remainder(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- Fix \`_collect_pairs\` so \`--substrate bis\` (and \`--substrate both\`) at the default \`--max-rows=0\` loads BIS instead of skipping it
- Replace the \`bis_cap != 0\` skip guard with an explicit \`should_load_bis\` flag; \`max_rows=0\` now correctly means unlimited (matching \`_bis_pair_stream\`'s own loop semantic)
- Drop-warning behaviour for \`--substrate both --max-rows N\` (N > 0, local fills cap) preserved
- Two regression tests pin \`args.max_rows == 0\` as a guard against future default flips

Surfaced by the PR #285 /code-review pass; pre-existing bug, not introduced by Bundle A.

## Follow-up not fixed here

Audit also surfaced \`backend/app/training/loop.py::_evaluate_model\` train/val loss divergence when the multi-task path is active in \`_train_step\` — val loss is computed on the single-task \`loss_fn\` while train uses \`multi_task_loss_fn\`. Cousin of the Bundle A.1 \`_evaluate\` bug but architecturally larger (eval needs to dispatch to \`forward_multi_task\`, assemble per-axis tensors from the val DataLoader, reconcile breakdown with \`EvaluationMetrics\`). Deserves its own PR with regression tests against \`test_forecaster_determinism.py\` byte-identity contract.

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_continued_pretraining.py -q\`