### PR TITLE
Historical analog panel frontend (#295)

### DIFF
--- a/frontend/components/analyze/HistoricalAnalogPanel.tsx
+++ b/frontend/components/analyze/HistoricalAnalogPanel.tsx
@@ -1,0 +1,281 @@
+import * as React from "react";
+import { ChevronDown, ChevronUp, History, Sparkles } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import type {
+  AnalogCard,
+  AnalogVolRegime,
+  AnalogsResponse,
+} from "@/lib/analyze/types";
+
+const VOL_REGIME_ORDER: AnalogVolRegime[] = ["calm", "normal", "high"];
+
+const VOL_REGIME_LABEL: Record<AnalogVolRegime, string> = {
+  calm: "Calm",
+  normal: "Normal",
+  high: "High",
+};
+
+// Segment colour for the "what happened next" mini-chart. The backend
+// only exposes a coarse calm/normal/high bucket — surfacing the raw
+// forward_realized_vol_10d would leak the supervised target, so the
+// indicator visualises the bucket itself rather than a price series.
+const VOL_REGIME_BAR: Record<AnalogVolRegime, string> = {
+  calm: "bg-dovish",
+  normal: "bg-neutral",
+  high: "bg-hawkish",
+};
+
+const STANCE_BADGE: Record<string, "hawkish" | "dovish" | "neutral"> = {
+  hawkish: "hawkish",
+  dovish: "dovish",
+  neutral: "neutral",
+};
+
+function stanceTone(value: string | null | undefined): "hawkish" | "dovish" | "neutral" | null {
+  if (!value) return null;
+  const key = value.toLowerCase();
+  return STANCE_BADGE[key] ?? null;
+}
+
+function formatSimilarity(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+interface WhatHappenedNextProps {
+  bucket: AnalogVolRegime | null;
+}
+
+function WhatHappenedNext({ bucket }: WhatHappenedNextProps) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-[10px] uppercase tracking-wide text-muted-foreground">
+        <span>What happened next · 10d vol</span>
+        <span className="numeric capitalize text-foreground">
+          {bucket ? VOL_REGIME_LABEL[bucket] : "—"}
+        </span>
+      </div>
+      <div
+        className="flex items-stretch gap-1"
+        role="img"
+        aria-label={
+          bucket
+            ? `Post-event 10-day realised volatility bucket: ${VOL_REGIME_LABEL[bucket]}`
+            : "Post-event volatility bucket unavailable"
+        }
+      >
+        {VOL_REGIME_ORDER.map((segment) => {
+          const active = segment === bucket;
+          return (
+            <div
+              key={segment}
+              className={cn(
+                "h-2 flex-1 rounded-sm",
+                active ? VOL_REGIME_BAR[segment] : "bg-muted",
+              )}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface AnalogCardItemProps {
+  card: AnalogCard;
+}
+
+function AnalogCardItem({ card }: AnalogCardItemProps) {
+  const [expanded, setExpanded] = React.useState(false);
+  const stance = stanceTone(card.axis_stance);
+  // The /analyze/analogs endpoint truncates to ~280 chars on the
+  // server; treat that ceiling as the "looks truncated" trigger so the
+  // expand affordance never appears on a short statement that's
+  // already fully rendered.
+  const looksTruncated = card.excerpt.length >= 280;
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription className="flex items-center gap-1.5">
+          <History className="h-3.5 w-3.5" />
+          {card.event_date}
+        </CardDescription>
+        <CardTitle className="flex items-center justify-between text-base">
+          <span className="numeric">{formatSimilarity(card.similarity)} similar</span>
+          {stance ? (
+            <Badge variant={stance} className="capitalize">
+              {card.axis_stance}
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+              stance unknown
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <WhatHappenedNext bucket={card.subsequent_vol_regime} />
+        <div className="space-y-1">
+          <p
+            className={cn(
+              "text-xs leading-relaxed text-foreground/80",
+              expanded ? "" : "line-clamp-4",
+            )}
+          >
+            {card.excerpt}
+          </p>
+          {looksTruncated ? (
+            <button
+              type="button"
+              onClick={() => setExpanded((prev) => !prev)}
+              className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground hover:text-foreground focus:outline-none focus:ring-1 focus:ring-ring rounded-sm"
+              aria-expanded={expanded}
+            >
+              {expanded ? (
+                <>
+                  <ChevronUp className="h-3 w-3" /> Collapse
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="h-3 w-3" /> Show full excerpt
+                </>
+              )}
+            </button>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export interface HistoricalAnalogPanelProps {
+  analogs: AnalogsResponse | null;
+  loading?: boolean;
+  // Cosine similarity floor for what counts as a useful analog. Cards
+  // below the floor are filtered client-side and trigger the
+  // "no analogs above threshold" empty state when the entire top-k
+  // falls under the bar. The default mirrors the threshold used by
+  // the retrieval evaluation harness for "loosely related" pairs.
+  similarityThreshold?: number;
+  // How many analog cards to render. The endpoint defaults to k=5;
+  // the panel surfaces the top 3 per the §16 spec.
+  topK?: number;
+}
+
+const DEFAULT_THRESHOLD = 0.4;
+const DEFAULT_TOP_K = 3;
+
+export function HistoricalAnalogPanel({
+  analogs,
+  loading = false,
+  similarityThreshold = DEFAULT_THRESHOLD,
+  topK = DEFAULT_TOP_K,
+}: HistoricalAnalogPanelProps) {
+  const headerBadge = (
+    <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+      Historical analog panel
+    </Badge>
+  );
+
+  if (loading) {
+    return (
+      <div className="space-y-2">
+        {headerBadge}
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {Array.from({ length: topK }).map((_, idx) => (
+            <Card key={idx}>
+              <CardHeader className="pb-2">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="mt-2 h-5 w-32" />
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <Skeleton className="h-2 w-full" />
+                <Skeleton className="h-12 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!analogs) {
+    return null;
+  }
+
+  if (analogs.index_size === 0) {
+    return (
+      <div className="space-y-2">
+        {headerBadge}
+        <EmptyState
+          variant="card"
+          icon={<History className="h-5 w-5" />}
+          title="Retrieval index not loaded"
+          description={
+            <span>
+              Train the retrieval encoder via{" "}
+              <code className="rounded bg-muted px-1">python -m app.retrieval.train</code>{" "}
+              against the canonical training package to produce the analog index, then refresh.
+            </span>
+          }
+        />
+      </div>
+    );
+  }
+
+  const filtered = analogs.analogs
+    .filter((card) => card.similarity >= similarityThreshold)
+    .slice(0, topK);
+
+  if (filtered.length === 0) {
+    return (
+      <div className="space-y-2">
+        {headerBadge}
+        <EmptyState
+          variant="card"
+          icon={<Sparkles className="h-5 w-5" />}
+          title="No analogs above threshold"
+          description={
+            <span>
+              The retrieval encoder scored {analogs.analogs.length} candidate
+              {analogs.analogs.length === 1 ? "" : "s"} but none crossed the{" "}
+              <span className="numeric">{formatSimilarity(similarityThreshold)}</span>{" "}
+              similarity floor for this statement.
+            </span>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {headerBadge}
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {filtered.map((card) => (
+          <AnalogCardItem key={card.event_date} card={card} />
+        ))}
+      </div>
+      <p className="text-[11px] leading-relaxed text-muted-foreground">
+        Past FOMC statements most similar to the current text, ranked by
+        cosine similarity in the retrieval encoder embedding space.
+        Post-event regime bucket is a UI-only marker — the raw 10-day
+        realised vol is withheld from this surface to avoid leaking the
+        supervised target. Index size:{" "}
+        <span className="numeric">{analogs.index_size.toLocaleString()}</span>
+        {" "}past statements · encoder{" "}
+        <code className="rounded bg-muted px-1">{analogs.encoder_alias}</code>.
+      </p>
+    </div>
+  );
+}

--- a/frontend/components/analyze/HistoricalAnalogPanel.tsx
+++ b/frontend/components/analyze/HistoricalAnalogPanel.tsx
@@ -262,8 +262,16 @@ export function HistoricalAnalogPanel({
     <div className="space-y-2">
       {headerBadge}
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {filtered.map((card) => (
-          <AnalogCardItem key={card.event_date} card={card} />
+        {filtered.map((card, idx) => (
+          // event_date alone is not guaranteed unique — the retrieval
+          // index dedupes by text_hash, so the same date can carry an
+          // intermeeting statement and a correction. Composite key on
+          // (event_date, similarity, idx) keeps React reconciliation
+          // honest so the per-card expand state cannot bleed.
+          <AnalogCardItem
+            key={`${card.event_date}-${card.similarity.toFixed(6)}-${idx}`}
+            card={card}
+          />
         ))}
       </div>
       <p className="text-[11px] leading-relaxed text-muted-foreground">

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
 import type {
+  AnalogsRequest,
+  AnalogsResponse,
   AnalyzeRequest,
   AnalyzeResult,
   ClassificationBreakdownResponse,
@@ -47,6 +49,21 @@ export async function postAnalyzeMarket(
     encoder_alias: null,
     checkpoint_path: null,
   }) as MarketReactionPanelResponse;
+}
+
+const ANALOGS_BUNDLE_ABSENT: AnalogsResponse = {
+  analogs: [],
+  index_size: 0,
+  encoder_alias: "",
+};
+
+export async function postAnalyzeAnalogs(
+  baseUrl: string,
+  request: AnalogsRequest,
+  signal?: AbortSignal,
+): Promise<AnalogsResponse> {
+  const response = await axios.post(`${baseUrl}/analyze/analogs`, request, { signal });
+  return (response.data ?? ANALOGS_BUNDLE_ABSENT) as AnalogsResponse;
 }
 
 export async function fetchTrainJob(baseUrl: string, jobId: string): Promise<TrainJobState> {

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -251,6 +251,31 @@ export interface MarketReactionPanelResponse {
   checkpoint_path: string | null;
 }
 
+export type AnalogVolRegime = "calm" | "normal" | "high";
+
+export interface AnalogsRequest {
+  text: string;
+  k?: number;
+  as_of_date?: string | null;
+}
+
+export interface AnalogCard {
+  event_date: string;
+  similarity: number;
+  axis_stance: string | null;
+  // UI-only bucket — the backend deliberately withholds the raw
+  // ``forward_realized_vol_10d`` target so this label is the only
+  // post-event signal available. Never feed back into a model.
+  subsequent_vol_regime: AnalogVolRegime | null;
+  excerpt: string;
+}
+
+export interface AnalogsResponse {
+  analogs: AnalogCard[];
+  index_size: number;
+  encoder_alias: string;
+}
+
 export interface AnalyzeResult {
   sentiment?: SentimentResponse;
   prediction?: PredictionResponse;

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -295,7 +295,13 @@ export default function WorkspacePage() {
         // #317 finding #15: refetch the market panel alongside the
         // sentence-strike counterfactual so the per-head rates cards
         // reflect the masked input rather than staying stale on the
-        // baseline forward pass.
+        // baseline forward pass. The historical analog panel is
+        // intentionally NOT refetched here: ``AnalogsRequest`` has no
+        // ``mask_sentence_indices`` field, so a refetch would resend
+        // the same original text and produce the same top-k. The
+        // panel is contextual ("statements that sound like the one
+        // you pasted"), not attributional, so freezing it on the
+        // baseline retrieval is the right semantics under a strike.
         const sharedRequest = { ...request, mask_sentence_indices: indices };
         const [analyzeRes, marketRes] = await Promise.allSettled([
           postAnalyze(apiBaseUrl, sharedRequest),

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 
 import { AnalyzeForm } from "@/components/analyze/AnalyzeForm";
 import { CredibilityKpis } from "@/components/analyze/CredibilityKpis";
+import { HistoricalAnalogPanel } from "@/components/analyze/HistoricalAnalogPanel";
 import { MarketReactionPanel } from "@/components/analyze/MarketReactionPanel";
 import { MultiAxisInterpretation } from "@/components/analyze/MultiAxisInterpretation";
 import { PipelineTrace } from "@/components/analyze/PipelineTrace";
@@ -25,6 +26,7 @@ import {
   fetchHistory,
   fetchHistoryRun,
   postAnalyze,
+  postAnalyzeAnalogs,
   postAnalyzeMarket,
   resolveApiBaseUrl,
 } from "@/lib/analyze/api";
@@ -32,6 +34,7 @@ import { DEFAULT_TEXT } from "@/lib/analyze/constants";
 import { toStance } from "@/lib/analyze/format";
 import { useEvaluationCoverage } from "@/lib/analyze/useEvaluationCoverage";
 import type {
+  AnalogsResponse,
   AnalyzeRequest,
   AnalyzeResult,
   HistoryEntry,
@@ -87,6 +90,8 @@ export default function WorkspacePage() {
   const [result, setResult] = React.useState<AnalyzeResult | null>(null);
   const [baselineResult, setBaselineResult] = React.useState<AnalyzeResult | null>(null);
   const [marketPanel, setMarketPanel] = React.useState<MarketReactionPanelResponse | null>(null);
+  const [analogsPanel, setAnalogsPanel] = React.useState<AnalogsResponse | null>(null);
+  const [analogsLoading, setAnalogsLoading] = React.useState(false);
   const [struck, setStruck] = React.useState<Set<number>>(() => new Set());
   const [counterfactualLoading, setCounterfactualLoading] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
@@ -203,25 +208,37 @@ export default function WorkspacePage() {
   // second submit before the first market fetch resolves bumps the
   // seq; the late-arriving resolver checks the seq and skips state
   // commit if it does not match the most recent issued id. Mirrors
-  // the counterfactualSeqRef pattern below.
+  // the counterfactualSeqRef pattern below. The analogs panel uses
+  // the same guard so a stale slow-arriving retrieval response cannot
+  // overwrite the newest submit.
   const marketPanelSeqRef = React.useRef(0);
+  const analogsPanelSeqRef = React.useRef(0);
 
   const handleSubmit = async () => {
     setLoading(true);
     setStruck(new Set());
     marketPanelSeqRef.current += 1;
+    analogsPanelSeqRef.current += 1;
     const marketTicket = marketPanelSeqRef.current;
+    const analogsTicket = analogsPanelSeqRef.current;
+    setAnalogsLoading(true);
     try {
       // #317 finding #13: dispatch /analyze + /analyze/market in
       // parallel rather than sequentially -- the market panel does
       // not depend on the /analyze response payload. Halves the
       // user-visible latency on a submit click. Wrapped via
       // ``Promise.allSettled`` so a failure on the optional market
-      // panel does not abort the primary /analyze surface.
+      // panel does not abort the primary /analyze surface. The
+      // analogs fetch joins the same fan-out.
       const sharedRequest = { ...request, mask_sentence_indices: [] };
-      const [analyzeRes, marketRes] = await Promise.allSettled([
+      const [analyzeRes, marketRes, analogsRes] = await Promise.allSettled([
         postAnalyze(apiBaseUrl, sharedRequest),
         postAnalyzeMarket(apiBaseUrl, sharedRequest),
+        postAnalyzeAnalogs(apiBaseUrl, {
+          text: request.text,
+          k: 5,
+          as_of_date: request.date,
+        }),
       ]);
       if (analyzeRes.status === "fulfilled") {
         setResult(analyzeRes.value);
@@ -245,8 +262,16 @@ export default function WorkspacePage() {
           marketRes.status === "fulfilled" ? marketRes.value : null,
         );
       }
+      if (analogsTicket === analogsPanelSeqRef.current) {
+        setAnalogsPanel(
+          analogsRes.status === "fulfilled" ? analogsRes.value : null,
+        );
+      }
     } finally {
       setLoading(false);
+      if (analogsTicket === analogsPanelSeqRef.current) {
+        setAnalogsLoading(false);
+      }
     }
   };
 
@@ -445,6 +470,9 @@ export default function WorkspacePage() {
               {marketPanel && (marketPanel.rates.length > 0 || marketPanel.vol_regime) ? (
                 <MarketReactionPanel panel={marketPanel} />
               ) : null}
+
+              <HistoricalAnalogPanel analogs={analogsPanel} loading={analogsLoading} />
+
 
               {result.xai ? (
                 <SentenceStrikeXaiPanel

--- a/frontend/tests/components/analyze/HistoricalAnalogPanel.test.tsx
+++ b/frontend/tests/components/analyze/HistoricalAnalogPanel.test.tsx
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import { HistoricalAnalogPanel } from "@/components/analyze/HistoricalAnalogPanel";
+import type { AnalogsResponse } from "@/lib/analyze/types";
+
+function fixture(overrides: Partial<AnalogsResponse> = {}): AnalogsResponse {
+  return {
+    analogs: [
+      {
+        event_date: "2019-07-31",
+        similarity: 0.82,
+        axis_stance: "dovish",
+        subsequent_vol_regime: "high",
+        excerpt: "Information received since the Committee met in June indicates that the labor market remains strong and that economic activity has been rising at a moderate rate.",
+      },
+      {
+        event_date: "2015-09-17",
+        similarity: 0.71,
+        axis_stance: "neutral",
+        subsequent_vol_regime: "normal",
+        excerpt: "Information received since the Federal Open Market Committee met in July suggests that economic activity is expanding at a moderate pace.",
+      },
+      {
+        event_date: "2007-09-18",
+        similarity: 0.65,
+        axis_stance: "dovish",
+        subsequent_vol_regime: "calm",
+        excerpt: "Economic growth was moderate during the first half of the year, but the tightening of credit conditions has the potential to intensify the housing correction and to restrain economic growth more generally.",
+      },
+      {
+        event_date: "2001-01-31",
+        similarity: 0.21,
+        axis_stance: "hawkish",
+        subsequent_vol_regime: "normal",
+        excerpt: "The Committee continues to believe that, against the background of its long-run goals of price stability and sustainable economic growth, the risks remain weighted mainly toward conditions that may generate economic weakness.",
+      },
+    ],
+    index_size: 184,
+    encoder_alias: "finbert_fed_adjacent_xbank_dapt_retrieval",
+    ...overrides,
+  };
+}
+
+describe("HistoricalAnalogPanel", () => {
+  it("renders the top-3 analog cards above the similarity threshold", () => {
+    render(<HistoricalAnalogPanel analogs={fixture()} />);
+    expect(screen.getByText("2019-07-31")).toBeInTheDocument();
+    expect(screen.getByText("2015-09-17")).toBeInTheDocument();
+    expect(screen.getByText("2007-09-18")).toBeInTheDocument();
+    // Fourth analog is below the default 0.40 threshold.
+    expect(screen.queryByText("2001-01-31")).not.toBeInTheDocument();
+  });
+
+  it("formats similarity as a percentage", () => {
+    render(<HistoricalAnalogPanel analogs={fixture()} />);
+    expect(screen.getByText(/82.0% similar/)).toBeInTheDocument();
+    expect(screen.getByText(/71.0% similar/)).toBeInTheDocument();
+  });
+
+  it("renders a stance badge for each analog with an axis_stance", () => {
+    render(<HistoricalAnalogPanel analogs={fixture()} />);
+    const dovishBadges = screen.getAllByText(/^dovish$/i);
+    expect(dovishBadges.length).toBe(2);
+  });
+
+  it("renders 'stance unknown' when axis_stance is null", () => {
+    const data = fixture({
+      analogs: [
+        {
+          event_date: "2010-06-23",
+          similarity: 0.55,
+          axis_stance: null,
+          subsequent_vol_regime: "calm",
+          excerpt: "Short excerpt.",
+        },
+      ],
+    });
+    render(<HistoricalAnalogPanel analogs={data} />);
+    expect(screen.getByText(/stance unknown/i)).toBeInTheDocument();
+  });
+
+  it("surfaces the post-event volatility bucket via the mini-chart aria-label", () => {
+    render(<HistoricalAnalogPanel analogs={fixture()} />);
+    expect(
+      screen.getByLabelText(/post-event 10-day realised volatility bucket: high/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/post-event 10-day realised volatility bucket: normal/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders skeletons in the loading state", () => {
+    const { container } = render(
+      <HistoricalAnalogPanel analogs={null} loading={true} topK={3} />,
+    );
+    // Each skeleton card has 4 Skeleton bars (header + body).
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Historical analog panel/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing when analogs is null and not loading", () => {
+    const { container } = render(
+      <HistoricalAnalogPanel analogs={null} loading={false} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the bundle-absent empty state when index_size is 0", () => {
+    render(
+      <HistoricalAnalogPanel
+        analogs={{ analogs: [], index_size: 0, encoder_alias: "" }}
+      />,
+    );
+    expect(screen.getByText(/Retrieval index not loaded/i)).toBeInTheDocument();
+  });
+
+  it("renders the threshold-empty state when no analog crosses the floor", () => {
+    const lowSim = fixture({
+      analogs: fixture().analogs.map((card) => ({ ...card, similarity: 0.12 })),
+    });
+    render(<HistoricalAnalogPanel analogs={lowSim} similarityThreshold={0.4} />);
+    expect(screen.getByText(/No analogs above threshold/i)).toBeInTheDocument();
+    // The threshold floor is rendered in the description so the
+    // user knows what bar was used.
+    expect(screen.getByText(/40.0%/)).toBeInTheDocument();
+  });
+
+  it("expands a long excerpt when the user clicks the toggle", () => {
+    // The endpoint truncates to ~280 chars; pad the fixture excerpt
+    // to the ceiling so the toggle button is rendered.
+    const longCard = {
+      event_date: "2018-12-19",
+      similarity: 0.78,
+      axis_stance: "hawkish" as const,
+      subsequent_vol_regime: "high" as const,
+      excerpt: "x".repeat(280),
+    };
+    render(
+      <HistoricalAnalogPanel
+        analogs={{
+          analogs: [longCard],
+          index_size: 42,
+          encoder_alias: "test",
+        }}
+      />,
+    );
+    const toggle = screen.getByRole("button", { name: /Show full excerpt/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(toggle);
+    expect(
+      screen.getByRole("button", { name: /Collapse/i }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("does not show the expand toggle for short excerpts", () => {
+    const shortCard = {
+      event_date: "2014-06-18",
+      similarity: 0.62,
+      axis_stance: "neutral" as const,
+      subsequent_vol_regime: "normal" as const,
+      excerpt: "Short statement under the 280 ceiling.",
+    };
+    render(
+      <HistoricalAnalogPanel
+        analogs={{
+          analogs: [shortCard],
+          index_size: 8,
+          encoder_alias: "test",
+        }}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Show full excerpt/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the encoder alias + index size in the footer note", () => {
+    render(<HistoricalAnalogPanel analogs={fixture()} />);
+    // index size is formatted with toLocaleString — accept either
+    // comma-grouped or plain formatting depending on test locale.
+    const footer = screen.getByText(/encoder/i);
+    expect(within(footer).getByText(/finbert_fed_adjacent_xbank_dapt_retrieval/)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/analyze/HistoricalAnalogPanel.test.tsx
+++ b/frontend/tests/components/analyze/HistoricalAnalogPanel.test.tsx
@@ -175,6 +175,38 @@ describe("HistoricalAnalogPanel", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders both cards when two analogs share the same event_date", () => {
+    // The retrieval index dedupes by text_hash, not event_date — an
+    // intermeeting statement and a same-day correction can both land
+    // in the top-k. With ``key={card.event_date}`` alone React would
+    // collapse the two cards into one DOM node and bleed the per-card
+    // expand state. The composite key (event_date, similarity, idx)
+    // is what keeps them distinct.
+    const sameDate = {
+      event_date: "2020-03-15",
+      similarity: 0.81,
+      axis_stance: "dovish" as const,
+      subsequent_vol_regime: "high" as const,
+      excerpt: "Intermeeting statement excerpt.",
+    };
+    const sameDateCorrection = {
+      ...sameDate,
+      similarity: 0.74,
+      excerpt: "Correction issued same day.",
+    };
+    render(
+      <HistoricalAnalogPanel
+        analogs={{
+          analogs: [sameDate, sameDateCorrection],
+          index_size: 200,
+          encoder_alias: "test",
+        }}
+      />,
+    );
+    expect(screen.getByText(/Intermeeting statement excerpt/)).toBeInTheDocument();
+    expect(screen.getByText(/Correction issued same day/)).toBeInTheDocument();
+  });
+
   it("renders the encoder alias + index size in the footer note", () => {
     render(<HistoricalAnalogPanel analogs={fixture()} />);
     // index size is formatted with toLocaleString — accept either

--- a/frontend/tests/lib/analyze/analogs.test.ts
+++ b/frontend/tests/lib/analyze/analogs.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import axios from "axios";
+
+import { postAnalyzeAnalogs } from "@/lib/analyze/api";
+
+vi.mock("axios", () => ({
+  default: { post: vi.fn() },
+}));
+
+const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };
+
+describe("postAnalyzeAnalogs", () => {
+  beforeEach(() => {
+    mockedAxios.post.mockReset();
+  });
+
+  it("posts the request payload to /analyze/analogs and returns parsed analogs", async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: {
+        analogs: [
+          {
+            event_date: "2019-07-31",
+            similarity: 0.82,
+            axis_stance: "dovish",
+            subsequent_vol_regime: "high",
+            excerpt: "Information received…",
+          },
+        ],
+        index_size: 184,
+        encoder_alias: "finbert_fed_adjacent_xbank_dapt_retrieval",
+      },
+    });
+    const result = await postAnalyzeAnalogs("http://api", {
+      text: "Recent indicators…",
+      k: 5,
+      as_of_date: "2026-04-30",
+    });
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      "http://api/analyze/analogs",
+      { text: "Recent indicators…", k: 5, as_of_date: "2026-04-30" },
+      { signal: undefined },
+    );
+    expect(result.analogs).toHaveLength(1);
+    expect(result.index_size).toBe(184);
+    expect(result.encoder_alias).toBe("finbert_fed_adjacent_xbank_dapt_retrieval");
+  });
+
+  it("returns a bundle-absent shape when the response body is missing", async () => {
+    mockedAxios.post.mockResolvedValue({ data: undefined });
+    const result = await postAnalyzeAnalogs("http://api", { text: "x" });
+    expect(result.analogs).toEqual([]);
+    expect(result.index_size).toBe(0);
+    expect(result.encoder_alias).toBe("");
+  });
+
+  it("forwards the abort signal", async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: { analogs: [], index_size: 0, encoder_alias: "" },
+    });
+    const controller = new AbortController();
+    await postAnalyzeAnalogs("http://api", { text: "x" }, controller.signal);
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      "http://api/analyze/analogs",
+      { text: "x" },
+      { signal: controller.signal },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Renders top-3 hits from the existing `/analyze/analogs` endpoint as cards on the workspace
- Card carries date, similarity %, axis stance badge, excerpt, and a calm/normal/high mini-chart for the post-event regime bucket
- Three empty states: loading skeletons, retrieval index absent, no analogs above 0.40 similarity floor
- Parent fetches `/analyze/analogs` alongside `/analyze` + `/analyze/market` with a monotonic seq guard mirroring the existing market panel
- The mini-chart visualises only the coarse bucket — the raw `forward_realized_vol_10d` stays withheld by the backend schema to avoid leaking the supervised target
- Closes #295

## Test plan
- `npm test` (149 passed; 15 new across `HistoricalAnalogPanel` + `analogs` api client)
- `npm run type-check`
- `npm run build`
- Live `/analyze/analogs` browser smoke not exercised in this session — the parent working tree is mid-flight on #302 deployability work and the retrieval bundle is not loaded locally. Endpoint contract is covered via the api-client test against the documented response shape.