### PR TITLE
Hawkish/dovish trajectory model + panel (#296)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,6 +51,10 @@ from app.schemas import (
     SettingsCheckpointsResponse,
     SymbolDescriptor,
     SymbolListResponse,
+    TrajectoryMarker,
+    TrajectoryProjection,
+    TrajectoryRequest,
+    TrajectoryResponse,
 )
 from app.evaluation.xai import attribute_text, split_sentences, to_response as xai_to_response
 from app.services.document_parser import (
@@ -1041,4 +1045,83 @@ async def analyze_analogs(payload: AnalogsRequest) -> AnalogsResponse:
         analogs=cards,
         index_size=int(result["index_size"]),
         encoder_alias=str(result["encoder_alias"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hawkish/dovish trajectory model (#296 — /analyze/trajectory)
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_TRAJECTORY_ENCODER_ALIAS = "finbert_fed_adjacent_xbank_dapt"
+
+
+@app.post("/analyze/trajectory", response_model=TrajectoryResponse)
+async def analyze_trajectory(payload: TrajectoryRequest) -> TrajectoryResponse:
+    """Project the FOMC stance trajectory ending at ``as_of_date``.
+
+    Loads the trajectory bundle (LSTM or Transformer arm + per-meeting
+    embedding index) on first hit via the singleton at
+    :mod:`app.services.trajectory`. When no bundle is present the
+    response is shaped with ``available=False`` and an empty
+    ``history`` so the frontend renders an empty state rather than
+    treating the call as a 5xx. Unexpected failures surface as a
+    sanitized 503.
+    """
+
+    from app.services import trajectory as trajectory_service
+
+    if not trajectory_service.bundle_available() and trajectory_service.get_state() is None:
+        return TrajectoryResponse(
+            available=False,
+            encoder_alias=_DEFAULT_TRAJECTORY_ENCODER_ALIAS,
+            history=[],
+            projected_next=None,
+            history_length=int(payload.history_length),
+            as_of_date=payload.as_of_date.isoformat(),
+        )
+
+    state = trajectory_service.get_state()
+    if state is None:
+        return TrajectoryResponse(
+            available=False,
+            encoder_alias=_DEFAULT_TRAJECTORY_ENCODER_ALIAS,
+            history=[],
+            projected_next=None,
+            history_length=int(payload.history_length),
+            as_of_date=payload.as_of_date.isoformat(),
+        )
+
+    try:
+        result = await run_in_threadpool(
+            trajectory_service.project_trajectory,
+            state,
+            as_of_date=payload.as_of_date,
+            history_length=payload.history_length,
+        )
+    except ValueError:
+        logger.warning("analyze_trajectory_validation_failed", exc_info=True)
+        raise HTTPException(status_code=422, detail="Invalid trajectory query") from None
+    except Exception:  # never let a downstream failure 500 the whole API
+        logger.exception("analyze_trajectory_failed")
+        raise HTTPException(
+            status_code=503, detail="Trajectory projection unavailable"
+        ) from None
+
+    history = [TrajectoryMarker(**marker) for marker in result.get("history", [])]
+    projection_payload = result.get("projected_next")
+    projection = (
+        TrajectoryProjection(**projection_payload)
+        if projection_payload is not None
+        else None
+    )
+    return TrajectoryResponse(
+        available=bool(result.get("available", False)),
+        history=history,
+        projected_next=projection,
+        architecture=result.get("architecture"),
+        encoder_alias=str(result.get("encoder_alias") or _DEFAULT_TRAJECTORY_ENCODER_ALIAS),
+        history_length=int(result.get("history_length", payload.history_length)),
+        train_end=result.get("train_end"),
+        as_of_date=str(result.get("as_of_date") or payload.as_of_date.isoformat()),
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -484,7 +484,7 @@ def _build_multi_axis_block(
     canonical_labels = ("hawkish", "dovish", "neutral")
     label = label_raw if label_raw in canonical_labels else "neutral"
 
-    distribution: dict[str, float] = {key: 0.0 for key in canonical_labels}
+    distribution: dict[str, float] = dict.fromkeys(canonical_labels, 0.0)
     for entry in sentiment.get("raw", []) or []:
         raw_label = str(entry.get("label", "")).strip().lower()
         if raw_label in distribution:
@@ -1124,4 +1124,5 @@ async def analyze_trajectory(payload: TrajectoryRequest) -> TrajectoryResponse:
         history_length=int(result.get("history_length", payload.history_length)),
         train_end=result.get("train_end"),
         as_of_date=str(result.get("as_of_date") or payload.as_of_date.isoformat()),
+        warning=result.get("warning"),
     )

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -237,3 +237,34 @@ encoders:
       same unpinned-local guard as ``finbert_fomc_only`` applies.
       Deployability lane (#302) will mirror the checkpoint to HF Hub
       in a follow-up — this PR keeps the artefact local.
+
+  trajectory_lstm:
+    repo: /data/artifacts/trajectory/trajectory_lstm/model.pt
+    revision: ""
+    gated: false
+    task: trajectory_classification
+    description: |
+      Sequence-of-meetings LSTM baseline (#296). Two layers, 64-dim
+      hidden. Consumes the per-meeting embedding produced by the
+      cross-bank DAPT encoder (``finbert_fed_adjacent_xbank_dapt``)
+      concatenated with the #291 pre-meeting market block (trailing
+      2y yield change in bps + z-scored VIX close + bias term).
+      Predicts the next meeting's stance (3-class hawkish / dovish /
+      neutral). Produced by ``python -m app.trajectory.train
+      --architecture lstm``; revision stays empty until the first
+      GPU run lands a pinned checkpoint.
+
+  trajectory_transformer:
+    repo: /data/artifacts/trajectory/trajectory_transformer/model.pt
+    revision: ""
+    gated: false
+    task: trajectory_classification
+    description: |
+      Sequence-of-meetings Transformer arm (#296). Encoder-only, four
+      layers, 64-dim model, four attention heads, learned positional
+      embeddings. Same input contract as ``trajectory_lstm``; the
+      architecture A/B is the methodological point of the trajectory
+      panel per §3 Panel 4 of the finalization roadmap. Produced by
+      ``python -m app.trajectory.train --architecture transformer``;
+      revision stays empty until the first GPU run lands a pinned
+      checkpoint.

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -687,3 +687,128 @@ class AnalogsResponse(BaseModel):
     analogs: list[AnalogCard] = Field(default_factory=list)
     index_size: int = Field(..., description="Total number of past statements in the loaded retrieval index.")
     encoder_alias: str = Field(..., description="Registry alias of the encoder used to embed the query.")
+
+
+# ---------------------------------------------------------------------------
+# Hawkish/dovish trajectory model (#296 — /analyze/trajectory)
+# ---------------------------------------------------------------------------
+
+
+class TrajectoryRequest(BaseModel):
+    """Project the FOMC stance trajectory as of ``as_of_date``.
+
+    Strict-backward by construction: the history slice only considers
+    meetings whose ``event_date <= as_of_date``. ``history_length``
+    caps the number of recent meetings rendered in the panel chart.
+    Defaults to 12 (~1.5 years of FOMC meetings) per the §3 Panel 4
+    spec.
+    """
+
+    model_config = _STRICT_REQUEST_CONFIG
+
+    as_of_date: date = Field(
+        ..., description="As-of date for the trajectory projection (YYYY-MM-DD)."
+    )
+    history_length: int = Field(
+        default=12,
+        ge=1,
+        le=60,
+        description="Number of past meetings to surface in the panel (1-60).",
+    )
+
+    @field_validator("as_of_date", mode="before")
+    @classmethod
+    def _coerce_as_of_date(cls, value: Any) -> Any:
+        if value is None or isinstance(value, date):
+            return value
+        if isinstance(value, str):
+            try:
+                return date.fromisoformat(value)
+            except ValueError as exc:
+                raise ValueError(
+                    f"as_of_date must be ISO YYYY-MM-DD, got {value!r}"
+                ) from exc
+        return value
+
+
+class TrajectoryMarker(BaseModel):
+    """One past FOMC meeting rendered as a semantic marker on the panel chart."""
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    event_date: str = Field(..., description="ISO date of the historical FOMC meeting.")
+    axis_stance: str | None = Field(
+        default=None,
+        description=(
+            "Stored stance label (hawkish / dovish / neutral) for the meeting. "
+            "None when the panel was trained against a corpus without labels."
+        ),
+    )
+    embedding_2d: tuple[float, float] = Field(
+        ...,
+        description=(
+            "PCA / UMAP projection of the meeting's encoder embedding to "
+            "2-D space, used as the marker's (x, y) coordinates."
+        ),
+    )
+
+
+class TrajectoryProjection(BaseModel):
+    """Next-meeting projection — predicted class + calibrated confidence band."""
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    predicted_stance: str = Field(
+        ..., description="Argmax over the next-meeting stance distribution."
+    )
+    class_probs: dict[str, float] = Field(
+        default_factory=dict,
+        description=(
+            "Per-class probability over hawkish / dovish / neutral. Sums "
+            "to 1.0 after defensive renormalisation."
+        ),
+    )
+    confidence_band: list[str] | None = Field(
+        default=None,
+        description=(
+            "APS-calibrated stance set (Romano et al. 2020). Empty when no "
+            "conformal sidecar shipped with the bundle; the UI then "
+            "renders the argmax marker without the confidence ring."
+        ),
+    )
+    conformal_alpha: float | None = Field(
+        default=None,
+        description="Conformal mis-coverage level applied to confidence_band.",
+    )
+
+
+class TrajectoryResponse(BaseModel):
+    """Result envelope for /analyze/trajectory."""
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    available: bool = Field(
+        ..., description="False when no trajectory bundle is loaded on this host."
+    )
+    history: list[TrajectoryMarker] = Field(default_factory=list)
+    projected_next: TrajectoryProjection | None = None
+    architecture: str | None = Field(
+        default=None,
+        description="lstm | transformer — which arm produced the projection.",
+    )
+    encoder_alias: str = Field(
+        default="",
+        description="Registry alias of the encoder backing the meeting embeddings.",
+    )
+    history_length: int = Field(
+        default=0,
+        description="How many past meetings were considered (after truncation).",
+    )
+    train_end: str | None = Field(
+        default=None,
+        description="Walk-forward boundary from the bundle manifest.",
+    )
+    as_of_date: str = Field(
+        default="",
+        description="Echo of the request as_of_date (ISO YYYY-MM-DD).",
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -812,3 +812,11 @@ class TrajectoryResponse(BaseModel):
         default="",
         description="Echo of the request as_of_date (ISO YYYY-MM-DD).",
     )
+    warning: str | None = Field(
+        default=None,
+        description=(
+            "Optional non-fatal advisory — set when ``as_of_date`` is "
+            "beyond the bundle's ``train_end`` so the caller can flag "
+            "that the projection extrapolates beyond the fold."
+        ),
+    )

--- a/backend/app/services/trajectory.py
+++ b/backend/app/services/trajectory.py
@@ -1,0 +1,454 @@
+"""Runtime singleton for the trajectory model endpoint (#296).
+
+Backs ``POST /analyze/trajectory`` in :mod:`app.main`. Loads the
+trained trajectory bundle produced by :mod:`app.trajectory.train` on
+the first request, caches the bundle on the worker, and serves
+subsequent queries from the in-memory state.
+
+Mirrors :mod:`app.services.analogs` — thread-safe lazy init, a
+``reset`` hook for the test suite, and a graceful "not available"
+state so a missing bundle never crashes the worker.
+
+The handler can be exercised in tests without a real torch checkpoint
+via :func:`install_state`, which lets a fixture inject a pre-built
+state directly.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date as date_type
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from app.config import DATA_DIR
+from app.trajectory.model import (
+    DEFAULT_HISTORY_LENGTH,
+    MARKET_FEATURE_DIM,
+    STANCE_CLASSES,
+    TrajectoryConfig,
+    load_model,
+    market_feature_vector,
+    pad_sequence,
+)
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_BUNDLE_DIR = DATA_DIR / "artifacts" / "trajectory" / "trajectory_transformer"
+PARQUET_NAME = "embedding_index.parquet"
+NPZ_NAME = "embedding_index.npz"
+MODEL_NAME = "model.pt"
+MANIFEST_NAME = "manifest.json"
+CONFORMAL_NAME = "conformal.json"
+
+MAX_HISTORY_LENGTH = 60
+MAX_TEXT_CHARS = 4096
+
+
+@dataclass(frozen=True)
+class _TrajectoryState:
+    """Loaded trajectory bundle ready to serve projections."""
+
+    model: Any
+    config: TrajectoryConfig
+    embeddings: np.ndarray  # (N, embedding_dim)
+    feature_mean: np.ndarray  # (embedding_dim,)
+    feature_std: np.ndarray  # (embedding_dim,)
+    metadata: pd.DataFrame
+    encoder_alias: str
+    encoder_revision: str
+    train_end: str | None
+    architecture: str
+    bundle_dir: Path
+    conformal_quantile: float | None
+    conformal_alpha: float | None
+    market_provider: Callable[[str], dict[str, float | None]] | None = None
+
+    @property
+    def size(self) -> int:
+        return int(self.embeddings.shape[0])
+
+
+_state: _TrajectoryState | None = None
+_state_lock = threading.Lock()
+
+
+def _resolve_bundle_dir() -> Path:
+    override = (os.environ.get("FED_PULSE_TRAJECTORY_DIR") or "").strip()
+    if override:
+        return Path(override)
+    return DEFAULT_BUNDLE_DIR
+
+
+def bundle_available() -> bool:
+    """Lightweight check used by /analyze/trajectory to short-circuit absent bundles."""
+
+    bundle = _resolve_bundle_dir()
+    if not bundle.exists():
+        return False
+    return all(
+        (bundle / name).exists()
+        for name in (PARQUET_NAME, NPZ_NAME, MODEL_NAME, MANIFEST_NAME)
+    )
+
+
+def _load_state() -> _TrajectoryState | None:
+    bundle_dir = _resolve_bundle_dir()
+    if not bundle_available():
+        _logger.info("trajectory_bundle_missing path=%s", bundle_dir)
+        return None
+    try:
+        metadata = pd.read_parquet(bundle_dir / PARQUET_NAME)
+        npz = np.load(bundle_dir / NPZ_NAME, allow_pickle=False)
+        embeddings = np.asarray(npz["embeddings"], dtype=np.float32)
+        feature_mean = np.asarray(
+            npz.get("feature_mean", np.zeros(embeddings.shape[1])),
+            dtype=np.float32,
+        )
+        feature_std = np.asarray(
+            npz.get("feature_std", np.ones(embeddings.shape[1])),
+            dtype=np.float32,
+        )
+        feature_std[feature_std < 1e-6] = 1.0
+    except Exception:  # pragma: no cover — guarded so a malformed bundle never 500s the worker
+        _logger.warning(
+            "trajectory_bundle_load_failed path=%s", bundle_dir, exc_info=True
+        )
+        return None
+
+    try:
+        model, config = load_model(bundle_dir / MODEL_NAME)
+    except Exception:
+        _logger.warning(
+            "trajectory_model_load_failed path=%s", bundle_dir, exc_info=True
+        )
+        return None
+
+    try:
+        manifest = json.loads((bundle_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
+    except Exception:  # pragma: no cover
+        manifest = {}
+
+    conformal_quantile: float | None = None
+    conformal_alpha: float | None = None
+    conformal_path = bundle_dir / CONFORMAL_NAME
+    if conformal_path.exists():
+        try:
+            payload = json.loads(conformal_path.read_text(encoding="utf-8"))
+            raw_q = payload.get("softmax_quantile")
+            if raw_q is not None:
+                conformal_quantile = float(raw_q)
+            raw_a = payload.get("alpha")
+            if raw_a is not None:
+                conformal_alpha = float(raw_a)
+        except Exception:  # pragma: no cover
+            conformal_quantile = None
+
+    return _TrajectoryState(
+        model=model,
+        config=config,
+        embeddings=embeddings,
+        feature_mean=feature_mean,
+        feature_std=feature_std,
+        metadata=metadata,
+        encoder_alias=str(manifest.get("encoder_alias", "")),
+        encoder_revision=str(manifest.get("encoder_revision", "")),
+        train_end=manifest.get("train_end"),
+        architecture=str(manifest.get("architecture", config.architecture)),
+        bundle_dir=bundle_dir,
+        conformal_quantile=conformal_quantile,
+        conformal_alpha=conformal_alpha,
+    )
+
+
+def get_state() -> _TrajectoryState | None:
+    global _state
+    if _state is not None:
+        return _state
+    with _state_lock:
+        if _state is None:
+            _state = _load_state()
+        return _state
+
+
+def reset_state() -> None:
+    global _state
+    with _state_lock:
+        _state = None
+
+
+def install_state(state: _TrajectoryState) -> None:
+    global _state
+    with _state_lock:
+        _state = state
+
+
+def build_state_for_tests(  # noqa: PLR0913 — keyword-only fixture knobs.
+    *,
+    model: Any,
+    config: TrajectoryConfig,
+    embeddings: np.ndarray,
+    metadata: pd.DataFrame,
+    feature_mean: np.ndarray | None = None,
+    feature_std: np.ndarray | None = None,
+    encoder_alias: str = "test_trajectory_encoder",
+    encoder_revision: str = "",
+    train_end: str | None = None,
+    architecture: str = "lstm",
+    bundle_dir: Path = Path("/dev/null"),
+    conformal_quantile: float | None = None,
+    conformal_alpha: float | None = None,
+    market_provider: Callable[[str], dict[str, float | None]] | None = None,
+) -> _TrajectoryState:
+    """Convenience constructor for tests / smoke harnesses."""
+
+    dim = int(embeddings.shape[1]) if embeddings.size else int(config.embedding_dim)
+    if feature_mean is None:
+        feature_mean = np.zeros(dim, dtype=np.float32)
+    if feature_std is None:
+        feature_std = np.ones(dim, dtype=np.float32)
+    return _TrajectoryState(
+        model=model,
+        config=config,
+        embeddings=np.asarray(embeddings, dtype=np.float32),
+        feature_mean=np.asarray(feature_mean, dtype=np.float32),
+        feature_std=np.asarray(feature_std, dtype=np.float32),
+        metadata=metadata,
+        encoder_alias=encoder_alias,
+        encoder_revision=encoder_revision,
+        train_end=train_end,
+        architecture=architecture,
+        bundle_dir=Path(bundle_dir),
+        conformal_quantile=conformal_quantile,
+        conformal_alpha=conformal_alpha,
+        market_provider=market_provider,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Query construction
+# ---------------------------------------------------------------------------
+
+
+def _slice_history(
+    metadata: pd.DataFrame,
+    *,
+    as_of_iso: str,
+    history_length: int,
+) -> pd.DataFrame:
+    """Strict-backward window: rows with ``event_date <= as_of`` (most recent ``N``)."""
+
+    if metadata.empty:
+        return metadata
+    eligible = metadata[metadata["event_date"].astype(str) <= as_of_iso]
+    if eligible.empty:
+        return eligible
+    eligible = eligible.sort_values("event_date").reset_index(drop=True)
+    return eligible.tail(int(history_length)).reset_index(drop=True)
+
+
+def _market_for(state: _TrajectoryState, event_date: str) -> tuple[float | None, float | None]:
+    """Return the per-meeting market block inputs for ``event_date``.
+
+    Production path: the metadata frame already carries
+    ``pre_meeting_trailing_2y_yield_change_5d_bps`` / ``vix_close``
+    columns when the trainer included them; fall through to the
+    optional ``market_provider`` callable when those columns are
+    absent (tests / hot-reload of an older bundle).
+    """
+
+    if state.metadata is not None and not state.metadata.empty:
+        row = state.metadata[state.metadata["event_date"].astype(str) == event_date]
+        if not row.empty:
+            r0 = row.iloc[0]
+            y = r0.get("pre_meeting_trailing_2y_yield_change_5d_bps")
+            v = r0.get("vix_close")
+            return _to_float_or_none(y), _to_float_or_none(v)
+    if state.market_provider is not None:
+        payload = state.market_provider(event_date)
+        return (
+            _to_float_or_none(payload.get("trailing_2y_yield_change_5d_bps")),
+            _to_float_or_none(payload.get("vix_close")),
+        )
+    return None, None
+
+
+def _to_float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    try:
+        scalar = float(value)
+    except (TypeError, ValueError):
+        return None
+    import math
+
+    if not math.isfinite(scalar):
+        return None
+    return scalar
+
+
+def _standardise_embedding(
+    embedding: np.ndarray, state: _TrajectoryState
+) -> np.ndarray:
+    if state.feature_mean.size == 0:
+        return embedding
+    return np.asarray(
+        (embedding - state.feature_mean) / state.feature_std, dtype=np.float32
+    )
+
+
+def project_trajectory(  # noqa: C901 — keep the branches inline so the data flow stays readable.
+    state: _TrajectoryState,
+    *,
+    as_of_date: date_type,
+    history_length: int = DEFAULT_HISTORY_LENGTH,
+) -> dict[str, Any]:
+    """Run inference + assemble the response payload.
+
+    Returns a dict matching the API shape — the FastAPI handler wraps
+    it with the typed response model. ``history`` is the most-recent
+    ``history_length`` real meetings with their 2D anchors and stance
+    labels; ``projected_next`` carries the predicted class
+    distribution + a confidence band derived from the conformal
+    softmax quantile (when the bundle ships one).
+    """
+
+    import torch
+
+    history_length = max(1, min(int(history_length), MAX_HISTORY_LENGTH))
+    as_of_iso = as_of_date.isoformat()
+    history_df = _slice_history(
+        state.metadata, as_of_iso=as_of_iso, history_length=history_length
+    )
+
+    history_markers: list[dict[str, Any]] = []
+    embeddings_window: list[np.ndarray] = []
+    market_blocks: list[np.ndarray] = []
+    for _, row in history_df.iterrows():
+        event_date = str(row["event_date"])
+        history_markers.append(
+            {
+                "event_date": event_date,
+                "axis_stance": _str_or_none(row.get("axis_stance")),
+                "embedding_2d": (
+                    float(row.get("embedding_2d_x", 0.0) or 0.0),
+                    float(row.get("embedding_2d_y", 0.0) or 0.0),
+                ),
+            }
+        )
+        # Resolve the row's embedding from the npz matrix using a date
+        # lookup. The matrix is row-aligned with the parquet so iloc
+        # by the parquet's matching positional index reads the right
+        # vector.
+        parquet_idx = int(
+            state.metadata.index[
+                state.metadata["event_date"].astype(str) == event_date
+            ][0]
+        )
+        raw_emb = state.embeddings[parquet_idx]
+        embeddings_window.append(_standardise_embedding(raw_emb, state))
+        y, v = _market_for(state, event_date)
+        market_blocks.append(
+            market_feature_vector(
+                trailing_2y_yield_change_5d_bps=y, vix_close=v
+            )
+        )
+
+    if not embeddings_window:
+        return {
+            "history": history_markers,
+            "projected_next": None,
+            "architecture": state.architecture,
+            "encoder_alias": state.encoder_alias,
+            "history_length": int(history_length),
+            "train_end": state.train_end,
+            "as_of_date": as_of_iso,
+            "available": False,
+        }
+
+    padded_inputs, mask = pad_sequence(
+        embeddings_window,
+        market_blocks,
+        history_length=history_length,
+    )
+
+    inputs_tensor = torch.tensor(
+        padded_inputs[np.newaxis, ...], dtype=torch.float32
+    )
+    mask_tensor = torch.tensor(mask[np.newaxis, ...], dtype=torch.bool)
+
+    state.model.eval()
+    with torch.no_grad():
+        logits, _ = state.model(inputs_tensor, mask_tensor)
+        softmax = torch.softmax(logits, dim=-1)
+        probs = softmax[0].detach().cpu().numpy()
+
+    class_probs = {STANCE_CLASSES[i]: float(probs[i]) for i in range(len(STANCE_CLASSES))}
+    # Defensive normalisation so the dict is always a valid probability
+    # distribution even if float drift accumulated through softmax.
+    total = float(sum(class_probs.values()))
+    if total > 0:
+        class_probs = {k: v / total for k, v in class_probs.items()}
+    argmax = max(class_probs, key=class_probs.get)  # type: ignore[arg-type]
+
+    confidence_band: list[str] | None = None
+    if state.conformal_quantile is not None:
+        keep = 1.0 - float(state.conformal_quantile)
+        included = [k for k, v in class_probs.items() if v >= keep]
+        confidence_band = included if included else [argmax]
+
+    projection = {
+        "predicted_stance": argmax,
+        "class_probs": class_probs,
+        "confidence_band": confidence_band,
+        "conformal_alpha": state.conformal_alpha,
+    }
+    return {
+        "history": history_markers,
+        "projected_next": projection,
+        "architecture": state.architecture,
+        "encoder_alias": state.encoder_alias,
+        "history_length": int(history_length),
+        "train_end": state.train_end,
+        "as_of_date": as_of_iso,
+        "available": True,
+    }
+
+
+def _str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    text = str(value).strip()
+    return text or None
+
+
+__all__ = [
+    "DEFAULT_HISTORY_LENGTH",
+    "MARKET_FEATURE_DIM",
+    "MAX_HISTORY_LENGTH",
+    "STANCE_CLASSES",
+    "build_state_for_tests",
+    "bundle_available",
+    "get_state",
+    "install_state",
+    "project_trajectory",
+    "reset_state",
+]

--- a/backend/app/services/trajectory.py
+++ b/backend/app/services/trajectory.py
@@ -100,6 +100,59 @@ def bundle_available() -> bool:
     )
 
 
+def _load_npz_arrays(
+    npz_path: Path, bundle_dir: Path
+) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """Load the embedding matrix + standardisation stats from the npz.
+
+    Falls back to zero-mean / unit-std with a logged warning when the
+    bundle predates the standardisation contract. ``NpzFile`` does not
+    support ``.get`` so the probe uses an explicit ``in .files`` check.
+    """
+
+    try:
+        npz = np.load(npz_path, allow_pickle=False)
+        embeddings = np.asarray(npz["embeddings"], dtype=np.float32)
+    except Exception:  # pragma: no cover — guarded so a malformed npz never 500s the worker
+        _logger.warning(
+            "trajectory_bundle_load_failed path=%s", bundle_dir, exc_info=True
+        )
+        return None
+    if "feature_mean" in npz.files:
+        feature_mean = np.asarray(npz["feature_mean"], dtype=np.float32)
+    else:
+        _logger.warning(
+            "trajectory_bundle_missing_feature_mean path=%s — falling back to zeros",
+            bundle_dir,
+        )
+        feature_mean = np.zeros(embeddings.shape[1], dtype=np.float32)
+    if "feature_std" in npz.files:
+        feature_std = np.asarray(npz["feature_std"], dtype=np.float32)
+    else:
+        _logger.warning(
+            "trajectory_bundle_missing_feature_std path=%s — falling back to ones",
+            bundle_dir,
+        )
+        feature_std = np.ones(embeddings.shape[1], dtype=np.float32)
+    feature_std[feature_std < 1e-6] = 1.0
+    return embeddings, feature_mean, feature_std
+
+
+def _load_conformal(bundle_dir: Path) -> tuple[float | None, float | None]:
+    conformal_path = bundle_dir / CONFORMAL_NAME
+    if not conformal_path.exists():
+        return None, None
+    try:
+        payload = json.loads(conformal_path.read_text(encoding="utf-8"))
+    except Exception:  # pragma: no cover
+        return None, None
+    raw_q = payload.get("softmax_quantile")
+    raw_a = payload.get("alpha")
+    q = float(raw_q) if raw_q is not None else None
+    a = float(raw_a) if raw_a is not None else None
+    return q, a
+
+
 def _load_state() -> _TrajectoryState | None:
     bundle_dir = _resolve_bundle_dir()
     if not bundle_available():
@@ -107,22 +160,15 @@ def _load_state() -> _TrajectoryState | None:
         return None
     try:
         metadata = pd.read_parquet(bundle_dir / PARQUET_NAME)
-        npz = np.load(bundle_dir / NPZ_NAME, allow_pickle=False)
-        embeddings = np.asarray(npz["embeddings"], dtype=np.float32)
-        feature_mean = np.asarray(
-            npz.get("feature_mean", np.zeros(embeddings.shape[1])),
-            dtype=np.float32,
-        )
-        feature_std = np.asarray(
-            npz.get("feature_std", np.ones(embeddings.shape[1])),
-            dtype=np.float32,
-        )
-        feature_std[feature_std < 1e-6] = 1.0
-    except Exception:  # pragma: no cover — guarded so a malformed bundle never 500s the worker
+    except Exception:  # pragma: no cover
         _logger.warning(
             "trajectory_bundle_load_failed path=%s", bundle_dir, exc_info=True
         )
         return None
+    loaded = _load_npz_arrays(bundle_dir / NPZ_NAME, bundle_dir)
+    if loaded is None:
+        return None
+    embeddings, feature_mean, feature_std = loaded
 
     try:
         model, config = load_model(bundle_dir / MODEL_NAME)
@@ -137,20 +183,7 @@ def _load_state() -> _TrajectoryState | None:
     except Exception:  # pragma: no cover
         manifest = {}
 
-    conformal_quantile: float | None = None
-    conformal_alpha: float | None = None
-    conformal_path = bundle_dir / CONFORMAL_NAME
-    if conformal_path.exists():
-        try:
-            payload = json.loads(conformal_path.read_text(encoding="utf-8"))
-            raw_q = payload.get("softmax_quantile")
-            if raw_q is not None:
-                conformal_quantile = float(raw_q)
-            raw_a = payload.get("alpha")
-            if raw_a is not None:
-                conformal_alpha = float(raw_a)
-        except Exception:  # pragma: no cover
-            conformal_quantile = None
+    conformal_quantile, conformal_alpha = _load_conformal(bundle_dir)
 
     return _TrajectoryState(
         model=model,
@@ -170,12 +203,27 @@ def _load_state() -> _TrajectoryState | None:
 
 
 def get_state() -> _TrajectoryState | None:
+    """Return the cached state, building it on first call.
+
+    Double-checked locking: the lock-free pre-check serves the steady
+    state, the lock is only contested on cold start, and the actual
+    bundle load (HF + torch + npz) runs OUTSIDE the lock so concurrent
+    first-hit requests do not serialize on the slow path. We accept
+    that two simultaneous first hits may both call ``_load_state``;
+    the second result is discarded by the compare-and-assign under the
+    lock so the worker still ends up with a single shared state.
+    """
+
     global _state
     if _state is not None:
         return _state
+    # Build outside the lock so a concurrent first-hit caller does not
+    # block on a multi-second torch.load. The worst case is duplicate
+    # work; correctness is preserved by the compare-and-assign below.
+    candidate = _load_state()
     with _state_lock:
         if _state is None:
-            _state = _load_state()
+            _state = candidate
         return _state
 
 
@@ -244,18 +292,29 @@ def _slice_history(
     as_of_iso: str,
     history_length: int,
 ) -> pd.DataFrame:
-    """Strict-backward window: rows with ``event_date <= as_of`` (most recent ``N``)."""
+    """Strict-backward window: rows with ``event_date < as_of`` (most recent ``N``).
+
+    Matches the strict-backward convention enforced by
+    :func:`app.retrieval.index.query` — a meeting whose ``event_date``
+    equals the query date is the meeting being projected, never an
+    eligible history marker.
+    """
 
     if metadata.empty:
         return metadata
-    eligible = metadata[metadata["event_date"].astype(str) <= as_of_iso]
+    eligible = metadata[metadata["event_date"].astype(str) < as_of_iso]
     if eligible.empty:
         return eligible
     eligible = eligible.sort_values("event_date").reset_index(drop=True)
     return eligible.tail(int(history_length)).reset_index(drop=True)
 
 
-def _market_for(state: _TrajectoryState, event_date: str) -> tuple[float | None, float | None]:
+def _market_for(
+    state: _TrajectoryState,
+    event_date: str,
+    *,
+    text_hash: str | None = None,
+) -> tuple[float | None, float | None]:
     """Return the per-meeting market block inputs for ``event_date``.
 
     Production path: the metadata frame already carries
@@ -263,10 +322,22 @@ def _market_for(state: _TrajectoryState, event_date: str) -> tuple[float | None,
     columns when the trainer included them; fall through to the
     optional ``market_provider`` callable when those columns are
     absent (tests / hot-reload of an older bundle).
+
+    ``text_hash`` disambiguates duplicate ``event_date`` rows (e.g.
+    intermeeting release stamped same-day as a statement). When set,
+    we key the lookup on the hash so the row returned matches the
+    history marker the embedding window was built from.
     """
 
     if state.metadata is not None and not state.metadata.empty:
-        row = state.metadata[state.metadata["event_date"].astype(str) == event_date]
+        if text_hash and "text_hash" in state.metadata.columns:
+            row = state.metadata[
+                state.metadata["text_hash"].astype(str) == str(text_hash)
+            ]
+        else:
+            row = state.metadata[
+                state.metadata["event_date"].astype(str) == event_date
+            ]
         if not row.empty:
             r0 = row.iloc[0]
             y = r0.get("pre_meeting_trailing_2y_yield_change_5d_bps")
@@ -337,8 +408,15 @@ def project_trajectory(  # noqa: C901 — keep the branches inline so the data f
     history_markers: list[dict[str, Any]] = []
     embeddings_window: list[np.ndarray] = []
     market_blocks: list[np.ndarray] = []
+    metadata_has_hash = (
+        state.metadata is not None and "text_hash" in state.metadata.columns
+    )
     for _, row in history_df.iterrows():
         event_date = str(row["event_date"])
+        text_hash_raw = row.get("text_hash") if metadata_has_hash else None
+        text_hash = (
+            str(text_hash_raw) if text_hash_raw is not None and str(text_hash_raw) != "" else None
+        )
         history_markers.append(
             {
                 "event_date": event_date,
@@ -349,22 +427,37 @@ def project_trajectory(  # noqa: C901 — keep the branches inline so the data f
                 ),
             }
         )
-        # Resolve the row's embedding from the npz matrix using a date
-        # lookup. The matrix is row-aligned with the parquet so iloc
-        # by the parquet's matching positional index reads the right
-        # vector.
-        parquet_idx = int(
-            state.metadata.index[
+        # Resolve the row's embedding from the npz matrix. With
+        # duplicate ``event_date`` rows (e.g. intermeeting release
+        # same-day as a statement) the date is not unique; prefer
+        # ``text_hash`` when the bundle carries it so the embedding,
+        # market block, and history marker all point at the same row.
+        if text_hash and metadata_has_hash:
+            matches = state.metadata.index[
+                state.metadata["text_hash"].astype(str) == text_hash
+            ]
+        else:
+            matches = state.metadata.index[
                 state.metadata["event_date"].astype(str) == event_date
-            ][0]
-        )
+            ]
+        parquet_idx = int(matches[0])
         raw_emb = state.embeddings[parquet_idx]
         embeddings_window.append(_standardise_embedding(raw_emb, state))
-        y, v = _market_for(state, event_date)
+        y, v = _market_for(state, event_date, text_hash=text_hash)
         market_blocks.append(
             market_feature_vector(
                 trailing_2y_yield_change_5d_bps=y, vix_close=v
             )
+        )
+
+    warning: str | None = None
+    if state.train_end and as_of_iso > str(state.train_end):
+        # The bundle's model never trained on meetings past ``train_end``;
+        # honour the request but flag the extrapolation so the caller
+        # can decide whether to surface a banner in the UI.
+        warning = (
+            "as_of_date is beyond train_end; projection extrapolates "
+            "beyond the walk-forward fold boundary"
         )
 
     if not embeddings_window:
@@ -377,6 +470,7 @@ def project_trajectory(  # noqa: C901 — keep the branches inline so the data f
             "train_end": state.train_end,
             "as_of_date": as_of_iso,
             "available": False,
+            "warning": warning,
         }
 
     padded_inputs, mask = pad_sequence(
@@ -425,6 +519,7 @@ def project_trajectory(  # noqa: C901 — keep the branches inline so the data f
         "train_end": state.train_end,
         "as_of_date": as_of_iso,
         "available": True,
+        "warning": warning,
     }
 
 

--- a/backend/app/trajectory/__init__.py
+++ b/backend/app/trajectory/__init__.py
@@ -1,0 +1,23 @@
+"""Hawkish/dovish trajectory model (#296).
+
+Sequence-of-meetings model over per-meeting encoder embeddings plus
+market context features. Distinct from the per-statement multi-axis
+classifier — different time scale (one decision per FOMC meeting rather
+than one decision per sentence) and a different mechanism (sequence
+model over the last N meetings rather than per-statement projection).
+
+Layout mirrors :mod:`app.retrieval`:
+
+* :mod:`app.trajectory.model` — two architectures (LSTM baseline +
+  small Transformer) plus the persistence helpers. The architecture
+  comparison is the methodological point per §3 Panel 4 of the
+  finalization roadmap.
+* :mod:`app.trajectory.train` — walk-forward training entry point that
+  respects the ``fold_manifest_expanding_walk_forward.json`` boundary
+  and emits a bundle under ``data/artifacts/trajectory/<run_name>/``.
+
+The runtime singleton at :mod:`app.services.trajectory` mounts the
+bundle for the FastAPI ``/analyze/trajectory`` handler.
+"""
+
+from __future__ import annotations

--- a/backend/app/trajectory/model.py
+++ b/backend/app/trajectory/model.py
@@ -170,9 +170,16 @@ def market_feature_vector(
 
     The block is fixed-width by design so the train + inference paths
     can concatenate it onto the encoder embedding without reasoning
-    about which #291 columns are present. ``None`` inputs degrade to
-    zero so a missing pre-meeting row contributes a no-signal block
-    rather than crashing the build.
+    about which #291 columns are present.
+
+    Missingness is signalled by ``None`` / ``NaN`` on the input — NOT
+    by a ``> 0`` heuristic on ``vix_close``. A future regime with a
+    near-zero or sub-mean VIX must still produce the correct z-score
+    rather than collapse into the missing-data bin. The bias slot
+    encodes an explicit "VIX is present" bit (``1.0`` when ``vix_close``
+    is a finite number, ``0.0`` when it is missing) so the model can
+    distinguish "no data" from "VIX printed exactly at the long-run
+    mean" without overloading the magnitude channel.
 
     ``vix_close`` is z-scored with a pinned mean / std (default 20 / 8
     matches the long-run distribution of ^VIX on the train slice). The
@@ -181,22 +188,28 @@ def market_feature_vector(
     apply at train + inference time.
     """
 
-    def _finite(value: float | None) -> float:
+    def _coerce(value: float | None) -> tuple[float, bool]:
+        """Return ``(value, is_missing)`` — missing when None / NaN / non-finite."""
+
+        if value is None:
+            return 0.0, True
         try:
-            if value is None:
-                return 0.0
             scalar = float(value)
         except (TypeError, ValueError):
-            return 0.0
+            return 0.0, True
         if not math.isfinite(scalar):
-            return 0.0
-        return scalar
+            return 0.0, True
+        return scalar, False
 
-    bias = 1.0
-    yield_bp = _finite(trailing_2y_yield_change_5d_bps)
-    vix_raw = _finite(vix_close)
+    yield_bp, _yield_missing = _coerce(trailing_2y_yield_change_5d_bps)
+    vix_raw, vix_missing = _coerce(vix_close)
     denom = float(vix_std) if vix_std and vix_std > 1e-9 else 1.0
-    vix_z = (vix_raw - float(vix_mean)) / denom if vix_raw > 0 else 0.0
+    # The bias slot doubles as the "VIX present" indicator: 1.0 when
+    # we have a real reading (sub-mean or otherwise), 0.0 when the
+    # input was None / NaN. Keeps MARKET_FEATURE_DIM stable while
+    # surfacing the missingness bit to the model.
+    bias = 0.0 if vix_missing else 1.0
+    vix_z = 0.0 if vix_missing else (vix_raw - float(vix_mean)) / denom
     return np.asarray([bias, yield_bp, vix_z], dtype=np.float32)
 
 
@@ -367,16 +380,30 @@ def _TransformerTrajectoryModel(config: TrajectoryConfig, torch_mod: Any) -> Any
             positions = torch_mod.arange(seq_len, device=inputs.device)
             pos_embed = self.position_embedding(positions).unsqueeze(0)
             projected = projected + pos_embed
+            effective_mask = mask
             key_padding_mask: Any | None = None
             if mask is not None:
                 # ``TransformerEncoder`` expects ``True`` for positions to
                 # IGNORE; our ``mask`` marks real positions as ``True``,
                 # so flip the polarity here.
-                key_padding_mask = ~mask.bool()
+                mask_bool = mask.bool()
+                # All-pad rows would feed ``softmax(-inf)`` into the
+                # attention layer and produce NaN. Force at least one
+                # position per row to be attended; the final-position
+                # pooler then reads a finite vector. The (now real)
+                # position is the last absolute slot — that mirrors
+                # ``_final_real_position``'s fallback when ``mask`` is
+                # entirely False (it clamps ``counts`` to 1).
+                all_pad = (~mask_bool).all(dim=1)
+                if all_pad.any():
+                    mask_bool = mask_bool.clone()
+                    mask_bool[all_pad, -1] = True
+                    effective_mask = mask_bool
+                key_padding_mask = ~mask_bool
             encoded = self.encoder(
                 projected, src_key_padding_mask=key_padding_mask
             )
-            pooled = _final_real_position(encoded, mask, torch_mod)
+            pooled = _final_real_position(encoded, effective_mask, torch_mod)
             pooled = self.dropout(pooled)
             logits = self.head(pooled)
             return logits, pooled
@@ -409,7 +436,12 @@ def save_model(model: Any, config: TrajectoryConfig, path: Path) -> None:
     """Persist a model + its config to a single ``.pt`` file.
 
     Writes via ``torch.save`` to a sibling ``.tmp`` path and renames so
-    a crash mid-write never leaves a truncated checkpoint on disk.
+    a crash mid-write never leaves a truncated checkpoint on disk. The
+    payload stores the config as a plain dict + the state_dict (tensor
+    leaves only) so the file can be reloaded with
+    ``torch.load(weights_only=True)`` — eliminating the pickle-RCE
+    surface that would otherwise be reachable via the
+    ``FED_PULSE_TRAJECTORY_DIR`` env override.
     """
 
     import os
@@ -418,9 +450,14 @@ def save_model(model: Any, config: TrajectoryConfig, path: Path) -> None:
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
+    # Persist config as a JSON string so the resulting checkpoint
+    # carries only str + tensor leaves — safe under weights_only=True
+    # on PyTorch >= 2.4. Older checkpoints written with a raw dict
+    # payload are handled at load time via a one-shot fallback.
+    config_json = _json_dumps(config.to_dict())
     torch.save(
         {
-            "config": config.to_dict(),
+            "config_json": config_json,
             "state_dict": model.state_dict(),
         },
         tmp,
@@ -428,18 +465,50 @@ def save_model(model: Any, config: TrajectoryConfig, path: Path) -> None:
     os.replace(tmp, path)
 
 
+def _json_dumps(payload: dict[str, Any]) -> str:
+    import json
+
+    return json.dumps(payload, sort_keys=True)
+
+
 def load_model(path: Path) -> tuple[Any, TrajectoryConfig]:
-    """Reconstruct a model + config from a checkpoint written by ``save_model``."""
+    """Reconstruct a model + config from a checkpoint written by ``save_model``.
+
+    Uses ``weights_only=True`` so the bundle directory (which can be
+    swapped via the ``FED_PULSE_TRAJECTORY_DIR`` env var) cannot be
+    used as a pickle-execution vector. The config travels as a JSON
+    string in the payload so only ``str`` + tensor leaves are
+    deserialised. Legacy checkpoints written under the prior
+    ``weights_only=False`` schema (raw ``config`` dict) are still
+    accepted via a guarded fallback that logs the trust assumption.
+    """
+
+    import json
 
     torch = _import_torch()
     path = Path(path)
     if not path.exists():
         raise FileNotFoundError(f"trajectory checkpoint not found: {path}")
-    # weights_only=False so the optimizer / config dict round-trips,
-    # but the file is project-internal so the trust boundary is the
-    # same as for the encoder checkpoints.
-    payload = torch.load(path, map_location="cpu", weights_only=False)
-    config = TrajectoryConfig.from_dict(payload["config"])
+    try:
+        payload = torch.load(path, map_location="cpu", weights_only=True)
+    except Exception:
+        # Legacy bundle: a dict-typed ``config`` leaf forces
+        # weights_only=False. Surfaces the trust boundary in the log
+        # so an operator can rebuild via ``app.trajectory.train`` to
+        # regain the hardened path.
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning(
+            "trajectory_checkpoint_legacy_pickle path=%s — falling back to "
+            "weights_only=False; rebuild the bundle to re-enable the "
+            "weights_only=True load path",
+            path,
+        )
+        payload = torch.load(path, map_location="cpu", weights_only=False)
+    if "config_json" in payload:
+        config = TrajectoryConfig.from_dict(json.loads(payload["config_json"]))
+    else:
+        config = TrajectoryConfig.from_dict(payload["config"])
     model = build_model(config)
     model.load_state_dict(payload["state_dict"])
     model.eval()

--- a/backend/app/trajectory/model.py
+++ b/backend/app/trajectory/model.py
@@ -1,0 +1,466 @@
+"""Trajectory model architectures + persistence (#296).
+
+Two architectures share the same input / output contract so the train
+script can A/B them on the same fold without bespoke wiring per side:
+
+* :class:`TrajectoryLSTM` — single-direction LSTM baseline. Two layers,
+  64-dim hidden. The conservative baseline against which the Transformer
+  arm is graded.
+* :class:`TrajectoryTransformer` — small encoder-only Transformer.
+  Four layers, 64-dim model, 4 attention heads. Learned positional
+  embeddings because the sequence is short (12 meetings) and a
+  sinusoidal table buys little at that scale.
+
+Both ingest a ``(B, T, D_in)`` float tensor where ``T`` is the meeting
+history length and ``D_in = embedding_dim + market_feature_dim``. The
+per-meeting market block carries the two #291 pre-meeting columns
+(``pre_meeting_trailing_2y_yield_change_5d_bps`` and a VIX proxy off
+``cross_asset.vix_close``) plus a leading bias term, so the dim is
+fixed at three for callers that follow :func:`market_feature_vector`.
+
+Padding is handled via a companion ``(B, T)`` bool ``mask`` where
+``True`` marks a real meeting and ``False`` marks a left-pad slot.
+
+The forward pass returns ``(logits, hidden_state)``:
+
+* ``logits`` is ``(B, n_classes)`` — log-odds over the next meeting's
+  stance, decoded from the final non-padded position.
+* ``hidden_state`` is ``(B, hidden_dim)`` — the pooled context vector
+  the train loop also exposes as the projected-next semantic anchor.
+
+Persistence is plain ``torch.save`` of a state-dict + an architecture
+tag string so :func:`load_model` can rebuild without inspecting the
+checkpoint. Manifests are written by the trainer (see
+:mod:`app.trajectory.train`); this module deliberately does not touch
+the filesystem.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+
+# --- Constants --------------------------------------------------------------
+
+# 3-class stance head: matches the canonical {hawkish, dovish, neutral}
+# label set documented in docs/data-and-training-contracts.md so the
+# trajectory head can be A/B'd against the per-statement classifier
+# without label-space surgery.
+STANCE_CLASSES: tuple[str, str, str] = ("hawkish", "dovish", "neutral")
+N_STANCE_CLASSES: int = len(STANCE_CLASSES)
+
+# Default history length per the issue (~1.5 years of FOMC meetings,
+# which is 8 scheduled + ~4 intermeeting in the modern era).
+DEFAULT_HISTORY_LENGTH: int = 12
+
+# Default architecture knobs. The Transformer side intentionally stays
+# small — the corpus has ~250 historical statements, so widening the
+# model trades training stability for a parameter count the data
+# cannot warrant.
+DEFAULT_LSTM_HIDDEN: int = 64
+DEFAULT_LSTM_LAYERS: int = 2
+DEFAULT_TRANSFORMER_LAYERS: int = 4
+DEFAULT_TRANSFORMER_D_MODEL: int = 64
+DEFAULT_TRANSFORMER_N_HEADS: int = 4
+DEFAULT_DROPOUT: float = 0.1
+
+# Per-meeting market feature dim: [bias, trailing_2y_yield_change_5d_bps,
+# vix_close_z]. Fixed so callers that build inputs via
+# :func:`market_feature_vector` stay schema-stable across rebuilds.
+MARKET_FEATURE_DIM: int = 3
+
+Architecture = Literal["lstm", "transformer"]
+
+
+@dataclass(frozen=True)
+class TrajectoryConfig:
+    """Hyperparameter envelope for both architectures."""
+
+    architecture: Architecture
+    embedding_dim: int
+    market_feature_dim: int = MARKET_FEATURE_DIM
+    history_length: int = DEFAULT_HISTORY_LENGTH
+    n_classes: int = N_STANCE_CLASSES
+    dropout: float = DEFAULT_DROPOUT
+    # LSTM-only knobs.
+    lstm_hidden: int = DEFAULT_LSTM_HIDDEN
+    lstm_layers: int = DEFAULT_LSTM_LAYERS
+    # Transformer-only knobs.
+    transformer_layers: int = DEFAULT_TRANSFORMER_LAYERS
+    transformer_d_model: int = DEFAULT_TRANSFORMER_D_MODEL
+    transformer_n_heads: int = DEFAULT_TRANSFORMER_N_HEADS
+
+    @property
+    def input_dim(self) -> int:
+        return int(self.embedding_dim + self.market_feature_dim)
+
+    @property
+    def hidden_dim(self) -> int:
+        """Width of the pooled context vector returned by ``forward``.
+
+        Equal to ``lstm_hidden`` for the LSTM arm and
+        ``transformer_d_model`` for the Transformer arm so a
+        downstream consumer (e.g. the projection layer in the runtime
+        singleton) does not have to branch on architecture.
+        """
+
+        if self.architecture == "lstm":
+            return int(self.lstm_hidden)
+        return int(self.transformer_d_model)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "architecture": self.architecture,
+            "embedding_dim": int(self.embedding_dim),
+            "market_feature_dim": int(self.market_feature_dim),
+            "history_length": int(self.history_length),
+            "n_classes": int(self.n_classes),
+            "dropout": float(self.dropout),
+            "lstm_hidden": int(self.lstm_hidden),
+            "lstm_layers": int(self.lstm_layers),
+            "transformer_layers": int(self.transformer_layers),
+            "transformer_d_model": int(self.transformer_d_model),
+            "transformer_n_heads": int(self.transformer_n_heads),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "TrajectoryConfig":
+        arch = str(payload.get("architecture", "lstm"))
+        if arch not in ("lstm", "transformer"):
+            raise ValueError(
+                f"architecture must be 'lstm' or 'transformer', got {arch!r}"
+            )
+        return cls(
+            architecture=arch,  # type: ignore[arg-type]
+            embedding_dim=int(payload["embedding_dim"]),
+            market_feature_dim=int(payload.get("market_feature_dim", MARKET_FEATURE_DIM)),
+            history_length=int(payload.get("history_length", DEFAULT_HISTORY_LENGTH)),
+            n_classes=int(payload.get("n_classes", N_STANCE_CLASSES)),
+            dropout=float(payload.get("dropout", DEFAULT_DROPOUT)),
+            lstm_hidden=int(payload.get("lstm_hidden", DEFAULT_LSTM_HIDDEN)),
+            lstm_layers=int(payload.get("lstm_layers", DEFAULT_LSTM_LAYERS)),
+            transformer_layers=int(
+                payload.get("transformer_layers", DEFAULT_TRANSFORMER_LAYERS)
+            ),
+            transformer_d_model=int(
+                payload.get("transformer_d_model", DEFAULT_TRANSFORMER_D_MODEL)
+            ),
+            transformer_n_heads=int(
+                payload.get("transformer_n_heads", DEFAULT_TRANSFORMER_N_HEADS)
+            ),
+        )
+
+
+# --- Feature builders -------------------------------------------------------
+
+
+def market_feature_vector(
+    *,
+    trailing_2y_yield_change_5d_bps: float | None,
+    vix_close: float | None,
+    vix_mean: float = 20.0,
+    vix_std: float = 8.0,
+) -> np.ndarray:
+    """Build the per-meeting market block as a ``(MARKET_FEATURE_DIM,)`` vector.
+
+    The block is fixed-width by design so the train + inference paths
+    can concatenate it onto the encoder embedding without reasoning
+    about which #291 columns are present. ``None`` inputs degrade to
+    zero so a missing pre-meeting row contributes a no-signal block
+    rather than crashing the build.
+
+    ``vix_close`` is z-scored with a pinned mean / std (default 20 / 8
+    matches the long-run distribution of ^VIX on the train slice). The
+    pinned moments mean the inference path does not have to ship a
+    scaler artifact alongside the model checkpoint — the same constants
+    apply at train + inference time.
+    """
+
+    def _finite(value: float | None) -> float:
+        try:
+            if value is None:
+                return 0.0
+            scalar = float(value)
+        except (TypeError, ValueError):
+            return 0.0
+        if not math.isfinite(scalar):
+            return 0.0
+        return scalar
+
+    bias = 1.0
+    yield_bp = _finite(trailing_2y_yield_change_5d_bps)
+    vix_raw = _finite(vix_close)
+    denom = float(vix_std) if vix_std and vix_std > 1e-9 else 1.0
+    vix_z = (vix_raw - float(vix_mean)) / denom if vix_raw > 0 else 0.0
+    return np.asarray([bias, yield_bp, vix_z], dtype=np.float32)
+
+
+def pad_sequence(
+    embeddings: Sequence[np.ndarray],
+    market_blocks: Sequence[np.ndarray],
+    *,
+    history_length: int = DEFAULT_HISTORY_LENGTH,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Left-pad two parallel meeting sequences into ``(T, D)`` + ``(T,)``.
+
+    ``embeddings`` and ``market_blocks`` must align row-by-row; the
+    function asserts equal length and returns the padded tensor stack
+    plus a boolean mask that marks real meetings as ``True`` and the
+    leading pad slots as ``False``. Padding goes at the front (most
+    recent meeting last) so the model's final-position decoder always
+    reads the most recent real meeting.
+
+    The function clips sequences longer than ``history_length`` to the
+    most recent ``history_length`` meetings — older meetings carry the
+    least predictive value for next-meeting stance and dropping them
+    keeps the input tensor dense.
+    """
+
+    if len(embeddings) != len(market_blocks):
+        raise ValueError(
+            "embeddings and market_blocks must align in length; "
+            f"got {len(embeddings)} vs {len(market_blocks)}"
+        )
+    if history_length <= 0:
+        raise ValueError(f"history_length must be positive; got {history_length}")
+    if not embeddings:
+        emb_dim = 1
+        mkt_dim = MARKET_FEATURE_DIM
+        zero_input = np.zeros(
+            (history_length, emb_dim + mkt_dim), dtype=np.float32
+        )
+        zero_mask = np.zeros(history_length, dtype=bool)
+        return zero_input, zero_mask
+
+    embedding_dim = int(np.asarray(embeddings[0]).shape[-1])
+    market_dim = int(np.asarray(market_blocks[0]).shape[-1])
+    rows = list(zip(embeddings, market_blocks))
+    if len(rows) > history_length:
+        rows = rows[-history_length:]
+    real_count = len(rows)
+    pad_count = history_length - real_count
+    input_dim = embedding_dim + market_dim
+    padded = np.zeros((history_length, input_dim), dtype=np.float32)
+    mask = np.zeros(history_length, dtype=bool)
+    for offset, (emb, mkt) in enumerate(rows):
+        slot = pad_count + offset
+        emb_arr = np.asarray(emb, dtype=np.float32).reshape(-1)
+        mkt_arr = np.asarray(mkt, dtype=np.float32).reshape(-1)
+        if emb_arr.shape[0] != embedding_dim:
+            raise ValueError(
+                "inconsistent embedding dim across meetings; "
+                f"expected {embedding_dim}, got {emb_arr.shape[0]}"
+            )
+        if mkt_arr.shape[0] != market_dim:
+            raise ValueError(
+                "inconsistent market block dim across meetings; "
+                f"expected {market_dim}, got {mkt_arr.shape[0]}"
+            )
+        padded[slot, :embedding_dim] = emb_arr
+        padded[slot, embedding_dim:] = mkt_arr
+        mask[slot] = True
+    return padded, mask
+
+
+# --- Architectures ----------------------------------------------------------
+#
+# The torch import is deferred so the module loads cleanly under any
+# import-time path that does not need to run a forward pass (typical
+# pytest collection of unrelated tests).
+
+
+def _import_torch() -> Any:
+    import torch  # type: ignore[import-not-found,unused-ignore]
+
+    return torch
+
+
+def build_model(config: TrajectoryConfig) -> Any:
+    """Construct a torch module matching ``config.architecture``.
+
+    Returns the module in evaluation mode by default; the trainer
+    flips it to train mode explicitly. The lazy torch import keeps the
+    rest of the module usable in environments where torch is mocked
+    out (some unit tests).
+    """
+
+    torch = _import_torch()
+
+    if config.architecture == "lstm":
+        return _LSTMTrajectoryModel(config, torch)
+    return _TransformerTrajectoryModel(config, torch)
+
+
+def _LSTMTrajectoryModel(config: TrajectoryConfig, torch_mod: Any) -> Any:
+    nn = torch_mod.nn
+
+    class _LSTM(nn.Module):  # type: ignore[misc, name-defined]
+        def __init__(self) -> None:
+            super().__init__()
+            self.config = config
+            self.input_proj = nn.Linear(config.input_dim, config.lstm_hidden)
+            self.lstm = nn.LSTM(
+                input_size=config.lstm_hidden,
+                hidden_size=config.lstm_hidden,
+                num_layers=config.lstm_layers,
+                dropout=config.dropout if config.lstm_layers > 1 else 0.0,
+                batch_first=True,
+            )
+            self.dropout = nn.Dropout(config.dropout)
+            self.head = nn.Linear(config.lstm_hidden, config.n_classes)
+
+        def forward(
+            self, inputs: Any, mask: Any | None = None
+        ) -> tuple[Any, Any]:
+            projected = self.input_proj(inputs)
+            outputs, _ = self.lstm(projected)
+            pooled = _final_real_position(outputs, mask, torch_mod)
+            pooled = self.dropout(pooled)
+            logits = self.head(pooled)
+            return logits, pooled
+
+    model = _LSTM()
+    model.eval()
+    return model
+
+
+def _TransformerTrajectoryModel(config: TrajectoryConfig, torch_mod: Any) -> Any:
+    nn = torch_mod.nn
+
+    class _Transformer(nn.Module):  # type: ignore[misc, name-defined]
+        def __init__(self) -> None:
+            super().__init__()
+            self.config = config
+            self.input_proj = nn.Linear(
+                config.input_dim, config.transformer_d_model
+            )
+            # Learned positional embeddings — sequence is short so a
+            # full table is cheaper than a sin/cos one and easier to
+            # introspect.
+            self.position_embedding = nn.Embedding(
+                config.history_length, config.transformer_d_model
+            )
+            encoder_layer = nn.TransformerEncoderLayer(
+                d_model=config.transformer_d_model,
+                nhead=config.transformer_n_heads,
+                dim_feedforward=config.transformer_d_model * 4,
+                dropout=config.dropout,
+                batch_first=True,
+                activation="gelu",
+            )
+            self.encoder = nn.TransformerEncoder(
+                encoder_layer, num_layers=config.transformer_layers
+            )
+            self.dropout = nn.Dropout(config.dropout)
+            self.head = nn.Linear(config.transformer_d_model, config.n_classes)
+
+        def forward(
+            self, inputs: Any, mask: Any | None = None
+        ) -> tuple[Any, Any]:
+            batch_size, seq_len, _ = inputs.shape
+            projected = self.input_proj(inputs)
+            positions = torch_mod.arange(seq_len, device=inputs.device)
+            pos_embed = self.position_embedding(positions).unsqueeze(0)
+            projected = projected + pos_embed
+            key_padding_mask: Any | None = None
+            if mask is not None:
+                # ``TransformerEncoder`` expects ``True`` for positions to
+                # IGNORE; our ``mask`` marks real positions as ``True``,
+                # so flip the polarity here.
+                key_padding_mask = ~mask.bool()
+            encoded = self.encoder(
+                projected, src_key_padding_mask=key_padding_mask
+            )
+            pooled = _final_real_position(encoded, mask, torch_mod)
+            pooled = self.dropout(pooled)
+            logits = self.head(pooled)
+            return logits, pooled
+
+    model = _Transformer()
+    model.eval()
+    return model
+
+
+def _final_real_position(outputs: Any, mask: Any | None, torch_mod: Any) -> Any:
+    """Gather the last non-pad position of each sequence in ``outputs``.
+
+    Falls back to the last absolute position when ``mask`` is None
+    (interpret-as-fully-real input). The mask convention matches
+    :func:`pad_sequence`: ``True`` = real, ``False`` = pad.
+    """
+
+    if mask is None:
+        return outputs[:, -1, :]
+    counts = mask.long().sum(dim=1).clamp(min=1)
+    last_idx = (counts - 1).long()
+    batch_idx = torch_mod.arange(outputs.size(0), device=outputs.device)
+    return outputs[batch_idx, last_idx, :]
+
+
+# --- Persistence ------------------------------------------------------------
+
+
+def save_model(model: Any, config: TrajectoryConfig, path: Path) -> None:
+    """Persist a model + its config to a single ``.pt`` file.
+
+    Writes via ``torch.save`` to a sibling ``.tmp`` path and renames so
+    a crash mid-write never leaves a truncated checkpoint on disk.
+    """
+
+    import os
+
+    torch = _import_torch()
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    torch.save(
+        {
+            "config": config.to_dict(),
+            "state_dict": model.state_dict(),
+        },
+        tmp,
+    )
+    os.replace(tmp, path)
+
+
+def load_model(path: Path) -> tuple[Any, TrajectoryConfig]:
+    """Reconstruct a model + config from a checkpoint written by ``save_model``."""
+
+    torch = _import_torch()
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"trajectory checkpoint not found: {path}")
+    # weights_only=False so the optimizer / config dict round-trips,
+    # but the file is project-internal so the trust boundary is the
+    # same as for the encoder checkpoints.
+    payload = torch.load(path, map_location="cpu", weights_only=False)
+    config = TrajectoryConfig.from_dict(payload["config"])
+    model = build_model(config)
+    model.load_state_dict(payload["state_dict"])
+    model.eval()
+    return model, config
+
+
+__all__ = [
+    "Architecture",
+    "DEFAULT_HISTORY_LENGTH",
+    "DEFAULT_LSTM_HIDDEN",
+    "DEFAULT_LSTM_LAYERS",
+    "DEFAULT_TRANSFORMER_D_MODEL",
+    "DEFAULT_TRANSFORMER_LAYERS",
+    "DEFAULT_TRANSFORMER_N_HEADS",
+    "MARKET_FEATURE_DIM",
+    "N_STANCE_CLASSES",
+    "STANCE_CLASSES",
+    "TrajectoryConfig",
+    "build_model",
+    "load_model",
+    "market_feature_vector",
+    "pad_sequence",
+    "save_model",
+]

--- a/backend/app/trajectory/train.py
+++ b/backend/app/trajectory/train.py
@@ -164,6 +164,37 @@ def resolve_train_end_from_fold(
     )
 
 
+def resolve_test_end_from_fold(
+    *,
+    events_parquet: Path,
+    fold_id: str,
+) -> str | None:
+    """Return the fold's ``test_end`` (or ``None`` when the manifest omits it).
+
+    The walk-forward holdout for fold ``F`` is every meeting with
+    ``event_date >= F.train_end AND event_date < F.test_end``. When the
+    manifest omits a ``test_end`` (older training packages) we treat
+    the slice as open-ended (every meeting past ``train_end`` becomes
+    holdout) so the trajectory metrics still measure something
+    walk-forward-correct.
+    """
+
+    manifest_path = events_parquet.parent / FOLD_MANIFEST_FILENAME
+    if not manifest_path.exists():
+        return None
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    for fold in payload.get("folds") or []:
+        if fold.get("fold_id") == fold_id:
+            raw = fold.get("test_end")
+            if not raw:
+                return None
+            return str(raw)
+    return None
+
+
 def distill_meeting_rows(events: pd.DataFrame) -> list[MeetingRow]:
     """Project ``events.parquet`` to one ``MeetingRow`` per FOMC statement.
 
@@ -309,39 +340,47 @@ def build_training_sequences(
     return sequences
 
 
-def standardise_inputs(
+def fit_standardisation_stats(
     sequences: list[TrainingSequence],
     *,
     embedding_dim: int,
-) -> tuple[list[TrainingSequence], np.ndarray, np.ndarray]:
-    """Z-score the per-meeting input slabs using train-slice statistics.
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute the per-embedding-feature mean / std over REAL timesteps.
 
-    Fits the mean / std on the concatenation of every REAL (non-pad)
-    timestep in ``sequences``, then applies the same transform to all
-    sequences in place. Returns the standardised sequences plus the
-    ``(D,)`` mean and std arrays so the inference path can reapply the
-    same transform without re-fitting.
-
-    Statistics are computed across the embedding axis only — the market
-    block enters the model already in interpretable units (bps, z-vol)
-    and z-scoring it a second time would over-shrink the signal.
+    Returns ``(mean, std)`` shaped ``(embedding_dim,)`` each. ``std`` is
+    floored at ``1e-6`` so a constant feature does not divide-by-zero
+    in the transform step. Empty input yields ``(zeros, ones)``.
     """
 
     if not sequences:
-        mean = np.zeros(embedding_dim, dtype=np.float32)
-        std = np.ones(embedding_dim, dtype=np.float32)
-        return sequences, mean, std
+        return (
+            np.zeros(embedding_dim, dtype=np.float32),
+            np.ones(embedding_dim, dtype=np.float32),
+        )
     stacked = np.concatenate(
         [seq.inputs[seq.mask, :embedding_dim] for seq in sequences if seq.mask.any()],
         axis=0,
     )
     if stacked.size == 0:
-        mean = np.zeros(embedding_dim, dtype=np.float32)
-        std = np.ones(embedding_dim, dtype=np.float32)
-        return sequences, mean, std
+        return (
+            np.zeros(embedding_dim, dtype=np.float32),
+            np.ones(embedding_dim, dtype=np.float32),
+        )
     mean = stacked.mean(axis=0).astype(np.float32)
     std = stacked.std(axis=0).astype(np.float32)
     std[std < 1e-6] = 1.0  # guard against constant features.
+    return mean, std
+
+
+def apply_standardisation(
+    sequences: list[TrainingSequence],
+    *,
+    embedding_dim: int,
+    mean: np.ndarray,
+    std: np.ndarray,
+) -> list[TrainingSequence]:
+    """Apply pre-fit ``(mean, std)`` to the embedding slab of every sequence."""
+
     rescaled: list[TrainingSequence] = []
     for seq in sequences:
         new_inputs = seq.inputs.copy()
@@ -360,6 +399,41 @@ def standardise_inputs(
                 label_index=seq.label_index,
             )
         )
+    return rescaled
+
+
+def standardise_inputs(
+    sequences: list[TrainingSequence],
+    *,
+    embedding_dim: int,
+    train_sequences: list[TrainingSequence] | None = None,
+) -> tuple[list[TrainingSequence], np.ndarray, np.ndarray]:
+    """Z-score the per-meeting input slabs using TRAIN-slice statistics.
+
+    The mean / std are fit on ``train_sequences`` when supplied — that
+    is the path the trainer takes after the temporal carve into
+    train / calibration / holdout, so the calibration and holdout
+    rows never contribute to the standardisation statistics. When
+    ``train_sequences`` is ``None`` we fall back to fitting on the
+    full ``sequences`` list (kept for backwards compatibility with
+    standalone callers, e.g. ad-hoc unit tests).
+
+    Statistics are computed across the embedding axis only — the market
+    block enters the model already in interpretable units (bps, z-vol)
+    and z-scoring it a second time would over-shrink the signal.
+    """
+
+    if not sequences:
+        return (
+            sequences,
+            np.zeros(embedding_dim, dtype=np.float32),
+            np.ones(embedding_dim, dtype=np.float32),
+        )
+    fit_source = train_sequences if train_sequences is not None else sequences
+    mean, std = fit_standardisation_stats(fit_source, embedding_dim=embedding_dim)
+    rescaled = apply_standardisation(
+        sequences, embedding_dim=embedding_dim, mean=mean, std=std
+    )
     return rescaled, mean, std
 
 
@@ -604,26 +678,65 @@ def evaluate_metrics(  # noqa: PLR0913 — keyword-only bootstrap knobs forwarde
 # ---------------------------------------------------------------------------
 
 
-def project_2d(matrix: np.ndarray) -> np.ndarray:
-    """Project an ``(N, d)`` embedding matrix to ``(N, 2)`` via PCA.
+def fit_pca_axes(
+    train_matrix: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Fit the centred-mean + top-2 principal axes on ``train_matrix``.
 
-    Uses ``np.linalg.svd`` directly so we do not pull a scikit-learn
-    dependency. Centres the matrix on the column mean first; with
-    fewer than 2 rows / 2 columns the function returns zeros so the
-    panel still renders a graceful empty state.
+    Returns ``(mean, components)`` where ``mean`` is ``(d,)`` and
+    ``components`` is ``(2, d)`` — the same shape ``vt[:2]`` returns
+    from :func:`np.linalg.svd`. Callers re-use the pair via
+    :func:`project_with_axes` so train / cal / holdout all land on the
+    same train-fit basis. Degraded inputs (fewer than 2 rows or
+    fewer than 2 columns) return all-zero axes; downstream projection
+    then falls back to zero coords so the panel still renders.
     """
+
+    arr = np.asarray(train_matrix, dtype=np.float32)
+    if arr.ndim != 2 or arr.shape[0] == 0 or arr.shape[1] < 2:
+        mean = (
+            np.zeros(arr.shape[1] if arr.ndim == 2 else 0, dtype=np.float32)
+        )
+        components = np.zeros((2, mean.shape[0]), dtype=np.float32)
+        return mean, components
+    mean = arr.mean(axis=0).astype(np.float32)
+    centred = arr - mean
+    try:
+        _, _, vt = np.linalg.svd(centred, full_matrices=False)
+    except np.linalg.LinAlgError:
+        return mean, np.zeros((2, arr.shape[1]), dtype=np.float32)
+    components = vt[:2].astype(np.float32)
+    return mean, components
+
+
+def project_with_axes(
+    matrix: np.ndarray,
+    *,
+    mean: np.ndarray,
+    components: np.ndarray,
+) -> np.ndarray:
+    """Project an ``(N, d)`` matrix onto pre-fit ``mean`` + ``components``."""
 
     arr = np.asarray(matrix, dtype=np.float32)
     if arr.ndim != 2 or arr.shape[0] == 0 or arr.shape[1] < 2:
         return np.zeros((max(arr.shape[0], 0), 2), dtype=np.float32)
-    centred = arr - arr.mean(axis=0, keepdims=True)
-    try:
-        _, _, vt = np.linalg.svd(centred, full_matrices=False)
-    except np.linalg.LinAlgError:
+    if components.shape[0] < 2 or (components == 0).all():
         return np.zeros((arr.shape[0], 2), dtype=np.float32)
-    components = vt[:2]
+    centred = arr - mean.reshape(1, -1)
     projected = centred @ components.T
     return np.asarray(projected, dtype=np.float32)
+
+
+def project_2d(matrix: np.ndarray) -> np.ndarray:
+    """Fit + project in one call — convenience for callers without a holdout.
+
+    Prefer :func:`fit_pca_axes` + :func:`project_with_axes` in the
+    walk-forward trainer so the holdout slice's embedding geometry
+    never leaks into the principal-axes fit.
+    """
+
+    mean, components = fit_pca_axes(matrix)
+    return project_with_axes(matrix, mean=mean, components=components)
 
 
 # ---------------------------------------------------------------------------
@@ -658,7 +771,7 @@ def _atomic_save_npz(path: Path, **arrays: np.ndarray) -> None:
     _atomic_write_bytes(path, buf.getvalue())
 
 
-def persist_bundle(  # noqa: PLR0913 — keyword-only persistence args mirror the trainer CLI.
+def persist_bundle(  # noqa: PLR0913, C901, PLR0912, PLR0915 — keyword-only persistence args mirror the trainer CLI.
     *,
     out_dir: Path,
     model: Any,
@@ -675,31 +788,77 @@ def persist_bundle(  # noqa: PLR0913 — keyword-only persistence args mirror th
     conformal_quantile: float | None,
     conformal_alpha: float | None,
     training_package_id: str | None = None,
+    pca_mean: np.ndarray | None = None,
+    pca_components: np.ndarray | None = None,
+    model_parameter_count: int | None = None,
 ) -> Path:
     """Persist the full trajectory bundle atomically.
 
     Writes happen in this order so a half-built bundle cannot pass the
     runtime singleton's pre-flight check:
 
-    1. parquet (meeting metadata + 2D coords)
-    2. .npz (raw embeddings + standardisation statistics)
+    1. parquet (meeting metadata + market columns + 2D coords)
+    2. .npz (raw embeddings + standardisation statistics + PCA axes)
     3. model.pt (state dict)
     4. metrics.json, conformal.json (optional)
     5. manifest.json (written LAST so its presence implies the bundle
        is complete; the runtime singleton keys availability on this file.)
+
+    Bundle hygiene rules enforced here:
+
+    * **train_end filter** — the persisted parquet / npz only carry
+      meetings with ``event_date < train_end``. The model never trained
+      on a meeting from the holdout slice, so projecting from one would
+      be a walk-forward leak at inference time. ``train_end=None``
+      degrades to "persist everything" for ad-hoc / smoke runs.
+    * **PCA axes from train slice** — when ``pca_mean`` and
+      ``pca_components`` are supplied, the 2D coords land on the
+      caller-fit basis (train-only). When omitted, we fit + project on
+      the persisted slice as a fallback for legacy callers.
+    * **market columns** — ``pre_meeting_trailing_2y_yield_change_5d_bps``
+      and ``vix_close`` ride along on the parquet so the runtime path
+      reads the same numbers the trainer saw. Missing inputs persist
+      as NaN; the runtime ``_market_for`` honours that with the
+      explicit-missing bit in the market feature vector.
     """
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    projected = project_2d(raw_embeddings)
-    if projected.shape[0] != len(meetings):
-        # PCA degraded to empty — fall back to zeros so the panel
-        # renders something rather than crashing the writer.
-        projected = np.zeros((len(meetings), 2), dtype=np.float32)
+    cutoff_iso = _validate_train_end(train_end)
+    if cutoff_iso is not None:
+        keep_mask = np.array(
+            [row.event_date < cutoff_iso for row in meetings], dtype=bool
+        )
+    else:
+        keep_mask = np.ones(len(meetings), dtype=bool)
+    kept_meetings = [m for m, keep in zip(meetings, keep_mask) if keep]
+    kept_embeddings = (
+        raw_embeddings[keep_mask] if raw_embeddings.size else raw_embeddings
+    )
+
+    # 2D projection: project the persisted slice onto the caller's
+    # pre-fit axes when available (walk-forward path); otherwise fit
+    # on the persisted slice itself (legacy / smoke path).
+    if pca_mean is not None and pca_components is not None and kept_embeddings.size:
+        projected = project_with_axes(
+            kept_embeddings, mean=pca_mean, components=pca_components
+        )
+    else:
+        # Fallback path: re-fit on the persisted slice. Safe because
+        # the persisted slice itself is train-side (post-cutoff rows
+        # were already dropped above), so the geometry still excludes
+        # holdout rows.
+        pca_mean, pca_components = fit_pca_axes(kept_embeddings)
+        projected = project_with_axes(
+            kept_embeddings, mean=pca_mean, components=pca_components
+        )
+    if projected.shape[0] != len(kept_meetings):
+        projected = np.zeros((len(kept_meetings), 2), dtype=np.float32)
+
     parquet_path = out_dir / "embedding_index.parquet"
     rows = []
-    for idx, row in enumerate(meetings):
+    for idx, row in enumerate(kept_meetings):
         rows.append(
             {
                 "event_date": row.event_date,
@@ -707,18 +866,36 @@ def persist_bundle(  # noqa: PLR0913 — keyword-only persistence args mirror th
                 "axis_stance": row.axis_stance,
                 "embedding_2d_x": float(projected[idx, 0]) if idx < projected.shape[0] else 0.0,
                 "embedding_2d_y": float(projected[idx, 1]) if idx < projected.shape[0] else 0.0,
+                "pre_meeting_trailing_2y_yield_change_5d_bps": (
+                    float(row.trailing_2y_yield_change_5d_bps)
+                    if row.trailing_2y_yield_change_5d_bps is not None
+                    else None
+                ),
+                "vix_close": (
+                    float(row.vix_close)
+                    if row.vix_close is not None
+                    else None
+                ),
             }
         )
     metadata_df = pd.DataFrame(rows)
     _atomic_write_parquet(metadata_df, parquet_path)
 
     npz_path = out_dir / "embedding_index.npz"
-    _atomic_save_npz(
-        npz_path,
-        embeddings=raw_embeddings.astype(np.float32),
-        feature_mean=feature_mean.astype(np.float32),
-        feature_std=feature_std.astype(np.float32),
-    )
+    npz_arrays: dict[str, np.ndarray] = {
+        "embeddings": (
+            kept_embeddings.astype(np.float32)
+            if kept_embeddings.size
+            else np.zeros((0, raw_embeddings.shape[1] if raw_embeddings.ndim == 2 else 0), dtype=np.float32)
+        ),
+        "feature_mean": feature_mean.astype(np.float32),
+        "feature_std": feature_std.astype(np.float32),
+    }
+    if pca_mean is not None:
+        npz_arrays["pca_mean"] = pca_mean.astype(np.float32)
+    if pca_components is not None:
+        npz_arrays["pca_components"] = pca_components.astype(np.float32)
+    _atomic_save_npz(npz_path, **npz_arrays)
 
     save_model(model, config, out_dir / "model.pt")
 
@@ -750,12 +927,20 @@ def persist_bundle(  # noqa: PLR0913 — keyword-only persistence args mirror th
         "history_length": config.history_length,
         "embedding_dim": config.embedding_dim,
         "n_classes": config.n_classes,
-        "row_count": int(len(meetings)),
+        "row_count": int(len(kept_meetings)),
         "training_package_id": training_package_id,
         "stance_classes": list(STANCE_CLASSES),
         "built_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "config": config.to_dict(),
+        # Calibration convention: the calibration partition is a
+        # temporal tail of the train slice (last ``calibration_share``
+        # of pre-train_end sequences). Holdout = the post-train_end
+        # meetings up to the fold's ``test_end`` boundary. See
+        # ``train_and_persist`` for the carving logic.
+        "calibration_convention": "tail_of_train_slice",
     }
+    if model_parameter_count is not None:
+        manifest["model_parameter_count"] = int(model_parameter_count)
     _atomic_write_text(
         out_dir / "manifest.json",
         json.dumps(manifest, indent=2, sort_keys=True),
@@ -882,33 +1067,125 @@ def train_and_persist(  # noqa: PLR0913, C901, PLR0912, PLR0915 — keyword-only
         history_length=history_length,
     )
 
-    sequences = build_training_sequences(
+    # Build BOTH the pre-train_end training pool (for fit) AND the
+    # post-train_end holdout pool (for walk-forward metrics) in a
+    # single pass over the meetings panel. Targets whose ``event_date``
+    # equals or exceeds ``train_end`` are walk-forward holdout; the
+    # rest are train + calibration. ``build_training_sequences`` with
+    # ``train_end=None`` returns every labelled target; we filter
+    # downstream with explicit boundaries so both slices share the
+    # same upstream pipeline.
+    all_sequences = build_training_sequences(
         meetings,
         embeddings=raw_embeddings,
         history_length=history_length,
-        train_end=resolved_train_end,
+        train_end=None,
     )
-    if not sequences:
+    if not all_sequences:
         raise RuntimeError(
             "training sequence build yielded zero rows — verify the parquet "
-            "carries statement rows with non-null axis_stance and that "
-            "train_end is not stripping every target."
+            "carries statement rows with non-null axis_stance."
         )
 
-    sequences, feature_mean, feature_std = standardise_inputs(
-        sequences, embedding_dim=embedding_dim
+    # Holdout boundary from the fold manifest when available. The
+    # walk-forward holdout for fold F is meetings with
+    # ``train_end <= event_date < test_end`` — exactly the slice the
+    # rest of the project's metrics benchmark against. When the
+    # manifest omits a ``test_end`` (or no fold was supplied) the
+    # holdout extends to end-of-history.
+    resolved_test_end: str | None = None
+    if fold_id is not None:
+        try:
+            resolved_test_end = resolve_test_end_from_fold(
+                events_parquet=Path(events_parquet), fold_id=fold_id
+            )
+        except Exception:  # pragma: no cover — guarded so a missing manifest never crashes the trainer
+            resolved_test_end = None
+
+    pre_cutoff: list[TrainingSequence] = []
+    post_cutoff: list[TrainingSequence] = []
+    if resolved_train_end is None:
+        pre_cutoff = list(all_sequences)
+    else:
+        for seq in all_sequences:
+            if seq.target_event_date < resolved_train_end:
+                pre_cutoff.append(seq)
+            else:
+                if (
+                    resolved_test_end is None
+                    or seq.target_event_date < resolved_test_end
+                ):
+                    post_cutoff.append(seq)
+    if not pre_cutoff:
+        raise RuntimeError(
+            "pre-train_end sequence pool is empty — verify train_end leaves "
+            "at least one labelled target inside the train slice."
+        )
+
+    # Calibration partition = TEMPORAL TAIL of the train slice (last
+    # ``calibration_share`` of pre-train_end sequences). Keeps the
+    # calibration pool walk-forward-correct without consuming holdout
+    # rows. ``holdout_share`` is preserved as a knob but only affects
+    # the legacy fallback path when no post-train_end slice exists.
+    n_pre = len(pre_cutoff)
+    n_calibration = max(0, int(n_pre * calibration_share))
+    train_sequences = pre_cutoff[: max(1, n_pre - n_calibration)]
+    calibration_sequences = pre_cutoff[max(1, n_pre - n_calibration) :]
+    if post_cutoff:
+        holdout_sequences = post_cutoff
+    else:
+        # Legacy / smoke fallback: no fold manifest and no train_end →
+        # carve a tail-of-train holdout so the metrics block is
+        # non-empty. This path is never the canonical walk-forward
+        # report and is documented as such in manifest.json.
+        n_holdout = max(0, int(n_pre * holdout_share))
+        if n_holdout > 0 and len(train_sequences) > n_holdout:
+            holdout_sequences = train_sequences[-n_holdout:]
+            train_sequences = train_sequences[:-n_holdout]
+        else:
+            holdout_sequences = []
+
+    # Standardise: fit mean / std on TRAIN ONLY, apply to all three
+    # partitions + the persisted raw_embeddings pathway (the inference
+    # path z-scores embeddings via the same stats stored in the npz).
+    feature_mean, feature_std = fit_standardisation_stats(
+        train_sequences, embedding_dim=embedding_dim
+    )
+    train_sequences = apply_standardisation(
+        train_sequences,
+        embedding_dim=embedding_dim,
+        mean=feature_mean,
+        std=feature_std,
+    )
+    calibration_sequences = apply_standardisation(
+        calibration_sequences,
+        embedding_dim=embedding_dim,
+        mean=feature_mean,
+        std=feature_std,
+    )
+    holdout_sequences = apply_standardisation(
+        holdout_sequences,
+        embedding_dim=embedding_dim,
+        mean=feature_mean,
+        std=feature_std,
     )
 
-    # Holdout / calibration carve from the END of the training pool so
-    # the slices are temporally contiguous (matches the walk-forward
-    # spirit of the rest of the project).
-    n_total = len(sequences)
-    n_calibration = max(0, int(n_total * calibration_share))
-    n_holdout = max(0, int(n_total * holdout_share))
-    n_train = max(1, n_total - n_calibration - n_holdout)
-    train_sequences = sequences[:n_train]
-    calibration_sequences = sequences[n_train : n_train + n_calibration]
-    holdout_sequences = sequences[n_train + n_calibration :]
+    # Fit the PCA projection axes on the TRAIN-SLICE embeddings only,
+    # so the 2D anchors that ship in the bundle never depend on the
+    # holdout slice's embedding geometry. The persisted parquet is
+    # filtered to the same train-slice rows in ``persist_bundle``.
+    if resolved_train_end is not None:
+        train_embedding_mask = np.array(
+            [row.event_date < resolved_train_end for row in meetings], dtype=bool
+        )
+    else:
+        train_embedding_mask = np.ones(len(meetings), dtype=bool)
+    train_embeddings_slice = (
+        raw_embeddings[train_embedding_mask]
+        if raw_embeddings.size
+        else raw_embeddings
+    )
+    pca_mean, pca_components = fit_pca_axes(train_embeddings_slice)
 
     model = train_model(
         train_sequences,
@@ -930,6 +1207,9 @@ def train_and_persist(  # noqa: PLR0913, C901, PLR0912, PLR0915 — keyword-only
                 evaluation["labels"].tolist(),
                 evaluation["predictions"].tolist(),
                 seed=seed,
+            ),
+            "holdout_slice": (
+                "post_train_end_to_test_end" if post_cutoff else "tail_of_train_fallback"
             ),
         }
         # Naive-prior baseline: predict the modal class of the train slice.
@@ -955,6 +1235,18 @@ def train_and_persist(  # noqa: PLR0913, C901, PLR0912, PLR0915 — keyword-only
         except ValueError:
             conformal_quantile = None
 
+    # Parameter count — methodological hygiene for the LSTM vs
+    # Transformer comparison. Logged on both the per-architecture
+    # metrics block and the manifest so a future reviewer can confirm
+    # the two arms ran with comparable capacity.
+    model_parameter_count: int | None = None
+    try:
+        model_parameter_count = int(sum(p.numel() for p in model.parameters()))
+        if metrics_payload is not None:
+            metrics_payload["model_parameter_count"] = model_parameter_count
+    except Exception:  # pragma: no cover — extremely defensive
+        model_parameter_count = None
+
     resolved_run_name = run_name or (
         DEFAULT_RUN_NAME_LSTM
         if architecture == "lstm"
@@ -977,12 +1269,18 @@ def train_and_persist(  # noqa: PLR0913, C901, PLR0912, PLR0915 — keyword-only
         conformal_quantile=conformal_quantile,
         conformal_alpha=conformal_alpha if conformal_quantile is not None else None,
         training_package_id=training_package_id,
+        pca_mean=pca_mean,
+        pca_components=pca_components,
+        model_parameter_count=model_parameter_count,
     )
     _logger.info(
-        "trajectory_train_done architecture=%s rows=%d holdout=%d out_dir=%s",
+        "trajectory_train_done architecture=%s train_rows=%d cal_rows=%d "
+        "holdout_rows=%d holdout_slice=%s out_dir=%s",
         architecture,
-        n_train,
+        len(train_sequences),
+        len(calibration_sequences),
         len(holdout_sequences),
+        "post_train_end" if post_cutoff else "tail_of_train_fallback",
         out_dir,
     )
     return out_dir

--- a/backend/app/trajectory/train.py
+++ b/backend/app/trajectory/train.py
@@ -1,0 +1,1055 @@
+"""Walk-forward trainer for the trajectory model (#296).
+
+Builds the per-meeting input panel from ``events.parquet``, applies
+the same strict-forward walk-forward cut as the retrieval encoder
+(:mod:`app.retrieval.train`), trains the architecture selected by
+``--architecture {lstm,transformer}``, and persists the bundle under
+``data/artifacts/trajectory/<run_name>/``.
+
+Bundle layout (matches the §13 acceptance for #296)::
+
+    model.pt           torch state_dict + config
+    embedding_index.npz
+                       pooled encoder embeddings per meeting,
+                       float32 (N, d). Row order tracks the
+                       sibling ``embedding_index.parquet``.
+    embedding_index.parquet
+                       per-meeting metadata (event_date, text_hash,
+                       axis_stance, embedding_2d). Used by the
+                       runtime singleton to assemble the response.
+    manifest.json      encoder alias + revision + train_end + fold_id
+                       + architecture + history_length.
+    metrics.json       per-architecture macro-F1 + directional
+                       accuracy with bootstrap CIs (when the
+                       holdout slice is non-empty).
+    conformal.json     APS softmax quantile for the calibrated
+                       prediction set (when the calibration slice
+                       has rows).
+
+Every file lands via a sibling ``.tmp`` + ``os.replace`` so a mid-write
+crash never leaves a half-built bundle behind.
+
+The encoder used to materialise per-meeting embeddings is the
+cross-bank DAPT checkpoint pinned at
+``finbert_fed_adjacent_xbank_dapt``. The forward pass mirrors the
+mean-pool the analog retrieval singleton uses (so the two surfaces
+read the same statement the same way). For test / smoke runs the
+``embed_fn`` argument lets callers inject a Python projection without
+loading the real encoder.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import random
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import date as date_type
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from app.config import DATA_DIR
+from app.evaluation.conformal import calibrate_classification_conformal
+from app.evaluation.regression_metrics import with_block_bootstrap_ci
+from app.trajectory.model import (
+    DEFAULT_HISTORY_LENGTH,
+    MARKET_FEATURE_DIM,
+    N_STANCE_CLASSES,
+    STANCE_CLASSES,
+    Architecture,
+    TrajectoryConfig,
+    build_model,
+    market_feature_vector,
+    pad_sequence,
+    save_model,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+DEFAULT_BASE_ENCODER_ALIAS = "finbert_fed_adjacent_xbank_dapt"
+DEFAULT_OUTPUT_ROOT = DATA_DIR / "artifacts" / "trajectory"
+DEFAULT_RUN_NAME_LSTM = "trajectory_lstm"
+DEFAULT_RUN_NAME_TRANSFORMER = "trajectory_transformer"
+DEFAULT_EPOCHS = 30
+DEFAULT_BATCH_SIZE = 8
+DEFAULT_LEARNING_RATE = 1e-3
+DEFAULT_WEIGHT_DECAY = 1e-5
+DEFAULT_SEED = 11
+DEFAULT_HOLDOUT_SHARE = 0.2
+DEFAULT_CALIBRATION_SHARE = 0.15
+DEFAULT_BOOTSTRAP_RESAMPLES = 500
+DEFAULT_BOOTSTRAP_BLOCK_SIZE = 4
+
+FOLD_MANIFEST_FILENAME = "fold_manifest_expanding_walk_forward.json"
+
+STANCE_TO_INDEX: dict[str, int] = {label: idx for idx, label in enumerate(STANCE_CLASSES)}
+
+
+# ---------------------------------------------------------------------------
+# Sequence construction
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TrainingSequence:
+    """One training row — a left-padded meeting window plus the next-meeting label."""
+
+    target_event_date: str
+    history_event_dates: tuple[str, ...]
+    inputs: np.ndarray  # (history_length, embedding_dim + market_feature_dim)
+    mask: np.ndarray  # (history_length,) bool, True = real meeting
+    label_index: int  # 0..n_classes-1
+
+
+@dataclass(frozen=True)
+class MeetingRow:
+    """One distilled meeting row — keeps the columns the trainer cares about."""
+
+    event_date: str
+    text_hash: str
+    text: str
+    axis_stance: str | None
+    trailing_2y_yield_change_5d_bps: float | None
+    vix_close: float | None
+
+
+def _validate_train_end(train_end: str | None) -> str | None:
+    if train_end is None or str(train_end).strip() == "":
+        return None
+    text = str(train_end).strip()
+    try:
+        return date_type.fromisoformat(text).isoformat()
+    except ValueError as exc:
+        raise ValueError(
+            f"train_end {train_end!r} is not a valid ISO date (YYYY-MM-DD)"
+        ) from exc
+
+
+def resolve_train_end_from_fold(
+    *,
+    events_parquet: Path,
+    fold_id: str,
+) -> str:
+    """Mirror :func:`app.retrieval.train.resolve_train_end_from_fold` so the
+    trajectory training surface respects the same fold definitions used by
+    every other walk-forward training script.
+    """
+
+    manifest_path = events_parquet.parent / FOLD_MANIFEST_FILENAME
+    if not manifest_path.exists():
+        raise ValueError(
+            f"fold manifest not found at {manifest_path}; pass --train-end explicitly"
+        )
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    folds = payload.get("folds") or []
+    for fold in folds:
+        if fold.get("fold_id") == fold_id:
+            train_end = fold.get("train_end")
+            if not train_end:
+                raise ValueError(
+                    f"fold {fold_id!r} in {manifest_path} carries no train_end"
+                )
+            return str(train_end)
+    available = sorted(str(f.get("fold_id", "")) for f in folds)
+    raise ValueError(
+        f"fold_id {fold_id!r} not found in {manifest_path}; available: {available}"
+    )
+
+
+def distill_meeting_rows(events: pd.DataFrame) -> list[MeetingRow]:
+    """Project ``events.parquet`` to one ``MeetingRow`` per FOMC statement.
+
+    The events parquet duplicates statements across horizons (1d / 5d
+    / 10d / 30d), so we keep the smallest-horizon row per ``text_hash``
+    — that row carries the same text and the same pre-meeting features
+    (which do not depend on horizon). Output rows are sorted by
+    ``event_date`` ascending so the sequence builder consumes them in
+    chronological order.
+    """
+
+    if "event_kind" not in events.columns:
+        raise KeyError("events parquet missing 'event_kind' column")
+    required_columns = ("event_date", "text", "text_hash", "axis_stance")
+    for column in required_columns:
+        if column not in events.columns:
+            raise KeyError(f"events parquet missing {column!r} column")
+
+    mask = events["event_kind"].astype(str).str.lower() == "statement"
+    df = events.loc[mask].copy()
+    if df.empty:
+        return []
+    df["event_date"] = df["event_date"].astype(str)
+    sort_cols = ["event_date", "text_hash"]
+    if "horizon" in df.columns:
+        sort_cols.append("horizon")
+    df = df.sort_values(sort_cols)
+    df = df.drop_duplicates(subset=["text_hash"], keep="first")
+    df = df.sort_values("event_date").reset_index(drop=True)
+
+    rows: list[MeetingRow] = []
+    for _, raw in df.iterrows():
+        rows.append(
+            MeetingRow(
+                event_date=str(raw["event_date"]),
+                text_hash=str(raw["text_hash"]),
+                text=str(raw.get("text") or ""),
+                axis_stance=_normalise_stance(raw.get("axis_stance")),
+                trailing_2y_yield_change_5d_bps=_safe_float(
+                    raw.get("pre_meeting_trailing_2y_yield_change_5d_bps")
+                ),
+                vix_close=_safe_float(raw.get("vix_close")),
+            )
+        )
+    return rows
+
+
+def _normalise_stance(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    text = str(value).strip().lower()
+    if text in STANCE_TO_INDEX:
+        return text
+    return None
+
+
+def _safe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    try:
+        scalar = float(value)
+    except (TypeError, ValueError):
+        return None
+    import math
+
+    if not math.isfinite(scalar):
+        return None
+    return scalar
+
+
+def build_training_sequences(
+    meetings: Sequence[MeetingRow],
+    *,
+    embeddings: Sequence[np.ndarray] | np.ndarray,
+    history_length: int = DEFAULT_HISTORY_LENGTH,
+    train_end: str | None = None,
+) -> list[TrainingSequence]:
+    """Build supervised next-meeting training rows over a meeting panel.
+
+    Each row uses ``meetings[i - history_length : i]`` as the history
+    window and ``meetings[i].axis_stance`` as the target. Rows where
+    the target stance is unknown are skipped. ``train_end`` (ISO date)
+    drops every row whose TARGET ``event_date >= train_end`` so the
+    model never trains on a meeting from the holdout slice — the same
+    strict-forward cut the retrieval encoder applies.
+    """
+
+    if history_length <= 0:
+        raise ValueError(f"history_length must be positive; got {history_length}")
+    embeddings_list = list(embeddings)
+    if len(embeddings_list) != len(meetings):
+        raise ValueError(
+            "embeddings and meetings must align in length; "
+            f"got {len(embeddings_list)} vs {len(meetings)}"
+        )
+    cutoff = _validate_train_end(train_end)
+
+    sequences: list[TrainingSequence] = []
+    for target_idx in range(1, len(meetings)):
+        target = meetings[target_idx]
+        if cutoff is not None and target.event_date >= cutoff:
+            # Strict-forward: a target on or after train_end leaks the
+            # holdout slice into training.
+            continue
+        if target.axis_stance is None:
+            continue
+        history_start = max(0, target_idx - history_length)
+        window = meetings[history_start:target_idx]
+        if not window:
+            continue
+        window_embeddings = [embeddings_list[i] for i in range(history_start, target_idx)]
+        window_markets = [
+            market_feature_vector(
+                trailing_2y_yield_change_5d_bps=row.trailing_2y_yield_change_5d_bps,
+                vix_close=row.vix_close,
+            )
+            for row in window
+        ]
+        inputs, mask = pad_sequence(
+            window_embeddings,
+            window_markets,
+            history_length=history_length,
+        )
+        sequences.append(
+            TrainingSequence(
+                target_event_date=target.event_date,
+                history_event_dates=tuple(row.event_date for row in window),
+                inputs=inputs,
+                mask=mask,
+                label_index=STANCE_TO_INDEX[target.axis_stance],
+            )
+        )
+    return sequences
+
+
+def standardise_inputs(
+    sequences: list[TrainingSequence],
+    *,
+    embedding_dim: int,
+) -> tuple[list[TrainingSequence], np.ndarray, np.ndarray]:
+    """Z-score the per-meeting input slabs using train-slice statistics.
+
+    Fits the mean / std on the concatenation of every REAL (non-pad)
+    timestep in ``sequences``, then applies the same transform to all
+    sequences in place. Returns the standardised sequences plus the
+    ``(D,)`` mean and std arrays so the inference path can reapply the
+    same transform without re-fitting.
+
+    Statistics are computed across the embedding axis only — the market
+    block enters the model already in interpretable units (bps, z-vol)
+    and z-scoring it a second time would over-shrink the signal.
+    """
+
+    if not sequences:
+        mean = np.zeros(embedding_dim, dtype=np.float32)
+        std = np.ones(embedding_dim, dtype=np.float32)
+        return sequences, mean, std
+    stacked = np.concatenate(
+        [seq.inputs[seq.mask, :embedding_dim] for seq in sequences if seq.mask.any()],
+        axis=0,
+    )
+    if stacked.size == 0:
+        mean = np.zeros(embedding_dim, dtype=np.float32)
+        std = np.ones(embedding_dim, dtype=np.float32)
+        return sequences, mean, std
+    mean = stacked.mean(axis=0).astype(np.float32)
+    std = stacked.std(axis=0).astype(np.float32)
+    std[std < 1e-6] = 1.0  # guard against constant features.
+    rescaled: list[TrainingSequence] = []
+    for seq in sequences:
+        new_inputs = seq.inputs.copy()
+        for t in range(seq.inputs.shape[0]):
+            if not seq.mask[t]:
+                continue
+            new_inputs[t, :embedding_dim] = (
+                new_inputs[t, :embedding_dim] - mean
+            ) / std
+        rescaled.append(
+            TrainingSequence(
+                target_event_date=seq.target_event_date,
+                history_event_dates=seq.history_event_dates,
+                inputs=new_inputs,
+                mask=seq.mask,
+                label_index=seq.label_index,
+            )
+        )
+    return rescaled, mean, std
+
+
+# ---------------------------------------------------------------------------
+# Training loop
+# ---------------------------------------------------------------------------
+
+
+def _set_all_seeds(seed: int) -> None:
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    try:
+        import torch
+
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
+    except ImportError:  # pragma: no cover
+        pass
+
+
+def _to_tensor_batch(sequences: Sequence[TrainingSequence], torch_mod: Any) -> tuple[Any, Any, Any]:
+    inputs = torch_mod.tensor(
+        np.stack([seq.inputs for seq in sequences], axis=0), dtype=torch_mod.float32
+    )
+    mask = torch_mod.tensor(
+        np.stack([seq.mask for seq in sequences], axis=0), dtype=torch_mod.bool
+    )
+    labels = torch_mod.tensor(
+        [seq.label_index for seq in sequences], dtype=torch_mod.long
+    )
+    return inputs, mask, labels
+
+
+def train_model(  # noqa: PLR0913 — keyword-only knobs mirror the train_and_persist CLI surface.
+    sequences: list[TrainingSequence],
+    config: TrajectoryConfig,
+    *,
+    epochs: int = DEFAULT_EPOCHS,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    learning_rate: float = DEFAULT_LEARNING_RATE,
+    weight_decay: float = DEFAULT_WEIGHT_DECAY,
+    seed: int = DEFAULT_SEED,
+) -> Any:
+    """Fit a trajectory model on the supplied sequence list.
+
+    Single-process CPU/GPU loop — small dataset (~250 meetings) means
+    even the full-fold pass takes seconds and a multi-worker DataLoader
+    would only add overhead. Returns the trained module in eval mode.
+    """
+
+    import torch
+
+    _set_all_seeds(seed)
+    model = build_model(config)
+    if not sequences:
+        return model
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    model.train()
+    optimizer = torch.optim.AdamW(
+        model.parameters(), lr=learning_rate, weight_decay=weight_decay
+    )
+    loss_fn = torch.nn.CrossEntropyLoss()
+
+    indices = list(range(len(sequences)))
+    rng = random.Random(seed)
+    for _epoch in range(epochs):
+        rng.shuffle(indices)
+        for start in range(0, len(indices), batch_size):
+            batch_idx = indices[start : start + batch_size]
+            batch = [sequences[i] for i in batch_idx]
+            inputs, mask, labels = _to_tensor_batch(batch, torch)
+            inputs = inputs.to(device)
+            mask = mask.to(device)
+            labels = labels.to(device)
+            optimizer.zero_grad()
+            logits, _ = model(inputs, mask)
+            loss = loss_fn(logits, labels)
+            loss.backward()
+            optimizer.step()
+    model.eval()
+    return model
+
+
+def evaluate_model(
+    model: Any,
+    sequences: list[TrainingSequence],
+) -> dict[str, Any]:
+    """Run inference on a sequence list and return logits + labels + softmax."""
+
+    import torch
+
+    if not sequences:
+        return {
+            "logits": np.zeros((0, N_STANCE_CLASSES), dtype=np.float32),
+            "softmax": np.zeros((0, N_STANCE_CLASSES), dtype=np.float32),
+            "labels": np.zeros(0, dtype=np.int64),
+            "predictions": np.zeros(0, dtype=np.int64),
+        }
+    model.eval()
+    with torch.no_grad():
+        inputs, mask, labels = _to_tensor_batch(sequences, torch)
+        logits, _ = model(inputs, mask)
+        softmax = torch.softmax(logits, dim=-1)
+        predictions = softmax.argmax(dim=-1)
+    return {
+        "logits": logits.detach().cpu().numpy(),
+        "softmax": softmax.detach().cpu().numpy(),
+        "labels": labels.detach().cpu().numpy(),
+        "predictions": predictions.detach().cpu().numpy(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+def macro_f1(true_labels: Sequence[int], predicted_labels: Sequence[int]) -> float:
+    if len(true_labels) == 0:
+        return float("nan")
+    per_class: list[float] = []
+    for cls in range(N_STANCE_CLASSES):
+        tp = sum(1 for t, p in zip(true_labels, predicted_labels) if t == cls and p == cls)
+        fp = sum(1 for t, p in zip(true_labels, predicted_labels) if t != cls and p == cls)
+        fn = sum(1 for t, p in zip(true_labels, predicted_labels) if t == cls and p != cls)
+        if tp + fp == 0 or tp + fn == 0:
+            per_class.append(0.0)
+            continue
+        precision = tp / (tp + fp)
+        recall = tp / (tp + fn)
+        if precision + recall == 0:
+            per_class.append(0.0)
+            continue
+        per_class.append(2 * precision * recall / (precision + recall))
+    return float(sum(per_class) / len(per_class))
+
+
+def directional_accuracy(
+    true_labels: Sequence[int], predicted_labels: Sequence[int]
+) -> float:
+    """Share of rows where the predicted class matches the truth.
+
+    Direct accuracy here — the 3-class stance set has no natural
+    ordering for a "signed delta" metric, so the classification
+    accuracy is the cleanest analogue of the regression-side directional
+    accuracy. Returns ``nan`` on empty input.
+    """
+
+    if len(true_labels) == 0:
+        return float("nan")
+    matches = sum(1 for t, p in zip(true_labels, predicted_labels) if t == p)
+    return matches / len(true_labels)
+
+
+def bootstrap_macro_f1(
+    true_labels: Sequence[int],
+    predicted_labels: Sequence[int],
+    *,
+    n_resamples: int = DEFAULT_BOOTSTRAP_RESAMPLES,
+    coverage: float = 0.95,
+    seed: int = 11,
+) -> tuple[float, float, float]:
+    """Naive (non-block) bootstrap CI for macro-F1.
+
+    Macro-F1 is not in :func:`with_block_bootstrap_ci`'s statistic
+    table (it is classification-specific), so we implement the
+    resample loop here. The block-bootstrap form fits the rates
+    regression metrics; for the classification head the rows are
+    already independent at the meeting level (one row per FOMC
+    meeting) and a naive bootstrap is the standard CI choice.
+    """
+
+    if len(true_labels) == 0:
+        return float("nan"), float("nan"), float("nan")
+    point = macro_f1(true_labels, predicted_labels)
+    if len(true_labels) < 2:
+        return point, point, point
+    rng = random.Random(seed)
+    n = len(true_labels)
+    samples: list[float] = []
+    for _ in range(n_resamples):
+        idx = [rng.randrange(n) for _ in range(n)]
+        sampled_true = [true_labels[i] for i in idx]
+        sampled_pred = [predicted_labels[i] for i in idx]
+        samples.append(macro_f1(sampled_true, sampled_pred))
+    samples.sort()
+    alpha = (1.0 - coverage) / 2.0
+    lo_idx = max(0, min(len(samples) - 1, int(alpha * len(samples))))
+    hi_idx = max(0, min(len(samples) - 1, int((1.0 - alpha) * len(samples)) - 1))
+    return point, samples[lo_idx], samples[hi_idx]
+
+
+def evaluate_metrics(  # noqa: PLR0913 — keyword-only bootstrap knobs forwarded to two CI helpers.
+    true_labels: Sequence[int],
+    predicted_labels: Sequence[int],
+    *,
+    n_resamples: int = DEFAULT_BOOTSTRAP_RESAMPLES,
+    block_size: int = DEFAULT_BOOTSTRAP_BLOCK_SIZE,
+    coverage: float = 0.95,
+    seed: int = 11,
+) -> dict[str, Any]:
+    """Compose macro-F1 + directional-accuracy with bootstrap CIs."""
+
+    f1_point, f1_lo, f1_hi = bootstrap_macro_f1(
+        true_labels,
+        predicted_labels,
+        n_resamples=n_resamples,
+        coverage=coverage,
+        seed=seed,
+    )
+    # The block-bootstrap directional accuracy from the regression
+    # metrics module accepts numeric pairs; encoding classes 0/1/2 as
+    # floats keeps the metric well-defined.
+    dir_ci = with_block_bootstrap_ci(
+        name="directional_accuracy",
+        predicted=[float(p) for p in predicted_labels],
+        observed=[float(t) for t in true_labels],
+        statistic="directional_accuracy",
+        block_size=block_size,
+        n_resamples=n_resamples,
+        coverage=coverage,
+        seed=seed,
+    )
+    return {
+        "macro_f1": {"point": f1_point, "lo": f1_lo, "hi": f1_hi, "coverage": coverage},
+        "directional_accuracy": {
+            "point": directional_accuracy(true_labels, predicted_labels),
+            "lo": dir_ci.lo,
+            "hi": dir_ci.hi,
+            "coverage": coverage,
+            "block_size": block_size,
+        },
+        "n": int(len(true_labels)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2D projection
+# ---------------------------------------------------------------------------
+
+
+def project_2d(matrix: np.ndarray) -> np.ndarray:
+    """Project an ``(N, d)`` embedding matrix to ``(N, 2)`` via PCA.
+
+    Uses ``np.linalg.svd`` directly so we do not pull a scikit-learn
+    dependency. Centres the matrix on the column mean first; with
+    fewer than 2 rows / 2 columns the function returns zeros so the
+    panel still renders a graceful empty state.
+    """
+
+    arr = np.asarray(matrix, dtype=np.float32)
+    if arr.ndim != 2 or arr.shape[0] == 0 or arr.shape[1] < 2:
+        return np.zeros((max(arr.shape[0], 0), 2), dtype=np.float32)
+    centred = arr - arr.mean(axis=0, keepdims=True)
+    try:
+        _, _, vt = np.linalg.svd(centred, full_matrices=False)
+    except np.linalg.LinAlgError:
+        return np.zeros((arr.shape[0], 2), dtype=np.float32)
+    components = vt[:2]
+    projected = centred @ components.T
+    return np.asarray(projected, dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Bundle persistence
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_bytes(path: Path, payload: bytes) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_bytes(payload)
+    os.replace(tmp, path)
+
+
+def _atomic_write_text(path: Path, payload: str) -> None:
+    _atomic_write_bytes(path, payload.encode("utf-8"))
+
+
+def _atomic_write_parquet(df: pd.DataFrame, path: Path) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    df.to_parquet(tmp, index=False)
+    os.replace(tmp, path)
+
+
+def _atomic_save_npz(path: Path, **arrays: np.ndarray) -> None:
+    import io
+
+    buf = io.BytesIO()
+    # mypy's numpy stubs flag the **kwargs splat as targeting savez's
+    # legacy ``allow_pickle`` positional. Cast through Any so the
+    # idiomatic call shape stays readable.
+    np.savez(buf, **arrays)  # type: ignore[arg-type]
+    _atomic_write_bytes(path, buf.getvalue())
+
+
+def persist_bundle(  # noqa: PLR0913 — keyword-only persistence args mirror the trainer CLI.
+    *,
+    out_dir: Path,
+    model: Any,
+    config: TrajectoryConfig,
+    meetings: Sequence[MeetingRow],
+    raw_embeddings: np.ndarray,
+    feature_mean: np.ndarray,
+    feature_std: np.ndarray,
+    encoder_alias: str,
+    encoder_revision: str,
+    train_end: str | None,
+    fold_id: str | None,
+    metrics: dict[str, Any] | None,
+    conformal_quantile: float | None,
+    conformal_alpha: float | None,
+    training_package_id: str | None = None,
+) -> Path:
+    """Persist the full trajectory bundle atomically.
+
+    Writes happen in this order so a half-built bundle cannot pass the
+    runtime singleton's pre-flight check:
+
+    1. parquet (meeting metadata + 2D coords)
+    2. .npz (raw embeddings + standardisation statistics)
+    3. model.pt (state dict)
+    4. metrics.json, conformal.json (optional)
+    5. manifest.json (written LAST so its presence implies the bundle
+       is complete; the runtime singleton keys availability on this file.)
+    """
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    projected = project_2d(raw_embeddings)
+    if projected.shape[0] != len(meetings):
+        # PCA degraded to empty — fall back to zeros so the panel
+        # renders something rather than crashing the writer.
+        projected = np.zeros((len(meetings), 2), dtype=np.float32)
+    parquet_path = out_dir / "embedding_index.parquet"
+    rows = []
+    for idx, row in enumerate(meetings):
+        rows.append(
+            {
+                "event_date": row.event_date,
+                "text_hash": row.text_hash,
+                "axis_stance": row.axis_stance,
+                "embedding_2d_x": float(projected[idx, 0]) if idx < projected.shape[0] else 0.0,
+                "embedding_2d_y": float(projected[idx, 1]) if idx < projected.shape[0] else 0.0,
+            }
+        )
+    metadata_df = pd.DataFrame(rows)
+    _atomic_write_parquet(metadata_df, parquet_path)
+
+    npz_path = out_dir / "embedding_index.npz"
+    _atomic_save_npz(
+        npz_path,
+        embeddings=raw_embeddings.astype(np.float32),
+        feature_mean=feature_mean.astype(np.float32),
+        feature_std=feature_std.astype(np.float32),
+    )
+
+    save_model(model, config, out_dir / "model.pt")
+
+    if metrics is not None:
+        _atomic_write_text(
+            out_dir / "metrics.json",
+            json.dumps(metrics, indent=2, sort_keys=True),
+        )
+
+    if conformal_quantile is not None:
+        _atomic_write_text(
+            out_dir / "conformal.json",
+            json.dumps(
+                {
+                    "softmax_quantile": float(conformal_quantile),
+                    "alpha": float(conformal_alpha or 0.2),
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+        )
+
+    manifest = {
+        "architecture": config.architecture,
+        "encoder_alias": encoder_alias,
+        "encoder_revision": encoder_revision,
+        "train_end": train_end,
+        "fold_id": fold_id,
+        "history_length": config.history_length,
+        "embedding_dim": config.embedding_dim,
+        "n_classes": config.n_classes,
+        "row_count": int(len(meetings)),
+        "training_package_id": training_package_id,
+        "stance_classes": list(STANCE_CLASSES),
+        "built_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "config": config.to_dict(),
+    }
+    _atomic_write_text(
+        out_dir / "manifest.json",
+        json.dumps(manifest, indent=2, sort_keys=True),
+    )
+    return out_dir
+
+
+# ---------------------------------------------------------------------------
+# Training entry point
+# ---------------------------------------------------------------------------
+
+
+def _default_embed_fn() -> Callable[[list[str]], np.ndarray]:
+    """Build the production embedder lazily (loads the DAPT encoder)."""
+
+    def _embed(texts: list[str]) -> np.ndarray:
+        from app.models.registry import encoder_ref
+        from transformers import AutoModel, AutoTokenizer  # type: ignore[import-not-found,unused-ignore]
+        import torch
+
+        ref = encoder_ref(DEFAULT_BASE_ENCODER_ALIAS)
+        if ref is None:
+            raise ValueError(
+                f"Encoder alias {DEFAULT_BASE_ENCODER_ALIAS!r} not in registry"
+            )
+        tokenizer = AutoTokenizer.from_pretrained(
+            ref.repo, local_files_only=True, trust_remote_code=False
+        )
+        model = AutoModel.from_pretrained(
+            ref.repo, local_files_only=True, trust_remote_code=False
+        )
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        model.to(device)
+        model.eval()
+        outs: list[np.ndarray] = []
+        for text in texts:
+            encoded = tokenizer(
+                text or "",
+                max_length=256,
+                padding="max_length",
+                truncation=True,
+                return_tensors="pt",
+            )
+            ids = encoded["input_ids"].to(device)
+            attn = encoded["attention_mask"].to(device)
+            with torch.no_grad():
+                out = model(input_ids=ids, attention_mask=attn)
+            mask = attn.unsqueeze(-1).to(out.last_hidden_state.dtype)
+            summed = (out.last_hidden_state * mask).sum(dim=1)
+            counts = mask.sum(dim=1).clamp(min=1.0)
+            pooled = (summed / counts).detach().cpu().numpy()
+            outs.append(np.asarray(pooled, dtype=np.float32).reshape(-1))
+        return np.stack(outs, axis=0).astype(np.float32)
+
+    return _embed
+
+
+def train_and_persist(  # noqa: PLR0913, C901, PLR0912, PLR0915 — keyword-only knobs mirror the CLI surface.
+    *,
+    events_parquet: Path,
+    architecture: Architecture,
+    base_encoder_alias: str = DEFAULT_BASE_ENCODER_ALIAS,
+    encoder_revision: str = "",
+    output_root: Path = DEFAULT_OUTPUT_ROOT,
+    run_name: str | None = None,
+    history_length: int = DEFAULT_HISTORY_LENGTH,
+    epochs: int = DEFAULT_EPOCHS,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    learning_rate: float = DEFAULT_LEARNING_RATE,
+    weight_decay: float = DEFAULT_WEIGHT_DECAY,
+    seed: int = DEFAULT_SEED,
+    train_end: str | None = None,
+    fold_id: str | None = None,
+    embed_fn: Callable[[list[str]], np.ndarray] | None = None,
+    holdout_share: float = DEFAULT_HOLDOUT_SHARE,
+    calibration_share: float = DEFAULT_CALIBRATION_SHARE,
+    conformal_alpha: float = 0.2,
+    training_package_id: str | None = None,
+) -> Path:
+    """End-to-end: read events, train, evaluate, persist the bundle.
+
+    Returns the bundle directory. The function is intentionally
+    rebuild-safe: every output file is written atomically and the
+    manifest lands last so a partial run cannot fool the runtime
+    pre-flight check.
+    """
+
+    if architecture not in ("lstm", "transformer"):
+        raise ValueError(
+            f"architecture must be 'lstm' or 'transformer'; got {architecture!r}"
+        )
+    if train_end is not None and fold_id is not None:
+        raise ValueError(
+            "--train-end and --fold-id are mutually exclusive; pass only one"
+        )
+    resolved_train_end: str | None
+    if fold_id is not None:
+        resolved_train_end = resolve_train_end_from_fold(
+            events_parquet=Path(events_parquet), fold_id=fold_id
+        )
+    else:
+        resolved_train_end = _validate_train_end(train_end)
+
+    events = pd.read_parquet(events_parquet)
+    meetings = distill_meeting_rows(events)
+    if not meetings:
+        raise RuntimeError(
+            f"events_parquet {events_parquet} yielded zero statement rows"
+        )
+
+    embedder = embed_fn if embed_fn is not None else _default_embed_fn()
+    raw_embeddings = np.asarray(
+        embedder([row.text for row in meetings]), dtype=np.float32
+    )
+    if raw_embeddings.ndim != 2 or raw_embeddings.shape[0] != len(meetings):
+        raise ValueError(
+            "embed_fn must return a 2-D array with one row per meeting; "
+            f"got shape {raw_embeddings.shape!r}"
+        )
+    embedding_dim = int(raw_embeddings.shape[1])
+    config = TrajectoryConfig(
+        architecture=architecture,
+        embedding_dim=embedding_dim,
+        history_length=history_length,
+    )
+
+    sequences = build_training_sequences(
+        meetings,
+        embeddings=raw_embeddings,
+        history_length=history_length,
+        train_end=resolved_train_end,
+    )
+    if not sequences:
+        raise RuntimeError(
+            "training sequence build yielded zero rows — verify the parquet "
+            "carries statement rows with non-null axis_stance and that "
+            "train_end is not stripping every target."
+        )
+
+    sequences, feature_mean, feature_std = standardise_inputs(
+        sequences, embedding_dim=embedding_dim
+    )
+
+    # Holdout / calibration carve from the END of the training pool so
+    # the slices are temporally contiguous (matches the walk-forward
+    # spirit of the rest of the project).
+    n_total = len(sequences)
+    n_calibration = max(0, int(n_total * calibration_share))
+    n_holdout = max(0, int(n_total * holdout_share))
+    n_train = max(1, n_total - n_calibration - n_holdout)
+    train_sequences = sequences[:n_train]
+    calibration_sequences = sequences[n_train : n_train + n_calibration]
+    holdout_sequences = sequences[n_train + n_calibration :]
+
+    model = train_model(
+        train_sequences,
+        config,
+        epochs=epochs,
+        batch_size=batch_size,
+        learning_rate=learning_rate,
+        weight_decay=weight_decay,
+        seed=seed,
+    )
+
+    metrics_payload: dict[str, Any] | None = None
+    conformal_quantile: float | None = None
+    if holdout_sequences:
+        evaluation = evaluate_model(model, holdout_sequences)
+        metrics_payload = {
+            "architecture": architecture,
+            "holdout": evaluate_metrics(
+                evaluation["labels"].tolist(),
+                evaluation["predictions"].tolist(),
+                seed=seed,
+            ),
+        }
+        # Naive-prior baseline: predict the modal class of the train slice.
+        if train_sequences:
+            train_labels = [seq.label_index for seq in train_sequences]
+            modal = max(set(train_labels), key=train_labels.count)
+            baseline_pred = [modal] * len(holdout_sequences)
+            metrics_payload["baseline_modal"] = evaluate_metrics(
+                evaluation["labels"].tolist(),
+                baseline_pred,
+                seed=seed,
+            )
+    if calibration_sequences:
+        cal_eval = evaluate_model(model, calibration_sequences)
+        try:
+            conformal_quantile = float(
+                calibrate_classification_conformal(
+                    softmax_scores=cal_eval["softmax"].tolist(),
+                    true_classes=cal_eval["labels"].tolist(),
+                    alpha=conformal_alpha,
+                )
+            )
+        except ValueError:
+            conformal_quantile = None
+
+    resolved_run_name = run_name or (
+        DEFAULT_RUN_NAME_LSTM
+        if architecture == "lstm"
+        else DEFAULT_RUN_NAME_TRANSFORMER
+    )
+    out_dir = Path(output_root) / resolved_run_name
+    persist_bundle(
+        out_dir=out_dir,
+        model=model,
+        config=config,
+        meetings=meetings,
+        raw_embeddings=raw_embeddings,
+        feature_mean=feature_mean,
+        feature_std=feature_std,
+        encoder_alias=base_encoder_alias,
+        encoder_revision=encoder_revision,
+        train_end=resolved_train_end,
+        fold_id=fold_id,
+        metrics=metrics_payload,
+        conformal_quantile=conformal_quantile,
+        conformal_alpha=conformal_alpha if conformal_quantile is not None else None,
+        training_package_id=training_package_id,
+    )
+    _logger.info(
+        "trajectory_train_done architecture=%s rows=%d holdout=%d out_dir=%s",
+        architecture,
+        n_train,
+        len(holdout_sequences),
+        out_dir,
+    )
+    return out_dir
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Train a trajectory model (LSTM or Transformer) (#296)."
+    )
+    parser.add_argument("--events-parquet", required=True, type=Path)
+    parser.add_argument(
+        "--architecture", required=True, choices=("lstm", "transformer")
+    )
+    parser.add_argument("--base-encoder-alias", default=DEFAULT_BASE_ENCODER_ALIAS)
+    parser.add_argument("--encoder-revision", default="")
+    parser.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT), type=Path)
+    parser.add_argument("--run-name", default=None)
+    parser.add_argument("--history-length", type=int, default=DEFAULT_HISTORY_LENGTH)
+    parser.add_argument("--epochs", type=int, default=DEFAULT_EPOCHS)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--learning-rate", type=float, default=DEFAULT_LEARNING_RATE)
+    parser.add_argument("--weight-decay", type=float, default=DEFAULT_WEIGHT_DECAY)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--train-end", default=None)
+    parser.add_argument("--fold-id", default=None)
+    parser.add_argument("--holdout-share", type=float, default=DEFAULT_HOLDOUT_SHARE)
+    parser.add_argument(
+        "--calibration-share", type=float, default=DEFAULT_CALIBRATION_SHARE
+    )
+    parser.add_argument("--conformal-alpha", type=float, default=0.2)
+    parser.add_argument("--training-package-id", default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    logging.basicConfig(
+        level=logging.INFO, format="%(levelname)s %(name)s %(message)s"
+    )
+    out_dir = train_and_persist(
+        events_parquet=args.events_parquet,
+        architecture=args.architecture,
+        base_encoder_alias=args.base_encoder_alias,
+        encoder_revision=args.encoder_revision,
+        output_root=args.output_root,
+        run_name=args.run_name,
+        history_length=args.history_length,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        learning_rate=args.learning_rate,
+        weight_decay=args.weight_decay,
+        seed=args.seed,
+        train_end=args.train_end,
+        fold_id=args.fold_id,
+        holdout_share=args.holdout_share,
+        calibration_share=args.calibration_share,
+        conformal_alpha=args.conformal_alpha,
+        training_package_id=args.training_package_id,
+    )
+    print(f"[trajectory.train] saved bundle to {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -248,3 +248,9 @@ module = [
   "numpy.*",
 ]
 ignore_missing_imports = true
+
+
+[tool.pytest.ini_options]
+markers = [
+  "slow: marks tests as slow (skip via -m 'not slow')",
+]

--- a/frontend/components/analyze/TrajectoryPanel.tsx
+++ b/frontend/components/analyze/TrajectoryPanel.tsx
@@ -1,0 +1,377 @@
+import * as React from "react";
+import {
+  CartesianGrid,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from "recharts";
+import { Compass, Sparkles } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export type TrajectoryStance = "hawkish" | "dovish" | "neutral";
+
+export interface TrajectoryMarker {
+  event_date: string;
+  axis_stance: string | null;
+  embedding_2d: [number, number];
+}
+
+export interface TrajectoryProjection {
+  predicted_stance: string;
+  class_probs: Record<string, number>;
+  confidence_band?: string[] | null;
+  conformal_alpha?: number | null;
+}
+
+export interface TrajectoryResponse {
+  available: boolean;
+  history: TrajectoryMarker[];
+  projected_next: TrajectoryProjection | null;
+  architecture?: string | null;
+  encoder_alias?: string;
+  history_length?: number;
+  train_end?: string | null;
+  as_of_date?: string;
+}
+
+interface TrajectoryPanelProps {
+  apiBaseUrl: string;
+  asOfDate: string; // ISO YYYY-MM-DD
+  historyLength?: number;
+}
+
+const STANCE_COLOR: Record<TrajectoryStance, string> = {
+  hawkish: "hsl(var(--down))", // red leaning — tighter policy
+  dovish: "hsl(var(--up))", // green leaning — looser policy
+  neutral: "hsl(var(--neutral))",
+};
+
+const STANCE_LABEL: Record<TrajectoryStance, string> = {
+  hawkish: "Hawkish",
+  dovish: "Dovish",
+  neutral: "Neutral",
+};
+
+function toStance(value: string | null | undefined): TrajectoryStance {
+  const v = (value ?? "").toLowerCase();
+  if (v === "hawkish" || v === "dovish" || v === "neutral") return v;
+  return "neutral";
+}
+
+interface ScatterRow {
+  x: number;
+  y: number;
+  stance: TrajectoryStance;
+  event_date: string;
+  recency: number;
+}
+
+function recencyOpacity(row: ScatterRow, total: number): number {
+  // More recent meetings render brighter; older meetings fade. Total
+  // controls the slope so a longer history does not wash out the most
+  // recent points. Always at least 0.35 so dots stay legible.
+  if (total <= 1) return 1;
+  const t = row.recency / Math.max(1, total - 1);
+  return 0.35 + 0.65 * t;
+}
+
+const TOOLTIP_STYLE: React.CSSProperties = {
+  background: "hsl(var(--popover))",
+  color: "hsl(var(--popover-foreground))",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: 6,
+  padding: "6px 8px",
+  fontSize: 12,
+};
+
+export function TrajectoryPanel({
+  apiBaseUrl,
+  asOfDate,
+  historyLength = 12,
+}: TrajectoryPanelProps) {
+  const [data, setData] = React.useState<TrajectoryResponse | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const response = await fetch(`${apiBaseUrl}/analyze/trajectory`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            as_of_date: asOfDate,
+            history_length: historyLength,
+          }),
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const payload = (await response.json()) as TrajectoryResponse;
+        if (!controller.signal.aborted) {
+          setData(payload);
+        }
+      } catch (err) {
+        if ((err as Error).name === "AbortError") return;
+        setError((err as Error).message || "Failed to load trajectory");
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    })();
+    return () => controller.abort();
+  }, [apiBaseUrl, asOfDate, historyLength]);
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardDescription className="flex items-center gap-1.5">
+            <Compass className="h-3.5 w-3.5" />
+            Hawkish / Dovish trajectory
+          </CardDescription>
+          <CardTitle>Loading…</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-64 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardDescription className="flex items-center gap-1.5">
+            <Compass className="h-3.5 w-3.5" />
+            Hawkish / Dovish trajectory
+          </CardDescription>
+          <CardTitle>Unavailable</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <EmptyState
+            variant="inline"
+            title="Trajectory panel offline"
+            description={
+              error
+                ? `Backend reported: ${error}`
+                : "No bundle loaded on this host."
+            }
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data.available || data.history.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardDescription className="flex items-center gap-1.5">
+            <Compass className="h-3.5 w-3.5" />
+            Hawkish / Dovish trajectory
+          </CardDescription>
+          <CardTitle>Not trained on this host</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <EmptyState
+            variant="inline"
+            title="Trajectory bundle absent"
+            description={
+              <span>
+                Run <code className="rounded bg-muted px-1">python -m app.trajectory.train --architecture transformer</code>{" "}
+                against the canonical training package to produce the bundle, then refresh.
+              </span>
+            }
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const total = data.history.length;
+  const rows: ScatterRow[] = data.history.map((m, idx) => ({
+    x: m.embedding_2d[0],
+    y: m.embedding_2d[1],
+    stance: toStance(m.axis_stance),
+    event_date: m.event_date,
+    recency: idx,
+  }));
+
+  const projection = data.projected_next;
+  const projectedStance = projection ? toStance(projection.predicted_stance) : "neutral";
+  // Project the next anchor as the simple delta extension of the last
+  // two real markers — visual heuristic only; the model's stance
+  // probability stays the load-bearing claim.
+  const projectedAnchor = (() => {
+    if (rows.length === 0) return { x: 0, y: 0 };
+    if (rows.length === 1) {
+      return { x: rows[0].x + 0.1, y: rows[0].y };
+    }
+    const last = rows[rows.length - 1];
+    const prev = rows[rows.length - 2];
+    return { x: last.x + (last.x - prev.x), y: last.y + (last.y - prev.y) };
+  })();
+
+  const projectionPoint = projection
+    ? [
+        {
+          x: projectedAnchor.x,
+          y: projectedAnchor.y,
+          stance: projectedStance,
+          event_date: "projected next",
+          recency: total,
+        },
+      ]
+    : [];
+
+  // One scatter per stance so we can colour the dots per stance without
+  // a custom shape function (Recharts colour-by-row gets awkward).
+  const byStance: Record<TrajectoryStance, ScatterRow[]> = {
+    hawkish: rows.filter((r) => r.stance === "hawkish"),
+    dovish: rows.filter((r) => r.stance === "dovish"),
+    neutral: rows.filter((r) => r.stance === "neutral"),
+  };
+
+  const probEntries = projection
+    ? (["hawkish", "dovish", "neutral"] as TrajectoryStance[]).map((s) => ({
+        stance: s,
+        prob: projection.class_probs[s] ?? 0,
+      }))
+    : [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardDescription className="flex items-center gap-1.5">
+          <Compass className="h-3.5 w-3.5" />
+          Hawkish / Dovish trajectory
+        </CardDescription>
+        <CardTitle className="flex items-center justify-between">
+          <span>Last {total} meetings · {data.architecture ?? "lstm"}</span>
+          {data.train_end ? (
+            <Badge variant="outline" className="numeric text-[10px]">
+              train_end · {data.train_end}
+            </Badge>
+          ) : null}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="h-72 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <ScatterChart margin={{ top: 12, right: 16, bottom: 12, left: 12 }}>
+              <CartesianGrid stroke="hsl(var(--border))" strokeDasharray="2 3" />
+              <XAxis
+                type="number"
+                dataKey="x"
+                name="component 1"
+                tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+                stroke="hsl(var(--border))"
+                tickFormatter={(v) => Number(v).toFixed(1)}
+              />
+              <YAxis
+                type="number"
+                dataKey="y"
+                name="component 2"
+                tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+                stroke="hsl(var(--border))"
+                tickFormatter={(v) => Number(v).toFixed(1)}
+              />
+              <ZAxis type="number" range={[60, 60]} />
+              <Tooltip
+                cursor={{ strokeDasharray: "2 3" }}
+                contentStyle={TOOLTIP_STYLE}
+                formatter={(value, name, ctx) => {
+                  const r = ctx?.payload as ScatterRow | undefined;
+                  if (!r) return ["—", String(name)];
+                  return [
+                    `${r.event_date} · ${STANCE_LABEL[r.stance]}`,
+                    "meeting",
+                  ];
+                }}
+                labelFormatter={() => ""}
+              />
+              {(Object.keys(byStance) as TrajectoryStance[]).map((stance) => (
+                <Scatter
+                  key={stance}
+                  name={STANCE_LABEL[stance]}
+                  data={byStance[stance].map((row) => ({
+                    ...row,
+                    fillOpacity: recencyOpacity(row, total),
+                  }))}
+                  fill={STANCE_COLOR[stance]}
+                  isAnimationActive={false}
+                />
+              ))}
+              {projection ? (
+                <Scatter
+                  name="Projected next"
+                  data={projectionPoint.map((row) => ({ ...row, fillOpacity: 0.85 }))}
+                  fill={STANCE_COLOR[projectedStance]}
+                  shape="star"
+                  isAnimationActive={false}
+                />
+              ) : null}
+            </ScatterChart>
+          </ResponsiveContainer>
+        </div>
+
+        {projection ? (
+          <div className="rounded-lg border border-border bg-muted/30 p-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Sparkles className="h-4 w-4 text-primary" />
+                <span className="text-sm font-medium">
+                  Projected next meeting: {STANCE_LABEL[projectedStance]}
+                </span>
+              </div>
+              {projection.confidence_band && projection.confidence_band.length > 0 ? (
+                <Badge variant="outline" className="text-[10px]">
+                  band · {projection.confidence_band.join(", ")}
+                </Badge>
+              ) : null}
+            </div>
+            <div className="mt-3 grid gap-2 sm:grid-cols-3">
+              {probEntries.map(({ stance, prob }) => (
+                <div key={stance} className="space-y-1">
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span className="capitalize">{STANCE_LABEL[stance]}</span>
+                    <span className="numeric font-medium text-foreground">
+                      {(prob * 100).toFixed(1)}%
+                    </span>
+                  </div>
+                  <Progress value={Math.round(prob * 100)} />
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          PCA projection of meeting-level embeddings from the cross-bank DAPT encoder.
+          Marker brightness encodes recency (older meetings fade); the star is the next-meeting
+          projection. Confidence band is the APS-calibrated stance set.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -13,6 +13,7 @@ import {
   type RegimeHistoryEntry,
 } from "@/components/analyze/RegimeHistoryStrip";
 import { SentenceStrikeXaiPanel } from "@/components/analyze/SentenceStrikeXaiPanel";
+import { TrajectoryPanel } from "@/components/analyze/TrajectoryPanel";
 import { WatchlistChips } from "@/components/analyze/WatchlistChips";
 import { Header } from "@/components/shell/header";
 import { StatusBar } from "@/components/shell/status-bar";
@@ -396,6 +397,12 @@ export default function WorkspacePage() {
                   loading={counterfactualLoading}
                 />
               ) : null}
+
+              <TrajectoryPanel
+                apiBaseUrl={apiBaseUrl}
+                asOfDate={request.date}
+                historyLength={12}
+              />
 
               <PipelineTrace result={result} inputText={request.text} />
 

--- a/tests/unit/test_trajectory_endpoint.py
+++ b/tests/unit/test_trajectory_endpoint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import numpy as np
@@ -190,3 +191,232 @@ def test_analyze_trajectory_validates_missing_as_of_date(client: TestClient) -> 
         json={"history_length": 12},
     )
     assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Strict-backward boundary (finding 1)
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_trajectory_excludes_meeting_on_as_of_date(
+    client: TestClient,
+) -> None:
+    """A meeting whose ``event_date`` equals ``as_of_date`` is the
+    meeting being projected — never an eligible history marker.
+    Strict-backward enforces ``event_date < as_of_date``.
+    """
+
+    _install_fake_trajectory_state()
+    response = client.post(
+        "/analyze/trajectory",
+        # Latest fixture date is 2022-06-15 — query it directly.
+        json={"as_of_date": "2022-06-15", "history_length": 12},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    dates = {marker["event_date"] for marker in body["history"]}
+    assert "2022-06-15" not in dates, (
+        f"history leaked the as_of meeting: {sorted(dates)}"
+    )
+
+
+def test_analyze_trajectory_disambiguates_duplicate_event_dates(
+    client: TestClient,
+) -> None:
+    """When two metadata rows share an ``event_date`` (e.g. statement +
+    intermeeting release on the same day) the embedding-row lookup
+    must key on ``text_hash`` so the embedding matches the marker
+    being projected. Without the fix the first row always wins.
+    """
+
+    metadata = pd.DataFrame(
+        [
+            {
+                "event_date": "2020-03-15",
+                "text_hash": "h_statement",
+                "axis_stance": "dovish",
+                "embedding_2d_x": 0.1,
+                "embedding_2d_y": 0.2,
+                "pre_meeting_trailing_2y_yield_change_5d_bps": 1.0,
+                "vix_close": 15.0,
+            },
+            # Distinct second row sharing the same event_date.
+            {
+                "event_date": "2020-03-15",
+                "text_hash": "h_intermeeting",
+                "axis_stance": "neutral",
+                "embedding_2d_x": -0.3,
+                "embedding_2d_y": 0.4,
+                "pre_meeting_trailing_2y_yield_change_5d_bps": -2.5,
+                "vix_close": 60.0,
+            },
+            {
+                "event_date": "2020-06-10",
+                "text_hash": "h_june",
+                "axis_stance": "dovish",
+                "embedding_2d_x": 0.5,
+                "embedding_2d_y": -0.1,
+                "pre_meeting_trailing_2y_yield_change_5d_bps": 0.5,
+                "vix_close": 28.0,
+            },
+        ]
+    )
+    embedding_dim = 6
+    rng = np.random.default_rng(11)
+    embeddings = rng.normal(size=(len(metadata), embedding_dim)).astype(np.float32)
+    # Make the two same-date rows trivially distinguishable.
+    embeddings[0] = 1.0
+    embeddings[1] = -1.0
+    config = traj_model.TrajectoryConfig(
+        architecture="lstm", embedding_dim=embedding_dim, history_length=3
+    )
+    model = traj_model.build_model(config)
+    state = trajectory_service.build_state_for_tests(
+        model=model,
+        config=config,
+        embeddings=embeddings,
+        metadata=metadata,
+        encoder_alias="test_trajectory_encoder",
+        train_end="2025-01-01",
+        architecture="lstm",
+        conformal_quantile=0.5,
+        conformal_alpha=0.2,
+    )
+    trajectory_service.install_state(state)
+    response = client.post(
+        "/analyze/trajectory",
+        json={"as_of_date": "2020-07-01", "history_length": 3},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    # Both same-date rows must surface in the history slice.
+    history_hashes = {marker.get("event_date") for marker in body["history"]}
+    assert "2020-03-15" in history_hashes
+    # Projection runs cleanly with the disambiguated lookups.
+    assert body["projected_next"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Warning when as_of beyond train_end (finding 5b)
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_trajectory_emits_warning_when_as_of_beyond_train_end(
+    client: TestClient,
+) -> None:
+    _install_fake_trajectory_state()
+    # State has train_end="2025-01-01" — query past it.
+    response = client.post(
+        "/analyze/trajectory",
+        json={"as_of_date": "2030-01-01", "history_length": 4},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body.get("warning") is not None
+    assert "train_end" in body["warning"]
+
+
+# ---------------------------------------------------------------------------
+# Real-encoder smoke (finding 16) — guarded slow test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_analyze_trajectory_real_encoder_load_path(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Exercise the production ``_load_state`` path end-to-end with a
+    tiny real encoder + a synthetic bundle. Covers the regression
+    surface every other endpoint test bypasses (they all install a
+    pre-built state directly).
+
+    Skipped automatically when the tiny encoder is not cached locally
+    so the suite can run offline; full CI fetches it on demand.
+    """
+
+    import os
+
+    tiny_repo = os.environ.get(
+        "FED_PULSE_TEST_TINY_ENCODER", "sshleifer/tiny-distilbert-base-uncased"
+    )
+    try:
+        from transformers import AutoModel, AutoTokenizer  # type: ignore[import-not-found,unused-ignore]
+    except Exception:  # pragma: no cover
+        pytest.skip("transformers not available")
+
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(tiny_repo)
+        encoder = AutoModel.from_pretrained(tiny_repo)
+    except Exception as exc:  # pragma: no cover — offline / rate-limited
+        pytest.skip(f"tiny encoder unavailable: {exc!r}")
+
+    # Build a synthetic bundle with a couple of meeting rows and
+    # standardisation stats so ``_load_state`` produces a valid state.
+    bundle = tmp_path / "trajectory_real"
+    bundle.mkdir()
+    embedding_dim = encoder.config.hidden_size
+    dates = ["2020-01-29", "2021-03-17", "2022-06-15"]
+    metadata = pd.DataFrame(
+        [
+            {
+                "event_date": dt,
+                "text_hash": f"h_{idx}",
+                "axis_stance": ["hawkish", "dovish", "neutral"][idx % 3],
+                "embedding_2d_x": float(idx),
+                "embedding_2d_y": float(-idx),
+                "pre_meeting_trailing_2y_yield_change_5d_bps": float(idx),
+                "vix_close": 15.0 + idx,
+            }
+            for idx, dt in enumerate(dates)
+        ]
+    )
+    metadata.to_parquet(bundle / "embedding_index.parquet", index=False)
+    rng = np.random.default_rng(11)
+    embeddings = rng.normal(size=(len(dates), embedding_dim)).astype(np.float32)
+    feature_mean = embeddings.mean(axis=0).astype(np.float32)
+    feature_std = embeddings.std(axis=0).astype(np.float32)
+    feature_std[feature_std < 1e-6] = 1.0
+    np.savez(
+        bundle / "embedding_index.npz",
+        embeddings=embeddings,
+        feature_mean=feature_mean,
+        feature_std=feature_std,
+    )
+    config = traj_model.TrajectoryConfig(
+        architecture="lstm", embedding_dim=embedding_dim, history_length=4
+    )
+    model = traj_model.build_model(config)
+    traj_model.save_model(model, config, bundle / "model.pt")
+    (bundle / "manifest.json").write_text(
+        json.dumps(
+            {
+                "architecture": "lstm",
+                "encoder_alias": tiny_repo,
+                "encoder_revision": "",
+                "train_end": "2025-01-01",
+                "history_length": 4,
+                "embedding_dim": embedding_dim,
+                "n_classes": 3,
+                "row_count": len(dates),
+                "stance_classes": ["hawkish", "dovish", "neutral"],
+                "config": config.to_dict(),
+                "built_at_utc": "2026-05-26T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("FED_PULSE_TRAJECTORY_DIR", str(bundle))
+    trajectory_service.reset_state()
+    response = client.post(
+        "/analyze/trajectory",
+        json={"as_of_date": "2023-01-01", "history_length": 4},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["available"] is True
+    assert body["projected_next"] is not None
+    assert body["encoder_alias"] == tiny_repo
+
+

--- a/tests/unit/test_trajectory_endpoint.py
+++ b/tests/unit/test_trajectory_endpoint.py
@@ -1,0 +1,192 @@
+"""Endpoint tests for POST /analyze/trajectory (#296)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("torch")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import app.main as main_mod  # noqa: E402
+from app.services import trajectory as trajectory_service  # noqa: E402
+from app.trajectory import model as traj_model  # noqa: E402
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(main_mod.app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_trajectory_singleton():
+    trajectory_service.reset_state()
+    yield
+    trajectory_service.reset_state()
+
+
+def _toy_metadata(dates: list[str]) -> pd.DataFrame:
+    rows = []
+    stance_cycle = ["dovish", "hawkish", "neutral"]
+    for idx, dt in enumerate(dates):
+        rows.append(
+            {
+                "event_date": dt,
+                "axis_stance": stance_cycle[idx % 3],
+                "embedding_2d_x": float(idx) * 0.1,
+                "embedding_2d_y": float(idx) * -0.2,
+                "pre_meeting_trailing_2y_yield_change_5d_bps": float(idx),
+                "vix_close": 15.0 + float(idx),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _install_fake_trajectory_state() -> None:
+    dates = [
+        "2010-03-16",
+        "2012-06-20",
+        "2015-03-18",
+        "2017-06-13",
+        "2019-07-30",
+        "2022-06-15",
+    ]
+    metadata = _toy_metadata(dates)
+    embedding_dim = 6
+    rng = np.random.default_rng(11)
+    embeddings = rng.normal(size=(len(dates), embedding_dim)).astype(np.float32)
+    config = traj_model.TrajectoryConfig(
+        architecture="lstm", embedding_dim=embedding_dim, history_length=4
+    )
+    model = traj_model.build_model(config)
+    state = trajectory_service.build_state_for_tests(
+        model=model,
+        config=config,
+        embeddings=embeddings,
+        metadata=metadata,
+        encoder_alias="test_trajectory_encoder",
+        train_end="2025-01-01",
+        architecture="lstm",
+        conformal_quantile=0.7,
+        conformal_alpha=0.2,
+    )
+    trajectory_service.install_state(state)
+
+
+def test_analyze_trajectory_returns_empty_when_bundle_missing(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("FED_PULSE_TRAJECTORY_DIR", str(tmp_path / "does-not-exist"))
+    response = client.post(
+        "/analyze/trajectory",
+        json={"as_of_date": "2024-01-01", "history_length": 12},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["available"] is False
+    assert body["history"] == []
+    assert body["projected_next"] is None
+    assert body["encoder_alias"] == "finbert_fed_adjacent_xbank_dapt"
+
+
+def test_analyze_trajectory_returns_history_and_projection(
+    client: TestClient,
+) -> None:
+    _install_fake_trajectory_state()
+    response = client.post(
+        "/analyze/trajectory",
+        json={"as_of_date": "2023-01-01", "history_length": 4},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["available"] is True
+    assert body["architecture"] == "lstm"
+    assert body["encoder_alias"] == "test_trajectory_encoder"
+    history = body["history"]
+    assert 1 <= len(history) <= 4
+    # Strictly backward: every history marker is on or before as_of.
+    for marker in history:
+        assert marker["event_date"] <= "2023-01-01"
+        assert isinstance(marker["embedding_2d"], list)
+        assert len(marker["embedding_2d"]) == 2
+    projection = body["projected_next"]
+    assert projection is not None
+    assert projection["predicted_stance"] in {"hawkish", "dovish", "neutral"}
+    probs = projection["class_probs"]
+    assert set(probs.keys()) == {"hawkish", "dovish", "neutral"}
+    assert sum(probs.values()) == pytest.approx(1.0, abs=1e-5)
+
+
+def test_analyze_trajectory_confidence_band_present_when_conformal_quantile_set(
+    client: TestClient,
+) -> None:
+    _install_fake_trajectory_state()
+    response = client.post(
+        "/analyze/trajectory",
+        json={"as_of_date": "2023-01-01", "history_length": 6},
+    )
+    assert response.status_code == 200
+    band = response.json()["projected_next"]["confidence_band"]
+    # A conformal_quantile of 0.7 → keep classes with prob >= 0.3, plus
+    # the argmax-fallback. Either way the band is a non-empty list of
+    # stance labels.
+    assert isinstance(band, list)
+    assert all(label in {"hawkish", "dovish", "neutral"} for label in band)
+
+
+def test_analyze_trajectory_503_does_not_leak_internal_errors(
+    client: TestClient,
+) -> None:
+    _install_fake_trajectory_state()
+
+    secret_path = "/internal/secret/trajectory/path"
+
+    def _explode(*_args, **_kwargs):
+        raise RuntimeError(f"boom at {secret_path}")
+
+    # Replace the projection callable on the imported module so the
+    # endpoint hits the sanitised exception arm.
+    original = trajectory_service.project_trajectory
+    try:
+        trajectory_service.project_trajectory = _explode  # type: ignore[assignment]
+        response = client.post(
+            "/analyze/trajectory",
+            json={"as_of_date": "2023-01-01", "history_length": 4},
+        )
+        assert response.status_code == 503
+        body = response.json()
+        assert body.get("detail") == "Trajectory projection unavailable"
+        assert secret_path not in response.text
+        assert "RuntimeError" not in response.text
+        assert "Traceback" not in response.text
+    finally:
+        trajectory_service.project_trajectory = original  # type: ignore[assignment]
+
+
+def test_analyze_trajectory_validates_history_length_lower_bound(client: TestClient) -> None:
+    response = client.post(
+        "/analyze/trajectory",
+        json={"as_of_date": "2023-01-01", "history_length": 0},
+    )
+    assert response.status_code == 422
+
+
+def test_analyze_trajectory_validates_history_length_upper_bound(client: TestClient) -> None:
+    response = client.post(
+        "/analyze/trajectory",
+        json={"as_of_date": "2023-01-01", "history_length": 999},
+    )
+    assert response.status_code == 422
+
+
+def test_analyze_trajectory_validates_missing_as_of_date(client: TestClient) -> None:
+    response = client.post(
+        "/analyze/trajectory",
+        json={"history_length": 12},
+    )
+    assert response.status_code == 422

--- a/tests/unit/test_trajectory_model.py
+++ b/tests/unit/test_trajectory_model.py
@@ -1,0 +1,264 @@
+"""Unit tests for the trajectory model architectures (#296).
+
+Covers:
+
+* Forward-pass shapes for both LSTM and Transformer arms.
+* The walk-forward filter at training-sequence build time — targets
+  with ``event_date >= train_end`` must never enter the train pool.
+* APS conformal calibration consumes the right calibration slice
+  (softmax probabilities + true class indices).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.evaluation.conformal import calibrate_classification_conformal  # noqa: E402
+from app.trajectory import model as traj_model  # noqa: E402
+from app.trajectory import train as traj_train  # noqa: E402
+
+
+def _make_meeting(
+    *,
+    event_date: str,
+    stance: str | None = "hawkish",
+    yield_bp: float | None = 1.0,
+    vix: float | None = 18.0,
+) -> traj_train.MeetingRow:
+    return traj_train.MeetingRow(
+        event_date=event_date,
+        text_hash=f"hash_{event_date}",
+        text=f"meeting {event_date}",
+        axis_stance=stance,
+        trailing_2y_yield_change_5d_bps=yield_bp,
+        vix_close=vix,
+    )
+
+
+def _meetings_panel() -> list[traj_train.MeetingRow]:
+    return [
+        _make_meeting(event_date="2010-03-16", stance="dovish"),
+        _make_meeting(event_date="2010-06-22", stance="dovish"),
+        _make_meeting(event_date="2011-01-25", stance="dovish"),
+        _make_meeting(event_date="2015-03-17", stance="hawkish"),
+        _make_meeting(event_date="2015-12-16", stance="neutral"),
+        _make_meeting(event_date="2017-06-13", stance="hawkish"),
+        _make_meeting(event_date="2019-07-30", stance="dovish"),
+        _make_meeting(event_date="2020-03-15", stance="dovish"),
+        _make_meeting(event_date="2022-06-15", stance="hawkish"),
+        _make_meeting(event_date="2023-05-03", stance="hawkish"),
+    ]
+
+
+def _toy_embeddings(meetings: list[traj_train.MeetingRow], *, dim: int = 8) -> np.ndarray:
+    """Deterministic toy embedding: hash the event_date into a fixed-dim vector."""
+
+    out = np.zeros((len(meetings), dim), dtype=np.float32)
+    for row_idx, row in enumerate(meetings):
+        seed_int = abs(hash(row.event_date)) % (2**32)
+        rng = np.random.default_rng(seed_int)
+        out[row_idx] = rng.normal(size=dim).astype(np.float32)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Forward-pass shape
+# ---------------------------------------------------------------------------
+
+
+def test_lstm_forward_returns_logits_and_hidden_of_expected_shape() -> None:
+    config = traj_model.TrajectoryConfig(
+        architecture="lstm",
+        embedding_dim=16,
+        history_length=12,
+    )
+    model = traj_model.build_model(config)
+    inputs = torch.randn(4, config.history_length, config.input_dim)
+    mask = torch.ones(4, config.history_length, dtype=torch.bool)
+    logits, hidden = model(inputs, mask)
+    assert logits.shape == (4, config.n_classes)
+    assert hidden.shape == (4, config.lstm_hidden)
+
+
+def test_transformer_forward_returns_logits_and_hidden_of_expected_shape() -> None:
+    config = traj_model.TrajectoryConfig(
+        architecture="transformer",
+        embedding_dim=16,
+        history_length=12,
+    )
+    model = traj_model.build_model(config)
+    inputs = torch.randn(3, config.history_length, config.input_dim)
+    mask = torch.ones(3, config.history_length, dtype=torch.bool)
+    logits, hidden = model(inputs, mask)
+    assert logits.shape == (3, config.n_classes)
+    assert hidden.shape == (3, config.transformer_d_model)
+
+
+def test_forward_pass_respects_mask_padding() -> None:
+    """Padded positions must not crash either architecture; final-real
+    position decoding handles the boundary even when a row has zero
+    real meetings (we still get a finite logits row from the fallback).
+    """
+
+    config = traj_model.TrajectoryConfig(
+        architecture="lstm", embedding_dim=8, history_length=6
+    )
+    model = traj_model.build_model(config)
+    inputs = torch.randn(2, 6, config.input_dim)
+    mask = torch.tensor(
+        [
+            [False, False, False, True, True, True],  # last 3 real
+            [True, True, True, True, True, True],  # all real
+        ],
+        dtype=torch.bool,
+    )
+    logits, _ = model(inputs, mask)
+    assert logits.shape == (2, config.n_classes)
+    assert torch.isfinite(logits).all()
+
+
+def test_save_and_load_round_trip_preserves_predictions(tmp_path) -> None:
+    config = traj_model.TrajectoryConfig(
+        architecture="transformer", embedding_dim=8, history_length=4
+    )
+    model = traj_model.build_model(config)
+    inputs = torch.randn(2, 4, config.input_dim)
+    mask = torch.ones(2, 4, dtype=torch.bool)
+    before_logits, _ = model(inputs, mask)
+    traj_model.save_model(model, config, tmp_path / "model.pt")
+    reloaded, reloaded_config = traj_model.load_model(tmp_path / "model.pt")
+    after_logits, _ = reloaded(inputs, mask)
+    assert reloaded_config.architecture == "transformer"
+    assert reloaded_config.embedding_dim == config.embedding_dim
+    assert torch.allclose(before_logits, after_logits, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward filter at sequence-build time
+# ---------------------------------------------------------------------------
+
+
+def test_build_training_sequences_drops_targets_on_or_after_train_end() -> None:
+    meetings = _meetings_panel()
+    embeddings = _toy_embeddings(meetings)
+    sequences = traj_train.build_training_sequences(
+        meetings,
+        embeddings=embeddings,
+        history_length=4,
+        train_end="2020-01-01",
+    )
+    # Every target date must lie strictly before 2020-01-01.
+    assert sequences, "expected sequences from the pre-2020 slice"
+    for seq in sequences:
+        assert seq.target_event_date < "2020-01-01"
+
+
+def test_build_training_sequences_includes_targets_below_train_end_only() -> None:
+    meetings = _meetings_panel()
+    embeddings = _toy_embeddings(meetings)
+    unfiltered = traj_train.build_training_sequences(
+        meetings, embeddings=embeddings, history_length=4
+    )
+    filtered = traj_train.build_training_sequences(
+        meetings, embeddings=embeddings, history_length=4, train_end="2015-12-16"
+    )
+    assert len(filtered) < len(unfiltered)
+    # 2015-12-16 must be excluded under strict <.
+    assert all(seq.target_event_date < "2015-12-16" for seq in filtered)
+
+
+def test_build_training_sequences_skips_unknown_stance_targets() -> None:
+    meetings = [
+        _make_meeting(event_date="2010-03-16", stance="dovish"),
+        _make_meeting(event_date="2010-06-22", stance=None),
+        _make_meeting(event_date="2011-01-25", stance="hawkish"),
+    ]
+    embeddings = _toy_embeddings(meetings)
+    sequences = traj_train.build_training_sequences(
+        meetings, embeddings=embeddings, history_length=2
+    )
+    target_dates = {seq.target_event_date for seq in sequences}
+    assert "2010-06-22" not in target_dates
+
+
+def test_build_training_sequences_left_pads_short_history() -> None:
+    meetings = _meetings_panel()
+    embeddings = _toy_embeddings(meetings)
+    sequences = traj_train.build_training_sequences(
+        meetings, embeddings=embeddings, history_length=12
+    )
+    # The very first non-skip target has only one meeting of context;
+    # left-pad must put the real meeting at the END of the window.
+    earliest = min(sequences, key=lambda s: s.target_event_date)
+    assert earliest.inputs.shape == (12, embeddings.shape[1] + traj_model.MARKET_FEATURE_DIM)
+    assert earliest.mask[-1] == bool(True)
+    assert not earliest.mask[0]
+
+
+# ---------------------------------------------------------------------------
+# Conformal calibration
+# ---------------------------------------------------------------------------
+
+
+def test_calibrate_classification_conformal_consumes_softmax_and_true_classes() -> None:
+    rng = np.random.default_rng(42)
+    softmax_rows = []
+    true_labels = []
+    for _ in range(40):
+        logits = rng.normal(size=3)
+        exp_l = np.exp(logits - logits.max())
+        probs = exp_l / exp_l.sum()
+        softmax_rows.append(probs.tolist())
+        true_labels.append(int(rng.integers(0, 3)))
+    quantile = calibrate_classification_conformal(
+        softmax_scores=softmax_rows, true_classes=true_labels, alpha=0.2
+    )
+    assert 0.0 <= quantile <= 1.0
+
+
+def test_conformal_calibration_uses_only_calibration_slice(tmp_path) -> None:
+    """A separate calibration slice must not be polluted by holdout rows."""
+
+    meetings = _meetings_panel()
+    embeddings = _toy_embeddings(meetings)
+    sequences = traj_train.build_training_sequences(
+        meetings, embeddings=embeddings, history_length=4
+    )
+    n = len(sequences)
+    n_cal = max(1, int(0.3 * n))
+    train_slice = sequences[: n - n_cal]
+    cal_slice = sequences[n - n_cal :]
+    assert train_slice and cal_slice, "expected non-empty train + cal partitions"
+
+    config = traj_model.TrajectoryConfig(
+        architecture="lstm",
+        embedding_dim=embeddings.shape[1],
+        history_length=4,
+    )
+    model = traj_train.train_model(train_slice, config, epochs=1, batch_size=2, seed=11)
+    cal_eval = traj_train.evaluate_model(model, cal_slice)
+    quantile = calibrate_classification_conformal(
+        softmax_scores=cal_eval["softmax"].tolist(),
+        true_classes=cal_eval["labels"].tolist(),
+        alpha=0.2,
+    )
+    assert 0.0 <= quantile <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Market feature builder
+# ---------------------------------------------------------------------------
+
+
+def test_market_feature_vector_zeroes_missing_inputs() -> None:
+    vec = traj_model.market_feature_vector(
+        trailing_2y_yield_change_5d_bps=None, vix_close=None
+    )
+    assert vec.shape == (traj_model.MARKET_FEATURE_DIM,)
+    # Bias term is always 1.0; other slots zero on missing input.
+    assert vec[0] == pytest.approx(1.0)
+    assert vec[1] == pytest.approx(0.0)
+    assert vec[2] == pytest.approx(0.0)

--- a/tests/unit/test_trajectory_model.py
+++ b/tests/unit/test_trajectory_model.py
@@ -97,14 +97,19 @@ def test_transformer_forward_returns_logits_and_hidden_of_expected_shape() -> No
     assert hidden.shape == (3, config.transformer_d_model)
 
 
-def test_forward_pass_respects_mask_padding() -> None:
+@pytest.mark.parametrize("arch", ["lstm", "transformer"])
+def test_forward_pass_respects_mask_padding(arch: str) -> None:
     """Padded positions must not crash either architecture; final-real
     position decoding handles the boundary even when a row has zero
     real meetings (we still get a finite logits row from the fallback).
+
+    Parametrised over both arms so a polarity bug in the Transformer's
+    ``key_padding_mask`` (e.g. forgetting the ``~`` flip) is caught
+    too — the LSTM-only coverage missed this category of regression.
     """
 
     config = traj_model.TrajectoryConfig(
-        architecture="lstm", embedding_dim=8, history_length=6
+        architecture=arch, embedding_dim=8, history_length=6  # type: ignore[arg-type]
     )
     model = traj_model.build_model(config)
     inputs = torch.randn(2, 6, config.input_dim)
@@ -118,6 +123,35 @@ def test_forward_pass_respects_mask_padding() -> None:
     logits, _ = model(inputs, mask)
     assert logits.shape == (2, config.n_classes)
     assert torch.isfinite(logits).all()
+
+
+@pytest.mark.parametrize("arch", ["lstm", "transformer"])
+def test_forward_pass_handles_all_pad_row_without_nan(arch: str) -> None:
+    """A row with zero real positions must produce finite logits.
+
+    The Transformer arm in particular: if ``src_key_padding_mask`` is
+    all-True the attention layer feeds ``softmax(-inf)`` and the
+    pooled vector becomes NaN. The forward path now forces at least
+    one position per row to be attended so the final-position pooler
+    reads a finite vector.
+    """
+
+    config = traj_model.TrajectoryConfig(
+        architecture=arch, embedding_dim=8, history_length=4  # type: ignore[arg-type]
+    )
+    model = traj_model.build_model(config)
+    inputs = torch.randn(2, 4, config.input_dim)
+    mask = torch.tensor(
+        [
+            [False, False, False, False],  # all-pad — would NaN without the guard
+            [True, True, True, True],  # all real
+        ],
+        dtype=torch.bool,
+    )
+    logits, hidden = model(inputs, mask)
+    assert logits.shape == (2, config.n_classes)
+    assert torch.isfinite(logits).all(), f"{arch}: logits contain NaN / inf on all-pad row"
+    assert torch.isfinite(hidden).all(), f"{arch}: hidden contains NaN / inf on all-pad row"
 
 
 def test_save_and_load_round_trip_preserves_predictions(tmp_path) -> None:
@@ -258,7 +292,68 @@ def test_market_feature_vector_zeroes_missing_inputs() -> None:
         trailing_2y_yield_change_5d_bps=None, vix_close=None
     )
     assert vec.shape == (traj_model.MARKET_FEATURE_DIM,)
-    # Bias term is always 1.0; other slots zero on missing input.
-    assert vec[0] == pytest.approx(1.0)
+    # Bias term doubles as the "VIX present" indicator — 0.0 on missing input.
+    assert vec[0] == pytest.approx(0.0)
     assert vec[1] == pytest.approx(0.0)
     assert vec[2] == pytest.approx(0.0)
+
+
+def test_market_feature_vector_marks_present_with_bias_indicator() -> None:
+    """A real VIX reading sets the bias=1 indicator regardless of magnitude.
+
+    A future low-vol regime can print a sub-mean VIX (e.g. 10) — the
+    old gating on ``vix_raw > 0`` would still flip on, but a regression
+    that re-introduces the "> mean" or "> 0" heuristic would collapse
+    sub-mean readings into the missing-data bin. The explicit-missing
+    bit on the bias slot makes the contract crisp.
+    """
+
+    vec = traj_model.market_feature_vector(
+        trailing_2y_yield_change_5d_bps=1.0, vix_close=10.0
+    )
+    assert vec[0] == pytest.approx(1.0)  # VIX present
+    # Sub-mean VIX yields a negative z-score, not zero.
+    assert vec[2] < 0.0
+
+
+def test_market_feature_vector_treats_nan_as_missing() -> None:
+    vec = traj_model.market_feature_vector(
+        trailing_2y_yield_change_5d_bps=float("nan"), vix_close=float("nan")
+    )
+    assert vec[0] == pytest.approx(0.0)
+    assert vec[1] == pytest.approx(0.0)
+    assert vec[2] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Parameter-count guardrails (LSTM vs Transformer comparison)
+# ---------------------------------------------------------------------------
+
+
+def test_both_architectures_report_comparable_parameter_counts() -> None:
+    """A LSTM-vs-Transformer comparison is meaningful only when capacity
+    is in the same ballpark. Default knobs should keep both arms within
+    one order of magnitude; a future config edit that blows out the
+    Transformer's parameter count (e.g. by widening ``d_model`` to 512)
+    should trip this guard before the headline metric is reported.
+    """
+
+    lstm_config = traj_model.TrajectoryConfig(
+        architecture="lstm", embedding_dim=64, history_length=12
+    )
+    transformer_config = traj_model.TrajectoryConfig(
+        architecture="transformer", embedding_dim=64, history_length=12
+    )
+    lstm_model = traj_model.build_model(lstm_config)
+    transformer_model = traj_model.build_model(transformer_config)
+    lstm_params = sum(p.numel() for p in lstm_model.parameters())
+    transformer_params = sum(p.numel() for p in transformer_model.parameters())
+    assert lstm_params > 0
+    assert transformer_params > 0
+    ratio = max(lstm_params, transformer_params) / max(
+        1, min(lstm_params, transformer_params)
+    )
+    assert ratio <= 10.0, (
+        f"LSTM/Transformer parameter counts out of comparable range: "
+        f"lstm={lstm_params}, transformer={transformer_params}, ratio={ratio:.2f}"
+    )

--- a/tests/unit/test_trajectory_train.py
+++ b/tests/unit/test_trajectory_train.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -307,3 +308,368 @@ def test_evaluate_metrics_returns_macro_f1_and_directional_accuracy() -> None:
     assert 0.0 <= metrics["macro_f1"]["point"] <= 1.0
     assert 0.0 <= metrics["directional_accuracy"]["point"] <= 1.0
     assert metrics["n"] == 6
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward carve + leakage tests
+# ---------------------------------------------------------------------------
+
+
+def test_train_and_persist_standardisation_fits_on_train_slice_only(
+    tmp_path: Path,
+) -> None:
+    """The persisted ``feature_mean`` must match what the train slice
+    alone produces — fitting on the full pool would leak holdout
+    statistics into the inference path.
+    """
+
+    events_parquet = tmp_path / "events.parquet"
+    _events_frame().to_parquet(events_parquet, index=False)
+    bundle = traj_train.train_and_persist(
+        events_parquet=events_parquet,
+        architecture="lstm",
+        output_root=tmp_path / "artifacts",
+        run_name="run_test",
+        history_length=3,
+        epochs=1,
+        batch_size=2,
+        seed=11,
+        train_end="2018-01-01",  # pre-cutoff sequences only ↔ pre-2018 targets
+        embed_fn=_toy_embedder,
+        holdout_share=0.0,
+        calibration_share=0.0,
+    )
+    persisted = np.load(bundle / "embedding_index.npz", allow_pickle=False)
+    persisted_mean = persisted["feature_mean"]
+    persisted_std = persisted["feature_std"]
+
+    # Rebuild the expected statistics from scratch using ONLY pre-2018 targets.
+    meetings = traj_train.distill_meeting_rows(_events_frame())
+    embeddings = _toy_embedder([row.text for row in meetings])
+    all_sequences = traj_train.build_training_sequences(
+        meetings, embeddings=embeddings, history_length=3, train_end=None
+    )
+    pre = [seq for seq in all_sequences if seq.target_event_date < "2018-01-01"]
+    expected_mean, expected_std = traj_train.fit_standardisation_stats(
+        pre, embedding_dim=embeddings.shape[1]
+    )
+    assert np.allclose(persisted_mean, expected_mean, atol=1e-5)
+    assert np.allclose(persisted_std, expected_std, atol=1e-5)
+
+
+def test_train_and_persist_pca_axes_fit_on_train_slice_only(
+    tmp_path: Path,
+) -> None:
+    """The persisted PCA axes must match a train-slice-only fit.
+
+    A regression that re-fits ``project_2d`` on the full corpus would
+    surface here as a mismatch between the persisted ``pca_mean`` /
+    ``pca_components`` and the train-only reconstruction.
+    """
+
+    events_parquet = tmp_path / "events.parquet"
+    _events_frame().to_parquet(events_parquet, index=False)
+    bundle = traj_train.train_and_persist(
+        events_parquet=events_parquet,
+        architecture="lstm",
+        output_root=tmp_path / "artifacts",
+        run_name="run_test",
+        history_length=3,
+        epochs=1,
+        batch_size=2,
+        seed=11,
+        train_end="2018-01-01",
+        embed_fn=_toy_embedder,
+        holdout_share=0.0,
+        calibration_share=0.0,
+    )
+    persisted = np.load(bundle / "embedding_index.npz", allow_pickle=False)
+    assert "pca_mean" in persisted.files
+    assert "pca_components" in persisted.files
+
+    meetings = traj_train.distill_meeting_rows(_events_frame())
+    embeddings = _toy_embedder([row.text for row in meetings])
+    train_mask = np.array(
+        [row.event_date < "2018-01-01" for row in meetings], dtype=bool
+    )
+    expected_mean, expected_components = traj_train.fit_pca_axes(embeddings[train_mask])
+    assert np.allclose(persisted["pca_mean"], expected_mean, atol=1e-5)
+    assert np.allclose(persisted["pca_components"], expected_components, atol=1e-5)
+
+
+def test_train_and_persist_parquet_filters_to_train_end(tmp_path: Path) -> None:
+    """The persisted ``embedding_index.parquet`` must drop post-train_end rows.
+
+    The runtime singleton's history window walks this file; surfacing
+    a meeting the model never trained on would be a walk-forward leak
+    at inference time.
+    """
+
+    events_parquet = tmp_path / "events.parquet"
+    _events_frame().to_parquet(events_parquet, index=False)
+    bundle = traj_train.train_and_persist(
+        events_parquet=events_parquet,
+        architecture="lstm",
+        output_root=tmp_path / "artifacts",
+        run_name="run_test",
+        history_length=3,
+        epochs=1,
+        batch_size=2,
+        seed=11,
+        train_end="2018-01-01",
+        embed_fn=_toy_embedder,
+        holdout_share=0.0,
+        calibration_share=0.0,
+    )
+    metadata = pd.read_parquet(bundle / "embedding_index.parquet")
+    assert not metadata.empty
+    assert (metadata["event_date"] < "2018-01-01").all(), (
+        f"persisted parquet leaked post-train_end rows: "
+        f"{metadata.loc[metadata['event_date'] >= '2018-01-01', 'event_date'].tolist()}"
+    )
+
+
+def test_train_and_persist_parquet_carries_market_columns(tmp_path: Path) -> None:
+    """The persisted parquet must carry the market columns the runtime
+    ``_market_for`` reads — otherwise inference reads None and the
+    market feature vector collapses to a no-signal block (train-vs-
+    inference distribution skew).
+    """
+
+    events_parquet = tmp_path / "events.parquet"
+    _events_frame().to_parquet(events_parquet, index=False)
+    bundle = traj_train.train_and_persist(
+        events_parquet=events_parquet,
+        architecture="lstm",
+        output_root=tmp_path / "artifacts",
+        run_name="run_test",
+        history_length=3,
+        epochs=1,
+        batch_size=2,
+        seed=11,
+        train_end="2025-01-01",
+        embed_fn=_toy_embedder,
+        holdout_share=0.0,
+        calibration_share=0.0,
+    )
+    metadata = pd.read_parquet(bundle / "embedding_index.parquet")
+    assert "pre_meeting_trailing_2y_yield_change_5d_bps" in metadata.columns
+    assert "vix_close" in metadata.columns
+    # Every row must carry finite market inputs (the fixture frame
+    # provides them for every meeting).
+    assert metadata["pre_meeting_trailing_2y_yield_change_5d_bps"].notna().all()
+    assert metadata["vix_close"].notna().all()
+
+
+def test_train_and_persist_manifest_includes_parameter_count(tmp_path: Path) -> None:
+    """``manifest.json`` must report ``model_parameter_count`` so the
+    LSTM-vs-Transformer comparison can be audited later.
+    """
+
+    events_parquet = tmp_path / "events.parquet"
+    _events_frame().to_parquet(events_parquet, index=False)
+    bundle = traj_train.train_and_persist(
+        events_parquet=events_parquet,
+        architecture="transformer",
+        output_root=tmp_path / "artifacts",
+        run_name="run_test",
+        history_length=3,
+        epochs=1,
+        batch_size=2,
+        seed=11,
+        train_end="2025-01-01",
+        embed_fn=_toy_embedder,
+        holdout_share=0.0,
+        calibration_share=0.0,
+    )
+    manifest = json.loads((bundle / "manifest.json").read_text(encoding="utf-8"))
+    assert "model_parameter_count" in manifest
+    assert manifest["model_parameter_count"] > 0
+
+
+def test_train_and_persist_feeds_calibration_slice_to_conformal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Spy on ``calibrate_classification_conformal`` to confirm the
+    trainer hands it the calibration partition's predictions — not
+    the train or holdout slices.
+    """
+
+    captured: dict[str, Any] = {}
+
+    def _spy(*, softmax_scores, true_classes, alpha):
+        captured["softmax_rows"] = list(softmax_scores)
+        captured["true_classes"] = list(true_classes)
+        captured["alpha"] = alpha
+        # Return a plausible quantile so the trainer persists conformal.json.
+        return 0.5
+
+    monkeypatch.setattr(
+        "app.trajectory.train.calibrate_classification_conformal", _spy
+    )
+
+    events_parquet = tmp_path / "events.parquet"
+    _events_frame().to_parquet(events_parquet, index=False)
+    traj_train.train_and_persist(
+        events_parquet=events_parquet,
+        architecture="lstm",
+        output_root=tmp_path / "artifacts",
+        run_name="run_test",
+        history_length=3,
+        epochs=1,
+        batch_size=2,
+        seed=11,
+        train_end="2025-01-01",
+        embed_fn=_toy_embedder,
+        holdout_share=0.0,
+        calibration_share=0.34,  # ensure non-empty cal partition
+        conformal_alpha=0.2,
+    )
+    assert captured, "calibrate_classification_conformal was not called"
+
+    # Reconstruct the calibration partition from the same upstream
+    # builder and confirm sizes line up. The trainer carves cal as
+    # the temporal tail of the train slice.
+    from typing import Any as _A  # noqa: F401 — local import keeps the spy block self-contained.
+
+    meetings = traj_train.distill_meeting_rows(_events_frame())
+    embeddings = _toy_embedder([row.text for row in meetings])
+    all_sequences = traj_train.build_training_sequences(
+        meetings, embeddings=embeddings, history_length=3, train_end=None
+    )
+    pre = [seq for seq in all_sequences if seq.target_event_date < "2025-01-01"]
+    n_pre = len(pre)
+    n_cal = max(0, int(n_pre * 0.34))
+    expected_cal = pre[max(1, n_pre - n_cal) :]
+    assert len(captured["softmax_rows"]) == len(expected_cal), (
+        f"spy saw {len(captured['softmax_rows'])} rows, expected {len(expected_cal)}"
+    )
+    assert len(captured["true_classes"]) == len(expected_cal)
+    assert captured["alpha"] == 0.2
+
+
+# ---------------------------------------------------------------------------
+# Atomic-write crash safety + npz fallback
+# ---------------------------------------------------------------------------
+
+
+def test_train_and_persist_does_not_leave_partial_bundle_on_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If ``os.replace`` crashes part-way through the persist, no
+    half-built bundle should survive — the manifest is the truth
+    marker the runtime keys on, so any earlier file without a
+    matching manifest is dead weight that the next training run
+    must overwrite cleanly.
+    """
+
+    real_replace = traj_train.os.replace
+    call_count = {"n": 0}
+
+    def _crash_after_first(src, dst):  # type: ignore[no-untyped-def]
+        call_count["n"] += 1
+        if call_count["n"] >= 2:
+            raise RuntimeError("simulated crash after first atomic-write")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(traj_train.os, "replace", _crash_after_first)
+
+    events_parquet = tmp_path / "events.parquet"
+    _events_frame().to_parquet(events_parquet, index=False)
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        traj_train.train_and_persist(
+            events_parquet=events_parquet,
+            architecture="lstm",
+            output_root=tmp_path / "artifacts",
+            run_name="run_crash",
+            history_length=3,
+            epochs=1,
+            batch_size=2,
+            seed=11,
+            train_end="2025-01-01",
+            embed_fn=_toy_embedder,
+            holdout_share=0.0,
+            calibration_share=0.0,
+        )
+    bundle = tmp_path / "artifacts" / "run_crash"
+    if bundle.exists():
+        # If the crash landed after some writes the manifest must NOT
+        # be present (it is the truth marker; without it the runtime
+        # treats the bundle as missing).
+        assert not (bundle / "manifest.json").exists(), (
+            "crash left a manifest behind — runtime would treat the partial "
+            "bundle as complete"
+        )
+
+
+# ---------------------------------------------------------------------------
+# NpzFile fallback (finding 9)
+# ---------------------------------------------------------------------------
+
+
+def test_service_load_state_falls_back_when_npz_missing_feature_mean(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A hand-built npz WITHOUT ``feature_mean`` must NOT crash the
+    runtime loader — the previous ``npz.get`` call raised KeyError
+    (NpzFile has no .get) and the wrapping ``except Exception``
+    swallowed the bundle as "missing". The probe is now an explicit
+    ``in npz.files`` check + a logged warning.
+    """
+
+    from app.services import trajectory as trajectory_service
+
+    bundle = tmp_path / "trajectory_test"
+    bundle.mkdir()
+    # Minimal parquet + npz pair (deliberately omit feature_mean / feature_std).
+    pd.DataFrame(
+        [
+            {
+                "event_date": "2020-01-01",
+                "text_hash": "h_2020",
+                "axis_stance": "neutral",
+                "embedding_2d_x": 0.0,
+                "embedding_2d_y": 0.0,
+                "pre_meeting_trailing_2y_yield_change_5d_bps": 0.0,
+                "vix_close": 20.0,
+            }
+        ]
+    ).to_parquet(bundle / "embedding_index.parquet", index=False)
+    np.savez(
+        bundle / "embedding_index.npz",
+        embeddings=np.zeros((1, 4), dtype=np.float32),
+    )
+    # Minimal model + manifest so bundle_available returns True.
+    config = traj_model.TrajectoryConfig(
+        architecture="lstm", embedding_dim=4, history_length=2
+    )
+    model = traj_model.build_model(config)
+    traj_model.save_model(model, config, bundle / "model.pt")
+    (bundle / "manifest.json").write_text(
+        json.dumps(
+            {
+                "architecture": "lstm",
+                "encoder_alias": "test",
+                "encoder_revision": "",
+                "train_end": "2025-01-01",
+                "history_length": 2,
+                "embedding_dim": 4,
+                "n_classes": 3,
+                "row_count": 1,
+                "stance_classes": ["hawkish", "dovish", "neutral"],
+                "config": config.to_dict(),
+                "built_at_utc": "2026-05-26T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("FED_PULSE_TRAJECTORY_DIR", str(bundle))
+    trajectory_service.reset_state()
+    try:
+        state = trajectory_service.get_state()
+        assert state is not None, "bundle without feature_mean should still load"
+        # Defaults must be sane — zeros for mean, ones for std (post-floor).
+        assert np.allclose(state.feature_mean, 0.0)
+        assert np.allclose(state.feature_std, 1.0)
+    finally:
+        trajectory_service.reset_state()

--- a/tests/unit/test_trajectory_train.py
+++ b/tests/unit/test_trajectory_train.py
@@ -1,0 +1,309 @@
+"""Unit tests for the trajectory train script (#296).
+
+Covers:
+
+* ``build_training_sequences`` filters by ``event_date < train_end``.
+* The bundle persist path writes atomically (no leftover ``.tmp`` files).
+* The manifest carries ``train_end`` + ``fold_id`` so the runtime
+  singleton can echo them back to the caller.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.trajectory import model as traj_model  # noqa: E402
+from app.trajectory import train as traj_train  # noqa: E402
+
+
+def _events_frame() -> pd.DataFrame:
+    rows = [
+        {
+            "event_date": "2010-03-16",
+            "event_kind": "statement",
+            "text": "2010 statement",
+            "text_hash": "h_2010",
+            "axis_stance": "dovish",
+            "pre_meeting_trailing_2y_yield_change_5d_bps": 1.5,
+            "vix_close": 22.0,
+            "horizon": 1,
+        },
+        {
+            "event_date": "2012-06-20",
+            "event_kind": "statement",
+            "text": "2012 statement",
+            "text_hash": "h_2012",
+            "axis_stance": "dovish",
+            "pre_meeting_trailing_2y_yield_change_5d_bps": -0.5,
+            "vix_close": 18.0,
+            "horizon": 1,
+        },
+        {
+            "event_date": "2015-03-18",
+            "event_kind": "statement",
+            "text": "2015 statement",
+            "text_hash": "h_2015",
+            "axis_stance": "neutral",
+            "pre_meeting_trailing_2y_yield_change_5d_bps": 3.0,
+            "vix_close": 16.0,
+            "horizon": 1,
+        },
+        {
+            "event_date": "2017-06-13",
+            "event_kind": "statement",
+            "text": "2017 statement",
+            "text_hash": "h_2017",
+            "axis_stance": "hawkish",
+            "pre_meeting_trailing_2y_yield_change_5d_bps": 4.5,
+            "vix_close": 12.0,
+            "horizon": 1,
+        },
+        {
+            "event_date": "2019-07-30",
+            "event_kind": "statement",
+            "text": "2019 statement",
+            "text_hash": "h_2019",
+            "axis_stance": "dovish",
+            "pre_meeting_trailing_2y_yield_change_5d_bps": -2.0,
+            "vix_close": 17.0,
+            "horizon": 1,
+        },
+        {
+            "event_date": "2022-06-15",
+            "event_kind": "statement",
+            "text": "2022 statement",
+            "text_hash": "h_2022",
+            "axis_stance": "hawkish",
+            "pre_meeting_trailing_2y_yield_change_5d_bps": 7.0,
+            "vix_close": 28.0,
+            "horizon": 1,
+        },
+        # Non-statement row that must be ignored by the distiller.
+        {
+            "event_date": "2022-06-15",
+            "event_kind": "macro_release",
+            "text": "CPI",
+            "text_hash": "h_macro_2022",
+            "axis_stance": None,
+            "horizon": 1,
+        },
+    ]
+    return pd.DataFrame(rows)
+
+
+def _toy_embedder(texts: list[str]) -> np.ndarray:
+    """Deterministic 4-dim projection — same text always maps to the same vector."""
+
+    out = np.zeros((len(texts), 4), dtype=np.float32)
+    for idx, text in enumerate(texts):
+        seed = abs(hash(text)) % (2**32)
+        rng = np.random.default_rng(seed)
+        out[idx] = rng.normal(size=4).astype(np.float32)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Sequence build
+# ---------------------------------------------------------------------------
+
+
+def test_distill_meeting_rows_drops_non_statement_kinds() -> None:
+    rows = traj_train.distill_meeting_rows(_events_frame())
+    assert all(row.text_hash.startswith("h_") for row in rows)
+    assert not any(row.text_hash == "h_macro_2022" for row in rows)
+    # Sorted ascending by event_date.
+    dates = [row.event_date for row in rows]
+    assert dates == sorted(dates)
+
+
+def test_build_training_sequences_filters_by_event_date(tmp_path: Path) -> None:
+    meetings = traj_train.distill_meeting_rows(_events_frame())
+    embeddings = _toy_embedder([row.text for row in meetings])
+    sequences = traj_train.build_training_sequences(
+        meetings, embeddings=embeddings, history_length=4, train_end="2018-01-01"
+    )
+    assert sequences, "expected at least one sequence under train_end=2018-01-01"
+    for seq in sequences:
+        assert seq.target_event_date < "2018-01-01"
+
+
+def test_build_training_sequences_rejects_zero_history_length() -> None:
+    meetings = traj_train.distill_meeting_rows(_events_frame())
+    embeddings = _toy_embedder([row.text for row in meetings])
+    with pytest.raises(ValueError, match="history_length"):
+        traj_train.build_training_sequences(
+            meetings, embeddings=embeddings, history_length=0
+        )
+
+
+# ---------------------------------------------------------------------------
+# Atomic writes + manifest
+# ---------------------------------------------------------------------------
+
+
+def test_train_and_persist_writes_atomic_bundle_without_leftover_tmp(
+    tmp_path: Path,
+) -> None:
+    events_parquet = tmp_path / "events.parquet"
+    _events_frame().to_parquet(events_parquet, index=False)
+    bundle = traj_train.train_and_persist(
+        events_parquet=events_parquet,
+        architecture="lstm",
+        output_root=tmp_path / "artifacts",
+        run_name="run_test",
+        history_length=3,
+        epochs=1,
+        batch_size=2,
+        seed=11,
+        train_end="2025-01-01",
+        embed_fn=_toy_embedder,
+        holdout_share=0.0,
+        calibration_share=0.0,
+    )
+
+    assert (bundle / "manifest.json").exists()
+    assert (bundle / "model.pt").exists()
+    assert (bundle / "embedding_index.parquet").exists()
+    assert (bundle / "embedding_index.npz").exists()
+    leftovers = list(bundle.glob("*.tmp"))
+    assert leftovers == [], f"atomic-write tmp files leaked: {leftovers}"
+
+
+def test_train_and_persist_manifest_carries_train_end_and_fold_id(
+    tmp_path: Path,
+) -> None:
+    events_parquet = tmp_path / "events.parquet"
+    _events_frame().to_parquet(events_parquet, index=False)
+    bundle = traj_train.train_and_persist(
+        events_parquet=events_parquet,
+        architecture="transformer",
+        output_root=tmp_path / "artifacts",
+        run_name="run_test",
+        history_length=3,
+        epochs=1,
+        batch_size=2,
+        seed=11,
+        train_end="2020-01-01",
+        embed_fn=_toy_embedder,
+        holdout_share=0.0,
+        calibration_share=0.0,
+    )
+    manifest = json.loads((bundle / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["train_end"] == "2020-01-01"
+    assert manifest["architecture"] == "transformer"
+    assert manifest["encoder_alias"] == traj_train.DEFAULT_BASE_ENCODER_ALIAS
+    assert manifest["history_length"] == 3
+
+
+def test_train_and_persist_writes_2d_projection_per_meeting(tmp_path: Path) -> None:
+    events_parquet = tmp_path / "events.parquet"
+    _events_frame().to_parquet(events_parquet, index=False)
+    bundle = traj_train.train_and_persist(
+        events_parquet=events_parquet,
+        architecture="lstm",
+        output_root=tmp_path / "artifacts",
+        run_name="run_test",
+        history_length=3,
+        epochs=1,
+        batch_size=2,
+        seed=11,
+        train_end="2025-01-01",
+        embed_fn=_toy_embedder,
+        holdout_share=0.0,
+        calibration_share=0.0,
+    )
+    metadata = pd.read_parquet(bundle / "embedding_index.parquet")
+    assert {"event_date", "axis_stance", "embedding_2d_x", "embedding_2d_y"} <= set(
+        metadata.columns
+    )
+    # Every meeting row must have a finite 2D anchor for the chart.
+    assert metadata["embedding_2d_x"].notna().all()
+    assert metadata["embedding_2d_y"].notna().all()
+
+
+def test_resolve_train_end_from_fold_matches_manifest(tmp_path: Path) -> None:
+    pkg = tmp_path / "tp_test"
+    pkg.mkdir()
+    events_parquet = pkg / "events.parquet"
+    _events_frame().to_parquet(events_parquet, index=False)
+    (pkg / traj_train.FOLD_MANIFEST_FILENAME).write_text(
+        json.dumps(
+            {
+                "folds": [
+                    {"fold_id": "wf_fold_1", "train_end": "2016-09-21"},
+                    {"fold_id": "wf_fold_2", "train_end": "2019-08-01"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    resolved = traj_train.resolve_train_end_from_fold(
+        events_parquet=events_parquet, fold_id="wf_fold_2"
+    )
+    assert resolved == "2019-08-01"
+
+
+def test_train_and_persist_rejects_mutually_exclusive_flags(tmp_path: Path) -> None:
+    events_parquet = tmp_path / "events.parquet"
+    _events_frame().to_parquet(events_parquet, index=False)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        traj_train.train_and_persist(
+            events_parquet=events_parquet,
+            architecture="lstm",
+            output_root=tmp_path / "artifacts",
+            run_name="run_test",
+            embed_fn=_toy_embedder,
+            train_end="2018-01-01",
+            fold_id="wf_fold_1",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Standardisation
+# ---------------------------------------------------------------------------
+
+
+def test_standardise_inputs_zscores_embedding_block_only(tmp_path: Path) -> None:
+    meetings = traj_train.distill_meeting_rows(_events_frame())
+    embeddings = _toy_embedder([row.text for row in meetings])
+    sequences = traj_train.build_training_sequences(
+        meetings, embeddings=embeddings, history_length=3
+    )
+    rescaled, mean, std = traj_train.standardise_inputs(
+        sequences, embedding_dim=embeddings.shape[1]
+    )
+    assert mean.shape == (embeddings.shape[1],)
+    assert std.shape == (embeddings.shape[1],)
+    # Market block must stay literally equal across (real positions).
+    for original, scaled in zip(sequences, rescaled):
+        for t in range(original.inputs.shape[0]):
+            if not original.mask[t]:
+                continue
+            assert np.allclose(
+                scaled.inputs[t, embeddings.shape[1] :],
+                original.inputs[t, embeddings.shape[1] :],
+            )
+
+
+# ---------------------------------------------------------------------------
+# Metrics smoke
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_metrics_returns_macro_f1_and_directional_accuracy() -> None:
+    metrics = traj_train.evaluate_metrics(
+        [0, 1, 2, 0, 1, 2],
+        [0, 1, 2, 0, 0, 2],
+        n_resamples=50,
+        seed=11,
+    )
+    assert 0.0 <= metrics["macro_f1"]["point"] <= 1.0
+    assert 0.0 <= metrics["directional_accuracy"]["point"] <= 1.0
+    assert metrics["n"] == 6


### PR DESCRIPTION
## Summary

- LSTM baseline + Transformer arm under `app/trajectory/`; same input contract
- Walk-forward trainer with `--train-end` / `--fold-id`; atomic bundle writes
- `/analyze/trajectory` route + `app.services.trajectory` singleton with sanitized 503
- `TrajectoryPanel` scatter chart with projected-next star + confidence band
- Cross-bank DAPT encoder embeddings + #291 pre-meeting market features
- APS conformal calibration on next-meeting softmax

## Test plan

- [ ] `docker compose -p fed-pulse-bundled run --rm backend pytest tests/unit/test_trajectory_model.py tests/unit/test_trajectory_train.py tests/unit/test_trajectory_endpoint.py -q`
- [ ] `docker compose -p fed-pulse-bundled run --rm backend mypy --strict --ignore-missing-imports --follow-imports=silent app/trajectory app/services/trajectory.py`
- [ ] `cd frontend && npm run build`