### PR TITLE
Historical analog retrieval encoder + /analyze/analogs endpoint (#294)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -993,20 +993,41 @@ async def analyze_analogs(payload: AnalogsRequest) -> AnalogsResponse:
     bundle is present (fresh checkout, encoder not yet trained) the
     response is shaped with an empty ``analogs`` list and
     ``index_size=0`` so the frontend can render an empty state rather
-    than treating the call as a 5xx.
+    than treating the call as a 5xx. Unexpected failures surface as a
+    sanitized 503 — internal paths / exception text never leak to the
+    client.
     """
 
     from app.services import analogs as analogs_service
 
+    # Pre-flight: if the bundle is permanently absent on disk and no
+    # state has been installed (e.g. by the test suite), short-circuit
+    # rather than paying ``_load_state`` + log a cold-miss on every
+    # request.
+    if not analogs_service.bundle_available() and analogs_service.get_state() is None:
+        return AnalogsResponse(
+            analogs=[],
+            index_size=0,
+            encoder_alias=_DEFAULT_RETRIEVAL_ENCODER_ALIAS,
+        )
+
     try:
         result = await run_in_threadpool(
-            analogs_service.find_analogs, payload.text, k=payload.k
+            analogs_service.find_analogs,
+            payload.text,
+            k=payload.k,
+            as_of_date=payload.as_of_date,
         )
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
-    except Exception as exc:  # pragma: no cover — never let a downstream failure 500 the whole API
-        logger.warning("analyze_analogs_failed", exc_info=True)
-        raise HTTPException(status_code=503, detail=f"Analog retrieval unavailable: {exc}") from exc
+    except ValueError:
+        # Surface a client-safe message instead of echoing the raw
+        # exception text (file paths, library internals).
+        logger.warning("analyze_analogs_validation_failed", exc_info=True)
+        raise HTTPException(status_code=422, detail="Invalid analog query") from None
+    except Exception:  # never let a downstream failure 500 the whole API
+        logger.exception("analyze_analogs_failed")
+        raise HTTPException(
+            status_code=503, detail="Analog retrieval unavailable"
+        ) from None
 
     if result is None:
         return AnalogsResponse(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,9 @@ from app.db import (
 from app.logging import configure_logging, get_logger
 from app.middleware.errors import RunIdMiddleware, register_error_handlers
 from app.schemas import (
+    AnalogCard,
+    AnalogsRequest,
+    AnalogsResponse,
     AnalyzeRequest,
     AnalyzeResponse,
     ArtifactFile,
@@ -971,3 +974,50 @@ def next_fomc_forecast() -> NextFomcForecastResponse:
     artifacts_dir = DATA_DIR / "artifacts" / "next_fomc"
     payload = load_next_fomc_artifacts(artifacts_dir)
     return NextFomcForecastResponse(**payload)
+
+
+# ---------------------------------------------------------------------------
+# Historical analog retrieval (#294 — /analyze/analogs)
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_RETRIEVAL_ENCODER_ALIAS = "finbert_fed_adjacent_xbank_dapt_retrieval"
+
+
+@app.post("/analyze/analogs", response_model=AnalogsResponse)
+async def analyze_analogs(payload: AnalogsRequest) -> AnalogsResponse:
+    """Return historical FOMC statements that semantically match ``text``.
+
+    Loads the fine-tuned retrieval encoder + persisted analog index on
+    first hit via the singleton at ``app.services.analogs``. When no
+    bundle is present (fresh checkout, encoder not yet trained) the
+    response is shaped with an empty ``analogs`` list and
+    ``index_size=0`` so the frontend can render an empty state rather
+    than treating the call as a 5xx.
+    """
+
+    from app.services import analogs as analogs_service
+
+    try:
+        result = await run_in_threadpool(
+            analogs_service.find_analogs, payload.text, k=payload.k
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover — never let a downstream failure 500 the whole API
+        logger.warning("analyze_analogs_failed", exc_info=True)
+        raise HTTPException(status_code=503, detail=f"Analog retrieval unavailable: {exc}") from exc
+
+    if result is None:
+        return AnalogsResponse(
+            analogs=[],
+            index_size=0,
+            encoder_alias=_DEFAULT_RETRIEVAL_ENCODER_ALIAS,
+        )
+
+    cards = [AnalogCard(**row) for row in analogs_service.render_analog_cards(result["hits"])]
+    return AnalogsResponse(
+        analogs=cards,
+        index_size=int(result["index_size"]),
+        encoder_alias=str(result["encoder_alias"]),
+    )

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -217,3 +217,23 @@ encoders:
       ``finbert_fed_adjacent_xbank_aux_stance_masked`` that re-litigates
       the Phase C substitute-not-complement prior. Validation accuracy
       at the best epoch: stance 0.978 / certainty 0.984 (val_loss=0.0974).
+
+  finbert_fed_adjacent_xbank_dapt_retrieval:
+    repo: /data/artifacts/retrieval/finbert_fed_adjacent_xbank_dapt_retrieval/checkpoint
+    revision: ""
+    gated: false
+    task: sentence_embedding
+    description: |
+      Sentence-transformer fine-tune (#294) layered on top of the
+      ``finbert_fed_adjacent_xbank_dapt`` MLM checkpoint. Produced by
+      ``python -m app.retrieval.train`` — contrastive
+      MultipleNegativesRankingLoss over same-meeting positive pairs
+      (statement / minutes / press_conference sharing an event_date in
+      ``events.parquet``). Powers ``/analyze/analogs``: the historical
+      FOMC-statement index lives at
+      ``data/artifacts/retrieval/<run-id>/index.parquet`` and the
+      encoder is mean-pooled over the document at query time. Revision
+      stays empty until the first GPU run lands a pinned checkpoint;
+      same unpinned-local guard as ``finbert_fomc_only`` applies.
+      Deployability lane (#302) will mirror the checkpoint to HF Hub
+      in a follow-up — this PR keeps the artefact local.

--- a/backend/app/retrieval/__init__.py
+++ b/backend/app/retrieval/__init__.py
@@ -1,0 +1,10 @@
+"""Historical analog retrieval (#294).
+
+Holds the sentence-transformer fine-tune driver
+(:mod:`app.retrieval.train`) plus the on-disk index used by
+``/analyze/analogs`` (:mod:`app.retrieval.index`). The runtime singleton
+that wires the two together for the FastAPI handler lives at
+:mod:`app.services.analogs`.
+"""
+
+from __future__ import annotations

--- a/backend/app/retrieval/index.py
+++ b/backend/app/retrieval/index.py
@@ -15,25 +15,38 @@ vectors so the dot product is the cosine similarity directly.
 Layout on disk under ``DATA_DIR / "artifacts" / "retrieval" / <run_id>``::
 
     index.parquet     metadata rows (event_date, text_hash,
-                      axis_stance, forward_realized_vol_10d, excerpt)
+                      axis_stance, subsequent_vol_regime, excerpt)
     embeddings.npy    float32 (N, d) embedding matrix; row order
                       matches the parquet
     manifest.json     encoder alias + revision + source training
-                      package id + row count + build timestamp
+                      package id + row count + build timestamp +
+                      train_end walk-forward boundary
 
 The runtime singleton at ``app.services.analogs`` loads these three
 files at first /analyze/analogs hit and reuses them for the lifetime
 of the worker.
+
+The metadata DOES NOT carry the raw supervised target
+``forward_realized_vol_10d`` — surfacing it as an analog field
+would tempt downstream consumers to feed API output back into a
+trained model and silently leak labels. Instead the build path
+buckets the value into ``calm`` / ``normal`` / ``high`` using the
+``VOL_REGIME_BUCKET_EDGES`` constant below (pinned from a held-out
+2000-2015 reference distribution) so the UI gets a coarse, stable
+flag without exposing the exact target value.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import os
 from dataclasses import dataclass
+from datetime import date as date_type
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -49,8 +62,24 @@ EXCERPT_CHARS = 280
 # truncates internally, but capping the string upstream keeps the
 # embedding helper from spending time on tail tokens that get dropped
 # anyway. 4096 chars ≈ 1024 tokens is comfortably above the FOMC
-# statement length distribution.
+# statement length distribution. Also applied to /analyze/analogs query
+# payloads in app.services.analogs.encode_query so a 10MB payload never
+# reaches the tokenizer.
 MAX_TEXT_CHARS = 4096
+
+# Bucket edges for ``forward_realized_vol_10d`` -> ``subsequent_vol_regime``.
+# Pinned as a module constant rather than computed at build time so the
+# bucket assignment is reproducible across rebuilds. The two cut points
+# correspond to the ~33rd and ~66th percentile of the 10-day realised
+# vol distribution on the ^GSPC train slice from 2000-01-01 through
+# 2015-12-31 (held-out from the production walk-forward folds, which
+# start at 2016-09-21). Values come from the same forward-realized-vol
+# computation that backs ``forward_realized_vol_10d`` in events.parquet
+# so the bucket boundaries are on the same scale as the underlying
+# series. Centring them on a pre-2016 slice means downstream rebuilds
+# do not move the bucket edges with new market data.
+VOL_REGIME_BUCKET_EDGES: tuple[float, float] = (0.012, 0.020)
+VolRegime = Literal["calm", "normal", "high"]
 
 INDEX_PARQUET_NAME = "index.parquet"
 EMBEDDINGS_NPY_NAME = "embeddings.npy"
@@ -60,7 +89,7 @@ METADATA_COLUMNS = (
     "event_date",
     "text_hash",
     "axis_stance",
-    "forward_realized_vol_10d",
+    "subsequent_vol_regime",
     "excerpt",
 )
 
@@ -96,6 +125,7 @@ class LoadedIndex:
     encoder_revision: str
     training_package_id: str | None
     built_at_utc: str
+    train_end: str | None = None
 
     @property
     def size(self) -> int:
@@ -115,9 +145,37 @@ class AnalogHit:
     event_date: str
     text_hash: str
     axis_stance: str | None
-    forward_realized_vol_10d: float | None
+    subsequent_vol_regime: VolRegime | None
     excerpt: str
     similarity: float
+
+
+def _bucket_vol(value: Any) -> VolRegime | None:
+    """Bucket a raw 10d-forward vol scalar into ``calm`` / ``normal`` / ``high``.
+
+    Returns ``None`` for missing / non-finite inputs so the column stays
+    nullable in the parquet without polluting the bucket distribution.
+    """
+
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    try:
+        scalar = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not np.isfinite(scalar):
+        return None
+    low, high = VOL_REGIME_BUCKET_EDGES
+    if scalar < low:
+        return "calm"
+    if scalar < high:
+        return "normal"
+    return "high"
 
 
 def _l2_normalise(matrix: np.ndarray, *, eps: float = 1e-12) -> np.ndarray:
@@ -138,7 +196,7 @@ def _l2_normalise(matrix: np.ndarray, *, eps: float = 1e-12) -> np.ndarray:
 def _ensure_metadata_columns(df: pd.DataFrame) -> pd.DataFrame:
     """Coerce / project a DataFrame to the canonical METADATA_COLUMNS shape.
 
-    Missing optional columns (axis_stance, forward_realized_vol_10d) are
+    Missing optional columns (axis_stance, subsequent_vol_regime) are
     filled with ``None``; the required event_date and text_hash columns
     raise if absent so a malformed parquet fails loudly at load time.
     """
@@ -153,8 +211,8 @@ def _ensure_metadata_columns(df: pd.DataFrame) -> pd.DataFrame:
     out["event_date"] = df["event_date"].astype(str)
     out["text_hash"] = df["text_hash"].astype(str)
     out["axis_stance"] = df.get("axis_stance", pd.Series([None] * len(df)))
-    out["forward_realized_vol_10d"] = df.get(
-        "forward_realized_vol_10d", pd.Series([None] * len(df))
+    out["subsequent_vol_regime"] = df.get(
+        "subsequent_vol_regime", pd.Series([None] * len(df))
     )
     excerpts = df.get("excerpt", pd.Series([""] * len(df))).astype(str)
     out["excerpt"] = excerpts.str.slice(0, EXCERPT_CHARS)
@@ -205,6 +263,35 @@ def _empty_embedding_matrix(dim: int) -> np.ndarray:
     return np.zeros((0, max(dim, 1)), dtype=np.float32)
 
 
+def _atomic_write_bytes(path: Path, payload: bytes) -> None:
+    """Write ``payload`` to ``path`` atomically via a sibling .tmp file."""
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_bytes(payload)
+    os.replace(tmp, path)
+
+
+def _atomic_write_text(path: Path, payload: str, *, encoding: str = "utf-8") -> None:
+    _atomic_write_bytes(path, payload.encode(encoding))
+
+
+def _atomic_write_parquet(df: pd.DataFrame, path: Path) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    df.to_parquet(tmp, index=False)
+    os.replace(tmp, path)
+
+
+def _atomic_save_npy(array: np.ndarray, path: Path) -> None:
+    # np.save appends ``.npy`` when the destination does not already end
+    # in that suffix, which would silently rename our staged file. Write
+    # bytes via a BytesIO buffer instead so the on-disk tmp path is exact.
+    import io
+
+    buf = io.BytesIO()
+    np.save(buf, array, allow_pickle=False)
+    _atomic_write_bytes(path, buf.getvalue())
+
+
 def build_index_from_events(  # noqa: PLR0913 — keyword-only builder args mirror the CLI; grouping would obscure the call site.
     events_parquet: Path,
     *,
@@ -213,6 +300,7 @@ def build_index_from_events(  # noqa: PLR0913 — keyword-only builder args mirr
     embed_fn,
     training_package_id: str | None = None,
     out_dir: Path,
+    train_end: str | None = None,
 ) -> LoadedIndex:
     """Build a retrieval index by embedding every statement row.
 
@@ -223,7 +311,14 @@ def build_index_from_events(  # noqa: PLR0913 — keyword-only builder args mirr
 
     Persists the parquet + embedding matrix + manifest under ``out_dir``
     and returns the in-memory ``LoadedIndex`` so the caller can validate
-    the build without a re-load round-trip.
+    the build without a re-load round-trip. Each file is written via a
+    sibling .tmp + atomic rename so a mid-write crash never leaves a
+    half-built bundle on disk; the manifest is written last so the
+    bundle is either complete or absent.
+
+    ``train_end`` is the resolved walk-forward boundary (ISO date or
+    ``None``) — persisted into the manifest so downstream consumers can
+    enforce the same boundary at query time.
     """
 
     out_dir = Path(out_dir)
@@ -242,7 +337,9 @@ def build_index_from_events(  # noqa: PLR0913 — keyword-only builder args mirr
                 "event_date": str(raw_row.get("event_date", "")),
                 "text_hash": str(raw_row.get("text_hash", "")),
                 "axis_stance": raw_row.get("axis_stance"),
-                "forward_realized_vol_10d": raw_row.get("forward_realized_vol_10d"),
+                "subsequent_vol_regime": _bucket_vol(
+                    raw_row.get("forward_realized_vol_10d")
+                ),
                 "excerpt": text[:EXCERPT_CHARS],
             }
         )
@@ -264,8 +361,12 @@ def build_index_from_events(  # noqa: PLR0913 — keyword-only builder args mirr
         embeddings = _l2_normalise(embeddings)
 
     paths = IndexPaths(directory=out_dir)
-    metadata.to_parquet(paths.parquet, index=False)
-    np.save(paths.embeddings, embeddings)
+    # Parquet + .npy first; manifest last so a mid-write crash never
+    # leaves a half-built bundle that ``load_index`` would happily
+    # consume.
+    _atomic_write_parquet(metadata, paths.parquet)
+    _atomic_save_npy(embeddings, paths.embeddings)
+    built_at_utc = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     manifest = {
         "encoder_alias": encoder_alias,
         "encoder_revision": encoder_revision,
@@ -273,9 +374,12 @@ def build_index_from_events(  # noqa: PLR0913 — keyword-only builder args mirr
         "row_count": int(len(metadata)),
         "embedding_dim": int(embeddings.shape[1]) if embeddings.size else 0,
         "events_parquet": str(events_parquet),
-        "built_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "built_at_utc": built_at_utc,
+        "train_end": train_end,
     }
-    paths.manifest.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    _atomic_write_text(
+        paths.manifest, json.dumps(manifest, indent=2, sort_keys=True)
+    )
 
     return LoadedIndex(
         embeddings=embeddings,
@@ -283,7 +387,8 @@ def build_index_from_events(  # noqa: PLR0913 — keyword-only builder args mirr
         encoder_alias=encoder_alias,
         encoder_revision=encoder_revision,
         training_package_id=training_package_id,
-        built_at_utc=manifest["built_at_utc"],
+        built_at_utc=built_at_utc,
+        train_end=train_end,
     )
 
 
@@ -304,7 +409,10 @@ def load_index(directory: Path) -> LoadedIndex:
                 f"missing {required.name}"
             )
     metadata = _ensure_metadata_columns(pd.read_parquet(paths.parquet))
-    raw_embeddings = np.load(paths.embeddings)
+    # allow_pickle=False guards against a tampered .npy attempting to
+    # smuggle arbitrary pickled objects through np.load — defence in
+    # depth since the embeddings on disk are always float32 arrays.
+    raw_embeddings = np.load(paths.embeddings, allow_pickle=False)
     embeddings = _l2_normalise(np.asarray(raw_embeddings, dtype=np.float32))
     if embeddings.shape[0] != len(metadata):
         raise ValueError(
@@ -312,6 +420,8 @@ def load_index(directory: Path) -> LoadedIndex:
             f"{embeddings.shape[0]} embeddings vs {len(metadata)} metadata rows"
         )
     manifest = json.loads(paths.manifest.read_text(encoding="utf-8"))
+    train_end_raw = manifest.get("train_end")
+    train_end = str(train_end_raw) if train_end_raw else None
     return LoadedIndex(
         embeddings=embeddings,
         metadata=metadata,
@@ -319,16 +429,59 @@ def load_index(directory: Path) -> LoadedIndex:
         encoder_revision=str(manifest.get("encoder_revision", "")),
         training_package_id=manifest.get("training_package_id"),
         built_at_utc=str(manifest.get("built_at_utc", "")),
+        train_end=train_end,
     )
 
 
-def query(index: LoadedIndex, query_embedding: np.ndarray, *, k: int = 5) -> list[AnalogHit]:
+def _as_of_to_iso(as_of_date: date_type | str | None) -> str | None:
+    """Normalise an as-of-date argument to an ISO YYYY-MM-DD string.
+
+    Accepts ``None`` (no filter), ``datetime.date`` (or ``datetime``),
+    or a string already in ISO form. Anything else raises ``ValueError``
+    so the caller sees a clean signal rather than a silent no-op.
+    """
+
+    if as_of_date is None:
+        return None
+    if isinstance(as_of_date, datetime):
+        return as_of_date.date().isoformat()
+    if isinstance(as_of_date, date_type):
+        return as_of_date.isoformat()
+    if isinstance(as_of_date, str):
+        # Validate that the string parses as an ISO date.
+        try:
+            return date_type.fromisoformat(as_of_date).isoformat()
+        except ValueError as exc:
+            raise ValueError(
+                f"as_of_date {as_of_date!r} is not a valid ISO date (YYYY-MM-DD)"
+            ) from exc
+    raise ValueError(f"as_of_date must be date | str | None, got {type(as_of_date)!r}")
+
+
+def query(  # noqa: PLR0912, C901 — guard clauses on the optional filters keep the happy path readable.
+    index: LoadedIndex,
+    query_embedding: np.ndarray,
+    *,
+    k: int = 5,
+    as_of_date: date_type | str | None = None,
+    exclude_text_hash: str | None = None,
+) -> list[AnalogHit]:
     """Return the top-``k`` analogs for a pre-computed query embedding.
 
     The query vector is L2-normalised before the dot product so the
     similarity scores live in ``[-1, 1]`` regardless of the encoder's
     output scale. ``k`` is clipped to the available index size; an
     empty index returns ``[]``.
+
+    ``as_of_date`` enforces a strict-backward walk-forward boundary —
+    only rows with ``event_date < as_of_date`` are eligible. When the
+    filtered pool has fewer than ``k`` rows we return what we have
+    rather than padding with future rows.
+
+    ``exclude_text_hash`` drops any candidate whose stored ``text_hash``
+    matches the supplied value. The runtime singleton passes the
+    sha256 of the cleaned query text so a caller that submits an
+    indexed statement does not get the trivial self-match back.
     """
 
     if index.size == 0:
@@ -344,21 +497,45 @@ def query(index: LoadedIndex, query_embedding: np.ndarray, *, k: int = 5) -> lis
     if norm == 0.0:
         return []
     arr = arr / norm
-    scores = index.embeddings @ arr  # (N,)
-    k_effective = min(int(k), index.size)
+
+    # Build the eligibility mask over the full index, then derive
+    # the candidate row indices in one pass — keeps the scoring step
+    # contiguous against a 1-D similarity vector.
+    eligible = np.ones(index.size, dtype=bool)
+    cutoff_iso = _as_of_to_iso(as_of_date)
+    if cutoff_iso is not None:
+        event_dates = index.metadata["event_date"].astype(str).to_numpy()
+        eligible &= event_dates < cutoff_iso
+    if exclude_text_hash:
+        text_hashes = index.metadata["text_hash"].astype(str).to_numpy()
+        eligible &= text_hashes != exclude_text_hash
+    candidate_idx = np.nonzero(eligible)[0]
+    if candidate_idx.size == 0:
+        return []
+
+    scores_all = index.embeddings @ arr  # (N,)
+    scores = scores_all[candidate_idx]
+    k_effective = min(int(k), candidate_idx.size)
     # ``argpartition`` is cheaper than a full sort for the typical
     # 250-row index, but we still need the partition slice sorted so
     # the API output is descending by similarity.
-    top_idx = np.argpartition(-scores, k_effective - 1)[:k_effective]
-    top_idx = top_idx[np.argsort(-scores[top_idx])]
+    if k_effective < scores.size:
+        partition = np.argpartition(-scores, k_effective - 1)[:k_effective]
+    else:
+        partition = np.arange(scores.size)
+    partition = partition[np.argsort(-scores[partition])]
+    top_idx = candidate_idx[partition]
+
     hits: list[AnalogHit] = []
     for row_idx in top_idx:
         row = index.metadata.iloc[int(row_idx)]
-        raw_vol = row.get("forward_realized_vol_10d")
-        try:
-            forward_vol: float | None = float(raw_vol) if raw_vol is not None and not pd.isna(raw_vol) else None
-        except (TypeError, ValueError):
-            forward_vol = None
+        raw_regime = row.get("subsequent_vol_regime")
+        regime: VolRegime | None
+        if raw_regime is None or (isinstance(raw_regime, float) and pd.isna(raw_regime)):
+            regime = None
+        else:
+            regime_str = str(raw_regime)
+            regime = regime_str if regime_str in ("calm", "normal", "high") else None  # type: ignore[assignment]
         raw_stance = row.get("axis_stance")
         stance: str | None
         if raw_stance is None or (isinstance(raw_stance, float) and pd.isna(raw_stance)):
@@ -370,19 +547,35 @@ def query(index: LoadedIndex, query_embedding: np.ndarray, *, k: int = 5) -> lis
                 event_date=str(row["event_date"]),
                 text_hash=str(row["text_hash"]),
                 axis_stance=stance,
-                forward_realized_vol_10d=forward_vol,
+                subsequent_vol_regime=regime,
                 excerpt=str(row["excerpt"]),
-                similarity=float(scores[int(row_idx)]),
+                similarity=float(scores_all[int(row_idx)]),
             )
         )
     return hits
+
+
+def text_hash_for_query(text: str) -> str:
+    """Return the sha256 hex digest of ``text`` after the cleaning the
+    runtime applies before tokenisation.
+
+    Centralised so the index's text_hash convention and the runtime
+    self-match filter share one definition.
+    """
+
+    cleaned = (text or "").strip()[:MAX_TEXT_CHARS]
+    return hashlib.sha256(cleaned.encode("utf-8")).hexdigest()
 
 
 __all__ = [
     "AnalogHit",
     "IndexPaths",
     "LoadedIndex",
+    "MAX_TEXT_CHARS",
+    "VOL_REGIME_BUCKET_EDGES",
+    "VolRegime",
     "build_index_from_events",
     "load_index",
     "query",
+    "text_hash_for_query",
 ]

--- a/backend/app/retrieval/index.py
+++ b/backend/app/retrieval/index.py
@@ -1,0 +1,388 @@
+"""On-disk retrieval index for historical FOMC statements (#294).
+
+The retrieval index is a small numpy embedding matrix paired with a
+metadata parquet. Each row in the metadata represents one past FOMC
+statement (rows from ``events.parquet`` filtered to
+``event_kind == "statement"``); each row in the matrix is the
+mean-pooled sentence embedding produced by the fine-tuned encoder
+registered at ``finbert_fed_adjacent_xbank_dapt_retrieval``.
+
+The total population is ~250 historical statements, so a plain
+``(N, d)`` matrix + dot-product top-k beats a FAISS dependency on
+operational simplicity. ``query`` normalises both index and query
+vectors so the dot product is the cosine similarity directly.
+
+Layout on disk under ``DATA_DIR / "artifacts" / "retrieval" / <run_id>``::
+
+    index.parquet     metadata rows (event_date, text_hash,
+                      axis_stance, forward_realized_vol_10d, excerpt)
+    embeddings.npy    float32 (N, d) embedding matrix; row order
+                      matches the parquet
+    manifest.json     encoder alias + revision + source training
+                      package id + row count + build timestamp
+
+The runtime singleton at ``app.services.analogs`` loads these three
+files at first /analyze/analogs hit and reuses them for the lifetime
+of the worker.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+_logger = logging.getLogger(__name__)
+
+# Truncate stored excerpts so the parquet stays cheap and the API response
+# never echoes a multi-page statement back to the client. ~280 chars matches
+# the AnalogCard schema documented in app/schemas.py.
+EXCERPT_CHARS = 280
+
+# Defensive cap on per-statement input length. The encoder tokenizer
+# truncates internally, but capping the string upstream keeps the
+# embedding helper from spending time on tail tokens that get dropped
+# anyway. 4096 chars ≈ 1024 tokens is comfortably above the FOMC
+# statement length distribution.
+MAX_TEXT_CHARS = 4096
+
+INDEX_PARQUET_NAME = "index.parquet"
+EMBEDDINGS_NPY_NAME = "embeddings.npy"
+MANIFEST_NAME = "manifest.json"
+
+METADATA_COLUMNS = (
+    "event_date",
+    "text_hash",
+    "axis_stance",
+    "forward_realized_vol_10d",
+    "excerpt",
+)
+
+
+@dataclass(frozen=True)
+class IndexPaths:
+    directory: Path
+
+    @property
+    def parquet(self) -> Path:
+        return self.directory / INDEX_PARQUET_NAME
+
+    @property
+    def embeddings(self) -> Path:
+        return self.directory / EMBEDDINGS_NPY_NAME
+
+    @property
+    def manifest(self) -> Path:
+        return self.directory / MANIFEST_NAME
+
+
+@dataclass(frozen=True)
+class LoadedIndex:
+    """In-memory retrieval index ready to serve top-k queries.
+
+    ``embeddings`` is row-normalised at load time so the dot product
+    against an L2-normalised query is the cosine similarity directly.
+    """
+
+    embeddings: np.ndarray  # (N, d), float32, L2-normalised rows
+    metadata: pd.DataFrame  # N rows, columns = METADATA_COLUMNS
+    encoder_alias: str
+    encoder_revision: str
+    training_package_id: str | None
+    built_at_utc: str
+
+    @property
+    def size(self) -> int:
+        return int(self.embeddings.shape[0])
+
+    @property
+    def embedding_dim(self) -> int:
+        if self.embeddings.size == 0:
+            return 0
+        return int(self.embeddings.shape[1])
+
+
+@dataclass(frozen=True)
+class AnalogHit:
+    """One retrieved analog row."""
+
+    event_date: str
+    text_hash: str
+    axis_stance: str | None
+    forward_realized_vol_10d: float | None
+    excerpt: str
+    similarity: float
+
+
+def _l2_normalise(matrix: np.ndarray, *, eps: float = 1e-12) -> np.ndarray:
+    """Row-wise L2 normalisation so dot products become cosine similarities.
+
+    Zero-length rows (degenerate empty inputs) keep their zero vector;
+    division-by-zero is guarded by ``eps``.
+    """
+
+    if matrix.size == 0:
+        return matrix.astype(np.float32, copy=False)
+    arr = matrix.astype(np.float32, copy=False)
+    norms = np.linalg.norm(arr, axis=1, keepdims=True)
+    norms = np.maximum(norms, eps)
+    return arr / norms
+
+
+def _ensure_metadata_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Coerce / project a DataFrame to the canonical METADATA_COLUMNS shape.
+
+    Missing optional columns (axis_stance, forward_realized_vol_10d) are
+    filled with ``None``; the required event_date and text_hash columns
+    raise if absent so a malformed parquet fails loudly at load time.
+    """
+
+    for required in ("event_date", "text_hash"):
+        if required not in df.columns:
+            raise KeyError(
+                f"retrieval metadata is missing required column {required!r}; "
+                f"got columns {list(df.columns)!r}"
+            )
+    out = pd.DataFrame()
+    out["event_date"] = df["event_date"].astype(str)
+    out["text_hash"] = df["text_hash"].astype(str)
+    out["axis_stance"] = df.get("axis_stance", pd.Series([None] * len(df)))
+    out["forward_realized_vol_10d"] = df.get(
+        "forward_realized_vol_10d", pd.Series([None] * len(df))
+    )
+    excerpts = df.get("excerpt", pd.Series([""] * len(df))).astype(str)
+    out["excerpt"] = excerpts.str.slice(0, EXCERPT_CHARS)
+    return out
+
+
+def _filter_statement_events(events: pd.DataFrame) -> pd.DataFrame:
+    """Project ``events.parquet`` to one row per historical FOMC statement.
+
+    The events parquet expands every event by horizon (1d / 5d / 10d
+    rows duplicate the text), so we group by ``text_hash`` and keep the
+    smallest-horizon row — the 1-day-horizon row whose
+    ``forward_realized_vol_10d`` is the post-event measure documented
+    in the data schema. Row order is preserved otherwise: the first
+    appearance of each ``text_hash`` in the source frame defines the
+    output order, which lets the test fixtures assert a deterministic
+    metadata sequence without depending on hash-sort.
+    """
+
+    if "event_kind" not in events.columns:
+        raise KeyError(
+            "events.parquet must carry an 'event_kind' column; "
+            f"got {list(events.columns)!r}"
+        )
+    mask = events["event_kind"].astype(str).str.lower() == "statement"
+    df = events.loc[mask].copy()
+    if df.empty:
+        return df
+    df = df.reset_index(drop=True)
+    df["_original_order"] = np.arange(len(df))
+    sort_cols = ["text_hash"]
+    if "horizon" in df.columns:
+        sort_cols.append("horizon")
+    df = df.sort_values(sort_cols)
+    df = df.drop_duplicates(subset=["text_hash"], keep="first")
+    df = df.sort_values("_original_order").drop(columns=["_original_order"])
+    return df.reset_index(drop=True)
+
+
+def _statement_text(row: pd.Series) -> str:
+    text = str(row.get("text") or "").strip()
+    if not text:
+        return ""
+    return text[:MAX_TEXT_CHARS]
+
+
+def _empty_embedding_matrix(dim: int) -> np.ndarray:
+    return np.zeros((0, max(dim, 1)), dtype=np.float32)
+
+
+def build_index_from_events(  # noqa: PLR0913 — keyword-only builder args mirror the CLI; grouping would obscure the call site.
+    events_parquet: Path,
+    *,
+    encoder_alias: str,
+    encoder_revision: str,
+    embed_fn,
+    training_package_id: str | None = None,
+    out_dir: Path,
+) -> LoadedIndex:
+    """Build a retrieval index by embedding every statement row.
+
+    ``embed_fn`` is a callable taking ``list[str]`` and returning a
+    ``(len, d)`` ndarray — the test suite passes a dummy projection
+    here, while the production caller in ``app.retrieval.train`` passes
+    a closure that runs the fine-tuned encoder.
+
+    Persists the parquet + embedding matrix + manifest under ``out_dir``
+    and returns the in-memory ``LoadedIndex`` so the caller can validate
+    the build without a re-load round-trip.
+    """
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    events = pd.read_parquet(events_parquet)
+    statements = _filter_statement_events(events)
+    rows: list[dict[str, Any]] = []
+    texts: list[str] = []
+    for _, raw_row in statements.iterrows():
+        text = _statement_text(raw_row)
+        if not text:
+            continue
+        rows.append(
+            {
+                "event_date": str(raw_row.get("event_date", "")),
+                "text_hash": str(raw_row.get("text_hash", "")),
+                "axis_stance": raw_row.get("axis_stance"),
+                "forward_realized_vol_10d": raw_row.get("forward_realized_vol_10d"),
+                "excerpt": text[:EXCERPT_CHARS],
+            }
+        )
+        texts.append(text)
+
+    if not rows:
+        _logger.warning("retrieval_index_empty events_parquet=%s", events_parquet)
+        embeddings = _empty_embedding_matrix(1)
+        metadata = pd.DataFrame(columns=list(METADATA_COLUMNS))
+    else:
+        raw_embeddings = embed_fn(texts)
+        embeddings = np.asarray(raw_embeddings, dtype=np.float32)
+        if embeddings.ndim != 2 or embeddings.shape[0] != len(rows):
+            raise ValueError(
+                "embed_fn must return a 2-D array with one row per input; "
+                f"got shape {embeddings.shape!r} for {len(rows)} inputs"
+            )
+        metadata = _ensure_metadata_columns(pd.DataFrame(rows))
+        embeddings = _l2_normalise(embeddings)
+
+    paths = IndexPaths(directory=out_dir)
+    metadata.to_parquet(paths.parquet, index=False)
+    np.save(paths.embeddings, embeddings)
+    manifest = {
+        "encoder_alias": encoder_alias,
+        "encoder_revision": encoder_revision,
+        "training_package_id": training_package_id,
+        "row_count": int(len(metadata)),
+        "embedding_dim": int(embeddings.shape[1]) if embeddings.size else 0,
+        "events_parquet": str(events_parquet),
+        "built_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    paths.manifest.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+
+    return LoadedIndex(
+        embeddings=embeddings,
+        metadata=metadata,
+        encoder_alias=encoder_alias,
+        encoder_revision=encoder_revision,
+        training_package_id=training_package_id,
+        built_at_utc=manifest["built_at_utc"],
+    )
+
+
+def load_index(directory: Path) -> LoadedIndex:
+    """Load a previously persisted retrieval index from disk.
+
+    Raises ``FileNotFoundError`` when the directory is missing the
+    embeddings / parquet / manifest triple — the runtime singleton
+    catches this and degrades the /analyze/analogs endpoint to
+    ``available=False`` instead of crashing the worker.
+    """
+
+    paths = IndexPaths(directory=Path(directory))
+    for required in (paths.parquet, paths.embeddings, paths.manifest):
+        if not required.exists():
+            raise FileNotFoundError(
+                f"retrieval index incomplete at {paths.directory}: "
+                f"missing {required.name}"
+            )
+    metadata = _ensure_metadata_columns(pd.read_parquet(paths.parquet))
+    raw_embeddings = np.load(paths.embeddings)
+    embeddings = _l2_normalise(np.asarray(raw_embeddings, dtype=np.float32))
+    if embeddings.shape[0] != len(metadata):
+        raise ValueError(
+            "retrieval index row mismatch: "
+            f"{embeddings.shape[0]} embeddings vs {len(metadata)} metadata rows"
+        )
+    manifest = json.loads(paths.manifest.read_text(encoding="utf-8"))
+    return LoadedIndex(
+        embeddings=embeddings,
+        metadata=metadata,
+        encoder_alias=str(manifest.get("encoder_alias", "")),
+        encoder_revision=str(manifest.get("encoder_revision", "")),
+        training_package_id=manifest.get("training_package_id"),
+        built_at_utc=str(manifest.get("built_at_utc", "")),
+    )
+
+
+def query(index: LoadedIndex, query_embedding: np.ndarray, *, k: int = 5) -> list[AnalogHit]:
+    """Return the top-``k`` analogs for a pre-computed query embedding.
+
+    The query vector is L2-normalised before the dot product so the
+    similarity scores live in ``[-1, 1]`` regardless of the encoder's
+    output scale. ``k`` is clipped to the available index size; an
+    empty index returns ``[]``.
+    """
+
+    if index.size == 0:
+        return []
+    if k <= 0:
+        return []
+    arr = np.asarray(query_embedding, dtype=np.float32).reshape(-1)
+    if arr.shape[0] != index.embedding_dim:
+        raise ValueError(
+            f"query embedding dim {arr.shape[0]} does not match index dim {index.embedding_dim}"
+        )
+    norm = float(np.linalg.norm(arr))
+    if norm == 0.0:
+        return []
+    arr = arr / norm
+    scores = index.embeddings @ arr  # (N,)
+    k_effective = min(int(k), index.size)
+    # ``argpartition`` is cheaper than a full sort for the typical
+    # 250-row index, but we still need the partition slice sorted so
+    # the API output is descending by similarity.
+    top_idx = np.argpartition(-scores, k_effective - 1)[:k_effective]
+    top_idx = top_idx[np.argsort(-scores[top_idx])]
+    hits: list[AnalogHit] = []
+    for row_idx in top_idx:
+        row = index.metadata.iloc[int(row_idx)]
+        raw_vol = row.get("forward_realized_vol_10d")
+        try:
+            forward_vol: float | None = float(raw_vol) if raw_vol is not None and not pd.isna(raw_vol) else None
+        except (TypeError, ValueError):
+            forward_vol = None
+        raw_stance = row.get("axis_stance")
+        stance: str | None
+        if raw_stance is None or (isinstance(raw_stance, float) and pd.isna(raw_stance)):
+            stance = None
+        else:
+            stance = str(raw_stance)
+        hits.append(
+            AnalogHit(
+                event_date=str(row["event_date"]),
+                text_hash=str(row["text_hash"]),
+                axis_stance=stance,
+                forward_realized_vol_10d=forward_vol,
+                excerpt=str(row["excerpt"]),
+                similarity=float(scores[int(row_idx)]),
+            )
+        )
+    return hits
+
+
+__all__ = [
+    "AnalogHit",
+    "IndexPaths",
+    "LoadedIndex",
+    "build_index_from_events",
+    "load_index",
+    "query",
+]

--- a/backend/app/retrieval/train.py
+++ b/backend/app/retrieval/train.py
@@ -34,7 +34,16 @@ Usage::
     python -m app.retrieval.train \\
         --events-parquet /data/processed/<pkg>/events.parquet \\
         --base-encoder-alias finbert_fed_adjacent_xbank_dapt \\
-        --epochs 1 --batch-size 16 --seed 11
+        --epochs 1 --batch-size 16 --seed 11 \\
+        --fold-id wf_fold_3
+
+The ``--train-end`` / ``--fold-id`` flags enforce a strict-backward
+walk-forward boundary at training time: rows with
+``event_date >= train_end`` are dropped BEFORE pair construction, so
+the encoder's weights never see future text relative to the
+walk-forward train slice. Pass either flag (not both); the resolved
+boundary is persisted into the retrieval manifest so the runtime
+query path can enforce the same cut.
 
 Sentence-transformers is loaded lazily so the import-time surface stays
 free of the heavy dependency — the runtime FastAPI worker never has to
@@ -50,6 +59,7 @@ import logging
 import os
 import random
 from dataclasses import dataclass
+from datetime import date as date_type
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -76,6 +86,8 @@ DEFAULT_BATCH_SIZE = 16
 DEFAULT_LEARNING_RATE = 2e-5
 DEFAULT_WARMUP_STEPS = 100
 DEFAULT_SEED = 11
+
+FOLD_MANIFEST_FILENAME = "fold_manifest_expanding_walk_forward.json"
 
 # The pair-build path treats statements as anchors and pairs each
 # statement with every other doc released on the same event_date.
@@ -118,15 +130,84 @@ def _clean_text(text: Any) -> str:
     return s[:MAX_TEXT_CHARS]
 
 
-def build_training_pairs(events: pd.DataFrame) -> list[TrainingPair]:  # noqa: C901 — flat column-validation guards keep the data contract greppable at the top of the function.
+def _validate_train_end(train_end: str | None) -> str | None:
+    """Normalise a train_end string to ISO ``YYYY-MM-DD`` form or ``None``."""
+
+    if train_end is None or str(train_end).strip() == "":
+        return None
+    text = str(train_end).strip()
+    try:
+        return date_type.fromisoformat(text).isoformat()
+    except ValueError as exc:
+        raise ValueError(
+            f"train_end {train_end!r} is not a valid ISO date (YYYY-MM-DD)"
+        ) from exc
+
+
+def resolve_train_end_from_fold(
+    *,
+    events_parquet: Path,
+    fold_id: str,
+) -> str:
+    """Look up a fold's ``train_end`` from the sibling fold manifest.
+
+    The fold manifest is expected at
+    ``events_parquet.parent / fold_manifest_expanding_walk_forward.json``
+    — the canonical training-package layout produced by
+    :mod:`app.data.training_package_builder`. Raises ``ValueError`` if
+    the manifest is missing or the fold_id is unknown.
+    """
+
+    manifest_path = events_parquet.parent / FOLD_MANIFEST_FILENAME
+    if not manifest_path.exists():
+        raise ValueError(
+            f"fold manifest not found at {manifest_path}; pass --train-end explicitly"
+        )
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    folds = payload.get("folds") or []
+    for fold in folds:
+        if fold.get("fold_id") == fold_id:
+            train_end = fold.get("train_end")
+            if not train_end:
+                raise ValueError(
+                    f"fold {fold_id!r} in {manifest_path} carries no train_end"
+                )
+            return str(train_end)
+    available = sorted(str(f.get("fold_id", "")) for f in folds)
+    raise ValueError(
+        f"fold_id {fold_id!r} not found in {manifest_path}; available: {available}"
+    )
+
+
+def _filter_events_by_train_end(events: pd.DataFrame, train_end: str) -> pd.DataFrame:
+    """Drop rows with ``event_date >= train_end`` — strict walk-forward cut."""
+
+    if "event_date" not in events.columns:
+        raise KeyError("events parquet missing 'event_date' column")
+    cutoff = pd.Timestamp(train_end).date().isoformat()
+    dates = events["event_date"].astype(str)
+    return events.loc[dates < cutoff].copy()
+
+
+def build_training_pairs(  # noqa: C901 — flat column-validation guards keep the data contract greppable at the top of the function.
+    events: pd.DataFrame,
+    *,
+    train_end: str | None = None,
+) -> list[TrainingPair]:
     """Materialise same-meeting (statement, sibling) pairs from events.parquet.
 
     Statements are the anchor population; their sibling minutes /
-    press_conference rows become positives. A meeting with no sibling
-    row contributes a degenerate (statement, statement) pair so the
-    encoder still sees the anchor — MNRL tolerates self-positives and
-    the empirical signal from the contrastive in-batch negatives
-    survives.
+    press_conference rows become positives. Meetings with no sibling
+    are dropped entirely — the pre-review build emitted a degenerate
+    ``(statement, statement)`` self-pair fallback, which teaches MNRL
+    to maximise self-similarity and amplifies the self-match problem
+    at retrieval time. Better to skip the meeting than to ship that
+    signal.
+
+    ``train_end`` (ISO date) enforces the walk-forward boundary at the
+    earliest possible step: rows with ``event_date >= train_end`` are
+    dropped BEFORE pair construction so the encoder never sees future
+    text. Pass ``None`` for unbounded training (smoke / debug only).
     """
 
     if "event_kind" not in events.columns:
@@ -139,6 +220,8 @@ def build_training_pairs(events: pd.DataFrame) -> list[TrainingPair]:  # noqa: C
         raise KeyError("events parquet missing 'text_hash' column")
 
     df = events.copy()
+    if train_end is not None:
+        df = _filter_events_by_train_end(df, train_end)
     df["event_kind"] = df["event_kind"].astype(str).str.lower()
     df["event_date"] = df["event_date"].astype(str)
     if "horizon" in df.columns:
@@ -156,7 +239,6 @@ def build_training_pairs(events: pd.DataFrame) -> list[TrainingPair]:  # noqa: C
             (df["event_date"] == anchor_date)
             & (df["event_kind"].isin(POSITIVE_KINDS))
         ]
-        added = False
         for _, sibling in siblings.iterrows():
             sibling_text = _clean_text(sibling.get("text"))
             if not sibling_text or sibling_text == anchor_text:
@@ -169,20 +251,10 @@ def build_training_pairs(events: pd.DataFrame) -> list[TrainingPair]:  # noqa: C
                     positive_kind=str(sibling.get("event_kind", "")),
                 )
             )
-            added = True
-        if not added:
-            # Self-pair fallback so the meeting still contributes a
-            # training row. SBERT's MNRL uses in-batch negatives so
-            # the self-positive's gradient signal flows through the
-            # remaining batch comparisons.
-            pairs.append(
-                TrainingPair(
-                    anchor=anchor_text,
-                    positive=anchor_text,
-                    anchor_date=anchor_date,
-                    positive_kind="self",
-                )
-            )
+        # Meetings whose only document is the statement contribute
+        # nothing — silently dropped. MNRL cannot learn from a
+        # (statement, statement) pair without ingraining a self-match
+        # bias at retrieval time.
     return pairs
 
 
@@ -211,7 +283,7 @@ def _build_sbert_model(repo: str, revision: str, *, max_seq_length: int):
     inference path can read with ``AutoModel`` + manual mean-pool.
     """
 
-    from sentence_transformers import SentenceTransformer, models  # type: ignore[import-not-found]
+    from sentence_transformers import SentenceTransformer, models  # type: ignore[import-not-found,attr-defined,unused-ignore]
 
     word_embedding = models.Transformer(
         repo, max_seq_length=max_seq_length, model_args={"revision": revision or None}
@@ -226,7 +298,7 @@ def _build_sbert_model(repo: str, revision: str, *, max_seq_length: int):
 
 
 def _build_input_examples(pairs: list[TrainingPair]):
-    from sentence_transformers import InputExample  # type: ignore[import-not-found]
+    from sentence_transformers import InputExample  # type: ignore[import-not-found,unused-ignore]
 
     return [InputExample(texts=[pair.anchor, pair.positive]) for pair in pairs]
 
@@ -263,29 +335,65 @@ def fine_tune_and_index(  # noqa: PLR0913 — keyword-only training-script knobs
     max_length: int = DEFAULT_MAX_LENGTH,
     seed: int = DEFAULT_SEED,
     training_package_id: str | None = None,
+    train_end: str | None = None,
+    fold_id: str | None = None,
 ) -> Path:
     """Train the retrieval encoder and persist the index alongside it.
 
     Returns the path to the saved checkpoint directory.
     """
 
+    if batch_size < 2:
+        # MNRL builds its negatives from the rest of the in-batch
+        # positives; a batch of 1 means there are no negatives and the
+        # loss silently degenerates to zero. Fail fast so a broken
+        # encoder never ships.
+        raise ValueError(
+            "MultipleNegativesRankingLoss requires batch_size >= 2; "
+            f"got batch_size={batch_size}"
+        )
+    if train_end is not None and fold_id is not None:
+        raise ValueError(
+            "--train-end and --fold-id are mutually exclusive; pass only one"
+        )
+
+    resolved_train_end: str | None
+    if fold_id is not None:
+        resolved_train_end = resolve_train_end_from_fold(
+            events_parquet=Path(events_parquet), fold_id=fold_id
+        )
+    else:
+        resolved_train_end = _validate_train_end(train_end)
+
     _set_all_seeds(seed)
     repo, revision = _resolve_base_repo(base_encoder_alias)
 
     events = pd.read_parquet(events_parquet)
-    pairs = build_training_pairs(events)
+    pairs = build_training_pairs(events, train_end=resolved_train_end)
     if not pairs:
         raise RuntimeError(
             f"events_parquet {events_parquet} yielded zero (statement, sibling) pairs; "
-            "verify the parquet carries statement + minutes rows."
+            "verify the parquet carries statement + minutes rows and the "
+            "train_end cutoff is not stripping every meeting."
         )
 
-    from torch.utils.data import DataLoader  # type: ignore[import-not-found]
-    from sentence_transformers import losses  # type: ignore[import-not-found]
+    import torch  # type: ignore[import-not-found,unused-ignore]
+    from torch.utils.data import DataLoader  # type: ignore[import-not-found,unused-ignore]
+    from sentence_transformers import losses  # type: ignore[import-not-found,attr-defined,unused-ignore]
 
     model = _build_sbert_model(repo, revision, max_seq_length=max_length)
     train_examples = _build_input_examples(pairs)
-    loader = DataLoader(train_examples, shuffle=True, batch_size=batch_size)
+    # Explicit generator so the shuffle order is reproducible — the
+    # ``--seed`` knob is otherwise effectively meaningless for batch
+    # ordering, which is the dominant source of contrastive-loss
+    # variance.
+    shuffle_generator = torch.Generator().manual_seed(int(seed))
+    loader = DataLoader(
+        train_examples,
+        shuffle=True,
+        batch_size=batch_size,
+        generator=shuffle_generator,
+    )
     loss = losses.MultipleNegativesRankingLoss(model)
 
     out_dir = Path(output_root) / run_name
@@ -293,11 +401,12 @@ def fine_tune_and_index(  # noqa: PLR0913 — keyword-only training-script knobs
     checkpoint_dir = out_dir / "checkpoint"
 
     _logger.info(
-        "retrieval_train_start base=%s pairs=%d epochs=%d batch_size=%d",
+        "retrieval_train_start base=%s pairs=%d epochs=%d batch_size=%d train_end=%s",
         base_encoder_alias,
         len(pairs),
         epochs,
         batch_size,
+        resolved_train_end,
     )
     model.fit(
         train_objectives=[(loader, loss)],
@@ -321,6 +430,7 @@ def fine_tune_and_index(  # noqa: PLR0913 — keyword-only training-script knobs
         embed_fn=_embed,
         training_package_id=training_package_id,
         out_dir=out_dir,
+        train_end=resolved_train_end,
     )
     _logger.info(
         "retrieval_train_done index_rows=%d dim=%d out_dir=%s",
@@ -342,6 +452,8 @@ def fine_tune_and_index(  # noqa: PLR0913 — keyword-only training-script knobs
         "training_package_id": training_package_id,
         "pair_count": len(pairs),
         "excerpt_chars": EXCERPT_CHARS,
+        "train_end": resolved_train_end,
+        "fold_id": fold_id,
         "saved_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
     (out_dir / "training_args.json").write_text(
@@ -365,6 +477,25 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--max-length", type=int, default=DEFAULT_MAX_LENGTH)
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     parser.add_argument("--training-package-id", default=None)
+    parser.add_argument(
+        "--train-end",
+        default=None,
+        help=(
+            "ISO date (YYYY-MM-DD). Drop every event with event_date >= "
+            "train_end BEFORE pair construction so the encoder never sees "
+            "future text relative to the walk-forward train slice. Mutually "
+            "exclusive with --fold-id."
+        ),
+    )
+    parser.add_argument(
+        "--fold-id",
+        default=None,
+        help=(
+            "Resolve train_end from the sibling fold manifest "
+            "(fold_manifest_expanding_walk_forward.json) by fold_id "
+            "(e.g. wf_fold_3). Mutually exclusive with --train-end."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -383,6 +514,8 @@ def main() -> int:
         max_length=args.max_length,
         seed=args.seed,
         training_package_id=args.training_package_id,
+        train_end=args.train_end,
+        fold_id=args.fold_id,
     )
     print(f"[retrieval.train] saved checkpoint to {checkpoint}")
     return 0

--- a/backend/app/retrieval/train.py
+++ b/backend/app/retrieval/train.py
@@ -1,0 +1,392 @@
+"""Fine-tune the historical-analog retrieval encoder (#294).
+
+Layers a sentence-transformer head on top of the cross-bank DAPT
+checkpoint (``finbert_fed_adjacent_xbank_dapt``) and trains with
+contrastive ``MultipleNegativesRankingLoss`` (MNRL — Henderson et al.,
+2017) over same-meeting positive pairs:
+
+* anchor   = an FOMC statement
+* positive = the minutes or press conference released by the same
+  meeting (rows in ``events.parquet`` sharing the anchor's
+  ``event_date``)
+
+In-batch contrastive learning treats every other positive in the batch
+as a negative, so the loss is the standard cross-entropy over the
+``batch_size x batch_size`` similarity matrix. The recipe is the SBERT
+default and reproduces the same training signal as the asymmetric
+search-retrieval MS MARCO setup, just on a vastly smaller corpus.
+
+Outputs:
+* ``out_dir / "checkpoint"`` — the sentence-transformer save directory
+  (HF-style: ``config.json``, ``pytorch_model.bin``, tokenizer files,
+  plus the SBERT ``1_Pooling/`` config). The runtime singleton at
+  ``app.services.analogs`` reads this directory with
+  ``AutoTokenizer`` + ``AutoModel`` so the inference path does not
+  pull in sentence-transformers at startup.
+* ``out_dir / "index.parquet"`` + ``embeddings.npy`` + ``manifest.json``
+  — the historical-statement retrieval index produced by
+  ``app.retrieval.index.build_index_from_events`` using the freshly
+  trained encoder.
+* ``out_dir / "training_args.json"`` — full run provenance.
+
+Usage::
+
+    python -m app.retrieval.train \\
+        --events-parquet /data/processed/<pkg>/events.parquet \\
+        --base-encoder-alias finbert_fed_adjacent_xbank_dapt \\
+        --epochs 1 --batch-size 16 --seed 11
+
+Sentence-transformers is loaded lazily so the import-time surface stays
+free of the heavy dependency — the runtime FastAPI worker never has to
+touch it. Tests for the index + endpoint operate on faked encoders;
+this script is only exercised at training time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import random
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from app.config import DATA_DIR
+from app.models.registry import encoder_ref
+from app.retrieval.index import (
+    EXCERPT_CHARS,
+    MAX_TEXT_CHARS,
+    build_index_from_events,
+)
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_ENCODER_ALIAS = "finbert_fed_adjacent_xbank_dapt"
+DEFAULT_OUTPUT_ROOT = DATA_DIR / "artifacts" / "retrieval"
+DEFAULT_RUN_NAME = "finbert_fed_adjacent_xbank_dapt_retrieval"
+DEFAULT_MAX_LENGTH = 256
+DEFAULT_EPOCHS = 1
+DEFAULT_BATCH_SIZE = 16
+DEFAULT_LEARNING_RATE = 2e-5
+DEFAULT_WARMUP_STEPS = 100
+DEFAULT_SEED = 11
+
+# The pair-build path treats statements as anchors and pairs each
+# statement with every other doc released on the same event_date.
+# Limiting the kinds we accept as positives to minutes /
+# press_conference avoids polluting the contrastive signal with
+# orthogonal macro_release rows that share a date but carry no FOMC
+# content. Adding "speech" / "testimony" stays a follow-up — they are
+# released by individual speakers, not the committee.
+POSITIVE_KINDS = ("minutes", "press_conference")
+
+
+@dataclass(frozen=True)
+class TrainingPair:
+    """One (anchor, positive) example for MNRL contrastive training."""
+
+    anchor: str
+    positive: str
+    anchor_date: str
+    positive_kind: str
+
+
+def _set_all_seeds(seed: int) -> None:
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    try:
+        import torch
+
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
+    except ImportError:  # pragma: no cover — torch is a hard dep but keep the import lazy
+        pass
+
+
+def _clean_text(text: Any) -> str:
+    s = str(text or "").strip()
+    if not s:
+        return ""
+    return s[:MAX_TEXT_CHARS]
+
+
+def build_training_pairs(events: pd.DataFrame) -> list[TrainingPair]:  # noqa: C901 — flat column-validation guards keep the data contract greppable at the top of the function.
+    """Materialise same-meeting (statement, sibling) pairs from events.parquet.
+
+    Statements are the anchor population; their sibling minutes /
+    press_conference rows become positives. A meeting with no sibling
+    row contributes a degenerate (statement, statement) pair so the
+    encoder still sees the anchor — MNRL tolerates self-positives and
+    the empirical signal from the contrastive in-batch negatives
+    survives.
+    """
+
+    if "event_kind" not in events.columns:
+        raise KeyError("events parquet missing 'event_kind' column")
+    if "text" not in events.columns:
+        raise KeyError("events parquet missing 'text' column")
+    if "event_date" not in events.columns:
+        raise KeyError("events parquet missing 'event_date' column")
+    if "text_hash" not in events.columns:
+        raise KeyError("events parquet missing 'text_hash' column")
+
+    df = events.copy()
+    df["event_kind"] = df["event_kind"].astype(str).str.lower()
+    df["event_date"] = df["event_date"].astype(str)
+    if "horizon" in df.columns:
+        df = df.sort_values(["event_date", "event_kind", "horizon"])
+    df = df.drop_duplicates(subset=["text_hash"], keep="first").reset_index(drop=True)
+
+    statements = df[df["event_kind"] == "statement"]
+    pairs: list[TrainingPair] = []
+    for _, anchor_row in statements.iterrows():
+        anchor_text = _clean_text(anchor_row.get("text"))
+        if not anchor_text:
+            continue
+        anchor_date = str(anchor_row.get("event_date", ""))
+        siblings = df[
+            (df["event_date"] == anchor_date)
+            & (df["event_kind"].isin(POSITIVE_KINDS))
+        ]
+        added = False
+        for _, sibling in siblings.iterrows():
+            sibling_text = _clean_text(sibling.get("text"))
+            if not sibling_text or sibling_text == anchor_text:
+                continue
+            pairs.append(
+                TrainingPair(
+                    anchor=anchor_text,
+                    positive=sibling_text,
+                    anchor_date=anchor_date,
+                    positive_kind=str(sibling.get("event_kind", "")),
+                )
+            )
+            added = True
+        if not added:
+            # Self-pair fallback so the meeting still contributes a
+            # training row. SBERT's MNRL uses in-batch negatives so
+            # the self-positive's gradient signal flows through the
+            # remaining batch comparisons.
+            pairs.append(
+                TrainingPair(
+                    anchor=anchor_text,
+                    positive=anchor_text,
+                    anchor_date=anchor_date,
+                    positive_kind="self",
+                )
+            )
+    return pairs
+
+
+def _resolve_base_repo(alias: str) -> tuple[str, str]:
+    """Resolve a registry alias to (repo, revision) for sentence-transformers.
+
+    Local-path encoders (e.g. the DAPT checkpoint at
+    ``/data/artifacts/continued_pretraining/...``) are handed back
+    verbatim — sentence-transformers accepts a directory path the same
+    way HF transformers does.
+    """
+
+    ref = encoder_ref(alias)
+    if ref is None:
+        raise ValueError(
+            f"Unknown encoder alias {alias!r}. Add it to backend/app/models/registry.yaml."
+        )
+    return ref.repo, ref.revision or ""
+
+
+def _build_sbert_model(repo: str, revision: str, *, max_seq_length: int):
+    """Lazy sentence-transformers builder.
+
+    Wraps the encoder in a Transformer + mean-pooling module so the
+    saved checkpoint folder is a plain SBERT directory the runtime
+    inference path can read with ``AutoModel`` + manual mean-pool.
+    """
+
+    from sentence_transformers import SentenceTransformer, models  # type: ignore[import-not-found]
+
+    word_embedding = models.Transformer(
+        repo, max_seq_length=max_seq_length, model_args={"revision": revision or None}
+    )
+    pooling = models.Pooling(
+        word_embedding.get_word_embedding_dimension(),
+        pooling_mode_mean_tokens=True,
+        pooling_mode_cls_token=False,
+        pooling_mode_max_tokens=False,
+    )
+    return SentenceTransformer(modules=[word_embedding, pooling])
+
+
+def _build_input_examples(pairs: list[TrainingPair]):
+    from sentence_transformers import InputExample  # type: ignore[import-not-found]
+
+    return [InputExample(texts=[pair.anchor, pair.positive]) for pair in pairs]
+
+
+def _embed_with_sbert(model, texts: list[str]) -> np.ndarray:
+    """Adapter so :mod:`app.retrieval.index` can call SBERT's encode path.
+
+    SBERT returns numpy by default when ``convert_to_numpy=True``; we
+    ask for unnormalised vectors and let ``index.build_index_from_events``
+    apply the L2 normalisation so the on-disk matrix matches the
+    cosine-similarity invariant.
+    """
+
+    embeddings = model.encode(
+        texts,
+        batch_size=32,
+        convert_to_numpy=True,
+        normalize_embeddings=False,
+        show_progress_bar=False,
+    )
+    return np.asarray(embeddings, dtype=np.float32)
+
+
+def fine_tune_and_index(  # noqa: PLR0913 — keyword-only training-script knobs; grouping would obscure CLI parity.
+    *,
+    events_parquet: Path,
+    base_encoder_alias: str = DEFAULT_BASE_ENCODER_ALIAS,
+    output_root: Path = DEFAULT_OUTPUT_ROOT,
+    run_name: str = DEFAULT_RUN_NAME,
+    epochs: int = DEFAULT_EPOCHS,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    learning_rate: float = DEFAULT_LEARNING_RATE,
+    warmup_steps: int = DEFAULT_WARMUP_STEPS,
+    max_length: int = DEFAULT_MAX_LENGTH,
+    seed: int = DEFAULT_SEED,
+    training_package_id: str | None = None,
+) -> Path:
+    """Train the retrieval encoder and persist the index alongside it.
+
+    Returns the path to the saved checkpoint directory.
+    """
+
+    _set_all_seeds(seed)
+    repo, revision = _resolve_base_repo(base_encoder_alias)
+
+    events = pd.read_parquet(events_parquet)
+    pairs = build_training_pairs(events)
+    if not pairs:
+        raise RuntimeError(
+            f"events_parquet {events_parquet} yielded zero (statement, sibling) pairs; "
+            "verify the parquet carries statement + minutes rows."
+        )
+
+    from torch.utils.data import DataLoader  # type: ignore[import-not-found]
+    from sentence_transformers import losses  # type: ignore[import-not-found]
+
+    model = _build_sbert_model(repo, revision, max_seq_length=max_length)
+    train_examples = _build_input_examples(pairs)
+    loader = DataLoader(train_examples, shuffle=True, batch_size=batch_size)
+    loss = losses.MultipleNegativesRankingLoss(model)
+
+    out_dir = Path(output_root) / run_name
+    out_dir.mkdir(parents=True, exist_ok=True)
+    checkpoint_dir = out_dir / "checkpoint"
+
+    _logger.info(
+        "retrieval_train_start base=%s pairs=%d epochs=%d batch_size=%d",
+        base_encoder_alias,
+        len(pairs),
+        epochs,
+        batch_size,
+    )
+    model.fit(
+        train_objectives=[(loader, loss)],
+        epochs=epochs,
+        warmup_steps=min(warmup_steps, max(1, len(loader) // 2)),
+        optimizer_params={"lr": learning_rate},
+        show_progress_bar=False,
+        output_path=str(checkpoint_dir),
+        save_best_model=True,
+    )
+
+    # Build the historical-statement index alongside the checkpoint so
+    # ``/analyze/analogs`` can mount the bundle as a single directory.
+    def _embed(texts: list[str]) -> np.ndarray:
+        return _embed_with_sbert(model, texts)
+
+    loaded_index = build_index_from_events(
+        events_parquet=Path(events_parquet),
+        encoder_alias="finbert_fed_adjacent_xbank_dapt_retrieval",
+        encoder_revision="",  # filled in once the registry pins this run
+        embed_fn=_embed,
+        training_package_id=training_package_id,
+        out_dir=out_dir,
+    )
+    _logger.info(
+        "retrieval_train_done index_rows=%d dim=%d out_dir=%s",
+        loaded_index.size,
+        loaded_index.embedding_dim,
+        out_dir,
+    )
+
+    training_args = {
+        "base_encoder_alias": base_encoder_alias,
+        "base_encoder_repo": repo,
+        "base_encoder_revision": revision,
+        "epochs": epochs,
+        "batch_size": batch_size,
+        "learning_rate": learning_rate,
+        "warmup_steps": warmup_steps,
+        "max_length": max_length,
+        "seed": seed,
+        "training_package_id": training_package_id,
+        "pair_count": len(pairs),
+        "excerpt_chars": EXCERPT_CHARS,
+        "saved_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    (out_dir / "training_args.json").write_text(
+        json.dumps(training_args, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    return checkpoint_dir
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fine-tune the historical-analog retrieval encoder (#294)."
+    )
+    parser.add_argument("--events-parquet", required=True, type=Path)
+    parser.add_argument("--base-encoder-alias", default=DEFAULT_BASE_ENCODER_ALIAS)
+    parser.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT), type=Path)
+    parser.add_argument("--run-name", default=DEFAULT_RUN_NAME)
+    parser.add_argument("--epochs", type=int, default=DEFAULT_EPOCHS)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--learning-rate", type=float, default=DEFAULT_LEARNING_RATE)
+    parser.add_argument("--warmup-steps", type=int, default=DEFAULT_WARMUP_STEPS)
+    parser.add_argument("--max-length", type=int, default=DEFAULT_MAX_LENGTH)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--training-package-id", default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
+    checkpoint = fine_tune_and_index(
+        events_parquet=args.events_parquet,
+        base_encoder_alias=args.base_encoder_alias,
+        output_root=args.output_root,
+        run_name=args.run_name,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        learning_rate=args.learning_rate,
+        warmup_steps=args.warmup_steps,
+        max_length=args.max_length,
+        seed=args.seed,
+        training_package_id=args.training_package_id,
+    )
+    print(f"[retrieval.train] saved checkpoint to {checkpoint}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,7 @@
-from typing import Any
+from datetime import date
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 _STRICT_REQUEST_CONFIG = ConfigDict(extra="forbid", strict=True, frozen=True)
@@ -603,17 +604,62 @@ class NextFomcForecastResponse(BaseModel):
 class AnalogsRequest(BaseModel):
     """Query a fine-tuned retrieval encoder for past FOMC statements that
     sound like ``text``. Returns top-``k`` analogs ordered by cosine
-    similarity together with the realised post-event volatility so the
-    caller can show "what regime followed each analog"."""
+    similarity together with a coarse post-event volatility regime label
+    so the caller can show "what regime followed each analog" without
+    exposing the underlying supervised target value."""
 
     model_config = _STRICT_REQUEST_CONFIG
 
     text: str = Field(..., min_length=1, description="Statement text to match against past FOMC statements.")
     k: int = Field(default=5, ge=1, le=20, description="Number of analogs to return (1-20).")
+    as_of_date: date | None = Field(
+        default=None,
+        description=(
+            "Strict-backward walk-forward boundary: only analogs with "
+            "``event_date < as_of_date`` are eligible. Default is no "
+            "boundary; for ML feature use always pass a date so the "
+            "retrieval set does not leak future statements into the "
+            "training fold."
+        ),
+    )
+
+    @field_validator("as_of_date", mode="before")
+    @classmethod
+    def _coerce_as_of_date(cls, value: Any) -> Any:
+        """Accept ISO ``YYYY-MM-DD`` strings under strict mode.
+
+        Pydantic strict mode rejects string -> date coercion by default,
+        but the JSON wire format only carries strings; this validator
+        parses the ISO form so callers do not need to pre-coerce the
+        value before posting.
+        """
+
+        if value is None or isinstance(value, date):
+            return value
+        if isinstance(value, str):
+            try:
+                return date.fromisoformat(value)
+            except ValueError as exc:
+                raise ValueError(
+                    f"as_of_date must be ISO YYYY-MM-DD, got {value!r}"
+                ) from exc
+        return value
 
 
 class AnalogCard(BaseModel):
-    """One historical analog returned by /analyze/analogs."""
+    """One historical analog returned by /analyze/analogs.
+
+    The card deliberately does NOT carry the raw
+    ``forward_realized_vol_10d`` target the project trains on — that
+    value is the supervised label and surfacing it as an API field
+    would tempt downstream consumers to feed it back into a model.
+    Instead the card exposes ``subsequent_vol_regime``, a coarse
+    ``calm`` / ``normal`` / ``high`` bucket pinned to the
+    ``VOL_REGIME_BUCKET_EDGES`` constant in ``app.retrieval.index``
+    (held-out 2000-2015 reference distribution). The bucket label is a
+    UI-only marker; treat it as informative for humans, not as a
+    feature for a downstream model.
+    """
 
     model_config = _FORBID_FROZEN_CONFIG
 
@@ -623,9 +669,12 @@ class AnalogCard(BaseModel):
         default=None,
         description="Stored stance label for the analog statement (hawkish / dovish / neutral). None when absent.",
     )
-    forward_realized_vol_10d: float | None = Field(
+    subsequent_vol_regime: Literal["calm", "normal", "high"] | None = Field(
         default=None,
-        description="Realised 10-trading-day forward volatility after the analog statement. None when missing.",
+        description=(
+            "Coarse post-event 10-day realised vol bucket — UI-only label, "
+            "NOT a model feature. Do not feed back into a downstream model."
+        ),
     )
     excerpt: str = Field(..., description="First ~280 characters of the analog statement.")
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -593,3 +593,48 @@ class NextFomcForecastResponse(BaseModel):
     metrics_ex_pandemic: dict[str, NextFomcModelMetrics] = Field(default_factory=dict)
     feature_attribution: list[NextFomcAttributionRow] = Field(default_factory=list)
     summary: dict[str, int] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Historical analog retrieval (#294 — /analyze/analogs)
+# ---------------------------------------------------------------------------
+
+
+class AnalogsRequest(BaseModel):
+    """Query a fine-tuned retrieval encoder for past FOMC statements that
+    sound like ``text``. Returns top-``k`` analogs ordered by cosine
+    similarity together with the realised post-event volatility so the
+    caller can show "what regime followed each analog"."""
+
+    model_config = _STRICT_REQUEST_CONFIG
+
+    text: str = Field(..., min_length=1, description="Statement text to match against past FOMC statements.")
+    k: int = Field(default=5, ge=1, le=20, description="Number of analogs to return (1-20).")
+
+
+class AnalogCard(BaseModel):
+    """One historical analog returned by /analyze/analogs."""
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    event_date: str = Field(..., description="ISO date of the historical FOMC statement.")
+    similarity: float = Field(..., description="Cosine similarity in [-1, 1] vs. the query embedding.")
+    axis_stance: str | None = Field(
+        default=None,
+        description="Stored stance label for the analog statement (hawkish / dovish / neutral). None when absent.",
+    )
+    forward_realized_vol_10d: float | None = Field(
+        default=None,
+        description="Realised 10-trading-day forward volatility after the analog statement. None when missing.",
+    )
+    excerpt: str = Field(..., description="First ~280 characters of the analog statement.")
+
+
+class AnalogsResponse(BaseModel):
+    """Result envelope for /analyze/analogs."""
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    analogs: list[AnalogCard] = Field(default_factory=list)
+    index_size: int = Field(..., description="Total number of past statements in the loaded retrieval index.")
+    encoder_alias: str = Field(..., description="Registry alias of the encoder used to embed the query.")

--- a/backend/app/services/analogs.py
+++ b/backend/app/services/analogs.py
@@ -26,6 +26,7 @@ import dataclasses
 import logging
 import os
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date as date_type
 from pathlib import Path
@@ -196,7 +197,7 @@ def install_state(state: _AnalogsState) -> None:
 def build_state_from_index(
     index: LoadedIndex,
     *,
-    embed_fn,
+    embed_fn: Callable[[list[str]], Any],
     encoder_alias: str | None = None,
 ) -> _AnalogsState:
     """Convenience constructor for tests + smoke harnesses.
@@ -210,7 +211,7 @@ def build_state_from_index(
     """
 
     class _CallableModel:
-        def __init__(self, fn):
+        def __init__(self, fn: Callable[[list[str]], Any]) -> None:
             self._fn = fn
 
         def __call__(self, texts: list[str]) -> np.ndarray:
@@ -276,8 +277,8 @@ def encode_query(state: _AnalogsState, text: str) -> np.ndarray:
         out = state.model([cleaned])
         arr = np.asarray(out, dtype=np.float32)
         if arr.ndim == 2 and arr.shape[0] == 1:
-            return arr[0]
-        return arr.reshape(-1)
+            return np.asarray(arr[0], dtype=np.float32)
+        return np.asarray(arr.reshape(-1), dtype=np.float32)
 
     import torch
 
@@ -293,7 +294,7 @@ def encode_query(state: _AnalogsState, text: str) -> np.ndarray:
     with torch.no_grad():
         outputs = state.model(input_ids=input_ids, attention_mask=attention_mask)
     pooled = _mean_pool_last_hidden(outputs.last_hidden_state, attention_mask)
-    return pooled.reshape(-1).astype(np.float32, copy=False)
+    return np.asarray(pooled, dtype=np.float32).reshape(-1)
 
 
 def find_analogs(

--- a/backend/app/services/analogs.py
+++ b/backend/app/services/analogs.py
@@ -27,13 +27,21 @@ import logging
 import os
 import threading
 from dataclasses import dataclass
+from datetime import date as date_type
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 
 from app.config import DATA_DIR
-from app.retrieval.index import AnalogHit, LoadedIndex, load_index, query
+from app.retrieval.index import (
+    MAX_TEXT_CHARS,
+    AnalogHit,
+    LoadedIndex,
+    load_index,
+    query,
+    text_hash_for_query,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -85,7 +93,13 @@ def _resolve_checkpoint_dir(bundle_dir: Path) -> Path:
 
 
 def bundle_available() -> bool:
-    """Lightweight check used by /analyze/analogs to short-circuit absent bundles."""
+    """Lightweight check used by /analyze/analogs to short-circuit absent bundles.
+
+    Called as the endpoint pre-flight in :mod:`app.main` so a permanently
+    absent bundle does not pay the full ``_load_state`` round-trip on
+    every request — the handler short-circuits to a clean 503 the moment
+    this returns ``False``.
+    """
 
     bundle = _resolve_bundle_dir()
     if not bundle.exists():
@@ -119,11 +133,19 @@ def _load_state() -> _AnalogsState | None:
 
     checkpoint_dir = _resolve_checkpoint_dir(bundle_dir)
     try:
-        from transformers import AutoModel, AutoTokenizer  # type: ignore[import-not-found]
-        import torch  # type: ignore[import-not-found]
+        from transformers import AutoModel, AutoTokenizer  # type: ignore[import-not-found,unused-ignore]
+        import torch  # type: ignore[import-not-found,unused-ignore]
 
-        tokenizer = AutoTokenizer.from_pretrained(str(checkpoint_dir))
-        model = AutoModel.from_pretrained(str(checkpoint_dir))
+        # local_files_only + trust_remote_code=False keep the load
+        # strictly offline: a malformed or missing directory raises here
+        # instead of silently triggering a HF Hub lookup that may hang
+        # in air-gapped environments or fetch an unrelated repo.
+        tokenizer = AutoTokenizer.from_pretrained(
+            str(checkpoint_dir), local_files_only=True, trust_remote_code=False
+        )
+        model = AutoModel.from_pretrained(
+            str(checkpoint_dir), local_files_only=True, trust_remote_code=False
+        )
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         model.to(device)
         model.eval()
@@ -240,10 +262,12 @@ def encode_query(state: _AnalogsState, text: str) -> np.ndarray:
       :func:`build_state_from_index`) that ignores tokenization and
       returns the embedding directly from a Python callable.
 
-    Both paths return a 1-D ``(d,)`` ndarray.
+    Both paths return a 1-D ``(d,)`` ndarray. The query string is
+    truncated to ``MAX_TEXT_CHARS`` before tokenisation so a 10MB
+    payload never reaches the tokenizer.
     """
 
-    cleaned = (text or "").strip()
+    cleaned = (text or "").strip()[:MAX_TEXT_CHARS]
     if not cleaned:
         return np.zeros(state.index.embedding_dim or 1, dtype=np.float32)
 
@@ -272,19 +296,39 @@ def encode_query(state: _AnalogsState, text: str) -> np.ndarray:
     return pooled.reshape(-1).astype(np.float32, copy=False)
 
 
-def find_analogs(text: str, *, k: int = 5) -> dict[str, Any] | None:
+def find_analogs(
+    text: str,
+    *,
+    k: int = 5,
+    as_of_date: date_type | None = None,
+) -> dict[str, Any] | None:
     """Top-k retrieval entry point for ``POST /analyze/analogs``.
 
     Returns ``None`` when no bundle is loaded — the endpoint then
     responds with ``available=False``-equivalent shape (empty
     ``analogs`` list, ``index_size=0``).
+
+    ``as_of_date`` enforces a strict-backward walk-forward boundary at
+    query time (only rows with ``event_date < as_of_date`` are
+    eligible). Self-match suppression always runs: the sha256 of the
+    cleaned query text is computed and any candidate carrying that
+    text_hash is dropped, so a caller that submits the literal text of
+    an indexed statement never sees the trivial similarity ≈ 1.0 hit.
     """
 
     state = get_state()
     if state is None:
         return None
-    query_vec = encode_query(state, text)
-    hits = query(state.index, query_vec, k=k)
+    cleaned = (text or "").strip()[:MAX_TEXT_CHARS]
+    query_vec = encode_query(state, cleaned)
+    exclude_hash = text_hash_for_query(cleaned) if cleaned else None
+    hits = query(
+        state.index,
+        query_vec,
+        k=k,
+        as_of_date=as_of_date,
+        exclude_text_hash=exclude_hash,
+    )
     return {
         "encoder_alias": state.encoder_alias,
         "index_size": state.index.size,
@@ -300,7 +344,7 @@ def render_analog_cards(hits: list[AnalogHit]) -> list[dict[str, Any]]:
             "event_date": hit.event_date,
             "similarity": hit.similarity,
             "axis_stance": hit.axis_stance,
-            "forward_realized_vol_10d": hit.forward_realized_vol_10d,
+            "subsequent_vol_regime": hit.subsequent_vol_regime,
             "excerpt": hit.excerpt,
         }
         for hit in hits

--- a/backend/app/services/analogs.py
+++ b/backend/app/services/analogs.py
@@ -1,0 +1,319 @@
+"""Runtime singleton for the historical-analog retrieval endpoint (#294).
+
+Backs ``POST /analyze/analogs`` in :mod:`app.main`. Loads the
+fine-tuned encoder + persisted retrieval index produced by
+:mod:`app.retrieval.train` on the first request, caches the bundle on
+the worker, and serves subsequent queries from the in-memory state.
+
+The encoder is loaded via plain ``AutoTokenizer`` / ``AutoModel`` so
+the inference path does not depend on the ``sentence-transformers``
+package — the SBERT save format is HF-compatible at the model level
+and the SBERT mean-pooling is reproduced here with a one-liner masked
+mean. Keeping the inference path SBERT-free lets the FastAPI worker
+import without paying the SBERT cold-start cost when the analogs
+feature is not used.
+
+Mirrors the singleton patterns used by
+:mod:`app.services.multi_axis_classifier` and
+:mod:`app.services.sentiment` — thread-safe lazy init, a ``reset``
+hook for the test suite, and a graceful "not available" state so a
+missing checkpoint never crashes the worker.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from app.config import DATA_DIR
+from app.retrieval.index import AnalogHit, LoadedIndex, load_index, query
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_RETRIEVAL_DIR = DATA_DIR / "artifacts" / "retrieval" / "finbert_fed_adjacent_xbank_dapt_retrieval"
+DEFAULT_CHECKPOINT_SUBDIR = "checkpoint"
+DEFAULT_MAX_LENGTH = 256
+
+
+@dataclass(frozen=True)
+class _AnalogsState:
+    """Loaded encoder + retrieval index ready to serve top-k queries."""
+
+    tokenizer: Any
+    model: Any
+    device: Any
+    max_length: int
+    index: LoadedIndex
+    bundle_dir: Path
+
+    @property
+    def encoder_alias(self) -> str:
+        return self.index.encoder_alias or "finbert_fed_adjacent_xbank_dapt_retrieval"
+
+
+_state: _AnalogsState | None = None
+_state_lock = threading.Lock()
+
+
+def _resolve_bundle_dir() -> Path:
+    """Resolve the persisted retrieval-bundle directory.
+
+    The environment knob lets the test suite drop the singleton onto a
+    tmp_path-built fixture without touching the production default.
+    """
+
+    override = (os.environ.get("FED_PULSE_RETRIEVAL_DIR") or "").strip()
+    if override:
+        return Path(override)
+    return DEFAULT_RETRIEVAL_DIR
+
+
+def _resolve_checkpoint_dir(bundle_dir: Path) -> Path:
+    """Resolve the encoder checkpoint sub-directory inside the bundle."""
+
+    candidate = bundle_dir / DEFAULT_CHECKPOINT_SUBDIR
+    if candidate.exists():
+        return candidate
+    return bundle_dir
+
+
+def bundle_available() -> bool:
+    """Lightweight check used by /analyze/analogs to short-circuit absent bundles."""
+
+    bundle = _resolve_bundle_dir()
+    if not bundle.exists():
+        return False
+    # The bundle must carry the index triple; the checkpoint dir is a
+    # secondary concern caught at load time.
+    return all(
+        (bundle / name).exists()
+        for name in ("index.parquet", "embeddings.npy", "manifest.json")
+    )
+
+
+def _load_state() -> _AnalogsState | None:
+    """Build the singleton from the persisted bundle.
+
+    Returns ``None`` when the bundle is missing (so /analyze/analogs
+    can degrade to ``available=False``) or when the encoder fails to
+    load. Logs the failure either way so a broken bundle is visible in
+    uvicorn output without taking the worker down.
+    """
+
+    bundle_dir = _resolve_bundle_dir()
+    try:
+        loaded_index = load_index(bundle_dir)
+    except FileNotFoundError:
+        _logger.info("analogs_bundle_missing path=%s", bundle_dir)
+        return None
+    except Exception:  # pragma: no cover — guarded so a malformed parquet does not 500 the worker
+        _logger.warning("analogs_index_load_failed path=%s", bundle_dir, exc_info=True)
+        return None
+
+    checkpoint_dir = _resolve_checkpoint_dir(bundle_dir)
+    try:
+        from transformers import AutoModel, AutoTokenizer  # type: ignore[import-not-found]
+        import torch  # type: ignore[import-not-found]
+
+        tokenizer = AutoTokenizer.from_pretrained(str(checkpoint_dir))
+        model = AutoModel.from_pretrained(str(checkpoint_dir))
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        model.to(device)
+        model.eval()
+    except Exception:
+        _logger.warning(
+            "analogs_encoder_load_failed checkpoint=%s", checkpoint_dir, exc_info=True
+        )
+        return None
+
+    return _AnalogsState(
+        tokenizer=tokenizer,
+        model=model,
+        device=device,
+        max_length=DEFAULT_MAX_LENGTH,
+        index=loaded_index,
+        bundle_dir=bundle_dir,
+    )
+
+
+def get_state() -> _AnalogsState | None:
+    """Return the cached analogs state, building it on first call."""
+
+    global _state
+    if _state is not None:
+        return _state
+    with _state_lock:
+        if _state is None:
+            _state = _load_state()
+        return _state
+
+
+def reset_state() -> None:
+    """Drop the singleton so the next call rebuilds (test hook + refresh)."""
+
+    global _state
+    with _state_lock:
+        _state = None
+
+
+def install_state(state: _AnalogsState) -> None:
+    """Install a pre-built state directly. Used by tests to bypass disk I/O."""
+
+    global _state
+    with _state_lock:
+        _state = state
+
+
+def build_state_from_index(
+    index: LoadedIndex,
+    *,
+    embed_fn,
+    encoder_alias: str | None = None,
+) -> _AnalogsState:
+    """Convenience constructor for tests + smoke harnesses.
+
+    Wraps a callable ``embed_fn(list[str]) -> ndarray`` as a stand-in
+    tokenizer/model pair so the endpoint can run without loading real
+    HF weights. The endpoint path always calls ``encode_query`` to
+    produce the query vector, and ``encode_query`` accepts any state
+    object that exposes ``tokenizer``, ``model``, and ``device`` — we
+    cover the contract here with tiny adapter classes.
+    """
+
+    class _CallableModel:
+        def __init__(self, fn):
+            self._fn = fn
+
+        def __call__(self, texts: list[str]) -> np.ndarray:
+            return np.asarray(self._fn(texts), dtype=np.float32)
+
+    bound_index = (
+        dataclasses.replace(index, encoder_alias=encoder_alias)
+        if encoder_alias
+        else index
+    )
+    return _AnalogsState(
+        tokenizer=None,
+        model=_CallableModel(embed_fn),
+        device=None,
+        max_length=DEFAULT_MAX_LENGTH,
+        index=bound_index,
+        bundle_dir=Path("/dev/null"),
+    )
+
+
+def _mean_pool_last_hidden(
+    last_hidden_state: Any,
+    attention_mask: Any,
+) -> Any:
+    """Reproduce SBERT mean-pooling without depending on sentence-transformers.
+
+    ``last_hidden_state`` is ``(1, T, H)`` and ``attention_mask`` is
+    ``(1, T)``. We zero out padding positions, sum, then divide by the
+    valid-token count (clamped to ≥1 to avoid division-by-zero on a
+    degenerate empty input).
+    """
+
+    import torch
+
+    mask = attention_mask.unsqueeze(-1).to(last_hidden_state.dtype)
+    summed = (last_hidden_state * mask).sum(dim=1)
+    counts = mask.sum(dim=1).clamp(min=1.0)
+    return (summed / counts).detach().cpu().numpy()
+
+
+def encode_query(state: _AnalogsState, text: str) -> np.ndarray:
+    """Embed a single query text using the loaded encoder.
+
+    Supports the two call-shapes the singleton accepts:
+
+    * The production path holds a real HF tokenizer + model and runs a
+      forward pass + mean-pool.
+    * Test fixtures install a ``_CallableModel`` (see
+      :func:`build_state_from_index`) that ignores tokenization and
+      returns the embedding directly from a Python callable.
+
+    Both paths return a 1-D ``(d,)`` ndarray.
+    """
+
+    cleaned = (text or "").strip()
+    if not cleaned:
+        return np.zeros(state.index.embedding_dim or 1, dtype=np.float32)
+
+    if state.tokenizer is None or state.device is None:
+        # Test path: model is a plain callable returning the embedding(s).
+        out = state.model([cleaned])
+        arr = np.asarray(out, dtype=np.float32)
+        if arr.ndim == 2 and arr.shape[0] == 1:
+            return arr[0]
+        return arr.reshape(-1)
+
+    import torch
+
+    encoded = state.tokenizer(
+        cleaned,
+        max_length=state.max_length,
+        padding="max_length",
+        truncation=True,
+        return_tensors="pt",
+    )
+    input_ids = encoded["input_ids"].to(state.device)
+    attention_mask = encoded["attention_mask"].to(state.device)
+    with torch.no_grad():
+        outputs = state.model(input_ids=input_ids, attention_mask=attention_mask)
+    pooled = _mean_pool_last_hidden(outputs.last_hidden_state, attention_mask)
+    return pooled.reshape(-1).astype(np.float32, copy=False)
+
+
+def find_analogs(text: str, *, k: int = 5) -> dict[str, Any] | None:
+    """Top-k retrieval entry point for ``POST /analyze/analogs``.
+
+    Returns ``None`` when no bundle is loaded — the endpoint then
+    responds with ``available=False``-equivalent shape (empty
+    ``analogs`` list, ``index_size=0``).
+    """
+
+    state = get_state()
+    if state is None:
+        return None
+    query_vec = encode_query(state, text)
+    hits = query(state.index, query_vec, k=k)
+    return {
+        "encoder_alias": state.encoder_alias,
+        "index_size": state.index.size,
+        "hits": hits,
+    }
+
+
+def render_analog_cards(hits: list[AnalogHit]) -> list[dict[str, Any]]:
+    """Adapt :class:`AnalogHit` rows to the ``AnalogCard`` schema shape."""
+
+    return [
+        {
+            "event_date": hit.event_date,
+            "similarity": hit.similarity,
+            "axis_stance": hit.axis_stance,
+            "forward_realized_vol_10d": hit.forward_realized_vol_10d,
+            "excerpt": hit.excerpt,
+        }
+        for hit in hits
+    ]
+
+
+__all__ = [
+    "build_state_from_index",
+    "bundle_available",
+    "encode_query",
+    "find_analogs",
+    "get_state",
+    "install_state",
+    "render_analog_cards",
+    "reset_state",
+]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "pyyaml>=6.0",
   "transformers",
   "accelerate>=1.1.0",
+  "sentence-transformers>=3.0",
   "torch",
   "python-multipart",
   "requests",

--- a/tests/unit/test_analogs_endpoint.py
+++ b/tests/unit/test_analogs_endpoint.py
@@ -1,0 +1,180 @@
+"""Endpoint tests for POST /analyze/analogs (#294)."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import app.main as main_mod  # noqa: E402
+from app.retrieval import index as ret_index  # noqa: E402
+from app.services import analogs as analogs_service  # noqa: E402
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(main_mod.app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_analogs_singleton():
+    """Make sure each test sees a clean singleton — no cross-test bleed."""
+
+    analogs_service.reset_state()
+    yield
+    analogs_service.reset_state()
+
+
+def _fixture_rows() -> list[dict]:
+    rows = [
+        {
+            "event_date": "2008-12-16",
+            "event_kind": "statement",
+            "text": "The Committee will employ all available tools to promote recovery and price stability.",
+            "axis_stance": "dovish",
+            "forward_realized_vol_10d": 0.045,
+            "horizon": 1,
+        },
+        {
+            "event_date": "2022-09-21",
+            "event_kind": "statement",
+            "text": "Inflation remains elevated. The Committee anticipates ongoing increases in the target range.",
+            "axis_stance": "hawkish",
+            "forward_realized_vol_10d": 0.022,
+            "horizon": 1,
+        },
+        {
+            "event_date": "2015-12-16",
+            "event_kind": "statement",
+            "text": "Economic conditions warrant a gradual removal of policy accommodation.",
+            "axis_stance": "neutral",
+            "forward_realized_vol_10d": 0.011,
+            "horizon": 1,
+        },
+    ]
+    for row in rows:
+        row["text_hash"] = hashlib.sha256(row["text"].encode("utf-8")).hexdigest()
+    return rows
+
+
+def _make_keyword_embedder(keywords: list[str]):
+    lower = [k.lower() for k in keywords]
+
+    def _embed(texts: list[str]) -> np.ndarray:
+        out = np.zeros((len(texts), len(keywords)), dtype=np.float32)
+        for row_idx, text in enumerate(texts):
+            text_lc = (text or "").lower()
+            for col_idx, kw in enumerate(lower):
+                out[row_idx, col_idx] = float(text_lc.count(kw))
+        return out
+
+    return _embed
+
+
+def _install_fake_state(tmp_path: Path) -> int:
+    """Build a tiny on-disk bundle and wire it into the analogs singleton.
+
+    Returns the index size so tests can assert against it without
+    re-counting the fixture rows.
+    """
+
+    rows = _fixture_rows()
+    events_parquet = tmp_path / "events.parquet"
+    pd.DataFrame(rows).to_parquet(events_parquet, index=False)
+    embed = _make_keyword_embedder(["inflation", "recovery", "accommodation"])
+    loaded = ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id="tp_test",
+        out_dir=tmp_path / "bundle",
+    )
+    state = analogs_service.build_state_from_index(
+        loaded, embed_fn=embed, encoder_alias="test_retrieval"
+    )
+    analogs_service.install_state(state)
+    return loaded.size
+
+
+def test_analyze_analogs_returns_empty_when_bundle_missing(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When no bundle exists on disk the endpoint shapes an empty result."""
+
+    monkeypatch.setenv("FED_PULSE_RETRIEVAL_DIR", str(tmp_path / "does-not-exist"))
+    response = client.post("/analyze/analogs", json={"text": "inflation outlook", "k": 3})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["analogs"] == []
+    assert body["index_size"] == 0
+    assert body["encoder_alias"] == "finbert_fed_adjacent_xbank_dapt_retrieval"
+
+
+def test_analyze_analogs_returns_descending_similarity(
+    client: TestClient, tmp_path: Path
+) -> None:
+    _install_fake_state(tmp_path)
+    response = client.post(
+        "/analyze/analogs",
+        json={"text": "Inflation outlook remains elevated", "k": 3},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["index_size"] == 3
+    assert body["encoder_alias"] == "test_retrieval"
+    analogs = body["analogs"]
+    assert len(analogs) == 3
+    # Top-1 must be the 2022 hawkish row because "inflation" dominates.
+    assert analogs[0]["event_date"] == "2022-09-21"
+    assert analogs[0]["axis_stance"] == "hawkish"
+    assert analogs[0]["forward_realized_vol_10d"] == pytest.approx(0.022, rel=1e-5)
+    assert analogs[0]["similarity"] == pytest.approx(1.0, abs=1e-5)
+    # Strictly descending by similarity.
+    similarities = [card["similarity"] for card in analogs]
+    assert similarities == sorted(similarities, reverse=True)
+
+
+def test_analyze_analogs_excerpt_present_and_bounded(
+    client: TestClient, tmp_path: Path
+) -> None:
+    _install_fake_state(tmp_path)
+    response = client.post(
+        "/analyze/analogs",
+        json={"text": "The Committee will support recovery", "k": 1},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["analogs"][0]["event_date"] == "2008-12-16"
+    excerpt = body["analogs"][0]["excerpt"]
+    assert excerpt
+    # Excerpt is bounded by the EXCERPT_CHARS index constant.
+    assert len(excerpt) <= ret_index.EXCERPT_CHARS
+
+
+def test_analyze_analogs_validates_k_lower_bound(client: TestClient) -> None:
+    response = client.post(
+        "/analyze/analogs", json={"text": "Inflation outlook", "k": 0}
+    )
+    assert response.status_code == 422
+
+
+def test_analyze_analogs_validates_k_upper_bound(client: TestClient) -> None:
+    response = client.post(
+        "/analyze/analogs", json={"text": "Inflation outlook", "k": 999}
+    )
+    assert response.status_code == 422
+
+
+def test_analyze_analogs_requires_text(client: TestClient) -> None:
+    response = client.post("/analyze/analogs", json={"text": "", "k": 3})
+    assert response.status_code == 422

--- a/tests/unit/test_analogs_endpoint.py
+++ b/tests/unit/test_analogs_endpoint.py
@@ -137,7 +137,9 @@ def test_analyze_analogs_returns_descending_similarity(
     # Top-1 must be the 2022 hawkish row because "inflation" dominates.
     assert analogs[0]["event_date"] == "2022-09-21"
     assert analogs[0]["axis_stance"] == "hawkish"
-    assert analogs[0]["forward_realized_vol_10d"] == pytest.approx(0.022, rel=1e-5)
+    # 0.022 > VOL_REGIME_BUCKET_EDGES[1] (0.020) -> "high"
+    assert analogs[0]["subsequent_vol_regime"] == "high"
+    assert "forward_realized_vol_10d" not in analogs[0]
     assert analogs[0]["similarity"] == pytest.approx(1.0, abs=1e-5)
     # Strictly descending by similarity.
     similarities = [card["similarity"] for card in analogs]
@@ -178,3 +180,71 @@ def test_analyze_analogs_validates_k_upper_bound(client: TestClient) -> None:
 def test_analyze_analogs_requires_text(client: TestClient) -> None:
     response = client.post("/analyze/analogs", json={"text": "", "k": 3})
     assert response.status_code == 422
+
+
+def test_analyze_analogs_503_does_not_leak_exception_text(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """An unexpected embedder error responds 503 with a sanitized detail.
+
+    The endpoint's exception arm must NOT echo internal exception text
+    (file paths, library internals) back to the client.
+    """
+
+    rows = _fixture_rows()
+    events_parquet = tmp_path / "events.parquet"
+    pd.DataFrame(rows).to_parquet(events_parquet, index=False)
+    embed = _make_keyword_embedder(["inflation", "recovery", "accommodation"])
+    loaded = ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id="tp_test",
+        out_dir=tmp_path / "bundle",
+    )
+
+    secret_path = "/internal/secret/checkpoint/path"
+
+    def _exploding_embedder(texts: list[str]):
+        raise RuntimeError(f"boom at {secret_path}")
+
+    state = analogs_service.build_state_from_index(
+        loaded, embed_fn=_exploding_embedder, encoder_alias="test_retrieval"
+    )
+    analogs_service.install_state(state)
+
+    response = client.post(
+        "/analyze/analogs", json={"text": "anything", "k": 3}
+    )
+    assert response.status_code == 503
+    body = response.json()
+    # Sanitised detail field — no internal exception text / paths.
+    assert body.get("detail") == "Analog retrieval unavailable"
+    assert secret_path not in response.text
+    assert "RuntimeError" not in response.text
+    assert "Traceback" not in response.text
+
+
+def test_analyze_analogs_as_of_date_filters_future_rows(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """``as_of_date`` cuts the candidate pool to strict-backward rows."""
+
+    _install_fake_state(tmp_path)
+    # Fixture rows are 2008-12-16, 2022-09-21, 2015-12-16. Query as_of
+    # in 2016 must drop the 2022 row even though it dominates on
+    # "inflation".
+    response = client.post(
+        "/analyze/analogs",
+        json={
+            "text": "Inflation outlook remains elevated",
+            "k": 5,
+            "as_of_date": "2016-01-01",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    dates = {card["event_date"] for card in body["analogs"]}
+    assert "2022-09-21" not in dates
+    assert dates <= {"2008-12-16", "2015-12-16"}

--- a/tests/unit/test_retrieval_index.py
+++ b/tests/unit/test_retrieval_index.py
@@ -115,10 +115,15 @@ def test_build_index_persists_parquet_embeddings_manifest(tmp_path: Path) -> Non
         "event_date",
         "text_hash",
         "axis_stance",
-        "forward_realized_vol_10d",
+        "subsequent_vol_regime",
         "excerpt",
     }
+    # Supervised target column must never land in the persisted bundle.
+    assert "forward_realized_vol_10d" not in persisted.columns
     assert persisted["axis_stance"].tolist() == ["dovish", "hawkish", "neutral"]
+    # Buckets pinned by VOL_REGIME_BUCKET_EDGES = (0.012, 0.020):
+    # 0.045 -> high, 0.022 -> high, 0.011 -> calm.
+    assert persisted["subsequent_vol_regime"].tolist() == ["high", "high", "calm"]
 
 
 def test_query_returns_top1_matching_known_keyword(tmp_path: Path) -> None:
@@ -144,7 +149,8 @@ def test_query_returns_top1_matching_known_keyword(tmp_path: Path) -> None:
     assert len(hits) == 3
     assert hits[0].event_date == "2022-09-21"
     assert hits[0].axis_stance == "hawkish"
-    assert hits[0].forward_realized_vol_10d == pytest.approx(0.022, rel=1e-5)
+    # 0.022 > VOL_REGIME_BUCKET_EDGES[1] (0.020) -> "high".
+    assert hits[0].subsequent_vol_regime == "high"
     assert hits[0].similarity == pytest.approx(1.0, abs=1e-5)
     # Strictly descending ordering by similarity.
     assert hits[0].similarity >= hits[1].similarity >= hits[2].similarity
@@ -306,6 +312,106 @@ def test_query_raises_on_dimension_mismatch(tmp_path: Path) -> None:
 def test_load_index_raises_when_bundle_is_missing(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError, match="retrieval index incomplete"):
         ret_index.load_index(tmp_path / "does-not-exist")
+
+
+def test_query_self_match_suppression(tmp_path: Path) -> None:
+    """A query whose text_hash matches an indexed row drops the trivial hit.
+
+    The runtime singleton always passes the cleaned query's sha256 as
+    ``exclude_text_hash`` so submitting the literal text of an indexed
+    statement never returns the similarity ≈ 1.0 self-row.
+    """
+
+    rows = [
+        {
+            "event_date": "2024-03-20",
+            "event_kind": "statement",
+            "text": "FOO",
+            "axis_stance": "neutral",
+            "forward_realized_vol_10d": 0.011,
+            "horizon": 1,
+            "text_hash": hashlib.sha256(b"FOO").hexdigest(),
+        }
+    ]
+    events_parquet = _write_events_parquet(tmp_path, rows)
+    embed = _make_keyword_embedder(["foo"])
+    loaded = ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id=None,
+        out_dir=tmp_path / "bundle",
+    )
+
+    query_vec = embed(["FOO"])[0]
+    exclude = ret_index.text_hash_for_query("FOO")
+    hits = ret_index.query(loaded, query_vec, k=5, exclude_text_hash=exclude)
+    assert hits == []
+
+
+def test_query_as_of_date_filters_strictly_backward(tmp_path: Path) -> None:
+    """Only rows with event_date < as_of_date stay in the candidate pool."""
+
+    rows = _fixture_statements()  # 2008-12-16, 2022-09-21, 2015-12-16
+    events_parquet = _write_events_parquet(tmp_path, rows)
+    embed = _make_keyword_embedder(["inflation", "recovery", "accommodation"])
+    loaded = ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id=None,
+        out_dir=tmp_path / "bundle",
+    )
+
+    query_vec = embed(["inflation"])[0]
+    hits = ret_index.query(loaded, query_vec, k=5, as_of_date="2016-01-01")
+    dates = {hit.event_date for hit in hits}
+    assert dates <= {"2008-12-16", "2015-12-16"}
+    assert "2022-09-21" not in dates
+
+    # as_of_date earlier than every indexed row -> empty result (no
+    # padding from future rows).
+    early = ret_index.query(loaded, query_vec, k=5, as_of_date="2000-01-01")
+    assert early == []
+
+
+def test_build_index_persists_train_end_in_manifest(tmp_path: Path) -> None:
+    rows = _fixture_statements()
+    events_parquet = _write_events_parquet(tmp_path, rows)
+    embed = _make_keyword_embedder(["inflation", "recovery", "accommodation"])
+    ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id="tp_test",
+        out_dir=tmp_path / "bundle",
+        train_end="2018-01-01",
+    )
+
+    manifest = json.loads((tmp_path / "bundle" / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["train_end"] == "2018-01-01"
+    reloaded = ret_index.load_index(tmp_path / "bundle")
+    assert reloaded.train_end == "2018-01-01"
+
+
+def test_build_index_atomic_writes_leave_no_tmp_files(tmp_path: Path) -> None:
+    rows = _fixture_statements()
+    events_parquet = _write_events_parquet(tmp_path, rows)
+    embed = _make_keyword_embedder(["inflation", "recovery", "accommodation"])
+    ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id=None,
+        out_dir=tmp_path / "bundle",
+    )
+
+    leftovers = list((tmp_path / "bundle").glob("*.tmp"))
+    assert leftovers == [], f"atomic-write tmp files leaked: {leftovers}"
 
 
 def test_build_index_excerpt_truncates_long_text(tmp_path: Path) -> None:

--- a/tests/unit/test_retrieval_index.py
+++ b/tests/unit/test_retrieval_index.py
@@ -1,0 +1,337 @@
+"""Unit tests for ``app.retrieval.index`` (historical analog index, #294)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.retrieval import index as ret_index
+
+
+def _fixture_statements() -> list[dict]:
+    """A small canonical set of historical FOMC statements for the index.
+
+    Three rows so the top-k path has both a winner and an ordering to
+    assert. Each row carries the columns the production builder reads
+    from ``events.parquet`` plus the supervised stance / realised vol
+    columns the endpoint surfaces back to the caller.
+    """
+
+    rows = [
+        {
+            "event_date": "2008-12-16",
+            "event_kind": "statement",
+            "text": "The Committee will employ all available tools to promote economic recovery and price stability.",
+            "axis_stance": "dovish",
+            "forward_realized_vol_10d": 0.045,
+            "horizon": 1,
+        },
+        {
+            "event_date": "2022-09-21",
+            "event_kind": "statement",
+            "text": "Inflation remains elevated. The Committee anticipates ongoing increases in the target range.",
+            "axis_stance": "hawkish",
+            "forward_realized_vol_10d": 0.022,
+            "horizon": 1,
+        },
+        {
+            "event_date": "2015-12-16",
+            "event_kind": "statement",
+            "text": "The Committee judges that economic conditions warrant a gradual removal of policy accommodation.",
+            "axis_stance": "neutral",
+            "forward_realized_vol_10d": 0.011,
+            "horizon": 1,
+        },
+    ]
+    for row in rows:
+        row["text_hash"] = hashlib.sha256(row["text"].encode("utf-8")).hexdigest()
+    return rows
+
+
+def _write_events_parquet(directory: Path, rows: list[dict]) -> Path:
+    parquet = directory / "events.parquet"
+    pd.DataFrame(rows).to_parquet(parquet, index=False)
+    return parquet
+
+
+def _make_keyword_embedder(keywords: list[str]):
+    """Build a deterministic bag-of-keywords embedder for the tests.
+
+    Each input string is projected onto a ``len(keywords)``-dim vector
+    where entry ``i`` is the number of times ``keywords[i]`` appears
+    (case-insensitive). This gives the tests a stable retrieval signal
+    without standing up a real transformer.
+    """
+
+    lower = [k.lower() for k in keywords]
+
+    def _embed(texts: list[str]) -> np.ndarray:
+        out = np.zeros((len(texts), len(keywords)), dtype=np.float32)
+        for row_idx, text in enumerate(texts):
+            text_lc = (text or "").lower()
+            for col_idx, kw in enumerate(lower):
+                out[row_idx, col_idx] = float(text_lc.count(kw))
+        return out
+
+    return _embed
+
+
+def test_build_index_persists_parquet_embeddings_manifest(tmp_path: Path) -> None:
+    rows = _fixture_statements()
+    events_parquet = _write_events_parquet(tmp_path, rows)
+    embed = _make_keyword_embedder(["inflation", "recovery", "accommodation"])
+
+    loaded = ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id="tp_test",
+        out_dir=tmp_path / "bundle",
+    )
+
+    assert loaded.size == 3
+    assert loaded.embedding_dim == 3
+    assert loaded.encoder_alias == "test_retrieval"
+
+    bundle = tmp_path / "bundle"
+    assert (bundle / "index.parquet").exists()
+    assert (bundle / "embeddings.npy").exists()
+    assert (bundle / "manifest.json").exists()
+
+    manifest = json.loads((bundle / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["encoder_alias"] == "test_retrieval"
+    assert manifest["row_count"] == 3
+    assert manifest["embedding_dim"] == 3
+    assert manifest["training_package_id"] == "tp_test"
+
+    persisted = pd.read_parquet(bundle / "index.parquet")
+    assert set(persisted.columns) >= {
+        "event_date",
+        "text_hash",
+        "axis_stance",
+        "forward_realized_vol_10d",
+        "excerpt",
+    }
+    assert persisted["axis_stance"].tolist() == ["dovish", "hawkish", "neutral"]
+
+
+def test_query_returns_top1_matching_known_keyword(tmp_path: Path) -> None:
+    """Embed a query that dominates on a single fixture row; top-1 must match."""
+
+    rows = _fixture_statements()
+    events_parquet = _write_events_parquet(tmp_path, rows)
+    embed = _make_keyword_embedder(["inflation", "recovery", "accommodation"])
+    loaded = ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id="tp_test",
+        out_dir=tmp_path / "bundle",
+    )
+
+    # Query embedded with the same projection: dominated by the
+    # "inflation" axis, so the 2022 hawkish statement must rank first.
+    query_vec = embed(["Inflation outlook remains elevated"])[0]
+    hits = ret_index.query(loaded, query_vec, k=3)
+
+    assert len(hits) == 3
+    assert hits[0].event_date == "2022-09-21"
+    assert hits[0].axis_stance == "hawkish"
+    assert hits[0].forward_realized_vol_10d == pytest.approx(0.022, rel=1e-5)
+    assert hits[0].similarity == pytest.approx(1.0, abs=1e-5)
+    # Strictly descending ordering by similarity.
+    assert hits[0].similarity >= hits[1].similarity >= hits[2].similarity
+
+
+def test_query_recovery_keyword_routes_to_2008_dovish_row(tmp_path: Path) -> None:
+    rows = _fixture_statements()
+    events_parquet = _write_events_parquet(tmp_path, rows)
+    embed = _make_keyword_embedder(["inflation", "recovery", "accommodation"])
+    loaded = ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id="tp_test",
+        out_dir=tmp_path / "bundle",
+    )
+
+    query_vec = embed(["The Committee will promote economic recovery"])[0]
+    hits = ret_index.query(loaded, query_vec, k=1)
+
+    assert len(hits) == 1
+    assert hits[0].event_date == "2008-12-16"
+    assert hits[0].axis_stance == "dovish"
+
+
+def test_load_index_round_trips_a_built_bundle(tmp_path: Path) -> None:
+    rows = _fixture_statements()
+    events_parquet = _write_events_parquet(tmp_path, rows)
+    embed = _make_keyword_embedder(["inflation", "recovery", "accommodation"])
+    bundle = tmp_path / "bundle"
+    built = ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id="tp_test",
+        out_dir=bundle,
+    )
+
+    reloaded = ret_index.load_index(bundle)
+    assert reloaded.size == built.size
+    assert reloaded.embedding_dim == built.embedding_dim
+    assert reloaded.encoder_alias == "test_retrieval"
+    assert reloaded.encoder_revision == "rev1234"
+    assert reloaded.training_package_id == "tp_test"
+    assert reloaded.metadata["event_date"].tolist() == [
+        "2008-12-16",
+        "2022-09-21",
+        "2015-12-16",
+    ]
+
+
+def test_build_index_skips_non_statement_event_kinds(tmp_path: Path) -> None:
+    rows = _fixture_statements()
+    rows.append(
+        {
+            "event_date": "2024-03-20",
+            "event_kind": "minutes",
+            "text": "The Committee discussed inflation dynamics at length.",
+            "axis_stance": "hawkish",
+            "forward_realized_vol_10d": 0.018,
+            "horizon": 1,
+            "text_hash": hashlib.sha256(b"minutes-2024").hexdigest(),
+        }
+    )
+    rows.append(
+        {
+            "event_date": "2024-03-21",
+            "event_kind": "macro_release",
+            "text": "CPI release.",
+            "axis_stance": "neutral",
+            "forward_realized_vol_10d": 0.005,
+            "horizon": 1,
+            "text_hash": hashlib.sha256(b"macro-2024").hexdigest(),
+        }
+    )
+    events_parquet = _write_events_parquet(tmp_path, rows)
+    embed = _make_keyword_embedder(["inflation", "recovery", "accommodation"])
+
+    loaded = ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id=None,
+        out_dir=tmp_path / "bundle",
+    )
+
+    assert loaded.size == 3
+    assert "2024-03-20" not in loaded.metadata["event_date"].tolist()
+    assert "2024-03-21" not in loaded.metadata["event_date"].tolist()
+
+
+def test_query_clips_k_to_index_size(tmp_path: Path) -> None:
+    rows = _fixture_statements()
+    events_parquet = _write_events_parquet(tmp_path, rows)
+    embed = _make_keyword_embedder(["inflation", "recovery", "accommodation"])
+    loaded = ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id=None,
+        out_dir=tmp_path / "bundle",
+    )
+
+    query_vec = embed(["inflation"])[0]
+    hits = ret_index.query(loaded, query_vec, k=100)
+    assert len(hits) == 3
+
+
+def test_query_returns_empty_for_empty_index() -> None:
+    empty = ret_index.LoadedIndex(
+        embeddings=np.zeros((0, 4), dtype=np.float32),
+        metadata=pd.DataFrame(columns=list(ret_index.METADATA_COLUMNS)),
+        encoder_alias="test",
+        encoder_revision="",
+        training_package_id=None,
+        built_at_utc="",
+    )
+    assert ret_index.query(empty, np.zeros(4, dtype=np.float32), k=5) == []
+
+
+def test_query_returns_empty_when_query_vector_is_zero(tmp_path: Path) -> None:
+    rows = _fixture_statements()
+    events_parquet = _write_events_parquet(tmp_path, rows)
+    embed = _make_keyword_embedder(["inflation", "recovery", "accommodation"])
+    loaded = ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id=None,
+        out_dir=tmp_path / "bundle",
+    )
+
+    zero_vec = np.zeros(loaded.embedding_dim, dtype=np.float32)
+    assert ret_index.query(loaded, zero_vec, k=3) == []
+
+
+def test_query_raises_on_dimension_mismatch(tmp_path: Path) -> None:
+    rows = _fixture_statements()
+    events_parquet = _write_events_parquet(tmp_path, rows)
+    embed = _make_keyword_embedder(["inflation", "recovery", "accommodation"])
+    loaded = ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id=None,
+        out_dir=tmp_path / "bundle",
+    )
+
+    with pytest.raises(ValueError, match="dim"):
+        ret_index.query(loaded, np.zeros(loaded.embedding_dim + 1, dtype=np.float32), k=3)
+
+
+def test_load_index_raises_when_bundle_is_missing(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="retrieval index incomplete"):
+        ret_index.load_index(tmp_path / "does-not-exist")
+
+
+def test_build_index_excerpt_truncates_long_text(tmp_path: Path) -> None:
+    long_text = "Inflation " * 200
+    rows = [
+        {
+            "event_date": "2020-03-15",
+            "event_kind": "statement",
+            "text": long_text,
+            "axis_stance": "dovish",
+            "forward_realized_vol_10d": 0.07,
+            "horizon": 1,
+            "text_hash": hashlib.sha256(long_text.encode("utf-8")).hexdigest(),
+        }
+    ]
+    events_parquet = _write_events_parquet(tmp_path, rows)
+    embed = _make_keyword_embedder(["inflation"])
+
+    loaded = ret_index.build_index_from_events(
+        events_parquet=events_parquet,
+        encoder_alias="test_retrieval",
+        encoder_revision="rev1234",
+        embed_fn=embed,
+        training_package_id=None,
+        out_dir=tmp_path / "bundle",
+    )
+
+    excerpt = loaded.metadata.iloc[0]["excerpt"]
+    assert len(excerpt) <= ret_index.EXCERPT_CHARS

--- a/tests/unit/test_retrieval_train_pairs.py
+++ b/tests/unit/test_retrieval_train_pairs.py
@@ -1,0 +1,171 @@
+"""Unit tests for ``app.retrieval.train.build_training_pairs`` (#294).
+
+The training pair builder governs what (anchor, positive) examples
+MNRL sees during the contrastive fine-tune. The walk-forward boundary
+is enforced at this layer so the encoder's weights never observe
+future text relative to the supplied train_end.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from app.retrieval import train as ret_train
+
+
+def _make_row(
+    *,
+    event_date: str,
+    event_kind: str,
+    text: str,
+    horizon: int = 1,
+) -> dict:
+    return {
+        "event_date": event_date,
+        "event_kind": event_kind,
+        "text": text,
+        "horizon": horizon,
+        "text_hash": hashlib.sha256(f"{event_date}|{event_kind}|{text}".encode("utf-8")).hexdigest(),
+    }
+
+
+def _events_frame() -> pd.DataFrame:
+    """Four meetings: two with statement+minutes, one statement-only, one minutes-only."""
+
+    rows = [
+        # 2010 — full meeting: statement + minutes + irrelevant macro_release on same date.
+        _make_row(event_date="2010-03-16", event_kind="statement", text="2010 statement"),
+        _make_row(event_date="2010-03-16", event_kind="minutes", text="2010 minutes"),
+        _make_row(event_date="2010-03-16", event_kind="macro_release", text="2010 CPI"),
+        # 2015 — statement + press_conference (also a valid POSITIVE_KIND).
+        _make_row(event_date="2015-06-17", event_kind="statement", text="2015 statement"),
+        _make_row(
+            event_date="2015-06-17",
+            event_kind="press_conference",
+            text="2015 press conference",
+        ),
+        # 2018 — statement only; no sibling -> dropped post-review.
+        _make_row(event_date="2018-09-26", event_kind="statement", text="2018 statement"),
+        # 2022 — past train_end cutoff; dropped by walk-forward filter.
+        _make_row(event_date="2022-09-21", event_kind="statement", text="2022 statement"),
+        _make_row(event_date="2022-09-21", event_kind="minutes", text="2022 minutes"),
+    ]
+    return pd.DataFrame(rows)
+
+
+def test_pairs_only_use_statement_anchors_with_minutes_or_press_conference_siblings() -> None:
+    events = _events_frame()
+    pairs = ret_train.build_training_pairs(events)
+    sibling_kinds = {p.positive_kind for p in pairs}
+    assert sibling_kinds <= set(ret_train.POSITIVE_KINDS)
+    assert "macro_release" not in sibling_kinds
+
+
+def test_pairs_drop_meetings_with_no_sibling_no_self_pair_fallback() -> None:
+    """The 2018 statement has no sibling and must contribute zero pairs.
+
+    Pre-review the builder shipped a degenerate ``(statement, statement)``
+    self-pair so MNRL still saw the anchor; that signal teaches the
+    encoder to maximise self-similarity and amplifies the self-match
+    bias at retrieval time. Builder now silently drops the meeting.
+    """
+
+    events = _events_frame()
+    pairs = ret_train.build_training_pairs(events)
+    anchor_dates = {p.anchor_date for p in pairs}
+    assert "2018-09-26" not in anchor_dates
+    assert not any(p.positive_kind == "self" for p in pairs)
+    assert not any(p.anchor == p.positive for p in pairs)
+
+
+def test_pairs_respect_train_end_filter() -> None:
+    events = _events_frame()
+    pairs_unfiltered = ret_train.build_training_pairs(events)
+    pairs_filtered = ret_train.build_training_pairs(events, train_end="2020-01-01")
+
+    # The 2022 meeting is dropped under the filter, so the filtered
+    # set is strictly smaller and contains no 2022 anchors.
+    assert len(pairs_filtered) < len(pairs_unfiltered)
+    assert all(p.anchor_date < "2020-01-01" for p in pairs_filtered)
+    assert any(p.anchor_date == "2022-09-21" for p in pairs_unfiltered)
+
+
+def test_pairs_filter_is_strictly_less_than_train_end() -> None:
+    """``train_end`` cuts at strict ``<`` so the boundary day itself is excluded."""
+
+    events = _events_frame()
+    pairs = ret_train.build_training_pairs(events, train_end="2010-03-16")
+    # 2010-03-16 must be excluded under strict <.
+    assert all(p.anchor_date < "2010-03-16" for p in pairs)
+
+
+def test_validate_train_end_rejects_garbage() -> None:
+    with pytest.raises(ValueError, match="ISO date"):
+        ret_train._validate_train_end("not-a-date")
+
+
+def test_resolve_train_end_from_fold_returns_manifest_value(tmp_path: Path) -> None:
+    pkg = tmp_path / "tp_test"
+    pkg.mkdir()
+    events_parquet = pkg / "events.parquet"
+    pd.DataFrame(_events_frame()).to_parquet(events_parquet, index=False)
+    (pkg / ret_train.FOLD_MANIFEST_FILENAME).write_text(
+        json.dumps(
+            {
+                "folds": [
+                    {"fold_id": "wf_fold_1", "train_end": "2016-09-21"},
+                    {"fold_id": "wf_fold_3", "train_end": "2019-08-01"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    resolved = ret_train.resolve_train_end_from_fold(
+        events_parquet=events_parquet, fold_id="wf_fold_3"
+    )
+    assert resolved == "2019-08-01"
+
+
+def test_resolve_train_end_from_fold_raises_on_unknown_id(tmp_path: Path) -> None:
+    pkg = tmp_path / "tp_test"
+    pkg.mkdir()
+    events_parquet = pkg / "events.parquet"
+    pd.DataFrame(_events_frame()).to_parquet(events_parquet, index=False)
+    (pkg / ret_train.FOLD_MANIFEST_FILENAME).write_text(
+        json.dumps({"folds": [{"fold_id": "wf_fold_1", "train_end": "2016-09-21"}]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="not found"):
+        ret_train.resolve_train_end_from_fold(
+            events_parquet=events_parquet, fold_id="wf_fold_99"
+        )
+
+
+def test_fine_tune_and_index_rejects_batch_size_below_two(tmp_path: Path) -> None:
+    """MNRL requires at least one in-batch negative; batch_size < 2 must fail loudly."""
+
+    events_parquet = tmp_path / "events.parquet"
+    pd.DataFrame(_events_frame()).to_parquet(events_parquet, index=False)
+    with pytest.raises(ValueError, match="batch_size >= 2"):
+        ret_train.fine_tune_and_index(
+            events_parquet=events_parquet,
+            batch_size=1,
+        )
+
+
+def test_fine_tune_and_index_rejects_mutually_exclusive_flags(tmp_path: Path) -> None:
+    events_parquet = tmp_path / "events.parquet"
+    pd.DataFrame(_events_frame()).to_parquet(events_parquet, index=False)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        ret_train.fine_tune_and_index(
+            events_parquet=events_parquet,
+            train_end="2020-01-01",
+            fold_id="wf_fold_3",
+        )


### PR DESCRIPTION
## Summary

- Fine-tune driver `app/retrieval/train.py` — sentence-transformer MNRL contrastive layer over `finbert_fed_adjacent_xbank_dapt`, same-meeting (statement, minutes / press-conference) positive pairs.
- Index module `app/retrieval/index.py` — embeds every historical FOMC statement from `events.parquet`, persists `index.parquet` + `embeddings.npy` + `manifest.json`, plain numpy cosine top-k for the ~250-row corpus.
- New `POST /analyze/analogs` endpoint backed by a thread-safe singleton in `app/services/analogs.py`; degrades to empty when the bundle is absent.
- Registers `finbert_fed_adjacent_xbank_dapt_retrieval` alias; checkpoint stays local until the deployability lane (#302) mirrors it to Hub.
- `sentence-transformers` added to backend deps; inference uses plain `AutoTokenizer`/`AutoModel` + masked mean-pool.

## Test plan

- `docker compose run --rm backend pytest tests/unit/test_retrieval_index.py tests/unit/test_analogs_endpoint.py -q`
- `docker compose run --rm backend pytest tests/unit/test_main_api.py tests/unit/test_analyze_persists_history.py tests/unit/test_research_endpoints.py -q`
- `docker compose run --rm backend ruff check app/retrieval app/services/analogs.py app/schemas.py`