### PR TITLE
Pin forecaster_canonical to dual-head revision (#322 follow-up)

### DIFF
--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -310,7 +310,7 @@ artefacts:
 
   forecaster_canonical:
     hf_uri: hf://yusufizzetmurat/fed-pulse-forecaster
-    revision: "c26182b61057ab02c169f57703be0a487d244fa6"
+    revision: "de318540e2c9def75c0b6068dcebf73fd22dbb1d"
     eager: true
     description: |
       Canonical multi-head forecaster checkpoint (#292). Loaded into


### PR DESCRIPTION
## Summary

- HF Hub revision flip from pre-#322 `c26182b6` → `de318540` on `yusufizzetmurat/fed-pulse-forecaster`
- New canonical checkpoint: `output_mode='classification'`, `head_mode='dual'` (post-#354), transformer hidden=128 num_layers=4
- `vol_regime_quantiles=(0.0062, 0.0098)`, trained on `tp_v3_macro_aug_2026_05_25_fwd_strict` wf_fold_5
- APS conformal sidecar shipped alongside: `forecaster_best.conformal.json` (softmax_quantile=0.9313 on 165 val rows)
- Resolves the deployed-frontend "regression mode" fallback (regime card was returning None without a sidecar)

## Test plan

- [ ] `docker compose run --rm backend python -c "from app.models.registry import load_artefacts; print(load_artefacts()['forecaster_canonical'])"` — revision matches
- [ ] On next deploy, /analyze returns a populated `regime_classification` block (predicted_set + coverage + bucket_source)