### PR TITLE
Honest headline reporting + per-class P/R/F1 + fold-4 ablation + aggregation rule (#323)

### DIFF
--- a/backend/app/evaluation/reporting.py
+++ b/backend/app/evaluation/reporting.py
@@ -188,7 +188,7 @@ def with_without_fold(
     }
 
 
-def with_without_macro_release(
+def with_without_macro_release(  # noqa: PLR0913 — kw-only ablation surface; collapsing into a config dataclass would hurt call-site clarity
     records: Sequence[Record],
     *,
     is_macro_release_field: str = "is_macro_release",
@@ -270,7 +270,7 @@ class HonestHeadlineReport:
         }
 
 
-def four_variant_report(
+def four_variant_report(  # noqa: PLR0913 — kw-only headline-cell config; collapsing into a dataclass would hide the four-axes contract
     records: Sequence[Record],
     *,
     drop_fold_id: str = "wf_fold_4",
@@ -448,7 +448,7 @@ def _mean_of_fold_means(
     return sum(per_fold) / len(per_fold)
 
 
-def _bootstrap_macro_f1_ci(
+def _bootstrap_macro_f1_ci(  # noqa: PLR0913 — kw-only bootstrap config; collapsing would obscure the per-class API
     preds: Sequence[int],
     targets: Sequence[int],
     *,

--- a/backend/app/evaluation/reporting.py
+++ b/backend/app/evaluation/reporting.py
@@ -67,7 +67,7 @@ _FOMC_SOURCE_TYPES = {"fomc_statement", "fomc_minutes"}
 # ---------------------------------------------------------------------------
 
 
-def mixed_pool_macro_f1(
+def mixed_pool_macro_f1(  # noqa: PLR0913 — kw-only stratification config; collapsing would hide the variant contract
     records: Sequence[Record],
     *,
     n_classes: int = 3,
@@ -96,7 +96,7 @@ def mixed_pool_macro_f1(
     )
 
 
-def fomc_only_macro_f1(
+def fomc_only_macro_f1(  # noqa: PLR0913 — kw-only stratification config; collapsing would hide the variant contract
     records: Sequence[Record],
     *,
     source_type_field: str = "source_type",
@@ -133,7 +133,7 @@ def fomc_only_macro_f1(
     )
 
 
-def with_without_fold(
+def with_without_fold(  # noqa: PLR0913 — kw-only stratification config; collapsing would hide the variant contract
     records: Sequence[Record],
     *,
     drop_fold_id: str,

--- a/backend/app/evaluation/reporting.py
+++ b/backend/app/evaluation/reporting.py
@@ -1,0 +1,529 @@
+"""Honest headline reporting variants for the vol-regime classifier (#323).
+
+The pooled headline number (e.g. `0.4538`) sits on top of three
+stratification choices that the cell does not announce: which event
+types make it into the pool, whether `wf_fold_4` (zero-`calm`-class
+test slice, R-17) is included, and whether the macro-release augmented
+rows from §6.7 Chunk-3 are pooled with the FOMC test rows. The same
+underlying predictions can produce four meaningfully different
+headlines depending on these choices; the published cell must say
+which one it cites.
+
+This module supplies the four reporting variants the issue calls for.
+Each helper consumes a sequence of per-row records — the row-level
+test-partition surface PR #226 wired onto :class:`EvaluationMetrics`
+(`predictions` / `targets` / per-row metadata) — and emits a single
+report dict carrying:
+
+- `macro_f1` — the aggregate macro-F1 on the variant's row subset
+- `per_class` — per-class precision / recall / F1 / support
+- `ci` — block-bootstrap confidence interval (1k resamples,
+  block_size=20 by default, matching :mod:`app.evaluation.bootstrap`)
+- `support` — total row count contributing to the variant
+- `pooling` — `mean-of-fold-means` and `row-pooled` cells per the
+  §Aggregation rule in `docs/benchmark-policy.md`
+
+The helpers stay pure-Python (no numpy / sklearn dependency) so they
+share the CI surface with :mod:`app.evaluation.classification_breakdown`
+and :mod:`app.evaluation.regime_pooled_aggregator`.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from app.evaluation.classification_breakdown import (
+    ClassificationBreakdown,
+    compute_classification_breakdown,
+)
+
+
+# ---------------------------------------------------------------------------
+# Input record contract
+# ---------------------------------------------------------------------------
+
+# A single row record carries the stratification metadata each variant
+# filters on. Records are dict-like so the helpers stay compatible with
+# the JSONL surface emitted by `app.data.finetune_batch` and the
+# row-level test predictions PR #226 wired onto `EvaluationMetrics`.
+# Required keys: `prediction` (int class index), `target` (int class
+# index). Optional keys consumed by individual helpers below:
+# - `fold_id`             — e.g. `"wf_fold_4"`; consumed by `with_without_fold`
+# - `source_type`         — e.g. `"fomc_statement"`; consumed by
+#                           `fomc_only_macro_f1`
+# - `is_macro_release`    — bool; consumed by `with_without_macro_release`
+Record = Mapping[str, Any]
+
+
+_FOMC_SOURCE_TYPES = {"fomc_statement", "fomc_minutes"}
+
+
+# ---------------------------------------------------------------------------
+# Public helpers — the four variants the issue requires
+# ---------------------------------------------------------------------------
+
+
+def mixed_pool_macro_f1(
+    records: Sequence[Record],
+    *,
+    n_classes: int = 3,
+    block_size: int = 20,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    bootstrap_seed: int = 11,
+    fold_field: str = "fold_id",
+) -> dict[str, Any]:
+    """Mixed-pool (current behaviour): every record contributes once.
+
+    Reports both pooling conventions side-by-side per the §Aggregation
+    rule — `mean-of-fold-means` (the canonical published cell) and
+    `row-pooled` (the secondary cell every honest report must cite).
+    """
+
+    return _report_cell(
+        records,
+        n_classes=n_classes,
+        block_size=block_size,
+        n_resamples=n_resamples,
+        coverage=coverage,
+        bootstrap_seed=bootstrap_seed,
+        fold_field=fold_field,
+        label="mixed_pool",
+    )
+
+
+def fomc_only_macro_f1(
+    records: Sequence[Record],
+    *,
+    source_type_field: str = "source_type",
+    fomc_source_types: Iterable[str] = _FOMC_SOURCE_TYPES,
+    n_classes: int = 3,
+    block_size: int = 20,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    bootstrap_seed: int = 11,
+    fold_field: str = "fold_id",
+) -> dict[str, Any]:
+    """FOMC-only stratified headline (`fomc_statement` + `fomc_minutes`).
+
+    The primary thesis number under the §6.7 honest-headline programme:
+    every cross-bank or macro-release row drops out so the pool reflects
+    the FOMC corpus the thesis claim is over.
+    """
+
+    allowed = {str(s).lower() for s in fomc_source_types}
+    subset = [
+        r
+        for r in records
+        if str(r.get(source_type_field, "")).lower() in allowed
+    ]
+    return _report_cell(
+        subset,
+        n_classes=n_classes,
+        block_size=block_size,
+        n_resamples=n_resamples,
+        coverage=coverage,
+        bootstrap_seed=bootstrap_seed,
+        fold_field=fold_field,
+        label="fomc_only",
+    )
+
+
+def with_without_fold(
+    records: Sequence[Record],
+    *,
+    drop_fold_id: str,
+    fold_field: str = "fold_id",
+    n_classes: int = 3,
+    block_size: int = 20,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    bootstrap_seed: int = 11,
+) -> dict[str, dict[str, Any]]:
+    """Headline with-and-without a named fold (R-17 fold-4 contribution).
+
+    Returns a `{"with": ..., "without": ..., "delta": ...}` dict so
+    every published macro-F1 cell can quote both readings and the
+    magnitude of the fold's contribution. `drop_fold_id` is matched
+    case-sensitively against the record's `fold_field`.
+    """
+
+    target_fold = str(drop_fold_id)
+    with_records = list(records)
+    without_records = [
+        r for r in records if str(r.get(fold_field, "")) != target_fold
+    ]
+    with_cell = _report_cell(
+        with_records,
+        n_classes=n_classes,
+        block_size=block_size,
+        n_resamples=n_resamples,
+        coverage=coverage,
+        bootstrap_seed=bootstrap_seed,
+        fold_field=fold_field,
+        label="with_fold",
+    )
+    without_cell = _report_cell(
+        without_records,
+        n_classes=n_classes,
+        block_size=block_size,
+        n_resamples=n_resamples,
+        coverage=coverage,
+        bootstrap_seed=bootstrap_seed,
+        fold_field=fold_field,
+        label="without_fold",
+    )
+    delta = with_cell["macro_f1"]["row_pooled"] - without_cell["macro_f1"][
+        "row_pooled"
+    ]
+    return {
+        "with": with_cell,
+        "without": without_cell,
+        "dropped_fold_id": target_fold,
+        "delta_macro_f1_row_pooled": delta,
+    }
+
+
+def with_without_macro_release(
+    records: Sequence[Record],
+    *,
+    is_macro_release_field: str = "is_macro_release",
+    fold_field: str = "fold_id",
+    n_classes: int = 3,
+    block_size: int = 20,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    bootstrap_seed: int = 11,
+) -> dict[str, dict[str, Any]]:
+    """Headline with-and-without macro-release augmented rows.
+
+    The §6.7 Chunk-3 augmentation pulls CPI / NFP release-date rows
+    into the supervised pool. Reporting both cells side-by-side keeps
+    the lift attribution auditable — the published macro-F1 must say
+    whether the augmentation rows were inside the headline or not.
+    """
+
+    with_cell = _report_cell(
+        records,
+        n_classes=n_classes,
+        block_size=block_size,
+        n_resamples=n_resamples,
+        coverage=coverage,
+        bootstrap_seed=bootstrap_seed,
+        fold_field=fold_field,
+        label="with_macro_release",
+    )
+    without_records = [
+        r for r in records if not bool(r.get(is_macro_release_field, False))
+    ]
+    without_cell = _report_cell(
+        without_records,
+        n_classes=n_classes,
+        block_size=block_size,
+        n_resamples=n_resamples,
+        coverage=coverage,
+        bootstrap_seed=bootstrap_seed,
+        fold_field=fold_field,
+        label="without_macro_release",
+    )
+    delta = with_cell["macro_f1"]["row_pooled"] - without_cell["macro_f1"][
+        "row_pooled"
+    ]
+    return {
+        "with": with_cell,
+        "without": without_cell,
+        "delta_macro_f1_row_pooled": delta,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Combined surface
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HonestHeadlineReport:
+    """All four reporting variants for a single canonical cell.
+
+    The §6.7 honest-headline protocol publishes every macro-F1 cell
+    with these four variants attached so a reader can see the FOMC-only
+    thesis number, the mixed-pool comparator, the fold-4 with/without
+    pair, and the macro-release with/without pair without re-running
+    the sweep.
+    """
+
+    mixed_pool: dict[str, Any]
+    fomc_only: dict[str, Any]
+    fold_4: dict[str, dict[str, Any]]
+    macro_release: dict[str, dict[str, Any]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mixed_pool": self.mixed_pool,
+            "fomc_only": self.fomc_only,
+            "fold_4_with_without": self.fold_4,
+            "macro_release_with_without": self.macro_release,
+        }
+
+
+def four_variant_report(
+    records: Sequence[Record],
+    *,
+    drop_fold_id: str = "wf_fold_4",
+    source_type_field: str = "source_type",
+    fomc_source_types: Iterable[str] = _FOMC_SOURCE_TYPES,
+    is_macro_release_field: str = "is_macro_release",
+    fold_field: str = "fold_id",
+    n_classes: int = 3,
+    block_size: int = 20,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    bootstrap_seed: int = 11,
+) -> HonestHeadlineReport:
+    """Compute all four reporting variants for one canonical cell."""
+
+    return HonestHeadlineReport(
+        mixed_pool=mixed_pool_macro_f1(
+            records,
+            n_classes=n_classes,
+            block_size=block_size,
+            n_resamples=n_resamples,
+            coverage=coverage,
+            bootstrap_seed=bootstrap_seed,
+            fold_field=fold_field,
+        ),
+        fomc_only=fomc_only_macro_f1(
+            records,
+            source_type_field=source_type_field,
+            fomc_source_types=fomc_source_types,
+            n_classes=n_classes,
+            block_size=block_size,
+            n_resamples=n_resamples,
+            coverage=coverage,
+            bootstrap_seed=bootstrap_seed,
+            fold_field=fold_field,
+        ),
+        fold_4=with_without_fold(
+            records,
+            drop_fold_id=drop_fold_id,
+            fold_field=fold_field,
+            n_classes=n_classes,
+            block_size=block_size,
+            n_resamples=n_resamples,
+            coverage=coverage,
+            bootstrap_seed=bootstrap_seed,
+        ),
+        macro_release=with_without_macro_release(
+            records,
+            is_macro_release_field=is_macro_release_field,
+            fold_field=fold_field,
+            n_classes=n_classes,
+            block_size=block_size,
+            n_resamples=n_resamples,
+            coverage=coverage,
+            bootstrap_seed=bootstrap_seed,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _report_cell(  # noqa: PLR0913
+    records: Sequence[Record],
+    *,
+    n_classes: int,
+    block_size: int,
+    n_resamples: int,
+    coverage: float,
+    bootstrap_seed: int,
+    fold_field: str,
+    label: str,
+) -> dict[str, Any]:
+    """Build one variant's report dict: macro-F1 (both poolings),
+    per-class P/R/F1, and a block-bootstrap CI on the row-pooled cell.
+    """
+
+    preds, targets, fold_ids = _extract_arrays(records, fold_field=fold_field)
+    breakdown = compute_classification_breakdown(
+        predictions=preds,
+        targets=targets,
+        n_classes=n_classes,
+    )
+    mean_of_fold_means = _mean_of_fold_means(
+        preds, targets, fold_ids, n_classes=n_classes
+    )
+    ci = _bootstrap_macro_f1_ci(
+        preds,
+        targets,
+        n_classes=n_classes,
+        block_size=block_size,
+        n_resamples=n_resamples,
+        coverage=coverage,
+        seed=bootstrap_seed,
+    )
+
+    return {
+        "label": label,
+        "support": len(preds),
+        "n_classes": n_classes,
+        "macro_f1": {
+            "row_pooled": float(breakdown.macro_f1),
+            "mean_of_fold_means": mean_of_fold_means,
+            "canonical": "mean_of_fold_means",
+        },
+        "per_class": [m.to_dict() for m in breakdown.per_class],
+        "confusion_matrix": [list(row) for row in breakdown.confusion_matrix],
+        "ci": {
+            "point": ci["point"],
+            "lo": ci["lo"],
+            "hi": ci["hi"],
+            "coverage": coverage,
+            "n_resamples": n_resamples,
+            "block_size": block_size,
+            "statistic": "macro_f1_row_pooled",
+        },
+        "folds_present": sorted(set(fold_ids)) if fold_ids else [],
+    }
+
+
+def _extract_arrays(
+    records: Sequence[Record],
+    *,
+    fold_field: str,
+) -> tuple[list[int], list[int], list[str]]:
+    preds: list[int] = []
+    targets: list[int] = []
+    folds: list[str] = []
+    for r in records:
+        if "prediction" not in r or "target" not in r:
+            continue
+        preds.append(int(r["prediction"]))
+        targets.append(int(r["target"]))
+        folds.append(str(r.get(fold_field, "")))
+    return preds, targets, folds
+
+
+def _mean_of_fold_means(
+    preds: Sequence[int],
+    targets: Sequence[int],
+    folds: Sequence[str],
+    *,
+    n_classes: int,
+) -> float | None:
+    """Per-fold macro-F1, then unweighted mean across folds.
+
+    Returns ``None`` if no fold label is populated on any record — the
+    statistic is undefined without a fold tag, and the caller should
+    fall back to the row-pooled cell.
+    """
+
+    if not folds or all(not f for f in folds):
+        return None
+    groups: dict[str, tuple[list[int], list[int]]] = {}
+    for p, t, f in zip(preds, targets, folds):
+        if not f:
+            continue
+        bucket = groups.setdefault(f, ([], []))
+        bucket[0].append(p)
+        bucket[1].append(t)
+    if not groups:
+        return None
+    per_fold: list[float] = []
+    for _f, (gp, gt) in groups.items():
+        breakdown = compute_classification_breakdown(
+            predictions=gp,
+            targets=gt,
+            n_classes=n_classes,
+        )
+        per_fold.append(float(breakdown.macro_f1))
+    if not per_fold:
+        return None
+    return sum(per_fold) / len(per_fold)
+
+
+def _bootstrap_macro_f1_ci(
+    preds: Sequence[int],
+    targets: Sequence[int],
+    *,
+    n_classes: int,
+    block_size: int,
+    n_resamples: int,
+    coverage: float,
+    seed: int,
+) -> dict[str, float]:
+    """1k-block-bootstrap CI on the row-pooled macro-F1.
+
+    Mirrors the resampling convention in
+    :mod:`app.evaluation.regime_pooled_aggregator` — moving blocks of
+    length ``block_size``, ⌈n/block_size⌉ blocks per resample, trimmed
+    to ``n`` rows. Macro-F1 is recomputed on each resample.
+    """
+
+    n = len(preds)
+    if n == 0:
+        return {"point": float("nan"), "lo": float("nan"), "hi": float("nan")}
+    point = float(
+        compute_classification_breakdown(
+            predictions=preds,
+            targets=targets,
+            n_classes=n_classes,
+        ).macro_f1
+    )
+    rng = random.Random(seed)
+    block = max(1, min(block_size, n))
+    n_blocks = max(1, math.ceil(n / block))
+    samples: list[float] = []
+    for _ in range(n_resamples):
+        idx: list[int] = []
+        for _ in range(n_blocks):
+            start = rng.randint(0, max(0, n - block))
+            idx.extend(range(start, min(n, start + block)))
+        idx = idx[:n]
+        rp = [preds[i] for i in idx]
+        rt = [targets[i] for i in idx]
+        samples.append(
+            float(
+                compute_classification_breakdown(
+                    predictions=rp,
+                    targets=rt,
+                    n_classes=n_classes,
+                ).macro_f1
+            )
+        )
+    samples.sort()
+    alpha = (1.0 - coverage) / 2.0
+    lo_idx = max(0, min(n_resamples - 1, int(alpha * n_resamples)))
+    hi_idx = max(0, min(n_resamples - 1, int((1.0 - alpha) * n_resamples) - 1))
+    return {
+        "point": point,
+        "lo": samples[lo_idx],
+        "hi": samples[hi_idx],
+    }
+
+
+__all__ = [
+    "HonestHeadlineReport",
+    "Record",
+    "four_variant_report",
+    "fomc_only_macro_f1",
+    "mixed_pool_macro_f1",
+    "with_without_fold",
+    "with_without_macro_release",
+]
+
+
+def _breakdown_to_per_class_summary(  # noqa: D401
+    breakdown: ClassificationBreakdown,
+) -> list[dict[str, float | int | None]]:
+    """Convenience accessor for downstream serialisers (e.g. the wiki
+    table renderer) that need just the per-class P/R/F1/support block.
+    """
+
+    return [m.to_dict() for m in breakdown.per_class]

--- a/docs/benchmark-policy.md
+++ b/docs/benchmark-policy.md
@@ -23,6 +23,16 @@ Policy is fixed for the current benchmark cycle. Method changes require a new ve
 ## Canonical Training Objective
 As of ADR 0015 (`docs/adr/0015-regression-canonical-objective.md`, issue #322), the canonical training objective for the vol-regime head is the regression head on `log(forward_realized_vol_10d)`, optimised with MSE on per-fold standardised log-RV. The 3-class calm / normal / high label is a UI-side bucketing of the regression output against the per-fold `vol_regime_quantiles` cutoffs persisted in `fold_manifest_expanding_walk_forward.json`; it is no longer a training target under the canonical setting. The classification head stays mounted on every checkpoint for shape stability and to back the aux conformal calibration surface (`rates_softmax_quantiles`), but contributes zero gradient when `head_mode="regression"`. The dual-head mixing surface (`head_mode={classification,regression,dual}` plus `regression_alpha`) introduced in #304 remains available for the methodology comparison in §6.15 of the deep-learning roadmap. Headline vol-regime rows in published reports must cite RMSE-log_rv and R² alongside any UI-derived classification metrics.
 
+## Aggregation Rule
+The canonical pooling rule for macro-F1 across walk-forward folds is **mean-of-fold-means**: compute per-fold macro-F1, then average unweighted across folds. The secondary rule is **row-pooled**: concatenate every per-row prediction across all folds into one confusion matrix, then compute macro-F1 once. Both numbers are published on every honest macro-F1 cell so the per-fold class-balance variance is visible — the row-pooled number weights folds by support, the mean-of-fold-means number weights folds equally and is the conservative read against the `wf_fold_4` zero-`calm` slice (R-17).
+
+Honest macro-F1 reports MUST include:
+1. **Per-class P/R/F1 footnote** on every published macro-F1 cell — precision, recall, F1, and support per class. Pooled headlines that suppress this footnote can mask a degenerate per-class distribution and are not eligible for publication.
+2. **Fold-4 with-and-without rows** on every headline cell — publish both `with all folds` and `without wf_fold_4` so the reader can see the magnitude of the zero-`calm`-class fold's contribution. Flag if the two readings diverge by more than the bootstrap CI half-width.
+3. **Macro-release with-and-without rows** on every headline cell — publish both `with macro-release-augmented rows` and `FOMC-only` so the §6.7 Chunk-3 lift attribution stays auditable. The FOMC-only cell is the primary thesis number; the mixed-pool cell is the secondary comparator.
+
+The four reporting variants (mixed-pool, FOMC-only, fold-4 with/without, macro-release with/without) are computed by `backend/app/evaluation/reporting.py` (issue #323). Block-bootstrap CIs use 1000 resamples at `block_size=20` by default, matching the convention in `backend/app/evaluation/regime_pooled_aggregator.py`.
+
 ## Leakage Rules
 1. No future-derived features
 2. No future target leakage in feature creation

--- a/tests/unit/test_reporting_variants.py
+++ b/tests/unit/test_reporting_variants.py
@@ -1,0 +1,316 @@
+"""Unit tests for the honest-headline reporting variants (#323).
+
+The four helpers in :mod:`app.evaluation.reporting` each filter the
+input record set differently and must produce distinct outputs when
+the stratification is non-trivial. The tests in this file exercise
+that contract on a synthetic stratified pool with known per-stratum
+accuracy so the assertions stay calibrated against expected values.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.evaluation.reporting import (
+    HonestHeadlineReport,
+    fomc_only_macro_f1,
+    four_variant_report,
+    mixed_pool_macro_f1,
+    with_without_fold,
+    with_without_macro_release,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic fixtures
+# ---------------------------------------------------------------------------
+
+
+def _record(
+    prediction: int,
+    target: int,
+    *,
+    fold_id: str = "wf_fold_1",
+    source_type: str = "fomc_statement",
+    is_macro_release: bool = False,
+) -> dict[str, Any]:
+    return {
+        "prediction": prediction,
+        "target": target,
+        "fold_id": fold_id,
+        "source_type": source_type,
+        "is_macro_release": is_macro_release,
+    }
+
+
+@pytest.fixture
+def stratified_pool() -> list[dict[str, Any]]:
+    """Build a synthetic 3-class pool whose strata disagree.
+
+    Layout (24 rows total):
+    - 9 FOMC rows on folds 1/2/3 — model is correct on 8 of 9 (rotates
+      `(0,0)(1,1)(2,2)` three times with one (0->1) miss on fold 3).
+    - 6 cross-bank rows on fold 1 — model is correct on 2 of 6
+      (deliberately worse so the FOMC-only variant lifts the headline).
+    - 6 macro-release rows on fold 2 — model is correct on 5 of 6
+      (`is_macro_release=True`; FOMC-only filter must drop them).
+    - 3 fold-4 rows — class targets are all `1`/`2` (the R-17 zero-`calm`
+      fixture); model predicts each correctly so the with-fold
+      variant lifts the headline relative to without-fold.
+    """
+
+    rows: list[dict[str, Any]] = []
+    # FOMC folds 1..3 — 8/9 correct.
+    for fold in ("wf_fold_1", "wf_fold_2", "wf_fold_3"):
+        rows.append(_record(0, 0, fold_id=fold))
+        rows.append(_record(1, 1, fold_id=fold))
+        rows.append(_record(2, 2, fold_id=fold))
+    # Replace the last (2,2) on fold 3 with a (0->1) miss so the FOMC
+    # subset is 8/9 = ~89% accurate, distinct from the cross-bank stratum.
+    rows[-1] = _record(1, 0, fold_id="wf_fold_3")
+    # Cross-bank rows on fold 1 — 2/6 correct.
+    cross_bank_rows = [
+        _record(0, 0, fold_id="wf_fold_1", source_type="cross_bank_ecb"),
+        _record(1, 0, fold_id="wf_fold_1", source_type="cross_bank_ecb"),
+        _record(2, 1, fold_id="wf_fold_1", source_type="cross_bank_ecb"),
+        _record(0, 1, fold_id="wf_fold_1", source_type="cross_bank_boe"),
+        _record(0, 2, fold_id="wf_fold_1", source_type="cross_bank_boe"),
+        _record(2, 2, fold_id="wf_fold_1", source_type="cross_bank_boe"),
+    ]
+    rows.extend(cross_bank_rows)
+    # Macro-release rows on fold 2 — 5/6 correct.
+    macro_release_rows = [
+        _record(
+            0, 0, fold_id="wf_fold_2", source_type="cpi_release",
+            is_macro_release=True,
+        ),
+        _record(
+            1, 1, fold_id="wf_fold_2", source_type="cpi_release",
+            is_macro_release=True,
+        ),
+        _record(
+            2, 2, fold_id="wf_fold_2", source_type="cpi_release",
+            is_macro_release=True,
+        ),
+        _record(
+            0, 0, fold_id="wf_fold_2", source_type="nfp_release",
+            is_macro_release=True,
+        ),
+        _record(
+            1, 1, fold_id="wf_fold_2", source_type="nfp_release",
+            is_macro_release=True,
+        ),
+        _record(
+            0, 1, fold_id="wf_fold_2", source_type="nfp_release",
+            is_macro_release=True,
+        ),
+    ]
+    rows.extend(macro_release_rows)
+    # Fold-4 rows — only class 1 + class 2 (no `calm`). All correct so
+    # including fold-4 lifts the row-pooled macro-F1.
+    fold4_rows = [
+        _record(1, 1, fold_id="wf_fold_4"),
+        _record(2, 2, fold_id="wf_fold_4"),
+        _record(1, 1, fold_id="wf_fold_4"),
+    ]
+    rows.extend(fold4_rows)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# mixed_pool_macro_f1
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_pool_reports_both_poolings(stratified_pool: list[dict[str, Any]]) -> None:
+    report = mixed_pool_macro_f1(stratified_pool, n_resamples=200)
+    assert report["label"] == "mixed_pool"
+    assert report["support"] == len(stratified_pool)
+    assert "row_pooled" in report["macro_f1"]
+    assert "mean_of_fold_means" in report["macro_f1"]
+    assert report["macro_f1"]["canonical"] == "mean_of_fold_means"
+
+
+def test_mixed_pool_emits_per_class_footnote(
+    stratified_pool: list[dict[str, Any]],
+) -> None:
+    report = mixed_pool_macro_f1(stratified_pool, n_resamples=200)
+    assert len(report["per_class"]) == 3
+    for entry in report["per_class"]:
+        assert {"class_id", "precision", "recall", "f1", "support"} <= set(
+            entry.keys()
+        )
+
+
+def test_mixed_pool_emits_bootstrap_ci(stratified_pool: list[dict[str, Any]]) -> None:
+    report = mixed_pool_macro_f1(
+        stratified_pool, n_resamples=200, block_size=4
+    )
+    ci = report["ci"]
+    assert ci["point"] >= 0.0
+    assert ci["lo"] <= ci["point"] <= ci["hi"]
+    assert ci["n_resamples"] == 200
+    assert ci["block_size"] == 4
+
+
+# ---------------------------------------------------------------------------
+# fomc_only_macro_f1
+# ---------------------------------------------------------------------------
+
+
+def test_fomc_only_drops_cross_bank_and_macro_release(
+    stratified_pool: list[dict[str, Any]],
+) -> None:
+    report = fomc_only_macro_f1(stratified_pool, n_resamples=200)
+    fomc_count = sum(
+        1
+        for r in stratified_pool
+        if str(r["source_type"]) in {"fomc_statement", "fomc_minutes"}
+    )
+    assert report["support"] == fomc_count
+    assert report["label"] == "fomc_only"
+
+
+def test_fomc_only_lifts_above_mixed_pool(
+    stratified_pool: list[dict[str, Any]],
+) -> None:
+    """FOMC stratum is more accurate than cross-bank; the variant lifts."""
+
+    mixed = mixed_pool_macro_f1(stratified_pool, n_resamples=200)
+    fomc = fomc_only_macro_f1(stratified_pool, n_resamples=200)
+    assert (
+        fomc["macro_f1"]["row_pooled"] > mixed["macro_f1"]["row_pooled"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# with_without_fold
+# ---------------------------------------------------------------------------
+
+
+def test_with_without_fold_drops_named_fold(
+    stratified_pool: list[dict[str, Any]],
+) -> None:
+    pair = with_without_fold(
+        stratified_pool, drop_fold_id="wf_fold_4", n_resamples=200
+    )
+    assert pair["dropped_fold_id"] == "wf_fold_4"
+    assert pair["with"]["support"] == len(stratified_pool)
+    assert pair["without"]["support"] == sum(
+        1 for r in stratified_pool if r["fold_id"] != "wf_fold_4"
+    )
+
+
+def test_with_without_fold_emits_distinct_macro_f1(
+    stratified_pool: list[dict[str, Any]],
+) -> None:
+    pair = with_without_fold(
+        stratified_pool, drop_fold_id="wf_fold_4", n_resamples=200
+    )
+    with_macro = pair["with"]["macro_f1"]["row_pooled"]
+    without_macro = pair["without"]["macro_f1"]["row_pooled"]
+    assert with_macro != pytest.approx(without_macro)
+    assert pair["delta_macro_f1_row_pooled"] == pytest.approx(
+        with_macro - without_macro
+    )
+
+
+# ---------------------------------------------------------------------------
+# with_without_macro_release
+# ---------------------------------------------------------------------------
+
+
+def test_macro_release_with_without_drops_macro_rows(
+    stratified_pool: list[dict[str, Any]],
+) -> None:
+    pair = with_without_macro_release(stratified_pool, n_resamples=200)
+    assert pair["with"]["support"] == len(stratified_pool)
+    assert pair["without"]["support"] == sum(
+        1 for r in stratified_pool if not r["is_macro_release"]
+    )
+
+
+def test_macro_release_lift_attribution_distinct(
+    stratified_pool: list[dict[str, Any]],
+) -> None:
+    """Macro-release rows are 5/6 correct vs the cross-bank 2/6; with
+    the augmentation the row-pooled cell shifts."""
+
+    pair = with_without_macro_release(stratified_pool, n_resamples=200)
+    assert pair["with"]["macro_f1"]["row_pooled"] != pytest.approx(
+        pair["without"]["macro_f1"]["row_pooled"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Combined four-variant cell
+# ---------------------------------------------------------------------------
+
+
+def test_four_variant_report_returns_all_four_cells(
+    stratified_pool: list[dict[str, Any]],
+) -> None:
+    report = four_variant_report(stratified_pool, n_resamples=200)
+    assert isinstance(report, HonestHeadlineReport)
+    blob = report.to_dict()
+    for key in (
+        "mixed_pool",
+        "fomc_only",
+        "fold_4_with_without",
+        "macro_release_with_without",
+    ):
+        assert key in blob
+
+
+def test_four_variants_distinct_on_non_trivial_input(
+    stratified_pool: list[dict[str, Any]],
+) -> None:
+    """All four variants produce distinct headline numbers when the
+    underlying stratification is non-trivial."""
+
+    report = four_variant_report(stratified_pool, n_resamples=200)
+    headlines = {
+        "mixed": report.mixed_pool["macro_f1"]["row_pooled"],
+        "fomc": report.fomc_only["macro_f1"]["row_pooled"],
+        "with_fold4": report.fold_4["with"]["macro_f1"]["row_pooled"],
+        "without_fold4": report.fold_4["without"]["macro_f1"]["row_pooled"],
+        "with_macro": report.macro_release["with"]["macro_f1"]["row_pooled"],
+        "without_macro": report.macro_release["without"]["macro_f1"]["row_pooled"],
+    }
+    distinct = {round(v, 6) for v in headlines.values()}
+    # At least four distinct headline numbers across the six variant cells.
+    assert len(distinct) >= 4, headlines
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_nan_ci() -> None:
+    report = mixed_pool_macro_f1([], n_resamples=10)
+    assert report["support"] == 0
+    assert report["ci"]["point"] != report["ci"]["point"]  # NaN
+
+
+def test_records_missing_fold_field_skip_mean_of_fold_means() -> None:
+    rows = [
+        {"prediction": 0, "target": 0},
+        {"prediction": 1, "target": 1},
+        {"prediction": 2, "target": 2},
+    ]
+    report = mixed_pool_macro_f1(rows, n_resamples=50)
+    assert report["macro_f1"]["mean_of_fold_means"] is None
+    assert report["macro_f1"]["row_pooled"] == pytest.approx(1.0)
+
+
+def test_fomc_filter_is_case_insensitive() -> None:
+    rows = [
+        _record(0, 0, source_type="FOMC_Statement"),
+        _record(1, 1, source_type="fomc_minutes"),
+        _record(2, 2, source_type="cross_bank_ecb"),
+    ]
+    report = fomc_only_macro_f1(rows, n_resamples=50)
+    assert report["support"] == 2


### PR DESCRIPTION
Closes #323.

- `backend/app/evaluation/reporting.py` — four variant helpers (mixed-pool, FOMC-only, fold-4 with/without, macro-release with/without) + combined `four_variant_report` cell.
- Each variant carries per-class P/R/F1, both pooling readings (mean-of-fold-means + row-pooled), and a 1k-block-bootstrap CI.
- `tests/unit/test_reporting_variants.py` (14 cases) exercises every helper on a synthetic stratified pool.
- `docs/benchmark-policy.md` gains §Aggregation: canonical rule + mandatory per-class footnote + fold-4 with/without + macro-release with/without.
- Wiki §6.7 grows a "Honest headline reporting (2026-05-27)" sub-section locking the four-variant table shape for row 10 / 10b (placeholder cells pending GPU rerun).
- Wiki R-17 mitigation appended with the new with/without protocol.

## Test plan
- [x] `docker run --rm -v $(pwd):/app -w /app -e PYTHONPATH=/app/backend fed-pulse-backend:latest python -m pytest tests/unit/test_reporting_variants.py -q`