### PR TITLE
Pin finbert_fed_adjacent_xbank_dapt alias to 2026-05-25 DAPT checkpoint

### DIFF
--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -168,8 +168,8 @@ encoders:
       for reproducibility but the embedding cache builds against s11.
 
   finbert_fed_adjacent_xbank_dapt:
-    repo: local/finbert-fed-adjacent-xbank-dapt
-    revision: ""
+    repo: /data/artifacts/continued_pretraining/finbert_fed_adjacent_xbank_dapt_20260525T185524Z_s11/checkpoint
+    revision: "20260525T185524Z_s11"
     gated: false
     task: masked_lm
     description: |


### PR DESCRIPTION
## Summary

- Bundle A.4 DAPT finished cleanly on the 4080 in ~40 min wall-clock (batch=32, 2 epochs, 150k pairs from \`bis_xbank\`)
- Pin the registry alias \`finbert_fed_adjacent_xbank_dapt\` to the resulting checkpoint at \`/data/artifacts/continued_pretraining/finbert_fed_adjacent_xbank_dapt_20260525T185524Z_s11/checkpoint\`
- Revision token \`20260525T185524Z_s11\` so subsequent runs are pinned

Loss curve over training: 6.08 → 4.46 → 2.81 → 2.31 → 2.27 final. Final epoch-averaged \`train_loss\` 2.679, throughput 126.8 samples/sec.

Per the §16 reframe, this encoder is the canonical artifact the new downstream heads (#292 multi-target rates, #294 retrieval, #296 trajectory) consume. The vol-regime macro-F1 evaluation lands as a documented row, not a gate.

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_model_registry.py -q\`