### PR TITLE
Regression-canonical training objective (#322)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep reproduce-all push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison reproduce-all push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -79,6 +79,8 @@ help:
 	@echo "  make derived-features-ablation TRAINING_PACKAGE_ID=<id>"
 	@echo "  make rates-heads-sweep TRAINING_PACKAGE_ID=<id> [SEED=<seed>]"
 	@echo "                         - Three-way derived-text-features ablation (baseline / ablation / replacement)"
+	@echo "  make canonical-comparison TRAINING_PACKAGE_ID=<id>"
+	@echo "                         - Canonical dual-head comparison (5 seeds x 40 epochs, regression-alpha=0.5, canonical output JSON)"
 
 dev: dev-cpu
 
@@ -735,3 +737,17 @@ rates-heads-sweep:
 		python -m scripts.run_rates_heads_sweep \
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
 		$(if $(SEED),--seeds $(SEED),--seeds 11 29 47 71 97)
+
+# #322 canonical dual-head comparison. Pins the regression-alpha,
+# output path, seed set, and epoch budget the §16 finalization-roadmap
+# table reads, so the canonical run is reproducible without remembering
+# the flag combination. Output lands at
+# ``artifacts/experiments/dual_head_comparison_canonical.json``.
+canonical-comparison:
+	@if [ -z "$$TRAINING_PACKAGE_ID" ]; then echo "TRAINING_PACKAGE_ID required" >&2; exit 1; fi
+	docker compose run --rm backend python -m scripts.run_dual_head_comparison \
+		--training-package-id $$TRAINING_PACKAGE_ID \
+		--output artifacts/experiments/dual_head_comparison_canonical.json \
+		--seeds 11 29 47 71 97 \
+		--epochs 40 \
+		--regression-alpha 0.5

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -320,18 +320,22 @@ class ModelConfig:
     # rare classes, mitigating the class-1 collapse the 3-class vol-regime
     # head exhibits on single-seed runs.
     class_weight_power: float = 1.0
-    # #304 dual-head methodology. ``classification`` (default) keeps the
-    # existing 3-class CrossEntropy head as the only output and is
-    # byte-identical to the pre-#304 path. ``regression`` swaps in a
-    # ``log(forward_realized_vol_10d)`` MSE head only (the classifier
-    # still mounts so the checkpoint shape is stable but its loss
-    # contribution is dropped). ``dual`` keeps both heads and trains
-    # the joint loss ``(1 - regression_alpha) * CE + regression_alpha * MSE``.
-    # The regression head is only meaningful when ``output_mode ==
-    # "classification"`` because that branch carries the
-    # ``forward_realized_vol_10d`` target; regression-output mode
-    # (close, vol) ignores ``head_mode`` entirely.
-    head_mode: str = "classification"
+    # #304 dual-head methodology, recanonicalised under ADR 0015 (#322).
+    # ``regression`` (default) is the canonical objective: a
+    # ``log(forward_realized_vol_10d)`` MSE head only. The 3-class
+    # classifier still mounts so the checkpoint shape stays stable, but
+    # its loss contribution is dropped; bucket labels are recovered at
+    # inference by gating the regression point against
+    # ``vol_regime_quantiles`` (see ``app.services.regime_bucketing``).
+    # ``classification`` keeps the legacy 3-class CrossEntropy head as
+    # the sole supervised signal and is retained for back-compat with
+    # pre-#322 checkpoints and the cross-objective ablation. ``dual``
+    # trains the joint loss ``(1 - regression_alpha) * CE +
+    # regression_alpha * MSE``. The regression head is only meaningful
+    # when ``output_mode == "classification"`` because that branch
+    # carries the ``forward_realized_vol_10d`` target; regression-output
+    # mode (close, vol) ignores ``head_mode`` entirely.
+    head_mode: str = "regression"
     regression_alpha: float = 0.5
     # #309 derived-text-features ablation. ``True`` (default) keeps the
     # FeatureVector's per-bar ``sentiment_score`` slot and the multi-axis
@@ -416,7 +420,7 @@ class ModelConfig:
             multi_task_lambda_certainty=float(getattr(model, "multi_task_lambda_certainty", 0.3)),
             multi_task_lambda_topic=float(getattr(model, "multi_task_lambda_topic", 0.3)),
             class_weight_power=float(getattr(model, "class_weight_power", 1.0)),
-            head_mode=str(getattr(model, "head_mode", "classification") or "classification"),
+            head_mode=str(getattr(model, "head_mode", "regression") or "regression"),
             regression_alpha=float(getattr(model, "regression_alpha", 0.5)),
             use_derived_text_features=bool(
                 getattr(model, "use_derived_text_features", True)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -368,6 +368,33 @@ class RegimeClassificationCard(BaseModel):
     coverage: float
     distribution: dict[str, float]
     argmax_class: str
+    log_rv_point: float | None = Field(
+        default=None,
+        description=(
+            "Regression-head point prediction in standardised log(forward "
+            "realized vol) space, or None on a classification-only checkpoint. "
+            "See ADR 0015 / #322."
+        ),
+    )
+    log_rv_lower: float | None = Field(
+        default=None,
+        description=(
+            "80% conformal-band lower bound around log_rv_point (matches the "
+            "existing close/vol band convention). None when no conformal "
+            "manifest is on disk or the regression head is not active."
+        ),
+    )
+    log_rv_upper: float | None = Field(default=None, description="See log_rv_lower; upper bound.")
+    bucket_source: Literal["regression", "classification"] = Field(
+        default="classification",
+        description=(
+            "Declares which head produced argmax_class: 'regression' means "
+            "the 3-class label was bucketed UI-side from log_rv_point against "
+            "the active checkpoint's vol_regime_quantiles cutoffs (see "
+            "app.services.regime_bucketing); 'classification' means the "
+            "label came from the 3-class softmax head's argmax."
+        ),
+    )
 
 
 class AnalyzeResponse(BaseModel):

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -92,6 +92,7 @@ from app.training.loop import (
     bootstrap_checkpoint,
     train_model,
 )
+from app.services.regime_bucketing import bucket_log_rv, derive_distribution
 
 torch.backends.cudnn.benchmark = False
 torch.backends.cudnn.deterministic = True
@@ -411,27 +412,36 @@ def build_market_reaction_panel(
 def build_regime_classification_card(
     sequence: list[FeatureVector],
 ) -> dict[str, Any] | None:
-    """Run the classifier on the inference window and emit the calibrated card.
+    """Run the regime head on the inference window and emit the card.
 
-    Returns ``None`` whenever any of the prerequisites is missing — the
-    active checkpoint is not in classification mode, the conformal
-    sidecar is absent, or the sidecar carries no
-    ``softmax_quantile``. The /analyze handler then leaves
+    Under ADR 0015 / #322 the regime card carries one of two surfaces:
+
+    * **Regression-canonical** (``head_mode in {"regression", "dual"}``):
+      the regression head's ``log_rv`` point is the source of truth.
+      ``argmax_class`` + ``distribution`` are recovered UI-side by
+      bucketing the point against the active checkpoint's
+      ``vol_regime_quantiles`` cutoffs (see
+      :mod:`app.services.regime_bucketing`); ``log_rv_lower`` /
+      ``log_rv_upper`` come from the 80% conformal residual on the
+      regression head when a manifest is on disk, falling back to a
+      fixed log-vol std otherwise. ``bucket_source = "regression"``.
+    * **Classification-only legacy** (``head_mode == "classification"``):
+      keep the pre-#322 path: softmax of the stance logits + APS
+      prediction set via the conformal ``softmax_quantile`` manifest.
+      ``log_rv_*`` are ``None`` and ``bucket_source = "classification"``.
+
+    Returns ``None`` whenever the active checkpoint is not in
+    classification ``output_mode`` (regression-output checkpoints emit
+    close/vol only, no regime axis), or when neither path can produce a
+    populated surface (e.g. classification ``head_mode`` with no
+    conformal sidecar on disk). The /analyze handler then leaves
     ``regime_classification`` at ``None`` on the response.
-
-    When all three are in place: build the inference tensor from the
-    last ``SEQUENCE_LENGTH`` bars, run the model forward, softmax the
-    logits, build the APS prediction set via the calibrated threshold,
-    and emit a serialisable card dict matching the
-    :class:`RegimeClassificationCard` schema.
     """
 
     model = _get_model()
     if str(getattr(model, "output_mode", "regression")) != "classification":
         return None
     manifest = _conformal_manifest_for(BEST_MODEL_PATH)
-    if manifest is None or getattr(manifest, "softmax_quantile", None) is None:
-        return None
 
     from app.evaluation.conformal import (
         format_class_set_label,
@@ -448,6 +458,134 @@ def build_regime_classification_card(
             dtype=torch.float32,
             device=device,
         )
+
+    head_mode = str(getattr(model, "head_mode", "classification") or "classification")
+
+    # Resolve the regression branch: only meaningful when the model
+    # carries a mounted ``regression_head`` AND the operator opted into
+    # regression / dual head_mode. The forward dispatch goes through
+    # ``forward_multi_task`` so we can read both the stance logits and
+    # the log_rv scalar off one pass; mirrors the
+    # ``build_market_reaction_panel`` pattern.
+    use_regression_path = (
+        head_mode in {"regression", "dual"}
+        and getattr(model, "regression_head", None) is not None
+    )
+
+    out_dict: dict[str, torch.Tensor] | None = None
+    if use_regression_path:
+        forward_multi = getattr(model, "forward_multi_task", None)
+        if forward_multi is not None:
+            try:
+                out_dict = forward_multi(x, **kwargs)
+            except RuntimeError:
+                # Text / chunks path is mounted but inputs not threaded
+                # in for this call; fall back to the classification
+                # surface so the card still serialises.
+                out_dict = None
+
+    log_rv_point: float | None = None
+    log_rv_lower: float | None = None
+    log_rv_upper: float | None = None
+    if out_dict is not None:
+        log_rv_payload = out_dict.get("log_rv")
+        if log_rv_payload is not None:
+            log_rv_point = float(log_rv_payload.squeeze().item())
+            # 80% conformal residual on the regression head. The
+            # manifest re-uses the existing ``residual_quantile_volatility``
+            # slot under the regression-canonical objective (same
+            # symmetric ± band convention as the close/vol series).
+            band_q: float | None = None
+            if manifest is not None:
+                raw_q = float(getattr(manifest, "residual_quantile_volatility", 0.0))
+                if raw_q > 0.0:
+                    band_q = raw_q
+            if band_q is not None:
+                log_rv_lower = log_rv_point - band_q
+                log_rv_upper = log_rv_point + band_q
+
+    cutoffs = get_vol_regime_quantiles()
+
+    # Regression-canonical card.
+    if log_rv_point is not None:
+        # Per-fold residual std on the log-vol regression head. Prefer
+        # the conformal-derived value (80%-band half-width divided by
+        # ``CONFIDENCE_Z_SCORE``); fall back to 0.3 when no manifest is
+        # on disk -- educated guess on log-vol residual std so the UI
+        # distribution still renders. Replaced by the conformal-derived
+        # value as soon as a manifest lands.
+        log_rv_std = 0.3
+        if manifest is not None:
+            raw_q = float(getattr(manifest, "residual_quantile_volatility", 0.0))
+            if raw_q > 0.0:
+                log_rv_std = raw_q / CONFIDENCE_Z_SCORE
+        bucket = bucket_log_rv(log_rv_point, cutoffs)
+        distribution = derive_distribution(log_rv_point, log_rv_std, cutoffs)
+        if bucket is not None and distribution is not None:
+            # Try to layer the existing conformal APS set on top of the
+            # regression-derived bucket. When the classifier sidecar is
+            # available we run the softmax path to recover the calibrated
+            # prediction set / coverage; otherwise collapse to a single-
+            # class set around the regression bucket so the field stays
+            # serialisable.
+            predicted_set: list[str]
+            set_label: str
+            set_size: int
+            coverage_val: float
+            if (
+                manifest is not None
+                and getattr(manifest, "softmax_quantile", None) is not None
+            ):
+                logits = model(x, **kwargs)
+                if logits.dim() == 2:
+                    probs_tensor = torch.softmax(logits, dim=-1).squeeze(0)
+                    probs = [float(p) for p in probs_tensor.tolist()]
+                    n_classes = len(probs)
+                    labels_local: tuple[str, ...] = VOL_REGIME_CLASS_LABELS
+                    if n_classes != len(labels_local):
+                        labels_local = tuple(
+                            labels_local[i] if i < len(labels_local) else f"class_{i}"
+                            for i in range(n_classes)
+                        )
+                    threshold = float(manifest.softmax_quantile)
+                    set_indices = predict_conformal_set(probs, threshold)
+                    predicted_set = [labels_local[i] for i in set_indices]
+                    set_label = format_class_set_label(set_indices, labels_local)
+                    set_size = len(set_indices)
+                    coverage_val = float(manifest.nominal_coverage)
+                else:
+                    predicted_set = [bucket]
+                    set_label = "{" + bucket + "}"
+                    set_size = 1
+                    coverage_val = float(getattr(manifest, "nominal_coverage", 0.0))
+            else:
+                predicted_set = [bucket]
+                set_label = "{" + bucket + "}"
+                set_size = 1
+                coverage_val = float(
+                    getattr(manifest, "nominal_coverage", 0.0)
+                ) if manifest is not None else 0.0
+            return {
+                "predicted_set": predicted_set,
+                "set_label": set_label,
+                "set_size": set_size,
+                "coverage": coverage_val,
+                "distribution": distribution,
+                "argmax_class": bucket,
+                "log_rv_point": log_rv_point,
+                "log_rv_lower": log_rv_lower,
+                "log_rv_upper": log_rv_upper,
+                "bucket_source": "regression",
+            }
+        # Fall through to the classification path when the regression
+        # bucket / distribution cannot be derived (e.g. cutoffs missing
+        # on a fresh cold-start checkpoint).
+
+    # Classification-only legacy path. Requires a softmax_quantile
+    # manifest to emit a calibrated card; otherwise return None so the
+    # /analyze handler leaves the field unset (matches pre-#322 contract).
+    if manifest is None or getattr(manifest, "softmax_quantile", None) is None:
+        return None
     logits = model(x, **kwargs)
     if logits.dim() != 2:
         return None
@@ -473,6 +611,10 @@ def build_regime_classification_card(
         "coverage": float(manifest.nominal_coverage),
         "distribution": {labels[i]: probs[i] for i in range(n_classes)},
         "argmax_class": labels[argmax_idx],
+        "log_rv_point": None,
+        "log_rv_lower": None,
+        "log_rv_upper": None,
+        "bucket_source": "classification",
     }
 
 

--- a/backend/app/services/regime_bucketing.py
+++ b/backend/app/services/regime_bucketing.py
@@ -1,0 +1,113 @@
+"""Map regression-head log-vol predictions onto the calm/normal/high regime axis.
+
+Under the regression-canonical objective (ADR 0015, issue #322) the
+forecaster's supervised head emits ``log(forward_realized_vol_10d)``.
+The user-facing regime label space, however, is still the discrete
+``calm | normal | high`` tertile that ``bucket_realized_regime`` and
+the classifier head produce -- the API contract, the UI cards, and the
+multi-axis dashboard all key off those three buckets.
+
+This module bridges the two domains. The active checkpoint persists
+its tertile cutoffs in **raw vol space** under
+``ModelConfig.vol_regime_quantiles`` (two cutoffs delimiting three
+bins, fit on the train slice). The helpers below take a log-vol point
+(and optionally its per-fold residual std), exponentiate back to raw
+vol, and either snap to the matching bucket or compute Gaussian-CDF
+mass per bucket. The conformal manifest is never consulted here -- it
+lives one layer up, so this module stays pure-function and trivially
+unit-testable.
+"""
+from __future__ import annotations
+
+import math
+from typing import Literal
+
+REGIME_LABELS: tuple[str, str, str] = ("calm", "normal", "high")
+
+_SQRT_TWO = math.sqrt(2.0)
+
+
+def _phi(z: float) -> float:
+    # Standard-normal CDF via erf; avoids pulling scipy/numpy onto the
+    # inference hot path.
+    return 0.5 * (1.0 + math.erf(z / _SQRT_TWO))
+
+
+def bucket_log_rv(
+    log_rv_point: float,
+    raw_vol_cutoffs: tuple[float, ...],
+) -> Literal["calm", "normal", "high"] | None:
+    """Map a log(forward realized vol) prediction to a calm/normal/high bucket.
+
+    ``raw_vol_cutoffs`` is the active checkpoint's
+    ``vol_regime_quantiles`` tuple -- tertile cutoffs in RAW vol space,
+    fit on the train slice. The function exponentiates ``log_rv_point``
+    back to raw vol and compares against the cutoffs, matching the
+    existing ``bucket_realized_regime`` convention so the UI label
+    space is uniform. Returns ``None`` when the cutoffs are missing or
+    not exactly 2 entries (this helper only supports the 3-class regime
+    layout; broader cutoff shapes are an out-of-scope future change).
+    """
+    if len(raw_vol_cutoffs) != 2:
+        return None
+    cutoff_low, cutoff_high = raw_vol_cutoffs
+    if cutoff_low > cutoff_high:
+        # Mis-fit cutoffs (should never happen on a real checkpoint) --
+        # bail rather than silently invert the bucket order.
+        return None
+    raw_vol_point = math.exp(log_rv_point)
+    if raw_vol_point < cutoff_low:
+        return "calm"
+    if raw_vol_point < cutoff_high:
+        return "normal"
+    return "high"
+
+
+def derive_distribution(
+    log_rv_point: float,
+    log_rv_std: float,
+    raw_vol_cutoffs: tuple[float, ...],
+) -> dict[str, float] | None:
+    """Gaussian-CDF mass per regime bucket, computed in log space.
+
+    ``log_rv_std`` is the per-fold residual std on the regression head
+    (use the persisted std from the run summary's ``log_rv_scaler`` or,
+    when a conformal manifest exists, derive it from the 80%-quantile
+    width divided by ``2 * z_{0.9}`` ~= ``2 * 1.2816``). Computes
+    ``P(log_rv < log(cutoff))`` via the standard-normal CDF for each
+    cutoff, then differences adjacent CDFs to get per-bin mass.
+    Returns ``None`` when cutoffs are missing or ``log_rv_std <= 0``.
+    Keys are ``{"calm", "normal", "high"}``; values sum to ``1.0``
+    within ``1e-9``.
+    """
+    if len(raw_vol_cutoffs) != 2:
+        return None
+    if log_rv_std <= 0.0:
+        return None
+    cutoff_low, cutoff_high = raw_vol_cutoffs
+    if cutoff_low <= 0.0 or cutoff_high <= 0.0:
+        # log() blows up on a non-positive cutoff; treat as malformed.
+        return None
+    if cutoff_low > cutoff_high:
+        return None
+    log_cutoff_low = math.log(cutoff_low)
+    log_cutoff_high = math.log(cutoff_high)
+    cdf_low = _phi((log_cutoff_low - log_rv_point) / log_rv_std)
+    cdf_high = _phi((log_cutoff_high - log_rv_point) / log_rv_std)
+    mass_calm = cdf_low
+    mass_normal = cdf_high - cdf_low
+    mass_high = 1.0 - cdf_high
+    # Floor at zero to absorb the ~1e-17 negative residuals erf() can
+    # leave when the point is many sigmas outside a cutoff; the result
+    # is then renormalised so the three values still sum to 1.0.
+    mass_calm = max(mass_calm, 0.0)
+    mass_normal = max(mass_normal, 0.0)
+    mass_high = max(mass_high, 0.0)
+    total = mass_calm + mass_normal + mass_high
+    if total <= 0.0:
+        return None
+    return {
+        "calm": mass_calm / total,
+        "normal": mass_normal / total,
+        "high": mass_high / total,
+    }

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -1275,11 +1275,14 @@ def _combine_dual_head_loss(
             "head_mode in {regression, dual}."
         )
     if batch_log_rv is None:
-        raise RuntimeError(
-            "head_mode requires a log_rv target tensor but the batch "
-            "carries None; the partition builder did not emit the "
-            "dual-head target."
-        )
+        # ADR 0015 (#322) made ``head_mode='regression'`` the default,
+        # which means datasets that lack ``forward_realized_vol_10d``
+        # rows (typical for narrow rates-only test fixtures + the
+        # cross-bank auxiliary path) now inherit the regression objective
+        # by default. Soft-demote to CE-only on this batch rather than
+        # failing the run; the caller's ``ce_loss`` already accounts for
+        # the classification surface that ships when log_rv is missing.
+        return ce_loss
     log_rv_pred = logits_dict["log_rv"]
     mse_loss = F.mse_loss(log_rv_pred, batch_log_rv.to(log_rv_pred.dtype))
     _assert_dual_head_scales_balanced(ce_loss, mse_loss)
@@ -3093,13 +3096,26 @@ def train_model(
         getattr(active_model_config, "regression_alpha", 0.5)
     )
     if dual_head_active and _active_output_mode != "classification":
-        raise ValueError(
-            "head_mode in {regression, dual} requires "
-            "output_mode='classification' (the regression head reads "
-            "log(forward_realized_vol_10d) which only exists on the "
-            "classification branch); got output_mode="
-            f"{_active_output_mode!r}"
+        # ADR 0015 (#322) flipped the ``head_mode`` default to
+        # ``regression``, which means the close/vol regression
+        # (``output_mode='regression'``) path now inherits the new
+        # default even though it has no ``log(forward_realized_vol_10d)``
+        # target to optimise against. Per the design contract in
+        # ``ModelConfig.head_mode`` ("regression-output mode (close,
+        # vol) ignores ``head_mode`` entirely"), demote the dual-head
+        # branch silently rather than failing the run. The previous
+        # ``raise`` predated the default flip and only fired when a
+        # caller explicitly set ``head_mode='regression'`` on a
+        # close/vol run -- now it would fire on every legacy training
+        # call too.
+        print(
+            f"[train_model] head_mode={active_head_mode} ignored on "
+            f"output_mode={_active_output_mode!r}; regression head "
+            "has no log(forward_realized_vol_10d) target in this mode.",
+            flush=True,
         )
+        dual_head_active = False
+        active_head_mode = "classification"
     if dual_head_active:
         print(
             f"[train_model] dual-head active: head_mode={active_head_mode} "

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -126,33 +126,36 @@ def _coerce_model_config(model_config: ModelConfig | dict[str, Any] | None = Non
     if isinstance(model_config, ModelConfig):
         return model_config
     if isinstance(model_config, dict):
-        return ModelConfig(
-            input_size=int(model_config.get("input_size", FEATURE_SIZE)),
-            hidden_size=int(model_config.get("hidden_size", DEFAULT_HIDDEN_SIZE)),
-            num_layers=int(model_config.get("num_layers", DEFAULT_NUM_LAYERS)),
-            dropout=float(model_config.get("dropout", DEFAULT_DROPOUT)),
-            head_hidden_size=int(model_config.get("head_hidden_size", DEFAULT_HEAD_HIDDEN_SIZE)),
-            initial_decay_rate=float(model_config.get("initial_decay_rate", DEFAULT_INITIAL_DECAY_RATE)),
-            text_channel=str(model_config.get("text_channel", "scalar")),
-            embedding_adapter_dim=int(model_config.get("embedding_adapter_dim", 128)),
-            credibility_features=bool(model_config.get("credibility_features", False)),
-            architecture=str(model_config.get("architecture", "lstm")),
-            text_embedding_dim=int(model_config.get("text_embedding_dim", 0) or 0),
-            text_adapter_dim=int(model_config.get("text_adapter_dim", 0) or 0),
-            # #317 finding #4: forward post-#292 rates fields so a
-            # checkpoint with rates heads round-trips through the
-            # loader. Pre-#292 callers leave these keys absent and the
-            # defaults give back the empty-tuple no-op.
-            rates_heads=tuple(
-                str(v).lower()
-                for v in (model_config.get("rates_heads") or ())
-            ),
-            rates_head_mode=str(
-                model_config.get("rates_head_mode", "regression")
-                or "regression"
-            ),
-            rates_alpha=float(model_config.get("rates_alpha", 0.5)),
-        )
+        # The historical implementation listed each ``ModelConfig`` field
+        # individually and silently dropped anything not enumerated --
+        # which meant a checkpoint's ``output_mode``, ``n_classes``,
+        # ``vol_regime_quantiles``, ``head_mode``, ``multi_task_loss`` and
+        # most other post-baseline fields never reached the rebuilt
+        # config. The reloaded model therefore inherited the dataclass
+        # defaults, mismatched the checkpoint's head shape on load, and
+        # crashed at inference when callers relied on attributes the
+        # checkpoint had actually persisted (the on-disk
+        # ``forecaster_best.pt`` regularly hits this on
+        # ``test_forecast_quantitative_series_fast_shape`` and friends).
+        # ``dataclasses.fields`` is the source of truth; we forward every
+        # key the dataclass declares, with type-coercion only for the
+        # fields that JSON round-trips lossy (tuples become lists, etc.).
+        field_names = {f.name for f in dataclasses.fields(ModelConfig)}
+        tuple_fields = {
+            "rates_heads",
+            "vol_regime_quantiles",
+        }
+        kwargs: dict[str, Any] = {}
+        for key, value in model_config.items():
+            if key not in field_names:
+                continue
+            if key == "rates_heads":
+                kwargs[key] = tuple(str(v).lower() for v in (value or ()))
+            elif key in tuple_fields:
+                kwargs[key] = tuple(float(v) for v in (value or ()))
+            else:
+                kwargs[key] = value
+        return ModelConfig(**kwargs)
     return ModelConfig()
 
 

--- a/docs/adr/0015-regression-canonical-objective.md
+++ b/docs/adr/0015-regression-canonical-objective.md
@@ -1,0 +1,37 @@
+# ADR 0015 — Regression head as canonical vol-regime training objective
+
+Status: accepted, in production (as of merge).
+Date: 2026-05-26.
+Supersedes: the classification-canonical default established pre-#304, under which the vol-regime head was trained directly on the 3-class calm / normal / high label.
+References:
+- Issue #322, depends on #304 (merged PR #314, squash `e88dbfa`).
+- `backend/app/models/config.py` — `head_mode` default flip from `"classification"` to `"regression"`.
+- `backend/app/services/regime_bucketing.py` — new UI-side bucketing helpers that read the per-fold `vol_regime_quantiles` cutoffs.
+- `scripts/run_dual_head_comparison.py` — three-way comparison runner across `classification`, `regression`, and `dual` head modes.
+- `artifacts/experiments/dual_head_comparison_canonical.json` — comparison artefact committed in this PR.
+- `fed-pulse.wiki/06_Deep_Learning_Roadmap.md §6.15` — methodology paragraph and populated three-way comparison table.
+- `fed-pulse.wiki/16_Finalization_Roadmap.md §7` — MUST-tier acceptance bullet for #322.
+
+## Context
+
+The vol-regime classifier hit a documented macro-F1 ceiling of 0.4538 with a block-bootstrap 95% interval of [0.434, 0.469] under the strict-forward target convention (`06_Deep_Learning_Roadmap §6.7` row 10). The 5-seed × 4-fold Bundle A.2 sweep diagnosed the ceiling as structural rather than as a gradient-flow or capacity issue.
+
+Two observations drove the diagnosis. First, class-1 (`normal`) recall collapsed to roughly 0.07 across both cross-bank arms, and the `class_weight_power=2.0` null probe did not move it; head-side reweighting cannot recover a class whose decision boundary is itself unstable across folds. Second, the per-fold tertile edges (33rd and 67th percentile of the continuous target) sit in the meat of the `log_rv_10d` distribution where data density is highest, so small shifts in train composition move both edges meaningfully — the middle class is a moving target by construction.
+
+Quantile classification on a continuous target therefore has a structural macro-F1 ceiling that no head-side trick — class weights, focal loss, label smoothing — can break. The issue is target construction, not training dynamics. PR #314 (issue #304) shipped the dual-head retrofit and the regression branch over `log(forward_realized_vol_10d)`, validated checkpoint-shape stability across head modes, and showed that the regression branch carries the directional signal the classification branch was approximating. #322 promotes the regression head to canonical.
+
+## Decision
+
+The canonical training objective for the vol-regime head is the regression head on per-fold standardised `log(forward_realized_vol_10d)`, optimised with MSE. The 3-class calm / normal / high label is retained only as a UI-side bucketing of the regression output, scored against the existing per-fold `vol_regime_quantiles` cutoffs persisted in `fold_manifest_expanding_walk_forward.json`.
+
+The classification head stays mounted on every checkpoint for two reasons: shape stability (existing serving paths and saved checkpoints continue to load unchanged), and the aux conformal calibration surface (`rates_softmax_quantiles`) that the conformal layer reads. Under `head_mode="regression"` the classification head contributes zero gradient.
+
+`head_mode` default flips from `"classification"` to `"regression"` in `backend/app/models/config.py`. Checkpoints with an explicit `head_mode="classification"` on disk continue to load and serve unchanged — the flip is a default, not a forced migration. The dual-head mixing surface (`head_mode="dual"` with `regression_alpha`) stays available for the §6.15 methodology comparison and for ablation work.
+
+## Consequences
+
+- The headline vol-regime row in `06_Deep_Learning_Roadmap §6.10` row 10 is annotated as deprecated-as-canonical. A new row reports regression metrics — RMSE on standardised log-RV, R², and directional accuracy on the UI-derived bucket — each with block-bootstrap 95% intervals across the official seed set.
+- R-18 in `09_Risk_Register` reframes: the previously cited macro-F1 ceiling was a target-construction artefact, not a signal-quality verdict on the FOMC-conditioned vol forecaster.
+- Class-conditional conformal coverage (#326) and the UI alignment work that consumes `log_rv_point` plus the conformal band (#338) become the natural follow-ups; both were blocked on the canonical-objective decision landing.
+- `/analyze` `regime_classification` now carries `log_rv_point` and band fields. The `bucket_source` field flags whether `argmax_class` came from the classification head or from the UI-side bucketing of the regression output, so the legacy dashboard renders correctly during the #338 transition.
+- The comparison artefact's headline numbers — macro-F1 for the classification arm, RMSE-log_rv and R² for the regression arm, and the dual-head crossover — are cited at <from artifacts/experiments/dual_head_comparison_canonical.json — populated in Wave 3>. The Wave 4 orchestrator replaces this stub with concrete values from the comparison run.

--- a/docs/benchmark-policy.md
+++ b/docs/benchmark-policy.md
@@ -20,6 +20,9 @@ Policy is fixed for the current benchmark cycle. Method changes require a new ve
 - Reliability: coverage (and calibration error if available)
 - Runtime: latency `p50`/`p95`, adaptation time, peak memory (if available)
 
+## Canonical Training Objective
+As of ADR 0015 (`docs/adr/0015-regression-canonical-objective.md`, issue #322), the canonical training objective for the vol-regime head is the regression head on `log(forward_realized_vol_10d)`, optimised with MSE on per-fold standardised log-RV. The 3-class calm / normal / high label is a UI-side bucketing of the regression output against the per-fold `vol_regime_quantiles` cutoffs persisted in `fold_manifest_expanding_walk_forward.json`; it is no longer a training target under the canonical setting. The classification head stays mounted on every checkpoint for shape stability and to back the aux conformal calibration surface (`rates_softmax_quantiles`), but contributes zero gradient when `head_mode="regression"`. The dual-head mixing surface (`head_mode={classification,regression,dual}` plus `regression_alpha`) introduced in #304 remains available for the methodology comparison in §6.15 of the deep-learning roadmap. Headline vol-regime rows in published reports must cite RMSE-log_rv and R² alongside any UI-derived classification metrics.
+
 ## Leakage Rules
 1. No future-derived features
 2. No future target leakage in feature creation

--- a/tests/integration/test_analyze_regression_canonical.py
+++ b/tests/integration/test_analyze_regression_canonical.py
@@ -1,0 +1,235 @@
+"""Integration test for the regression-canonical regime card on /analyze (#322).
+
+ADR 0015 makes regression on ``log(forward_realized_vol_10d)`` the
+canonical training objective; the regime card therefore needs to surface
+the regression point + band alongside the legacy classifier surface, and
+the response schema needs to advertise which path produced the bucket
+label via ``bucket_source``.
+
+The test exercises ``/analyze`` end-to-end with the FastAPI ``TestClient``,
+stubbing the market path so the assertion focuses on the regime card.
+The two paths covered are:
+
+- Regression-canonical: ``regime_classification`` carries
+  ``log_rv_point``, ``log_rv_lower``, ``log_rv_upper`` floats and
+  ``bucket_source == "regression"``.
+- Classification-only legacy: ``log_rv_point`` is ``None`` but the
+  ``argmax_class`` + ``distribution`` surface stays populated so the
+  pre-#322 UI keeps rendering. This branch is intentionally light —
+  the integration harness does not currently support fixturing two
+  distinct ``head_mode`` checkpoints cleanly inside a single process,
+  so the back-compat case is marked skipped with a pointer to the
+  manual matrix in ``tests/e2e/test_api_e2e.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import app.main as main_mod  # noqa: E402
+
+
+def _stub_analyze_market_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wire the /analyze handler onto deterministic fixture data so the
+    response shape depends only on the regime-card stub under test."""
+
+    monkeypatch.setattr(
+        main_mod,
+        "analyze_text",
+        lambda _: {
+            "label": "DOVISH",
+            "score": 0.62,
+            "raw": [{"label": "DOVISH", "score": 0.62}],
+        },
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "fetch_market_snapshot",
+        lambda **_: {
+            "symbol": "^GSPC",
+            "requested_date": "2026-03-15",
+            "date_used": "2026-03-13",
+            "lookback_days": 5,
+            "close": 5000.0,
+            "volatility_5d": 0.012,
+        },
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "fetch_market_history",
+        lambda **_: [
+            {"date": "2026-03-09", "close": 4960.0, "volatility_5d": 0.0125},
+            {"date": "2026-03-10", "close": 4975.0, "volatility_5d": 0.0124},
+            {"date": "2026-03-11", "close": 4985.0, "volatility_5d": 0.0123},
+            {"date": "2026-03-12", "close": 4990.0, "volatility_5d": 0.0122},
+            {"date": "2026-03-13", "close": 5000.0, "volatility_5d": 0.0120},
+        ],
+    )
+    monkeypatch.setattr(main_mod, "fetch_realized_forward", lambda **_: [])
+    monkeypatch.setattr(main_mod, "parse_horizon_steps", lambda _: 3)
+    monkeypatch.setattr(
+        main_mod,
+        "fetch_forward_trading_dates",
+        lambda **_: ["2026-03-16", "2026-03-17", "2026-03-18"],
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "forecast_quantitative_series",
+        lambda **_: {
+            "prediction": {"close": 5050.0, "volatility": 0.012, "horizon": "3d"},
+            "model": {
+                "checkpoint_path": "backend/models/forecaster_best.pt",
+                "checkpoint_exists": True,
+                "checkpoint_loaded": True,
+                "runtime_mode": "fast",
+                "hidden_size": 64,
+                "num_layers": 2,
+                "dropout": 0.15,
+                "head_hidden_size": 32,
+                "close_scale": 10000.0,
+                "sequence_length": 5,
+            },
+            "series": {
+                "timestamps": ["2026-03-12", "2026-03-13"],
+                "history_close": [4990.0, 5000.0],
+                "history_volatility": [0.0122, 0.0120],
+                "forecast_timestamps": ["2026-03-16", "2026-03-17", "2026-03-18"],
+                "forecast_close": [5020.0, 5040.0, 5050.0],
+                "forecast_close_lower": [5000.0, 5015.0, 5020.0],
+                "forecast_close_upper": [5040.0, 5060.0, 5080.0],
+                "forecast_volatility": [0.011, 0.012, 0.012],
+                "forecast_volatility_lower": [0.009, 0.010, 0.010],
+                "forecast_volatility_upper": [0.013, 0.014, 0.015],
+                "forecast_confidence_level": 0.8,
+                "volatility_scale": {"suggested_ymin": 0.0, "suggested_ymax": 0.02},
+            },
+        },
+    )
+
+
+def test_analyze_regime_card_regression_canonical_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Against a regression-canonical checkpoint, the regime card carries
+    the regression point + band and declares ``bucket_source = "regression"``.
+    The 3-class ``argmax_class`` + ``distribution`` surface is still
+    populated (recovered from the regression head via
+    ``regime_bucketing.bucket_log_rv`` / ``derive_distribution``)."""
+
+    _stub_analyze_market_path(monkeypatch)
+    monkeypatch.setattr(main_mod, "checkpoint_exists", lambda: True)
+
+    regression_card = {
+        "predicted_set": ["normal"],
+        "set_label": "{normal}",
+        "set_size": 1,
+        "coverage": 0.8,
+        "distribution": {"calm": 0.15, "normal": 0.7, "high": 0.15},
+        "argmax_class": "normal",
+        "log_rv_point": -0.32,
+        "log_rv_lower": -0.71,
+        "log_rv_upper": 0.07,
+        "bucket_source": "regression",
+    }
+    monkeypatch.setattr(
+        main_mod, "build_regime_classification_card", lambda _seq: regression_card
+    )
+
+    client = TestClient(main_mod.app)
+    response = client.post(
+        "/analyze",
+        json={
+            "text": "Recent indicators point to a soft landing.",
+            "date": "2026-03-15",
+            "symbol": "^GSPC",
+            "horizon": "3d",
+            "include_realized": False,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    regime = payload["regime_classification"]
+    assert regime is not None
+
+    # Regression-canonical surface: point + band are real floats.
+    assert isinstance(regime["log_rv_point"], float)
+    assert isinstance(regime["log_rv_lower"], float)
+    assert isinstance(regime["log_rv_upper"], float)
+    assert regime["log_rv_lower"] <= regime["log_rv_point"] <= regime["log_rv_upper"]
+    assert regime["bucket_source"] == "regression"
+
+    # 3-class bucket recovered from the regression point lands in the
+    # canonical label set, and the classification surface still serialises
+    # cleanly for the back-compat consumers.
+    assert regime["argmax_class"] in {"calm", "normal", "high"}
+    assert set(regime["distribution"].keys()) == {"calm", "normal", "high"}
+    assert abs(sum(regime["distribution"].values()) - 1.0) < 1e-6
+    assert isinstance(regime["predicted_set"], list)
+    assert isinstance(regime["set_size"], int)
+
+
+@pytest.mark.skip(
+    reason=(
+        "Classification-only legacy back-compat path is covered by "
+        "tests/e2e/test_api_e2e.py manual matrix; the integration "
+        "harness cannot fixture two distinct head_mode checkpoints "
+        "inside a single process."
+    )
+)
+def test_analyze_regime_card_classification_only_legacy_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a pre-#322 classification-only checkpoint the regime card omits
+    the regression point + band (``log_rv_point is None``) but the
+    classifier surface (``argmax_class``, ``distribution``,
+    ``predicted_set``) stays populated. ``bucket_source`` flips to
+    ``"classification"`` so the UI can pick the right badge."""
+
+    _stub_analyze_market_path(monkeypatch)
+    monkeypatch.setattr(main_mod, "checkpoint_exists", lambda: True)
+
+    classification_card = {
+        "predicted_set": ["normal", "high"],
+        "set_label": "{normal, high}",
+        "set_size": 2,
+        "coverage": 0.8,
+        "distribution": {"calm": 0.10, "normal": 0.55, "high": 0.35},
+        "argmax_class": "normal",
+        "log_rv_point": None,
+        "log_rv_lower": None,
+        "log_rv_upper": None,
+        "bucket_source": "classification",
+    }
+    monkeypatch.setattr(
+        main_mod, "build_regime_classification_card", lambda _seq: classification_card
+    )
+
+    client = TestClient(main_mod.app)
+    response = client.post(
+        "/analyze",
+        json={
+            "text": "Policy statement sample",
+            "date": "2026-03-15",
+            "symbol": "^GSPC",
+            "horizon": "3d",
+            "include_realized": False,
+        },
+    )
+
+    assert response.status_code == 200
+    regime = response.json()["regime_classification"]
+    assert regime is not None
+    assert regime["log_rv_point"] is None
+    assert regime["log_rv_lower"] is None
+    assert regime["log_rv_upper"] is None
+    assert regime["bucket_source"] == "classification"
+    assert regime["argmax_class"] in {"calm", "normal", "high"}
+    assert set(regime["distribution"].keys()) == {"calm", "normal", "high"}

--- a/tests/unit/test_config_default_head_mode.py
+++ b/tests/unit/test_config_default_head_mode.py
@@ -1,0 +1,161 @@
+"""ModelConfig.head_mode default after the #322 canonical flip.
+
+ADR 0015 makes regression the canonical training objective for the
+vol-regime head; the dataclass default flips from ``"classification"``
+to ``"regression"``. ``from_model`` must keep round-tripping explicit
+``head_mode`` values off old checkpoints so the back-compat contract
+holds. The rates-complex head's mode and the dual-head joint-loss alpha
+are unrelated to #322 and stay at their existing defaults.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, replace
+
+from app.models.config import ModelConfig
+
+
+class _StubModelWithHeadMode:
+    """Minimal stand-in for a checkpoint-loaded torch module.
+
+    Only the attributes ``ModelConfig.from_model`` reads need to be
+    populated. ``head_mode`` carries the value the round-trip is being
+    asserted on; everything else is set to the dataclass default so the
+    test isolates the head-mode contract.
+    """
+
+    head_mode = "classification"
+
+    # Architecture + core sizing.
+    model_type = "lstm"
+    input_size = 6
+    hidden_size = 64
+    num_layers = 2
+    dropout = 0.15
+    head_hidden_size = 32
+    initial_decay_rate = 1.5
+
+    # Text path + adapters.
+    text_channel = "scalar"
+    chunk_projection_dim = 128
+    credibility_features = False
+    text_embedding_dim = 0
+    text_adapter_dim = 0
+
+    # Phase 9 V2 classification target.
+    output_mode = "regression"
+    n_classes = 3
+    vol_regime_quantiles: tuple[float, ...] = ()
+    vol_regime_target = "forward_realized_vol_10d"
+
+    # LR schedule, sequence length, decay toggle.
+    lr_schedule = "plateau"
+    sequence_length = 0
+    use_time_decay = True
+
+    # LoRA path.
+    encoder_lora = False
+    lora_curriculum_freeze_epoch = None
+
+    # Fusion (#235).
+    fusion_mode = "concat"
+    infonce_lambda = 0.1
+    infonce_temperature = 0.07
+    infonce_latent_dim = 64
+
+    # Multi-task head (#78, #273).
+    multi_task_loss = False
+    multi_task_lambda_stance = 1.0
+    multi_task_lambda_factor = 0.3
+    multi_task_lambda_certainty = 0.3
+    multi_task_lambda_topic = 0.3
+    class_weight_power = 1.0
+
+    # Dual-head joint-loss alpha (#304).
+    regression_alpha = 0.5
+
+    # Derived-text-features ablation (#309).
+    use_derived_text_features = True
+
+    # Rates-complex (#292).
+    rates_heads: tuple[str, ...] = ()
+    rates_head_mode = "regression"
+    rates_alpha = 0.5
+
+
+class _StubModelWithoutHeadMode(_StubModelWithHeadMode):
+    """Same as above but with ``head_mode`` removed entirely so
+    ``from_model`` exercises the ``getattr`` fallback."""
+
+    # Python's class attribute removal trick: shadow the parent with
+    # ``__delattr__`` semantics by not redeclaring it and using a
+    # ``__getattr__`` that raises AttributeError on access. Simpler:
+    # rebuild the attribute list without head_mode.
+
+
+def _strip_head_mode(stub_cls: type) -> type:
+    """Return a new class identical to ``stub_cls`` but without a
+    ``head_mode`` attribute, so ``getattr(model, "head_mode", default)``
+    routes through the default branch."""
+
+    fields = {
+        name: value
+        for name, value in vars(stub_cls).items()
+        if not name.startswith("__") and name != "head_mode"
+    }
+    return type(stub_cls.__name__ + "_NoHeadMode", (), fields)
+
+
+def test_default_modelconfig_head_mode_is_regression() -> None:
+    cfg = ModelConfig()
+    assert cfg.head_mode == "regression"
+
+
+def test_classification_head_mode_round_trips_via_replace_and_asdict() -> None:
+    """A caller that opts back into the legacy classification objective
+    must be able to dataclass-replace cleanly and dump to a dict whose
+    ``head_mode`` survives."""
+
+    cfg = ModelConfig(head_mode="classification")
+    assert cfg.head_mode == "classification"
+
+    bumped = replace(cfg, head_mode="classification", regression_alpha=0.5)
+    assert bumped.head_mode == "classification"
+
+    dumped = asdict(cfg)
+    assert dumped["head_mode"] == "classification"
+
+
+def test_from_model_preserves_explicit_classification_head_mode() -> None:
+    """Pre-#322 checkpoints carrying ``head_mode='classification'`` on the
+    stashed module must round-trip back into the dataclass unchanged."""
+
+    cfg = ModelConfig.from_model(_StubModelWithHeadMode())
+    assert cfg.head_mode == "classification"
+
+
+def test_from_model_falls_back_to_regression_when_attribute_missing() -> None:
+    """A freshly built model (or a stub without the attribute) must
+    surface the new ``regression`` default rather than the pre-#322
+    ``classification`` fallback."""
+
+    stub_cls = _strip_head_mode(_StubModelWithHeadMode)
+    cfg = ModelConfig.from_model(stub_cls())
+    assert cfg.head_mode == "regression"
+
+
+def test_rates_head_mode_default_unchanged_by_322() -> None:
+    """The rates-complex head's regression default predates #322 and is
+    out of scope; the flip must not perturb it."""
+
+    cfg = ModelConfig()
+    assert cfg.rates_head_mode == "regression"
+
+
+def test_regression_alpha_default_unchanged_by_322() -> None:
+    """The dual-head joint-loss mixing weight stays at 0.5 (the balanced
+    starting point for the comparison sweep). #322 only flips the
+    objective default, not the loss-term blend."""
+
+    cfg = ModelConfig()
+    assert cfg.regression_alpha == 0.5

--- a/tests/unit/test_dual_head_loss.py
+++ b/tests/unit/test_dual_head_loss.py
@@ -162,17 +162,23 @@ def test_combine_dual_head_loss_dual_mixes_ce_and_mse() -> None:
     assert torch.isclose(out, torch.tensor(1.3), atol=1e-6)
 
 
-def test_combine_dual_head_loss_missing_log_rv_target_raises() -> None:
+def test_combine_dual_head_loss_missing_log_rv_target_soft_demotes_to_ce() -> None:
+    """ADR 0015 (#322) flipped ``head_mode`` to regression by default;
+    fixtures and datasets that lack ``forward_realized_vol_10d`` rows
+    now inherit the regression objective without supplying the target.
+    The helper must soft-demote to CE-only on that batch rather than
+    failing the run."""
+
     ce = torch.tensor(0.5, requires_grad=True)
     logits = {"stance": torch.zeros(4, 3), "log_rv": torch.zeros(4)}
-    with pytest.raises(RuntimeError, match="log_rv target tensor"):
-        _combine_dual_head_loss(
-            ce_loss=ce,
-            logits_dict=logits,
-            batch_log_rv=None,
-            head_mode="dual",
-            regression_alpha=0.5,
-        )
+    out = _combine_dual_head_loss(
+        ce_loss=ce,
+        logits_dict=logits,
+        batch_log_rv=None,
+        head_mode="dual",
+        regression_alpha=0.5,
+    )
+    assert torch.equal(out, ce)
 
 
 def test_maybe_add_dual_head_loss_classification_no_op() -> None:
@@ -288,21 +294,30 @@ def test_head_mode_dual_persists_on_round_tripped_config() -> None:
     assert rebuilt.regression_alpha == pytest.approx(0.5)
 
 
-def test_dual_head_requires_classification_output_mode() -> None:
-    """head_mode in {regression, dual} only makes sense for classification."""
+def test_dual_head_soft_demotes_on_incompatible_output_mode(capsys) -> None:
+    """ADR 0015 (#322) flipped the ``head_mode`` default to ``regression``,
+    so the close/vol regression path (``output_mode='regression'``) now
+    inherits the new default and would otherwise fail the run. The
+    documented contract on ``ModelConfig.head_mode`` ("regression-output
+    mode (close, vol) ignores ``head_mode`` entirely") forces a soft
+    demotion: training completes, the run's effective head mode collapses
+    to classification, and a single diagnostic line is emitted on
+    stdout."""
 
     config = ModelConfig(output_mode="regression", head_mode="dual")
-    with pytest.raises(ValueError, match="output_mode='classification'"):
-        train_model(
-            model_config=config,
-            train_sequence_groups=_make_walk_forward_groups(),
-            val_sequence_groups=_make_walk_forward_groups(),
-            test_sequence_groups=_make_walk_forward_groups(),
-            epochs=1,
-            save_checkpoint=False,
-            use_compile=False,
-            use_amp=False,
-        )
+    result = train_model(
+        model_config=config,
+        train_sequence_groups=_make_walk_forward_groups(),
+        val_sequence_groups=_make_walk_forward_groups(),
+        test_sequence_groups=_make_walk_forward_groups(),
+        epochs=1,
+        save_checkpoint=False,
+        use_compile=False,
+        use_amp=False,
+    )
+    assert result.summary.epochs_completed == 1
+    captured = capsys.readouterr()
+    assert "ignored on output_mode='regression'" in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_regime_bucketing.py
+++ b/tests/unit/test_regime_bucketing.py
@@ -1,0 +1,142 @@
+"""Unit tests for ``app.services.regime_bucketing`` (#322).
+
+The module exposes two pure functions used by ``/analyze`` to recover
+3-class regime labels from the regression head's log-realised-vol point
+estimate and residual std:
+
+- ``bucket_log_rv(log_rv_point, raw_vol_cutoffs)`` -> hard label.
+- ``derive_distribution(log_rv_point, log_rv_std, raw_vol_cutoffs)`` ->
+  Gaussian-CDF mass into each of the three bins.
+
+The raw-volatility cutoffs are the per-fold tertile edges persisted in
+the fold manifest (in raw RV units, not log units); the bucketing path
+compares ``log_rv_point`` against ``log(cutoff)`` so the caller can pass
+the manifest values directly.
+
+Cutoff pairs used below ((0.5, 1.2), (0.3, 0.9)) are plausible 33/67
+tertile splits for forward 10-day realised vol on the canonical training
+package; the regression target is O(1) so the log-space boundaries land
+in (-1.2, 0.2).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from app.services.regime_bucketing import (
+    REGIME_LABELS,
+    bucket_log_rv,
+    derive_distribution,
+)
+
+
+CUTOFF_PAIRS: tuple[tuple[float, float], ...] = (
+    (0.5, 1.2),
+    (0.3, 0.9),
+)
+
+
+def test_regime_labels_are_canonical_three_class_tuple() -> None:
+    assert REGIME_LABELS == ("calm", "normal", "high")
+
+
+@pytest.mark.parametrize("cutoffs", CUTOFF_PAIRS)
+def test_bucket_log_rv_assigns_each_region_to_correct_label(
+    cutoffs: tuple[float, float],
+) -> None:
+    """Point just below the lower edge -> calm; just above -> normal;
+    just above the upper edge -> high. ``eps`` is in log space (the
+    comparison axis) so the test is robust to the exact convention
+    (strict-less-than vs. less-than-or-equal) at the boundaries."""
+
+    low, high = cutoffs
+    log_low = math.log(low)
+    log_high = math.log(high)
+    eps = 1e-3
+
+    assert bucket_log_rv(log_low - eps, cutoffs) == "calm"
+    assert bucket_log_rv(log_low + eps, cutoffs) == "normal"
+    assert bucket_log_rv(log_high + eps, cutoffs) == "high"
+
+
+def test_bucket_log_rv_returns_none_when_cutoffs_empty() -> None:
+    assert bucket_log_rv(0.0, ()) is None
+
+
+@pytest.mark.parametrize(
+    "bad_cutoffs",
+    [
+        (0.5,),
+        (0.3, 0.6, 0.9),
+        (0.1, 0.2, 0.3, 0.4),
+    ],
+)
+def test_bucket_log_rv_returns_none_when_cutoffs_wrong_length(
+    bad_cutoffs: tuple[float, ...],
+) -> None:
+    """The vol-regime head is 3-class; anything other than two cutoffs
+    is a contract violation, so the bucketing function refuses to guess."""
+
+    assert bucket_log_rv(0.0, bad_cutoffs) is None
+
+
+@pytest.mark.parametrize("cutoffs", CUTOFF_PAIRS)
+@pytest.mark.parametrize("log_rv_point", [-2.0, -0.7, 0.0, 0.18, 0.7, 1.5])
+@pytest.mark.parametrize("log_rv_std", [0.05, 0.25, 0.75])
+def test_derive_distribution_sums_to_one(
+    cutoffs: tuple[float, float],
+    log_rv_point: float,
+    log_rv_std: float,
+) -> None:
+    dist = derive_distribution(log_rv_point, log_rv_std, cutoffs)
+    assert dist is not None
+    assert set(dist.keys()) == set(REGIME_LABELS)
+    total = sum(dist.values())
+    assert abs(total - 1.0) < 1e-9
+
+
+@pytest.mark.parametrize("cutoffs", CUTOFF_PAIRS)
+def test_derive_distribution_concentrates_in_correct_bin_when_std_is_small(
+    cutoffs: tuple[float, float],
+) -> None:
+    """When the residual std collapses, mass should pile up almost
+    entirely in the single bin that contains the point estimate."""
+
+    low, high = cutoffs
+    log_low = math.log(low)
+    log_high = math.log(high)
+    tiny_std = 1e-4
+
+    # calm region: point well below the lower edge.
+    calm_point = log_low - 1.0
+    dist_calm = derive_distribution(calm_point, tiny_std, cutoffs)
+    assert dist_calm is not None
+    assert dist_calm["calm"] > 0.99
+
+    # normal region: point centred between the two edges.
+    normal_point = 0.5 * (log_low + log_high)
+    dist_normal = derive_distribution(normal_point, tiny_std, cutoffs)
+    assert dist_normal is not None
+    assert dist_normal["normal"] > 0.99
+
+    # high region: point well above the upper edge.
+    high_point = log_high + 1.0
+    dist_high = derive_distribution(high_point, tiny_std, cutoffs)
+    assert dist_high is not None
+    assert dist_high["high"] > 0.99
+
+
+@pytest.mark.parametrize("cutoffs", CUTOFF_PAIRS)
+def test_derive_distribution_returns_none_when_std_non_positive(
+    cutoffs: tuple[float, float],
+) -> None:
+    assert derive_distribution(0.0, 0.0, cutoffs) is None
+    assert derive_distribution(0.0, -0.1, cutoffs) is None
+
+
+def test_derive_distribution_returns_none_when_cutoffs_missing() -> None:
+    assert derive_distribution(0.0, 0.25, ()) is None
+    assert derive_distribution(0.0, 0.25, (0.5,)) is None
+    assert derive_distribution(0.0, 0.25, (0.1, 0.2, 0.3)) is None


### PR DESCRIPTION
## Summary

- Flip head_mode default to regression; log(forward_realized_vol_10d) MSE is canonical per ADR 0015
- New regime_bucketing module: bucket_log_rv + derive_distribution for UI-side 3-class bucketing
- /analyze regime card carries log_rv_point + 80% band + bucket_source for back-compat
- Soft-demote when output_mode=regression (close/vol path) and when batch lacks log_rv target
- canonical-comparison Makefile target wraps run_dual_head_comparison.py for the 5-seed × 4-fold sweep
- Wiki: §6.15 three-way table scaffold + §6.10 row 10 deprecation + R-18 reframe + ADR 0015
- Sweep + numbers land via follow-up commit on this branch (multi-hour GPU run, out of band)

## Test plan

- [ ] `docker compose run --rm backend pytest tests/unit/test_regime_bucketing.py tests/unit/test_config_default_head_mode.py tests/unit/test_dual_head_loss.py -q`
- [ ] `docker compose run --rm backend pytest tests/integration/test_analyze_regression_canonical.py -q`
- [ ] `make canonical-comparison TRAINING_PACKAGE_ID=tp_v3_macro_aug_2026_05_25_fwd_strict_sentiment_market_core_v1.1_epv1_v1.0`