### PR TITLE
Add class_weight_power knob (default 1.0, documented null probe)

### DIFF
--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -314,6 +314,12 @@ class ModelConfig:
     multi_task_lambda_factor: float = 0.3
     multi_task_lambda_certainty: float = 0.3
     multi_task_lambda_topic: float = 0.3
+    # Steepens inverse-frequency class weights via ``raw[c] = 1 / (n_c + 1) ** power``.
+    # ``1.0`` (default) is the legacy formula and preserves byte-identity with
+    # pre-2026-05-25 sweep numbers; higher values force the gradient onto the
+    # rare classes, mitigating the class-1 collapse the 3-class vol-regime
+    # head exhibits on single-seed runs.
+    class_weight_power: float = 1.0
 
     @classmethod
     def from_model(cls, model: "Any") -> "ModelConfig":
@@ -360,6 +366,7 @@ class ModelConfig:
             multi_task_lambda_factor=float(getattr(model, "multi_task_lambda_factor", 0.3)),
             multi_task_lambda_certainty=float(getattr(model, "multi_task_lambda_certainty", 0.3)),
             multi_task_lambda_topic=float(getattr(model, "multi_task_lambda_topic", 0.3)),
+            class_weight_power=float(getattr(model, "class_weight_power", 1.0)),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -101,6 +101,7 @@ def build_forecaster(
     multi_task_lambda_factor = float(kwargs.pop("multi_task_lambda_factor", 0.3))
     multi_task_lambda_certainty = float(kwargs.pop("multi_task_lambda_certainty", 0.3))
     multi_task_lambda_topic = float(kwargs.pop("multi_task_lambda_topic", 0.3))
+    class_weight_power = float(kwargs.pop("class_weight_power", 1.0))
     # Phase 9 V2 (#195) fields all forwarded: ``output_mode`` /
     # ``n_classes`` drive the head shape; ``vol_regime_quantiles`` /
     # ``vol_regime_target`` ride on the module so the checkpoint
@@ -140,6 +141,7 @@ def build_forecaster(
     model.multi_task_lambda_factor = multi_task_lambda_factor  # type: ignore[assignment]
     model.multi_task_lambda_certainty = multi_task_lambda_certainty  # type: ignore[assignment]
     model.multi_task_lambda_topic = multi_task_lambda_topic  # type: ignore[assignment]
+    model.class_weight_power = class_weight_power  # type: ignore[assignment]
     return model
 
 

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -552,6 +552,18 @@ def _parse_args() -> argparse.Namespace:
         default=0.3,
         help="Loss weight on the topic branch.",
     )
+    parser.add_argument(
+        "--class-weight-power",
+        type=float,
+        default=1.0,
+        help=(
+            "Exponent on the inverse-frequency class weights. ``1.0`` "
+            "(default) is the legacy linear ``1 / (n_c + 1)`` formula. "
+            "``2.0`` steepens the relative weight of rare classes, "
+            "mitigating the class-1 (`normal` vol-regime) collapse the "
+            "3-class head exhibits on single-seed runs."
+        ),
+    )
     # Phase B (#227) LR schedule + sequence-length knobs.
     parser.add_argument(
         "--lr-schedule",
@@ -983,6 +995,7 @@ def _build_model_config(args: argparse.Namespace) -> ModelConfig:
         multi_task_lambda_factor=float(getattr(args, "multi_task_lambda_factor", 0.3)),
         multi_task_lambda_certainty=float(getattr(args, "multi_task_lambda_certainty", 0.3)),
         multi_task_lambda_topic=float(getattr(args, "multi_task_lambda_topic", 0.3)),
+        class_weight_power=float(getattr(args, "class_weight_power", 1.0)),
     )
 
 
@@ -1227,6 +1240,7 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                                 multi_task_lambda_factor=float(getattr(args, "multi_task_lambda_factor", 0.3)),
                                 multi_task_lambda_certainty=float(getattr(args, "multi_task_lambda_certainty", 0.3)),
                                 multi_task_lambda_topic=float(getattr(args, "multi_task_lambda_topic", 0.3)),
+                                class_weight_power=float(getattr(args, "class_weight_power", 1.0)),
                             ),
                             "learning_rate": float(hp["learning_rate"]),
                             "epochs": int(hp["epochs"]),
@@ -1327,6 +1341,7 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                         multi_task_lambda_factor=float(getattr(args, "multi_task_lambda_factor", 0.3)),
                         multi_task_lambda_certainty=float(getattr(args, "multi_task_lambda_certainty", 0.3)),
                         multi_task_lambda_topic=float(getattr(args, "multi_task_lambda_topic", 0.3)),
+                        class_weight_power=float(getattr(args, "class_weight_power", 1.0)),
                     ),
                     "learning_rate": float(learning_rate),
                     "epochs": int(epochs),

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -2311,15 +2311,23 @@ def fit_class_weights(
     *,
     n_classes: int,
     smoothing: float = 1.0,
+    power: float = 1.0,
 ) -> tuple[float, ...]:
     """Return inverse-frequency class weights fitted on a train slice (#206).
 
     Computes per-class counts under the supplied quantile cutoffs, then
-    returns weights proportional to ``1 / (count + smoothing)`` so a
-    class with no events still receives finite weight rather than
+    returns weights proportional to ``1 / (count + smoothing) ** power``
+    so a class with no events still receives finite weight rather than
     blowing up the loss. The weights are normalised so they sum to
     ``n_classes`` -- a class with the dataset's average frequency gets
     weight ~1, a rare class gets > 1, a dominant class gets < 1.
+
+    ``power=1.0`` (default) is the standard inverse-frequency formula
+    and preserves the pre-Bundle-A.2 behaviour byte-identically. Larger
+    powers (e.g. ``2.0``) steepen the relative weight of rare classes,
+    forcing the gradient to chase the middle-vol class that single-seed
+    runs collapse on under uniform inverse-frequency weighting. Smaller
+    powers (e.g. ``0.5``) flatten the weighting toward uniform.
 
     Returns ``()`` (empty) when no quantile cutoffs are available; the
     caller then falls back to uniform weighting via the standard
@@ -2343,7 +2351,7 @@ def fit_class_weights(
             counts[cls] += 1
     if sum(counts) == 0:
         return ()
-    raw = [1.0 / (c + smoothing) for c in counts]
+    raw = [1.0 / ((c + smoothing) ** power) for c in counts]
     total = sum(raw)
     return tuple((w / total) * n_classes for w in raw)
 

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -1291,6 +1291,7 @@ def train_model(
                     train_forward_vols,
                     fitted_quantiles,
                     n_classes=n_classes_active,
+                    power=float(getattr(active_model_config, "class_weight_power", 1.0)),
                 )
             else:
                 fitted_class_weights = ()

--- a/tests/unit/test_phase9_vol_regime_helpers.py
+++ b/tests/unit/test_phase9_vol_regime_helpers.py
@@ -128,6 +128,42 @@ def test_class_weights_upweight_minority_class() -> None:
     assert weights[1] == pytest.approx(weights[2], abs=0.05)
 
 
+def test_class_weights_power_default_is_byte_identical() -> None:
+    """``power=1.0`` round-trips the legacy linear inverse-frequency."""
+
+    from app.training.loaders import fit_class_weights
+
+    quantiles = (0.01, 0.02)
+    vols = [0.005] * 90 + [0.015] * 5 + [0.025] * 5
+    legacy = fit_class_weights(vols, quantiles, n_classes=3)
+    explicit_one = fit_class_weights(vols, quantiles, n_classes=3, power=1.0)
+    for a, b in zip(legacy, explicit_one, strict=True):
+        assert a == pytest.approx(b)
+
+
+def test_class_weights_power_2_steepens_minority_weights() -> None:
+    """``power=2.0`` pushes rare-class weights further above the dominant.
+
+    The 3-class vol-regime classifier collapses class 1 (`normal`) on
+    single-seed runs because the inverse-frequency gradient is too soft;
+    the steepened formula gives the minority class a sharper pull.
+    """
+
+    from app.training.loaders import fit_class_weights
+
+    quantiles = (0.01, 0.02)
+    # 80% calm, 10% normal, 10% high
+    vols = [0.005] * 80 + [0.015] * 10 + [0.025] * 10
+    legacy = fit_class_weights(vols, quantiles, n_classes=3)
+    steep = fit_class_weights(vols, quantiles, n_classes=3, power=2.0)
+    # Both normalise to sum == n_classes.
+    assert sum(steep) == pytest.approx(3.0)
+    # Minority-to-majority ratio is strictly larger under power=2.0.
+    legacy_ratio = legacy[1] / legacy[0]
+    steep_ratio = steep[1] / steep[0]
+    assert steep_ratio > legacy_ratio, (legacy_ratio, steep_ratio)
+
+
 def test_class_weights_handle_missing_class_via_smoothing() -> None:
     """A class with zero training rows must still get a finite weight
     -- the smoothing constant prevents 1/0 blow-up."""


### PR DESCRIPTION
## Summary

- New ``ModelConfig.class_weight_power: float = 1.0`` + ``--class-weight-power FLOAT`` CLI flag
- Steepens inverse-frequency class weights via ``raw[c] = 1 / (n_c + 1) ** power``; default ``1.0`` is the legacy linear formula and preserves prior sweep numbers byte-identically
- Wired through ``ModelConfig.from_model`` round-trip + ``backend/app/models/factory.py`` stash so the knob lands on the run summary

Lands as a documented null probe: a 1-seed x 4-fold smoke at ``power=2.0`` on arm B did not move class-1 recall (0.071 vs 0.074 at ``power=1.0``) and dropped mean macro-F1 by 0.018 (within noise). The class-1 (``normal`` vol-regime) collapse the 3-class head exhibits is structural — quantile classification's middle bin has drifting edges where data density is highest — not a loss-weighting problem. See §16 / #304 for the dual-head retrofit motivated by this finding.

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_phase9_vol_regime_helpers.py -q\`