### PR TITLE
Class-conditional conformal coverage + set-size distribution (#326)

### DIFF
--- a/backend/app/evaluation/conformal.py
+++ b/backend/app/evaluation/conformal.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+from collections import Counter
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
@@ -48,6 +49,27 @@ class ConformalManifest:
     softmax_quantile: float | None = None
     rates_residual_quantiles: dict[str, float] | None = None
     rates_softmax_quantiles: dict[str, float] | None = None
+    # #326 conditional-coverage diagnostics. Both fields are computed on
+    # the same calibration partition the ``softmax_quantile`` was fitted
+    # on so they stay paired with the manifest's nominal coverage claim.
+    # ``class_conditional_coverage`` maps the class label (string,
+    # matches the active checkpoint's ``stance_classes`` / regime label
+    # tuple) to empirical coverage = fraction of rows in that class
+    # whose true label is inside the APS prediction set. A class whose
+    # row count is zero on the calibration fold maps to ``nan``.
+    # ``set_size_distribution`` maps the integer set size (``1``, ``2``,
+    # ``3`` for the 3-class regime target) to the fraction of rows
+    # emitting that set size, summing to ``1.0`` within finite-sample
+    # rounding. Pre-#326 manifests round-trip with both fields ``None``.
+    # On regression-canonical checkpoints the same fields carry the
+    # bucketed-regression interpretation -- the calibrator bins the
+    # predicted log_rv via ``bucket_log_rv`` and reports the same
+    # diagnostics under the regression band's coverage surface; the
+    # manifest's ``notes`` field surfaces the dual interpretation so a
+    # downstream reader can tell which calibration produced the
+    # numbers.
+    class_conditional_coverage: dict[str, float] | None = None
+    set_size_distribution: dict[int, float] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -66,6 +88,18 @@ class ConformalManifest:
             "rates_softmax_quantiles": (
                 dict(self.rates_softmax_quantiles)
                 if self.rates_softmax_quantiles
+                else None
+            ),
+            "class_conditional_coverage": (
+                {str(k): float(v) for k, v in self.class_conditional_coverage.items()}
+                if self.class_conditional_coverage
+                else None
+            ),
+            "set_size_distribution": (
+                # JSON object keys must be strings; the loader reverses
+                # this to int on read.
+                {str(int(k)): float(v) for k, v in self.set_size_distribution.items()}
+                if self.set_size_distribution
                 else None
             ),
         }
@@ -279,6 +313,223 @@ def empirical_classification_coverage(
     return inside / len(predicted_sets)
 
 
+def compute_class_conditional_coverage(
+    predicted_sets: Sequence[Sequence[int]],
+    true_classes: Sequence[int],
+    class_names: Sequence[str],
+) -> dict[str, float]:
+    """Per-class empirical coverage on the calibration partition (#326).
+
+    APS marginally covers ``1 - alpha`` of rows under exchangeability;
+    that guarantee is silent on the per-class slice. A model whose
+    softmax is systematically miscalibrated on one class (the #326
+    canonical example: ``normal`` at ~7 % recall on the 3-class
+    vol-regime head) can emit prediction sets that exclude that class
+    almost every row while marginal coverage still reads at nominal.
+    The helper measures the per-class slice directly: for each class
+    label, divide ``#{rows whose true class is in the set}`` by
+    ``#{rows whose true class is that label}``.
+
+    ``class_names`` is the active checkpoint's label tuple (regime
+    label tuple on the vol-regime head; stance label tuple on the
+    stance head). Classes with zero rows on the calibration partition
+    map to ``float('nan')`` so the downstream gap-flag helper can
+    distinguish "empty slice" from "degenerate coverage". Returns a
+    fresh dict keyed by the string label so the manifest round-trip
+    stays serialisable.
+    """
+
+    if len(predicted_sets) != len(true_classes):
+        raise ValueError(
+            f"predicted_sets ({len(predicted_sets)}) and true_classes "
+            f"({len(true_classes)}) must align in length."
+        )
+    if not class_names:
+        raise ValueError("class_names must carry at least one label.")
+    coverage: dict[str, float] = {}
+    for class_idx, label in enumerate(class_names):
+        row_total = 0
+        inside = 0
+        for predicted_set, true_class in zip(predicted_sets, true_classes):
+            if int(true_class) != class_idx:
+                continue
+            row_total += 1
+            if int(true_class) in {int(x) for x in predicted_set}:
+                inside += 1
+        coverage[str(label)] = (
+            float(inside) / float(row_total) if row_total > 0 else float("nan")
+        )
+    return coverage
+
+
+def compute_set_size_distribution(
+    predicted_sets: Sequence[Sequence[int]],
+    *,
+    n_classes: int = 3,
+) -> dict[int, float]:
+    """Fraction of rows emitting each prediction-set size (#326).
+
+    The 3-class APS surface admits sizes ``{1, 2, 3}``; the helper
+    returns a dict keyed by every size in ``[1, n_classes]`` so the
+    distribution sums to 1.0 even when one or more sizes never appear
+    (their entry is ``0.0`` rather than missing). Pathological empty
+    sets (which ``predict_conformal_set`` already rewrites to the
+    argmax singleton) would land in the ``0`` bucket, which is
+    intentionally absent from the contract -- if a future surface
+    emits true empty sets, this helper will raise rather than silently
+    hide them.
+
+    Returns a fresh dict keyed by ``int``. ``n_classes`` defaults to
+    3 to match the active vol-regime / stance heads; callers on a
+    different cardinality target pass the right number.
+    """
+
+    if n_classes < 1:
+        raise ValueError(f"n_classes must be >= 1; got {n_classes!r}.")
+    total = len(predicted_sets)
+    if total == 0:
+        # NaN per bucket so an empty partition does not fabricate a
+        # 0.0 mass for every size -- the caller knows the calibration
+        # partition was empty and needs to surface that on the
+        # manifest.
+        return {k: float("nan") for k in range(1, n_classes + 1)}
+    counts: Counter[int] = Counter()
+    for predicted_set in predicted_sets:
+        size = len(predicted_set)
+        if size <= 0:
+            raise ValueError(
+                "predicted_sets must not carry empty sets; APS contract "
+                "rewrites empties to {argmax} (see predict_conformal_set)."
+            )
+        if size > n_classes:
+            raise ValueError(
+                f"predicted set size {size} exceeds n_classes={n_classes}."
+            )
+        counts[size] += 1
+    return {k: float(counts.get(k, 0)) / float(total) for k in range(1, n_classes + 1)}
+
+
+def class_conditional_gap_flag(
+    coverage_dict: Mapping[str, float],
+    *,
+    nominal: float = 0.80,
+    tolerance: float = 0.10,
+) -> list[str]:
+    """Return the class names whose conditional coverage falls > tolerance below nominal.
+
+    A class with ``coverage < (nominal - tolerance)`` lands on the
+    flag list. NaN coverage (empty class slice on the calibration
+    partition) is skipped silently -- absence of evidence is not
+    evidence of a degenerate coverage gap, and the gap diagnostic
+    should not fire purely on a small-sample fold.
+
+    Defaults track the #326 issue contract: nominal 0.80, tolerance
+    0.10 (so 0.70 is the gap threshold). Class names returned in the
+    order ``coverage_dict`` iterates so a deterministic dict ordering
+    upstream produces a deterministic flag list.
+    """
+
+    if not (0.0 <= nominal <= 1.0):
+        raise ValueError(f"nominal must lie in [0, 1]; got {nominal!r}.")
+    if tolerance < 0.0:
+        raise ValueError(f"tolerance must be >= 0; got {tolerance!r}.")
+    # Float epsilon: ``0.80 - 0.10`` lands at ``0.7000000000000001`` so
+    # a class with coverage exactly ``0.70`` would otherwise flag under
+    # ``cov < threshold``. The issue contract is "> tolerance below"
+    # nominal — a class whose gap is exactly ``tolerance`` is on the
+    # boundary and must NOT flag. Compare the gap directly instead of
+    # the subtracted threshold so the boundary case is clean.
+    flagged: list[str] = []
+    for label, coverage in coverage_dict.items():
+        cov = float(coverage)
+        if not math.isfinite(cov):
+            continue
+        gap = float(nominal) - cov
+        if gap > tolerance + 1e-12:
+            flagged.append(str(label))
+    return flagged
+
+
+def compute_regression_band_class_coverage(
+    *,
+    log_rv_predictions: Sequence[float],
+    log_rv_actuals: Sequence[float],
+    residual_quantile: float,
+    raw_vol_cutoffs: tuple[float, ...],
+    class_names: Sequence[str] = ("calm", "normal", "high"),
+) -> dict[str, float]:
+    """Per-class coverage of a regression-canonical conformal band (#326).
+
+    On the regression-canonical surface (ADR 0015 / #322) there is no
+    softmax to threshold; the calibrated object is a band
+    ``[y_hat - q, y_hat + q]`` in log-vol space. This helper carries
+    the dual interpretation issue #326 asks for: bucket the true
+    log_rv via the active checkpoint's tertile cutoffs and report,
+    per class, the fraction of rows whose true value sits inside the
+    regression band.
+
+    A class with zero rows on the calibration partition maps to
+    ``float('nan')`` so ``class_conditional_gap_flag`` can skip it.
+    The helper is intentionally pure -- it imports nothing from the
+    bucketing service to keep the unit tests trivially mockable; the
+    caller is responsible for passing the live ``raw_vol_cutoffs``
+    tuple off the active ``ModelConfig.vol_regime_quantiles``.
+    """
+
+    if len(log_rv_predictions) != len(log_rv_actuals):
+        raise ValueError(
+            f"log_rv_predictions ({len(log_rv_predictions)}) and "
+            f"log_rv_actuals ({len(log_rv_actuals)}) must align in length."
+        )
+    if len(raw_vol_cutoffs) != 2:
+        raise ValueError(
+            f"raw_vol_cutoffs must carry exactly two cutoffs; "
+            f"got {len(raw_vol_cutoffs)}."
+        )
+    cutoff_low, cutoff_high = (float(c) for c in raw_vol_cutoffs)
+    if cutoff_low <= 0.0 or cutoff_high <= 0.0 or cutoff_low > cutoff_high:
+        raise ValueError(
+            f"raw_vol_cutoffs must be positive and ordered; got {raw_vol_cutoffs!r}."
+        )
+    q = float(residual_quantile)
+    log_cutoff_low = math.log(cutoff_low)
+    log_cutoff_high = math.log(cutoff_high)
+
+    def _bucket(raw_value: float) -> str | None:
+        if not math.isfinite(raw_value):
+            return None
+        if raw_value < log_cutoff_low:
+            return class_names[0] if len(class_names) >= 1 else None
+        if raw_value < log_cutoff_high:
+            return class_names[1] if len(class_names) >= 2 else None
+        return class_names[2] if len(class_names) >= 3 else None
+
+    rows_per_class: Counter[str] = Counter()
+    inside_per_class: Counter[str] = Counter()
+    for pred, actual in zip(log_rv_predictions, log_rv_actuals):
+        try:
+            p = float(pred)
+            a = float(actual)
+        except (TypeError, ValueError):
+            continue
+        if not (math.isfinite(p) and math.isfinite(a)):
+            continue
+        bucket = _bucket(a)
+        if bucket is None:
+            continue
+        rows_per_class[bucket] += 1
+        if (p - q) <= a <= (p + q):
+            inside_per_class[bucket] += 1
+    coverage: dict[str, float] = {}
+    for label in class_names:
+        total = rows_per_class.get(str(label), 0)
+        if total == 0:
+            coverage[str(label)] = float("nan")
+        else:
+            coverage[str(label)] = float(inside_per_class.get(str(label), 0)) / float(total)
+    return coverage
+
+
 def format_class_set_label(
     predicted_set: Sequence[int],
     class_names: Sequence[str],
@@ -352,6 +603,36 @@ def load_manifest(path: Path | str) -> ConformalManifest:
         }
         if not rates_softmax:
             rates_softmax = None
+    # #326 conditional diagnostics. Pre-#326 manifests on disk simply
+    # lack both keys; the loader resolves them to ``None`` so the
+    # ConformalManifest constructor keeps its existing default and the
+    # back-compat contract holds.
+    class_cond_raw = payload.get("class_conditional_coverage")
+    set_size_raw = payload.get("set_size_distribution")
+    class_cond: dict[str, float] | None = None
+    set_size: dict[int, float] | None = None
+    if isinstance(class_cond_raw, Mapping):
+        class_cond = {
+            str(k): float(v)
+            for k, v in class_cond_raw.items()
+            if v is not None
+        }
+        if not class_cond:
+            class_cond = None
+    if isinstance(set_size_raw, Mapping):
+        # JSON object keys are strings on disk; cast back to int. A
+        # malformed key (non-integer) is dropped silently so a stale
+        # manifest does not crash the inference loader.
+        parsed: dict[int, float] = {}
+        for k, v in set_size_raw.items():
+            if v is None:
+                continue
+            try:
+                parsed[int(k)] = float(v)
+            except (TypeError, ValueError):
+                continue
+        if parsed:
+            set_size = parsed
     return ConformalManifest(
         alpha=float(payload["alpha"]),
         nominal_coverage=float(payload["nominal_coverage"]),
@@ -366,6 +647,8 @@ def load_manifest(path: Path | str) -> ConformalManifest:
         ),
         rates_residual_quantiles=rates_residuals,
         rates_softmax_quantiles=rates_softmax,
+        class_conditional_coverage=class_cond,
+        set_size_distribution=set_size,
     )
 
 

--- a/backend/app/evaluation/conformal.py
+++ b/backend/app/evaluation/conformal.py
@@ -91,15 +91,28 @@ class ConformalManifest:
                 else None
             ),
             "class_conditional_coverage": (
-                {str(k): float(v) for k, v in self.class_conditional_coverage.items()}
-                if self.class_conditional_coverage
+                # NaN sneaks in when a class is absent from the calibration
+                # fold (compute_class_conditional_coverage returns float('nan')
+                # for empty class slices); json.dumps would emit the bare
+                # `NaN` token, which is not RFC-8259-compliant and would
+                # crash load_manifest on read. Map NaN to None so the JSON
+                # round-trip stays valid.
+                {
+                    str(k): (None if not math.isfinite(float(v)) else float(v))
+                    for k, v in self.class_conditional_coverage.items()
+                }
+                if self.class_conditional_coverage is not None
                 else None
             ),
             "set_size_distribution": (
                 # JSON object keys must be strings; the loader reverses
-                # this to int on read.
-                {str(int(k)): float(v) for k, v in self.set_size_distribution.items()}
-                if self.set_size_distribution
+                # this to int on read. NaN handling mirrors the class
+                # coverage branch above.
+                {
+                    str(int(k)): (None if not math.isfinite(float(v)) else float(v))
+                    for k, v in self.set_size_distribution.items()
+                }
+                if self.set_size_distribution is not None
                 else None
             ),
         }

--- a/backend/app/evaluation/conformal.py
+++ b/backend/app/evaluation/conformal.py
@@ -450,7 +450,7 @@ def class_conditional_gap_flag(
     return flagged
 
 
-def compute_regression_band_class_coverage(
+def compute_regression_band_class_coverage(  # noqa: C901 — single-pass validation + bucketing, intentionally branchy
     *,
     log_rv_predictions: Sequence[float],
     log_rv_actuals: Sequence[float],
@@ -568,7 +568,7 @@ def empirical_coverage(
     return inside / len(predictions)
 
 
-def load_manifest(path: Path | str) -> ConformalManifest:
+def load_manifest(path: Path | str) -> ConformalManifest:  # noqa: C901 — JSON deserialiser with many optional back-compat fields
     """Read a JSON manifest. Residual quantile fields default to 0.0
     when absent (classification-only manifests written by
     ``save_manifest`` drop them); the inference loader treats a 0.0

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -874,7 +874,11 @@ def _maybe_write_classification_conformal_manifest(
         DEFAULT_CLASSIFICATION_ALPHA,
         ConformalManifest,
         calibrate_classification_conformal,
+        class_conditional_gap_flag,
+        compute_class_conditional_coverage,
+        compute_set_size_distribution,
         load_manifest,
+        predict_conformal_set,
         save_manifest,
     )
 
@@ -887,6 +891,38 @@ def _maybe_write_classification_conformal_manifest(
     except ValueError as exc:
         print(f"[conformal] classification calibration skipped: {exc}", flush=True)
         return
+
+    # #326 conditional diagnostics. Rebuild APS sets on the same val
+    # rows the threshold was fitted on -- self-coverage is the
+    # canonical reporting partition for split-conformal (Romano 2020
+    # §4) and matches the "calibration fold" the issue contract names.
+    # Class labels come from the active config's regime tuple; the
+    # helper falls back to ``["class_0", "class_1", ...]`` when no
+    # class names tuple is available so the helper is not gated on a
+    # ModelConfig fixture in tests / smoke runs.
+    n_classes = max((len(row) for row in class_scores), default=0)
+    class_names = _resolve_class_names_for_conformal(n_classes)
+    predicted_sets = [predict_conformal_set(row, softmax_q) for row in class_scores]
+    try:
+        class_cond = compute_class_conditional_coverage(
+            predicted_sets, targets, class_names
+        )
+    except ValueError as exc:
+        print(
+            f"[conformal] class-conditional coverage skipped: {exc}",
+            flush=True,
+        )
+        class_cond = None
+    try:
+        set_size = compute_set_size_distribution(
+            predicted_sets, n_classes=n_classes
+        )
+    except ValueError as exc:
+        print(
+            f"[conformal] set-size distribution skipped: {exc}",
+            flush=True,
+        )
+        set_size = None
 
     sidecar = Path(str(checkpoint_target.with_suffix("")) + ".conformal.json")
     if sidecar.exists():
@@ -911,6 +947,8 @@ def _maybe_write_classification_conformal_manifest(
                 softmax_quantile=softmax_q,
                 rates_residual_quantiles=existing.rates_residual_quantiles,
                 rates_softmax_quantiles=existing.rates_softmax_quantiles,
+                class_conditional_coverage=class_cond,
+                set_size_distribution=set_size,
             )
         except Exception:
             # Stale / unreadable sidecar — overwrite with a classification-only
@@ -923,6 +961,8 @@ def _maybe_write_classification_conformal_manifest(
                 residual_quantile_volatility=0.0,
                 calibration_n=len(class_scores),
                 softmax_quantile=softmax_q,
+                class_conditional_coverage=class_cond,
+                set_size_distribution=set_size,
             )
     else:
         manifest = ConformalManifest(
@@ -932,13 +972,66 @@ def _maybe_write_classification_conformal_manifest(
             residual_quantile_volatility=0.0,
             calibration_n=len(class_scores),
             softmax_quantile=softmax_q,
+            class_conditional_coverage=class_cond,
+            set_size_distribution=set_size,
         )
     save_manifest(manifest, sidecar)
+    # #326 class-conditional coverage gap flag. Surface degenerate
+    # per-class coverage (any class falling >0.10 below nominal) on
+    # the calibration log so the operator sees the warning before the
+    # checkpoint goes to inference -- the marginal coverage number
+    # alone can hide a class systematically dropped from the set
+    # (the issue's canonical normal-class collapse case).
+    flagged: list[str] = []
+    if class_cond:
+        flagged = class_conditional_gap_flag(
+            class_cond,
+            nominal=1.0 - DEFAULT_CLASSIFICATION_ALPHA,
+            tolerance=0.10,
+        )
     print(
         f"[conformal] calibrated softmax_quantile={softmax_q:.4f} "
         f"on n={len(class_scores)} val rows -> {sidecar.name}",
         flush=True,
     )
+    if class_cond is not None:
+        cov_repr = ", ".join(
+            f"{k}={v:.3f}" for k, v in class_cond.items()
+        )
+        print(f"[conformal] class-conditional coverage: {cov_repr}", flush=True)
+    if set_size is not None:
+        size_repr = ", ".join(
+            f"|S|={k}:{v:.3f}" for k, v in set_size.items()
+        )
+        print(f"[conformal] set-size distribution: {size_repr}", flush=True)
+    if flagged:
+        print(
+            "[conformal] WARNING class-conditional coverage gap > 0.10 below "
+            f"nominal on: {flagged}",
+            flush=True,
+        )
+
+
+def _resolve_class_names_for_conformal(n_classes: int) -> list[str]:
+    """Resolve the class label tuple the conformal diagnostics key on (#326).
+
+    The 3-class vol-regime head uses the canonical
+    ``("calm", "normal", "high")`` tuple from
+    :mod:`app.services.regime_bucketing`. On a different cardinality
+    (stance head, future multi-axis variants) the helper falls back
+    to ``[f"class_{i}"]`` so the conditional-coverage dict still
+    round-trips through the manifest -- the operator can rename the
+    keys downstream when the surface is wired through the API.
+    """
+
+    if n_classes == 3:
+        try:
+            from app.services.regime_bucketing import REGIME_LABELS
+
+            return list(REGIME_LABELS)
+        except Exception:  # pragma: no cover -- defensive
+            pass
+    return [f"class_{i}" for i in range(max(0, n_classes))]
 
 
 def _maybe_write_rates_conformal_manifest(
@@ -1051,6 +1144,16 @@ def _maybe_write_rates_conformal_manifest(
                 "calibration_n": existing.calibration_n,
                 "notes": existing.notes,
                 "softmax_quantile": existing.softmax_quantile,
+                # #326 conditional diagnostics. Preserve the
+                # classification-side conditional fields written by
+                # ``_maybe_write_classification_conformal_manifest``;
+                # the rates step does not produce its own
+                # class-conditional view (rates heads are per-row
+                # regression, not classification) so the merge keeps
+                # whatever the prior step wrote rather than clobbering
+                # the fields back to None.
+                "class_conditional_coverage": existing.class_conditional_coverage,
+                "set_size_distribution": existing.set_size_distribution,
             }
         )
     if rates_residuals:

--- a/tests/unit/test_conformal_class_conditional.py
+++ b/tests/unit/test_conformal_class_conditional.py
@@ -336,6 +336,41 @@ def test_manifest_round_trip_loads_pre_326_manifests_with_none() -> None:
     assert loaded.softmax_quantile == pytest.approx(0.30)
 
 
+def test_manifest_round_trip_handles_nan_class_slice() -> None:
+    """When a class is absent from the calibration fold,
+    ``compute_class_conditional_coverage`` returns ``float('nan')`` for that
+    class. The bare ``NaN`` token is not RFC-8259-compliant JSON, so
+    ``save_manifest`` must serialise it as ``null`` and ``load_manifest``
+    must round-trip the remaining finite entries cleanly (the all-NaN map
+    collapses to ``None`` via the existing empty-after-filter guard)."""
+
+    manifest = ConformalManifest(
+        alpha=0.2,
+        nominal_coverage=0.8,
+        residual_quantile_close=11.0,
+        residual_quantile_volatility=0.02,
+        calibration_n=300,
+        softmax_quantile=0.4,
+        class_conditional_coverage={
+            "calm": 0.83,
+            "normal": float("nan"),
+            "high": 0.71,
+        },
+        set_size_distribution={1: 0.6, 2: float("nan"), 3: 0.0},
+    )
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "nan-slice.conformal.json"
+        save_manifest(manifest, path)
+        # The serialised file must be valid JSON (json.loads would raise
+        # JSONDecodeError otherwise).
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert payload["class_conditional_coverage"]["normal"] is None
+        assert payload["set_size_distribution"]["2"] is None
+        loaded = load_manifest(path)
+    assert loaded.class_conditional_coverage == {"calm": 0.83, "high": 0.71}
+    assert loaded.set_size_distribution == {1: 0.6, 3: 0.0}
+
+
 def test_save_manifest_omits_none_class_conditional_fields() -> None:
     """A manifest without the new fields populated must serialise
     without the keys so a downstream reader of the legacy schema

--- a/tests/unit/test_conformal_class_conditional.py
+++ b/tests/unit/test_conformal_class_conditional.py
@@ -1,0 +1,598 @@
+"""Class-conditional coverage + set-size distribution diagnostics (#326).
+
+APS conformal calibration gives a marginal coverage guarantee under
+exchangeability, but the per-class slice is silent. When the model's
+softmax systematically excludes one class (the canonical normal-class
+collapse on the 3-class vol-regime head), marginal 0.80 coverage can
+hide degenerate per-class coverage like
+``{calm: 0.95, normal: 0.05, high: 0.92}``.
+
+These tests cover the helpers that surface the gap:
+
+* ``compute_class_conditional_coverage`` -- per-class empirical
+  coverage on the calibration fold.
+* ``compute_set_size_distribution`` -- Pr[|S|=k] for k in {1, 2, 3}.
+* ``class_conditional_gap_flag`` -- class names whose coverage falls
+  >0.10 below nominal.
+* ``compute_regression_band_class_coverage`` -- the dual interpretation
+  on the regression-canonical surface, where buckets come from
+  ``bucket_log_rv`` and the conformal object is a residual band.
+
+Plus the manifest round-trip carrying both new fields, and an end-to-
+end calibration-path test that walks
+``_maybe_write_classification_conformal_manifest`` on synthetic
+data and asserts the persisted sidecar carries the new fields.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import random
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from app.evaluation.conformal import (
+    ConformalManifest,
+    calibrate_classification_conformal,
+    class_conditional_gap_flag,
+    compute_class_conditional_coverage,
+    compute_regression_band_class_coverage,
+    compute_set_size_distribution,
+    load_manifest,
+    predict_conformal_set,
+    save_manifest,
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_class_conditional_coverage
+# ---------------------------------------------------------------------------
+
+
+def test_class_conditional_coverage_perfect_when_every_set_contains_truth() -> None:
+    """Trivial sanity: every prediction set contains the true class →
+    each class slice covers at 1.0."""
+
+    sets = [[0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2]]
+    truths = [0, 1, 2, 0, 1]
+    out = compute_class_conditional_coverage(sets, truths, ("calm", "normal", "high"))
+    assert out == {"calm": 1.0, "normal": 1.0, "high": 1.0}
+
+
+def test_class_conditional_coverage_detects_normal_collapse() -> None:
+    """Issue #326's canonical case: APS sets systematically omit
+    class 1 (``normal``). Marginal coverage stays high because the
+    sets cover the other two classes; the per-class slice on
+    ``normal`` collapses to ~0."""
+
+    # 100 rows total; class 0 / 1 / 2 each get ~33 rows.
+    # Sets always contain {0, 2} — never include class 1.
+    sets = [[0, 2]] * 99
+    truths = [i % 3 for i in range(99)]  # 33 per class
+    out = compute_class_conditional_coverage(sets, truths, ("calm", "normal", "high"))
+    assert out["calm"] == pytest.approx(1.0)
+    assert out["normal"] == pytest.approx(0.0)
+    assert out["high"] == pytest.approx(1.0)
+
+
+def test_class_conditional_coverage_returns_nan_for_empty_slice() -> None:
+    """A class with zero rows on the calibration partition must map
+    to NaN so the gap-flag helper can skip it cleanly rather than
+    flagging a 0/0 division."""
+
+    sets = [[0]]
+    truths = [0]
+    out = compute_class_conditional_coverage(sets, truths, ("calm", "normal", "high"))
+    assert out["calm"] == pytest.approx(1.0)
+    assert math.isnan(out["normal"])
+    assert math.isnan(out["high"])
+
+
+def test_class_conditional_coverage_rejects_length_mismatch() -> None:
+    with pytest.raises(ValueError):
+        compute_class_conditional_coverage([[0]], [0, 1], ("a", "b"))
+
+
+def test_class_conditional_coverage_rejects_empty_class_names() -> None:
+    with pytest.raises(ValueError):
+        compute_class_conditional_coverage([[0]], [0], ())
+
+
+# ---------------------------------------------------------------------------
+# compute_set_size_distribution
+# ---------------------------------------------------------------------------
+
+
+def test_set_size_distribution_sums_to_one() -> None:
+    sets = [[0], [0, 1], [0, 1, 2], [0], [1, 2]]
+    out = compute_set_size_distribution(sets, n_classes=3)
+    assert sum(out.values()) == pytest.approx(1.0)
+    assert out[1] == pytest.approx(2 / 5)
+    assert out[2] == pytest.approx(2 / 5)
+    assert out[3] == pytest.approx(1 / 5)
+
+
+def test_set_size_distribution_handles_missing_sizes() -> None:
+    """Sizes never observed must appear with mass 0.0 -- the contract
+    is the full ``[1, n_classes]`` keyspace so a downstream consumer
+    can render every bucket without a key-error."""
+
+    sets = [[0], [1], [2]]
+    out = compute_set_size_distribution(sets, n_classes=3)
+    assert set(out.keys()) == {1, 2, 3}
+    assert out[1] == pytest.approx(1.0)
+    assert out[2] == pytest.approx(0.0)
+    assert out[3] == pytest.approx(0.0)
+
+
+def test_set_size_distribution_rejects_empty_set() -> None:
+    """``predict_conformal_set`` never emits empties (argmax fallback);
+    if a caller smuggles one in, the helper must surface that loudly
+    rather than silently bucket into 0."""
+
+    with pytest.raises(ValueError):
+        compute_set_size_distribution([[]], n_classes=3)
+
+
+def test_set_size_distribution_rejects_oversized_set() -> None:
+    with pytest.raises(ValueError):
+        compute_set_size_distribution([[0, 1, 2, 3]], n_classes=3)
+
+
+def test_set_size_distribution_empty_input_returns_nans() -> None:
+    out = compute_set_size_distribution([], n_classes=3)
+    assert set(out.keys()) == {1, 2, 3}
+    for v in out.values():
+        assert math.isnan(v)
+
+
+# ---------------------------------------------------------------------------
+# class_conditional_gap_flag
+# ---------------------------------------------------------------------------
+
+
+def test_gap_flag_fires_on_degenerate_class() -> None:
+    """The canonical issue case: ``normal`` at 0.05 must be flagged
+    on the 0.80 nominal / 0.10 tolerance contract."""
+
+    coverage = {"calm": 0.85, "normal": 0.05, "high": 0.82}
+    flagged = class_conditional_gap_flag(coverage, nominal=0.80, tolerance=0.10)
+    assert flagged == ["normal"]
+
+
+def test_gap_flag_quiet_when_all_classes_in_band() -> None:
+    coverage = {"calm": 0.78, "normal": 0.74, "high": 0.81}
+    flagged = class_conditional_gap_flag(coverage, nominal=0.80, tolerance=0.10)
+    assert flagged == []
+
+
+def test_gap_flag_skips_nan_slices() -> None:
+    """An empty class slice (NaN coverage) must not fire the flag --
+    absence of evidence is not evidence of a degenerate gap."""
+
+    coverage = {"calm": 0.85, "normal": float("nan"), "high": 0.82}
+    flagged = class_conditional_gap_flag(coverage, nominal=0.80, tolerance=0.10)
+    assert flagged == []
+
+
+def test_gap_flag_threshold_inclusive_on_equal() -> None:
+    """Coverage exactly equal to ``nominal - tolerance`` (0.70 in the
+    default contract) is on the boundary -- the helper does NOT flag
+    it, matching the issue's '>0.10 below' wording."""
+
+    coverage = {"normal": 0.70}
+    assert class_conditional_gap_flag(coverage, nominal=0.80, tolerance=0.10) == []
+
+
+def test_gap_flag_returns_multiple_classes_in_input_order() -> None:
+    coverage = {"calm": 0.10, "normal": 0.05, "high": 0.85}
+    flagged = class_conditional_gap_flag(coverage, nominal=0.80, tolerance=0.10)
+    assert flagged == ["calm", "normal"]
+
+
+def test_gap_flag_rejects_invalid_nominal() -> None:
+    with pytest.raises(ValueError):
+        class_conditional_gap_flag({"a": 0.5}, nominal=1.5, tolerance=0.1)
+
+
+def test_gap_flag_rejects_negative_tolerance() -> None:
+    with pytest.raises(ValueError):
+        class_conditional_gap_flag({"a": 0.5}, nominal=0.8, tolerance=-0.1)
+
+
+# ---------------------------------------------------------------------------
+# compute_regression_band_class_coverage (regression-canonical dual)
+# ---------------------------------------------------------------------------
+
+
+def test_regression_band_perfect_when_band_is_wide_enough() -> None:
+    """A wide residual quantile must cover every bucket at 1.0 -- a
+    sanity check that the bucketing + band-membership logic does not
+    accidentally exclude rows."""
+
+    # Cutoffs in raw vol space → log cutoffs around log(0.10) and log(0.20).
+    cutoffs = (0.10, 0.20)
+    # Synthetic predictions perfectly equal to actuals, but bucket by truth.
+    log_rv_actuals = [math.log(0.05), math.log(0.15), math.log(0.30)] * 20
+    log_rv_predictions = [v + 0.01 for v in log_rv_actuals]
+    out = compute_regression_band_class_coverage(
+        log_rv_predictions=log_rv_predictions,
+        log_rv_actuals=log_rv_actuals,
+        residual_quantile=1.0,  # very wide
+        raw_vol_cutoffs=cutoffs,
+    )
+    assert out["calm"] == pytest.approx(1.0)
+    assert out["normal"] == pytest.approx(1.0)
+    assert out["high"] == pytest.approx(1.0)
+
+
+def test_regression_band_zero_when_band_is_too_tight() -> None:
+    """A vanishingly small residual quantile + non-zero residuals →
+    every class slice covers at 0.0."""
+
+    cutoffs = (0.10, 0.20)
+    log_rv_actuals = [math.log(0.05), math.log(0.15), math.log(0.30)] * 20
+    log_rv_predictions = [v + 0.5 for v in log_rv_actuals]
+    out = compute_regression_band_class_coverage(
+        log_rv_predictions=log_rv_predictions,
+        log_rv_actuals=log_rv_actuals,
+        residual_quantile=1e-9,
+        raw_vol_cutoffs=cutoffs,
+    )
+    assert out["calm"] == pytest.approx(0.0)
+    assert out["normal"] == pytest.approx(0.0)
+    assert out["high"] == pytest.approx(0.0)
+
+
+def test_regression_band_nan_for_empty_bucket() -> None:
+    cutoffs = (0.10, 0.20)
+    # Only ``calm`` rows; ``normal`` and ``high`` slices empty → NaN.
+    log_rv_actuals = [math.log(0.05)] * 5
+    log_rv_predictions = list(log_rv_actuals)
+    out = compute_regression_band_class_coverage(
+        log_rv_predictions=log_rv_predictions,
+        log_rv_actuals=log_rv_actuals,
+        residual_quantile=0.5,
+        raw_vol_cutoffs=cutoffs,
+    )
+    assert out["calm"] == pytest.approx(1.0)
+    assert math.isnan(out["normal"])
+    assert math.isnan(out["high"])
+
+
+def test_regression_band_rejects_mismatched_cutoffs() -> None:
+    with pytest.raises(ValueError):
+        compute_regression_band_class_coverage(
+            log_rv_predictions=[0.0],
+            log_rv_actuals=[0.0],
+            residual_quantile=0.1,
+            raw_vol_cutoffs=(0.20, 0.10),  # inverted
+        )
+
+
+def test_regression_band_rejects_length_mismatch() -> None:
+    with pytest.raises(ValueError):
+        compute_regression_band_class_coverage(
+            log_rv_predictions=[0.0, 0.1],
+            log_rv_actuals=[0.0],
+            residual_quantile=0.1,
+            raw_vol_cutoffs=(0.10, 0.20),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Manifest round-trip carrying the new fields
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_round_trip_preserves_class_conditional_fields() -> None:
+    manifest = ConformalManifest(
+        alpha=0.2,
+        nominal_coverage=0.8,
+        residual_quantile_close=0.0,
+        residual_quantile_volatility=0.0,
+        calibration_n=250,
+        softmax_quantile=0.42,
+        class_conditional_coverage={"calm": 0.81, "normal": 0.05, "high": 0.79},
+        set_size_distribution={1: 0.4, 2: 0.45, 3: 0.15},
+    )
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "manifest.conformal.json"
+        save_manifest(manifest, path)
+        loaded = load_manifest(path)
+    assert loaded.class_conditional_coverage == {
+        "calm": pytest.approx(0.81),
+        "normal": pytest.approx(0.05),
+        "high": pytest.approx(0.79),
+    }
+    assert loaded.set_size_distribution is not None
+    assert loaded.set_size_distribution[1] == pytest.approx(0.4)
+    assert loaded.set_size_distribution[2] == pytest.approx(0.45)
+    assert loaded.set_size_distribution[3] == pytest.approx(0.15)
+
+
+def test_manifest_round_trip_loads_pre_326_manifests_with_none() -> None:
+    """Pre-#326 manifests on disk lack both new keys. The loader must
+    read them cleanly with both fields ``None`` so existing
+    deployments survive the upgrade."""
+
+    legacy_payload = {
+        "alpha": 0.2,
+        "nominal_coverage": 0.8,
+        "residual_quantile_close": 11.0,
+        "residual_quantile_volatility": 0.02,
+        "calibration_n": 300,
+        "softmax_quantile": 0.30,
+    }
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "legacy.conformal.json"
+        path.write_text(json.dumps(legacy_payload), encoding="utf-8")
+        loaded = load_manifest(path)
+    assert loaded.class_conditional_coverage is None
+    assert loaded.set_size_distribution is None
+    assert loaded.softmax_quantile == pytest.approx(0.30)
+
+
+def test_save_manifest_omits_none_class_conditional_fields() -> None:
+    """A manifest without the new fields populated must serialise
+    without the keys so a downstream reader of the legacy schema
+    does not pick up ``null`` values it has to handle."""
+
+    manifest = ConformalManifest(
+        alpha=0.2,
+        nominal_coverage=0.8,
+        residual_quantile_close=11.0,
+        residual_quantile_volatility=0.02,
+        calibration_n=300,
+        softmax_quantile=0.3,
+    )
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "regression-only.conformal.json"
+        save_manifest(manifest, path)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    assert "class_conditional_coverage" not in payload
+    assert "set_size_distribution" not in payload
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: calibration path populates the new fields on the sidecar
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_collapse_softmax(n: int, *, seed: int = 0):
+    """Generate softmax rows where class 1 is systematically suppressed.
+
+    Models the issue case: class 1 is rare (~10 % of rows, matching the
+    ``normal`` recall ~7 % the issue cites), and on the rare rows
+    where it IS the truth, the softmax confidently picks one of the
+    other two classes (class 1 stays at ~0.05). The bulk-correct
+    rows (classes 0 + 2 with their own truth at ~0.85) drive the APS
+    threshold low, so ``1 - softmax`` for class 1 rarely clears the
+    bar → class 1 systematically excluded from prediction sets, and
+    its conditional coverage collapses.
+    """
+
+    rng = random.Random(seed)
+    softmax: list[list[float]] = []
+    true_classes: list[int] = []
+    for _ in range(n):
+        # 10% class 1, ~45% class 0 / 2 each — drives a low APS
+        # threshold from the confident-correct rows.
+        roll = rng.random()
+        if roll < 0.10:
+            y = 1
+        elif roll < 0.55:
+            y = 0
+        else:
+            y = 2
+        true_classes.append(y)
+        if y == 1:
+            # Truth is normal but model misclassifies as calm or high.
+            other = rng.choice([0, 2])
+            row = [0.05, 0.05, 0.05]
+            row[other] = 0.90
+        else:
+            # Confident correct on the majority classes -- this drives
+            # the calibration threshold low.
+            row = [0.03, 0.03, 0.03]
+            row[y] = 0.94
+        s = sum(row)
+        softmax.append([v / s for v in row])
+    return softmax, true_classes
+
+
+def test_calibration_path_persists_new_fields_and_flags_collapse() -> None:
+    """End-to-end: the training-loop helper
+    ``_maybe_write_classification_conformal_manifest`` consumes
+    synthetic ``EvaluationMetrics`` whose class-1 softmax is
+    suppressed and writes a sidecar that carries
+    ``class_conditional_coverage`` + ``set_size_distribution``. The
+    canonical normal-class slice must show degenerate coverage."""
+
+    from app.evaluation.metrics import EvaluationMetrics
+    from app.training.loop import _maybe_write_classification_conformal_manifest
+
+    softmax, truths = _synthetic_collapse_softmax(450, seed=7)
+    metrics = EvaluationMetrics(
+        loss=0.5,
+        close_rmse=float("inf"),
+        volatility_rmse=float("inf"),
+        combined_rmse=float("inf"),
+        regime_accuracy=0.6,
+        regime_f1_macro=0.5,
+        regime_loss=0.5,
+        class_scores=softmax,
+        targets=truths,
+    )
+    with tempfile.TemporaryDirectory() as td:
+        ckpt = Path(td) / "forecaster_best.pt"
+        ckpt.write_bytes(b"")
+        _maybe_write_classification_conformal_manifest(metrics, ckpt)
+        sidecar = Path(td) / "forecaster_best.conformal.json"
+        assert sidecar.exists()
+        loaded = load_manifest(sidecar)
+
+    assert loaded.softmax_quantile is not None
+    assert loaded.class_conditional_coverage is not None
+    assert loaded.set_size_distribution is not None
+    # The set-size distribution must sum to 1.0 within rounding.
+    assert sum(loaded.set_size_distribution.values()) == pytest.approx(1.0, abs=1e-6)
+    # The flag helper must fire on the synthetic collapse fixture:
+    # class ``normal`` (index 1) is systematically excluded so its
+    # coverage falls well below the 0.70 gap threshold.
+    flagged = class_conditional_gap_flag(
+        loaded.class_conditional_coverage, nominal=0.80, tolerance=0.10
+    )
+    assert "normal" in flagged, (
+        "class_conditional_gap_flag must surface the collapsed normal "
+        f"class; coverage={loaded.class_conditional_coverage}"
+    )
+
+
+def test_calibration_path_clean_signal_does_not_flag() -> None:
+    """A well-behaved synthetic fixture (every class equally well
+    served) must NOT trigger the gap flag -- guards against a
+    false-positive on the rejection contract."""
+
+    from app.evaluation.metrics import EvaluationMetrics
+    from app.training.loop import _maybe_write_classification_conformal_manifest
+
+    rng = random.Random(11)
+    n = 600
+    softmax: list[list[float]] = []
+    truths: list[int] = []
+    for _ in range(n):
+        y = rng.randint(0, 2)
+        truths.append(y)
+        correct = rng.random() < 0.85
+        row = [0.10, 0.10, 0.10]
+        winner = y if correct else (y + rng.choice([1, 2])) % 3
+        row[winner] = 0.80
+        s = sum(row)
+        softmax.append([v / s for v in row])
+    metrics = EvaluationMetrics(
+        loss=0.5,
+        close_rmse=float("inf"),
+        volatility_rmse=float("inf"),
+        combined_rmse=float("inf"),
+        regime_accuracy=0.6,
+        regime_f1_macro=0.5,
+        regime_loss=0.5,
+        class_scores=softmax,
+        targets=truths,
+    )
+    with tempfile.TemporaryDirectory() as td:
+        ckpt = Path(td) / "forecaster_best.pt"
+        ckpt.write_bytes(b"")
+        _maybe_write_classification_conformal_manifest(metrics, ckpt)
+        sidecar = Path(td) / "forecaster_best.conformal.json"
+        loaded = load_manifest(sidecar)
+
+    assert loaded.class_conditional_coverage is not None
+    flagged = class_conditional_gap_flag(
+        loaded.class_conditional_coverage, nominal=0.80, tolerance=0.10
+    )
+    assert flagged == [], (
+        "clean synthetic signal must not trigger the gap flag; "
+        f"coverage={loaded.class_conditional_coverage}"
+    )
+
+
+def test_rates_calibration_preserves_class_conditional_fields() -> None:
+    """The per-rates-head calibration step merges onto the sidecar
+    written by ``_maybe_write_classification_conformal_manifest``;
+    the merge must NOT clobber the class-conditional fields the prior
+    step persisted. Regression guard against a silent drop of the
+    #326 diagnostics when the dual-head path runs after
+    classification."""
+
+    from app.evaluation.metrics import EvaluationMetrics
+    from app.training.loop import (
+        _maybe_write_classification_conformal_manifest,
+        _maybe_write_rates_conformal_manifest,
+    )
+
+    softmax, truths = _synthetic_collapse_softmax(300, seed=17)
+    cls_metrics = EvaluationMetrics(
+        loss=0.5,
+        close_rmse=float("inf"),
+        volatility_rmse=float("inf"),
+        combined_rmse=float("inf"),
+        regime_accuracy=0.6,
+        regime_f1_macro=0.5,
+        regime_loss=0.5,
+        class_scores=softmax,
+        targets=truths,
+    )
+    # Build a rates metrics block with enough rows to fit the per-head
+    # residual quantile but no per-head class arrays (mimicking the
+    # regression-only rates surface).
+    rates_metrics = {
+        "2y": {
+            "predictions_bps": [float(i) for i in range(20)],
+            "actuals_bps": [float(i + 1) for i in range(20)],
+        }
+    }
+    rates_eval_metrics = EvaluationMetrics(
+        loss=0.5,
+        close_rmse=float("inf"),
+        volatility_rmse=float("inf"),
+        combined_rmse=float("inf"),
+        regime_accuracy=0.6,
+        regime_f1_macro=0.5,
+        regime_loss=0.5,
+        class_scores=softmax,
+        targets=truths,
+        rates_metrics=rates_metrics,
+    )
+    with tempfile.TemporaryDirectory() as td:
+        ckpt = Path(td) / "forecaster_best.pt"
+        ckpt.write_bytes(b"")
+        _maybe_write_classification_conformal_manifest(cls_metrics, ckpt)
+        sidecar = Path(td) / "forecaster_best.conformal.json"
+        before = load_manifest(sidecar)
+        assert before.class_conditional_coverage is not None
+        assert before.set_size_distribution is not None
+        _maybe_write_rates_conformal_manifest(
+            rates_eval_metrics, ckpt, head_names=["2y"]
+        )
+        after = load_manifest(sidecar)
+    assert after.class_conditional_coverage == before.class_conditional_coverage
+    assert after.set_size_distribution == before.set_size_distribution
+    assert after.rates_residual_quantiles is not None
+    assert "2y" in after.rates_residual_quantiles
+
+
+def test_calibration_path_emits_diagnostic_logs(capsys) -> None:
+    """The calibration helper must print one
+    ``[conformal] class-conditional coverage:`` line and one
+    ``[conformal] set-size distribution:`` line whenever the
+    diagnostics populate, so the operator sees the per-class slice
+    on the calibration breadcrumb without grepping the manifest."""
+
+    from app.evaluation.metrics import EvaluationMetrics
+    from app.training.loop import _maybe_write_classification_conformal_manifest
+
+    softmax, truths = _synthetic_collapse_softmax(300, seed=13)
+    metrics = EvaluationMetrics(
+        loss=0.5,
+        close_rmse=float("inf"),
+        volatility_rmse=float("inf"),
+        combined_rmse=float("inf"),
+        regime_accuracy=0.6,
+        regime_f1_macro=0.5,
+        regime_loss=0.5,
+        class_scores=softmax,
+        targets=truths,
+    )
+    with tempfile.TemporaryDirectory() as td:
+        ckpt = Path(td) / "forecaster_best.pt"
+        ckpt.write_bytes(b"")
+        _maybe_write_classification_conformal_manifest(metrics, ckpt)
+    captured = capsys.readouterr().out
+    assert "class-conditional coverage" in captured
+    assert "set-size distribution" in captured
+    assert "WARNING class-conditional coverage gap" in captured


### PR DESCRIPTION
## Summary
- Adds per-class empirical coverage + set-size distribution diagnostics to the APS conformal surface; flags collapse when any class falls > 0.10 below nominal.
- Surfaces the dual interpretation under regression-canonical mode via `compute_regression_band_class_coverage`.
- Manifest schema back-compat preserved: pre-#326 sidecars load with the new fields at `None`.
- Wiki §6.12 documents the new fields, the flag contract, and the regression-band dual.

Closes #326.

## Test plan
- `docker run --rm -v $(pwd):/app -w /app -e PYTHONPATH=/app/backend fed-pulse-backend:latest python -m pytest tests/unit/test_conformal_class_conditional.py -q`
- `docker run --rm -v $(pwd):/app -w /app -e PYTHONPATH=/app/backend fed-pulse-backend:latest python -m pytest tests/ -k conformal -q`