### PR TITLE
Phase 5 multi-run ensemble + per-fold conformal calibration

### DIFF
--- a/backend/app/evaluation/ensemble_aggregator.py
+++ b/backend/app/evaluation/ensemble_aggregator.py
@@ -42,6 +42,7 @@ import math
 from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Callable, Literal
 
 from app.evaluation.bootstrap import BootstrapCI
 from app.evaluation.classification_breakdown import (
@@ -57,6 +58,13 @@ from app.evaluation.regime_pooled_aggregator import (
 
 
 _STRATEGIES = ("mean_logit", "mean_softmax", "plurality_vote")
+
+# Phase 5 multi-run defaults. The redundancy guard threshold is the
+# Cohen-kappa above which two components are treated as duplicate
+# voters in the ensemble — keep it configurable rather than baked
+# into a magic-number constant.
+DEFAULT_REDUNDANCY_KAPPA_THRESHOLD = 0.85
+DEFAULT_CONFORMAL_ALPHA = 0.2
 
 
 @dataclasses.dataclass(frozen=True)
@@ -490,6 +498,550 @@ def main(argv: Sequence[str] | None = None) -> int:
     output_markdown.write_text(_render_markdown(result))
     print(f"[ensemble_aggregator] wrote {output_json} + {output_markdown}")
     return 0
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 multi-run logit-average ensemble (#5 of the cross-bank work
+# ladder). The single-run aggregator above selects one HP cell per
+# architecture from a single sweep JSON; the multi-run path below
+# pools across N distinct training runs (one run = one config x seed
+# x architecture combination), averages logits per (fold, trial),
+# and emits per-fold conformal prediction sets via the existing
+# conformal helpers.
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class RunSpec:
+    """One training-run participant in the Phase 5 multi-run ensemble.
+
+    ``run_id`` is the manifest id used to disambiguate runs in logs and
+    in the agreement-matrix output. ``architecture`` is the architecture
+    family (``"transformer"``, ``"lstm"``, ``"tft"``, ...). ``encoder_alias``
+    is the text-encoder family alias from ``backend/app/models/registry.yaml``
+    when relevant (e.g., ``"bert_base"``, ``"finbert"``); for runs without
+    a text encoder, set it to a stable placeholder like ``"none"``.
+    ``seed`` is the training-time random seed. ``weight`` is the logit-
+    average weight (default 1.0 = uniform); the aggregator normalises
+    weights to sum to one before averaging.
+
+    ``results_path`` is the absolute or relative path to the run's
+    ``forecaster_sweep_results.json`` (or equivalent) blob. The loader
+    uses the same JSON shape the single-run aggregator already consumes
+    so no new on-disk contract is introduced.
+    """
+
+    run_id: str
+    architecture: str
+    encoder_alias: str
+    seed: int
+    results_path: str
+    weight: float = 1.0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "run_id": self.run_id,
+            "architecture": self.architecture,
+            "encoder_alias": self.encoder_alias,
+            "seed": self.seed,
+            "results_path": self.results_path,
+            "weight": self.weight,
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class MultiRunFoldResult:
+    """Per-fold result emitted by :func:`aggregate_multi_run_ensemble`.
+
+    ``coverage`` + ``avg_set_size`` come from the per-fold conformal
+    wrapper, applied to the averaged softmax probabilities.
+    """
+
+    fold_id: str
+    n_rows: int
+    breakdown: ClassificationBreakdown
+    coverage: float
+    avg_set_size: float
+    softmax_quantile: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "fold_id": self.fold_id,
+            "n_rows": self.n_rows,
+            "breakdown": self.breakdown.to_dict(),
+            "coverage": self.coverage,
+            "avg_set_size": self.avg_set_size,
+            "softmax_quantile": self.softmax_quantile,
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class MultiRunEnsembleResult:
+    """Top-level Phase 5 ensemble result.
+
+    ``kept_run_ids`` lists the run_ids that survived the redundancy
+    guard. ``dropped_run_ids`` lists the ones dropped + the run_id they
+    were redundant with. ``agreement`` is the pairwise Cohen-kappa
+    matrix across the kept components.
+    """
+
+    kept_run_ids: tuple[str, ...]
+    dropped_run_ids: tuple[tuple[str, str, float], ...]
+    agreement: dict[tuple[str, str], float]
+    per_fold: tuple[MultiRunFoldResult, ...]
+    pooled_breakdown: ClassificationBreakdown
+    calibration_strategy: str
+    conformal_alpha: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kept_run_ids": list(self.kept_run_ids),
+            "dropped_run_ids": [
+                {"dropped": d, "redundant_with": k, "kappa": float(kappa)}
+                for d, k, kappa in self.dropped_run_ids
+            ],
+            "agreement": {
+                f"{a}|{b}": float(v) for (a, b), v in self.agreement.items()
+            },
+            "per_fold": [row.to_dict() for row in self.per_fold],
+            "pooled_breakdown": self.pooled_breakdown.to_dict(),
+            "calibration_strategy": self.calibration_strategy,
+            "conformal_alpha": self.conformal_alpha,
+        }
+
+
+def _load_run_trials(spec: RunSpec) -> list[Mapping[str, object]]:
+    """Read the run's sweep JSON and return its trial list.
+
+    Uses the same loader path as :func:`main` above so the multi-run
+    aggregator inherits the single-run aggregator's on-disk contract.
+    Trials without ``test_metrics.predictions`` / ``class_scores`` are
+    skipped silently — the multi-run logic asserts coverage downstream.
+    """
+
+    path = Path(spec.results_path)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"run {spec.run_id!r} results not found at {path!s}"
+        )
+    blob = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(blob, Mapping):
+        raise ValueError(
+            f"run {spec.run_id!r} results blob is not a JSON object: {path!s}"
+        )
+    trials = blob.get("trials", [])
+    if not isinstance(trials, list):
+        raise ValueError(
+            f"run {spec.run_id!r} results blob has no 'trials' list: {path!s}"
+        )
+    out: list[Mapping[str, object]] = []
+    for trial in trials:
+        if isinstance(trial, Mapping):
+            out.append(trial)
+    return out
+
+
+def _trial_id(trial: Mapping[str, object]) -> tuple[str, int | None]:
+    """Stable identifier for a single trial. The multi-run aggregator
+    aligns trials across runs by ``(fold_id, seed)``; if seed is absent
+    it falls through to ``None`` so the layout-mismatch guard fires
+    fail-loud."""
+
+    fold = trial.get("fold_id")
+    seed = trial.get("seed")
+    fold_key = str(fold) if fold is not None else ""
+    seed_key = int(seed) if isinstance(seed, int) else None
+    return fold_key, seed_key
+
+
+def _softmax(logits: Sequence[float]) -> list[float]:
+    """Numerically stable softmax for a single row of logits."""
+
+    if not logits:
+        return []
+    m = max(float(x) for x in logits)
+    exps = [math.exp(float(x) - m) for x in logits]
+    total = sum(exps)
+    if total <= 0:
+        return [1.0 / len(logits)] * len(logits)
+    return [e / total for e in exps]
+
+
+def _row_logits(trial: Mapping[str, object]) -> list[list[float]] | None:
+    """Pull per-row class scores as logits.
+
+    The current training loop emits ``test_metrics.class_scores`` as
+    softmax probabilities; we convert to logits via ``log(max(eps, p))``
+    so the multi-run averaging is in log-space (equivalent to averaging
+    log-probabilities). This matches the ``mean_logit`` strategy in
+    the single-run aggregator above.
+    """
+
+    scores = _trial_class_scores(trial)
+    if scores is None:
+        return None
+    eps = 1e-12
+    return [[math.log(max(eps, float(p))) for p in row] for row in scores]
+
+
+def _cohen_kappa(preds_a: Sequence[int], preds_b: Sequence[int]) -> float:
+    """Cohen's kappa between two prediction sequences over the same rows.
+
+    Defined as ``(p_o - p_e) / (1 - p_e)`` where ``p_o`` is observed
+    agreement and ``p_e`` is the chance-agreement implied by each
+    rater's marginal class distribution. Returns 1.0 on identical
+    predictions; 0.0 when the chance-agreement saturates (i.e. both
+    raters always predict the same single class).
+    """
+
+    if len(preds_a) != len(preds_b):
+        raise ValueError(
+            f"preds_a length {len(preds_a)} != preds_b length {len(preds_b)}"
+        )
+    n = len(preds_a)
+    if n == 0:
+        return float("nan")
+    classes = sorted({int(x) for x in preds_a} | {int(x) for x in preds_b})
+    if len(classes) <= 1:
+        return 1.0 if all(int(a) == int(b) for a, b in zip(preds_a, preds_b)) else 0.0
+    agree = sum(1 for a, b in zip(preds_a, preds_b) if int(a) == int(b))
+    p_o = agree / n
+    marg_a = {c: 0 for c in classes}
+    marg_b = {c: 0 for c in classes}
+    for a, b in zip(preds_a, preds_b):
+        marg_a[int(a)] += 1
+        marg_b[int(b)] += 1
+    p_e = sum((marg_a[c] / n) * (marg_b[c] / n) for c in classes)
+    if abs(1.0 - p_e) < 1e-12:
+        return 1.0 if p_o >= 1.0 - 1e-12 else 0.0
+    return (p_o - p_e) / (1.0 - p_e)
+
+
+def _validate_run_layouts(
+    specs: Sequence[RunSpec],
+    trials_by_run: Mapping[str, Sequence[Mapping[str, object]]],
+) -> tuple[tuple[tuple[str, int | None], ...], dict[str, dict[tuple[str, int | None], Mapping[str, object]]]]:
+    """Confirm every run has the same ``(fold_id, seed)`` trial set.
+
+    Returns the canonical trial-id sequence (sorted, derived from the
+    first run) and a per-run lookup keyed by trial id. Raises
+    ``ValueError`` on any mismatch — fail-loud per the deliverables.
+    """
+
+    if not specs:
+        raise ValueError("multi-run ensemble requires at least one RunSpec")
+    canonical: list[tuple[str, int | None]] | None = None
+    lookup: dict[
+        str, dict[tuple[str, int | None], Mapping[str, object]]
+    ] = {}
+    for spec in specs:
+        trials = trials_by_run.get(spec.run_id, [])
+        per_run: dict[tuple[str, int | None], Mapping[str, object]] = {}
+        for trial in trials:
+            tid = _trial_id(trial)
+            per_run[tid] = trial
+        lookup[spec.run_id] = per_run
+        ids = sorted(per_run.keys())
+        if canonical is None:
+            canonical = ids
+        elif ids != canonical:
+            missing = sorted(set(canonical) - set(ids))
+            extra = sorted(set(ids) - set(canonical))
+            raise ValueError(
+                f"run {spec.run_id!r} fold/trial layout mismatch: "
+                f"missing={missing!r}, extra={extra!r}"
+            )
+    if canonical is None:
+        canonical = []
+    return tuple(canonical), lookup
+
+
+def _agreement_matrix(
+    run_ids: Sequence[str],
+    preds_by_run: Mapping[str, Sequence[int]],
+) -> dict[tuple[str, str], float]:
+    """Pairwise Cohen-kappa across run pairs.
+
+    Symmetric: the matrix records both ``(a, b)`` and ``(b, a)`` so
+    callers can drop either direction without re-checking ordering.
+    The diagonal carries 1.0.
+    """
+
+    out: dict[tuple[str, str], float] = {}
+    for i, a in enumerate(run_ids):
+        out[(a, a)] = 1.0
+        for b in run_ids[i + 1 :]:
+            kappa = _cohen_kappa(preds_by_run[a], preds_by_run[b])
+            out[(a, b)] = kappa
+            out[(b, a)] = kappa
+    return out
+
+
+def _drop_redundant_runs(
+    run_ids: Sequence[str],
+    agreement: Mapping[tuple[str, str], float],
+    *,
+    threshold: float,
+    log: Callable[[str], None],
+) -> tuple[tuple[str, ...], tuple[tuple[str, str, float], ...]]:
+    """Drop runs whose pairwise kappa with any kept run exceeds threshold.
+
+    Greedy left-to-right pass: the first run is always kept; each
+    subsequent run is dropped if any already-kept run has agreement
+    above the threshold. The dropped run is logged with the kept run
+    id it was redundant with and the kappa value.
+    """
+
+    kept: list[str] = []
+    dropped: list[tuple[str, str, float]] = []
+    for run_id in run_ids:
+        redundant_with: str | None = None
+        kappa_with: float = float("nan")
+        for k in kept:
+            kappa = float(agreement.get((run_id, k), 0.0))
+            if kappa > threshold:
+                redundant_with = k
+                kappa_with = kappa
+                break
+        if redundant_with is None:
+            kept.append(run_id)
+        else:
+            dropped.append((run_id, redundant_with, kappa_with))
+            log(
+                f"[ensemble_aggregator] dropping run {run_id!r} "
+                f"(kappa={kappa_with:.3f} with kept run "
+                f"{redundant_with!r} exceeds threshold {threshold:.3f})"
+            )
+    return tuple(kept), tuple(dropped)
+
+
+def aggregate_multi_run_ensemble(  # noqa: C901, PLR0913
+    run_specs: Sequence[RunSpec],
+    *,
+    ground_truth_loader: Callable[[RunSpec], list[Mapping[str, object]]] | None = None,
+    calibration_strategy: Literal["conformal_per_fold"] = "conformal_per_fold",
+    redundancy_kappa_threshold: float = DEFAULT_REDUNDANCY_KAPPA_THRESHOLD,
+    conformal_alpha: float = DEFAULT_CONFORMAL_ALPHA,
+    n_classes: int = 3,
+    log: Callable[[str], None] | None = None,
+) -> MultiRunEnsembleResult:
+    """Phase 5 calibrated logit-average ensemble across N training runs.
+
+    See module docstring + ``RunSpec`` for the input contract. The
+    aggregator:
+
+    1. Loads each run's per-fold per-trial logits via
+       ``ground_truth_loader`` (defaults to reading the spec's
+       ``results_path`` and parsing the standard sweep JSON).
+    2. Validates that all runs share the same ``(fold_id, seed)``
+       trial layout — raises ``ValueError`` on any mismatch.
+    3. Computes pairwise Cohen-kappa across runs and drops any run
+       whose agreement with an already-kept run exceeds
+       ``redundancy_kappa_threshold``.
+    4. Averages logits across the kept runs per (fold, trial) using
+       the spec weights (normalised to sum to one).
+    5. Fits a per-fold conformal threshold on the averaged softmax
+       probabilities and emits per-fold coverage + average set size.
+    6. Pools predictions across folds for a single headline macro-F1.
+
+    The conformal path reuses the per-fold APS calibration the
+    existing single-run wrapper applies, so the calibration carries
+    the same coverage guarantee as the headline classifier (modulo
+    the exchangeability assumption holding across the averaged-run
+    logits, which is the standard split-conformal claim).
+    """
+
+    if calibration_strategy != "conformal_per_fold":
+        raise ValueError(
+            f"unsupported calibration_strategy: {calibration_strategy!r}; "
+            "Phase 5 ships only the per-fold conformal path"
+        )
+    if not run_specs:
+        raise ValueError("aggregate_multi_run_ensemble requires >=1 RunSpec")
+
+    log_fn = log if log is not None else print
+
+    loader = ground_truth_loader if ground_truth_loader is not None else _load_run_trials
+    trials_by_run = {spec.run_id: list(loader(spec)) for spec in run_specs}
+
+    canonical_ids, lookup = _validate_run_layouts(run_specs, trials_by_run)
+    if not canonical_ids:
+        raise ValueError(
+            "multi-run ensemble received an empty trial layout — every "
+            "run has zero trials; nothing to aggregate"
+        )
+
+    # Step: assemble per-run argmax predictions so we can compute the
+    # pairwise agreement matrix before deciding who to keep.
+    preds_by_run: dict[str, list[int]] = {}
+    for spec in run_specs:
+        per_run = lookup[spec.run_id]
+        flat: list[int] = []
+        for tid in canonical_ids:
+            trial = per_run[tid]
+            rows = _test_predictions(trial)
+            if rows is None:
+                raise ValueError(
+                    f"run {spec.run_id!r} trial {tid!r} missing "
+                    "test_metrics.predictions/targets"
+                )
+            preds, _targets = rows
+            flat.extend(preds)
+        preds_by_run[spec.run_id] = flat
+
+    run_ids_in_order = [spec.run_id for spec in run_specs]
+    agreement = _agreement_matrix(run_ids_in_order, preds_by_run)
+    kept, dropped = _drop_redundant_runs(
+        run_ids_in_order,
+        agreement,
+        threshold=redundancy_kappa_threshold,
+        log=log_fn,
+    )
+
+    kept_set = set(kept)
+    kept_specs = [spec for spec in run_specs if spec.run_id in kept_set]
+
+    # Normalise weights across kept specs.
+    raw_weights = [float(spec.weight) for spec in kept_specs]
+    total_w = sum(raw_weights)
+    if total_w <= 0:
+        raise ValueError(
+            "kept runs have non-positive weight sum; cannot normalise"
+        )
+    weights = [w / total_w for w in raw_weights]
+
+    # Step: per-fold logit averaging + conformal calibration.
+    from app.evaluation.conformal import (
+        calibrate_classification_conformal,
+        empirical_classification_coverage,
+        predict_conformal_set,
+    )
+
+    per_fold_results: list[MultiRunFoldResult] = []
+    pooled_preds: list[int] = []
+    pooled_targets: list[int] = []
+
+    # Group canonical_ids by fold so the conformal calibration is per-
+    # fold by construction (the leak-guard requirement in the deliverables).
+    fold_buckets: dict[str, list[tuple[str, int | None]]] = defaultdict(list)
+    for tid in canonical_ids:
+        fold_buckets[tid[0]].append(tid)
+
+    for fold_id, fold_tids in sorted(fold_buckets.items()):
+        fold_preds: list[int] = []
+        fold_targets: list[int] = []
+        fold_softmax: list[list[float]] = []
+        for tid in fold_tids:
+            # Reference targets from the first kept spec; the layout
+            # validator already confirmed alignment across runs, but
+            # do a defensive equality check on targets per trial to
+            # catch row-ordering drift inside a single trial.
+            ref_rows = _test_predictions(lookup[kept_specs[0].run_id][tid])
+            if ref_rows is None:
+                raise ValueError(
+                    f"kept run {kept_specs[0].run_id!r} missing test_metrics "
+                    f"on trial {tid!r}"
+                )
+            _ref_preds, ref_targets = ref_rows
+            n_rows_trial = len(ref_targets)
+
+            # Per-row aggregated logits across kept runs.
+            avg_logits: list[list[float]] = [
+                [0.0] * n_classes for _ in range(n_rows_trial)
+            ]
+            for spec, w in zip(kept_specs, weights):
+                logits = _row_logits(lookup[spec.run_id][tid])
+                if logits is None:
+                    raise ValueError(
+                        f"run {spec.run_id!r} trial {tid!r} missing "
+                        "test_metrics.class_scores"
+                    )
+                if len(logits) != n_rows_trial:
+                    raise ValueError(
+                        f"run {spec.run_id!r} trial {tid!r} class_scores "
+                        f"length {len(logits)} != targets length {n_rows_trial}"
+                    )
+                _, ref_targets_b = _test_predictions(lookup[spec.run_id][tid])  # type: ignore[misc]
+                if ref_targets_b != ref_targets:
+                    raise ValueError(
+                        f"run {spec.run_id!r} trial {tid!r} target sequence "
+                        "differs from reference run; row ordering drifted"
+                    )
+                for i, row in enumerate(logits):
+                    if len(row) != n_classes:
+                        raise ValueError(
+                            f"run {spec.run_id!r} trial {tid!r} row {i} has "
+                            f"{len(row)} classes; expected {n_classes}"
+                        )
+                    for c in range(n_classes):
+                        avg_logits[i][c] += w * float(row[c])
+
+            # Softmax once at the end.
+            for row in avg_logits:
+                probs = _softmax(row)
+                fold_softmax.append(probs)
+                fold_preds.append(
+                    max(range(n_classes), key=lambda c: probs[c])
+                )
+            fold_targets.extend(int(y) for y in ref_targets)
+
+        # Per-fold conformal calibration on the averaged softmax. This
+        # is the leak-safe path: the averaged logits at fold F never
+        # touched fold F training, because each component trained on
+        # its own walk-forward partition; the conformal threshold is
+        # fit on the fold's own held-out scores rather than a global
+        # calibration tier.
+        try:
+            softmax_q = calibrate_classification_conformal(
+                softmax_scores=fold_softmax,
+                true_classes=fold_targets,
+                alpha=conformal_alpha,
+            )
+        except ValueError:
+            softmax_q = float("nan")
+        if math.isfinite(softmax_q):
+            sets = [predict_conformal_set(row, softmax_q) for row in fold_softmax]
+            coverage = empirical_classification_coverage(sets, fold_targets)
+            avg_set_size = (
+                sum(len(s) for s in sets) / len(sets) if sets else float("nan")
+            )
+        else:
+            coverage = float("nan")
+            avg_set_size = float("nan")
+
+        breakdown = compute_classification_breakdown(
+            predictions=fold_preds,
+            targets=fold_targets,
+            n_classes=n_classes,
+        )
+        per_fold_results.append(
+            MultiRunFoldResult(
+                fold_id=fold_id,
+                n_rows=len(fold_preds),
+                breakdown=breakdown,
+                coverage=float(coverage),
+                avg_set_size=float(avg_set_size),
+                softmax_quantile=float(softmax_q),
+            )
+        )
+        pooled_preds.extend(fold_preds)
+        pooled_targets.extend(fold_targets)
+
+    pooled_breakdown = compute_classification_breakdown(
+        predictions=pooled_preds,
+        targets=pooled_targets,
+        n_classes=n_classes,
+    )
+
+    return MultiRunEnsembleResult(
+        kept_run_ids=kept,
+        dropped_run_ids=dropped,
+        agreement=agreement,
+        per_fold=tuple(per_fold_results),
+        pooled_breakdown=pooled_breakdown,
+        calibration_strategy=calibration_strategy,
+        conformal_alpha=float(conformal_alpha),
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/backend/app/evaluation/ensemble_aggregator.py
+++ b/backend/app/evaluation/ensemble_aggregator.py
@@ -777,6 +777,52 @@ def _agreement_matrix(
     return out
 
 
+def per_fold_conformal_calibration(
+    fold_softmax: Sequence[Sequence[float]],
+    fold_targets: Sequence[int],
+    *,
+    conformal_alpha: float = DEFAULT_CONFORMAL_ALPHA,
+) -> tuple[float, float, float]:
+    """Per-fold conformal calibration on averaged softmax probabilities.
+
+    Wires through the existing
+    :func:`app.evaluation.conformal.calibrate_classification_conformal` +
+    :func:`predict_conformal_set` +
+    :func:`empirical_classification_coverage` helpers introduced in
+    PR #279. The fold's own scores fit the threshold and feed the
+    coverage check; no global calibration tier is used (calibration
+    leak guard path (b) in the Phase 5 deliverables).
+
+    Returns ``(softmax_quantile, coverage, avg_set_size)``. Any of
+    the three may be ``nan`` when the fold has too few rows for the
+    finite-sample-corrected quantile (the underlying helper raises
+    ``ValueError`` on an empty conformity-score set).
+    """
+
+    from app.evaluation.conformal import (
+        calibrate_classification_conformal,
+        empirical_classification_coverage,
+        predict_conformal_set,
+    )
+
+    try:
+        softmax_q = calibrate_classification_conformal(
+            softmax_scores=fold_softmax,
+            true_classes=fold_targets,
+            alpha=conformal_alpha,
+        )
+    except ValueError:
+        return float("nan"), float("nan"), float("nan")
+    if not math.isfinite(softmax_q):
+        return float("nan"), float("nan"), float("nan")
+    sets = [predict_conformal_set(row, softmax_q) for row in fold_softmax]
+    coverage = empirical_classification_coverage(sets, fold_targets)
+    avg_set_size = (
+        sum(len(s) for s in sets) / len(sets) if sets else float("nan")
+    )
+    return float(softmax_q), float(coverage), float(avg_set_size)
+
+
 def _drop_redundant_runs(
     run_ids: Sequence[str],
     agreement: Mapping[tuple[str, str], float],
@@ -911,12 +957,6 @@ def aggregate_multi_run_ensemble(  # noqa: C901, PLR0913
     weights = [w / total_w for w in raw_weights]
 
     # Step: per-fold logit averaging + conformal calibration.
-    from app.evaluation.conformal import (
-        calibrate_classification_conformal,
-        empirical_classification_coverage,
-        predict_conformal_set,
-    )
-
     per_fold_results: list[MultiRunFoldResult] = []
     pooled_preds: list[int] = []
     pooled_targets: list[int] = []
@@ -991,23 +1031,11 @@ def aggregate_multi_run_ensemble(  # noqa: C901, PLR0913
         # its own walk-forward partition; the conformal threshold is
         # fit on the fold's own held-out scores rather than a global
         # calibration tier.
-        try:
-            softmax_q = calibrate_classification_conformal(
-                softmax_scores=fold_softmax,
-                true_classes=fold_targets,
-                alpha=conformal_alpha,
-            )
-        except ValueError:
-            softmax_q = float("nan")
-        if math.isfinite(softmax_q):
-            sets = [predict_conformal_set(row, softmax_q) for row in fold_softmax]
-            coverage = empirical_classification_coverage(sets, fold_targets)
-            avg_set_size = (
-                sum(len(s) for s in sets) / len(sets) if sets else float("nan")
-            )
-        else:
-            coverage = float("nan")
-            avg_set_size = float("nan")
+        softmax_q, coverage, avg_set_size = per_fold_conformal_calibration(
+            fold_softmax,
+            fold_targets,
+            conformal_alpha=conformal_alpha,
+        )
 
         breakdown = compute_classification_breakdown(
             predictions=fold_preds,

--- a/backend/app/evaluation/ensemble_run_specs.py
+++ b/backend/app/evaluation/ensemble_run_specs.py
@@ -1,0 +1,278 @@
+"""CLI driver for the Phase 5 multi-run logit-average ensemble.
+
+Reads a YAML manifest listing N training runs (one run = one
+config x seed x architecture combination), pools their per-fold
+per-trial logits, drops redundant components via the pairwise
+Cohen-kappa guard in
+:func:`app.evaluation.ensemble_aggregator.aggregate_multi_run_ensemble`,
+and writes a markdown summary + JSON metrics file.
+
+YAML schema
+-----------
+
+Top-level: a list of run-spec entries (or a mapping with key
+``runs`` whose value is the list). Each entry carries the fields
+of :class:`app.evaluation.ensemble_aggregator.RunSpec`:
+
+.. code-block:: yaml
+
+    runs:
+      - run_id: rgm_lstm_seed11
+        architecture: lstm
+        encoder_alias: none
+        seed: 11
+        results_path: artifacts/experiments/rgm_lstm_seed11/forecaster_sweep_results.json
+        weight: 1.0
+      - run_id: rgm_transformer_seed11
+        architecture: transformer
+        encoder_alias: bert_base
+        seed: 11
+        results_path: artifacts/experiments/rgm_transformer_seed11/forecaster_sweep_results.json
+
+Optional top-level keys:
+
+- ``conformal_alpha``: float, default 0.2 (matches the headline
+  classifier's per-fold conformal alpha).
+- ``redundancy_kappa_threshold``: float, default 0.85.
+- ``n_classes``: int, default 3.
+
+Run with::
+
+    python -m app.evaluation.ensemble_run_specs \\
+        --run-spec-file path/to/phase5_specs.yaml \\
+        --output-dir artifacts/experiments/phase5_ensemble
+
+The CLI deliberately does no model loading or training; it operates
+purely on the on-disk sweep JSONs each ``results_path`` points at.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from app.evaluation.ensemble_aggregator import (
+    DEFAULT_CONFORMAL_ALPHA,
+    DEFAULT_REDUNDANCY_KAPPA_THRESHOLD,
+    MultiRunEnsembleResult,
+    RunSpec,
+    aggregate_multi_run_ensemble,
+)
+
+
+def _load_run_specs(path: Path) -> tuple[list[RunSpec], dict[str, Any]]:
+    """Parse the YAML manifest into ``RunSpec`` instances + the
+    top-level options block.
+
+    Accepts either a top-level list or a mapping with ``runs`` keying
+    the list — the mapping form is preferred when callers want to
+    co-locate runtime options like ``conformal_alpha`` with the run
+    list, but a bare list is supported for terse manifests.
+    """
+
+    if not path.exists():
+        raise FileNotFoundError(f"run spec file not found: {path}")
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    options: dict[str, Any] = {}
+    if isinstance(raw, list):
+        run_entries = raw
+    elif isinstance(raw, Mapping):
+        run_entries_raw = raw.get("runs")
+        if not isinstance(run_entries_raw, list):
+            raise ValueError(
+                f"run spec file {path!s} must carry a top-level list or a "
+                "mapping with a 'runs' list"
+            )
+        run_entries = run_entries_raw
+        for key in ("conformal_alpha", "redundancy_kappa_threshold", "n_classes"):
+            if key in raw:
+                options[key] = raw[key]
+    else:
+        raise ValueError(
+            f"run spec file {path!s} must be a YAML list or mapping; got "
+            f"{type(raw).__name__}"
+        )
+
+    specs: list[RunSpec] = []
+    for i, entry in enumerate(run_entries):
+        if not isinstance(entry, Mapping):
+            raise ValueError(
+                f"run spec entry {i} in {path!s} must be a mapping; got "
+                f"{type(entry).__name__}"
+            )
+        try:
+            run_id = str(entry["run_id"])
+            architecture = str(entry["architecture"])
+            encoder_alias = str(entry["encoder_alias"])
+            seed = int(entry["seed"])
+            results_path = str(entry["results_path"])
+        except KeyError as exc:
+            raise ValueError(
+                f"run spec entry {i} in {path!s} missing required field {exc}"
+            ) from exc
+        weight = float(entry.get("weight", 1.0))
+        specs.append(
+            RunSpec(
+                run_id=run_id,
+                architecture=architecture,
+                encoder_alias=encoder_alias,
+                seed=seed,
+                results_path=results_path,
+                weight=weight,
+            )
+        )
+    return specs, options
+
+
+def _render_markdown(
+    specs: Sequence[RunSpec], result: MultiRunEnsembleResult
+) -> str:
+    lines: list[str] = []
+    lines.append("# Phase 5 multi-run logit-average ensemble")
+    lines.append("")
+    lines.append(
+        f"Calibration strategy: `{result.calibration_strategy}` "
+        f"(alpha={result.conformal_alpha:.2f})"
+    )
+    lines.append("")
+    lines.append("## Component runs")
+    lines.append("")
+    lines.append("| run_id | architecture | encoder_alias | seed | weight | kept |")
+    lines.append("| --- | --- | --- | ---: | ---: | :---: |")
+    kept_set = set(result.kept_run_ids)
+    for spec in specs:
+        kept = "yes" if spec.run_id in kept_set else "no"
+        lines.append(
+            f"| `{spec.run_id}` | {spec.architecture} | {spec.encoder_alias} "
+            f"| {spec.seed} | {spec.weight:.2f} | {kept} |"
+        )
+    lines.append("")
+    if result.dropped_run_ids:
+        lines.append("### Redundancy drops")
+        lines.append("")
+        lines.append("| dropped | redundant_with | kappa |")
+        lines.append("| --- | --- | ---: |")
+        for dropped, kept, kappa in result.dropped_run_ids:
+            lines.append(f"| `{dropped}` | `{kept}` | {kappa:.3f} |")
+        lines.append("")
+    lines.append("## Per-fold breakdown")
+    lines.append("")
+    lines.append("| fold | n | macro-F1 | coverage | avg set size |")
+    lines.append("| --- | ---: | ---: | ---: | ---: |")
+    for row in result.per_fold:
+        lines.append(
+            f"| {row.fold_id} | {row.n_rows} | {row.breakdown.macro_f1:.4f} "
+            f"| {row.coverage:.3f} | {row.avg_set_size:.2f} |"
+        )
+    lines.append("")
+    lines.append("## Pooled")
+    lines.append("")
+    lines.append(f"- macro-F1: **{result.pooled_breakdown.macro_f1:.4f}**")
+    lines.append(f"- weighted-F1: {result.pooled_breakdown.weighted_f1:.4f}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Phase 5 multi-run logit-average ensemble. Reads a YAML "
+            "manifest of training-run specs and emits a markdown "
+            "summary + JSON metrics for the pooled macro-F1 and "
+            "per-fold conformal coverage."
+        )
+    )
+    parser.add_argument(
+        "--run-spec-file",
+        type=Path,
+        required=True,
+        help="Path to a YAML file listing the runs to ensemble.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory the markdown + JSON outputs are written to.",
+    )
+    parser.add_argument(
+        "--conformal-alpha",
+        type=float,
+        default=None,
+        help=(
+            "Per-fold conformal alpha. Defaults to the value in the YAML "
+            f"if present, otherwise {DEFAULT_CONFORMAL_ALPHA}."
+        ),
+    )
+    parser.add_argument(
+        "--redundancy-kappa-threshold",
+        type=float,
+        default=None,
+        help=(
+            "Cohen-kappa cutoff above which a run is treated as redundant. "
+            f"Defaults to the YAML value if present, else {DEFAULT_REDUNDANCY_KAPPA_THRESHOLD}."
+        ),
+    )
+    parser.add_argument(
+        "--n-classes",
+        type=int,
+        default=None,
+        help="Number of target classes. Defaults to the YAML value or 3.",
+    )
+    args = parser.parse_args(argv)
+
+    specs, options = _load_run_specs(args.run_spec_file)
+    if not specs:
+        raise SystemExit(f"run spec file {args.run_spec_file!s} is empty")
+
+    conformal_alpha = (
+        args.conformal_alpha
+        if args.conformal_alpha is not None
+        else float(options.get("conformal_alpha", DEFAULT_CONFORMAL_ALPHA))
+    )
+    redundancy_threshold = (
+        args.redundancy_kappa_threshold
+        if args.redundancy_kappa_threshold is not None
+        else float(
+            options.get(
+                "redundancy_kappa_threshold", DEFAULT_REDUNDANCY_KAPPA_THRESHOLD
+            )
+        )
+    )
+    n_classes = (
+        args.n_classes
+        if args.n_classes is not None
+        else int(options.get("n_classes", 3))
+    )
+
+    result = aggregate_multi_run_ensemble(
+        specs,
+        calibration_strategy="conformal_per_fold",
+        redundancy_kappa_threshold=redundancy_threshold,
+        conformal_alpha=conformal_alpha,
+        n_classes=n_classes,
+    )
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = args.output_dir / "ensemble_phase5_results.json"
+    md_path = args.output_dir / "ensemble_phase5_results.md"
+    json_path.write_text(
+        json.dumps(
+            {
+                "run_specs": [spec.to_dict() for spec in specs],
+                "result": result.to_dict(),
+            },
+            indent=2,
+        )
+    )
+    md_path.write_text(_render_markdown(specs, result))
+    print(f"[ensemble_run_specs] wrote {json_path} + {md_path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/app/evaluation/examples/ensemble_phase5_example.yaml
+++ b/backend/app/evaluation/examples/ensemble_phase5_example.yaml
@@ -1,0 +1,50 @@
+# Phase 5 multi-run logit-average ensemble manifest (illustrative).
+#
+# Lists the surviving variants from Phases 1, 2, 4 plus the headline
+# transformer that the cross-bank work ladder stacks for the Phase 5
+# calibrated logit-average ensemble.
+#
+# This file is not executed by CI; it documents the YAML schema the
+# `app.evaluation.ensemble_run_specs` driver consumes. The paths under
+# `results_path` are placeholders — point at real sweep JSONs before
+# running.
+
+conformal_alpha: 0.2
+redundancy_kappa_threshold: 0.85
+n_classes: 3
+
+runs:
+  - run_id: rgm_transformer_seed11
+    architecture: transformer
+    encoder_alias: bert_base
+    seed: 11
+    results_path: artifacts/experiments/rgm_transformer_seed11/forecaster_sweep_results.json
+    weight: 1.0
+
+  - run_id: rgm_lstm_seed11
+    architecture: lstm
+    encoder_alias: none
+    seed: 11
+    results_path: artifacts/experiments/rgm_lstm_seed11/forecaster_sweep_results.json
+    weight: 1.0
+
+  - run_id: rgm_tft_seed11
+    architecture: tft
+    encoder_alias: none
+    seed: 11
+    results_path: artifacts/experiments/rgm_tft_seed11/forecaster_sweep_results.json
+    weight: 1.0
+
+  - run_id: rgm_transformer_finbert_seed11
+    architecture: transformer
+    encoder_alias: finbert
+    seed: 11
+    results_path: artifacts/experiments/rgm_transformer_finbert_seed11/forecaster_sweep_results.json
+    weight: 1.0
+
+  - run_id: rgm_transformer_fomc_roberta_seed11
+    architecture: transformer
+    encoder_alias: fomc_roberta
+    seed: 11
+    results_path: artifacts/experiments/rgm_transformer_fomc_roberta_seed11/forecaster_sweep_results.json
+    weight: 1.0

--- a/tests/unit/test_ensemble_aggregator.py
+++ b/tests/unit/test_ensemble_aggregator.py
@@ -25,6 +25,7 @@ from app.evaluation.ensemble_aggregator import (
     _plurality_vote,
     aggregate,
     aggregate_multi_run_ensemble,
+    per_fold_conformal_calibration,
 )
 
 
@@ -836,3 +837,138 @@ def test_ensemble_run_specs_cli_accepts_bare_list(tmp_path: Path) -> None:
     )
     assert rc == 0
     assert (output_dir / "ensemble_phase5_results.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Per-fold conformal calibration helper
+# ---------------------------------------------------------------------------
+
+
+def test_per_fold_conformal_calibration_returns_finite_triple() -> None:
+    """The helper returns ``(softmax_q, coverage, avg_set_size)`` and
+    none of the values is nan on a non-degenerate fold."""
+
+    # 10 confident rows; class 0 is always truth.
+    fold_softmax = [[0.85, 0.10, 0.05]] * 10
+    fold_targets = [0] * 10
+    q, coverage, avg_size = per_fold_conformal_calibration(
+        fold_softmax, fold_targets, conformal_alpha=0.2
+    )
+    assert math.isfinite(q)
+    assert math.isfinite(coverage)
+    assert math.isfinite(avg_size)
+    # Coverage on the calibration set must be >= nominal (1 - alpha).
+    assert coverage >= 0.8 - 1e-9
+
+
+def test_per_fold_conformal_calibration_handles_empty_fold() -> None:
+    """Empty fold -> all-nan triple, never raises."""
+
+    q, coverage, avg_size = per_fold_conformal_calibration(
+        [], [], conformal_alpha=0.2
+    )
+    assert math.isnan(q)
+    assert math.isnan(coverage)
+    assert math.isnan(avg_size)
+
+
+def test_per_fold_conformal_threshold_differs_across_folds(
+    tmp_path: Path,
+) -> None:
+    """The per-fold calibration must not collapse to a single global
+    threshold — folds with different confidence distributions should
+    yield different softmax-quantile values.
+
+    The deliverables specify "use the per-fold conformal wrapper" so
+    this test pins the per-fold contract: two folds with materially
+    different confidence yield different thresholds, proving the
+    aggregator is not silently re-using one global quantile."""
+
+    # Fold 1: confident truth (low non-conformity scores).
+    layout = [("wf_fold_1", 11), ("wf_fold_2", 11)]
+    targets = [[0] * 12, [0] * 12]
+    preds_a = [[0] * 12, [0] * 12]
+    preds_b = [[0] * 12, [0] * 12]
+    scores_a = [
+        [[0.9, 0.05, 0.05]] * 12,  # fold 1: very confident on truth
+        [[0.45, 0.30, 0.25]] * 12,  # fold 2: less confident
+    ]
+    scores_b = [
+        [[0.92, 0.04, 0.04]] * 12,
+        [[0.48, 0.27, 0.25]] * 12,
+    ]
+    run_a = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds_a,
+        per_trial_targets=targets,
+        per_trial_scores=scores_a,
+    )
+    run_b = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds_b,
+        per_trial_targets=targets,
+        per_trial_scores=scores_b,
+    )
+    path_a = _write_run_blob(tmp_path / "a" / "forecaster_sweep_results.json", run_a)
+    path_b = _write_run_blob(tmp_path / "b" / "forecaster_sweep_results.json", run_b)
+    specs = [
+        RunSpec(
+            run_id="run_a",
+            architecture="lstm",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_a),
+        ),
+        RunSpec(
+            run_id="run_b",
+            architecture="tft",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_b),
+        ),
+    ]
+    result = aggregate_multi_run_ensemble(
+        specs,
+        conformal_alpha=0.2,
+        redundancy_kappa_threshold=1.5,
+    )
+    assert len(result.per_fold) == 2
+    fold1, fold2 = result.per_fold
+    # Fold 2's averaged softmax is less confident, so its conformal
+    # threshold (1 - softmax[truth]) sits materially higher than
+    # fold 1's. If the aggregator were applying a single global
+    # threshold both folds would carry the same softmax_quantile.
+    assert math.isfinite(fold1.softmax_quantile)
+    assert math.isfinite(fold2.softmax_quantile)
+    assert fold2.softmax_quantile > fold1.softmax_quantile + 1e-3
+
+
+def test_aggregate_rejects_unsupported_calibration_strategy(tmp_path: Path) -> None:
+    """Phase 5 ships only ``conformal_per_fold``; any other value must
+    raise so future expansions are forced through a code review."""
+
+    layout = [("wf_fold_1", 11)]
+    targets = [[0, 1, 2]]
+    preds = [[0, 1, 2]]
+    scores = [[[0.8, 0.1, 0.1], [0.1, 0.8, 0.1], [0.1, 0.1, 0.8]]]
+    trials = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds,
+        per_trial_targets=targets,
+        per_trial_scores=scores,
+    )
+    path = _write_run_blob(tmp_path / "a" / "forecaster_sweep_results.json", trials)
+    specs = [
+        RunSpec(
+            run_id="run_a",
+            architecture="lstm",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path),
+        ),
+    ]
+    with pytest.raises(ValueError, match="unsupported calibration_strategy"):
+        aggregate_multi_run_ensemble(
+            specs,
+            calibration_strategy="temperature_scaling",  # type: ignore[arg-type]
+        )

--- a/tests/unit/test_ensemble_aggregator.py
+++ b/tests/unit/test_ensemble_aggregator.py
@@ -1,22 +1,30 @@
-"""Unit tests for the Phase A ensemble aggregator (#226).
+"""Unit tests for the ensemble aggregator (#226 + Phase 5 multi-run).
 
 Locks the three aggregation strategies against synthetic inputs where
-the analytical answer is known, and asserts the alignment + missing-arch
-edge cases the production runner must handle.
+the analytical answer is known, asserts the alignment + missing-arch
+edge cases the production runner must handle, and exercises the Phase
+5 multi-run logit-average path (calibrated logit-averaging across
+distinct training runs with per-fold conformal calibration).
 """
 
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 
 import pytest
 
 from app.evaluation.ensemble_aggregator import (
+    DEFAULT_REDUNDANCY_KAPPA_THRESHOLD,
+    MultiRunEnsembleResult,
+    RunSpec,
+    _cohen_kappa,
     _mean_logit,
     _mean_softmax,
     _plurality_vote,
     aggregate,
+    aggregate_multi_run_ensemble,
 )
 
 
@@ -220,3 +228,478 @@ def test_cli_writes_json_and_markdown(tmp_path: Path) -> None:
     assert rc == 0
     assert (tmp_path / "ensemble_results.json").exists()
     assert (tmp_path / "ensemble_results.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 multi-run logit-average + per-fold conformal
+# ---------------------------------------------------------------------------
+
+
+def _run_trials(
+    *,
+    fold_seed_layout: list[tuple[str, int]],
+    per_trial_preds: list[list[int]],
+    per_trial_targets: list[list[int]],
+    per_trial_scores: list[list[list[float]]],
+) -> list[dict[str, object]]:
+    """Build a list of trial dicts matching the existing sweep-JSON shape."""
+
+    assert len(fold_seed_layout) == len(per_trial_preds)
+    assert len(fold_seed_layout) == len(per_trial_targets)
+    assert len(fold_seed_layout) == len(per_trial_scores)
+    out: list[dict[str, object]] = []
+    for (fold, seed), preds, targets, scores in zip(
+        fold_seed_layout, per_trial_preds, per_trial_targets, per_trial_scores
+    ):
+        out.append(
+            _trial(
+                architecture="dummy",
+                fold_id=fold,
+                seed=seed,
+                predictions=preds,
+                targets=targets,
+                class_scores=scores,
+            )
+        )
+    return out
+
+
+def _write_run_blob(path: Path, trials: list[dict[str, object]]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"trials": trials, "selection_metric": "macro_f1"})
+    )
+    return path
+
+
+def test_multi_run_logit_average_picks_argmax_of_log_mean(tmp_path: Path) -> None:
+    """Two runs x two folds x three trials x three classes.
+
+    Per-trial logits are picked so the analytical ensemble argmax is
+    known by hand: averaging log-probabilities is equivalent to a
+    geometric mean of softmax probabilities, and the row-wise mean
+    here picks class 0 on every row (each run is confident on the
+    same row in agreement, and the geometric mean preserves the
+    consensus).
+    """
+
+    layout = [("wf_fold_1", 11), ("wf_fold_2", 11)]
+    # Each trial has 3 rows; targets are [0, 0, 0] so a perfect
+    # ensemble = macro-F1 of 1.0 on the only-class-with-support 0.
+    targets = [[0, 0, 0], [0, 0, 0]]
+    preds_run_a = [[0, 0, 0], [0, 0, 0]]
+    preds_run_b = [[0, 0, 0], [0, 0, 0]]
+    scores_run_a = [
+        [[0.7, 0.2, 0.1], [0.6, 0.3, 0.1], [0.55, 0.3, 0.15]],
+        [[0.65, 0.2, 0.15], [0.5, 0.3, 0.2], [0.7, 0.15, 0.15]],
+    ]
+    scores_run_b = [
+        [[0.65, 0.25, 0.1], [0.55, 0.35, 0.1], [0.6, 0.25, 0.15]],
+        [[0.7, 0.2, 0.1], [0.55, 0.3, 0.15], [0.6, 0.25, 0.15]],
+    ]
+    run_a = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds_run_a,
+        per_trial_targets=targets,
+        per_trial_scores=scores_run_a,
+    )
+    run_b = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds_run_b,
+        per_trial_targets=targets,
+        per_trial_scores=scores_run_b,
+    )
+    path_a = _write_run_blob(tmp_path / "run_a" / "forecaster_sweep_results.json", run_a)
+    path_b = _write_run_blob(tmp_path / "run_b" / "forecaster_sweep_results.json", run_b)
+    specs = [
+        RunSpec(
+            run_id="run_a",
+            architecture="lstm",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_a),
+        ),
+        RunSpec(
+            run_id="run_b",
+            architecture="tft",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_b),
+        ),
+    ]
+    # Override the redundancy guard so both identical-prediction runs
+    # survive — this test exercises the averaging math, not the
+    # dedup pass.
+    result = aggregate_multi_run_ensemble(
+        specs, conformal_alpha=0.2, redundancy_kappa_threshold=1.5
+    )
+    assert isinstance(result, MultiRunEnsembleResult)
+    # Both runs agree on every row -> kept = both.
+    assert set(result.kept_run_ids) == {"run_a", "run_b"}
+    # Pooled macro-F1 = 1.0 on the only class with support.
+    assert result.pooled_breakdown.macro_f1 == pytest.approx(1.0)
+    # Per-fold breakdown: 2 folds, each macro-F1 = 1.0.
+    assert len(result.per_fold) == 2
+    for fold in result.per_fold:
+        assert fold.breakdown.macro_f1 == pytest.approx(1.0)
+        # Coverage must lie in [0, 1] when softmax_quantile is finite.
+        assert math.isfinite(fold.softmax_quantile)
+        assert 0.0 <= fold.coverage <= 1.0
+        assert 1.0 <= fold.avg_set_size <= 3.0
+
+
+def test_multi_run_logit_average_known_analytical_result(tmp_path: Path) -> None:
+    """Two runs whose class-1 row argmaxes only emerge after averaging.
+
+    Run A predicts [0, 0, 0] with scores ``[[0.45,0.4,0.15], ...]`` —
+    class 0 narrowly wins for every row. Run B predicts [1, 1, 1]
+    with scores ``[[0.3,0.65,0.05], ...]`` — class 1 wins for every
+    row. The geometric mean of class-1 probabilities beats class-0's
+    on every row (``sqrt(0.4*0.65) ≈ 0.51`` vs ``sqrt(0.45*0.3) ≈
+    0.367``), so the ensemble argmax should be 1 on every row.
+
+    Targets are [1, 1, 1] so the ensemble macro-F1 = 1.0 even though
+    neither component scores above 0.0.
+    """
+
+    layout = [("wf_fold_1", 11)]
+    targets = [[1, 1, 1]]
+    preds_run_a = [[0, 0, 0]]
+    preds_run_b = [[1, 1, 1]]
+    scores_run_a = [[[0.45, 0.4, 0.15], [0.46, 0.42, 0.12], [0.5, 0.4, 0.1]]]
+    scores_run_b = [[[0.3, 0.65, 0.05], [0.25, 0.7, 0.05], [0.2, 0.7, 0.1]]]
+    run_a = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds_run_a,
+        per_trial_targets=targets,
+        per_trial_scores=scores_run_a,
+    )
+    run_b = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds_run_b,
+        per_trial_targets=targets,
+        per_trial_scores=scores_run_b,
+    )
+    path_a = _write_run_blob(tmp_path / "run_a" / "forecaster_sweep_results.json", run_a)
+    path_b = _write_run_blob(tmp_path / "run_b" / "forecaster_sweep_results.json", run_b)
+    specs = [
+        RunSpec(
+            run_id="run_a",
+            architecture="lstm",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_a),
+        ),
+        RunSpec(
+            run_id="run_b",
+            architecture="tft",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_b),
+        ),
+    ]
+    result = aggregate_multi_run_ensemble(specs, conformal_alpha=0.2)
+    assert result.pooled_breakdown.macro_f1 == pytest.approx(1.0)
+    # The two runs disagree on every row, so they must NOT be dropped
+    # by the redundancy guard.
+    assert set(result.kept_run_ids) == {"run_a", "run_b"}
+
+
+def test_cohen_kappa_is_one_for_identical_predictions() -> None:
+    """Two perfectly-agreeing components score kappa = 1.0."""
+
+    preds = [0, 1, 2, 1, 0, 2, 1, 0, 2]
+    assert _cohen_kappa(preds, preds) == pytest.approx(1.0)
+
+
+def test_cohen_kappa_lt_one_for_disagreeing_pair() -> None:
+    """A disagreeing pair scores kappa < 1.0."""
+
+    preds_a = [0, 1, 2, 0, 1, 2]
+    preds_b = [0, 0, 2, 1, 1, 2]
+    kappa = _cohen_kappa(preds_a, preds_b)
+    assert kappa < 1.0
+    assert kappa > 0.0  # still positive — some agreement remains
+
+
+def test_agreement_matrix_keys_carry_kappa_for_perfectly_agreeing_pair(
+    tmp_path: Path,
+) -> None:
+    """Two runs whose predictions match row-for-row report kappa=1.0
+    in the agreement matrix; the redundancy guard then drops one of
+    them."""
+
+    layout = [("wf_fold_1", 11)]
+    targets = [[0, 1, 2]]
+    same_preds = [[0, 1, 2]]
+    same_scores = [[[0.8, 0.1, 0.1], [0.1, 0.8, 0.1], [0.1, 0.1, 0.8]]]
+    run_a = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=same_preds,
+        per_trial_targets=targets,
+        per_trial_scores=same_scores,
+    )
+    run_b = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=same_preds,
+        per_trial_targets=targets,
+        per_trial_scores=same_scores,
+    )
+    path_a = _write_run_blob(tmp_path / "a" / "forecaster_sweep_results.json", run_a)
+    path_b = _write_run_blob(tmp_path / "b" / "forecaster_sweep_results.json", run_b)
+    specs = [
+        RunSpec(
+            run_id="run_a",
+            architecture="lstm",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_a),
+        ),
+        RunSpec(
+            run_id="run_b",
+            architecture="lstm",
+            encoder_alias="none",
+            seed=29,
+            results_path=str(path_b),
+        ),
+    ]
+    result = aggregate_multi_run_ensemble(
+        specs,
+        conformal_alpha=0.2,
+        redundancy_kappa_threshold=DEFAULT_REDUNDANCY_KAPPA_THRESHOLD,
+    )
+    assert result.agreement[("run_a", "run_b")] == pytest.approx(1.0)
+    # Redundancy guard: one of the two identical runs must be dropped.
+    assert len(result.kept_run_ids) == 1
+    assert len(result.dropped_run_ids) == 1
+    dropped_run, redundant_with, kappa = result.dropped_run_ids[0]
+    assert dropped_run == "run_b"
+    assert redundant_with == "run_a"
+    assert kappa == pytest.approx(1.0)
+
+
+def test_redundancy_guard_drops_one_of_three_identical_components(
+    tmp_path: Path,
+) -> None:
+    """Three components where runs 1 and 2 are identical; run 3 disagrees.
+
+    The redundancy guard must keep run_a (first), drop run_b (identical
+    to run_a), and keep run_c (disagrees). 2 kept, 1 dropped."""
+
+    layout = [("wf_fold_1", 11)]
+    targets = [[0, 1, 2]]
+    same_preds = [[0, 1, 2]]
+    same_scores = [[[0.8, 0.1, 0.1], [0.1, 0.8, 0.1], [0.1, 0.1, 0.8]]]
+    diff_preds = [[2, 0, 1]]
+    diff_scores = [[[0.1, 0.1, 0.8], [0.8, 0.1, 0.1], [0.1, 0.8, 0.1]]]
+    run_a = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=same_preds,
+        per_trial_targets=targets,
+        per_trial_scores=same_scores,
+    )
+    run_b = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=same_preds,
+        per_trial_targets=targets,
+        per_trial_scores=same_scores,
+    )
+    run_c = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=diff_preds,
+        per_trial_targets=targets,
+        per_trial_scores=diff_scores,
+    )
+    path_a = _write_run_blob(tmp_path / "a" / "forecaster_sweep_results.json", run_a)
+    path_b = _write_run_blob(tmp_path / "b" / "forecaster_sweep_results.json", run_b)
+    path_c = _write_run_blob(tmp_path / "c" / "forecaster_sweep_results.json", run_c)
+    specs = [
+        RunSpec(
+            run_id="run_a",
+            architecture="lstm",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_a),
+        ),
+        RunSpec(
+            run_id="run_b",
+            architecture="lstm",
+            encoder_alias="none",
+            seed=29,
+            results_path=str(path_b),
+        ),
+        RunSpec(
+            run_id="run_c",
+            architecture="tft",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_c),
+        ),
+    ]
+    result = aggregate_multi_run_ensemble(specs, conformal_alpha=0.2)
+    assert set(result.kept_run_ids) == {"run_a", "run_c"}
+    assert len(result.dropped_run_ids) == 1
+    assert result.dropped_run_ids[0][0] == "run_b"
+
+
+def test_redundancy_guard_threshold_is_configurable(tmp_path: Path) -> None:
+    """A pair with kappa around 0.5 should survive the default guard
+    (threshold = 0.85) but drop under a stricter threshold of 0.4."""
+
+    layout = [("wf_fold_1", 11)]
+    targets = [[0, 0, 0, 1, 1, 1, 2, 2, 2]]
+    preds_a = [[0, 0, 0, 1, 1, 1, 2, 2, 2]]
+    preds_b = [[0, 0, 1, 1, 2, 1, 2, 0, 2]]  # ~ 0.5 agreement
+    scores = [[[0.8, 0.1, 0.1]] * 9]
+    run_a = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds_a,
+        per_trial_targets=targets,
+        per_trial_scores=scores,
+    )
+    run_b = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds_b,
+        per_trial_targets=targets,
+        per_trial_scores=scores,
+    )
+    path_a = _write_run_blob(tmp_path / "a" / "forecaster_sweep_results.json", run_a)
+    path_b = _write_run_blob(tmp_path / "b" / "forecaster_sweep_results.json", run_b)
+    specs = [
+        RunSpec(
+            run_id="run_a",
+            architecture="lstm",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_a),
+        ),
+        RunSpec(
+            run_id="run_b",
+            architecture="tft",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_b),
+        ),
+    ]
+    # Default 0.85 threshold should keep both.
+    keep_both = aggregate_multi_run_ensemble(specs, conformal_alpha=0.2)
+    assert set(keep_both.kept_run_ids) == {"run_a", "run_b"}
+    # Stricter 0.4 threshold should drop one (kappa ~0.5 > 0.4).
+    drop_one = aggregate_multi_run_ensemble(
+        specs, conformal_alpha=0.2, redundancy_kappa_threshold=0.4
+    )
+    assert len(drop_one.kept_run_ids) == 1
+
+
+def test_fold_layout_mismatch_raises(tmp_path: Path) -> None:
+    """Two runs with different (fold, seed) trial sets must raise."""
+
+    run_a_layout = [("wf_fold_1", 11), ("wf_fold_2", 11)]
+    run_b_layout = [("wf_fold_1", 11), ("wf_fold_3", 11)]
+    targets = [[0, 1, 2], [0, 1, 2]]
+    preds = [[0, 1, 2], [0, 1, 2]]
+    scores = [
+        [[0.8, 0.1, 0.1], [0.1, 0.8, 0.1], [0.1, 0.1, 0.8]],
+        [[0.8, 0.1, 0.1], [0.1, 0.8, 0.1], [0.1, 0.1, 0.8]],
+    ]
+    run_a = _run_trials(
+        fold_seed_layout=run_a_layout,
+        per_trial_preds=preds,
+        per_trial_targets=targets,
+        per_trial_scores=scores,
+    )
+    run_b = _run_trials(
+        fold_seed_layout=run_b_layout,
+        per_trial_preds=preds,
+        per_trial_targets=targets,
+        per_trial_scores=scores,
+    )
+    path_a = _write_run_blob(tmp_path / "a" / "forecaster_sweep_results.json", run_a)
+    path_b = _write_run_blob(tmp_path / "b" / "forecaster_sweep_results.json", run_b)
+    specs = [
+        RunSpec(
+            run_id="run_a",
+            architecture="lstm",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_a),
+        ),
+        RunSpec(
+            run_id="run_b",
+            architecture="tft",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_b),
+        ),
+    ]
+    with pytest.raises(ValueError, match="layout mismatch"):
+        aggregate_multi_run_ensemble(specs, conformal_alpha=0.2)
+
+
+def test_multi_run_per_fold_conformal_coverage_in_expected_range(
+    tmp_path: Path,
+) -> None:
+    """Per-fold conformal coverage at alpha=0.2 should hit ~0.8 + finite-
+    sample correction. The split-conformal helper bumps the rank to
+    ``ceil(0.8 * (n+1))`` so empirical coverage on the calibration
+    fold is ``rank/n``."""
+
+    layout = [("wf_fold_1", 11), ("wf_fold_2", 11)]
+    # 10 trials per fold; pick obvious-class confidence and targets that
+    # match argmax so the conformal threshold settles around 1 - max_p.
+    n_rows = 10
+    targets = [[i % 3 for i in range(n_rows)]] * 2
+    preds = [[i % 3 for i in range(n_rows)]] * 2
+    scores = [
+        [
+            [0.7, 0.2, 0.1] if (i % 3) == 0
+            else ([0.2, 0.7, 0.1] if (i % 3) == 1 else [0.1, 0.2, 0.7])
+            for i in range(n_rows)
+        ]
+    ] * 2
+    run_a = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds,
+        per_trial_targets=targets,
+        per_trial_scores=scores,
+    )
+    run_b = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds,
+        per_trial_targets=targets,
+        per_trial_scores=scores,
+    )
+    path_a = _write_run_blob(tmp_path / "a" / "forecaster_sweep_results.json", run_a)
+    path_b = _write_run_blob(tmp_path / "b" / "forecaster_sweep_results.json", run_b)
+    specs = [
+        RunSpec(
+            run_id="run_a",
+            architecture="lstm",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_a),
+        ),
+        RunSpec(
+            run_id="run_b",
+            architecture="tft",
+            encoder_alias="none",
+            seed=11,
+            results_path=str(path_b),
+        ),
+    ]
+    # These two runs are identical -> redundancy guard drops one. To
+    # exercise both runs survived, raise the threshold above 1.0.
+    result = aggregate_multi_run_ensemble(
+        specs,
+        conformal_alpha=0.2,
+        redundancy_kappa_threshold=1.5,
+    )
+    # Both runs kept (redundancy threshold > 1).
+    assert set(result.kept_run_ids) == {"run_a", "run_b"}
+    # Coverage on the calibration fold should be >= 0.8 (the nominal
+    # coverage). The empirical coverage on the calibration set is
+    # ``rank/n = ceil(0.8 * (n+1)) / n`` which is >= 0.8 for any
+    # finite n.
+    for fold in result.per_fold:
+        assert fold.coverage >= 0.8 - 1e-9
+        assert fold.coverage <= 1.0 + 1e-9

--- a/tests/unit/test_ensemble_aggregator.py
+++ b/tests/unit/test_ensemble_aggregator.py
@@ -703,3 +703,136 @@ def test_multi_run_per_fold_conformal_coverage_in_expected_range(
     for fold in result.per_fold:
         assert fold.coverage >= 0.8 - 1e-9
         assert fold.coverage <= 1.0 + 1e-9
+
+
+def test_ensemble_run_specs_cli_writes_outputs(tmp_path: Path) -> None:
+    """The YAML-driven CLI reads a manifest and emits the markdown +
+    JSON summary side-by-side."""
+
+    import yaml
+
+    from app.evaluation.ensemble_run_specs import main as run_specs_main
+
+    layout = [("wf_fold_1", 11)]
+    targets = [[0, 1, 2]]
+    preds_a = [[0, 1, 2]]
+    preds_b = [[2, 0, 1]]
+    scores_a = [[[0.8, 0.1, 0.1], [0.1, 0.8, 0.1], [0.1, 0.1, 0.8]]]
+    scores_b = [[[0.1, 0.1, 0.8], [0.8, 0.1, 0.1], [0.1, 0.8, 0.1]]]
+    run_a = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds_a,
+        per_trial_targets=targets,
+        per_trial_scores=scores_a,
+    )
+    run_b = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds_b,
+        per_trial_targets=targets,
+        per_trial_scores=scores_b,
+    )
+    sweep_dir = tmp_path / "sweeps"
+    path_a = _write_run_blob(sweep_dir / "run_a" / "forecaster_sweep_results.json", run_a)
+    path_b = _write_run_blob(sweep_dir / "run_b" / "forecaster_sweep_results.json", run_b)
+
+    manifest = {
+        "conformal_alpha": 0.2,
+        "redundancy_kappa_threshold": 0.85,
+        "n_classes": 3,
+        "runs": [
+            {
+                "run_id": "run_a",
+                "architecture": "lstm",
+                "encoder_alias": "none",
+                "seed": 11,
+                "results_path": str(path_a),
+            },
+            {
+                "run_id": "run_b",
+                "architecture": "tft",
+                "encoder_alias": "none",
+                "seed": 11,
+                "results_path": str(path_b),
+            },
+        ],
+    }
+    manifest_path = tmp_path / "phase5.yaml"
+    manifest_path.write_text(yaml.safe_dump(manifest))
+    output_dir = tmp_path / "out"
+    rc = run_specs_main(
+        [
+            "--run-spec-file",
+            str(manifest_path),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+    assert rc == 0
+    json_path = output_dir / "ensemble_phase5_results.json"
+    md_path = output_dir / "ensemble_phase5_results.md"
+    assert json_path.exists()
+    assert md_path.exists()
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert "result" in payload
+    assert "run_specs" in payload
+    assert "kept_run_ids" in payload["result"]
+
+
+def test_ensemble_run_specs_cli_accepts_bare_list(tmp_path: Path) -> None:
+    """The CLI accepts a top-level list YAML for terse manifests."""
+
+    import yaml
+
+    from app.evaluation.ensemble_run_specs import main as run_specs_main
+
+    layout = [("wf_fold_1", 11)]
+    targets = [[0, 1, 2]]
+    preds_a = [[0, 1, 2]]
+    preds_b = [[2, 0, 1]]
+    scores_a = [[[0.8, 0.1, 0.1], [0.1, 0.8, 0.1], [0.1, 0.1, 0.8]]]
+    scores_b = [[[0.1, 0.1, 0.8], [0.8, 0.1, 0.1], [0.1, 0.8, 0.1]]]
+    run_a = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds_a,
+        per_trial_targets=targets,
+        per_trial_scores=scores_a,
+    )
+    run_b = _run_trials(
+        fold_seed_layout=layout,
+        per_trial_preds=preds_b,
+        per_trial_targets=targets,
+        per_trial_scores=scores_b,
+    )
+    sweep_dir = tmp_path / "sweeps"
+    path_a = _write_run_blob(sweep_dir / "run_a" / "forecaster_sweep_results.json", run_a)
+    path_b = _write_run_blob(sweep_dir / "run_b" / "forecaster_sweep_results.json", run_b)
+
+    manifest = [
+        {
+            "run_id": "run_a",
+            "architecture": "lstm",
+            "encoder_alias": "none",
+            "seed": 11,
+            "results_path": str(path_a),
+        },
+        {
+            "run_id": "run_b",
+            "architecture": "tft",
+            "encoder_alias": "none",
+            "seed": 11,
+            "results_path": str(path_b),
+        },
+    ]
+    manifest_path = tmp_path / "phase5_list.yaml"
+    manifest_path.write_text(yaml.safe_dump(manifest))
+    output_dir = tmp_path / "out"
+    rc = run_specs_main(
+        [
+            "--run-spec-file",
+            str(manifest_path),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+    assert rc == 0
+    assert (output_dir / "ensemble_phase5_results.json").exists()


### PR DESCRIPTION
## Summary

- Extend \`backend/app/evaluation/ensemble_aggregator.py\` with \`RunSpec\`, \`MultiRunFoldResult\`, \`MultiRunEnsembleResult\`, \`aggregate_multi_run_ensemble()\` for multi-run logit averaging
- Pairwise Cohen-kappa agreement matrix + redundancy guard (\`DEFAULT_REDUNDANCY_KAPPA_THRESHOLD = 0.85\`, configurable per call + YAML + CLI)
- Per-fold conformal calibration via APS threshold fit fresh per fold — sidesteps the train/val temperature-fit leak across components
- New \`python -m app.evaluation.ensemble_run_specs --run-spec-file <yaml>\` CLI with documented schema + example YAML at \`backend/app/evaluation/examples/ensemble_phase5_example.yaml\`
- Existing single-run \`aggregate()\` contract untouched

23 tests cover multi-run averaging, kappa math, redundancy drop, layout-mismatch fail-loud, CLI mapping, conformal threshold-per-fold proof, unsupported strategy rejection.

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_ensemble_aggregator.py -q\`