### PR TITLE
Canonical encoder split: classifier vs retrieval substrate (#330)

### DIFF
--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -52,8 +52,28 @@ from app.training.loss import MultiTaskLoss
 _logger = logging.getLogger(__name__)
 
 DEFAULT_CHECKPOINT_PATH = MODEL_CHECKPOINT_DIR / "text_multi_axis_best.pt"
-DEFAULT_ENCODER_ALIAS = "finbert_fed_adjacent"
 DEFAULT_ARTIFACT_ROOT = DATA_DIR / "artifacts" / "text_multi_axis"
+
+
+def _default_classifier_encoder_alias() -> str:
+    """Resolve the canonical ``role: classifier`` encoder (ADR 0019).
+
+    Falls back to the historical hard-coded alias when the registry has
+    no ``role: classifier`` tag so the classifier training CLI keeps
+    booting on legacy configs (mirrors the retrieval entrypoint).
+    """
+
+    # Late import to avoid pulling the full registry yaml at module
+    # import time on environments that only need the dataclasses.
+    from app.models.registry import resolve_by_role
+
+    try:
+        return resolve_by_role("classifier")
+    except KeyError:
+        return "finbert_fed_adjacent"
+
+
+DEFAULT_ENCODER_ALIAS = _default_classifier_encoder_alias()
 
 
 @dataclass

--- a/backend/app/models/registry.py
+++ b/backend/app/models/registry.py
@@ -5,9 +5,18 @@ import re
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
+
+# Canonical encoder roles (ADR 0019). Two encoders win the canonical
+# slots: the FOMC-only DAPT substrate as the headline classifier, and
+# the cross-bank DAPT encoder as the retrieval base. The pre-#330
+# arrangement pinned the cross-bank DAPT substrate as the single
+# canonical encoder despite Bundle A.2 / A.4 returning null on the
+# vol-regime classifier — one substrate doing two jobs poorly.
+EncoderRole = Literal["classifier", "retrieval"]
+KNOWN_ROLES: tuple[str, ...] = ("classifier", "retrieval")
 
 # HF Hub repo-id format: ``owner/name`` where each side starts with an
 # alphanumeric and may contain ``[a-zA-Z0-9_.-]``. The grammar matches
@@ -40,6 +49,11 @@ class EncoderRef:
     gated: bool
     task: str
     description: str
+    # Canonical role tag (ADR 0019). ``None`` for entries that do not
+    # claim either canonical slot — bake-off siblings, control ablations,
+    # placeholder rows. Two tagged entries ship: ``classifier`` for the
+    # headline substrate, ``retrieval`` for the retrieval base.
+    role: str | None = None
 
 
 @lru_cache(maxsize=1)
@@ -51,6 +65,7 @@ def load_registry(path: Path | None = None) -> dict[str, EncoderRef]:
     for alias, fields in encoders.items():
         if not isinstance(fields, dict):
             continue
+        raw_role = fields.get("role")
         ref = EncoderRef(
             alias=alias,
             repo=str(fields["repo"]),
@@ -58,12 +73,50 @@ def load_registry(path: Path | None = None) -> dict[str, EncoderRef]:
             gated=bool(fields.get("gated", False)),
             task=str(fields.get("task", "classification")),
             description=str(fields.get("description", "")),
+            role=str(raw_role) if raw_role is not None else None,
         )
         by_repo[ref.repo] = ref
         by_repo[ref.alias] = ref
         for repo_alias in fields.get("repo_aliases") or ():
             by_repo[str(repo_alias)] = ref
     return by_repo
+
+
+def resolve_by_role(role: EncoderRole) -> str:
+    """Return the canonical encoder alias for the given role (ADR 0019).
+
+    Two roles are recognised: ``classifier`` (headline classification
+    substrate) and ``retrieval`` (retrieval base). The resolver scans
+    the encoder block once, dedup-keyed by ``alias`` so callers see
+    each registered entry once, and returns the first ``alias`` whose
+    ``role:`` matches.
+
+    Raises :class:`KeyError` when the role is unknown (not in
+    :data:`KNOWN_ROLES`) or when no encoder in the registry carries
+    that role tag. Callers that want to gracefully fall back to a
+    legacy default should resolve through :func:`encoder_ref` or a
+    callsite-specific default constant, not through this function.
+    """
+
+    if role not in KNOWN_ROLES:
+        raise KeyError(
+            f"unknown encoder role {role!r}; known roles: {KNOWN_ROLES}"
+        )
+    registry = load_registry()
+    # Dedup by alias — the loader fans an entry out across ``repo`` /
+    # ``alias`` / ``repo_aliases`` keys, so scanning ``.values()``
+    # directly would visit the same ref multiple times.
+    seen: set[str] = set()
+    for ref in registry.values():
+        if ref.alias in seen:
+            continue
+        seen.add(ref.alias)
+        if ref.role == role:
+            return ref.alias
+    raise KeyError(
+        f"no encoder with role={role!r} registered in models/registry.yaml; "
+        f"known roles: {KNOWN_ROLES}"
+    )
 
 
 def revision_for(repo_or_alias: str) -> str | None:

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -128,6 +128,7 @@ encoders:
     revision: ""
     gated: false
     task: masked_lm
+    role: classifier
     description: |
       Round 3 (#242) corpus-ablation sibling of ``finbert_fed_adjacent``.
       Continued-pretrained on FOMC statements + minutes ONLY (~48 docs,
@@ -136,6 +137,12 @@ encoders:
       revision stays empty until the first GPU run lands a checkpoint;
       ``encoder_ref`` treats this as "unpinned local" and the bake-off
       CLI will refuse to load it until the path + revision are filled in.
+
+      Carries ``role: classifier`` under ADR 0019 — the canonical
+      classifier substrate. Bundle A.2 / A.4 returned null on vol-regime
+      against the cross-bank DAPT encoder, so the FOMC-only DAPT
+      substrate keeps the headline classifier role and the cross-bank
+      DAPT encoder owns the retrieval role only.
 
   finbert_bis_only:
     repo: local/finbert-bis-only
@@ -172,6 +179,7 @@ encoders:
     revision: "20260525T185524Z_s11"
     gated: false
     task: masked_lm
+    role: retrieval
     description: |
       DAPT substrate-extension sibling of ``finbert_fed_adjacent``. Same
       MLM+NSP recipe, but the pretraining substrate adds the 5 cross-bank
@@ -183,6 +191,12 @@ encoders:
       ``make finbert-fed-adjacent-xbank-dapt-pretrain``. Revision stays
       empty until the first GPU run lands a checkpoint; same unpinned-
       local guard as ``finbert_fomc_only`` applies.
+
+      Carries ``role: retrieval`` under ADR 0019 — the canonical
+      retrieval substrate. Bundle A.2 / A.4 showed the cross-bank
+      supervised + DAPT layers null on the headline classifier target,
+      so this encoder owns the retrieval role only; the classifier role
+      is held by ``finbert_fomc_only``.
 
   finbert_fed_adjacent_xbank_aux_stance_masked:
     repo: /data/artifacts/text_multi_axis/text_multi_axis_20260525T105459Z/hf_checkpoints

--- a/backend/app/retrieval/train.py
+++ b/backend/app/retrieval/train.py
@@ -68,7 +68,7 @@ import numpy as np
 import pandas as pd
 
 from app.config import DATA_DIR
-from app.models.registry import encoder_ref
+from app.models.registry import encoder_ref, resolve_by_role
 from app.retrieval.index import (
     EXCERPT_CHARS,
     MAX_TEXT_CHARS,
@@ -77,7 +77,23 @@ from app.retrieval.index import (
 
 _logger = logging.getLogger(__name__)
 
-DEFAULT_BASE_ENCODER_ALIAS = "finbert_fed_adjacent_xbank_dapt"
+
+def _default_retrieval_base_alias() -> str:
+    """Resolve the canonical ``role: retrieval`` encoder (ADR 0019).
+
+    Falls back to the historical hard-coded alias if the registry has
+    no ``role: retrieval`` tag (e.g. a future registry rewrite that
+    drops the role-tagging convention) so the retrieval entrypoint
+    keeps booting on legacy configs.
+    """
+
+    try:
+        return resolve_by_role("retrieval")
+    except KeyError:
+        return "finbert_fed_adjacent_xbank_dapt"
+
+
+DEFAULT_BASE_ENCODER_ALIAS = _default_retrieval_base_alias()
 DEFAULT_OUTPUT_ROOT = DATA_DIR / "artifacts" / "retrieval"
 DEFAULT_RUN_NAME = "finbert_fed_adjacent_xbank_dapt_retrieval"
 DEFAULT_MAX_LENGTH = 256

--- a/docs/adr/0019-canonical-encoder-split-classifier-retrieval.md
+++ b/docs/adr/0019-canonical-encoder-split-classifier-retrieval.md
@@ -1,0 +1,46 @@
+# ADR 0019 — Canonical encoder split: classifier substrate vs retrieval substrate
+
+Status: accepted, in production (as of merge).
+Date: 2026-05-27.
+Supersedes: the single-canonical-encoder arrangement under which `finbert_fed_adjacent_xbank_dapt` was pinned as both the headline classifier substrate and the retrieval base.
+References:
+- Issue #330.
+- `backend/app/models/registry.yaml` — `role:` tags on the two canonical entries.
+- `backend/app/models/registry.py` — `resolve_by_role(role)` + `EncoderRole` literal.
+- `backend/app/data/train_text_multi_axis_classifier.py` — classification training entrypoint, picks the encoder via `resolve_by_role("classifier")`.
+- `backend/app/retrieval/train.py` — retrieval entrypoint, picks the base encoder via `resolve_by_role("retrieval")`.
+- `tests/unit/test_registry_role_resolution.py` — role-resolver contract tests.
+- `fed-pulse.wiki/06_Deep_Learning_Roadmap.md §6.7` — canonical headline cell, now keyed off the classifier substrate.
+
+## Context
+
+The DAPT checkpoint `finbert_fed_adjacent_xbank_dapt` was pinned as the sole canonical encoder. It carried both jobs: the headline classifier substrate that the multi-axis classifier fine-tunes against, and the retrieval base that `app.retrieval.train` layers a sentence-transformer head on top of.
+
+Bundle A.2 (cross-bank supervision arms — stance-masked + weighted) and Bundle A.4 (cross-bank DAPT substrate extension) both returned null on the vol-regime headline target. The substitute-not-complement diagnosis under §16 framed the cross-bank corpus as a substrate rather than a target-side complement. The justification for keeping the cross-bank DAPT encoder canonical was the downstream retrieval task — same-meeting positive pairs that span statement / minutes / press_conference rows benefit from a multilingual-fed substrate — not the headline classifier.
+
+One substrate doing two jobs poorly. The classifier picked a substrate that has no measured lift on its own target; the retrieval task picked a substrate that was justified on the wrong axis.
+
+## Decision
+
+Split the canonical encoder slot into two role-tagged entries. Both ship in `backend/app/models/registry.yaml`:
+
+- **Classifier substrate (`role: classifier`):** `finbert_fomc_only` — the pre-cross-bank FOMC-only DAPT encoder. Owns the headline classification training contract.
+- **Retrieval substrate (`role: retrieval`):** `finbert_fed_adjacent_xbank_dapt` — the cross-bank DAPT encoder. Continues as the retrieval base; the contrastive head trains on top of it under `app.retrieval.train`.
+
+The registry loader (`load_registry`) reads the new `role:` field into `EncoderRef.role` (defaults to `None` for every untagged entry — bake-off siblings, control ablations, placeholder rows). A new `resolve_by_role(role: Literal["classifier", "retrieval"]) -> str` function returns the first registered alias whose role matches; an unknown role label raises `KeyError` at the boundary.
+
+The two training entrypoints route through the role resolver with a hard-coded fallback that mirrors the pre-#330 default:
+
+- `backend/app/data/train_text_multi_axis_classifier.py` resolves `DEFAULT_ENCODER_ALIAS` via `resolve_by_role("classifier")`, falling back to `"finbert_fed_adjacent"` if the registry has no classifier tag.
+- `backend/app/retrieval/train.py` resolves `DEFAULT_BASE_ENCODER_ALIAS` via `resolve_by_role("retrieval")`, falling back to `"finbert_fed_adjacent_xbank_dapt"`.
+
+Back-compat: callers that resolve by alias (the previous default — `encoder_ref(alias)`, `revision_for(alias)`, etc.) keep working unchanged. The new `role:` field is additive; registries written before this ADR continue to load with every `EncoderRef.role` at `None`.
+
+## Consequences
+
+- The canonical headline cell in `fed-pulse.wiki/06_Deep_Learning_Roadmap.md §6.7` is now keyed off the classifier substrate. The cross-bank cell that previously held the headline stays in §6.7 for historical record, annotated as deprecated-as-canonical. The §6.7 re-run against the classifier substrate is filed as a follow-up — placeholder row pinned until the next 5-seed × 4-fold sweep lands.
+- The retrieval pipeline (`/analyze/analogs`) keeps the cross-bank DAPT encoder as its base. The retrieval bundle on HF Hub (`yusufizzetmurat/fed-pulse-retrieval`) does not need a re-push; the artefact pin in `registry.yaml` `artefacts:` block stays unchanged because the retrieval base is the same encoder.
+- The `EncoderRef` dataclass grows one optional field (`role: str | None`). Existing callers that destructure `EncoderRef` by position would break if the dataclass were positional, but every callsite uses keyword access (`ref.repo`, `ref.alias`, etc.), so the addition is non-breaking.
+- Future role additions (e.g. `role: rerank`, `role: nsp_aux`) drop into the `KNOWN_ROLES` tuple without further plumbing. The `Literal` type and the runtime tuple share one source of truth, so a typo at the callsite fails type-check and runtime symmetrically.
+- The `forecaster.py` singleton path does not consume the new role tag — `/analyze` loads a serving checkpoint by file path (`backend/models/forecaster_best.pt`) rather than by registry alias. Role tagging is a training-time contract; it does not change the serving entrypoint surface.
+- Wiki `12_Architecture_Decision_Records.md` index does not list this ADR yet; the index update is filed as a follow-up to keep this PR's wiki diff narrow.

--- a/tests/unit/test_registry_role_resolution.py
+++ b/tests/unit/test_registry_role_resolution.py
@@ -1,0 +1,155 @@
+"""Role-keyed encoder resolution (ADR 0019 / #330).
+
+The canonical encoder slot is split into two roles: ``classifier`` for
+the headline classification substrate and ``retrieval`` for the
+retrieval base. The resolver returns the alias whose ``role:`` tag
+matches; a registry without role tags still loads cleanly for legacy
+callers, and an unknown role raises ``KeyError`` at the boundary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _reset_registry_cache() -> None:
+    from app.models.registry import load_registry
+
+    load_registry.cache_clear()
+
+
+def test_classifier_role_resolves_to_fomc_only() -> None:
+    """``role: classifier`` returns the FOMC-only DAPT substrate.
+
+    Per ADR 0019 the headline classifier substrate is the pre-cross-bank
+    encoder (``finbert_fomc_only``), not the cross-bank DAPT encoder.
+    The cross-bank DAPT encoder owns the retrieval role only.
+    """
+    _reset_registry_cache()
+    from app.models.registry import resolve_by_role
+
+    alias = resolve_by_role("classifier")
+    assert alias == "finbert_fomc_only", (
+        f"expected classifier substrate to resolve to 'finbert_fomc_only'; got {alias!r}"
+    )
+
+
+def test_retrieval_role_resolves_to_xbank_dapt() -> None:
+    """``role: retrieval`` returns the cross-bank DAPT encoder."""
+    _reset_registry_cache()
+    from app.models.registry import resolve_by_role
+
+    alias = resolve_by_role("retrieval")
+    assert alias == "finbert_fed_adjacent_xbank_dapt", (
+        "expected retrieval substrate to resolve to "
+        f"'finbert_fed_adjacent_xbank_dapt'; got {alias!r}"
+    )
+
+
+def test_unknown_role_raises_key_error() -> None:
+    """An unknown role label fails fast at the resolver boundary."""
+    _reset_registry_cache()
+    from app.models.registry import resolve_by_role
+
+    with pytest.raises(KeyError, match="unknown encoder role"):
+        resolve_by_role("not_a_real_role")  # type: ignore[arg-type]
+
+
+def test_role_field_is_none_for_untagged_entries() -> None:
+    """Entries without an explicit ``role:`` carry ``role=None``.
+
+    The ``EncoderRef`` dataclass leaves ``role`` at ``None`` for every
+    bake-off sibling and control ablation; only the two canonical
+    entries (classifier + retrieval) carry a tag. This is what makes
+    the ``resolve_by_role`` scan deterministic — it stops at the
+    first tagged row and ignores untagged neighbours.
+    """
+    _reset_registry_cache()
+    from app.models.registry import encoder_ref
+
+    finbert = encoder_ref("finbert")
+    assert finbert is not None
+    assert finbert.role is None
+
+    finbert_tone = encoder_ref("finbert_tone")
+    assert finbert_tone is not None
+    assert finbert_tone.role is None
+
+
+def test_role_tags_present_on_canonical_entries() -> None:
+    """The two canonical entries carry the expected role tags."""
+    _reset_registry_cache()
+    from app.models.registry import encoder_ref
+
+    classifier = encoder_ref("finbert_fomc_only")
+    assert classifier is not None
+    assert classifier.role == "classifier"
+
+    retrieval = encoder_ref("finbert_fed_adjacent_xbank_dapt")
+    assert retrieval is not None
+    assert retrieval.role == "retrieval"
+
+
+def test_legacy_registry_without_roles_still_loads(tmp_path: Path) -> None:
+    """A registry whose entries omit ``role:`` loads cleanly.
+
+    Back-compat guard: pre-#330 registry YAMLs carry no ``role:`` key.
+    The loader must accept them and leave every ``EncoderRef.role`` at
+    ``None`` so callers that resolve by alias (the previous default)
+    keep working unchanged. ``resolve_by_role`` raises ``KeyError`` on
+    the legacy shape because there is no tagged entry to point at —
+    callsites are expected to fall back to a hard-coded default in
+    that path (mirrors how the retrieval / classifier entrypoints
+    guard their imports).
+    """
+    legacy_yaml = """
+updated_at: 2026-01-01
+
+encoders:
+  legacy_one:
+    repo: ProsusAI/finbert
+    revision: deadbeef
+    gated: false
+    task: classification
+    description: legacy entry without role tag.
+
+  legacy_two:
+    repo: gtfintechlab/FOMC-RoBERTa
+    revision: cafef00d
+    gated: false
+    task: classification
+    description: second legacy entry.
+"""
+    yaml_path = tmp_path / "registry.yaml"
+    yaml_path.write_text(legacy_yaml.strip(), encoding="utf-8")
+
+    from app.models.registry import load_registry
+
+    load_registry.cache_clear()
+    registry = load_registry(yaml_path)
+    load_registry.cache_clear()  # reset so other tests see the canonical yaml
+
+    assert "legacy_one" in registry
+    assert "legacy_two" in registry
+    assert registry["legacy_one"].role is None
+    assert registry["legacy_two"].role is None
+
+
+def test_resolve_by_role_dedups_alias_fanout() -> None:
+    """The resolver visits each entry once despite the alias / repo fanout.
+
+    ``load_registry`` keys each ``EncoderRef`` under ``alias``, ``repo``,
+    and every ``repo_aliases`` entry — a naive ``.values()`` scan would
+    visit the same ref multiple times. The dedup pass keeps the scan
+    deterministic so the first ``role: <x>`` hit wins.
+    """
+    _reset_registry_cache()
+    from app.models.registry import resolve_by_role
+
+    # Both roles must resolve to a unique alias; if the scan double-
+    # visited a ref the result would still be correct but the dedup
+    # contract is what keeps role-uniqueness debuggable when a future
+    # registry edit introduces an accidental second tagged row.
+    assert resolve_by_role("classifier") != resolve_by_role("retrieval")


### PR DESCRIPTION
## Summary

- Register two canonical encoders in `registry.yaml` with explicit `role` tags
- `role: classifier` → `finbert_fomc_only` (pre-cross-bank substrate)
- `role: retrieval` → `finbert_fed_adjacent_xbank_dapt` (cross-bank DAPT)
- `resolve_by_role` helper in `registry.py` with legacy-default fallback
- Classification + retrieval entrypoints route through role-keyed resolution
- ADR 0019 documents the split; canonical-headline rerun against classifier substrate pinned as follow-up

## Test plan

- [ ] `docker compose run --rm backend pytest tests/unit/test_registry_role_resolution.py -q`
- [ ] `docker compose run --rm backend pytest tests/ -k registry -q`