### PR TITLE
Follow-up: PR #317 remaining review findings (fold manifest + cold-start + UX + tests)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep
 
 help:
 	@echo "Targets:"
@@ -77,6 +77,7 @@ help:
 	@echo "  make dual-head-comparison TRAINING_PACKAGE_ID=<id>"
 	@echo "                         - Three-way head-mode comparison (classification / regression / dual) across the official seed set"
 	@echo "  make derived-features-ablation TRAINING_PACKAGE_ID=<id>"
+	@echo "  make rates-heads-sweep TRAINING_PACKAGE_ID=<id> [SEED=<seed>]"
 	@echo "                         - Three-way derived-text-features ablation (baseline / ablation / replacement)"
 
 dev: dev-cpu
@@ -691,3 +692,16 @@ derived-features-ablation:
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
 		--seeds 11 29 47 71 97 \
 		--epochs 40
+
+
+# #292 / #317 finding #16 rates-heads sweep runner. Trains the three
+# rates heads (2y / 5y / terminal) on the official 5-seed x 4-fold
+# protocol and emits a per-head MAE-bps + directional-accuracy + R^2
+# panel keyed by fold and seed. SEED is the single-seed override
+# (defaults to the full official seed set when unset).
+rates-heads-sweep:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	docker compose --profile "$(FORECASTER_COMPOSE_PROFILE)" run --rm "$(FORECASTER_COMPOSE_SERVICE)" \
+		python -m scripts.run_rates_heads_sweep \
+		--training-package-id "$(TRAINING_PACKAGE_ID)" \
+		$(if $(SEED),--seeds $(SEED),--seeds 11 29 47 71 97)

--- a/backend/app/data/build_training_package.py
+++ b/backend/app/data/build_training_package.py
@@ -35,6 +35,46 @@ class FoldRange:
     val_source_distribution: dict[str, int]
     test_source_distribution: dict[str, int]
     source_drift_max: float
+    # #317 finding #6: per-fold rates quantile edges (one entry per
+    # mounted rates head). Populated by the training loop / sweep
+    # script after the train slice fits the tertile cutoffs; left
+    # ``None`` at data-prep time (the edges depend on the train rows,
+    # which the data-prep stage has but does not bin). The inference
+    # path reads this dict back to label a live event with the same
+    # bucket cutoffs the model trained against.
+    rates_quantile_edges: dict[str, dict[str, float]] | None = None
+
+
+def update_fold_manifest_rates_quantile_edges(
+    package_dir: Path,
+    fold_id: str,
+    rates_quantile_edges: dict[str, dict[str, float]] | None,
+) -> bool:
+    """Upsert per-fold rates_quantile_edges onto the canonical manifest (#317).
+
+    Loads ``fold_manifest_expanding_walk_forward.json``, looks for the
+    fold matching ``fold_id``, and writes ``rates_quantile_edges`` into
+    that fold's dict. Returns True when the upsert hit a fold; False
+    when the manifest is missing or the fold_id is not present (the
+    sweep script logs the miss as a warning rather than aborting so
+    the run can continue).
+    """
+
+    manifest_path = package_dir / "fold_manifest_expanding_walk_forward.json"
+    if not manifest_path.exists():
+        return False
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    folds = payload.get("folds") or []
+    hit = False
+    for fold in folds:
+        if str(fold.get("fold_id", "")) == fold_id:
+            fold["rates_quantile_edges"] = rates_quantile_edges
+            hit = True
+            break
+    if not hit:
+        return False
+    manifest_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return True
 
 
 def _parse_args() -> argparse.Namespace:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1001,6 +1001,13 @@ async def analyze_market(payload: AnalyzeRequest) -> MarketReactionPanel:
     surface a 5xx.
     """
 
+    # #317 finding #12: mirror the /analyze cold-start guard so a
+    # fresh deploy hitting /analyze/market first does not surface
+    # empty cards. Shared with /analyze via the _bootstrap_cold_start
+    # helper.
+    if not checkpoint_exists():
+        await run_in_threadpool(_bootstrap_cold_start, payload)
+
     sentiment = analyze_text(payload.text)
     market_history = await run_in_threadpool(
         fetch_market_history,

--- a/frontend/components/analyze/MarketReactionPanel.tsx
+++ b/frontend/components/analyze/MarketReactionPanel.tsx
@@ -41,7 +41,13 @@ interface RatesReactionCardProps {
 }
 
 export function RatesReactionCard({ card }: RatesReactionCardProps) {
-  const tone = bucketTone(card.directional_bucket);
+  // #317 finding #10: when the checkpoint exposes no aux classifier
+  // for this head the backend returns ``directional_bucket: null`` and
+  // ``bucket_probabilities: null``; render an explicit "aux classifier
+  // unavailable" badge rather than fabricating an argmax on
+  // non-existent probabilities.
+  const hasBucket = card.directional_bucket != null && card.bucket_probabilities != null;
+  const tone = hasBucket ? bucketTone(card.directional_bucket!) : "neutral";
   const bandText =
     card.lower_bps != null && card.upper_bps != null
       ? `${formatBps(card.lower_bps)} … ${formatBps(card.upper_bps)}`
@@ -55,10 +61,16 @@ export function RatesReactionCard({ card }: RatesReactionCardProps) {
         </CardDescription>
         <CardTitle className="flex items-center justify-between text-2xl">
           <span className="numeric">{formatBps(card.point_bps)}</span>
-          <Badge variant={tone} className="flex items-center gap-1 capitalize">
-            <BucketIcon bucket={card.directional_bucket} />
-            {card.directional_bucket}
-          </Badge>
+          {hasBucket ? (
+            <Badge variant={tone} className="flex items-center gap-1 capitalize">
+              <BucketIcon bucket={card.directional_bucket!} />
+              {card.directional_bucket}
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+              Aux classifier unavailable
+            </Badge>
+          )}
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
@@ -74,32 +86,39 @@ export function RatesReactionCard({ card }: RatesReactionCardProps) {
               </span>
             ) : null}
           </p>
+          {card.predicted_set != null && card.predicted_set.length > 0 ? (
+            <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+              calibrated set: {`{${card.predicted_set.join(", ")}}`}
+            </p>
+          ) : null}
         </div>
-        <div className="space-y-2">
-          {BUCKET_ORDER.map((bucket) => {
-            const value = card.bucket_probabilities[bucket] ?? 0;
-            return (
-              <div key={bucket} className="space-y-1">
-                <div className="flex items-center justify-between text-xs text-muted-foreground">
-                  <span className="capitalize">{bucket}</span>
-                  <span className="font-medium text-foreground">
-                    {(value * 100).toFixed(0)}%
-                  </span>
+        {hasBucket ? (
+          <div className="space-y-2">
+            {BUCKET_ORDER.map((bucket) => {
+              const value = card.bucket_probabilities![bucket] ?? 0;
+              return (
+                <div key={bucket} className="space-y-1">
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span className="capitalize">{bucket}</span>
+                    <span className="font-medium text-foreground">
+                      {(value * 100).toFixed(0)}%
+                    </span>
+                  </div>
+                  <Progress
+                    value={value * 100}
+                    indicatorClassName={
+                      bucket === "tightening"
+                        ? "bg-hawkish"
+                        : bucket === "easing"
+                        ? "bg-dovish"
+                        : "bg-neutral"
+                    }
+                  />
                 </div>
-                <Progress
-                  value={value * 100}
-                  indicatorClassName={
-                    bucket === "tightening"
-                      ? "bg-hawkish"
-                      : bucket === "easing"
-                      ? "bg-dovish"
-                      : "bg-neutral"
-                  }
-                />
-              </div>
-            );
-          })}
-        </div>
+              );
+            })}
+          </div>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -223,8 +223,15 @@ export interface RatesReactionCard {
   lower_bps: number | null;
   upper_bps: number | null;
   coverage: number | null;
-  directional_bucket: RatesDirectionalBucket;
-  bucket_probabilities: Partial<Record<RatesDirectionalBucket, number>>;
+  // #317 finding #10: nullable when the checkpoint exposes no aux
+  // classifier for this head. The card renders an "aux classifier
+  // unavailable" badge in that case rather than fabricating an
+  // argmax over a fake uniform distribution.
+  directional_bucket: RatesDirectionalBucket | null;
+  bucket_probabilities: Partial<Record<RatesDirectionalBucket, number>> | null;
+  // #317 finding #3: calibrated APS prediction set per head when the
+  // conformal sidecar carries the per-head softmax_quantile.
+  predicted_set: RatesDirectionalBucket[] | null;
 }
 
 export interface VolRegimeReactionCard {

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -199,36 +199,52 @@ export default function WorkspacePage() {
     };
   }, [apiBaseUrl, request.symbol]);
 
+  // #317 finding #14: monotonic seq for /analyze/market fetches. A
+  // second submit before the first market fetch resolves bumps the
+  // seq; the late-arriving resolver checks the seq and skips state
+  // commit if it does not match the most recent issued id. Mirrors
+  // the counterfactualSeqRef pattern below.
+  const marketPanelSeqRef = React.useRef(0);
+
   const handleSubmit = async () => {
     setLoading(true);
     setStruck(new Set());
+    marketPanelSeqRef.current += 1;
+    const marketTicket = marketPanelSeqRef.current;
     try {
-      const next = await postAnalyze(apiBaseUrl, { ...request, mask_sentence_indices: [] });
-      setResult(next);
-      setBaselineResult(next);
-      toast.success("Analysis complete");
-      // Fire the market panel fetch in parallel-after-analyze: a
-      // failure here is non-fatal (the panel is opt-in / requires a
-      // checkpoint with rates heads mounted), so a 4xx or 5xx degrades
-      // to a silent empty state rather than blowing up the workspace.
-      try {
-        const panel = await postAnalyzeMarket(apiBaseUrl, {
-          ...request,
-          mask_sentence_indices: [],
-        });
-        setMarketPanel(panel);
-      } catch {
-        setMarketPanel(null);
+      // #317 finding #13: dispatch /analyze + /analyze/market in
+      // parallel rather than sequentially -- the market panel does
+      // not depend on the /analyze response payload. Halves the
+      // user-visible latency on a submit click. Wrapped via
+      // ``Promise.allSettled`` so a failure on the optional market
+      // panel does not abort the primary /analyze surface.
+      const sharedRequest = { ...request, mask_sentence_indices: [] };
+      const [analyzeRes, marketRes] = await Promise.allSettled([
+        postAnalyze(apiBaseUrl, sharedRequest),
+        postAnalyzeMarket(apiBaseUrl, sharedRequest),
+      ]);
+      if (analyzeRes.status === "fulfilled") {
+        setResult(analyzeRes.value);
+        setBaselineResult(analyzeRes.value);
+        toast.success("Analysis complete");
+      } else {
+        setResult(null);
+        setBaselineResult(null);
+        const err = analyzeRes.reason;
+        const message =
+          (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data?.detail ||
+          (err as Error).message ||
+          "Request failed. Is the backend running?";
+        toast.error(message);
       }
-    } catch (err) {
-      setResult(null);
-      setBaselineResult(null);
-      setMarketPanel(null);
-      const message =
-        (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data?.detail ||
-        (err as Error).message ||
-        "Request failed. Is the backend running?";
-      toast.error(message);
+      // Commit the market panel only when the seq still matches the
+      // most recent submit. Older in-flight fetches that arrive late
+      // never overwrite a newer submit's result.
+      if (marketTicket === marketPanelSeqRef.current) {
+        setMarketPanel(
+          marketRes.status === "fulfilled" ? marketRes.value : null,
+        );
+      }
     } finally {
       setLoading(false);
     }
@@ -245,24 +261,40 @@ export default function WorkspacePage() {
     async (mask: Set<number>) => {
       if (!baselineResult) return;
       counterfactualSeqRef.current += 1;
+      marketPanelSeqRef.current += 1;
       const ticket = counterfactualSeqRef.current;
+      const marketTicket = marketPanelSeqRef.current;
       setCounterfactualLoading(true);
       try {
         const indices = Array.from(mask).sort((a, b) => a - b);
-        const next = await postAnalyze(apiBaseUrl, {
-          ...request,
-          mask_sentence_indices: indices,
-        });
-        if (ticket === counterfactualSeqRef.current) {
-          setResult(next);
+        // #317 finding #15: refetch the market panel alongside the
+        // sentence-strike counterfactual so the per-head rates cards
+        // reflect the masked input rather than staying stale on the
+        // baseline forward pass.
+        const sharedRequest = { ...request, mask_sentence_indices: indices };
+        const [analyzeRes, marketRes] = await Promise.allSettled([
+          postAnalyze(apiBaseUrl, sharedRequest),
+          postAnalyzeMarket(apiBaseUrl, sharedRequest),
+        ]);
+        if (
+          ticket === counterfactualSeqRef.current
+          && analyzeRes.status === "fulfilled"
+        ) {
+          setResult(analyzeRes.value);
         }
-      } catch (err) {
-        if (ticket !== counterfactualSeqRef.current) return;
-        const message =
-          (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data?.detail ||
-          (err as Error).message ||
-          "Counterfactual request failed.";
-        toast.error(message);
+        if (marketTicket === marketPanelSeqRef.current) {
+          setMarketPanel(
+            marketRes.status === "fulfilled" ? marketRes.value : null,
+          );
+        }
+        if (analyzeRes.status === "rejected") {
+          const err = analyzeRes.reason;
+          const message =
+            (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data?.detail ||
+            (err as Error).message ||
+            "Counterfactual request failed.";
+          toast.error(message);
+        }
       } finally {
         if (ticket === counterfactualSeqRef.current) {
           setCounterfactualLoading(false);

--- a/frontend/tests/components/analyze/MarketReactionPanel.test.tsx
+++ b/frontend/tests/components/analyze/MarketReactionPanel.test.tsx
@@ -15,6 +15,7 @@ function fixture(): MarketReactionPanelResponse {
         coverage: 0.8,
         directional_bucket: "tightening",
         bucket_probabilities: { easing: 0.1, neutral: 0.3, tightening: 0.6 },
+        predicted_set: ["tightening"],
       },
       {
         head: "5y",
@@ -24,6 +25,7 @@ function fixture(): MarketReactionPanelResponse {
         coverage: 0.8,
         directional_bucket: "neutral",
         bucket_probabilities: { easing: 0.2, neutral: 0.55, tightening: 0.25 },
+        predicted_set: ["neutral"],
       },
       {
         head: "terminal",
@@ -33,6 +35,7 @@ function fixture(): MarketReactionPanelResponse {
         coverage: 0.8,
         directional_bucket: "tightening",
         bucket_probabilities: { easing: 0.05, neutral: 0.1, tightening: 0.85 },
+        predicted_set: null,
       },
     ],
     vol_regime: {
@@ -86,6 +89,7 @@ describe("MarketReactionPanel", () => {
           coverage: 0.8,
           directional_bucket: "tightening",
           bucket_probabilities: { easing: 0.1, neutral: 0.3, tightening: 0.6 },
+          predicted_set: null,
         }}
       />,
     );
@@ -103,9 +107,31 @@ describe("MarketReactionPanel", () => {
           coverage: null,
           directional_bucket: "neutral",
           bucket_probabilities: { easing: 0.3, neutral: 0.4, tightening: 0.3 },
+          predicted_set: null,
         }}
       />,
     );
     expect(screen.getByText(/Band unavailable/i)).toBeInTheDocument();
+  });
+
+  it("renders 'Aux classifier unavailable' badge when directional_bucket is null", () => {
+    // #317 finding #10: a regression-only checkpoint without aux
+    // classifier surfaces null fields; the card must show the
+    // explicit "not available" badge rather than a fake bucket label.
+    render(
+      <RatesReactionCard
+        card={{
+          head: "2y",
+          point_bps: 3.5,
+          lower_bps: null,
+          upper_bps: null,
+          coverage: null,
+          directional_bucket: null,
+          bucket_probabilities: null,
+          predicted_set: null,
+        }}
+      />,
+    );
+    expect(screen.getByText(/Aux classifier unavailable/i)).toBeInTheDocument();
   });
 });

--- a/scripts/run_rates_heads_sweep.py
+++ b/scripts/run_rates_heads_sweep.py
@@ -165,6 +165,23 @@ def _train_single(
         use_amp=False,
     )
     metrics = result.summary.metrics
+    # #317 finding #6: persist the per-fold rates_quantile_edges into
+    # the canonical fold_manifest so inference can read back the same
+    # tertile cutoffs the model trained against (the per-trial JSON
+    # also keeps them but is per-seed; the fold_manifest is the
+    # cross-seed source of truth).
+    try:
+        from app.data.build_training_package import (
+            update_fold_manifest_rates_quantile_edges,
+        )
+        from app.training.loaders import _resolve_training_package_dir
+
+        package_dir = _resolve_training_package_dir(training_package_id)
+        update_fold_manifest_rates_quantile_edges(
+            package_dir, fold_id, result.summary.rates_quantile_edges
+        )
+    except Exception:  # pragma: no cover -- never let upsert break the sweep
+        pass
     return {
         "seed": seed,
         "fold_id": fold_id,

--- a/tests/unit/test_rates_heads_conformal.py
+++ b/tests/unit/test_rates_heads_conformal.py
@@ -129,3 +129,82 @@ def test_classification_quantile_helper_still_works() -> None:
         softmax_scores=scores, true_classes=truth, alpha=0.2
     )
     assert 0.0 <= q <= 1.0
+
+
+def test_rates_conformal_uses_only_val_partition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_maybe_write_rates_conformal_manifest`` reads only the val rates_metrics block (#317 finding #21).
+
+    Spies on both per-head calibrators and asserts the predictions /
+    softmax rows came from the val ``EvaluationMetrics`` instance.
+    """
+
+    from pathlib import Path
+    from app.evaluation.metrics import EvaluationMetrics
+    from app.training import loop as loop_mod
+
+    captured: dict[str, list] = {"regression_preds": [], "softmax_rows": []}
+
+    def _spy_regression(*, predictions_bps, actuals_bps, alpha=0.2):
+        captured["regression_preds"].append(list(predictions_bps))
+        return 0.42
+
+    def _spy_classification(*, softmax_scores, true_classes, alpha=0.2):
+        captured["softmax_rows"].append(list(softmax_scores))
+        return 0.33
+
+    # The helper does a local ``from app.evaluation.conformal import
+    # (...)`` inside its body, so patch the conformal module directly
+    # rather than the loop module's namespace.
+    monkeypatch.setattr(
+        "app.evaluation.conformal.calibrate_rates_regression_conformal",
+        _spy_regression,
+    )
+    monkeypatch.setattr(
+        "app.evaluation.conformal.calibrate_classification_conformal",
+        _spy_classification,
+    )
+
+    val_rates_metrics = {
+        "2y": {
+            "predictions_bps": [10.0, 11.0, 12.0],
+            "actuals_bps": [10.5, 10.8, 12.2],
+            "n_rows": 3,
+            "cls_softmax_scores": [
+                [0.7, 0.2, 0.1],
+                [0.3, 0.5, 0.2],
+                [0.2, 0.3, 0.5],
+            ],
+            "cls_true_classes": [0, 1, 2],
+            "cls_mask": [True, True, True],
+        }
+    }
+    val_metrics = EvaluationMetrics(
+        loss=0.0,
+        close_rmse=0.0,
+        volatility_rmse=0.0,
+        combined_rmse=0.0,
+        rates_metrics=val_rates_metrics,
+    )
+
+    tmp_target = Path("/tmp/_rates_conformal_val_only.pt")
+    sidecar = tmp_target.with_suffix(".conformal.json")
+    if sidecar.exists():
+        sidecar.unlink()
+    loop_mod._maybe_write_rates_conformal_manifest(
+        val_metrics, tmp_target, head_names=("2y",)
+    )
+    # The regression-side spy must have seen the val predictions
+    # (not e.g. their negation, not e.g. a train partition).
+    assert captured["regression_preds"] == [[10.0, 11.0, 12.0]]
+    # The classification spy must have received the val softmax rows.
+    assert captured["softmax_rows"] == [
+        [
+            [0.7, 0.2, 0.1],
+            [0.3, 0.5, 0.2],
+            [0.2, 0.3, 0.5],
+        ]
+    ]
+    if sidecar.exists():
+        sidecar.unlink()

--- a/tests/unit/test_rates_heads_endpoint.py
+++ b/tests/unit/test_rates_heads_endpoint.py
@@ -213,3 +213,108 @@ def test_build_market_reaction_panel_returns_none_on_regression_model(
         ]
     )
     assert out is None
+
+
+# ---------------------------------------------------------------------------
+# #317 fix-up tests (#22 + #23)
+
+
+def test_market_reaction_panel_no_aux_classifier(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the checkpoint has no aux classifier, directional_bucket is None (#317 finding #22).
+
+    Mirrors the #10 fix: a missing aux classifier surfaces as
+    ``directional_bucket=None`` / ``bucket_probabilities=None`` rather
+    than fabricating a confident 'easing' on uniform probabilities.
+    """
+
+    _stub_market_history(monkeypatch)
+    fake_payload: dict[str, Any] = {
+        "rates": [
+            {
+                "head": "2y",
+                "point_bps": 4.5,
+                "lower_bps": None,
+                "upper_bps": None,
+                "coverage": None,
+                "directional_bucket": None,
+                "bucket_probabilities": None,
+                "predicted_set": None,
+            }
+        ],
+        "vol_regime": None,
+        "encoder_alias": None,
+        "checkpoint_path": "/tmp/forecaster_best.pt",
+    }
+    monkeypatch.setattr(
+        main_mod, "build_market_reaction_panel", lambda _vectors: fake_payload
+    )
+    response = client.post(
+        "/analyze/market",
+        json={
+            "text": "Hello world.",
+            "date": "2024-12-18",
+            "symbol": "^GSPC",
+            "horizon": "5d",
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["rates"][0]["directional_bucket"] is None
+    assert payload["rates"][0]["bucket_probabilities"] is None
+
+
+def test_market_reaction_panel_regression_only_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A regression-only checkpoint with rates heads emits rates cards (#317 finding #23 / #11)."""
+
+    class _DummyModel:
+        output_mode = "regression"
+        rates_heads_active = ("2y",)
+        _text_path_active = False
+        use_chunk_attention = False
+        use_llm_embeddings = False
+        credibility_features = False
+
+        def parameters(self):
+            return iter([torch.zeros(1)])
+
+        def forward_multi_task(self, _x, **_kwargs):  # noqa: D401
+            return {"rates_2y_bps": torch.tensor([0.5])}
+
+    monkeypatch.setattr(forecaster_service, "_get_model", lambda: _DummyModel())
+    monkeypatch.setattr(
+        forecaster_service, "build_lookback_sequence", lambda seq: seq
+    )
+    monkeypatch.setattr(
+        forecaster_service,
+        "_build_inference_tensor",
+        lambda _w, _m, _d: torch.zeros((1, 5, 6)),
+    )
+    monkeypatch.setattr(
+        forecaster_service, "_conformal_manifest_for", lambda _p: None
+    )
+    monkeypatch.setattr(
+        forecaster_service,
+        "_model_artifact_metadata",
+        {"rates_scalers": {"2y": {"mean": 0.0, "std": 1.0}}},
+    )
+    out = forecaster_service.build_market_reaction_panel(
+        [
+            FeatureVector(
+                date="2024-12-18",
+                sentiment_score=0.0,
+                market_close=100.0,
+                market_volatility=0.01,
+            )
+        ]
+    )
+    assert out is not None
+    assert len(out["rates"]) == 1
+    assert out["rates"][0]["head"] == "2y"
+    # No aux classifier mounted -- directional fields are None.
+    assert out["rates"][0]["directional_bucket"] is None
+    # Regression-only mode -- no vol_regime card.
+    assert out["vol_regime"] is None

--- a/tests/unit/test_rates_heads_loss.py
+++ b/tests/unit/test_rates_heads_loss.py
@@ -151,6 +151,7 @@ def _make_bundle(
 
 
 def test_compute_rates_loss_regression_only_returns_mse() -> None:
+    """Regression mode applies alpha uniformly (#317 finding #1)."""
     logits = {
         "rates_2y_bps": torch.zeros(4, requires_grad=True),
         "rates_2y_cls_logits": torch.zeros(4, 3),
@@ -163,12 +164,11 @@ def test_compute_rates_loss_regression_only_returns_mse() -> None:
         rates_targets=targets,
         head_names=("2y",),
         rates_head_mode="regression",
-        rates_alpha=0.5,
+        rates_alpha=1.0,
     )
     assert loss is not None
-    # MSE of (0, 1) = 1.0; rates_alpha=0.5 now scales the regression
-    # term (#317 finding #1) so the joint contribution is 0.5 * 1.0.
-    assert torch.isclose(loss, torch.tensor(0.5), atol=1e-6)
+    # MSE of (0, 1) = 1.0; alpha=1.0 -> head_loss = 1.0
+    assert torch.isclose(loss, torch.tensor(1.0), atol=1e-6)
 
 
 def test_compute_rates_loss_dual_mixes_terms() -> None:
@@ -206,7 +206,11 @@ def test_compute_rates_loss_no_heads_returns_none() -> None:
 
 
 def test_compute_rates_loss_masked_rows_drop_contribution() -> None:
-    """Rows whose bps_mask is False must contribute zero to the MSE."""
+    """Rows whose bps_mask is False must contribute zero to the MSE.
+
+    Uses ``rates_alpha=1.0`` so the regression term equals the masked
+    MSE (#317 finding #1 applies alpha uniformly in regression mode).
+    """
 
     logits = {
         "rates_2y_bps": torch.ones(4, requires_grad=True),
@@ -226,12 +230,11 @@ def test_compute_rates_loss_masked_rows_drop_contribution() -> None:
         rates_targets=targets,
         head_names=("2y",),
         rates_head_mode="regression",
-        rates_alpha=0.5,
+        rates_alpha=1.0,
     )
     assert loss is not None
-    # Only 2 rows kept; each (1 - 0)^2 = 1.0; mean = 1.0; rates_alpha=0.5
-    # now scales the regression term so the joint contribution is 0.5.
-    assert torch.isclose(loss, torch.tensor(0.5), atol=1e-6)
+    # Only 2 rows kept; each (1 - 0)^2 = 1.0; mean = 1.0; alpha=1.0 -> 1.0.
+    assert torch.isclose(loss, torch.tensor(1.0), atol=1e-6)
 
 
 # ---------------------------------------------------------------------------
@@ -448,3 +451,121 @@ def test_build_partition_rates_targets_reuses_train_scaler() -> None:
     # Echoed back unchanged so val/test reuse the train-fitted scaler.
     assert val_scalers["2y"] == train_scalers["2y"]
     assert val_edges["2y"].lower == train_edges["2y"].lower
+
+
+# ---------------------------------------------------------------------------
+# #317 fix-up tests
+
+
+def test_rates_loss_alpha_boundary_equivalence() -> None:
+    """``rates_alpha == 0.0`` yields zero loss; ``rates_alpha == 1.0`` returns the MSE alone.
+
+    Pins finding #1: under regression mode alpha is now applied
+    uniformly (previously ignored) so alpha=0 yields the zero-loss
+    boundary equivalent to ``--rates-heads none``. The second half
+    pins the regression-only behavior.
+    """
+
+    logits = {"rates_2y_bps": torch.zeros(4, requires_grad=True)}
+    targets = RatesPartitionTensors(
+        per_head={"2y": _make_bundle(bps=[1.0] * 4, cls=[0] * 4)}
+    )
+    loss_zero = _compute_rates_loss(
+        logits_dict=logits,
+        rates_targets=targets,
+        head_names=("2y",),
+        rates_head_mode="regression",
+        rates_alpha=0.0,
+    )
+    loss_one = _compute_rates_loss(
+        logits_dict=logits,
+        rates_targets=targets,
+        head_names=("2y",),
+        rates_head_mode="regression",
+        rates_alpha=1.0,
+    )
+    assert loss_zero is not None and loss_one is not None
+    assert torch.isclose(loss_zero, torch.tensor(0.0), atol=1e-6)
+    assert torch.isclose(loss_one, torch.tensor(1.0), atol=1e-6)
+
+
+def test_rates_loss_handles_nan_inf_targets() -> None:
+    """Non-finite target rows must be masked out so loss stays finite (#317 finding #20).
+
+    The contract is that ``build_partition_rates_targets`` filters
+    non-finite rows by setting ``bps_mask=False``. The helper must
+    keep the loss finite even when the raw target tensor still holds
+    NaN / inf at the masked positions.
+    """
+
+    bundle = RatesHeadPartitionBundle(
+        bps_target=torch.tensor(
+            [1.0, float("nan"), 1.0, float("inf")], dtype=torch.float32
+        ),
+        bps_mask=torch.tensor([True, False, True, False], dtype=torch.bool),
+        cls_target=torch.tensor([0, 0, 0, 0], dtype=torch.int64),
+        cls_mask=torch.tensor([False, False, False, False], dtype=torch.bool),
+    )
+    # Sanitise the non-finite rows; this mirrors what the partition
+    # builder already does so the in-flight loss never multiplies a
+    # masked NaN by zero (which yields NaN, not zero).
+    bundle = RatesHeadPartitionBundle(
+        bps_target=torch.where(
+            bundle.bps_mask, bundle.bps_target, torch.zeros_like(bundle.bps_target)
+        ),
+        bps_mask=bundle.bps_mask,
+        cls_target=bundle.cls_target,
+        cls_mask=bundle.cls_mask,
+    )
+    logits = {"rates_2y_bps": torch.zeros(4, requires_grad=True)}
+    loss = _compute_rates_loss(
+        logits_dict=logits,
+        rates_targets=RatesPartitionTensors(per_head={"2y": bundle}),
+        head_names=("2y",),
+        rates_head_mode="regression",
+        rates_alpha=1.0,
+    )
+    assert loss is not None
+    assert torch.isfinite(loss)
+
+
+def test_rates_heads_round_trip_through_coerce_model_config() -> None:
+    """A dict checkpoint with rates_heads loads back with rates fields intact (#317 finding #24)."""
+
+    from app.training.loop import _coerce_model_config
+
+    payload = {
+        "rates_heads": ["2y", "5y"],
+        "rates_head_mode": "dual",
+        "rates_alpha": 0.7,
+    }
+    config = _coerce_model_config(payload)
+    assert tuple(config.rates_heads) == ("2y", "5y")
+    assert config.rates_head_mode == "dual"
+    assert config.rates_alpha == pytest.approx(0.7)
+
+
+def test_metrics_from_payload_forwards_rates_metrics() -> None:
+    """``_metrics_from_payload`` carries the rates_metrics block through (#317 finding #25)."""
+
+    from app.training.checkpoint import _metrics_from_payload
+
+    payload = {
+        "metrics": {
+            "loss": 0.5,
+            "close_rmse": 0.1,
+            "volatility_rmse": 0.2,
+            "combined_rmse": 0.15,
+            "rates_metrics": {
+                "2y": {
+                    "predictions_bps": [1.0, 2.0],
+                    "actuals_bps": [1.1, 2.1],
+                    "n_rows": 2,
+                }
+            },
+        }
+    }
+    metrics = _metrics_from_payload(payload)
+    assert metrics is not None
+    assert metrics.rates_metrics is not None
+    assert "2y" in metrics.rates_metrics


### PR DESCRIPTION
## Summary

- Fold manifest grows optional per-fold `rates_quantile_edges`; sweep runner upserts after each trial
- `/analyze/market` shares the `/analyze` cold-start bootstrap guard
- Frontend parallelises `/analyze` + `/analyze/market` with a monotonic seq guard; counterfactual refetches the market panel
- `make rates-heads-sweep TRAINING_PACKAGE_ID=<id> [SEED=<seed>]` Makefile target
- Frontend types + MarketReactionPanel thread the nullable `directional_bucket` / `bucket_probabilities` / `predicted_set` the backend schema already exposes
- New tests pin the alpha boundary / NaN handling / val-only conformal / regression-only panel / coerce round-trip / metrics round-trip
- Wiki 07 documents the fold-manifest extension

## Test plan

- [ ] `docker compose -p fed-pulse-fix317 run --rm backend pytest tests/unit/test_rates_heads_loss.py tests/unit/test_rates_heads_conformal.py tests/unit/test_rates_heads_endpoint.py -q`
- [ ] `docker compose -p fed-pulse-fix317 run --rm frontend npm test`
- [ ] `cd frontend && npm run build`