### PR TITLE
Per-fold quantile framing + LLM cache immutability (#337)

### DIFF
--- a/backend/app/data/quantile_labels.py
+++ b/backend/app/data/quantile_labels.py
@@ -11,11 +11,22 @@ fold and assigns one of three labels to every row in the fold:
 - ``neutral`` (= ``0``) — change in ``[33rd, 67th)``
 - ``tightening`` (= ``+1``) — change at or above the 67th percentile
 
-The bin edges are computed strictly from the train slice (no
-look-ahead) and the edge pair is persisted alongside the fold's metadata
-so the training-package reader and the conformal calibrator both see
-the same boundaries. The 33/67 quantiles match the convention pinned by
+The bin edges are computed per fold from that fold's train slice and
+the edge pair is persisted alongside the fold's metadata so the
+training-package reader and the conformal calibrator both see the
+same boundaries. The 33/67 quantiles match the convention pinned by
 the existing vol-regime classifier (calm / normal / high).
+
+The per-fold fit is leakage-irrelevant rather than leakage-protective:
+the tertile boundary is a property of the underlying volatility
+distribution, not of the train split. The §15 data-integrity audit
+confirms the cutoffs move by ~4-7% relative across the five
+walk-forward folds (q33 = 0.0063 -> 0.0067, q67 = 0.0099 -> 0.0103),
+so a single global cutoff on the pooled distribution yields nearly
+identical class assignments. Per-fold fitting is preserved for
+contract symmetry with the rest of the train-only statistics block
+(scalers, class weights) — it is not the mechanism that keeps the
+labelling protocol honest.
 """
 
 from __future__ import annotations

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -354,3 +354,24 @@ artefacts:
     description: |
       Per-encoder embedding caches lazy-fetched on first use by
       ``app.data.embedding_cache.ensure_local``.
+
+# Integrity pin for the B1 (#212) LLM-as-features cache. The cache is the
+# authoritative artefact for the §6.6 Tier 4 / Tier 5 experiments — the
+# Anthropic model snapshot it was extracted against (`claude-sonnet-4-6`)
+# will be retired upstream, so the extraction is reproducible from the
+# in-tree script + pinned snapshot today but not re-extractable from a
+# future model. Treat the cache file as immutable; integrity is enforced
+# by the sha256 below (see ``tests/unit/test_llm_features_pin.py``).
+llm_features:
+  cache_path: data/raw/llm_features/claude-sonnet-4-6_2026-05-19.v1/tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0.parquet
+  sha256: 159eb09e58e932adcd0f191aaf3aa80c61d62c466a2955785237429932794bf7
+  size_bytes: 89406
+  model: claude-sonnet-4-6
+  temperature: 0
+  pinned_at: 2026-05-27
+  immutability_note: |
+    This cache is reproducible from the in-tree extraction script + the
+    pinned Anthropic model snapshot. When the model snapshot deprecates
+    (Anthropic retires claude-sonnet-4-6), the extraction is no longer
+    replicable from a future model. The cache file is the authoritative
+    artefact; do not delete or regenerate without an ADR.

--- a/docs/data-and-training-contracts.md
+++ b/docs/data-and-training-contracts.md
@@ -377,6 +377,36 @@ land via `scripts/cache_voyage_embeddings.py --allow-network`; the
 SOURCES.lock format is identical to the Hugging Face encoders so a
 downstream consumer reads voyage rows with no shape change.
 
+## LLM-features cache immutability
+
+The B1 (#212) LLM-as-features cache at
+`data/raw/llm_features/claude-sonnet-4-6_2026-05-19.v1/tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0.parquet`
+is the authoritative artefact for the §6.6 Tier 4 / Tier 5 results.
+The catalogue was extracted with Claude Sonnet 4.6 at temperature 0;
+reproducibility binds to that specific Anthropic model snapshot.
+Anthropic will eventually retire `claude-sonnet-4-6`, after which the
+extraction script cannot reproduce the cache byte-for-byte from a
+future model — a successor model would shift category-level
+agreement on the 10-feature catalogue even at the same temperature.
+
+Rule:
+
+1. **Do not delete or regenerate the cache file.** It is the only
+   reproducible artefact for the §6.6 LLM-features experiment once
+   `claude-sonnet-4-6` is deprecated. If the cache is lost, the
+   experiment is irreplicable and the §6.6 Tier 4 / Tier 5 rows
+   cannot be re-derived from a future model snapshot.
+2. **Integrity is enforced by the registry SHA pin.** The cache
+   `sha256` + `size_bytes` are pinned in
+   `backend/app/models/registry.yaml` under the `llm_features:`
+   top-level block; a tampered cache file fails the
+   `tests/unit/test_llm_features_pin.py` integrity check.
+3. **A regeneration requires an ADR.** Any change to the catalogue,
+   the model snapshot, or the cache content must land as an
+   `Architecture Decision Record` in
+   `fed-pulse.wiki/12_Architecture_Decision_Records.md` together
+   with a registry pin bump; silent regenerations are forbidden.
+
 ## Structured linguistic features (Phase 8)
 
 `backend/app/features/linguistic.py` emits a 15-dim interpretable

--- a/tests/unit/test_llm_features_pin.py
+++ b/tests/unit/test_llm_features_pin.py
@@ -1,0 +1,111 @@
+"""Integrity pin for the B1 (#212) LLM-as-features cache (#337).
+
+The cache parquet is the authoritative artefact for the §6.6 Tier 4 /
+Tier 5 results — it was extracted against the Claude Sonnet 4.6 model
+snapshot at temperature 0 and is not re-extractable from a future
+model once Anthropic deprecates `claude-sonnet-4-6`. The integrity
+contract is the `llm_features:` block in
+``backend/app/models/registry.yaml``: this test asserts the block
+carries every required key and, when the cache file is on disk, that
+the pinned SHA matches the file. CI runs without the cache mounted —
+the second assertion skips cleanly in that environment.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.models.registry import MODEL_REGISTRY_PATH
+
+_REQUIRED_KEYS = (
+    "cache_path",
+    "sha256",
+    "size_bytes",
+    "model",
+    "temperature",
+    "pinned_at",
+    "immutability_note",
+)
+
+
+def _load_llm_features_block() -> dict:
+    raw = yaml.safe_load(MODEL_REGISTRY_PATH.read_text(encoding="utf-8"))
+    assert "llm_features" in raw, (
+        "registry.yaml must carry a top-level `llm_features:` block (#337)"
+    )
+    return raw["llm_features"]
+
+
+def test_registry_carries_llm_features_block_with_required_keys() -> None:
+    block = _load_llm_features_block()
+    missing = [k for k in _REQUIRED_KEYS if k not in block]
+    assert not missing, f"llm_features block missing required keys: {missing!r}"
+
+
+def test_llm_features_block_field_shapes() -> None:
+    block = _load_llm_features_block()
+    sha = str(block["sha256"]).strip()
+    assert len(sha) == 64 and all(c in "0123456789abcdef" for c in sha), (
+        f"sha256 must be a 64-char lowercase hex digest; got {sha!r}"
+    )
+    assert int(block["size_bytes"]) > 0, "size_bytes must be a positive int"
+    assert block["model"] == "claude-sonnet-4-6", (
+        "model snapshot pin must read 'claude-sonnet-4-6' — the cache binds "
+        "reproducibility to this exact Anthropic snapshot"
+    )
+    assert float(block["temperature"]) == 0.0, "temperature must be 0"
+    # Smoke check on the immutability note: it must mention the ADR
+    # escape hatch so a future contributor cannot silently regenerate.
+    assert "ADR" in str(block["immutability_note"]), (
+        "immutability_note must reference the ADR escape hatch"
+    )
+
+
+def _resolve_cache_path(cache_path_rel: str) -> Path | None:
+    # registry.yaml is at <repo>/backend/app/models/registry.yaml; the
+    # cache path is repo-relative. Walk up four parents to land at the
+    # repo root, then join.
+    repo_root = MODEL_REGISTRY_PATH.resolve().parents[3]
+    candidate = repo_root / cache_path_rel
+    if candidate.exists():
+        return candidate
+    # Fall back to the CWD-relative path (CI runners sometimes mount
+    # the repo at the working directory rather than the conventional
+    # location).
+    cwd_candidate = Path.cwd() / cache_path_rel
+    if cwd_candidate.exists():
+        return cwd_candidate
+    return None
+
+
+def test_pinned_sha_matches_cache_when_present() -> None:
+    block = _load_llm_features_block()
+    cache_path_rel = str(block["cache_path"])
+    cache_path = _resolve_cache_path(cache_path_rel)
+    if cache_path is None:
+        pytest.skip(
+            f"LLM-features cache not present at {cache_path_rel!r}; the "
+            "registry pin is asserted on the dev / GPU host only."
+        )
+    expected_sha = str(block["sha256"]).strip().lower()
+    expected_size = int(block["size_bytes"])
+    actual_size = cache_path.stat().st_size
+    assert actual_size == expected_size, (
+        f"cache size drift: pinned {expected_size}, on-disk {actual_size} "
+        f"({cache_path}); the cache file must not be regenerated outside "
+        "an ADR (see docs/data-and-training-contracts.md)"
+    )
+    hasher = hashlib.sha256()
+    with cache_path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            hasher.update(chunk)
+    actual_sha = hasher.hexdigest()
+    assert actual_sha == expected_sha, (
+        f"cache sha drift: pinned {expected_sha}, on-disk {actual_sha} "
+        f"({cache_path}); the cache file must not be regenerated outside "
+        "an ADR (see docs/data-and-training-contracts.md)"
+    )


### PR DESCRIPTION
## Summary

- `registry.yaml` new `llm_features:` block pinning cache path + SHA-256 + size + model snapshot + immutability note
- `docs/data-and-training-contracts.md` LLM-features cache immutability rule (no-delete, SHA-pin, ADR-required)
- `backend/app/data/quantile_labels.py` rewrites "per-fold leakage protection" framing → "boundary is a property of the distribution, not the train split"
- Wiki §6 framing updated consistently across hits
- §6.6 caveat: LLM-features reproducible from cache but not re-extractable from a future model snapshot
- Test pins registry block + SHA integrity (skip-if-cache-missing)

## Test plan

- [ ] `docker compose run --rm backend pytest tests/unit/test_llm_features_pin.py -q`