### PR TITLE
Drop TFT from canonical architecture sweep with footnote (#331)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,11 +183,17 @@ train-text-multi-axis-classifier:
 		--learning-rate $(LEARNING_RATE)
 
 # Forecaster architecture sweep. The default target runs the
-# rich-feature path (35-dim per-bar input) across all eight registered
+# rich-feature path (35-dim per-bar input) across the seven canonical
 # architectures (lstm, lstm_attn, gru, tcn, transformer, dlinear,
-# informer, tft) x the official 5-seed set {11, 29, 47, 71, 97}, so the
+# informer) x the official 5-seed set {11, 29, 47, 71, 97}, so the
 # forecaster sees the four feature families the data pipeline already
 # ships (credibility, linguistic, MP-surprise, multi-axis) on every bar.
+#
+# TFT is excluded from the canonical sweep targets per ADR 0020 (the
+# generic classifier head strips the native quantile-output + Variable
+# Selection Network inductive bias). The ``tft`` identifier and module
+# are kept for back-compat with existing checkpoints; opt back in by
+# passing ``--architectures tft`` explicitly on the trainer command line.
 #
 # The default target draws a random subset of HP combos from the full
 # cross-product (--random-search-samples=50, seed=42) and runs eight
@@ -245,7 +251,7 @@ forecaster-sweep:
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
 		--sweep \
 		--rich-features \
-		--architectures lstm lstm_attn gru tcn transformer dlinear informer tft \
+		--architectures lstm lstm_attn gru tcn transformer dlinear informer \
 		--seeds 11 29 47 71 97 \
 		--folds wf_fold_1 wf_fold_2 wf_fold_3 wf_fold_4 \
 		--hidden-sizes 32 64 128 \
@@ -275,7 +281,7 @@ forecaster-sweep-exhaustive:
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
 		--sweep \
 		--rich-features \
-		--architectures lstm lstm_attn gru tcn transformer dlinear informer tft \
+		--architectures lstm lstm_attn gru tcn transformer dlinear informer \
 		--seeds 11 29 47 71 97 \
 		--hidden-sizes 32 64 128 \
 		--num-layers-grid 1 2 3 \
@@ -302,7 +308,7 @@ forecaster-sweep-shuffled-control:
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
 		--sweep \
 		--rich-features \
-		--architectures lstm lstm_attn gru tcn transformer dlinear informer tft \
+		--architectures lstm lstm_attn gru tcn transformer dlinear informer \
 		--seeds 11 29 47 71 97 \
 		--hidden-sizes 64 \
 		--num-layers-grid 2 \

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,8 @@
-from app.models.config import FORECASTER_ARCHITECTURES
+from app.models.config import (
+    CANONICAL_SWEEP_ARCHITECTURES,
+    FORECASTER_ARCHITECTURES,
+    TFT_EXCLUSION_REASON,
+)
 from app.models.registry import (
     MODEL_REGISTRY_PATH,
     EncoderRef,
@@ -7,9 +11,11 @@ from app.models.registry import (
 )
 
 __all__ = [
+    "CANONICAL_SWEEP_ARCHITECTURES",
     "EncoderRef",
     "FORECASTER_ARCHITECTURES",
     "MODEL_REGISTRY_PATH",
+    "TFT_EXCLUSION_REASON",
     "load_registry",
     "revision_for",
 ]

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -216,6 +216,30 @@ FORECASTER_ARCHITECTURES: tuple[str, ...] = (
     "tft",
 )
 
+# Architectures excluded from the canonical sweep targets. See ADR 0020
+# (``docs/adr/0020-tft-architecture-comparison-exclusion.md``) and the
+# footnote on ``fed-pulse.wiki/06_Deep_Learning_Roadmap.md §6.7`` for
+# the rationale. TFT's published recipe routes predictions through its
+# native quantile output + Variable Selection Network; the in-repo
+# encoder pools to a generic classifier head, which strips the
+# inductive bias the architecture is designed around. The 0.3803 row
+# from §6.6 is retained as historical record only. A faithful
+# quantile-head reimplementation is filed as a STRETCH follow-up.
+#
+# The architecture identifier stays in ``FORECASTER_ARCHITECTURES`` so
+# existing checkpoints that recorded ``architecture='tft'`` continue to
+# load and the ``TFTEncoder`` module remains importable; new sweeps
+# should iterate ``CANONICAL_SWEEP_ARCHITECTURES`` instead.
+TFT_EXCLUSION_REASON: str = (
+    "TFT excluded from canonical architecture sweep per ADR 0020 "
+    "(generic classifier head strips the native quantile-output + "
+    "Variable Selection Network inductive bias). Faithful "
+    "quantile-head reimplementation is a STRETCH-tier follow-up."
+)
+CANONICAL_SWEEP_ARCHITECTURES: tuple[str, ...] = tuple(
+    arch for arch in FORECASTER_ARCHITECTURES if arch != "tft"
+)
+
 
 @dataclass(frozen=True)
 class ModelConfig:

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -23,9 +23,14 @@ InfoNCE is research-only and rejects ``role="serving"``.
 
 from __future__ import annotations
 
+import warnings
 from typing import Any, Literal
 
-from app.models.config import FORECASTER_ARCHITECTURES, ModelConfig
+from app.models.config import (
+    FORECASTER_ARCHITECTURES,
+    TFT_EXCLUSION_REASON,
+    ModelConfig,
+)
 from app.models.multimodal_forecaster import MultiModalForecasterModel
 from app.models.research_model import ForecasterResearchModel
 from app.models.serving_model import ForecasterServingModel
@@ -59,6 +64,16 @@ def build_forecaster(
         raise ValueError(
             f"Unknown architecture: {architecture!r}. "
             f"Allowed: {sorted(FORECASTER_ARCHITECTURES)}"
+        )
+    # TFT stays importable + checkpoint-loadable for back-compat, but is
+    # excluded from canonical sweep targets. Surface a DeprecationWarning
+    # whenever the factory is asked to build one so a future sweep that
+    # mis-includes TFT does not silently regress the comparison.
+    if architecture == "tft":
+        warnings.warn(
+            TFT_EXCLUSION_REASON,
+            DeprecationWarning,
+            stacklevel=2,
         )
 
     if role not in {"research", "serving"}:

--- a/docs/adr/0020-tft-architecture-comparison-exclusion.md
+++ b/docs/adr/0020-tft-architecture-comparison-exclusion.md
@@ -1,0 +1,44 @@
+# ADR 0020 — TFT excluded from the canonical architecture comparison
+
+Status: accepted, in production (as of merge).
+Date: 2026-05-27.
+References:
+- Issue #331.
+- `backend/app/models/config.py` — `FORECASTER_ARCHITECTURES`, `CANONICAL_SWEEP_ARCHITECTURES`, `TFT_EXCLUSION_REASON`.
+- `backend/app/models/factory.py` — `DeprecationWarning` raised when `architecture="tft"` is requested.
+- `backend/app/models/tft.py` — `TFTEncoder` module, retained for back-compat with existing checkpoints.
+- `scripts/run_regime_architecture_sweep.py` — `_DEFAULT_ARCHITECTURES` (TFT absent).
+- `Makefile` — `forecaster-sweep`, `forecaster-sweep-exhaustive`, `forecaster-sweep-shuffled-control` (TFT absent from default architecture lists).
+- `fed-pulse.wiki/06_Deep_Learning_Roadmap.md §6.7` — footnote citing this ADR.
+- `tests/unit/test_tft_excluded_from_canonical_sweep.py` — guard against TFT silently re-entering canonical sweep defaults.
+
+## Context
+
+The in-repo TFT implementation (`backend/app/models/tft.py`) ports the encoder-side pieces of the published Temporal Fusion Transformer: per-timestep Variable-Selection Network (VSN), GRN-gated residual blocks, and a multi-head self-attention block over the selected representation. The forecaster pipeline mean-pools that encoder output and routes the pooled vector through the generic classifier head the other seven architectures share.
+
+TFT is designed to emit predictions via its native quantile head paired with the VSN. The published recipe routes per-timestep variable importances + static-covariate enrichment through that head end-to-end; the head is the part the architecture's inductive bias is organised around. Mean-pooling the encoder output and feeding a generic classifier head strips half of TFT's design — the comparison row that lands at 0.3803 macro-F1 in §6.6 measures the encoder under a head it was not designed for, not the architecture as published.
+
+Two paths are available:
+
+- **Option A — implement TFT faithfully.** Port the native quantile output + the VSN-aware head, retune random-search HP at the new head's surface, rerun §6.7 with a faithful TFT row. Multi-day GPU + ML-engineering work; STRETCH-tier per the §6 roadmap.
+- **Option B — drop TFT from the canonical comparison.** Document the exclusion in this ADR + a §6.7 footnote, remove TFT from the canonical sweep defaults, preserve the 0.3803 result in the wiki only as historical record. 1-day SHOULD-tier path per the §6 roadmap.
+
+The §6 roadmap allows either; advisor scope does not require both. Shipping a hostile-evaluation row of TFT as a published comparison number is the option the brief explicitly rules out.
+
+## Decision
+
+Option B. TFT is excluded from the canonical architecture comparison.
+
+The module `backend/app/models/tft.py` and the `"tft"` identifier in `FORECASTER_ARCHITECTURES` are retained so existing checkpoints that recorded `architecture="tft"` continue to load and the encoder unit tests at `tests/unit/test_tft.py` keep running. A new constant `CANONICAL_SWEEP_ARCHITECTURES` excludes `"tft"` and is the tuple new sweep code iterates. `build_forecaster` raises a `DeprecationWarning` (`TFT_EXCLUSION_REASON`) when asked to build a TFT instance so a future sweep that mis-includes the identifier surfaces the exclusion in the trainer logs rather than silently regressing the comparison.
+
+The default architecture lists in `scripts/run_regime_architecture_sweep.py` and in the Makefile sweep targets (`forecaster-sweep`, `forecaster-sweep-exhaustive`, `forecaster-sweep-shuffled-control`) drop `"tft"`. The trainer CLI's `--architecture` / `--architectures` flags still accept `"tft"` so an operator can opt back in for a one-off investigation; the canonical published comparison does not include it.
+
+`fed-pulse.wiki/06_Deep_Learning_Roadmap.md §6.7` carries a footnote citing this ADR. The 0.3803 figure from §6.6 stays in the wiki as historical record of the deprecated-target / generic-head measurement; no headline cell cites TFT going forward.
+
+## Consequences
+
+- Canonical sweep numbers no longer cite TFT. The four architectures cited in the §6.7 post-correction table (`gru`, `tcn`, `transformer`, `lstm_attn`) remain the published comparison set.
+- Existing TFT checkpoints continue to load — the back-compat shim on the architecture identifier is preserved on purpose. The `TFTEncoder` module is not deleted.
+- A future faithful-TFT reimplementation (Option A) is filed as a STRETCH follow-up; the gate for re-adding TFT to the canonical comparison is a faithful quantile-head implementation, not a re-run of the existing generic-head wiring.
+- The unit test at `tests/unit/test_tft_excluded_from_canonical_sweep.py` pins `CANONICAL_SWEEP_ARCHITECTURES` and the regime-arch-sweep runner's default list. Re-adding TFT to the canonical surface requires updating this ADR + the test together.
+- The `DeprecationWarning` raised at `build_forecaster` time means an operator who explicitly opts back in via `--architectures tft` still gets the build but receives a clear log message — silent regressions of the canonical comparison are blocked.

--- a/scripts/run_regime_architecture_sweep.py
+++ b/scripts/run_regime_architecture_sweep.py
@@ -27,12 +27,18 @@ from pathlib import Path
 
 _DEFAULT_REPORT_ROOT = Path("data/artifacts/regime_arch_sweep")
 
+# TFT is intentionally absent from the canonical sweep targets. See
+# ``docs/adr/0020-tft-architecture-comparison-exclusion.md`` and the
+# §6.7 footnote in ``fed-pulse.wiki/06_Deep_Learning_Roadmap.md`` --
+# the in-repo generic-head evaluation is architecture-mismatch with
+# TFT's native quantile + VSN inductive bias; the 0.3803 result lives
+# in the wiki only as historical record. Pass ``--architectures tft``
+# explicitly to opt back in for a one-off investigation.
 _DEFAULT_ARCHITECTURES = (
     "lstm_attn",
     "gru",
     "tcn",
     "transformer",
-    "tft",
 )
 
 
@@ -108,7 +114,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--architectures",
         nargs="+",
         default=list(_DEFAULT_ARCHITECTURES),
-        help="Architectures to sweep. Default: lstm_attn, gru, tcn, transformer, tft.",
+        help=(
+            "Architectures to sweep. Default: lstm_attn, gru, tcn, transformer. "
+            "TFT is excluded from the canonical comparison per ADR 0020; "
+            "pass --architectures tft explicitly to opt in."
+        ),
     )
     parser.add_argument(
         "--seeds",

--- a/tests/unit/test_tft_excluded_from_canonical_sweep.py
+++ b/tests/unit/test_tft_excluded_from_canonical_sweep.py
@@ -1,0 +1,140 @@
+"""Guard against TFT silently re-entering canonical sweep defaults (#331).
+
+ADR 0020 excludes TFT from the canonical architecture comparison.
+The exclusion bites at three surfaces:
+
+1. ``app.models.config.CANONICAL_SWEEP_ARCHITECTURES`` -- the tuple new
+   sweep code iterates -- must omit ``"tft"`` while
+   ``FORECASTER_ARCHITECTURES`` retains it (the encoder module +
+   existing checkpoints rely on the identifier remaining importable).
+2. ``scripts.run_regime_architecture_sweep._DEFAULT_ARCHITECTURES`` --
+   the default architecture list the canonical sweep runner uses when
+   the CLI flag is not passed -- must omit ``"tft"``.
+3. ``app.models.factory.build_forecaster`` must raise a
+   ``DeprecationWarning`` (carrying ``TFT_EXCLUSION_REASON``) when
+   asked to build a TFT instance, so an opt-in re-run surfaces the
+   exclusion in the trainer logs.
+
+Re-adding TFT to the canonical surface requires updating both this
+test and ADR 0020 -- the failure mode is a loud test, not a silent
+sweep regression.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from app.models import (
+    CANONICAL_SWEEP_ARCHITECTURES,
+    FORECASTER_ARCHITECTURES,
+    TFT_EXCLUSION_REASON,
+)
+
+
+def test_canonical_sweep_architectures_excludes_tft() -> None:
+    """``CANONICAL_SWEEP_ARCHITECTURES`` omits ``"tft"`` -- per ADR 0020."""
+
+    assert "tft" not in CANONICAL_SWEEP_ARCHITECTURES, (
+        "TFT must stay out of the canonical sweep targets per ADR 0020. "
+        "Re-adding it requires a faithful native-quantile-head implementation "
+        "(STRETCH); update ADR 0020 + this test in lockstep."
+    )
+
+
+def test_forecaster_architectures_retains_tft_for_backcompat() -> None:
+    """``FORECASTER_ARCHITECTURES`` keeps ``"tft"`` so existing checkpoints load.
+
+    The back-compat surface is intentional -- dropping the identifier
+    would break checkpoint round-tripping through ``ModelConfig.from_model``
+    on any artefact that recorded ``architecture="tft"``.
+    """
+
+    assert "tft" in FORECASTER_ARCHITECTURES, (
+        "TFT must stay in FORECASTER_ARCHITECTURES so existing checkpoints "
+        "and the TFTEncoder module remain back-compat-loadable. The "
+        "exclusion lives in CANONICAL_SWEEP_ARCHITECTURES, not here."
+    )
+
+
+def test_canonical_sweep_is_subset_of_forecaster_architectures() -> None:
+    """The canonical tuple is a strict subset of the full registry."""
+
+    assert set(CANONICAL_SWEEP_ARCHITECTURES).issubset(
+        set(FORECASTER_ARCHITECTURES)
+    )
+    assert set(CANONICAL_SWEEP_ARCHITECTURES) < set(FORECASTER_ARCHITECTURES)
+
+
+def test_tft_exclusion_reason_cites_adr_quantile_head() -> None:
+    """``TFT_EXCLUSION_REASON`` documents the ADR rationale."""
+
+    assert "ADR 0020" in TFT_EXCLUSION_REASON
+    assert "quantile" in TFT_EXCLUSION_REASON.lower()
+    assert "vsn" in TFT_EXCLUSION_REASON.lower() or "variable selection" in TFT_EXCLUSION_REASON.lower()
+
+
+def test_regime_arch_sweep_default_architectures_excludes_tft() -> None:
+    """``scripts/run_regime_architecture_sweep.py`` default list omits TFT.
+
+    This is the runner the ``make regime-arch-sweep`` target invokes.
+    A canonical sweep dispatched without ``--architectures`` must not
+    include TFT in its per-architecture report.
+
+    The script lives under ``scripts/`` which is not a Python package
+    (no ``__init__.py``); we load the module directly off its file
+    path so the test runs from any pytest working directory.
+    """
+
+    import importlib.util
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "run_regime_architecture_sweep.py"
+    assert script_path.is_file(), f"runner missing at {script_path}"
+
+    spec = importlib.util.spec_from_file_location(
+        "_test_regime_arch_sweep_module", script_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    default_architectures = module._DEFAULT_ARCHITECTURES
+    assert "tft" not in default_architectures, (
+        "regime_arch_sweep _DEFAULT_ARCHITECTURES must exclude TFT per "
+        "ADR 0020; pass --architectures tft explicitly to opt back in."
+    )
+    # The canonical four-architecture comparison: gru / tcn / transformer
+    # / lstm_attn (the §6.7 post-correction headline set). Order is not
+    # asserted; membership is.
+    assert {"gru", "tcn", "transformer", "lstm_attn"}.issubset(
+        set(default_architectures)
+    )
+
+
+def test_build_forecaster_emits_deprecation_warning_for_tft() -> None:
+    """``build_forecaster`` warns when asked to build a TFT instance.
+
+    The factory still builds the module (back-compat: checkpoints that
+    recorded ``architecture="tft"`` must continue to load), but the
+    deprecation warning surfaces ADR 0020 in the trainer logs so a
+    canonical sweep that mis-includes TFT cannot regress silently.
+    """
+
+    pytest.importorskip("torch")
+    from app.models.config import ModelConfig
+    from app.models.factory import build_forecaster
+
+    config = ModelConfig(architecture="tft")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        build_forecaster(config, role="research")
+    deprecation = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecation, (
+        "Building a TFT forecaster must emit a DeprecationWarning citing "
+        "ADR 0020 (see TFT_EXCLUSION_REASON)."
+    )
+    messages = " ".join(str(w.message) for w in deprecation)
+    assert "ADR 0020" in messages


### PR DESCRIPTION
## Summary

- TFT removed from sweep runners' default architecture list (canonical sweeps no longer mount TFT)
- `backend/app/models/tft.py` kept for back-compat — existing checkpoints still load
- DeprecationWarning fires when TFT is explicitly selected
- ADR 0020 documents the exclusion (architecture-mismatch with generic classifier head)
- §6.7 footnote cites the exclusion reason; faithful TFT quantile-head impl pinned as STRETCH follow-up
- Test pins TFT exclusion from canonical sweep defaults

## Test plan

- [ ] `docker compose run --rm backend pytest tests/unit/test_tft_excluded_from_canonical_sweep.py -q`