### PR TITLE
Fix multi-encoder mode collapsing text_embedding_dim to 0

### DIFF
--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -943,7 +943,12 @@ def _resolve_text_embedding_dim(args: argparse.Namespace) -> int:
         "nomic_embed_text_v15": 768,
         "voyage_finance_2": 1024,
     }
-    encoder = str(getattr(args, "text_encoder", "none") or "none")
+    # Multi-encoder mode (``--text-encoders alias_a alias_b``) leaves the
+    # singular ``args.text_encoder`` unset; resolve via the encoder axis so
+    # the embedding dim picks up the first alias instead of collapsing the
+    # text path to zero.
+    encoders = _resolved_encoder_axis(args)
+    encoder = next((str(e) for e in encoders if e and str(e) != "none"), "none")
     if encoder == "none":
         return 0
     return int(table.get(encoder, 768))

--- a/tests/unit/test_forecaster_sweep_candidates.py
+++ b/tests/unit/test_forecaster_sweep_candidates.py
@@ -17,6 +17,7 @@ pytest.importorskip("torch")
 
 from app.train_forecaster import (
     _parse_args,  # type: ignore[attr-defined]
+    _resolve_text_embedding_dim,  # type: ignore[attr-defined]
     TEXT_ENCODER_CHOICES,
     build_sweep_candidates,
 )
@@ -250,3 +251,50 @@ def test_xbank_aux_aliases_are_registered_choices() -> None:
     assert "finbert_fed_adjacent_xbank_aux_weighted" in TEXT_ENCODER_CHOICES
     # And the queued DAPT alias pre-empts a future Bundle A.4 blocker.
     assert "finbert_fed_adjacent_xbank_dapt" in TEXT_ENCODER_CHOICES
+
+
+def test_resolve_text_embedding_dim_reads_plural_encoders_flag() -> None:
+    """Multi-encoder mode resolves the embedding dim off the encoder axis.
+
+    The singular ``args.text_encoder`` is unset under the mutually
+    exclusive ``--text-encoders alias_a alias_b`` flag; the dim helper
+    must pick up the first alias from the axis instead of collapsing the
+    text path to zero. The collapse was the silent root cause of the
+    Bundle A.2 smoke sweep returning bit-identical losses across arms
+    (the text branch was never wired into the model).
+    """
+
+    args = argparse.Namespace(
+        text_encoder="none",
+        text_encoders=[
+            "finbert_fed_adjacent_xbank_aux_stance_masked",
+            "finbert_fed_adjacent_xbank_aux_weighted",
+        ],
+        use_text_embeddings=True,
+        training_package_id="tp_dummy_v1",
+    )
+    assert _resolve_text_embedding_dim(args) == 768
+
+
+def test_resolve_text_embedding_dim_singular_back_compat() -> None:
+    """Single-encoder runs preserve the legacy lookup path."""
+
+    args = argparse.Namespace(
+        text_encoder="finbert_fed_adjacent",
+        text_encoders=None,
+        use_text_embeddings=True,
+        training_package_id="tp_dummy_v1",
+    )
+    assert _resolve_text_embedding_dim(args) == 768
+
+
+def test_resolve_text_embedding_dim_returns_zero_when_disabled() -> None:
+    """Text-off path stays at zero regardless of which flag form."""
+
+    args = argparse.Namespace(
+        text_encoder="none",
+        text_encoders=None,
+        use_text_embeddings=True,
+        training_package_id="tp_dummy_v1",
+    )
+    assert _resolve_text_embedding_dim(args) == 0


### PR DESCRIPTION
## Summary

- \`_resolve_text_embedding_dim\` read \`args.text_encoder\` (singular) which is \`None\` under the mutually exclusive \`--text-encoders\` flag, returning 0 and silently disabling the text branch
- Resolve via \`_resolved_encoder_axis\` so both flag forms pick up the encoder; falls back to 0 only when no encoder is set
- Bundle A.2 smoke sweep returned bit-identical losses across arm A vs arm B because of this — text path wasn't wired into the model

Three regression tests cover multi-encoder, singular back-compat, and disabled paths.

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_forecaster_sweep_candidates.py -q\`