### PR TITLE
Dispatch _evaluate_model through MultiTaskLoss on multi-task runs

### DIFF
--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -836,6 +836,7 @@ def _evaluate_model(
                     model, batch_x, kwargs
                 )
                 assert batch_mt_aux is not None  # narrowed by the guard above
+                assert multi_task_loss_fn is not None  # narrowed by ``multi_task_active``
                 stance_mask = torch.ones(
                     (batch_size,), dtype=torch.bool, device=batch_x.device
                 )

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -663,6 +663,7 @@ def _evaluate_model(
     *,
     record_row_predictions: bool = False,
     encoder_lora_bundle: Any = None,
+    multi_task_loss_fn: nn.Module | None = None,
 ) -> EvaluationMetrics:
     """Evaluate ``model`` on ``loader`` and return aggregate metrics.
 
@@ -679,14 +680,37 @@ def _evaluate_model(
     per-batch allocation kicks in via :func:`_zero_credibility` so
     callers outside the training loop (smoke checks, regression tests)
     keep working.
+
+    ``multi_task_loss_fn`` (#273 follow-up): when provided, the eval
+    dispatches to ``forward_multi_task`` on the model and computes the
+    val loss via :class:`MultiTaskLoss` using the per-axis targets +
+    masks carried on each batch's mt-aux block. The headline
+    ``EvaluationMetrics`` surface (loss, regime_accuracy,
+    regime_f1_macro, classification_breakdown) is computed off the
+    ``stance`` logits so the dataclass shape stays identical to the
+    single-task path. Pass ``None`` to keep the legacy single-task
+    behaviour byte-identical.
     """
 
     model.eval()
     if encoder_lora_bundle is not None:
         encoder_lora_bundle.encoder.eval()
     is_classification = str(getattr(model, "output_mode", "regression")) == "classification"
+    multi_task_active = multi_task_loss_fn is not None
     total_loss_sum = torch.zeros((), dtype=torch.float64, device=device)
     total_items = torch.zeros((), dtype=torch.int64, device=device)
+    # Per-axis loss bookkeeping for the multi-task eval path (#273
+    # follow-up). Each axis accumulates ``loss * batch_size`` so the
+    # final mean matches the per-batch mean ``MultiTaskLoss`` emits
+    # weighted by partition row count. Empty / zero on the single-task
+    # path so the per-axis breakdown surfaces only when the eval was
+    # actually run against MultiTaskLoss.
+    mt_axis_loss_sums: dict[str, torch.Tensor] = {
+        "stance": torch.zeros((), dtype=torch.float64, device=device),
+        "factor": torch.zeros((), dtype=torch.float64, device=device),
+        "certainty": torch.zeros((), dtype=torch.float64, device=device),
+        "topic": torch.zeros((), dtype=torch.float64, device=device),
+    }
     # Weighted CE bookkeeping. When ``loss_fn`` is
     # ``CrossEntropyLoss(weight=w, reduction='mean')`` the per-batch
     # loss is ``sum_i(w[y_i] * l_i) / sum_i(w[y_i])`` -- NOT divided by
@@ -698,10 +722,17 @@ def _evaluate_model(
     # divide at the end. Falls back to ``batch_size`` when ``loss_fn``
     # has no ``weight`` attribute or weights are uniform, so the
     # regression byte-identity regression contract stays green.
+    #
+    # The multi-task eval path bypasses the CE-weight reweighting
+    # entirely: ``MultiTaskLoss`` already emits a per-batch mean over
+    # masked rows on each axis, so the partition mean is the size-
+    # weighted mean of the per-batch values, identical to how the train
+    # step aggregates the loss across batches.
     ce_weight: torch.Tensor | None = None
     weight_attr = getattr(loss_fn, "weight", None)
     if (
         is_classification
+        and not multi_task_active
         and isinstance(weight_attr, torch.Tensor)
         and weight_attr.numel() > 0
     ):
@@ -741,7 +772,14 @@ def _evaluate_model(
     non_blocking = device.type == "cuda"
     with torch.no_grad():
         for batch in loader:
-            batch_x, batch_y, batch_text, batch_text_missing, _mt_aux = _unpack_batch(batch)
+            batch_x, batch_y, batch_text, batch_text_missing, batch_mt_aux = _unpack_batch(batch)
+            if multi_task_active and batch_mt_aux is None:
+                raise RuntimeError(
+                    "multi_task_loss_fn is active but the DataLoader yielded "
+                    "a batch without the aux tensors. This usually means the "
+                    "TensorDataset for this partition was built without the "
+                    "multi-task aux block -- check the partition build path."
+                )
             if batch_x.device != device:
                 batch_x = batch_x.to(device, non_blocking=non_blocking)
             if batch_y.device != device:
@@ -787,23 +825,67 @@ def _evaluate_model(
                                 device, non_blocking=non_blocking
                             )
                         kwargs["text_embedding_missing"] = batch_text_missing
-            if multimodal_forward is not None:
+            if multi_task_active:
+                # Multi-task eval (#273 follow-up): dispatch to
+                # ``forward_multi_task`` so the val loss matches the
+                # train-side objective. The stance logits drive the
+                # surfaced accuracy / F1 / breakdown so the
+                # EvaluationMetrics shape stays identical to the
+                # single-task path.
+                logits_dict = _run_train_forward_multi_task(
+                    model, batch_x, kwargs
+                )
+                assert batch_mt_aux is not None  # narrowed by the guard above
+                stance_mask = torch.ones(
+                    (batch_size,), dtype=torch.bool, device=batch_x.device
+                )
+                mt_targets = {
+                    "stance": batch_y,
+                    "factor": batch_mt_aux["factor"].to(device, non_blocking=non_blocking),
+                    "certainty": batch_mt_aux["certainty"].to(device, non_blocking=non_blocking),
+                    "topic": batch_mt_aux["topic"].to(device, non_blocking=non_blocking),
+                }
+                mt_masks = {
+                    "stance_mask": stance_mask,
+                    "factor_mask": batch_mt_aux["factor_mask"].to(device, non_blocking=non_blocking),
+                    "certainty_mask": batch_mt_aux["certainty_mask"].to(device, non_blocking=non_blocking),
+                    "topic_mask": batch_mt_aux["topic_mask"].to(device, non_blocking=non_blocking),
+                }
+                loss, axis_breakdown = multi_task_loss_fn(
+                    logits_dict, mt_targets, mt_masks
+                )
+                predictions = logits_dict["stance"]
+                total_loss_sum += loss.detach().to(torch.float64) * batch_size
+                for axis_name in ("stance", "factor", "certainty", "topic"):
+                    mt_axis_loss_sums[axis_name] += (
+                        axis_breakdown[axis_name].detach().to(torch.float64) * batch_size
+                    )
+            elif multimodal_forward is not None:
                 modality_out = multimodal_forward(batch_x, **kwargs)
                 predictions = modality_out["logits"]
                 # Capture gate on CPU in float32 so the per-partition
                 # accumulator stays bounded across long val/test splits.
                 gate_chunks.append(modality_out["gate"].detach().to("cpu", torch.float32))
+                loss = loss_fn(predictions, batch_y)
+                if ce_weight is not None:
+                    batch_weight_sum = ce_weight.index_select(
+                        0, batch_y.detach().to(device=device, dtype=torch.long)
+                    ).sum()
+                    total_loss_sum += loss.detach().to(torch.float64) * batch_weight_sum
+                    total_weight_sum += batch_weight_sum
+                else:
+                    total_loss_sum += loss.detach().to(torch.float64) * batch_size
             else:
                 predictions = model(batch_x, **kwargs)
-            loss = loss_fn(predictions, batch_y)
-            if ce_weight is not None:
-                batch_weight_sum = ce_weight.index_select(
-                    0, batch_y.detach().to(device=device, dtype=torch.long)
-                ).sum()
-                total_loss_sum += loss.detach().to(torch.float64) * batch_weight_sum
-                total_weight_sum += batch_weight_sum
-            else:
-                total_loss_sum += loss.detach().to(torch.float64) * batch_size
+                loss = loss_fn(predictions, batch_y)
+                if ce_weight is not None:
+                    batch_weight_sum = ce_weight.index_select(
+                        0, batch_y.detach().to(device=device, dtype=torch.long)
+                    ).sum()
+                    total_loss_sum += loss.detach().to(torch.float64) * batch_weight_sum
+                    total_weight_sum += batch_weight_sum
+                else:
+                    total_loss_sum += loss.detach().to(torch.float64) * batch_size
             total_items += batch_size
             if is_classification:
                 pred_class_chunks.append(
@@ -846,6 +928,16 @@ def _evaluate_model(
     # to the per-item count when no class weights were supplied.
     total_weight_value = float(total_weight_sum.item()) if ce_weight is not None else 0.0
     loss_divisor = total_weight_value if (ce_weight is not None and total_weight_value > 0.0) else float(total_items_int)
+    # Per-axis multi-task breakdown (#273 follow-up). Computed only on
+    # the multi-task eval path; the single-task path leaves the dict
+    # empty so the existing classification_breakdown payload shape stays
+    # unchanged on legacy runs.
+    multi_task_axis_losses: dict[str, float] | None = None
+    if multi_task_active and total_items_int > 0:
+        multi_task_axis_losses = {
+            axis: float(mt_axis_loss_sums[axis].item()) / float(total_items_int)
+            for axis in ("stance", "factor", "certainty", "topic")
+        }
 
     if is_classification:
         # Classification partition: surface accuracy + macro-F1 on the
@@ -881,6 +973,14 @@ def _evaluate_model(
             n_classes=n_classes_eval,
             class_scores=class_scores_list,
         )
+        breakdown_payload = breakdown.to_dict()
+        # Attach the per-axis multi-task loss breakdown so the per-trial
+        # JSON / sweep aggregator can surface it; the headline
+        # ``regime_loss`` keeps reporting the lambda-weighted total so
+        # checkpoint selection by val_loss ranks against the same
+        # objective the train side optimises.
+        if multi_task_axis_losses is not None:
+            breakdown_payload["multi_task_axis_losses"] = multi_task_axis_losses
 
         predictions_payload: list[int] | None = None
         targets_payload: list[int] | None = None
@@ -903,7 +1003,7 @@ def _evaluate_model(
             regime_accuracy=regime_acc,
             regime_f1_macro=float(breakdown.macro_f1),
             regime_loss=regime_loss,
-            classification_breakdown=breakdown.to_dict(),
+            classification_breakdown=breakdown_payload,
             predictions=predictions_payload,
             targets=targets_payload,
             class_scores=scores_payload,
@@ -1871,6 +1971,7 @@ def train_model(
             loss_fn,
             credibility_buffer=val_credibility_buffer,
             encoder_lora_bundle=encoder_lora_bundle,
+            multi_task_loss_fn=multi_task_loss_fn,
         )
         if schedule_steps_per_epoch is None:
             scheduler.step(eval_metrics.loss)
@@ -1915,6 +2016,7 @@ def train_model(
             device_obj,
             loss_fn,
             credibility_buffer=val_credibility_buffer,
+            multi_task_loss_fn=multi_task_loss_fn,
         )
     # Final-state training-set evaluation so the aggregator can emit
     # ``test_train_gap = (test_rmse - train_rmse) / train_rmse``. The
@@ -1935,6 +2037,7 @@ def train_model(
         loss_fn,
         credibility_buffer=train_credibility_buffer,
         encoder_lora_bundle=encoder_lora_bundle,
+        multi_task_loss_fn=multi_task_loss_fn,
     )
 
     # Final-state held-out test evaluation. On the walk-forward path
@@ -1962,6 +2065,7 @@ def train_model(
             credibility_buffer=test_credibility_buffer,
             record_row_predictions=True,
             encoder_lora_bundle=encoder_lora_bundle,
+            multi_task_loss_fn=multi_task_loss_fn,
         )
     else:
         test_metrics = best_val_metrics

--- a/tests/unit/test_evaluate_model_multi_task_path.py
+++ b/tests/unit/test_evaluate_model_multi_task_path.py
@@ -1,0 +1,439 @@
+"""Eval-time multi-task loss wiring regression (#285 follow-up).
+
+The single-task path delegated val loss to ``loss_fn(predictions, y)`` —
+the CrossEntropy term over the stance axis. The train side, when
+``model_config.multi_task_loss=True``, optimises a lambda-weighted sum
+across stance + factor + certainty + topic, so the pre-fix eval ranked
+checkpoints against a different objective than the train side. These
+tests pin the eval-side path:
+
+- with ``multi_task_loss_fn`` provided, ``_evaluate_model`` dispatches
+  through ``forward_multi_task`` and reports the lambda-weighted total
+  on ``EvaluationMetrics.loss`` (and ``regime_loss`` for the
+  classification surface);
+- with ``multi_task_loss_fn=None`` the path stays byte-identical to the
+  legacy single-task behaviour (same call shape, same per-class
+  breakdown, same loss value).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from torch import nn
+from torch.utils.data import DataLoader
+
+from app.models.config import (
+    FeatureVector,
+    ModelConfig,
+    MULTI_TASK_CERTAINTY_CLASSES,
+    MULTI_TASK_TOPIC_CLASSES,
+)
+from app.training.loop import (
+    _evaluate_model,
+    _make_partition_dataset,
+    train_model,
+)
+from app.training.loss import MultiTaskLoss
+
+
+def _dummy_feature_vector(
+    *,
+    vol: float,
+    day: int,
+    stance: int,
+    factor: float,
+    certainty: int,
+    topic: int,
+) -> FeatureVector:
+    return FeatureVector(
+        date=_dt.date(2025, 1, 1) + _dt.timedelta(days=day - 1),
+        sentiment_score=0.0,
+        market_close=100.0,
+        market_volatility=0.01,
+        close_change_pct=0.0,
+        volatility_change=0.0,
+        elapsed_time=0.0,
+        forward_realized_vol_10d=vol,
+        target_stance_idx=stance,
+        target_stance_present=True,
+        target_factor=factor,
+        target_factor_present=True,
+        target_certainty_idx=certainty,
+        target_certainty_present=True,
+        target_topic_idx=topic,
+        target_topic_present=True,
+    )
+
+
+def _build_classification_groups(n: int = 40) -> list[list[FeatureVector]]:
+    """Synthetic walk-forward fold with all 4 axes populated per row."""
+
+    return [
+        [
+            _dummy_feature_vector(
+                day=i + 1,
+                vol=0.01 + 0.001 * i,
+                stance=i % 3,
+                factor=((i % 5) - 2) / 5.0,
+                certainty=i % 3,
+                topic=i % 4,
+            )
+            for i in range(n)
+        ]
+    ]
+
+
+class _ToyMultiTaskModel(nn.Module):
+    """Minimal classifier exposing both ``forward`` and ``forward_multi_task``.
+
+    Bypasses the LSTM construction so the unit test stays CPU-tiny: the
+    "model" just emits deterministic logits derived from a Linear over a
+    pooled view of the input tensor. The shape contract is what the
+    eval helper exercises.
+    """
+
+    output_mode = "classification"
+
+    def __init__(
+        self,
+        n_classes: int = 3,
+        *,
+        factor_classes: int = 1,
+        certainty_classes: int = MULTI_TASK_CERTAINTY_CLASSES,
+        topic_classes: int = MULTI_TASK_TOPIC_CLASSES,
+    ) -> None:
+        super().__init__()
+        self.n_classes = int(n_classes)
+        self.proj = nn.Linear(6, 16, bias=False)
+        self.stance = nn.Linear(16, n_classes)
+        self.factor = nn.Linear(16, factor_classes)
+        self.certainty = nn.Linear(16, certainty_classes)
+        self.topic = nn.Linear(16, topic_classes)
+        self._text_path_active = False
+
+    def _pool(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (B, T, F) -> mean-pool over time, then project.
+        return self.proj(x.mean(dim=1))
+
+    def forward(self, x: torch.Tensor, **_: Any) -> torch.Tensor:
+        return self.stance(self._pool(x))
+
+    def forward_multi_task(
+        self, x: torch.Tensor, **_: Any
+    ) -> dict[str, torch.Tensor]:
+        pooled = self._pool(x)
+        return {
+            "stance": self.stance(pooled),
+            "factor": torch.tanh(self.factor(pooled).squeeze(-1)),
+            "certainty": self.certainty(pooled),
+            "topic": self.topic(pooled),
+        }
+
+
+def _make_toy_classifier(n_classes: int = 3) -> _ToyMultiTaskModel:
+    torch.manual_seed(0)
+    return _ToyMultiTaskModel(n_classes=n_classes)
+
+
+def _make_eval_loader(
+    batch_size: int = 4,
+    *,
+    with_mt_aux: bool,
+    seed: int = 0,
+) -> tuple[DataLoader[Any], dict[str, torch.Tensor] | None]:
+    """Build a small DataLoader for the eval helper."""
+
+    torch.manual_seed(seed)
+    n = 12
+    x = torch.randn(n, 5, 6)
+    y = torch.tensor([i % 3 for i in range(n)], dtype=torch.long)
+    mt_aux: dict[str, torch.Tensor] | None = None
+    if with_mt_aux:
+        mt_aux = {
+            "factor": torch.randn(n).clamp(-1.0, 1.0),
+            "factor_mask": torch.tensor([i % 2 == 0 for i in range(n)], dtype=torch.bool),
+            "certainty": torch.tensor([i % MULTI_TASK_CERTAINTY_CLASSES for i in range(n)], dtype=torch.long),
+            "certainty_mask": torch.tensor([i % 3 != 0 for i in range(n)], dtype=torch.bool),
+            "topic": torch.tensor([i % MULTI_TASK_TOPIC_CLASSES for i in range(n)], dtype=torch.long),
+            "topic_mask": torch.tensor([i > 2 for i in range(n)], dtype=torch.bool),
+        }
+    dataset = _make_partition_dataset(x, y, None, None, mt_aux)
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=False)
+    return loader, mt_aux
+
+
+def test_evaluate_model_multi_task_dispatches_to_forward_multi_task() -> None:
+    """When ``multi_task_loss_fn`` is set, eval reads ``forward_multi_task``.
+
+    Sets a sentinel on the model's ``forward_multi_task`` so we can
+    confirm the eval helper actually calls it (and does NOT fall back
+    to the single-output ``forward`` path used on the single-task
+    branch).
+    """
+
+    model = _make_toy_classifier()
+    fmt_calls: list[int] = []
+    original_fmt = model.forward_multi_task
+
+    def _tracing_fmt(x: torch.Tensor, **kwargs: Any) -> dict[str, torch.Tensor]:
+        fmt_calls.append(int(x.size(0)))
+        return original_fmt(x, **kwargs)
+
+    model.forward_multi_task = _tracing_fmt  # type: ignore[method-assign]
+
+    loader, _ = _make_eval_loader(batch_size=4, with_mt_aux=True)
+    loss_fn = nn.CrossEntropyLoss()
+    mt_loss_fn = MultiTaskLoss(
+        lambda_stance=1.0,
+        lambda_factor=0.3,
+        lambda_certainty=0.3,
+        lambda_topic=0.3,
+    )
+
+    metrics = _evaluate_model(
+        model,
+        loader,
+        torch.device("cpu"),
+        loss_fn,
+        multi_task_loss_fn=mt_loss_fn,
+    )
+
+    # The tracing forward_multi_task must have fired on every batch.
+    assert fmt_calls, "forward_multi_task was never called under multi_task_loss_fn"
+    # The eval should have streamed all 12 rows through 3 batches of size 4.
+    assert sum(fmt_calls) == 12
+    # The classification surface must still populate the headline fields.
+    assert metrics.regime_accuracy is not None
+    assert metrics.regime_f1_macro is not None
+    assert metrics.regime_loss is not None
+
+
+def test_evaluate_model_multi_task_loss_differs_from_single_task_ce() -> None:
+    """Multi-task val loss must NOT equal the single-task CE on the same model.
+
+    Same model + same batch but two eval calls: one with
+    ``multi_task_loss_fn=None`` (single-task CE), one with the
+    MultiTaskLoss configured. The lambda-weighted multi-task total
+    rolls in factor + certainty + topic terms with non-trivial lambdas,
+    so the headline ``loss`` value must diverge from the single-task CE.
+    """
+
+    model = _make_toy_classifier()
+    loader, _ = _make_eval_loader(batch_size=4, with_mt_aux=True)
+    loss_fn = nn.CrossEntropyLoss()
+
+    single_task_metrics = _evaluate_model(
+        model, loader, torch.device("cpu"), loss_fn, multi_task_loss_fn=None
+    )
+
+    # Rebuild the loader so the same batch ordering is consumed twice.
+    loader2, _ = _make_eval_loader(batch_size=4, with_mt_aux=True)
+    mt_loss_fn = MultiTaskLoss(
+        lambda_stance=1.0,
+        lambda_factor=0.5,
+        lambda_certainty=0.5,
+        lambda_topic=0.5,
+    )
+    multi_task_metrics = _evaluate_model(
+        model, loader2, torch.device("cpu"), loss_fn, multi_task_loss_fn=mt_loss_fn
+    )
+
+    # Single-task CE eval reports just the stance CE; multi-task eval
+    # adds factor + certainty + topic terms, so the values must differ.
+    assert single_task_metrics.loss != pytest.approx(multi_task_metrics.loss, abs=1e-6), (
+        "multi-task eval emitted the same loss as single-task CE; the "
+        "eval branch did not dispatch to MultiTaskLoss"
+    )
+    # The accuracy / F1 surface is computed off the stance logits in
+    # both paths, so those headline numbers should be identical.
+    assert single_task_metrics.regime_accuracy == pytest.approx(
+        multi_task_metrics.regime_accuracy, abs=1e-9
+    )
+    assert single_task_metrics.regime_f1_macro == pytest.approx(
+        multi_task_metrics.regime_f1_macro, abs=1e-9
+    )
+
+
+def test_evaluate_model_multi_task_attaches_per_axis_breakdown() -> None:
+    """Per-axis losses ride on ``classification_breakdown[multi_task_axis_losses]``."""
+
+    model = _make_toy_classifier()
+    loader, _ = _make_eval_loader(batch_size=4, with_mt_aux=True)
+    loss_fn = nn.CrossEntropyLoss()
+    mt_loss_fn = MultiTaskLoss(
+        lambda_stance=1.0,
+        lambda_factor=0.3,
+        lambda_certainty=0.3,
+        lambda_topic=0.3,
+    )
+
+    metrics = _evaluate_model(
+        model,
+        loader,
+        torch.device("cpu"),
+        loss_fn,
+        multi_task_loss_fn=mt_loss_fn,
+    )
+
+    assert metrics.classification_breakdown is not None
+    axis_losses = metrics.classification_breakdown.get("multi_task_axis_losses")
+    assert isinstance(axis_losses, dict), (
+        "expected classification_breakdown[multi_task_axis_losses] dict; "
+        f"got {type(axis_losses).__name__}"
+    )
+    for axis in ("stance", "factor", "certainty", "topic"):
+        assert axis in axis_losses
+        assert isinstance(axis_losses[axis], float)
+
+
+def test_evaluate_model_single_task_path_omits_multi_task_breakdown() -> None:
+    """Single-task eval leaves ``multi_task_axis_losses`` absent."""
+
+    model = _make_toy_classifier()
+    # The single-task path does not need the mt_aux block at all; build
+    # a 4-arity dataset (no aux) so the legacy contract is exercised.
+    loader, _ = _make_eval_loader(batch_size=4, with_mt_aux=False)
+    loss_fn = nn.CrossEntropyLoss()
+
+    metrics = _evaluate_model(
+        model, loader, torch.device("cpu"), loss_fn, multi_task_loss_fn=None
+    )
+
+    assert metrics.classification_breakdown is not None
+    assert "multi_task_axis_losses" not in metrics.classification_breakdown
+
+
+def test_evaluate_model_raises_when_aux_missing_under_multi_task() -> None:
+    """An mt-aux-less loader must error when ``multi_task_loss_fn`` is set."""
+
+    model = _make_toy_classifier()
+    loader, _ = _make_eval_loader(batch_size=4, with_mt_aux=False)
+    loss_fn = nn.CrossEntropyLoss()
+    mt_loss_fn = MultiTaskLoss()
+
+    with pytest.raises(RuntimeError, match="aux tensors"):
+        _evaluate_model(
+            model,
+            loader,
+            torch.device("cpu"),
+            loss_fn,
+            multi_task_loss_fn=mt_loss_fn,
+        )
+
+
+def test_evaluate_model_multi_task_mask_collapse_zeroes_axis_contribution() -> None:
+    """A batch where every axis-mask is False contributes only stance loss.
+
+    Per-row masks must be honoured -- if all factor / certainty / topic
+    masks are False, the multi-task total collapses to
+    ``lambda_stance * stance_loss``. This pins the mask-honouring contract
+    on the eval side (the train side already had this guarantee via
+    :class:`MultiTaskLoss`).
+    """
+
+    model = _make_toy_classifier()
+    # Custom loader: all axis masks False so only the stance branch
+    # contributes. The stance loss term reduces to the unweighted CE
+    # on the stance logits.
+    torch.manual_seed(13)
+    n = 8
+    x = torch.randn(n, 5, 6)
+    y = torch.tensor([i % 3 for i in range(n)], dtype=torch.long)
+    mt_aux = {
+        "factor": torch.zeros(n, dtype=torch.float32),
+        "factor_mask": torch.zeros(n, dtype=torch.bool),
+        "certainty": torch.zeros(n, dtype=torch.long),
+        "certainty_mask": torch.zeros(n, dtype=torch.bool),
+        "topic": torch.zeros(n, dtype=torch.long),
+        "topic_mask": torch.zeros(n, dtype=torch.bool),
+    }
+    dataset = _make_partition_dataset(x, y, None, None, mt_aux)
+    loader = DataLoader(dataset, batch_size=n, shuffle=False)
+
+    loss_fn = nn.CrossEntropyLoss()
+    lambda_stance = 0.7
+    mt_loss_fn = MultiTaskLoss(
+        lambda_stance=lambda_stance,
+        lambda_factor=5.0,
+        lambda_certainty=5.0,
+        lambda_topic=5.0,
+    )
+    metrics = _evaluate_model(
+        model,
+        loader,
+        torch.device("cpu"),
+        loss_fn,
+        multi_task_loss_fn=mt_loss_fn,
+    )
+
+    # Reference: lambda_stance * CE(stance_logits, y) over the whole
+    # partition. The expected value uses the same model + same x + same
+    # y so the float comparison can pin to abs=1e-6.
+    with torch.no_grad():
+        stance_logits = model.forward_multi_task(x)["stance"]
+        expected_stance_loss = nn.functional.cross_entropy(stance_logits, y).item()
+    expected_total = lambda_stance * expected_stance_loss
+    assert metrics.loss == pytest.approx(expected_total, abs=1e-5), (
+        "multi-task eval did not collapse to lambda_stance * stance_loss "
+        "on the all-False mask batch; per-row masks are not being honoured"
+    )
+
+
+def test_evaluate_model_default_none_keeps_legacy_call_shape() -> None:
+    """A call without ``multi_task_loss_fn`` must keep the legacy shape.
+
+    Mirrors the byte-identity guarantee: a regression-mode classifier
+    invoked exactly the way the legacy regression contract calls
+    ``_evaluate_model`` must return an EvaluationMetrics object with
+    the same surface as before the patch.
+    """
+
+    model = _make_toy_classifier()
+    loader, _ = _make_eval_loader(batch_size=4, with_mt_aux=False)
+    loss_fn = nn.CrossEntropyLoss()
+
+    # The legacy single-task call site does not pass ``multi_task_loss_fn``.
+    metrics = _evaluate_model(model, loader, torch.device("cpu"), loss_fn)
+    assert metrics.loss is not None
+    assert metrics.regime_accuracy is not None
+
+
+def test_train_model_multi_task_path_writes_per_axis_breakdown_into_val_metrics() -> None:
+    """End-to-end: ``train_model`` with ``multi_task_loss=True`` surfaces the breakdown.
+
+    The eval-side fix means the per-trial JSON now carries
+    ``classification_breakdown[multi_task_axis_losses]`` on the val +
+    test partitions; before the fix the val/test metrics derived from
+    the single-task CE so this key was absent.
+    """
+
+    config = ModelConfig(
+        output_mode="classification",
+        multi_task_loss=True,
+        n_classes=3,
+    )
+    groups = _build_classification_groups(n=40)
+    result = train_model(
+        model_config=config,
+        train_sequence_groups=groups,
+        val_sequence_groups=groups,
+        test_sequence_groups=groups,
+        epochs=1,
+        batch_size=8,
+        seed=11,
+        save_checkpoint=False,
+        use_compile=False,
+        use_amp=False,
+    )
+    val_metrics = result.summary.val_metrics
+    assert val_metrics is not None
+    assert val_metrics.classification_breakdown is not None
+    assert "multi_task_axis_losses" in val_metrics.classification_breakdown
+    axis_losses = val_metrics.classification_breakdown["multi_task_axis_losses"]
+    assert set(axis_losses.keys()) == {"stance", "factor", "certainty", "topic"}


### PR DESCRIPTION
## Summary

- \`_evaluate_model\` (forecaster training loop) gains optional \`multi_task_loss_fn\` kwarg; new branch dispatches \`forward_multi_task\` + assembles per-axis targets/masks from each batch's mt-aux block + accumulates \`MultiTaskLoss\` total
- All four call sites (epoch eval, late-stopping fallback, train re-eval, test eval) pass \`multi_task_loss_fn\` so checkpoint selection ranks against the same objective the train step optimises
- Per-axis breakdown attached to \`classification_breakdown["multi_task_axis_losses"]\` for diagnostic value
- Single-task path byte-identical when kwarg is \`None\` (the default)

Closes the deferred audit finding from PR #285 /code-review — cousin of the Bundle A.1 \`_evaluate\` fix in the multi-axis text trainer, but for the forecaster training loop.

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_evaluate_model_multi_task_path.py tests/unit/test_multi_task_loop_wiring.py tests/regression/ -q\`