### PR TITLE
Multi-task null lead + factor-axis disposition (#328)

### DIFF
--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -962,6 +962,25 @@ def _save_hf_encoder_directory(
     tokenizer.save_pretrained(str(checkpoint_dir))
 
 
+def _factor_coverage_fraction(rows: list[_AxisRow]) -> float:
+    """Fraction of supervised rows that carried a populated factor label.
+
+    Issue #328: the inference service uses this stamp to gate the
+    factor card on the /analyze response. A canonical training pool
+    today carries 0 % factor coverage (the gss_factor source rows are
+    not joined into the events.parquet aggregation), so the regression
+    head emits effectively-random values; gating the response on the
+    persisted coverage is how the surface stops rendering noise as a
+    prediction. An empty row list returns 0.0 so a misconfigured run
+    that produces no rows still trips the gate.
+    """
+
+    if not rows:
+        return 0.0
+    populated = sum(1 for r in rows if bool(r.masks.get("factor", False)))
+    return populated / len(rows)
+
+
 def _save_checkpoint(
     model: TextMultiAxisClassifier,
     *,
@@ -969,6 +988,7 @@ def _save_checkpoint(
     metrics: dict[str, float],
     args: argparse.Namespace,
     class_weights: dict[str, torch.Tensor],
+    factor_coverage: float,
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -1016,11 +1036,22 @@ def _save_checkpoint(
                 if bool(getattr(args, "gtfintechlab_fed_only", False))
                 else str(getattr(args, "cross_bank_supervision", "off"))
             ),
+            # Issue #328: persist the fraction of train rows that
+            # carried a populated ``axis_factor`` label so the
+            # inference service can gate the factor card on it.
+            # Coverage < threshold (default 0.01) drops the card
+            # from the /analyze response — the factor branch has
+            # trained almost exclusively on the masked-out path on
+            # those checkpoints and its outputs are noise. ADR 0018
+            # captures the decision.
+            "factor_coverage": float(factor_coverage),
         },
         "saved_at_utc": datetime.now(timezone.utc).isoformat(),
     }
     torch.save(payload, path)
-    _logger.info("checkpoint_written path=%s", path)
+    _logger.info(
+        "checkpoint_written path=%s factor_coverage=%.4f", path, factor_coverage
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1081,6 +1112,17 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     class_weights = _build_axis_class_weights(train_rows)
+    # Compute factor coverage on the train slice (the supervision the
+    # head actually trained on, not the whole corpus). Persisted onto
+    # the checkpoint payload so the inference service can gate the
+    # factor card on it (#328 / ADR 0018).
+    factor_coverage = _factor_coverage_fraction(train_rows)
+    _logger.info(
+        "factor_axis_coverage train_rows=%d populated=%d coverage=%.4f",
+        len(train_rows),
+        sum(1 for r in train_rows if bool(r.masks.get("factor", False))),
+        factor_coverage,
+    )
 
     from transformers import AutoTokenizer
 
@@ -1174,6 +1216,7 @@ def main(argv: list[str] | None = None) -> int:
                 metrics=best_metrics,
                 args=args,
                 class_weights=class_weights,
+                factor_coverage=factor_coverage,
             )
             _save_hf_encoder_directory(model, tokenizer, hf_checkpoint_dir)
             print(f"[multi_axis] hf checkpoint saved to {hf_checkpoint_dir}")

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -981,7 +981,7 @@ def _factor_coverage_fraction(rows: list[_AxisRow]) -> float:
     return populated / len(rows)
 
 
-def _save_checkpoint(
+def _save_checkpoint(  # noqa: PLR0913 — kw-only checkpoint envelope; collapsing the metadata kwargs into a single dataclass would obscure the persisted fields
     model: TextMultiAxisClassifier,
     *,
     path: Path,

--- a/backend/app/services/multi_axis_classifier.py
+++ b/backend/app/services/multi_axis_classifier.py
@@ -36,6 +36,19 @@ from app.models.text_multi_axis_classifier import TextMultiAxisClassifier
 
 DEFAULT_CHECKPOINT_PATH = MODEL_CHECKPOINT_DIR / "text_multi_axis_best.pt"
 DEFAULT_MAX_LENGTH = 256
+# Below this factor-axis label coverage on the training pool, the
+# factor branch's tanh-bounded regression head has trained almost
+# exclusively on the masked-out path and emits effectively random
+# values at inference. The /analyze response then omits the factor
+# card (the MultiAxisBlock.factor field is None) so the frontend
+# renders honest absence instead of noise dressed as a prediction.
+# Issue #328 picks 0.01 (1 %) as the gate: a coverage tag of 0.0
+# (the canonical training package today) trips it, while a real
+# gss_factor backfill of even a few hundred rows across ~3 k FOMC
+# rows would clear it. The threshold is conservative on purpose —
+# we would rather under-emit a real-but-marginal prediction than
+# render a low-coverage one that the user reads as load-bearing.
+DEFAULT_FACTOR_COVERAGE_GATE = 0.01
 
 _logger = logging.getLogger(__name__)
 _state: "_ClassifierState | None" = None
@@ -49,6 +62,12 @@ class _ClassifierState:
     device: torch.device
     max_length: int
     encoder_alias: str
+    # Fraction of the training pool that carried a populated
+    # axis_factor label. None when the persisted checkpoint pre-dates
+    # the #328 coverage stamp (treated as "unknown" → factor stays
+    # gated off to match the new default behaviour).
+    factor_coverage: float | None
+    factor_coverage_threshold: float
 
 
 def _resolve_checkpoint_path() -> Path:
@@ -124,13 +143,68 @@ def _load_state() -> _ClassifierState | None:
     max_length = int(
         (payload.get("training_args") or {}).get("max_length") or DEFAULT_MAX_LENGTH
     )
+    factor_coverage = _coerce_factor_coverage(payload)
+    threshold = _resolve_factor_coverage_threshold()
     return _ClassifierState(
         model=model,
         tokenizer=tokenizer,
         device=device,
         max_length=max_length,
         encoder_alias=encoder_alias,
+        factor_coverage=factor_coverage,
+        factor_coverage_threshold=threshold,
     )
+
+
+def _coerce_factor_coverage(payload: dict[str, Any]) -> float | None:
+    """Read the persisted factor-axis label coverage off the payload.
+
+    The trainer stamps the fraction of train rows that carried a
+    populated ``axis_factor`` label under ``training_args.factor_coverage``.
+    Pre-#328 checkpoints predate the stamp; ``None`` flags the unknown
+    case so the inference path treats them like a 0 %-coverage run
+    (factor card stays absent rather than rendering effectively-random
+    predictions). The ``metadata`` fallback path mirrors the same key
+    so a future caller can write it on the metadata side without
+    breaking the loader.
+    """
+
+    for bucket_key in ("training_args", "metadata"):
+        bucket = payload.get(bucket_key)
+        if not isinstance(bucket, dict):
+            continue
+        raw = bucket.get("factor_coverage")
+        if raw is None:
+            continue
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if value != value:  # NaN
+            continue
+        return max(0.0, min(1.0, value))
+    return None
+
+
+def _resolve_factor_coverage_threshold() -> float:
+    """Env-override hook for the factor-axis coverage gate.
+
+    Defaults to ``DEFAULT_FACTOR_COVERAGE_GATE`` (0.01). The env knob
+    is intentional — a future training run that backfills factor labels
+    from the gss_factor source can lower the gate without a code change
+    if the team decides 0.01 is too strict.
+    """
+
+    raw = (os.environ.get("FED_PULSE_TEXT_MULTI_AXIS_FACTOR_GATE") or "").strip()
+    if not raw:
+        return DEFAULT_FACTOR_COVERAGE_GATE
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_FACTOR_COVERAGE_GATE
+    if value != value or value < 0.0:
+        return DEFAULT_FACTOR_COVERAGE_GATE
+    return value
 
 
 def get_loaded_encoder_alias() -> str | None:
@@ -183,6 +257,14 @@ def score_text(text: str) -> dict[str, Any] | None:
     ``app.schemas`` — keys for stance / factor / certainty / topic
     each carrying ``label``, ``confidence``, and (where applicable)
     a per-class distribution.
+
+    The factor card is gated on the persisted factor-axis label
+    coverage (#328): when the active checkpoint's training pool
+    carried < ``DEFAULT_FACTOR_COVERAGE_GATE`` (1 %) populated
+    ``axis_factor`` rows, the regression head trained almost
+    exclusively on the masked-out path and its outputs are noise. The
+    response then carries ``factor=None`` so the frontend renders an
+    absent card instead of rendering noise dressed as a prediction.
     """
 
     state = get_classifier()
@@ -210,8 +292,6 @@ def score_text(text: str) -> dict[str, Any] | None:
         for i in range(len(MULTI_TASK_STANCE_LABELS))
     }
 
-    factor_value = float(logits["factor"][0].item())
-
     certainty_probs = torch.softmax(logits["certainty"], dim=-1)[0]
     certainty_idx = int(certainty_probs.argmax().item())
     certainty_label = MULTI_TASK_CERTAINTY_LABELS[certainty_idx]
@@ -228,20 +308,15 @@ def score_text(text: str) -> dict[str, Any] | None:
         for i in range(len(MULTI_TASK_TOPIC_LABELS))
     }
 
+    factor_card = _build_factor_card(state, logits)
+
     return {
         "stance": {
             "label": stance_label,
             "confidence": float(stance_probs[stance_idx].item()),
             "distribution": stance_dist,
         },
-        "factor": {
-            "value": max(-1.0, min(1.0, factor_value)),
-            # Factor regression confidence is not a probability; for now
-            # we emit the absolute value as a proxy ("how far from
-            # neutral") and the frontend renders it as the bar
-            # magnitude. Calibration is a follow-up.
-            "confidence": min(1.0, abs(factor_value)),
-        },
+        "factor": factor_card,
         "certainty": {
             "label": certainty_label,
             "confidence": float(certainty_probs[certainty_idx].item()),
@@ -252,4 +327,36 @@ def score_text(text: str) -> dict[str, Any] | None:
             "confidence": float(topic_probs[topic_idx].item()),
             "distribution": topic_dist,
         },
+    }
+
+
+def _build_factor_card(
+    state: _ClassifierState, logits: dict[str, torch.Tensor]
+) -> dict[str, float] | None:
+    """Return the factor card or ``None`` per the coverage gate (#328).
+
+    Coverage below the gate (or ``None`` on a pre-#328 checkpoint that
+    did not stamp the field) drops the card entirely so the
+    ``MultiAxisBlock.factor`` field surfaces as ``None``. Above the
+    gate, the head's tanh output is clipped to [-1, 1] and surfaced
+    as the card value with the legacy abs-as-confidence proxy.
+    """
+
+    coverage = state.factor_coverage
+    threshold = state.factor_coverage_threshold
+    if coverage is None or coverage < threshold:
+        _logger.debug(
+            "multi_axis_factor_card_absent coverage=%s threshold=%s",
+            coverage,
+            threshold,
+        )
+        return None
+    factor_value = float(logits["factor"][0].item())
+    return {
+        "value": max(-1.0, min(1.0, factor_value)),
+        # Factor regression confidence is not a probability; we emit
+        # the absolute value as a proxy ("how far from neutral") and
+        # the frontend renders it as the bar magnitude. Calibration
+        # is a follow-up.
+        "confidence": min(1.0, abs(factor_value)),
     }

--- a/docs/adr/0018-multi-task-null-and-factor-disposition.md
+++ b/docs/adr/0018-multi-task-null-and-factor-disposition.md
@@ -1,0 +1,68 @@
+# ADR 0018 — Multi-task auxiliary loss null finding + factor-axis disposition
+
+Status: accepted, in production (as of merge).
+Date: 2026-05-27.
+References:
+- Issue #328.
+- PR #282 — wired `MultiTaskLoss` through the regime classifier (the joint training pass this ADR concludes).
+- ADR 0009 — multi-axis label set the factor axis lives on.
+- `backend/app/training/loss.py` — `MultiTaskLoss` (kept; no behavioural change).
+- `backend/app/data/train_text_multi_axis_classifier.py` — text-axis classifier trainer; now persists per-checkpoint factor-axis coverage onto `training_args.factor_coverage`.
+- `backend/app/services/multi_axis_classifier.py` — inference service; gates the `factor` card on the persisted coverage.
+- `backend/app/schemas.py` — `MultiAxisBlock.factor` (already typed `Optional` since #78).
+- `06_Deep_Learning_Roadmap.md` §6.7 (joint-vs-stance-only comparison row) and §6.13 (null-result framing).
+
+## Context
+
+Two related questions about the multi-task surface had to be settled together.
+
+**1. Did the joint training pass lift the regime headline?**
+
+PR #282 ran the canonical Transformer cell with `multi_task_loss=True` against the strict-forward training package. Same 5 seeds × 4 folds protocol, default lambdas (λ_stance=1.0, λ_factor=λ_certainty=λ_topic=0.3).
+
+| Variant | Macro-F1 (n=20) | 95% CI | Std |
+| --- | ---: | --- | ---: |
+| Stance-only baseline | 0.4308 | [0.419, 0.443] | 0.037 |
+| Multi-task (λ_aux = 0.3 each) | 0.4371 | [0.421, 0.459] | 0.064 |
+| Δ | +0.0063 | overlapping | +0.027 (worse) |
+
+Point estimate moved up 1.5 %. The CIs overlap heavily, std grew ~70 % (0.037 → 0.064), and three of four folds gained but wf_fold_1 dropped 0.057. The auxiliary axes are pulling the backbone in inconsistent directions across folds at the default lambda balance. The follow-up "rescue" options were filed (lambda sweep, two-stage warm-up, per-fold λ fitting) but the wiki framed the wiring as a "foundation for cheap follow-ups" rather than as a result, which overclaims.
+
+**2. Why does the factor card on `/analyze` look like noise?**
+
+The text-axis classifier ships a four-branch head (stance / factor / certainty / topic). On the canonical training package the supervised pool used for the text classifier has 0 % `axis_factor` coverage — the `gss_factor` source rows are not joined into the events.parquet aggregation, and the gtfintechlab cross-bank rows do not carry a factor label by schema. The factor branch trains almost exclusively on the masked-out path (mask=False everywhere, loss contribution always zero) and emits effectively-random tanh-bounded values at inference. One of the four `/analyze` multi-axis cards was rendering noise dressed as a prediction.
+
+## Decision
+
+### Multi-task null framing
+
+Report the joint-vs-stance-only result as a documented null. The auxiliary axes (factor / certainty / topic) do not carry information the encoder is not already extracting from stance on the vol-regime target — the 1.5 % point-estimate move is inside the CI, the variance penalty is real, and the per-fold variance increase rules out a "just-needs-tuning" framing without further evidence. Stop tuning lambdas hoping for a lift on the headline; the multi-task wiring stays in the codebase because the per-axis output surface (factor / certainty / topic cards on `/analyze`) consumes it, but it is no longer pitched as a regime-headline lever.
+
+Concretely:
+- The §6.7 architecture-sweep section keeps the joint-vs-stance-only row (already landed) but the prose around it now reads as an explicit null rather than a "first pass" framing.
+- §6.13 ("Multi-task auxiliary-loss foundation") is rewritten to lead with the null finding (CIs overlap, std grew 70 %) rather than the deferred-joint-training rationale.
+- Future lambda-tuning work is descoped — the filed follow-ups (lambda sweep, two-stage warm-up) stay listed for completeness but are not on the critical path.
+
+### Factor-axis disposition — option (a), don't mount
+
+Two candidate paths were on the table:
+
+- **(a) Don't mount the head when factor coverage = 0 %.** The inference service reads the persisted `factor_coverage` off the active checkpoint and omits the factor card from the `/analyze` response when coverage falls below a threshold. `MultiAxisBlock.factor` is already `Optional` (it has been since #78), so wire compat is free. Estimated cost: ~30 lines on the service + ~10 lines on the trainer to stamp the field.
+- **(b) Backfill from gss_factor source rows.** Pull the `axis_factor` regression target off the `gss_factor` source rows into the supervised text classifier's training pool. Estimated cost: changes in `app.data.ingest_sources`, the events-parquet aggregator, and the classifier's row loader; requires re-running the canonical text-classifier checkpoint to consume the backfilled rows. Days of work + a checkpoint refresh.
+
+**Picked (a).** The cost gap is large (hours vs days), the user-facing outcome of (a) — honest absence on the card — is what the brief flagged as "cleanest from a no-noise standpoint", and (b) does not retire the gate anyway: even with a backfill, a future training pool change that drops factor coverage back to zero would put the surface in the same noise-rendering state. The gate is the right contract regardless; (b) is the orthogonal data-pipeline change that lifts the gate when the coverage is real, and stays available as a follow-up issue.
+
+### Implementation surface
+
+- `backend/app/data/train_text_multi_axis_classifier.py`: the trainer computes `factor_coverage = populated_rows / total_rows` on the train slice (the supervision the head actually trained on, not the whole corpus) and stamps it on the checkpoint envelope under `training_args.factor_coverage`. The log line carries the coverage so the operator sees it inline with `checkpoint_written`.
+- `backend/app/services/multi_axis_classifier.py`: `_ClassifierState` carries the coverage stamp + the gate threshold; `score_text` calls `_build_factor_card` which returns `None` when `coverage < threshold` (default 0.01 = 1 %). The threshold is overridable via `FED_PULSE_TEXT_MULTI_AXIS_FACTOR_GATE` so a future operator can tune without a code change. Pre-#328 checkpoints (no stamp on the payload) are treated as unknown → card stays absent, consistent with the new default.
+- `backend/app/schemas.py`: `MultiAxisBlock.factor: MultiAxisFactorCard | None = None` was already in the schema since #78, so existing OpenAPI consumers do not see a contract change. The `factor` key now reliably surfaces as `None` on a 0 %-coverage checkpoint rather than as a noise card.
+- `tests/unit/test_factor_axis_gating.py`: pins the gate end-to-end on the service surface — 0 % coverage drops the card, above-threshold coverage emits a real value, pre-#328 payloads (no stamp) drop the card, the env override knob works, the trainer's coverage helper matches the service's gate semantics.
+
+## Consequences
+
+- The `/analyze` response no longer renders a factor card on the canonical checkpoint. The frontend already handles `factor: null` (the schema has been `Optional` since #78), so no frontend change is required.
+- The multi-task wiring stays in the codebase. It still powers the certainty / topic cards on `/analyze` (those axes have ≥ 35 % label coverage on the supervised corpus today), and the joint-loss code path is what those cards' classifier learned on.
+- A future operator who backfills the `gss_factor` source rows into the supervised pool will see coverage climb above the 0.01 gate automatically; no code change required.
+- A future operator who decides 0.01 is too lax / too strict can override via the env knob without redeploying — the gate is the contract, not the literal threshold.
+- Documentation in `06_Deep_Learning_Roadmap.md` §6.7 and §6.13 carries the null finding explicitly. Wiki §12 (ADR index) is intentionally not touched in this PR; ADR 0018 sits in `docs/adr/` alongside the other accepted ADRs and the §12 index is updated in a separate change.

--- a/tests/unit/test_factor_axis_gating.py
+++ b/tests/unit/test_factor_axis_gating.py
@@ -1,0 +1,340 @@
+"""Factor-axis gating on the multi-axis classifier (#328).
+
+The text multi-axis classifier ships with four output branches
+(stance / factor / certainty / topic), but the canonical training
+package today has 0 % ``axis_factor`` label coverage — the factor
+regression branch trains almost exclusively on the masked-out path,
+so its outputs are noise. ADR 0018 documents the decision to gate
+the factor card on the persisted coverage so the /analyze response
+emits ``factor=None`` rather than rendering a noise prediction.
+
+These tests pin the gating contract end-to-end on the inference
+service:
+
+- A 0 % coverage stamp drops the factor card.
+- A pre-#328 checkpoint (no ``factor_coverage`` field on the payload)
+  also drops the card — the absent stamp is treated as "unknown",
+  consistent with the new default behaviour rather than the legacy
+  one.
+- A coverage stamp above the gate emits a real factor value.
+- The other three cards (stance / certainty / topic) keep emitting
+  regardless of the factor stamp — gating is scoped to the factor
+  card only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+import pytest
+import torch
+
+from app.services import multi_axis_classifier as svc
+
+
+class _StubModel:
+    """Stand-in for ``TextMultiAxisClassifier`` in the service tests.
+
+    The unit under test is the gating logic in ``score_text`` /
+    ``_build_factor_card``; the actual transformer forward is
+    irrelevant. The stub returns deterministic logits so the test
+    asserts on the gate, not on softmax numerics.
+    """
+
+    def __init__(self, *, factor_value: float = 0.7) -> None:
+        self._factor_value = float(factor_value)
+
+    def __call__(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        del input_ids, attention_mask  # unused — fixture passes shaped tensors
+        return {
+            # Single-row batches: shape (1, n_classes) for classifier
+            # heads, (1,) for the regression head — matches the
+            # TextMultiAxisClassifier forward contract.
+            "stance": torch.tensor([[0.1, 0.7, 0.2]]),
+            "factor": torch.tensor([self._factor_value]),
+            "certainty": torch.tensor([[0.6, 0.3, 0.1]]),
+            "topic": torch.tensor([[0.5, 0.2, 0.2, 0.1]]),
+        }
+
+
+class _StubTokenizer:
+    """Returns a single fixed-shape encoded batch.
+
+    The classifier service tokenizes once per ``score_text`` call;
+    the stub keeps the call signature compatible without dragging a
+    real tokenizer (and its HF dependency) into the unit test.
+    """
+
+    def __call__(
+        self,
+        text: str,
+        *,
+        max_length: int,
+        padding: str,
+        truncation: bool,
+        return_tensors: str,
+    ) -> dict[str, torch.Tensor]:
+        del text, max_length, padding, truncation, return_tensors
+        return {
+            "input_ids": torch.zeros((1, 8), dtype=torch.long),
+            "attention_mask": torch.ones((1, 8), dtype=torch.long),
+        }
+
+
+def _install_state(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    factor_coverage: float | None,
+    factor_value: float = 0.7,
+    threshold: float = svc.DEFAULT_FACTOR_COVERAGE_GATE,
+) -> None:
+    """Drop a fully-formed ``_ClassifierState`` into the singleton slot.
+
+    Bypasses ``_load_state`` so the test does not hit the HF
+    encoder/tokenizer load path; the gating logic in ``score_text``
+    only reads ``factor_coverage`` + ``factor_coverage_threshold``
+    off the state, which is what the test exercises.
+    """
+
+    state = svc._ClassifierState(
+        model=_StubModel(factor_value=factor_value),
+        tokenizer=_StubTokenizer(),
+        device=torch.device("cpu"),
+        max_length=8,
+        encoder_alias="stub_encoder",
+        factor_coverage=factor_coverage,
+        factor_coverage_threshold=threshold,
+    )
+    svc.reset_classifier()
+    monkeypatch.setattr(svc, "_state", state)
+
+
+def test_factor_card_absent_when_coverage_is_zero(monkeypatch) -> None:
+    """0 % training-pool factor coverage trips the gate (factor=None).
+
+    The canonical training package today is exactly this case — the
+    factor head emits noise so the /analyze response omits the card."""
+
+    _install_state(monkeypatch, factor_coverage=0.0)
+    block = svc.score_text("FOMC statement body")
+    assert block is not None
+    assert block["factor"] is None
+    # The other three axes stay populated — the gate is scoped to factor.
+    assert block["stance"]["label"] in {"hawkish", "dovish", "neutral"}
+    assert block["certainty"]["label"] in {"certain", "uncertain", "neutral"}
+    assert block["topic"]["label"] in {
+        "macro",
+        "forward_guidance",
+        "market_reaction",
+        "other",
+    }
+
+
+def test_factor_card_absent_when_coverage_below_threshold(monkeypatch) -> None:
+    """Coverage just below the gate also drops the card.
+
+    Pins the strict-less-than comparison in ``_build_factor_card``;
+    a coverage of 0.005 (half the default 0.01 gate) is treated the
+    same as 0 %."""
+
+    _install_state(monkeypatch, factor_coverage=0.005)
+    block = svc.score_text("FOMC statement body")
+    assert block is not None
+    assert block["factor"] is None
+
+
+def test_factor_card_absent_when_coverage_missing(monkeypatch) -> None:
+    """Pre-#328 checkpoints that did not stamp ``factor_coverage`` are
+    treated as unknown and drop the card.
+
+    This is the safer default: rendering a noise prediction off a
+    legacy checkpoint would surface the very behaviour ADR 0018
+    closes out."""
+
+    _install_state(monkeypatch, factor_coverage=None)
+    block = svc.score_text("FOMC statement body")
+    assert block is not None
+    assert block["factor"] is None
+
+
+def test_factor_card_emits_when_coverage_above_threshold(monkeypatch) -> None:
+    """Real coverage above the gate emits the card with the head's value.
+
+    Sanity check that the gate is the only thing controlling the
+    card's emission — the factor head's forward still drives the
+    value when the gate is open."""
+
+    _install_state(monkeypatch, factor_coverage=0.5, factor_value=0.42)
+    block = svc.score_text("FOMC statement body")
+    assert block is not None
+    factor = block["factor"]
+    assert factor is not None
+    assert pytest.approx(factor["value"], abs=1e-6) == 0.42
+    # Confidence is the abs-as-confidence proxy documented in the service.
+    assert pytest.approx(factor["confidence"], abs=1e-6) == 0.42
+
+
+def test_factor_card_emits_at_threshold_boundary(monkeypatch) -> None:
+    """At exactly the threshold the card emits (``< threshold`` drops).
+
+    Locks the boundary condition: 0.01 coverage with a 0.01 gate
+    yields a populated card; only strictly-lower values are gated
+    off. Future operators tuning the gate via env override know the
+    interval is right-open."""
+
+    _install_state(
+        monkeypatch,
+        factor_coverage=svc.DEFAULT_FACTOR_COVERAGE_GATE,
+        factor_value=-0.31,
+    )
+    block = svc.score_text("FOMC statement body")
+    assert block is not None
+    assert block["factor"] is not None
+    assert block["factor"]["value"] == pytest.approx(-0.31, abs=1e-6)
+
+
+def test_factor_card_respects_env_threshold_override(monkeypatch) -> None:
+    """Tighter threshold via env knob drops a previously-passing coverage.
+
+    Surfaces the operator-facing escape hatch: a 0.5 gate via the
+    ``FED_PULSE_TEXT_MULTI_AXIS_FACTOR_GATE`` env wins over the 0.01
+    default; a 0.3 coverage that would otherwise emit gets gated off."""
+
+    monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_FACTOR_GATE", "0.5")
+    threshold = svc._resolve_factor_coverage_threshold()
+    assert threshold == pytest.approx(0.5)
+    _install_state(
+        monkeypatch,
+        factor_coverage=0.3,
+        threshold=threshold,
+    )
+    block = svc.score_text("FOMC statement body")
+    assert block is not None
+    assert block["factor"] is None
+
+
+def test_coerce_factor_coverage_reads_training_args() -> None:
+    """The loader reads coverage off ``training_args.factor_coverage``.
+
+    Pins the payload contract: the trainer's persistence path writes
+    the float under ``training_args``; the inference loader reads it
+    back from the same key (with a ``metadata`` fallback for
+    forward-compat). Pre-#328 payloads (no key) come back as None."""
+
+    assert svc._coerce_factor_coverage({}) is None
+    assert svc._coerce_factor_coverage({"training_args": {}}) is None
+    assert (
+        svc._coerce_factor_coverage(
+            {"training_args": {"factor_coverage": 0.7}}
+        )
+        == pytest.approx(0.7)
+    )
+    # Fallback path on the metadata bucket so a future writer that
+    # stamps the field there does not break the loader.
+    assert (
+        svc._coerce_factor_coverage(
+            {"metadata": {"factor_coverage": 0.25}}
+        )
+        == pytest.approx(0.25)
+    )
+    # Garbage / NaN values clip to None so a malformed payload does
+    # not blow up the gate.
+    import math
+
+    assert (
+        svc._coerce_factor_coverage(
+            {"training_args": {"factor_coverage": "not a float"}}
+        )
+        is None
+    )
+    assert (
+        svc._coerce_factor_coverage(
+            {"training_args": {"factor_coverage": math.nan}}
+        )
+        is None
+    )
+
+
+def test_factor_coverage_clipped_to_unit_interval() -> None:
+    """Out-of-range stamps are clipped to [0, 1] rather than rejected.
+
+    Defensive — a malformed payload that wrote 1.7 or -0.2 still
+    yields a sane gate decision. 1.7 clips to 1.0 (emits), -0.2 clips
+    to 0.0 (gated)."""
+
+    assert svc._coerce_factor_coverage(
+        {"training_args": {"factor_coverage": 1.7}}
+    ) == pytest.approx(1.0)
+    assert svc._coerce_factor_coverage(
+        {"training_args": {"factor_coverage": -0.5}}
+    ) == pytest.approx(0.0)
+
+
+def test_multi_axis_state_dataclass_carries_coverage_fields() -> None:
+    """The dataclass surface includes the two new fields (#328).
+
+    Touch the dataclass directly so a future refactor that drops
+    either field will trip this test loudly rather than silently
+    breaking the gate at runtime."""
+
+    state = svc._ClassifierState(
+        model=_StubModel(),
+        tokenizer=_StubTokenizer(),
+        device=torch.device("cpu"),
+        max_length=8,
+        encoder_alias="stub_encoder",
+        factor_coverage=0.0,
+        factor_coverage_threshold=svc.DEFAULT_FACTOR_COVERAGE_GATE,
+    )
+    # ``replace`` is the canonical mutation helper for frozen
+    # dataclasses; using it here doubles as a check that both fields
+    # are named exactly as the rest of the service expects.
+    bumped = replace(state, factor_coverage=0.5)
+    assert bumped.factor_coverage == pytest.approx(0.5)
+    assert bumped.factor_coverage_threshold == pytest.approx(
+        svc.DEFAULT_FACTOR_COVERAGE_GATE
+    )
+
+
+def test_factor_coverage_fraction_helper_on_trainer_rows() -> None:
+    """The trainer's row-counting helper matches the gate semantics.
+
+    Mirrors the service-side gate on the trainer-side stamp source:
+    rows that flag factor populated count toward the numerator,
+    everything else does not, and an empty input list returns 0.0
+    so misconfigured runs trip the gate cleanly downstream."""
+
+    from app.data.train_text_multi_axis_classifier import (
+        _AxisRow,
+        _factor_coverage_fraction,
+    )
+
+    def _row(factor_present: bool) -> _AxisRow:
+        return _AxisRow(
+            text="x",
+            targets={"stance": 0, "factor": 0.0, "certainty": 0, "topic": 0},
+            masks={
+                "stance": True,
+                "factor": factor_present,
+                "certainty": False,
+                "topic": False,
+            },
+        )
+
+    assert _factor_coverage_fraction([]) == pytest.approx(0.0)
+    rows: list[_AxisRow] = [
+        _row(False),
+        _row(False),
+        _row(True),
+        _row(False),
+    ]
+    # 1 of 4 → 0.25.
+    assert _factor_coverage_fraction(rows) == pytest.approx(0.25)
+    rows_all_populated = [_row(True), _row(True), _row(True)]
+    assert _factor_coverage_fraction(rows_all_populated) == pytest.approx(1.0)

--- a/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
+++ b/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
@@ -771,6 +771,7 @@ def test_checkpoint_payload_records_effective_cross_bank_under_fed_only(
         metrics={"val_loss": 0.0},
         args=args,
         class_weights={},
+        factor_coverage=0.0,
     )
     payload = torch.load(ckpt_path, weights_only=False)
     ta = payload["training_args"]
@@ -780,6 +781,9 @@ def test_checkpoint_payload_records_effective_cross_bank_under_fed_only(
     # fed_only the cross-bank pool is empty so the arm reduces to off.
     assert ta["effective_cross_bank_supervision"] == "off"
     assert ta["gtfintechlab_fed_only"] is True
+    # The #328 factor-coverage stamp rides on every checkpoint so the
+    # inference service can gate the factor card on it.
+    assert ta["factor_coverage"] == 0.0
 
 
 def test_checkpoint_payload_effective_matches_raw_when_not_fed_only(
@@ -799,9 +803,13 @@ def test_checkpoint_payload_effective_matches_raw_when_not_fed_only(
         metrics={"val_loss": 0.0},
         args=args,
         class_weights={},
+        factor_coverage=0.25,
     )
     payload = torch.load(ckpt_path, weights_only=False)
     ta = payload["training_args"]
     assert ta["cross_bank_supervision"] == "weighted"
     assert ta["effective_cross_bank_supervision"] == "weighted"
     assert ta["gtfintechlab_fed_only"] is False
+    # The trainer rounds-trips whatever coverage the caller computed
+    # onto the payload — the gate decision lives on the inference side.
+    assert ta["factor_coverage"] == 0.25


### PR DESCRIPTION
## Summary

- Joint-vs-stance-only result reframed as a documented null on regime headline (CIs overlap, std grew ~70 %).
- Inference path gates the `/analyze` factor card on persisted training-pool coverage so the canonical 0 %-coverage checkpoint stops rendering noise.
- Trainer stamps `training_args.factor_coverage` on every checkpoint envelope; pre-#328 checkpoints treated as unknown and gated off.
- ADR 0018 records the null framing + the option-(a) choice over a gss_factor backfill.
- §6.13 leads with the null finding; §6.7 prose tightened away from the "foundation for cheap follow-ups" framing.

## Test plan

- [x] \`docker run --rm -v \$(pwd):/app -w /app -e PYTHONPATH=/app/backend fed-pulse-backend:latest python -m pytest tests/unit/test_factor_axis_gating.py -q\` (10 passed)
- [x] Multi-task regression suite (\`test_multi_axis_classifier_service\`, \`test_analyze_response_multi_axis_block\`, \`test_train_text_multi_axis_*\`, \`test_classifier_per_bank_eval\`, \`test_multi_task_loss_*\`, \`test_multi_task_head_shape\`) — 45 passed.