### PR TITLE
Rates-complex data foundations (#291)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier
 
 help:
 	@echo "Targets:"
@@ -60,6 +60,7 @@ help:
 	@echo "  make macro-state      - Build the FRED macro-state parquet (Phase 8 #147)"
 	@echo "  make build-macro-state - Same as macro-state, named for the data-asset suite"
 	@echo "  make build-mp-surprises - Build the MP-surprise time-series parquet"
+	@echo "  make build-rates-panel - Build the daily rates panel (DGS1/2/5/10, DFEDTARU, #291)"
 	@echo "  make rebuild-linguistic-features TRAINING_PACKAGE_ID=<id>"
 	@echo "                         - Re-emit linguistic_features.parquet for a training package"
 	@echo "  make cache-voyage-embeddings"
@@ -599,6 +600,22 @@ build-mp-surprises:
 	docker compose run --rm backend \
 		python -m app.data.mp_surprise \
 		--output data/external/fred/mp_surprises.parquet
+
+# Build the daily rates panel at data/external/fred/rates_panel.parquet
+# (#291). Carries DGS1/2/5/10, T10Y2Y, T10Y3M, DFEDTARU, DFEDTARL with
+# strict-backward publication-date indexing. Required by the
+# event_dataset_builder when emitting rates-complex forward targets and
+# pre-meeting expectation features. Requires FRED_API_KEY in .env on
+# first run; subsequent runs reuse the per-series JSON cache.
+RATES_PANEL_START ?= 2008-01-01
+RATES_PANEL_END ?= today
+build-rates-panel:
+	@test -f .env || (echo ".env required for FRED_API_KEY"; exit 1)
+	docker compose run --rm backend \
+		python -m app.data.rates_panel \
+		--start "$(RATES_PANEL_START)" \
+		--end "$(RATES_PANEL_END)" \
+		--output data/external/fred/rates_panel.parquet
 
 # Re-emit linguistic_features.parquet for a given training package. The
 # default output filename and LDA-artifact filenames live under the package

--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -150,6 +150,14 @@ from app.data.macro_releases import (
     build_heuristic_calendar,
     load_macro_release_calendar,
 )
+from app.data.rates_event_features import (
+    FORWARD_TARGET_COLUMNS,
+    PRE_MEETING_LEVEL_COLUMNS,
+    PreMeetingFeatures,
+    compute_pre_meeting_features,
+    forward_yield_change_bps,
+)
+from app.data.rates_panel import RatesPanelLookup, load_rates_panel_lookup
 from app.features.credibility import CredibilityVector
 from app.services.credibility_loader import load_credibility_for_run
 
@@ -1291,6 +1299,8 @@ def _build_event_rows(
     concurrent_macro_window_days: int = CONCURRENT_MACRO_TRADING_DAY_RADIUS,
     intra_meeting_shift: dict[str, float] | None = None,
     cross_asset_lookup: dict[_dt.date, dict[str, float]] | None = None,
+    rates_lookup: RatesPanelLookup | None = None,
+    rates_horizon: int = 5,
 ) -> list[dict[str, Any]]:
     event_date = _date(doc.event_date)
     as_of_ts = _as_of_for_event(doc.event_date, doc.event_kind)
@@ -1358,6 +1368,30 @@ def _build_event_rows(
             "intra_meeting_factor_shift": math.nan,
         }
 
+    # Rates-complex forward targets (#291). Strict-forward bps changes
+    # over the rates panel's t -> t+rates_horizon trading-day window.
+    # Empty lookup -> every target is None and the column degrades
+    # cleanly to a nullable float on the parquet write side.
+    rates_forward_targets: dict[str, float | None] = {
+        target_column: None for _, target_column in FORWARD_TARGET_COLUMNS
+    }
+    if rates_lookup is not None:
+        for column, target_column in FORWARD_TARGET_COLUMNS:
+            rates_forward_targets[target_column] = forward_yield_change_bps(
+                rates_lookup,
+                asset_series.dates,
+                column=column,
+                event_date=as_of_date,
+                horizon=rates_horizon,
+            )
+
+    # Pre-meeting expectation features (#291). Strict-backward at t-1.
+    pre_meeting: PreMeetingFeatures | None = None
+    if rates_lookup is not None:
+        pre_meeting = compute_pre_meeting_features(
+            rates_lookup, asset_series.dates, event_date=as_of_date
+        )
+
     rows: list[dict[str, Any]] = []
     for h in horizons:
         tgt = targets.get(h)
@@ -1418,9 +1452,67 @@ def _build_event_rows(
                     intra_meeting_shift["intra_meeting_factor_shift"]
                 ),
                 "realized_date": realized_date.isoformat() if realized_date else None,
+                # --- Rates-complex forward targets (#291), raw bps ---
+                "yield_2y_change_5d": _maybe_float(
+                    rates_forward_targets.get("yield_2y_change_5d")
+                ),
+                "yield_5y_change_5d": _maybe_float(
+                    rates_forward_targets.get("yield_5y_change_5d")
+                ),
+                "terminal_rate_change_5d": _maybe_float(
+                    rates_forward_targets.get("terminal_rate_change_5d")
+                ),
+                # --- Pre-meeting expectation features (#291) ---
+                "pre_meeting_yield_1y": _pre_meeting_field(pre_meeting, "pre_meeting_yield_1y"),
+                "pre_meeting_yield_2y": _pre_meeting_field(pre_meeting, "pre_meeting_yield_2y"),
+                "pre_meeting_yield_5y": _pre_meeting_field(pre_meeting, "pre_meeting_yield_5y"),
+                "pre_meeting_yield_10y": _pre_meeting_field(pre_meeting, "pre_meeting_yield_10y"),
+                "pre_meeting_slope_10y_2y": _pre_meeting_field(
+                    pre_meeting, "pre_meeting_slope_10y_2y"
+                ),
+                "pre_meeting_slope_10y_3m": _pre_meeting_field(
+                    pre_meeting, "pre_meeting_slope_10y_3m"
+                ),
+                "pre_meeting_trailing_2y_yield_change_5d_bps": _pre_meeting_field(
+                    pre_meeting, "pre_meeting_trailing_2y_yield_change_5d_bps"
+                ),
+                "pre_meeting_implied_next_move_bps": _pre_meeting_field(
+                    pre_meeting, "pre_meeting_implied_next_move_bps"
+                ),
+                "pre_meeting_implied_hike_prob": _pre_meeting_field(
+                    pre_meeting, "pre_meeting_implied_hike_prob"
+                ),
+                "pre_meeting_implied_cut_prob": _pre_meeting_field(
+                    pre_meeting, "pre_meeting_implied_cut_prob"
+                ),
+                "pre_meeting_implied_pause_prob": _pre_meeting_field(
+                    pre_meeting, "pre_meeting_implied_pause_prob"
+                ),
+                "pre_meeting_days_since_last_rate_change": _pre_meeting_field(
+                    pre_meeting, "pre_meeting_days_since_last_rate_change"
+                ),
             }
         )
     return rows
+
+
+def _maybe_float(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _pre_meeting_field(
+    features: PreMeetingFeatures | None, field_name: str
+) -> float | None:
+    if features is None:
+        return None
+    value = getattr(features, field_name)
+    if value is None:
+        return None
+    return float(value)
+
+
 
 
 _CREDIBILITY_EMPTY_INPUTS_WARNED = False
@@ -1503,6 +1595,23 @@ COLUMN_ORDER = (
     "intra_meeting_certainty_shift",
     "intra_meeting_factor_shift",
     "realized_date",
+    # Rates-complex forward targets (#291)
+    "yield_2y_change_5d",
+    "yield_5y_change_5d",
+    "terminal_rate_change_5d",
+    # Pre-meeting expectation features (#291)
+    "pre_meeting_yield_1y",
+    "pre_meeting_yield_2y",
+    "pre_meeting_yield_5y",
+    "pre_meeting_yield_10y",
+    "pre_meeting_slope_10y_2y",
+    "pre_meeting_slope_10y_3m",
+    "pre_meeting_trailing_2y_yield_change_5d_bps",
+    "pre_meeting_implied_next_move_bps",
+    "pre_meeting_implied_hike_prob",
+    "pre_meeting_implied_cut_prob",
+    "pre_meeting_implied_pause_prob",
+    "pre_meeting_days_since_last_rate_change",
 )
 
 
@@ -1524,6 +1633,9 @@ def build_event_rows(
     macro_release_calendar: MacroReleaseCalendar | None = None,
     macro_release_csv_path: Path | str | None = None,
     concurrent_macro_window_days: int = CONCURRENT_MACRO_TRADING_DAY_RADIUS,
+    rates_panel_path: Path | str | None = None,
+    rates_lookup: RatesPanelLookup | None = None,
+    rates_horizon: int = 5,
 ) -> pd.DataFrame:
     """Build the events DataFrame for one training package.
 
@@ -1615,6 +1727,20 @@ def build_event_rows(
         "fred_series_id": fred_series_id,
     }
 
+    # Rates panel lookup (#291). Tests inject ``rates_lookup`` directly;
+    # the pipeline path resolves the parquet at the supplied
+    # ``rates_panel_path`` or under ``fred_cache_dir / 'rates_panel.parquet'``
+    # by default, and degrades cleanly to an empty lookup when the file
+    # is absent so a fresh checkout still produces an events.parquet.
+    if rates_lookup is None:
+        resolved_rates_path: Path | None = None
+        if rates_panel_path is not None:
+            resolved_rates_path = Path(rates_panel_path)
+        elif fred_cache_dir is not None:
+            resolved_rates_path = Path(fred_cache_dir) / "rates_panel.parquet"
+        if resolved_rates_path is not None:
+            rates_lookup = load_rates_panel_lookup(resolved_rates_path)
+
     out_rows: list[dict[str, Any]] = []
     for doc in docs:
         rows = _build_event_rows(
@@ -1629,6 +1755,8 @@ def build_event_rows(
             concurrent_macro_window_days=concurrent_macro_window_days,
             intra_meeting_shift=intra_meeting_shifts.get(doc.event_date),
             cross_asset_lookup=cross_asset_lookup,
+            rates_lookup=rates_lookup,
+            rates_horizon=rates_horizon,
         )
         if not rows:
             summary.dropped_no_prior_window += 1
@@ -1756,6 +1884,25 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "attribution (~25%); set 0 to require exact same-day overlap."
         ),
     )
+    parser.add_argument(
+        "--rates-panel-path",
+        default=None,
+        help=(
+            "Path to data/external/fred/rates_panel.parquet for the "
+            "#291 rates-complex feature columns. Defaults to "
+            "<fred-cache-dir>/rates_panel.parquet; a missing file "
+            "degrades to null columns on every event row."
+        ),
+    )
+    parser.add_argument(
+        "--rates-horizon",
+        type=int,
+        default=5,
+        help=(
+            "Trading-day horizon for the strict-forward yield-change "
+            "targets (default: 5)."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -1812,6 +1959,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         fred_cache_dir=Path(args.fred_cache_dir) if args.fred_cache_dir else None,
         summary=summary,
         macro_release_calendar=macro_calendar,
+        rates_panel_path=args.rates_panel_path,
+        rates_horizon=int(args.rates_horizon),
     )
     output_path = Path(args.output)
     if not output_path.is_absolute():
@@ -1849,6 +1998,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             summary=full_summary,
             macro_release_calendar=macro_calendar,
             keep_all_sources=True,
+            rates_panel_path=args.rates_panel_path,
+            rates_horizon=int(args.rates_horizon),
         )
         full_output_path = Path(full_output_arg)
         if not full_output_path.is_absolute():

--- a/backend/app/data/quantile_labels.py
+++ b/backend/app/data/quantile_labels.py
@@ -1,0 +1,191 @@
+"""Per-fold 3-class quantile labels for the rates-complex regression targets (#291).
+
+The rates-complex heads (#292) ship regression as the primary output:
+``yield_2y_change_5d``, ``yield_5y_change_5d``, and
+``terminal_rate_change_5d`` are stored in raw basis points on every
+event row. For the optional product-surface classification view, this
+module computes per-fold tertile cutoffs on the *train slice* of each
+fold and assigns one of three labels to every row in the fold:
+
+- ``easing`` (= ``-1``) — change below the 33rd percentile of the train slice
+- ``neutral`` (= ``0``) — change in ``[33rd, 67th)``
+- ``tightening`` (= ``+1``) — change at or above the 67th percentile
+
+The bin edges are computed strictly from the train slice (no
+look-ahead) and the edge pair is persisted alongside the fold's metadata
+so the training-package reader and the conformal calibrator both see
+the same boundaries. The 33/67 quantiles match the convention pinned by
+the existing vol-regime classifier (calm / normal / high).
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+# Numeric encoding of the three classes. Pinned so downstream consumers
+# (loss weighting, confusion-matrix renderer) reuse the same convention
+# without re-deriving the order. The vol-regime classifier uses 0 / 1 / 2
+# for calm / normal / high; the rates direction class uses signed -1 /
+# 0 / +1 because direction has natural sign and a signed encoding keeps
+# directional-accuracy computations (sign(pred) == sign(obs)) consistent
+# with the regression target.
+EASING_LABEL = -1
+NEUTRAL_LABEL = 0
+TIGHTENING_LABEL = 1
+
+# Quantile cut points. Matches the (1/3, 2/3) split used by the existing
+# vol-regime classifier so the binning convention is uniform across the
+# product's classification heads.
+LOWER_QUANTILE = 1.0 / 3.0
+UPPER_QUANTILE = 2.0 / 3.0
+
+
+@dataclass(frozen=True)
+class QuantileBinEdges:
+    """Tertile cutoffs computed on a single fold's train slice.
+
+    Both edges are inclusive on the lower side and exclusive on the
+    upper side, matching the standard pandas ``qcut`` convention.
+
+    ``column`` records which target the edges were computed on so the
+    fold-manifest entry is self-describing.
+    """
+
+    column: str
+    lower: float
+    upper: float
+    n_train_rows: int
+
+    def to_dict(self) -> dict[str, float | int | str]:
+        return {
+            "column": self.column,
+            "lower": float(self.lower),
+            "upper": float(self.upper),
+            "n_train_rows": int(self.n_train_rows),
+        }
+
+
+def _empirical_quantile(values: Sequence[float], q: float) -> float:
+    """Linear-interpolation empirical quantile (matches numpy default).
+
+    Pulled out so the module stays import-light (no numpy dependency at
+    fold-manifest write time) and so the cutoff convention is stable
+    across pandas versions that change ``qcut`` interpolation defaults.
+    """
+
+    if not values:
+        return float("nan")
+    if not 0.0 <= q <= 1.0:
+        raise ValueError(f"q must be in [0, 1]; got {q!r}")
+    cleaned = sorted(float(v) for v in values if v is not None and math.isfinite(float(v)))
+    n = len(cleaned)
+    if n == 0:
+        return float("nan")
+    if n == 1:
+        return cleaned[0]
+    pos = q * (n - 1)
+    lo = int(math.floor(pos))
+    hi = int(math.ceil(pos))
+    if lo == hi:
+        return cleaned[lo]
+    weight = pos - lo
+    return cleaned[lo] * (1.0 - weight) + cleaned[hi] * weight
+
+
+def compute_bin_edges(
+    train_values: Sequence[float],
+    *,
+    column: str,
+) -> QuantileBinEdges:
+    """Compute the (lower, upper) tertile cutoffs on a train slice.
+
+    Rows whose target is ``None`` or non-finite are dropped before the
+    quantile is computed; ``n_train_rows`` reports the count of surviving
+    finite values.
+    """
+
+    finite = [
+        float(v) for v in train_values
+        if v is not None and not (isinstance(v, float) and math.isnan(v))
+    ]
+    if not finite:
+        nan = float("nan")
+        return QuantileBinEdges(column=column, lower=nan, upper=nan, n_train_rows=0)
+
+    lower = _empirical_quantile(finite, LOWER_QUANTILE)
+    upper = _empirical_quantile(finite, UPPER_QUANTILE)
+    return QuantileBinEdges(
+        column=column,
+        lower=lower,
+        upper=upper,
+        n_train_rows=len(finite),
+    )
+
+
+def label_for_value(value: float | None, edges: QuantileBinEdges) -> int | None:
+    """Map a raw bps change to one of the three class labels.
+
+    Returns ``None`` when ``value`` is missing or the edges are not
+    finite (the empty-train-slice case).
+    """
+
+    if value is None:
+        return None
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(v):
+        return None
+    if not (math.isfinite(edges.lower) and math.isfinite(edges.upper)):
+        return None
+    if v < edges.lower:
+        return EASING_LABEL
+    if v < edges.upper:
+        return NEUTRAL_LABEL
+    return TIGHTENING_LABEL
+
+
+def assign_labels(
+    values: Sequence[float | None],
+    edges: QuantileBinEdges,
+) -> list[int | None]:
+    """Apply :func:`label_for_value` to every entry in ``values``."""
+
+    return [label_for_value(v, edges) for v in values]
+
+
+def fold_manifest_entry(
+    *,
+    fold_id: str,
+    edges_by_column: Mapping[str, QuantileBinEdges],
+) -> dict[str, dict[str, float | int | str] | str]:
+    """Build the fold-manifest payload for one fold.
+
+    Returns a dict shaped like ``{"fold_id": <id>, "quantile_bin_edges":
+    {<column>: {...}}}`` that the training-package writer merges into
+    each fold's metadata block. The shape is JSON-serializable as-is.
+    """
+
+    return {
+        "fold_id": fold_id,
+        "quantile_bin_edges": {
+            column: edges.to_dict() for column, edges in edges_by_column.items()
+        },
+    }
+
+
+__all__ = (
+    "EASING_LABEL",
+    "LOWER_QUANTILE",
+    "NEUTRAL_LABEL",
+    "QuantileBinEdges",
+    "TIGHTENING_LABEL",
+    "UPPER_QUANTILE",
+    "assign_labels",
+    "compute_bin_edges",
+    "fold_manifest_entry",
+    "label_for_value",
+)

--- a/backend/app/data/rates_event_features.py
+++ b/backend/app/data/rates_event_features.py
@@ -157,9 +157,15 @@ def forward_yield_change_bps(
     calendar runs out before ``t+horizon``.
     """
 
+    # Baseline ``t``: snap forward to the first trading day on or after
+    # event_date. When event_date sits past the calendar's last entry
+    # (stale yfinance cache vs. real-time FOMC date), fall back to
+    # event_date itself rather than dropping the most-recent event's
+    # target to None — the rates lookup gracefully resolves non-trading
+    # event dates via the same yield_on_or_before semantics.
     t = trading_day_offset(trading_calendar, event_date, offset=0)
     if t is None:
-        return None
+        t = event_date
     base = lookup.yield_on_or_before(column, t)
     if base is None:
         return None
@@ -249,7 +255,7 @@ def days_since_last_rate_change(
     *,
     column: str = "ff_target_upper",
     tolerance_bps: float = 0.5,
-    max_lookback_days: int = 730,
+    max_lookback_days: int = 3650,
 ) -> int | None:
     """Calendar days since the most recent change in ``ff_target_upper``.
 
@@ -263,6 +269,13 @@ def days_since_last_rate_change(
     ``tolerance_bps`` defaults to 0.5 bp to ignore micro-rounding in the
     published rate series; FOMC moves are 25 bps minimum, so the
     threshold is conservative.
+
+    ``max_lookback_days`` defaults to 10 years so multi-year pause
+    regimes (2009-12 to 2015-12 ZLB; 2020-03 to 2022-03 emergency
+    hold) still emit a positive gap rather than silently nulling the
+    feature for every FOMC meeting in those windows — the "very long
+    pause" signal is exactly the value a forecaster needs in those
+    regimes.
     """
 
     dates = lookup.dates_by_column.get(column)

--- a/backend/app/data/rates_event_features.py
+++ b/backend/app/data/rates_event_features.py
@@ -1,0 +1,403 @@
+"""Event-row helpers for the rates-complex heads (#291).
+
+Two families of features:
+
+- **Forward change targets** (strict-forward, in basis points). For each
+  FOMC event at date ``t`` and each yield column ``y``, the 5-day target
+  is ``yield_y[t+5] - yield_y[t]`` measured in raw bps (``× 100`` since
+  FRED publishes yields as percent). Strict-forward semantics match the
+  convention pinned by ``tests/unit/test_forward_realized_vol_strict_forward.py``
+  for the existing realized-vol target: ``yield_y[t]`` is the close-of-day
+  yield on the FOMC event date, ``yield_y[t+5]`` is the close 5 trading
+  days later, and ``yield_y[t-1]`` never appears in the target window.
+  This keeps the target measuring the *post-announcement drift* and not
+  the announcement-day reaction, which the surprise-decomposition issue
+  (#305) treats separately.
+
+- **Pre-meeting expectation features** (strict-backward at ``t-1``). For
+  each FOMC event the values are computed only from FRED observations
+  with publication date strictly before the meeting date. A 5-day
+  trailing yield change uses ``yield[t-1] - yield[t-6]`` in bps. The
+  time-since-last-rate-change feature walks the DFEDTARU step series
+  backward from ``t-1`` and counts trading days. The implied next-move
+  proxy uses ``(1y Treasury - upper Fed Funds target)`` at ``t-1``,
+  bucketed into hike / cut / pause probabilities under a 25-bps
+  standard-move threshold.
+
+The FRED-only implied-probability bucketing is the conservative baseline
+for #291. The CME 30-day Fed Funds futures replacement is reserved for
+#305 (surprise decomposition); the column names here are pinned so the
+upgrade is a drop-in replacement.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.data.rates_panel import RatesPanelLookup
+
+
+# Standard FOMC move increment, in basis points. Used by
+# :func:`implied_move_probabilities` to bucket the 1y-implied next-move
+# proxy into hike / cut / pause probabilities. The 12.5-bps half-move
+# threshold is the canonical hike/cut detection boundary used by
+# Bloomberg's World Interest Rate Probability product and by the
+# fed-funds-futures-implied probability literature (Kuttner 2001, GSS
+# 2005). The threshold is symmetric: ``|implied| < 12.5`` => pause;
+# ``|implied| in [12.5, 25)`` => fractional hike or cut; ``|implied| >= 25``
+# => full hike or cut.
+STANDARD_MOVE_BPS: float = 25.0
+HALF_MOVE_BPS: float = 12.5
+
+# Columns covered by the strict-forward target family.
+FORWARD_TARGET_COLUMNS: tuple[tuple[str, str], ...] = (
+    # (rates_panel column, output target column name)
+    ("treas_2y", "yield_2y_change_5d"),
+    ("treas_5y", "yield_5y_change_5d"),
+    # 1y constant-maturity Treasury proxies the terminal rate when CME
+    # Fed Funds futures are unavailable. The column name keeps the
+    # ``terminal_rate_*`` convention so the futures-based replacement
+    # (#305) drops in without a schema migration.
+    ("treas_1y", "terminal_rate_change_5d"),
+)
+
+# Columns covered by the strict-backward pre-meeting yield level family.
+PRE_MEETING_LEVEL_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("treas_1y", "pre_meeting_yield_1y"),
+    ("treas_2y", "pre_meeting_yield_2y"),
+    ("treas_5y", "pre_meeting_yield_5y"),
+    ("treas_10y", "pre_meeting_yield_10y"),
+    ("slope_10y_2y", "pre_meeting_slope_10y_2y"),
+    ("slope_10y_3m", "pre_meeting_slope_10y_3m"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Trading-day arithmetic
+# ---------------------------------------------------------------------------
+
+
+def trading_day_offset(
+    trading_calendar: Sequence[_dt.date],
+    anchor: _dt.date,
+    *,
+    offset: int,
+) -> _dt.date | None:
+    """Return ``anchor`` shifted forward by ``offset`` trading days.
+
+    The "first trading day on or after the anchor" is treated as position
+    0 (the anchor itself when it is a trading day; otherwise the next
+    one). A positive offset moves forward, a negative offset moves
+    backward. Returns ``None`` when the resulting position falls outside
+    the calendar.
+    """
+
+    import bisect as _bisect
+
+    if not trading_calendar:
+        return None
+
+    idx_on_or_after = _bisect.bisect_left(trading_calendar, anchor)
+    if idx_on_or_after >= len(trading_calendar):
+        # Anchor sits past the last calendar day; fall back to the
+        # last calendar entry as the reference point for forward
+        # offsets that would never resolve.
+        return None
+    target_idx = idx_on_or_after + offset
+    if target_idx < 0 or target_idx >= len(trading_calendar):
+        return None
+    return trading_calendar[target_idx]
+
+
+def last_trading_day_strictly_before(
+    trading_calendar: Sequence[_dt.date],
+    anchor: _dt.date,
+) -> _dt.date | None:
+    """Return the largest calendar date strictly less than ``anchor``."""
+
+    import bisect as _bisect
+
+    if not trading_calendar:
+        return None
+    idx = _bisect.bisect_left(trading_calendar, anchor)
+    if idx == 0:
+        return None
+    return trading_calendar[idx - 1]
+
+
+# ---------------------------------------------------------------------------
+# Forward change targets (strict-forward, bps)
+# ---------------------------------------------------------------------------
+
+
+def forward_yield_change_bps(
+    lookup: "RatesPanelLookup",
+    trading_calendar: Sequence[_dt.date],
+    *,
+    column: str,
+    event_date: _dt.date,
+    horizon: int = 5,
+) -> float | None:
+    """Strict-forward ``t+horizon`` yield change in basis points.
+
+    Returns ``(yield[t+horizon] - yield[t]) * 100`` where ``t`` is the
+    first trading day on or after ``event_date`` (the announcement-day
+    close that already reflects the FOMC reaction) and ``t+horizon`` is
+    the close ``horizon`` trading days later. Both endpoints are looked
+    up via :meth:`RatesPanelLookup.yield_on_or_before`. Snapping the
+    baseline forward to the next trading day matches the convention
+    used by ``app.data.event_dataset_builder._forward_realized_vol``,
+    which is pinned by ``test_forward_realized_vol_strict_forward.py``.
+
+    Returns ``None`` when either endpoint is unavailable or when the
+    calendar runs out before ``t+horizon``.
+    """
+
+    t = trading_day_offset(trading_calendar, event_date, offset=0)
+    if t is None:
+        return None
+    base = lookup.yield_on_or_before(column, t)
+    if base is None:
+        return None
+
+    t_plus_h = trading_day_offset(trading_calendar, event_date, offset=horizon)
+    if t_plus_h is None:
+        return None
+    endpoint = lookup.yield_on_or_before(column, t_plus_h)
+    if endpoint is None:
+        return None
+    return (endpoint - base) * 100.0
+
+
+# ---------------------------------------------------------------------------
+# Pre-meeting expectation features (strict-backward at t-1)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PreMeetingFeatures:
+    """Bundle of strict-backward pre-meeting expectation features.
+
+    Every field is computed from FRED observations with publication date
+    strictly before the FOMC event date. A field is ``None`` when the
+    underlying series has no observation before the event date (the
+    earliest events in 2008 fall in this bucket for DFEDTARU before
+    its FRED start date).
+    """
+
+    pre_meeting_yield_1y: float | None
+    pre_meeting_yield_2y: float | None
+    pre_meeting_yield_5y: float | None
+    pre_meeting_yield_10y: float | None
+    pre_meeting_slope_10y_2y: float | None
+    pre_meeting_slope_10y_3m: float | None
+    pre_meeting_trailing_2y_yield_change_5d_bps: float | None
+    pre_meeting_implied_next_move_bps: float | None
+    pre_meeting_implied_hike_prob: float | None
+    pre_meeting_implied_cut_prob: float | None
+    pre_meeting_implied_pause_prob: float | None
+    pre_meeting_days_since_last_rate_change: int | None
+
+
+def trailing_yield_change_bps(
+    lookup: "RatesPanelLookup",
+    trading_calendar: Sequence[_dt.date],
+    *,
+    column: str,
+    event_date: _dt.date,
+    horizon: int = 5,
+) -> float | None:
+    """Strict-backward trailing yield change in basis points.
+
+    Returns ``(yield[t-1] - yield[t-1-horizon]) * 100`` where ``t-1`` is
+    the last trading day strictly before ``event_date`` and ``t-1-horizon``
+    is the close ``horizon`` trading days earlier. Both endpoints use
+    :meth:`RatesPanelLookup.yield_strictly_before` so neither leaks any
+    observation with publication date ``>= event_date``.
+
+    Returns ``None`` when either endpoint is unavailable.
+    """
+
+    anchor = last_trading_day_strictly_before(trading_calendar, event_date)
+    if anchor is None:
+        return None
+
+    endpoint = lookup.yield_strictly_before(column, event_date)
+    if endpoint is None:
+        return None
+
+    earlier_anchor = trading_day_offset(
+        trading_calendar, anchor, offset=-horizon
+    )
+    if earlier_anchor is None:
+        return None
+    # ``yield_strictly_before`` reads pub_date < target; ``earlier_anchor + 1``
+    # is the smallest date that still admits the earlier_anchor publication.
+    base = lookup.yield_strictly_before(column, earlier_anchor + _dt.timedelta(days=1))
+    if base is None:
+        return None
+    return (endpoint - base) * 100.0
+
+
+def days_since_last_rate_change(
+    lookup: "RatesPanelLookup",
+    event_date: _dt.date,
+    *,
+    column: str = "ff_target_upper",
+    tolerance_bps: float = 0.5,
+    max_lookback_days: int = 730,
+) -> int | None:
+    """Calendar days since the most recent change in ``ff_target_upper``.
+
+    Walks the FRED DFEDTARU step series backward from the last observation
+    strictly before ``event_date`` and returns the calendar-day gap to
+    the first prior observation whose value differs by more than
+    ``tolerance_bps`` (in percent: 0.5 bps == 0.005 percent). Returns
+    ``None`` when no change is found within ``max_lookback_days`` or when
+    the series has no observations before ``event_date``.
+
+    ``tolerance_bps`` defaults to 0.5 bp to ignore micro-rounding in the
+    published rate series; FOMC moves are 25 bps minimum, so the
+    threshold is conservative.
+    """
+
+    dates = lookup.dates_by_column.get(column)
+    values = lookup.values_by_column.get(column)
+    if not dates or not values:
+        return None
+
+    import bisect as _bisect
+
+    idx = _bisect.bisect_left(dates, event_date)
+    if idx == 0:
+        return None
+
+    current_value = values[idx - 1]
+    tolerance_pct = tolerance_bps / 100.0
+    earliest_pos = idx - 1
+    # Walk backward looking for the first observation differing from
+    # ``current_value`` by more than the tolerance. The change date is
+    # the observation *after* that one (the first one matching the new
+    # level), so the gap is ``current_date - change_date``.
+    walk_pos = idx - 2
+    last_change_idx: int | None = None
+    while walk_pos >= 0:
+        if abs(values[walk_pos] - current_value) > tolerance_pct:
+            last_change_idx = walk_pos + 1
+            break
+        walk_pos -= 1
+    if last_change_idx is None:
+        return None
+
+    gap = (dates[earliest_pos] - dates[last_change_idx]).days
+    # ``last_change_idx`` is the first observation with the *new* value;
+    # the gap measures how many days the new level has been in place.
+    if gap > max_lookback_days:
+        return None
+    return int(gap)
+
+
+def implied_next_move_bps(
+    lookup: "RatesPanelLookup",
+    event_date: _dt.date,
+) -> float | None:
+    """FRED-only implied next-move proxy at ``t-1`` in basis points.
+
+    Computed as ``(1y Treasury yield - upper Fed Funds target) * 100``
+    using strict-backward observations at the last trading day before
+    ``event_date``. A positive value indicates the 1y curve prices net
+    hikes; a negative value prices net cuts.
+
+    This is the conservative FRED-only baseline; #305 (surprise
+    decomposition) replaces it with a CME 30-day Fed Funds futures
+    construction.
+
+    Returns ``None`` when either input is unavailable (FF target is
+    absent before 2008-12-16 when DFEDTARU starts).
+    """
+
+    yield_1y = lookup.yield_strictly_before("treas_1y", event_date)
+    ff_upper = lookup.yield_strictly_before("ff_target_upper", event_date)
+    if yield_1y is None or ff_upper is None:
+        return None
+    return (yield_1y - ff_upper) * 100.0
+
+
+def implied_move_probabilities(
+    implied_bps: float | None,
+) -> tuple[float | None, float | None, float | None]:
+    """Bucket the implied next-move proxy into hike / cut / pause probs.
+
+    Returns ``(hike_prob, cut_prob, pause_prob)``. Each probability is in
+    ``[0, 1]`` and the three values sum to 1.0 within floating-point
+    tolerance.
+
+    Bucketing rules with :data:`STANDARD_MOVE_BPS` = 25 bps and
+    :data:`HALF_MOVE_BPS` = 12.5 bps:
+
+    - ``|implied| < 12.5`` => pause_prob = 1, hike = cut = 0
+    - ``+12.5 <= implied < +25`` => hike_prob = (implied - 12.5)/12.5,
+      pause_prob = 1 - hike_prob, cut = 0
+    - ``implied >= +25`` => hike_prob = 1, pause = cut = 0
+    - mirror cases for negative implied values
+
+    Returns ``(None, None, None)`` when ``implied_bps`` is ``None``.
+    """
+
+    if implied_bps is None:
+        return (None, None, None)
+
+    abs_bps = abs(implied_bps)
+    if abs_bps < HALF_MOVE_BPS:
+        return (0.0, 0.0, 1.0)
+
+    if abs_bps >= STANDARD_MOVE_BPS:
+        directional = 1.0
+    else:
+        # Linearly ramp from 0 at ``HALF_MOVE_BPS`` to 1 at
+        # ``STANDARD_MOVE_BPS``.
+        directional = (abs_bps - HALF_MOVE_BPS) / (STANDARD_MOVE_BPS - HALF_MOVE_BPS)
+
+    pause = 1.0 - directional
+    if implied_bps > 0:
+        return (directional, 0.0, pause)
+    return (0.0, directional, pause)
+
+
+def compute_pre_meeting_features(
+    lookup: "RatesPanelLookup",
+    trading_calendar: Sequence[_dt.date],
+    *,
+    event_date: _dt.date,
+) -> PreMeetingFeatures:
+    """Bundle every pre-meeting expectation feature for one FOMC event."""
+
+    levels: dict[str, float | None] = {}
+    for column, output_name in PRE_MEETING_LEVEL_COLUMNS:
+        levels[output_name] = lookup.yield_strictly_before(column, event_date)
+
+    trailing_2y = trailing_yield_change_bps(
+        lookup, trading_calendar, column="treas_2y", event_date=event_date, horizon=5
+    )
+    implied_bps = implied_next_move_bps(lookup, event_date)
+    hike_prob, cut_prob, pause_prob = implied_move_probabilities(implied_bps)
+    days_since = days_since_last_rate_change(lookup, event_date)
+
+    return PreMeetingFeatures(
+        pre_meeting_yield_1y=levels["pre_meeting_yield_1y"],
+        pre_meeting_yield_2y=levels["pre_meeting_yield_2y"],
+        pre_meeting_yield_5y=levels["pre_meeting_yield_5y"],
+        pre_meeting_yield_10y=levels["pre_meeting_yield_10y"],
+        pre_meeting_slope_10y_2y=levels["pre_meeting_slope_10y_2y"],
+        pre_meeting_slope_10y_3m=levels["pre_meeting_slope_10y_3m"],
+        pre_meeting_trailing_2y_yield_change_5d_bps=trailing_2y,
+        pre_meeting_implied_next_move_bps=implied_bps,
+        pre_meeting_implied_hike_prob=hike_prob,
+        pre_meeting_implied_cut_prob=cut_prob,
+        pre_meeting_implied_pause_prob=pause_prob,
+        pre_meeting_days_since_last_rate_change=days_since,
+    )

--- a/backend/app/data/rates_panel.py
+++ b/backend/app/data/rates_panel.py
@@ -1,0 +1,604 @@
+"""Daily Treasury yield + Fed Funds target panel for the rates-complex heads.
+
+Mirrors :mod:`app.data.macro_state` but covers the daily rates surface
+the FOMC forecaster needs both *before* the meeting (strict-backward
+pre-meeting expectation features at ``t-1``) and *after* the meeting
+(strict-forward ``t+1..t+5`` change targets stored in raw basis points).
+
+The panel emits one row per business day in ``[start, end]`` with the
+last-published value strictly before that date for every series. Two
+lookup helpers expose the same shape to event-time consumers:
+
+- :func:`yield_strictly_before` reads the last value published with
+  ``pub_date < event_date`` -- the convention for pre-meeting features.
+- :func:`yield_on_or_before` reads the last value with
+  ``pub_date <= event_date`` -- the convention for the close-of-day
+  baseline used by forward change targets.
+
+Series
+------
+
+==================== ============================ =================================
+column               FRED series                  units
+==================== ============================ =================================
+``treas_1y``         ``DGS1``                     % (1-year constant maturity)
+``treas_2y``         ``DGS2``                     % (2-year constant maturity)
+``treas_5y``         ``DGS5``                     % (5-year constant maturity)
+``treas_10y``        ``DGS10``                    % (10-year constant maturity)
+``slope_10y_2y``     ``T10Y2Y``                   pct points (10y minus 2y)
+``slope_10y_3m``     ``T10Y3M``                   pct points (10y minus 3m)
+``ff_target_upper``  ``DFEDTARU``                 % (Fed Funds upper bound)
+``ff_target_lower``  ``DFEDTARL``                 % (Fed Funds lower bound)
+==================== ============================ =================================
+
+All eight series publish daily on FRED with a zero-day delay (observation
+date == publication date), so the strict-backward / on-or-before lookups
+operate directly on the reference date without a publication-delay shift.
+
+Pre-2008 the FOMC used a single ``DFEDTAR`` (target rate) series rather
+than the upper/lower band. The bundle here covers 2008-present cleanly;
+earlier history surfaces as nulls and downstream consumers fall back to
+``treas_1y`` as the terminal-rate proxy.
+
+Determinism
+-----------
+
+Same FRED inputs imply the same parquet rows. Output is sorted by
+``as_of_date`` (mergesort, stable) and re-runs produce byte-identical
+parquet under zstd-level-3 + statistics-off + dictionary-off, matching
+the pattern from :mod:`app.data.macro_state`.
+
+CLI
+---
+
+::
+
+    python -m app.data.rates_panel \\
+        --start 2008-01-01 --end today \\
+        --output data/external/fred/rates_panel.parquet
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.services.fred_client import (
+    DEFAULT_CACHE_DIR as FRED_CACHE_DIR,
+    FredSeriesResponse,
+    SOURCES_LOCK_NAME,
+    fetch_fred_series,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_START = "2008-01-01"
+DEFAULT_OUTPUT_NAME = "rates_panel.parquet"
+DEFAULT_LOCK_KEY = "rates_panel"
+
+# FRED series feeding the panel. Order is pinned so the SOURCES.lock
+# entry and tests can iterate the tuple without surprises.
+RATES_SERIES_IDS: tuple[str, ...] = (
+    "DGS1",
+    "DGS2",
+    "DGS5",
+    "DGS10",
+    "T10Y2Y",
+    "T10Y3M",
+    "DFEDTARU",
+    "DFEDTARL",
+)
+
+# All series are daily market-data with a zero publication delay (FRED
+# observation date == publication date for the rates surface).
+PUBLICATION_DELAY_DAYS: int = 0
+
+# Mapping from FRED series id to the parquet column name.
+COLUMN_BY_SERIES: dict[str, str] = {
+    "DGS1": "treas_1y",
+    "DGS2": "treas_2y",
+    "DGS5": "treas_5y",
+    "DGS10": "treas_10y",
+    "T10Y2Y": "slope_10y_2y",
+    "T10Y3M": "slope_10y_3m",
+    "DFEDTARU": "ff_target_upper",
+    "DFEDTARL": "ff_target_lower",
+}
+
+# Output column order. Pinned for determinism + tests.
+COLUMN_ORDER: tuple[str, ...] = (
+    "as_of_date",
+    "treas_1y",
+    "treas_2y",
+    "treas_5y",
+    "treas_10y",
+    "slope_10y_2y",
+    "slope_10y_3m",
+    "ff_target_upper",
+    "ff_target_lower",
+    "publication_delay_days",
+    "data_version",
+)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _DailyObservation:
+    reference_date: _dt.date
+    value: float
+
+
+@dataclass
+class RatesPanelArtifacts:
+    """Returned by :func:`build_rates_panel`."""
+
+    frame: pd.DataFrame
+    fred_series_used: tuple[str, ...]
+    publication_delay_days: int
+    rows_written: int
+    data_version: str
+    value_hash: str
+
+
+@dataclass(frozen=True)
+class RatesPanelLookup:
+    """In-memory view of the rates panel keyed by publication date.
+
+    Constructed once per pipeline run and queried per FOMC event.
+    ``yield_strictly_before`` returns the last value with
+    ``pub_date < target`` (pre-meeting convention). ``yield_on_or_before``
+    returns the last value with ``pub_date <= target`` (close-of-day
+    baseline for forward-change targets).
+    """
+
+    dates_by_column: Mapping[str, tuple[_dt.date, ...]]
+    values_by_column: Mapping[str, tuple[float, ...]]
+
+    def yield_strictly_before(self, column: str, target: _dt.date) -> float | None:
+        dates = self.dates_by_column.get(column)
+        values = self.values_by_column.get(column)
+        if not dates or not values:
+            return None
+        import bisect as _bisect
+
+        idx = _bisect.bisect_left(dates, target)
+        if idx == 0:
+            return None
+        return values[idx - 1]
+
+    def yield_on_or_before(self, column: str, target: _dt.date) -> float | None:
+        dates = self.dates_by_column.get(column)
+        values = self.values_by_column.get(column)
+        if not dates or not values:
+            return None
+        import bisect as _bisect
+
+        idx = _bisect.bisect_right(dates, target)
+        if idx == 0:
+            return None
+        return values[idx - 1]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _clean_float(value: float | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        fv = float(value)
+    except (TypeError, ValueError):
+        return None
+    if fv != fv:  # NaN
+        return None
+    return fv
+
+
+def _daily_observations(series: FredSeriesResponse) -> list[_DailyObservation]:
+    out: list[_DailyObservation] = []
+    for obs in series.observations:
+        if obs.value is None:
+            continue
+        try:
+            d = _dt.date.fromisoformat(obs.date)
+        except ValueError:
+            continue
+        out.append(_DailyObservation(reference_date=d, value=float(obs.value)))
+    out.sort(key=lambda r: r.reference_date)
+    return out
+
+
+def _value_strictly_before(
+    pub_index: Sequence[tuple[_dt.date, float]], as_of: _dt.date
+) -> tuple[_dt.date | None, float | None]:
+    import bisect as _bisect
+
+    if not pub_index:
+        return (None, None)
+    dates = [d for d, _ in pub_index]
+    idx = _bisect.bisect_left(dates, as_of)
+    if idx == 0:
+        return (None, None)
+    pub_date, val = pub_index[idx - 1]
+    return (pub_date, val)
+
+
+def _shifted_publication_index(
+    observations: Sequence[_DailyObservation], *, delay_days: int
+) -> list[tuple[_dt.date, float]]:
+    if delay_days < 0:
+        raise ValueError(f"delay_days must be >= 0, got {delay_days}")
+    return [
+        (obs.reference_date + _dt.timedelta(days=delay_days), float(obs.value))
+        for obs in observations
+    ]
+
+
+def _business_days(start: _dt.date, end: _dt.date) -> list[_dt.date]:
+    out: list[_dt.date] = []
+    d = start
+    while d <= end:
+        if d.weekday() < 5:
+            out.append(d)
+        d += _dt.timedelta(days=1)
+    return out
+
+
+def _round(value: float | None, ndigits: int = 6) -> float | None:
+    if value is None:
+        return None
+    return round(value, ndigits)
+
+
+def _empty_frame() -> pd.DataFrame:
+    return pd.DataFrame({c: pd.Series(dtype="object") for c in COLUMN_ORDER})
+
+
+# ---------------------------------------------------------------------------
+# Top-level builder
+# ---------------------------------------------------------------------------
+
+
+def build_rates_panel(
+    *,
+    start: _dt.date,
+    end: _dt.date,
+    fred_responses: Mapping[str, FredSeriesResponse],
+    as_of_dates: Sequence[_dt.date] | None = None,
+    publication_delay_days: int = PUBLICATION_DELAY_DAYS,
+) -> RatesPanelArtifacts:
+    """Assemble the rates panel frame.
+
+    Parameters
+    ----------
+    start, end:
+        Inclusive bounds on ``as_of_date``. When ``as_of_dates`` is None,
+        emits one row per business day in ``[start, end]``.
+    fred_responses:
+        Pre-loaded FRED responses keyed by series id. Must cover every id
+        in :data:`RATES_SERIES_IDS`.
+    as_of_dates:
+        Optional explicit list of as-of dates. When supplied, the frame
+        has one row per supplied date (sorted, deduped).
+    publication_delay_days:
+        Days added to each daily observation's reference date before the
+        as-of join. Defaults to 0 (the rates surface publishes same-day).
+    """
+
+    missing = [sid for sid in RATES_SERIES_IDS if sid not in fred_responses]
+    if missing:
+        raise KeyError(f"Missing FRED series for rates_panel: {missing}")
+
+    panel_indices: dict[str, list[tuple[_dt.date, float]]] = {}
+    for series_id in RATES_SERIES_IDS:
+        observations = _daily_observations(fred_responses[series_id])
+        panel_indices[series_id] = _shifted_publication_index(
+            observations, delay_days=publication_delay_days
+        )
+
+    if as_of_dates is None:
+        target_dates = _business_days(start, end)
+    else:
+        target_dates = sorted({d for d in as_of_dates if start <= d <= end})
+
+    rows: list[dict[str, Any]] = []
+    for d in target_dates:
+        payload: dict[str, Any] = {"as_of_date": d.isoformat()}
+        for series_id, column_name in COLUMN_BY_SERIES.items():
+            _, val = _value_strictly_before(panel_indices[series_id], d)
+            payload[column_name] = _round(_clean_float(val))
+        payload["publication_delay_days"] = int(publication_delay_days)
+        rows.append(payload)
+
+    data_version = _data_version_hash(
+        fred_responses,
+        publication_delay_days=publication_delay_days,
+        target_dates=target_dates,
+    )
+    for r in rows:
+        r["data_version"] = data_version
+
+    frame = pd.DataFrame(rows) if rows else _empty_frame()
+    if not frame.empty:
+        frame = frame.sort_values("as_of_date", kind="mergesort").reset_index(drop=True)
+        frame = frame[list(COLUMN_ORDER)]
+
+    return RatesPanelArtifacts(
+        frame=frame,
+        fred_series_used=tuple(sorted(fred_responses)),
+        publication_delay_days=int(publication_delay_days),
+        rows_written=len(rows),
+        data_version=data_version,
+        value_hash=dataframe_value_hash(frame),
+    )
+
+
+def _data_version_hash(
+    series_responses: Mapping[str, FredSeriesResponse],
+    *,
+    publication_delay_days: int,
+    target_dates: Sequence[_dt.date],
+) -> str:
+    parts: list[str] = [f"delay={publication_delay_days}"]
+    for series_id in sorted(series_responses):
+        resp = series_responses[series_id]
+        parts.append(f"{series_id}|{resp.observation_end}|{resp.count}")
+    parts.append(f"target_n={len(target_dates)}")
+    if target_dates:
+        parts.append(f"target_first={target_dates[0].isoformat()}")
+        parts.append(f"target_last={target_dates[-1].isoformat()}")
+    digest = hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def dataframe_value_hash(frame: pd.DataFrame) -> str:
+    if frame.empty:
+        return hashlib.sha256(b"empty").hexdigest()
+    cols = [c for c in COLUMN_ORDER if c in frame.columns]
+    if not cols:
+        cols = list(frame.columns)
+    ordered = frame[cols].copy()
+    str_rows = ordered.astype(object).map(
+        lambda v: "" if v is None or (isinstance(v, float) and v != v) else str(v)
+    )
+    serialised = ["|".join(str(v) for v in row) for row in str_rows.to_numpy().tolist()]
+    serialised.sort()
+    payload = "\n".join(serialised) + "\n" + "|".join(cols)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Parquet writer + SOURCES.lock update
+# ---------------------------------------------------------------------------
+
+
+def _sha256_of_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def write_rates_panel_parquet(frame: pd.DataFrame, output_path: Path) -> str:
+    """Write deterministically and return the sha256 of the parquet bytes."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_parquet(
+        output_path,
+        engine="pyarrow",
+        index=False,
+        compression="zstd",
+        compression_level=3,
+        write_statistics=False,
+        use_dictionary=False,
+    )
+    return _sha256_of_file(output_path)
+
+
+def update_sources_lock(
+    *,
+    lock_path: Path,
+    artifacts: RatesPanelArtifacts,
+    parquet_path: Path,
+    parquet_sha256: str,
+    lock_key: str = DEFAULT_LOCK_KEY,
+) -> None:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    existing: dict[str, Any] = {}
+    if lock_path.exists():
+        try:
+            existing = json.loads(lock_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            existing = {}
+    entry = {
+        "parquet_path": str(parquet_path.name),
+        "sha256": parquet_sha256,
+        "fred_series": list(artifacts.fred_series_used),
+        "rows": int(artifacts.rows_written),
+        "publication_delay_days": int(artifacts.publication_delay_days),
+        "columns": dict(COLUMN_BY_SERIES),
+        "data_version": artifacts.data_version,
+        "value_hash": artifacts.value_hash,
+        "retrieved_at_utc": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+    }
+    existing[lock_key] = entry
+    lock_path.write_text(json.dumps(existing, indent=2, sort_keys=True), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Lookup loader (read-side helper for event_dataset_builder)
+# ---------------------------------------------------------------------------
+
+
+def load_rates_panel_lookup(parquet_path: Path) -> RatesPanelLookup:
+    """Read ``rates_panel.parquet`` and build the in-memory lookup.
+
+    Falls back to an empty lookup when the file is missing -- callers
+    that depend on the rates panel pass through the strict-backward /
+    forward queries which return ``None`` for every column, and the
+    event-row builder records the missing values without aborting the
+    whole pipeline. This mirrors how the linguistic and credibility
+    loaders degrade when their inputs are absent.
+    """
+
+    if not parquet_path.exists():
+        return RatesPanelLookup(dates_by_column={}, values_by_column={})
+
+    frame = pd.read_parquet(parquet_path)
+    if frame.empty or "as_of_date" not in frame.columns:
+        return RatesPanelLookup(dates_by_column={}, values_by_column={})
+
+    frame = frame.sort_values("as_of_date", kind="mergesort").reset_index(drop=True)
+    parsed_dates = [_dt.date.fromisoformat(str(d)[:10]) for d in frame["as_of_date"]]
+
+    dates_by_column: dict[str, tuple[_dt.date, ...]] = {}
+    values_by_column: dict[str, tuple[float, ...]] = {}
+    for column in COLUMN_BY_SERIES.values():
+        if column not in frame.columns:
+            continue
+        pairs = [
+            (d, float(v))
+            for d, v in zip(parsed_dates, frame[column].tolist())
+            if v is not None and v == v  # filter NaN
+        ]
+        dates_by_column[column] = tuple(p[0] for p in pairs)
+        values_by_column[column] = tuple(p[1] for p in pairs)
+
+    return RatesPanelLookup(
+        dates_by_column=dates_by_column,
+        values_by_column=values_by_column,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _hydrate_fred_responses(
+    *,
+    start: _dt.date,
+    end: _dt.date,
+    cache_dir: Path,
+    transport: httpx.BaseTransport | None = None,
+    force_refresh: bool = False,
+) -> dict[str, FredSeriesResponse]:
+    """Fetch every required series via :func:`fetch_fred_series`."""
+
+    out: dict[str, FredSeriesResponse] = {}
+    for sid in RATES_SERIES_IDS:
+        out[sid] = fetch_fred_series(
+            sid,
+            start=start.isoformat(),
+            end=end.isoformat(),
+            cache_dir=cache_dir,
+            transport=transport,
+            force_refresh=force_refresh,
+        )
+    return out
+
+
+def _parse_end(value: str) -> _dt.date:
+    if value.lower() == "today":
+        return _dt.date.today()
+    return _dt.date.fromisoformat(value)
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build the daily rates panel parquet at "
+            "data/external/fred/rates_panel.parquet for the #291 rates-complex heads."
+        ),
+    )
+    parser.add_argument("--start", default=DEFAULT_START)
+    parser.add_argument("--end", default="today")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT_NAME)
+    parser.add_argument("--cache-dir", default=str(FRED_CACHE_DIR))
+    parser.add_argument("--force-refresh", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    start = _dt.date.fromisoformat(args.start)
+    end = _parse_end(args.end)
+    cache_dir = Path(args.cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    responses = _hydrate_fred_responses(
+        start=start,
+        end=end,
+        cache_dir=cache_dir,
+        force_refresh=args.force_refresh,
+    )
+
+    artifacts = build_rates_panel(
+        start=start,
+        end=end,
+        fred_responses=responses,
+    )
+
+    output_path = Path(args.output)
+    if not output_path.is_absolute():
+        output_path = cache_dir / output_path
+    parquet_sha = write_rates_panel_parquet(artifacts.frame, output_path)
+    update_sources_lock(
+        lock_path=cache_dir / SOURCES_LOCK_NAME,
+        artifacts=artifacts,
+        parquet_path=output_path,
+        parquet_sha256=parquet_sha,
+    )
+
+    print(f"[rates-panel] rows: {artifacts.rows_written}")
+    print(f"[rates-panel] data_version: {artifacts.data_version}")
+    print(f"[rates-panel] parquet sha256: {parquet_sha}")
+    print(f"[rates-panel] series: {', '.join(artifacts.fred_series_used)}")
+    if not artifacts.frame.empty:
+        tail = artifacts.frame.tail(3)
+        print("[rates-panel] 3 most recent rows:")
+        for _, row in tail.iterrows():
+            print(
+                "  {d} 1y={y1} 2y={y2} 5y={y5} 10y={y10} 10y-2y={s2} 10y-3m={s3} ffu={u} ffl={l}".format(
+                    d=row["as_of_date"],
+                    y1=_fmt(row["treas_1y"]),
+                    y2=_fmt(row["treas_2y"]),
+                    y5=_fmt(row["treas_5y"]),
+                    y10=_fmt(row["treas_10y"]),
+                    s2=_fmt(row["slope_10y_2y"]),
+                    s3=_fmt(row["slope_10y_3m"]),
+                    u=_fmt(row["ff_target_upper"]),
+                    l=_fmt(row["ff_target_lower"]),
+                )
+            )
+    return 0
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "None"
+    try:
+        return f"{float(value):.3f}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/app/data/rates_panel.py
+++ b/backend/app/data/rates_panel.py
@@ -226,15 +226,27 @@ def _daily_observations(series: FredSeriesResponse) -> list[_DailyObservation]:
     return out
 
 
-def _value_strictly_before(
+def _value_on_or_before(
     pub_index: Sequence[tuple[_dt.date, float]], as_of: _dt.date
 ) -> tuple[_dt.date | None, float | None]:
+    """Return the latest ``(pub_date, value)`` with ``pub_date <= as_of``.
+
+    The panel stores this raw "close as of date" value at each parquet
+    row. :class:`RatesPanelLookup` then layers strict-backward or
+    on-or-before semantics on top via its own bisect calls, so the
+    panel build itself must NOT pre-apply a shift — doing so would
+    double-shift every value returned by :meth:`yield_on_or_before`
+    and :meth:`yield_strictly_before` (an earlier draft of this
+    module used strict-before semantics in the build and silently
+    emitted values one trading day stale).
+    """
+
     import bisect as _bisect
 
     if not pub_index:
         return (None, None)
     dates = [d for d, _ in pub_index]
-    idx = _bisect.bisect_left(dates, as_of)
+    idx = _bisect.bisect_right(dates, as_of)
     if idx == 0:
         return (None, None)
     pub_date, val = pub_index[idx - 1]
@@ -323,7 +335,10 @@ def build_rates_panel(
     for d in target_dates:
         payload: dict[str, Any] = {"as_of_date": d.isoformat()}
         for series_id, column_name in COLUMN_BY_SERIES.items():
-            _, val = _value_strictly_before(panel_indices[series_id], d)
+            # Store the close-of-day value as of `d`. Strict-backward
+            # semantics are applied by RatesPanelLookup at query time,
+            # so pre-shifting here would double-shift every consumer.
+            _, val = _value_on_or_before(panel_indices[series_id], d)
             payload[column_name] = _round(_clean_float(val))
         payload["publication_delay_days"] = int(publication_delay_days)
         rows.append(payload)

--- a/backend/app/data/schemas.py
+++ b/backend/app/data/schemas.py
@@ -578,6 +578,46 @@ _EVENT_ROW_COLUMNS: dict[str, Column] = {
         float, nullable=True, required=True, coerce=True
     ),
     "intra_meeting_factor_shift": Column(float, nullable=True, required=True, coerce=True),
+    # ----- #291 rates-complex forward targets (raw bps) -----
+    # required=False so older events.parquet files (pre #291) validate
+    # without the columns present. The pipeline emits None when the
+    # rates panel is unavailable so the schema stays nullable.
+    "yield_2y_change_5d": Column(float, nullable=True, required=False, coerce=True),
+    "yield_5y_change_5d": Column(float, nullable=True, required=False, coerce=True),
+    "terminal_rate_change_5d": Column(float, nullable=True, required=False, coerce=True),
+    # ----- #291 pre-meeting expectation features (strict-backward at t-1) -----
+    "pre_meeting_yield_1y": Column(float, nullable=True, required=False, coerce=True),
+    "pre_meeting_yield_2y": Column(float, nullable=True, required=False, coerce=True),
+    "pre_meeting_yield_5y": Column(float, nullable=True, required=False, coerce=True),
+    "pre_meeting_yield_10y": Column(float, nullable=True, required=False, coerce=True),
+    "pre_meeting_slope_10y_2y": Column(float, nullable=True, required=False, coerce=True),
+    "pre_meeting_slope_10y_3m": Column(float, nullable=True, required=False, coerce=True),
+    "pre_meeting_trailing_2y_yield_change_5d_bps": Column(
+        float, nullable=True, required=False, coerce=True
+    ),
+    "pre_meeting_implied_next_move_bps": Column(
+        float, nullable=True, required=False, coerce=True
+    ),
+    "pre_meeting_implied_hike_prob": Column(
+        float, nullable=True, required=False, coerce=True
+    ),
+    "pre_meeting_implied_cut_prob": Column(
+        float, nullable=True, required=False, coerce=True
+    ),
+    "pre_meeting_implied_pause_prob": Column(
+        float, nullable=True, required=False, coerce=True
+    ),
+    "pre_meeting_days_since_last_rate_change": Column(
+        float,
+        nullable=True,
+        required=False,
+        coerce=True,
+        description=(
+            "Calendar-day gap since the last DFEDTARU step change at t-1; "
+            "stored as float so pandas keeps the nullable semantics across "
+            "pyarrow round-trips (int columns cannot hold NaN)."
+        ),
+    ),
 }
 
 

--- a/backend/app/evaluation/regression_metrics.py
+++ b/backend/app/evaluation/regression_metrics.py
@@ -1,0 +1,357 @@
+"""Regression-head walk-forward metrics with block-bootstrap CIs (#291).
+
+The rates-complex heads added by #292 predict yield changes in raw basis
+points rather than a discrete class label. Reporting parity with the
+existing classification heads needs three metrics computed on the same
+walk-forward partition:
+
+- :func:`mae_bps` — mean absolute error in basis points (natural finance
+  unit; comparable across folds without scale normalization).
+- :func:`directional_accuracy` — share of rows where the predicted sign
+  matches the observed sign. Zero-magnitude predictions or observations
+  contribute via the :data:`ZERO_TOLERANCE_BPS` rule below.
+- :func:`r_squared` — coefficient of determination against the
+  observation mean. Comparable across folds when the target scale is
+  stationary (basis points are scale-stable across the 2008-present
+  window).
+
+Each metric ships with a :func:`with_block_bootstrap_ci` wrapper that
+emits a :class:`app.evaluation.bootstrap.BootstrapCI` over a row-level
+resample. Block size defaults to 5 (the post-event horizon used by the
+forward-yield targets) so the resampled rows share the temporal
+auto-correlation structure of the original walk-forward partition.
+
+The metrics are model-agnostic: the input is two equal-length numeric
+sequences (``predicted``, ``observed``) plus an optional row weight.
+This keeps the helpers usable from every training path (forecaster,
+LSTM baseline, regression-ensemble aggregator) without pulling a model
+dependency.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from app.evaluation.bootstrap import BootstrapCI, block_bootstrap_ci
+
+# A predicted or observed value with absolute magnitude below this
+# threshold (in bps) is treated as a "no-move" signal for the directional
+# accuracy metric. Picked at 0.5 bps because the FOMC moves in 25-bp
+# increments and rates desks colloquially treat moves below 1 bp as
+# noise; the half-bp threshold sits well below any economically
+# meaningful signal while excluding pure floating-point dither.
+ZERO_TOLERANCE_BPS: float = 0.5
+
+# Default block size for the moving-block bootstrap. Matches the 5-day
+# post-event horizon used by the forward-yield targets so the resampled
+# rows preserve the autocorrelation structure of the underlying
+# event-window panel.
+DEFAULT_BLOCK_SIZE: int = 5
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_paired(predicted: Sequence[float], observed: Sequence[float]) -> int:
+    if len(predicted) != len(observed):
+        raise ValueError(
+            f"predicted and observed must be equal length; "
+            f"got {len(predicted)} vs {len(observed)}"
+        )
+    return len(predicted)
+
+
+def _clean_pairs(
+    predicted: Sequence[float], observed: Sequence[float]
+) -> list[tuple[float, float]]:
+    pairs: list[tuple[float, float]] = []
+    for p, o in zip(predicted, observed):
+        if p is None or o is None:
+            continue
+        try:
+            pf = float(p)
+            of = float(o)
+        except (TypeError, ValueError):
+            continue
+        if not (math.isfinite(pf) and math.isfinite(of)):
+            continue
+        pairs.append((pf, of))
+    return pairs
+
+
+def _sign(value: float) -> int:
+    """Three-way sign with a no-move band around zero."""
+
+    if value > ZERO_TOLERANCE_BPS:
+        return 1
+    if value < -ZERO_TOLERANCE_BPS:
+        return -1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Point estimates
+# ---------------------------------------------------------------------------
+
+
+def mae_bps(predicted: Sequence[float], observed: Sequence[float]) -> float:
+    """Mean absolute error of paired predictions, in basis points.
+
+    Returns ``nan`` when no finite pair survives the cleaning pass.
+    Inputs are assumed to already carry basis-point units; the function
+    does not rescale.
+    """
+
+    _validate_paired(predicted, observed)
+    pairs = _clean_pairs(predicted, observed)
+    if not pairs:
+        return float("nan")
+    return sum(abs(p - o) for p, o in pairs) / len(pairs)
+
+
+def directional_accuracy(
+    predicted: Sequence[float], observed: Sequence[float]
+) -> float:
+    """Share of rows where the predicted sign matches the observed sign.
+
+    Uses the three-way sign with a :data:`ZERO_TOLERANCE_BPS` no-move
+    band, so a row where both predicted and observed are within the
+    band counts as a match (both classified as "no move"). The
+    convention treats a directional miss (predicted up, observed
+    down) and a confidence miss (predicted up, observed flat) as
+    equally wrong.
+
+    Returns ``nan`` when no finite pair survives the cleaning pass.
+    """
+
+    _validate_paired(predicted, observed)
+    pairs = _clean_pairs(predicted, observed)
+    if not pairs:
+        return float("nan")
+    correct = sum(1 for p, o in pairs if _sign(p) == _sign(o))
+    return correct / len(pairs)
+
+
+def r_squared(predicted: Sequence[float], observed: Sequence[float]) -> float:
+    """Coefficient of determination against the observation mean.
+
+    Returns ``nan`` when fewer than two finite pairs survive (R^2 is
+    undefined on a single observation). Returns 1.0 when the
+    observations are constant and predictions match exactly; returns
+    a large negative number when predictions are systematically biased
+    relative to the observation mean.
+    """
+
+    _validate_paired(predicted, observed)
+    pairs = _clean_pairs(predicted, observed)
+    if len(pairs) < 2:
+        return float("nan")
+    obs = [o for _, o in pairs]
+    mean_obs = sum(obs) / len(obs)
+    ss_tot = sum((o - mean_obs) ** 2 for o in obs)
+    ss_res = sum((o - p) ** 2 for p, o in pairs)
+    if ss_tot <= 1e-18:
+        # Constant observation series. Define R^2 = 1 when residuals
+        # are exactly zero, else 0 (the typical sklearn convention is
+        # NaN here, but a 0 / 1 binary keeps the metric monotone in
+        # the "did we match a constant?" sense without polluting the
+        # aggregator with NaN handling).
+        return 1.0 if ss_res <= 1e-18 else 0.0
+    return 1.0 - ss_res / ss_tot
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap CI wrappers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RegressionMetricCI:
+    """Point estimate + block-bootstrap CI for a regression-head metric."""
+
+    name: str
+    point: float
+    lo: float
+    hi: float
+    coverage: float
+    n_resamples: int
+    block_size: int
+    n_observations: int
+
+    def to_dict(self) -> dict[str, float | int | str]:
+        return {
+            "name": self.name,
+            "point": self.point,
+            "lo": self.lo,
+            "hi": self.hi,
+            "coverage": self.coverage,
+            "n_resamples": self.n_resamples,
+            "block_size": self.block_size,
+            "n_observations": self.n_observations,
+        }
+
+
+def with_block_bootstrap_ci(
+    *,
+    name: str,
+    predicted: Sequence[float],
+    observed: Sequence[float],
+    statistic: str,
+    block_size: int = DEFAULT_BLOCK_SIZE,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    seed: int = 11,
+) -> RegressionMetricCI:
+    """Resample row-level pair indices via the moving-block bootstrap.
+
+    ``statistic`` selects which point estimate to compute on each
+    resample. Supported values: ``"mae_bps"``, ``"directional_accuracy"``,
+    ``"r_squared"``. Each resample draws contiguous index blocks (length
+    ``block_size``) with replacement until the resample length matches
+    the original sample.
+    """
+
+    _validate_paired(predicted, observed)
+    pairs = _clean_pairs(predicted, observed)
+    if not pairs:
+        nan = float("nan")
+        return RegressionMetricCI(
+            name=name,
+            point=nan,
+            lo=nan,
+            hi=nan,
+            coverage=coverage,
+            n_resamples=n_resamples,
+            block_size=block_size,
+            n_observations=0,
+        )
+
+    point_fns = {
+        "mae_bps": lambda preds, obs: mae_bps(preds, obs),
+        "directional_accuracy": lambda preds, obs: directional_accuracy(preds, obs),
+        "r_squared": lambda preds, obs: r_squared(preds, obs),
+    }
+    if statistic not in point_fns:
+        raise ValueError(
+            f"unsupported statistic={statistic!r}; "
+            f"expected one of {sorted(point_fns)}"
+        )
+
+    point_fn = point_fns[statistic]
+    cleaned_preds = [p for p, _ in pairs]
+    cleaned_obs = [o for _, o in pairs]
+    point = point_fn(cleaned_preds, cleaned_obs)
+
+    # Reuse the block-bootstrap index generator from
+    # :mod:`app.evaluation.bootstrap` so the resampling distribution
+    # matches the classification-head metrics' CI construction.
+    import random
+
+    rng = random.Random(seed)
+    samples: list[float] = []
+    n = len(pairs)
+    # Compute the metric on each resample.
+    from app.evaluation.bootstrap import _resample_indices  # type: ignore[attr-defined]
+
+    for _ in range(n_resamples):
+        idx = _resample_indices(n, block_size, rng)
+        resample_preds = [cleaned_preds[i] for i in idx]
+        resample_obs = [cleaned_obs[i] for i in idx]
+        samples.append(point_fn(resample_preds, resample_obs))
+
+    samples = [s for s in samples if math.isfinite(s)]
+    if not samples:
+        nan = float("nan")
+        return RegressionMetricCI(
+            name=name,
+            point=point,
+            lo=nan,
+            hi=nan,
+            coverage=coverage,
+            n_resamples=n_resamples,
+            block_size=block_size,
+            n_observations=n,
+        )
+
+    samples.sort()
+    alpha = (1.0 - coverage) / 2.0
+    lo_idx = int(alpha * len(samples))
+    hi_idx = int((1.0 - alpha) * len(samples)) - 1
+    lo_idx = max(0, min(len(samples) - 1, lo_idx))
+    hi_idx = max(0, min(len(samples) - 1, hi_idx))
+    return RegressionMetricCI(
+        name=name,
+        point=point,
+        lo=samples[lo_idx],
+        hi=samples[hi_idx],
+        coverage=coverage,
+        n_resamples=n_resamples,
+        block_size=block_size,
+        n_observations=n,
+    )
+
+
+def regression_metric_panel(
+    *,
+    predicted: Sequence[float],
+    observed: Sequence[float],
+    block_size: int = DEFAULT_BLOCK_SIZE,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    seed: int = 11,
+) -> dict[str, RegressionMetricCI]:
+    """Compute MAE-bps, directional accuracy, and R^2 with bootstrap CIs."""
+
+    return {
+        "mae_bps": with_block_bootstrap_ci(
+            name="mae_bps",
+            predicted=predicted,
+            observed=observed,
+            statistic="mae_bps",
+            block_size=block_size,
+            n_resamples=n_resamples,
+            coverage=coverage,
+            seed=seed,
+        ),
+        "directional_accuracy": with_block_bootstrap_ci(
+            name="directional_accuracy",
+            predicted=predicted,
+            observed=observed,
+            statistic="directional_accuracy",
+            block_size=block_size,
+            n_resamples=n_resamples,
+            coverage=coverage,
+            seed=seed,
+        ),
+        "r_squared": with_block_bootstrap_ci(
+            name="r_squared",
+            predicted=predicted,
+            observed=observed,
+            statistic="r_squared",
+            block_size=block_size,
+            n_resamples=n_resamples,
+            coverage=coverage,
+            seed=seed,
+        ),
+    }
+
+
+# Re-export the underlying CI dataclass for callers that want to mix
+# regression-head CIs with the existing classification-head CIs from
+# :mod:`app.evaluation.bootstrap`.
+__all__ = (
+    "BootstrapCI",
+    "DEFAULT_BLOCK_SIZE",
+    "RegressionMetricCI",
+    "ZERO_TOLERANCE_BPS",
+    "block_bootstrap_ci",
+    "directional_accuracy",
+    "mae_bps",
+    "r_squared",
+    "regression_metric_panel",
+    "with_block_bootstrap_ci",
+)

--- a/backend/app/evaluation/regression_metrics.py
+++ b/backend/app/evaluation/regression_metrics.py
@@ -31,7 +31,7 @@ dependency.
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 from app.evaluation.bootstrap import BootstrapCI, block_bootstrap_ci
@@ -230,10 +230,12 @@ def with_block_bootstrap_ci(  # noqa: PLR0913 — keyword-only args mirror the b
             n_observations=0,
         )
 
-    point_fns = {
-        "mae_bps": lambda preds, obs: mae_bps(preds, obs),
-        "directional_accuracy": lambda preds, obs: directional_accuracy(preds, obs),
-        "r_squared": lambda preds, obs: r_squared(preds, obs),
+    point_fns: dict[
+        str, Callable[[Sequence[float], Sequence[float]], float]
+    ] = {
+        "mae_bps": mae_bps,
+        "directional_accuracy": directional_accuracy,
+        "r_squared": r_squared,
     }
     if statistic not in point_fns:
         raise ValueError(
@@ -255,7 +257,7 @@ def with_block_bootstrap_ci(  # noqa: PLR0913 — keyword-only args mirror the b
     samples: list[float] = []
     n = len(pairs)
     # Compute the metric on each resample.
-    from app.evaluation.bootstrap import _resample_indices  # type: ignore[attr-defined]
+    from app.evaluation.bootstrap import _resample_indices
 
     for _ in range(n_resamples):
         idx = _resample_indices(n, block_size, rng)

--- a/backend/app/evaluation/regression_metrics.py
+++ b/backend/app/evaluation/regression_metrics.py
@@ -195,7 +195,7 @@ class RegressionMetricCI:
         }
 
 
-def with_block_bootstrap_ci(
+def with_block_bootstrap_ci(  # noqa: PLR0913 — keyword-only args mirror the bootstrap.block_bootstrap_ci surface; collapsing into a config dataclass would obscure the call sites.
     *,
     name: str,
     predicted: Sequence[float],
@@ -295,7 +295,7 @@ def with_block_bootstrap_ci(
     )
 
 
-def regression_metric_panel(
+def regression_metric_panel(  # noqa: PLR0913 — keyword-only resample knobs forwarded to three with_block_bootstrap_ci calls; a config dataclass would just rename the same fields.
     *,
     predicted: Sequence[float],
     observed: Sequence[float],

--- a/tests/unit/test_forward_yield_change_strict_forward.py
+++ b/tests/unit/test_forward_yield_change_strict_forward.py
@@ -1,0 +1,146 @@
+"""Pin strict-forward semantics for the rates-complex forward targets (#291).
+
+The forward yield-change targets (``yield_2y_change_5d``,
+``yield_5y_change_5d``, ``terminal_rate_change_5d``) must mirror the
+convention pinned by ``test_forward_realized_vol_strict_forward.py`` for
+the existing vol-regime target: ``yield[t-1]`` never appears in the
+target window, ``yield[t]`` (the FOMC announcement-day close) is the
+baseline, and ``yield[t+horizon]`` is the endpoint.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+import pytest
+
+from app.data.rates_event_features import (
+    FORWARD_TARGET_COLUMNS,
+    forward_yield_change_bps,
+)
+from app.data.rates_panel import RatesPanelLookup
+
+
+def _dense_business_calendar(start: _dt.date, n: int) -> list[_dt.date]:
+    days: list[_dt.date] = []
+    cursor = start
+    while len(days) < n:
+        if cursor.weekday() < 5:
+            days.append(cursor)
+        cursor += _dt.timedelta(days=1)
+    return days
+
+
+def _build_lookup(
+    column: str, observations: list[tuple[_dt.date, float]]
+) -> RatesPanelLookup:
+    pairs = sorted(observations)
+    return RatesPanelLookup(
+        dates_by_column={column: tuple(d for d, _ in pairs)},
+        values_by_column={column: tuple(v for _, v in pairs)},
+    )
+
+
+def test_forward_change_uses_event_day_as_baseline_not_prior_day() -> None:
+    """``yield[t-1]`` must NOT participate in the target window.
+
+    Construct a series where the announcement-day jump is 100 bps
+    (DGS2 jumps from 4.00 to 5.00 between t-1 and t) and every
+    strictly-forward observation is flat at 5.00. Under the strict-
+    forward convention the 5-day change is exactly zero (baseline =
+    endpoint = 5.00). Under the deprecated ``yield[t+5] - yield[t-1]``
+    convention it would be +100 bps.
+    """
+
+    calendar = _dense_business_calendar(_dt.date(2026, 1, 5), 30)
+    event = calendar[10]  # t at index 10
+    observations = []
+    for i, day in enumerate(calendar):
+        if i < 10:
+            observations.append((day, 4.00))  # pre-event flat at 4.00
+        else:
+            observations.append((day, 5.00))  # event day + post-event flat at 5.00
+
+    lookup = _build_lookup("treas_2y", observations)
+    bps = forward_yield_change_bps(
+        lookup, calendar, column="treas_2y", event_date=event, horizon=5
+    )
+    assert bps == pytest.approx(0.0, abs=1e-9), (
+        "Strict-forward yield change with constant post-event yields "
+        f"must collapse to 0; got {bps}. A non-zero value means the "
+        "announcement-day jump leaked into the target window."
+    )
+
+
+def test_forward_change_endpoint_is_t_plus_horizon_close() -> None:
+    """The endpoint must be ``yield[t+horizon]``, not ``yield[t+horizon-1]``."""
+
+    calendar = _dense_business_calendar(_dt.date(2026, 1, 5), 30)
+    event = calendar[10]
+    observations = []
+    for i, day in enumerate(calendar):
+        if i <= 14:
+            observations.append((day, 4.50))  # t=10 .. t+4 flat at 4.50
+        elif i == 15:
+            observations.append((day, 4.75))  # t+5 jumps to 4.75 (+25 bps)
+        else:
+            observations.append((day, 4.75))
+
+    lookup = _build_lookup("treas_2y", observations)
+    bps = forward_yield_change_bps(
+        lookup, calendar, column="treas_2y", event_date=event, horizon=5
+    )
+    assert bps == pytest.approx(25.0, abs=1e-9), (
+        f"5-day forward change should be +25 bps (4.50 → 4.75); got {bps}."
+    )
+
+
+def test_forward_change_returns_none_at_end_of_calendar() -> None:
+    """An event within ``horizon`` trading days of the calendar end yields None."""
+
+    calendar = _dense_business_calendar(_dt.date(2026, 1, 5), 12)
+    event = calendar[10]  # only 1 trading day after t in the calendar
+    observations = [(day, 4.50) for day in calendar]
+
+    lookup = _build_lookup("treas_2y", observations)
+    bps = forward_yield_change_bps(
+        lookup, calendar, column="treas_2y", event_date=event, horizon=5
+    )
+    assert bps is None
+
+
+def test_forward_change_returns_none_when_column_missing() -> None:
+    """A column absent from the lookup degrades to None per row."""
+
+    calendar = _dense_business_calendar(_dt.date(2026, 1, 5), 30)
+    event = calendar[10]
+    lookup = RatesPanelLookup(dates_by_column={}, values_by_column={})
+
+    for fred_column, _ in FORWARD_TARGET_COLUMNS:
+        assert forward_yield_change_bps(
+            lookup, calendar, column=fred_column, event_date=event, horizon=5
+        ) is None
+
+
+def test_forward_change_uses_strict_forward_for_non_trading_day_event() -> None:
+    """A weekend event date should snap forward to the next trading day."""
+
+    calendar = _dense_business_calendar(_dt.date(2026, 1, 5), 30)
+    # Calendar starts on Mon 2026-01-05; calendar[4] is Fri 2026-01-09.
+    # Adding two calendar days lands on Sun 2026-01-11; ``t`` then
+    # snaps to calendar[5] = Mon 2026-01-12 as the first trading day
+    # on or after the event date.
+    sunday_event = calendar[4] + _dt.timedelta(days=2)
+    assert sunday_event.weekday() == 6, "test setup: event date must be a Sunday"
+
+    observations = [(day, 4.00 + 0.1 * i) for i, day in enumerate(calendar)]
+    # values: 4.0, 4.1, 4.2, ..., monotonically rising by 10 bps per
+    # trading day. With t snapped to calendar[5] (yield 4.5),
+    # t+5 = calendar[10] (yield 5.0). Strict-forward change = +50 bps.
+    lookup = _build_lookup("treas_2y", observations)
+    bps = forward_yield_change_bps(
+        lookup, calendar, column="treas_2y", event_date=sunday_event, horizon=5
+    )
+    assert bps == pytest.approx(50.0, abs=1e-9), (
+        f"Strict-forward snap should produce +50 bps; got {bps}."
+    )

--- a/tests/unit/test_pre_meeting_features.py
+++ b/tests/unit/test_pre_meeting_features.py
@@ -1,0 +1,206 @@
+"""Pin strict-backward semantics for the pre-meeting expectation features (#291)."""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+import pytest
+
+from app.data.rates_event_features import (
+    HALF_MOVE_BPS,
+    STANDARD_MOVE_BPS,
+    compute_pre_meeting_features,
+    days_since_last_rate_change,
+    implied_move_probabilities,
+    implied_next_move_bps,
+    trailing_yield_change_bps,
+)
+from app.data.rates_panel import RatesPanelLookup
+
+
+def _dense_business_calendar(start: _dt.date, n: int) -> list[_dt.date]:
+    days: list[_dt.date] = []
+    cursor = start
+    while len(days) < n:
+        if cursor.weekday() < 5:
+            days.append(cursor)
+        cursor += _dt.timedelta(days=1)
+    return days
+
+
+def _build_lookup(
+    columns: dict[str, list[tuple[_dt.date, float]]],
+) -> RatesPanelLookup:
+    dates: dict[str, tuple[_dt.date, ...]] = {}
+    values: dict[str, tuple[float, ...]] = {}
+    for column, observations in columns.items():
+        pairs = sorted(observations)
+        dates[column] = tuple(d for d, _ in pairs)
+        values[column] = tuple(v for _, v in pairs)
+    return RatesPanelLookup(dates_by_column=dates, values_by_column=values)
+
+
+def test_pre_meeting_features_never_consume_event_day_observation() -> None:
+    """No pre-meeting feature may read a yield published on event_date itself.
+
+    Construct a series where the announcement-day yield jumps to a
+    sentinel value (999.0). If any pre-meeting feature absorbs it the
+    contract has regressed.
+    """
+
+    calendar = _dense_business_calendar(_dt.date(2026, 1, 5), 30)
+    event = calendar[15]
+    observations: dict[str, list[tuple[_dt.date, float]]] = {}
+    for column in (
+        "treas_1y",
+        "treas_2y",
+        "treas_5y",
+        "treas_10y",
+        "slope_10y_2y",
+        "slope_10y_3m",
+        "ff_target_upper",
+    ):
+        observations[column] = []
+        for i, day in enumerate(calendar):
+            if day < event:
+                # Pre-event: stable plausible level so the strict-backward
+                # answer is a real number, not the sentinel.
+                observations[column].append((day, 1.00))
+            else:
+                # Event day + after: sentinel that no strict-backward
+                # feature is allowed to read.
+                observations[column].append((day, 999.0))
+
+    lookup = _build_lookup(observations)
+    features = compute_pre_meeting_features(lookup, calendar, event_date=event)
+
+    for field, value in features.__dict__.items():
+        if value is None:
+            continue
+        # None of the strict-backward features may equal the sentinel
+        # or anywhere near 999. The trailing change is in bps, and
+        # implied probabilities are bounded in [0, 1], so the absolute
+        # ceiling check below is loose enough to catch any leak without
+        # false positives.
+        assert abs(value) < 500.0, (
+            f"Pre-meeting feature {field!r} leaked the sentinel "
+            f"event-day observation (value={value})"
+        )
+
+
+def test_trailing_yield_change_uses_strict_backward_endpoints() -> None:
+    """`trailing_yield_change_bps` reads the t-1 / t-6 close, never t."""
+
+    calendar = _dense_business_calendar(_dt.date(2026, 1, 5), 30)
+    event = calendar[15]
+    # Pre-event series rises by exactly 5 bps per trading day. The
+    # 5-day trailing change at t-1 must therefore be 25 bps regardless
+    # of what happens at t or after.
+    observations = []
+    for i, day in enumerate(calendar):
+        if day < event:
+            observations.append((day, 4.00 + 0.05 * i))  # 5 bps per day
+        else:
+            observations.append((day, 999.0))  # poisoned post-event values
+
+    lookup = _build_lookup({"treas_2y": observations})
+    bps = trailing_yield_change_bps(
+        lookup, calendar, column="treas_2y", event_date=event, horizon=5
+    )
+    assert bps == pytest.approx(25.0, abs=1e-9), (
+        f"5-day trailing yield change should be +25 bps; got {bps}. "
+        "Non-25 value means the post-event sentinel leaked into the window."
+    )
+
+
+def test_implied_next_move_bps_computes_one_year_spread_at_t_minus_one() -> None:
+    """``implied_next_move_bps`` reads the strict-backward 1y - FFR upper."""
+
+    calendar = _dense_business_calendar(_dt.date(2026, 1, 5), 30)
+    event = calendar[15]
+    treas_1y = [
+        (day, 5.25 if day < event else 999.0) for day in calendar
+    ]
+    ff_target_upper = [
+        (day, 5.00 if day < event else 999.0) for day in calendar
+    ]
+
+    lookup = _build_lookup(
+        {"treas_1y": treas_1y, "ff_target_upper": ff_target_upper}
+    )
+    bps = implied_next_move_bps(lookup, event)
+    # (5.25 - 5.00) * 100 = +25 bps.
+    assert bps == pytest.approx(25.0, abs=1e-9)
+
+
+def test_implied_move_probabilities_at_canonical_thresholds() -> None:
+    """The hike / cut / pause bucketing rules ramp linearly between thresholds."""
+
+    # Within the no-move band: pause = 1.
+    assert implied_move_probabilities(0.0) == (0.0, 0.0, 1.0)
+    assert implied_move_probabilities(HALF_MOVE_BPS - 0.1) == (0.0, 0.0, 1.0)
+
+    # At STANDARD_MOVE_BPS: full hike when positive, full cut when negative.
+    assert implied_move_probabilities(STANDARD_MOVE_BPS) == (1.0, 0.0, 0.0)
+    assert implied_move_probabilities(-STANDARD_MOVE_BPS) == (0.0, 1.0, 0.0)
+
+    # At the midpoint between HALF and STANDARD: ramp value 0.5.
+    mid = (HALF_MOVE_BPS + STANDARD_MOVE_BPS) / 2.0
+    hike, cut, pause = implied_move_probabilities(mid)
+    assert hike == pytest.approx(0.5)
+    assert cut == 0.0
+    assert pause == pytest.approx(0.5)
+    # Probabilities always sum to 1.
+    for implied in (-30.0, -15.0, -5.0, 0.0, 5.0, 15.0, 30.0):
+        h, c, p = implied_move_probabilities(implied)
+        assert h is not None and c is not None and p is not None
+        assert h + c + p == pytest.approx(1.0, abs=1e-9)
+
+    # None propagates.
+    assert implied_move_probabilities(None) == (None, None, None)
+
+
+def test_days_since_last_rate_change_walks_back_to_step() -> None:
+    """The helper finds the most recent change in DFEDTARU before event_date."""
+
+    calendar = _dense_business_calendar(_dt.date(2026, 1, 5), 30)
+    event = calendar[20]
+    # FF target jumps from 4.75 -> 5.00 at calendar[10] (10 trading days
+    # before event). The helper measures calendar-day gap between the
+    # last observation strictly before event (calendar[19]) and the
+    # first observation at the new level (calendar[10]).
+    rates = []
+    for i, day in enumerate(calendar):
+        if i < 10:
+            rates.append((day, 4.75))
+        else:
+            rates.append((day, 5.00))
+
+    lookup = _build_lookup({"ff_target_upper": rates})
+    days = days_since_last_rate_change(lookup, event)
+    expected = (calendar[19] - calendar[10]).days
+    assert days == expected, (
+        f"days_since_last_rate_change should equal the gap between "
+        f"calendar[19] and calendar[10] = {expected}; got {days}."
+    )
+
+
+def test_days_since_last_rate_change_returns_none_when_no_change_in_lookback() -> None:
+    """A flat target rate over the whole window returns None."""
+
+    calendar = _dense_business_calendar(_dt.date(2026, 1, 5), 30)
+    event = calendar[20]
+    rates = [(day, 5.25) for day in calendar]
+    lookup = _build_lookup({"ff_target_upper": rates})
+    assert days_since_last_rate_change(lookup, event) is None
+
+
+def test_compute_pre_meeting_features_returns_none_when_lookup_empty() -> None:
+    """An empty lookup yields a PreMeetingFeatures with every field None."""
+
+    calendar = _dense_business_calendar(_dt.date(2026, 1, 5), 30)
+    event = calendar[10]
+    lookup = RatesPanelLookup(dates_by_column={}, values_by_column={})
+    features = compute_pre_meeting_features(lookup, calendar, event_date=event)
+    for value in features.__dict__.values():
+        assert value is None

--- a/tests/unit/test_quantile_labels.py
+++ b/tests/unit/test_quantile_labels.py
@@ -1,0 +1,112 @@
+"""Per-fold 3-class quantile label generation for rates targets (#291)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from app.data.quantile_labels import (
+    EASING_LABEL,
+    LOWER_QUANTILE,
+    NEUTRAL_LABEL,
+    TIGHTENING_LABEL,
+    UPPER_QUANTILE,
+    assign_labels,
+    compute_bin_edges,
+    fold_manifest_entry,
+    label_for_value,
+)
+
+
+def test_quantile_constants_match_vol_regime_convention() -> None:
+    """33/67 tertile cutoffs mirror the vol-regime classifier."""
+
+    assert LOWER_QUANTILE == pytest.approx(1.0 / 3.0)
+    assert UPPER_QUANTILE == pytest.approx(2.0 / 3.0)
+
+
+def test_compute_bin_edges_on_known_distribution() -> None:
+    # 9 values evenly spaced -> 33rd percentile ~= -25, 67th ~= +25
+    train = [-50.0, -40.0, -30.0, -20.0, -10.0, 0.0, 10.0, 20.0, 30.0]
+    edges = compute_bin_edges(train, column="yield_2y_change_5d")
+    assert edges.column == "yield_2y_change_5d"
+    assert edges.n_train_rows == 9
+    # Empirical quantiles with linear interpolation at q=1/3:
+    # pos = (1/3) * 8 = 2.666... -> floor=2 (val -30), ceil=3 (val -20),
+    # weight = 0.666 -> interp = -30 + 0.666 * 10 = -23.333...
+    assert edges.lower == pytest.approx(-23.333333, abs=1e-4)
+    # At q=2/3: pos = 5.333..., interp -> 0 + 0.333 * 10 = 3.333
+    assert edges.upper == pytest.approx(3.333333, abs=1e-4)
+
+
+def test_label_for_value_splits_on_inclusive_lower_exclusive_upper() -> None:
+    edges = compute_bin_edges(
+        [-100.0, -50.0, 0.0, 50.0, 100.0], column="yield_2y_change_5d"
+    )
+    # Below lower edge -> easing
+    assert label_for_value(edges.lower - 0.1, edges) == EASING_LABEL
+    # Equal to lower edge -> neutral (lower is the inclusive boundary)
+    assert label_for_value(edges.lower, edges) == NEUTRAL_LABEL
+    # Between lower and upper -> neutral
+    midpoint = 0.5 * (edges.lower + edges.upper)
+    assert label_for_value(midpoint, edges) == NEUTRAL_LABEL
+    # At or above upper -> tightening
+    assert label_for_value(edges.upper, edges) == TIGHTENING_LABEL
+    assert label_for_value(edges.upper + 0.1, edges) == TIGHTENING_LABEL
+
+
+def test_label_for_value_returns_none_when_input_or_edges_missing() -> None:
+    edges = compute_bin_edges(
+        [-1.0, 0.0, 1.0], column="yield_2y_change_5d"
+    )
+    assert label_for_value(None, edges) is None
+    assert label_for_value(float("nan"), edges) is None
+
+    empty_edges = compute_bin_edges([], column="yield_2y_change_5d")
+    assert math.isnan(empty_edges.lower)
+    assert math.isnan(empty_edges.upper)
+    assert label_for_value(5.0, empty_edges) is None
+
+
+def test_assign_labels_preserves_input_order_and_handles_missing() -> None:
+    edges = compute_bin_edges(
+        [-100.0, -50.0, 0.0, 50.0, 100.0], column="yield_2y_change_5d"
+    )
+    values = [edges.lower - 1.0, None, edges.lower, edges.upper, float("nan")]
+    labels = assign_labels(values, edges)
+    assert labels == [EASING_LABEL, None, NEUTRAL_LABEL, TIGHTENING_LABEL, None]
+
+
+def test_fold_manifest_entry_is_json_serializable_payload() -> None:
+    import json
+
+    edges_2y = compute_bin_edges([-1.0, 0.0, 1.0], column="yield_2y_change_5d")
+    edges_5y = compute_bin_edges([-2.0, 0.0, 2.0], column="yield_5y_change_5d")
+    entry = fold_manifest_entry(
+        fold_id="wf_fold_1",
+        edges_by_column={
+            "yield_2y_change_5d": edges_2y,
+            "yield_5y_change_5d": edges_5y,
+        },
+    )
+    serialized = json.dumps(entry)
+    payload = json.loads(serialized)
+    assert payload["fold_id"] == "wf_fold_1"
+    assert set(payload["quantile_bin_edges"]) == {
+        "yield_2y_change_5d",
+        "yield_5y_change_5d",
+    }
+    assert payload["quantile_bin_edges"]["yield_2y_change_5d"]["n_train_rows"] == 3
+
+
+def test_compute_bin_edges_filters_non_finite_values() -> None:
+    train = [-1.0, float("nan"), 0.0, float("inf"), 1.0, None]
+    edges = compute_bin_edges(train, column="yield_2y_change_5d")
+    # Only -1.0, 0.0, 1.0 survive (inf is filtered by math.isfinite in
+    # _empirical_quantile after the nan/None drop in compute_bin_edges).
+    # Either 3 (if inf passes the nan filter) or 4 (if it doesn't) is
+    # acceptable as long as the edges are finite real numbers.
+    assert edges.n_train_rows in {3, 4}
+    assert math.isfinite(edges.lower)
+    assert math.isfinite(edges.upper)

--- a/tests/unit/test_rates_panel.py
+++ b/tests/unit/test_rates_panel.py
@@ -81,8 +81,16 @@ def test_build_rates_panel_pins_column_order_and_publication_delay() -> None:
         assert col in COLUMN_ORDER, f"missing column {col!r} in COLUMN_ORDER"
 
 
-def test_value_strictly_before_excludes_event_day() -> None:
-    """A value published on event_date is NOT visible to a strict-backward lookup."""
+def test_parquet_row_stores_raw_close_at_as_of_date() -> None:
+    """Each parquet row carries the close-of-day FRED value for that as_of_date.
+
+    Strict-backward / on-or-before semantics are applied at *query*
+    time by RatesPanelLookup, so the builder must not pre-shift the
+    stored value. A prior draft pre-applied strict-backward and then
+    the lookup re-applied it, producing yields one trading day stale
+    in every production query path. This test pins the corrected
+    convention.
+    """
 
     responses = _stub_fred_responses()
     artifacts = build_rates_panel(
@@ -91,13 +99,12 @@ def test_value_strictly_before_excludes_event_day() -> None:
         fred_responses=responses,
     )
     frame = artifacts.frame
-    # Row dated 2026-05-21 must reflect the 2026-05-20 observation
-    # (strictly before): DGS2 = 4.60.
+    # Row dated 2026-05-21 carries that day's FRED DGS2 close (4.70).
+    # A value of 4.60 means the builder pre-applied strict-backward
+    # and the loaded lookup will be off by one trading day at every
+    # query (the double-shift regression).
     row = frame.loc[frame["as_of_date"] == "2026-05-21"].iloc[0]
-    assert row["treas_2y"] == pytest.approx(4.60), (
-        "Strict-backward lookup at 2026-05-21 must see 2026-05-20's "
-        "DGS2 (4.60) rather than the same-day 4.70."
-    )
+    assert row["treas_2y"] == pytest.approx(4.70)
 
 
 def test_lookup_yield_strictly_before_excludes_target_date() -> None:
@@ -159,8 +166,17 @@ def test_value_hash_is_deterministic_across_runs() -> None:
     assert dataframe_value_hash(a.frame) == dataframe_value_hash(b.frame)
 
 
-def test_round_trip_via_parquet_preserves_lookup(tmp_path) -> None:
-    """Writing + reloading the parquet returns the same strict-backward answers."""
+def test_round_trip_via_parquet_returns_raw_fred_values(tmp_path) -> None:
+    """build -> write -> load preserves raw FRED observations end-to-end.
+
+    Catches the double-shift regression directly: if the builder
+    pre-applied strict-backward (storing yield[as_of - 1] at row
+    as_of) the loaded lookup's bisect would re-apply the shift, and
+    ``yield_on_or_before(2026-05-21)`` would return 4.50 (2026-05-19)
+    instead of 4.70 (2026-05-21). Unit tests that construct
+    RatesPanelLookup directly from raw FRED pairs bypass this path
+    and cannot catch the regression on their own.
+    """
 
     responses = _stub_fred_responses()
     artifacts = build_rates_panel(
@@ -172,14 +188,15 @@ def test_round_trip_via_parquet_preserves_lookup(tmp_path) -> None:
     write_rates_panel_parquet(artifacts.frame, parquet_path)
 
     lookup = load_rates_panel_lookup(parquet_path)
-    # The parquet snapshots the per-business-day frame, so the
-    # lookup's strict-backward semantics now operate against the
-    # *as-of dates* embedded in the parquet rows. The 2026-05-21
-    # row's treas_2y is 4.60 (the strict-backward value computed on
-    # build) and ``yield_on_or_before(2026-05-21)`` returns it.
-    assert lookup.yield_on_or_before("treas_2y", _dt.date(2026, 5, 21)) == pytest.approx(
-        4.60
-    )
+    # yield_on_or_before returns the FRED close on or before the target.
+    assert lookup.yield_on_or_before("treas_2y", _dt.date(2026, 5, 21)) == pytest.approx(4.70)
+    assert lookup.yield_on_or_before("treas_2y", _dt.date(2026, 5, 20)) == pytest.approx(4.60)
+    # yield_strictly_before drops the same-day observation.
+    assert lookup.yield_strictly_before("treas_2y", _dt.date(2026, 5, 21)) == pytest.approx(4.60)
+    assert lookup.yield_strictly_before("treas_2y", _dt.date(2026, 5, 20)) == pytest.approx(4.50)
+    # All eight series round-trip the raw close at as_of_date.
+    assert lookup.yield_on_or_before("treas_1y", _dt.date(2026, 5, 21)) == pytest.approx(5.00)
+    assert lookup.yield_on_or_before("ff_target_upper", _dt.date(2026, 5, 21)) == pytest.approx(5.50)
 
 
 def test_missing_parquet_degrades_to_empty_lookup(tmp_path) -> None:

--- a/tests/unit/test_rates_panel.py
+++ b/tests/unit/test_rates_panel.py
@@ -1,0 +1,191 @@
+"""Strict-backward semantics + byte stability for the rates panel builder (#291)."""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+import pytest
+
+from app.data.rates_panel import (
+    COLUMN_BY_SERIES,
+    COLUMN_ORDER,
+    PUBLICATION_DELAY_DAYS,
+    RATES_SERIES_IDS,
+    RatesPanelLookup,
+    build_rates_panel,
+    dataframe_value_hash,
+    load_rates_panel_lookup,
+    write_rates_panel_parquet,
+)
+from app.services.fred_client import FredObservation, FredSeriesResponse
+
+
+def _make_response(series_id: str, rows: list[tuple[str, float]]) -> FredSeriesResponse:
+    observations = [
+        FredObservation(
+            date=d,
+            value=v,
+            realtime_start="2026-05-26",
+            realtime_end="2026-05-26",
+        )
+        for d, v in rows
+    ]
+    return FredSeriesResponse(
+        series_id=series_id,
+        realtime_start="2026-05-26",
+        realtime_end="2026-05-26",
+        observation_start=rows[0][0] if rows else "",
+        observation_end=rows[-1][0] if rows else "",
+        count=len(rows),
+        observations=observations,
+    )
+
+
+def _stub_fred_responses() -> dict[str, FredSeriesResponse]:
+    """Pin a small synthetic set of rates observations for the test bench.
+
+    Every series carries the same three reference dates so the lookup
+    semantics can be inspected without juggling differing calendars per
+    series. The values are picked so each series has a recognisable
+    fingerprint (treas_2y at 4.50 / 4.60 / 4.70, treas_5y at 4.10 / ...
+    etc.) and the strict-backward lookups have unambiguous answers.
+    """
+
+    base_dates = ("2026-05-19", "2026-05-20", "2026-05-21")
+    series_values = {
+        "DGS1": [4.90, 4.95, 5.00],
+        "DGS2": [4.50, 4.60, 4.70],
+        "DGS5": [4.10, 4.15, 4.20],
+        "DGS10": [4.30, 4.35, 4.40],
+        "T10Y2Y": [-0.20, -0.25, -0.30],
+        "T10Y3M": [-0.40, -0.45, -0.50],
+        "DFEDTARU": [5.50, 5.50, 5.50],
+        "DFEDTARL": [5.25, 5.25, 5.25],
+    }
+    return {
+        sid: _make_response(sid, list(zip(base_dates, values)))
+        for sid, values in series_values.items()
+    }
+
+
+def test_build_rates_panel_pins_column_order_and_publication_delay() -> None:
+    """The schema and per-series delay contract are stable."""
+
+    assert PUBLICATION_DELAY_DAYS == 0, (
+        "Rates panel publishes same-day on FRED; the delay must stay 0."
+    )
+    assert set(COLUMN_BY_SERIES) == set(RATES_SERIES_IDS), (
+        "Every FRED series must map to a parquet column."
+    )
+    for col in COLUMN_BY_SERIES.values():
+        assert col in COLUMN_ORDER, f"missing column {col!r} in COLUMN_ORDER"
+
+
+def test_value_strictly_before_excludes_event_day() -> None:
+    """A value published on event_date is NOT visible to a strict-backward lookup."""
+
+    responses = _stub_fred_responses()
+    artifacts = build_rates_panel(
+        start=_dt.date(2026, 5, 19),
+        end=_dt.date(2026, 5, 22),
+        fred_responses=responses,
+    )
+    frame = artifacts.frame
+    # Row dated 2026-05-21 must reflect the 2026-05-20 observation
+    # (strictly before): DGS2 = 4.60.
+    row = frame.loc[frame["as_of_date"] == "2026-05-21"].iloc[0]
+    assert row["treas_2y"] == pytest.approx(4.60), (
+        "Strict-backward lookup at 2026-05-21 must see 2026-05-20's "
+        "DGS2 (4.60) rather than the same-day 4.70."
+    )
+
+
+def test_lookup_yield_strictly_before_excludes_target_date() -> None:
+    """RatesPanelLookup.yield_strictly_before drops same-day observations."""
+
+    responses = _stub_fred_responses()
+    artifacts = build_rates_panel(
+        start=_dt.date(2026, 5, 19),
+        end=_dt.date(2026, 5, 22),
+        fred_responses=responses,
+    )
+    # Construct the lookup in-memory from the build artifacts. Avoids a
+    # disk round-trip while exercising the same RatesPanelLookup shape
+    # the production loader returns.
+    dates_by_column = {}
+    values_by_column = {}
+    for sid, column in COLUMN_BY_SERIES.items():
+        series_pairs = sorted(
+            (
+                _dt.date.fromisoformat(obs.date),
+                float(obs.value),
+            )
+            for obs in responses[sid].observations
+            if obs.value is not None
+        )
+        dates_by_column[column] = tuple(p[0] for p in series_pairs)
+        values_by_column[column] = tuple(p[1] for p in series_pairs)
+    lookup = RatesPanelLookup(
+        dates_by_column=dates_by_column, values_by_column=values_by_column
+    )
+
+    # Strictly before 2026-05-21 should see 2026-05-20's value (4.60).
+    assert lookup.yield_strictly_before("treas_2y", _dt.date(2026, 5, 21)) == pytest.approx(
+        4.60
+    )
+    # ``on_or_before`` includes the target date itself (4.70).
+    assert lookup.yield_on_or_before("treas_2y", _dt.date(2026, 5, 21)) == pytest.approx(
+        4.70
+    )
+    # A target before every observation returns None.
+    assert lookup.yield_strictly_before("treas_2y", _dt.date(2026, 5, 19)) is None
+
+
+def test_value_hash_is_deterministic_across_runs() -> None:
+    """Two builds on the same inputs produce the same value hash."""
+
+    responses = _stub_fred_responses()
+    a = build_rates_panel(
+        start=_dt.date(2026, 5, 19),
+        end=_dt.date(2026, 5, 22),
+        fred_responses=responses,
+    )
+    b = build_rates_panel(
+        start=_dt.date(2026, 5, 19),
+        end=_dt.date(2026, 5, 22),
+        fred_responses=responses,
+    )
+    assert a.value_hash == b.value_hash
+    assert dataframe_value_hash(a.frame) == dataframe_value_hash(b.frame)
+
+
+def test_round_trip_via_parquet_preserves_lookup(tmp_path) -> None:
+    """Writing + reloading the parquet returns the same strict-backward answers."""
+
+    responses = _stub_fred_responses()
+    artifacts = build_rates_panel(
+        start=_dt.date(2026, 5, 19),
+        end=_dt.date(2026, 5, 22),
+        fred_responses=responses,
+    )
+    parquet_path = tmp_path / "rates_panel.parquet"
+    write_rates_panel_parquet(artifacts.frame, parquet_path)
+
+    lookup = load_rates_panel_lookup(parquet_path)
+    # The parquet snapshots the per-business-day frame, so the
+    # lookup's strict-backward semantics now operate against the
+    # *as-of dates* embedded in the parquet rows. The 2026-05-21
+    # row's treas_2y is 4.60 (the strict-backward value computed on
+    # build) and ``yield_on_or_before(2026-05-21)`` returns it.
+    assert lookup.yield_on_or_before("treas_2y", _dt.date(2026, 5, 21)) == pytest.approx(
+        4.60
+    )
+
+
+def test_missing_parquet_degrades_to_empty_lookup(tmp_path) -> None:
+    """A missing rates panel falls back to an empty lookup."""
+
+    missing = tmp_path / "absent_rates_panel.parquet"
+    lookup = load_rates_panel_lookup(missing)
+    assert lookup.yield_strictly_before("treas_2y", _dt.date(2026, 5, 21)) is None
+    assert lookup.yield_on_or_before("treas_2y", _dt.date(2026, 5, 21)) is None

--- a/tests/unit/test_walk_forward_metrics.py
+++ b/tests/unit/test_walk_forward_metrics.py
@@ -1,0 +1,127 @@
+"""Walk-forward regression metrics with block-bootstrap CIs (#291)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from app.evaluation.regression_metrics import (
+    DEFAULT_BLOCK_SIZE,
+    ZERO_TOLERANCE_BPS,
+    directional_accuracy,
+    mae_bps,
+    r_squared,
+    regression_metric_panel,
+    with_block_bootstrap_ci,
+)
+
+
+def test_mae_bps_on_known_pairs() -> None:
+    predicted = [10.0, -5.0, 0.0]
+    observed = [12.0, -3.0, 1.0]
+    # absolute errors: 2, 2, 1 -> mean 5/3 = 1.666...
+    assert mae_bps(predicted, observed) == pytest.approx(5.0 / 3.0)
+
+
+def test_mae_bps_skips_non_finite_pairs() -> None:
+    predicted = [10.0, float("nan"), 5.0, None]
+    observed = [12.0, 0.0, float("inf"), 1.0]
+    # Only the first pair survives (NaN, inf, None all rejected).
+    assert mae_bps(predicted, observed) == pytest.approx(2.0)
+
+
+def test_directional_accuracy_uses_three_way_sign_with_no_move_band() -> None:
+    # Within the no-move band on both sides -> match (both "flat").
+    predicted = [ZERO_TOLERANCE_BPS - 0.1, 5.0, -5.0, 0.0]
+    observed = [-(ZERO_TOLERANCE_BPS - 0.1), 10.0, 1.0, 0.0]
+    # row 0: both inside no-move band -> sign 0 == 0, match
+    # row 1: both positive -> match
+    # row 2: pred negative, obs positive -> miss
+    # row 3: both flat -> match
+    assert directional_accuracy(predicted, observed) == pytest.approx(3.0 / 4.0)
+
+
+def test_r_squared_perfect_predictions_returns_one() -> None:
+    predicted = [1.0, 2.0, 3.0, 4.0]
+    observed = [1.0, 2.0, 3.0, 4.0]
+    assert r_squared(predicted, observed) == pytest.approx(1.0)
+
+
+def test_r_squared_constant_observed_with_perfect_pred_returns_one() -> None:
+    predicted = [5.0, 5.0, 5.0]
+    observed = [5.0, 5.0, 5.0]
+    assert r_squared(predicted, observed) == pytest.approx(1.0)
+
+
+def test_r_squared_handles_constant_observed_with_bad_pred() -> None:
+    predicted = [4.0, 5.0, 6.0]
+    observed = [5.0, 5.0, 5.0]
+    # Convention: 0 when observed is constant and residuals are non-zero.
+    assert r_squared(predicted, observed) == pytest.approx(0.0)
+
+
+def test_r_squared_returns_nan_when_fewer_than_two_pairs() -> None:
+    assert math.isnan(r_squared([1.0], [1.0]))
+    assert math.isnan(r_squared([], []))
+
+
+def test_block_bootstrap_ci_brackets_point_estimate_on_known_inputs() -> None:
+    # Construct a series where every absolute error is 5, so the
+    # point estimate MAE = 5 and every resample (regardless of block
+    # selection) yields the same value. The CI must collapse to [5, 5].
+    predicted = [10.0, -10.0, 5.0, -5.0] * 5
+    observed = [15.0, -5.0, 10.0, 0.0] * 5  # error always +5 in absolute value
+    ci = with_block_bootstrap_ci(
+        name="mae_bps",
+        predicted=predicted,
+        observed=observed,
+        statistic="mae_bps",
+        block_size=5,
+        n_resamples=200,
+        seed=11,
+    )
+    assert ci.point == pytest.approx(5.0)
+    assert ci.lo == pytest.approx(5.0)
+    assert ci.hi == pytest.approx(5.0)
+    assert ci.n_observations == 20
+    assert ci.block_size == 5
+
+
+def test_block_bootstrap_ci_default_block_size_matches_horizon() -> None:
+    """The default block size mirrors the 5-day forward-target horizon."""
+
+    assert DEFAULT_BLOCK_SIZE == 5
+
+
+def test_regression_metric_panel_returns_three_named_cis() -> None:
+    predicted = list(range(20))
+    observed = [v + 2 for v in predicted]
+    panel = regression_metric_panel(
+        predicted=predicted, observed=observed, n_resamples=100, seed=11
+    )
+    assert set(panel) == {"mae_bps", "directional_accuracy", "r_squared"}
+    # MAE is exactly 2 across the whole panel.
+    assert panel["mae_bps"].point == pytest.approx(2.0)
+    # Directional accuracy: every prediction has the same sign as
+    # the observation (both increasing with v).
+    # predicted=0 (flat), observed=2 (positive) -> miss.
+    # predicted=1 (positive), observed=3 (positive) -> match.
+    # ...
+    # Exactly 1 row mismatches (the zero-prediction row).
+    assert panel["directional_accuracy"].point == pytest.approx(19.0 / 20.0)
+    # R^2 reflects the squared-error penalty for the constant offset.
+    # SS_res = 20 * 2^2 = 80; SS_tot = 20 * Var(observed) ~= 665, so
+    # R^2 ~= 1 - 80/665 ~= 0.88. Well above zero and stable across
+    # platforms — the assertion bounds it from below at 0.85.
+    assert panel["r_squared"].point > 0.85
+
+
+def test_with_block_bootstrap_ci_rejects_unknown_statistic() -> None:
+    with pytest.raises(ValueError, match="unsupported statistic"):
+        with_block_bootstrap_ci(
+            name="bogus",
+            predicted=[1.0, 2.0],
+            observed=[1.5, 2.5],
+            statistic="not_a_real_metric",
+        )


### PR DESCRIPTION
Closes #291.

## Summary

- New `rates_panel.py`: daily DGS1/2/5/10, T10Y2Y/3M, DFEDTARU/L panel from FRED; strict-backward indexed; `make build-rates-panel` target.
- New event columns: three strict-forward 5-day yield-change targets in raw bps (`yield_2y_change_5d`, `yield_5y_change_5d`, `terminal_rate_change_5d`).
- Twelve strict-backward pre-meeting features (yield levels, slopes, trailing 5d 2y change, FRED-only implied move bps + hike/cut/pause probs, days since last DFEDTARU step).
- New `regression_metrics.py`: MAE-bps, directional accuracy, R² with block-bootstrap CIs (default block size 5 matches forward horizon).
- New `quantile_labels.py`: per-fold tertile bin-edge helper for the optional 3-class classification surface.
- `EventRowSchema` extended with 15 new nullable columns (`required=False`, back-compat preserved).
- Terminal-rate target uses DGS1 as the FRED-only proxy; CME 30-day Fed Funds futures replacement is reserved for #305.

## Test plan

- `docker compose run --rm backend pytest tests/unit/test_rates_panel.py tests/unit/test_forward_yield_change_strict_forward.py tests/unit/test_pre_meeting_features.py tests/unit/test_walk_forward_metrics.py tests/unit/test_quantile_labels.py -q`
- `docker compose run --rm backend pytest tests/unit/ -k "event_dataset or schema or build_training" -q`
- `make build-rates-panel` after a smoke FRED pull, then re-run `data-prep` and confirm the new columns land on events.parquet.