### PR TITLE
Reproducibility numerical-contract CI smoke (#335)

### DIFF
--- a/.github/workflows/reproduce-smoke.yml
+++ b/.github/workflows/reproduce-smoke.yml
@@ -1,0 +1,60 @@
+name: reproduce-smoke
+
+# Numerical-contract guard for `make reproduce-all` (#335).
+#
+# Runs a 1-seed x 1-fold smoke variant of the canonical dual-head
+# training on every merge to `dev` and asserts the resulting macro-F1
+# stays within +/- 0.005 of the pinned reference value in
+# `tests/regression/reproducibility_reference.json`. The reference cell
+# is anchored at
+# `backend/artifacts/experiments/dual_head_comparison_canonical.json`
+# (cell `summary.dual.regime_f1_macro.mean`).
+#
+# CPU-only on `ubuntu-latest`: the 1-seed x 1-fold smoke is light
+# enough that the cloud-GPU runner is not required. Falls back to a
+# clear failure if `HF_TOKEN` is unavailable (the smoke pulls the
+# canonical training package from HF Hub via `scripts/reproduce_all.py`).
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: reproduce-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reproduce-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: false
+    env:
+      TRAINING_PACKAGE_ID: tp_v3_macro_aug_2026_05_25_fwd_strict_sentiment_market_core_v1.1_epv1_v1.0
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      PYTHONPATH: backend
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+
+      - name: setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: install backend deps
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[dev]"
+
+      - name: verify reference cell is well-formed
+        run: |
+          pytest tests/regression/test_reproducibility_reference.py -q
+
+      - name: run reproducibility smoke
+        run: |
+          make reproduce-smoke \
+            TRAINING_PACKAGE_ID="${TRAINING_PACKAGE_ID}" \
+            SEED=11

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison text-path-ab reproduce-all push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison text-path-ab reproduce-all reproduce-smoke push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -82,6 +82,8 @@ help:
 	@echo "  make canonical-comparison TRAINING_PACKAGE_ID=<id>"
 	@echo "  make text-path-ab TRAINING_PACKAGE_ID=<id>"
 	@echo "                         - Canonical dual-head comparison (5 seeds x 40 epochs, regression-alpha=0.5, canonical output JSON)"
+	@echo "  make reproduce-smoke TRAINING_PACKAGE_ID=<id> [SEED=11]"
+	@echo "                         - 1-seed x 1-fold dual-head smoke + numerical-contract assertion (#335 CI guard)"
 
 dev: dev-cpu
 
@@ -152,6 +154,23 @@ reproduce-all:
 		backend bash -c '\
 			set -e && \
 			python scripts/reproduce_all.py'
+
+# Numerical-contract CI guard (#335). Runs a 1-seed x 1-fold smoke
+# variant of the canonical dual-head training and asserts the resulting
+# macro-F1 stays within the pinned tolerance in
+# ``tests/regression/reproducibility_reference.json``. Designed to run
+# on the ``ubuntu-latest`` GitHub runner without docker compose so the
+# ``reproduce-smoke`` workflow can call it directly. Gates on
+# ``TRAINING_PACKAGE_ID`` so a typo on the workflow input fails fast
+# instead of pulling the wrong artefact.
+reproduce-smoke:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	FED_PULSE_REPRODUCE_SMOKE=1 \
+	PYTHONPATH=backend \
+	python -m scripts.run_reproducibility_smoke \
+		--training-package-id "$(TRAINING_PACKAGE_ID)" \
+		--seed "$(SEED)" \
+		--reference-path tests/regression/reproducibility_reference.json
 
 # One-time push of every canonical artefact to HF Hub. Runs the
 # idempotent uploader in dry-run by default so the operator can sanity

--- a/scripts/assert_reproducibility_smoke.py
+++ b/scripts/assert_reproducibility_smoke.py
@@ -1,0 +1,113 @@
+"""Numerical-contract guard for the reproducibility CI smoke (#335).
+
+Reads the pinned reference cell at
+``tests/regression/reproducibility_reference.json`` and the metric the
+just-finished smoke training emitted onto disk, then asserts the
+observed value sits within the reference tolerance. Exits 1 with a
+clear diff on mismatch so a future training-pipeline change cannot
+silently drift the canonical headline.
+
+CLI shape::
+
+    python -m scripts.assert_reproducibility_smoke \
+        --observed-value 0.4193 \
+        [--reference-path tests/regression/reproducibility_reference.json]
+
+The workflow extracts ``observed_value`` from the smoke run's sweep
+report and pipes it in via ``--observed-value``. Keeping the metric
+extraction out of this script lets it stay framework-agnostic — any
+training pipeline that can write a single macro-F1 number to stdout
+plugs in unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_REFERENCE_PATH = REPO_ROOT / "tests" / "regression" / "reproducibility_reference.json"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Assert a smoke training's macro-F1 stays within the pinned "
+            "reproducibility tolerance (#335 numerical-contract guard)."
+        )
+    )
+    parser.add_argument(
+        "--observed-value",
+        type=float,
+        required=True,
+        help="Macro-F1 (or other pinned metric) from the just-finished smoke run.",
+    )
+    parser.add_argument(
+        "--reference-path",
+        type=Path,
+        default=DEFAULT_REFERENCE_PATH,
+        help="Path to the pinned reference JSON. Defaults to the in-repo location.",
+    )
+    return parser.parse_args()
+
+
+def _load_reference(path: Path) -> dict[str, object]:
+    if not path.exists():
+        raise SystemExit(f"reference file missing: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"reference file is not valid JSON ({path}): {exc}") from exc
+    required = {"reference_value", "tolerance", "metric"}
+    missing = required - set(payload)
+    if missing:
+        raise SystemExit(f"reference file missing required keys {sorted(missing)}: {path}")
+    return payload
+
+
+def main() -> int:
+    args = _parse_args()
+    reference = _load_reference(args.reference_path)
+
+    reference_value = float(reference["reference_value"])  # type: ignore[arg-type]
+    tolerance = float(reference["tolerance"])  # type: ignore[arg-type]
+    metric = str(reference["metric"])
+    observed = float(args.observed_value)
+    diff = observed - reference_value
+
+    print(
+        f"[reproduce-smoke] metric={metric} observed={observed:.6f} "
+        f"reference={reference_value:.6f} tolerance=+/-{tolerance:.6f} "
+        f"diff={diff:+.6f}",
+        flush=True,
+    )
+
+    if abs(diff) > tolerance:
+        print(
+            "[reproduce-smoke] FAIL — observed metric drifted outside the "
+            "pinned tolerance. Investigate before merging.",
+            flush=True,
+        )
+        print(
+            f"  metric:    {metric}\n"
+            f"  observed:  {observed:.6f}\n"
+            f"  reference: {reference_value:.6f}\n"
+            f"  tolerance: +/-{tolerance:.6f}\n"
+            f"  diff:      {diff:+.6f}\n"
+            f"  source:    {reference.get('source_artefact')} "
+            f"(cell {reference.get('source_artefact_cell')})",
+            flush=True,
+        )
+        return 1
+
+    print(
+        "[reproduce-smoke] OK — observed metric inside the pinned tolerance.",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_reproducibility_smoke.py
+++ b/scripts/run_reproducibility_smoke.py
@@ -1,0 +1,211 @@
+"""1-seed x 1-fold reproducibility smoke runner (#335).
+
+Drives ``app.train_forecaster`` in dual-head mode against the canonical
+training package for one seed and one fold, then extracts the
+``regime_f1_macro`` metric from the sweep report and hands it to
+``scripts.assert_reproducibility_smoke`` for tolerance checking.
+
+This is the CI entrypoint behind ``make reproduce-smoke``. The
+``make reproduce-all`` target stays the docker-compose / full-pipeline
+flow; this script is the smaller native-python equivalent the
+``reproduce-smoke`` GitHub Actions workflow calls so the contract can
+run on the standard ``ubuntu-latest`` runner without a docker daemon.
+
+Exits non-zero on any of: training failure, missing sweep report,
+missing metric cell, or assertion failure. Each failure prints a clear
+message so a reviewer reading the workflow log sees the root cause.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKEND_DIR = REPO_ROOT / "backend"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "1-seed x 1-fold canonical dual-head smoke + numerical-contract "
+            "assertion (#335)."
+        )
+    )
+    parser.add_argument(
+        "--training-package-id",
+        required=True,
+        help="Training package id under data/processed/.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=11,
+        help="Single seed to train (default 11; first of the official set).",
+    )
+    parser.add_argument(
+        "--fold-id",
+        default="wf_fold_1",
+        help="Walk-forward fold id from the package's fold manifest.",
+    )
+    parser.add_argument(
+        "--reference-path",
+        type=Path,
+        default=REPO_ROOT / "tests" / "regression" / "reproducibility_reference.json",
+        help="Path to the pinned reference JSON.",
+    )
+    parser.add_argument(
+        "--report-path",
+        type=Path,
+        default=REPO_ROOT / "backend" / "artifacts" / "reproduce_smoke" / "forecaster_sweep_results.json",
+        help="Where the training run's sweep report is written.",
+    )
+    return parser.parse_args()
+
+
+def _pull_training_package(training_package_id: str) -> None:
+    """Pull the canonical training package via the existing reproduce_all script.
+
+    Reuses the production-tested artefact pull so the smoke + the full
+    fresh-machine reproduction share the same code path. Skips the pull
+    when the package is already on disk so a re-run on the same runner
+    does not re-download.
+    """
+
+    target = REPO_ROOT / "data" / "processed" / training_package_id
+    if target.exists() and any(target.iterdir()):
+        print(f"[reproduce-smoke] training package already on disk at {target}", flush=True)
+        return
+
+    canonical_target = REPO_ROOT / "data" / "processed" / "canonical"
+    env = {**os.environ, "FED_PULSE_REPRODUCE_TP_ID": training_package_id}
+    print(
+        f"[reproduce-smoke] pulling training package {training_package_id} via "
+        "scripts/reproduce_all.py (artefact pull only) ...",
+        flush=True,
+    )
+    # ``reproduce_all.py`` pulls + runs a 1-epoch training; we only need
+    # the pull here, so we exec the import surface directly.
+    pull_cmd = [
+        sys.executable,
+        "-c",
+        "import sys; sys.path.insert(0, 'scripts'); "
+        "from reproduce_all import _ensure_training_package; "
+        "_ensure_training_package()",
+    ]
+    result = subprocess.run(pull_cmd, cwd=str(REPO_ROOT), env=env)
+    if result.returncode != 0:
+        raise SystemExit(
+            f"[reproduce-smoke] training-package pull failed (exit={result.returncode}); "
+            "see logs above"
+        )
+
+    # ``reproduce_all._ensure_training_package`` copies into
+    # ``data/processed/<FED_PULSE_REPRODUCE_TP_ID>``. Align it with the
+    # canonical id the trainer expects so downstream consumers find the
+    # parquet under the same name they trained against.
+    if canonical_target.exists() and not target.exists():
+        shutil.copytree(canonical_target, target)
+
+
+def _run_smoke_training(
+    *,
+    training_package_id: str,
+    seed: int,
+    fold_id: str,
+    report_path: Path,
+) -> None:
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        "-m",
+        "app.train_forecaster",
+        "--training-package-id",
+        training_package_id,
+        "--seed",
+        str(seed),
+        "--epochs",
+        "1",
+        "--head-mode",
+        "dual",
+        "--folds",
+        fold_id,
+        "--protocol",
+        "walk-forward",
+        "--report-path",
+        str(report_path),
+    ]
+    print(f"[reproduce-smoke] training: {' '.join(cmd)}", flush=True)
+    env = {**os.environ, "PYTHONPATH": str(BACKEND_DIR)}
+    result = subprocess.run(cmd, cwd=str(BACKEND_DIR), env=env)
+    if result.returncode != 0:
+        raise SystemExit(
+            f"[reproduce-smoke] smoke training failed (exit={result.returncode}); "
+            "see backend logs above"
+        )
+
+
+def _extract_regime_f1_macro(report_path: Path) -> float:
+    if not report_path.exists():
+        raise SystemExit(f"[reproduce-smoke] sweep report missing at {report_path}")
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    trials = payload.get("trials") or []
+    if not trials:
+        raise SystemExit(
+            f"[reproduce-smoke] sweep report at {report_path} has no trials"
+        )
+    # The smoke runs a single (seed, fold, hp) cell, so the trial set
+    # collapses to one record. Pick the first selected trial when
+    # available (mirrors the production trial-selection rule) else fall
+    # back to the first record.
+    trial = next(
+        (record for record in trials if record.get("selected")),
+        trials[0],
+    )
+    metrics = (trial.get("summary") or {}).get("metrics") or {}
+    value = metrics.get("regime_f1_macro")
+    if value is None:
+        # The trainer emits regime_f1_macro inside val_metrics + test_metrics
+        # on the walk-forward path; pick test when present so the smoke
+        # reads the same surface the canonical-comparison sweep aggregates.
+        test_metrics = (trial.get("summary") or {}).get("test_metrics") or {}
+        value = test_metrics.get("regime_f1_macro")
+    if value is None:
+        raise SystemExit(
+            "[reproduce-smoke] regime_f1_macro absent from the sweep report; "
+            "check that the dual-head training surface still emits the metric"
+        )
+    return float(value)
+
+
+def main() -> int:
+    args = _parse_args()
+    _pull_training_package(args.training_package_id)
+    _run_smoke_training(
+        training_package_id=args.training_package_id,
+        seed=args.seed,
+        fold_id=args.fold_id,
+        report_path=args.report_path,
+    )
+    observed = _extract_regime_f1_macro(args.report_path)
+    assert_cmd = [
+        sys.executable,
+        "-m",
+        "scripts.assert_reproducibility_smoke",
+        "--observed-value",
+        f"{observed:.6f}",
+        "--reference-path",
+        str(args.reference_path),
+    ]
+    print(f"[reproduce-smoke] asserting: {' '.join(assert_cmd)}", flush=True)
+    result = subprocess.run(assert_cmd, cwd=str(REPO_ROOT))
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/regression/reproducibility_reference.json
+++ b/tests/regression/reproducibility_reference.json
@@ -1,0 +1,9 @@
+{
+  "training_package_id": "tp_v3_macro_aug_2026_05_25_fwd_strict_sentiment_market_core_v1.1_epv1_v1.0",
+  "head_mode": "dual",
+  "metric": "regime_f1_macro",
+  "reference_value": 0.419,
+  "tolerance": 0.005,
+  "source_artefact": "backend/artifacts/experiments/dual_head_comparison_canonical.json",
+  "source_artefact_cell": "summary.dual.regime_f1_macro.mean"
+}

--- a/tests/regression/test_reproducibility_reference.py
+++ b/tests/regression/test_reproducibility_reference.py
@@ -1,0 +1,109 @@
+"""Schema + extraction guard for the reproducibility reference cell (#335).
+
+The pinned reference JSON drives the ``reproduce-smoke`` CI workflow.
+If a future change to the canonical-comparison sweep renames a cell or
+drops a key the workflow asserts against, the assertion script would
+fail in CI with a confusing error. This test pins the reference cell's
+shape and the source-artefact path it points at so the failure surfaces
+at PR review time instead of inside a 25-minute workflow run.
+
+The test deliberately does NOT import any backend modules — the
+reference is plain JSON the workflow consumes before any training code
+runs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REFERENCE_PATH = REPO_ROOT / "tests" / "regression" / "reproducibility_reference.json"
+REQUIRED_KEYS = {
+    "training_package_id",
+    "head_mode",
+    "metric",
+    "reference_value",
+    "tolerance",
+    "source_artefact",
+    "source_artefact_cell",
+}
+
+
+@pytest.fixture(scope="module")
+def reference_payload() -> dict[str, object]:
+    assert REFERENCE_PATH.exists(), f"reference JSON missing at {REFERENCE_PATH}"
+    return json.loads(REFERENCE_PATH.read_text(encoding="utf-8"))
+
+
+def test_reference_json_carries_required_keys(reference_payload: dict[str, object]) -> None:
+    missing = REQUIRED_KEYS - set(reference_payload)
+    assert not missing, f"reference JSON missing required keys: {sorted(missing)}"
+
+
+def test_reference_value_and_tolerance_are_floats(reference_payload: dict[str, object]) -> None:
+    assert isinstance(reference_payload["reference_value"], (int, float))
+    assert isinstance(reference_payload["tolerance"], (int, float))
+    assert 0.0 < float(reference_payload["tolerance"]) < 1.0, (
+        "tolerance must sit in (0, 1); a 0.5 tolerance trivially passes and a "
+        "0.0 tolerance can never pass"
+    )
+    assert 0.0 <= float(reference_payload["reference_value"]) <= 1.0, (
+        "reference value is a macro-F1; it must sit in [0, 1]"
+    )
+
+
+def test_source_artefact_cell_is_dotted_path(reference_payload: dict[str, object]) -> None:
+    cell = str(reference_payload["source_artefact_cell"])
+    parts = cell.split(".")
+    assert len(parts) >= 3, (
+        f"source_artefact_cell '{cell}' should be a dotted path with at least "
+        "three segments (e.g. 'summary.dual.regime_f1_macro.mean')"
+    )
+    assert parts[0] == "summary", (
+        f"source_artefact_cell '{cell}' should start at the 'summary' key of "
+        "the canonical-comparison output"
+    )
+
+
+def test_source_artefact_cell_extracts_cleanly_when_present(
+    reference_payload: dict[str, object],
+) -> None:
+    """If the canonical sweep artefact is on disk, the pinned cell must extract.
+
+    The artefact is not in git (it is large + regenerated on every sweep
+    revision), so the test skips when absent. When present — for instance
+    on a developer box that just ran the canonical sweep — the cell must
+    extract cleanly and match the pinned reference within the tolerance.
+    """
+
+    artefact_path = REPO_ROOT / str(reference_payload["source_artefact"])
+    if not artefact_path.exists():
+        pytest.skip(f"canonical sweep artefact absent at {artefact_path}")
+
+    payload = json.loads(artefact_path.read_text(encoding="utf-8"))
+    cursor: object = payload
+    for part in str(reference_payload["source_artefact_cell"]).split("."):
+        assert isinstance(cursor, dict), (
+            f"source_artefact_cell traversal hit a non-dict at part '{part}' "
+            f"of '{reference_payload['source_artefact_cell']}'"
+        )
+        assert part in cursor, (
+            f"source_artefact_cell '{reference_payload['source_artefact_cell']}' "
+            f"missing key '{part}' in {artefact_path.name}"
+        )
+        cursor = cursor[part]
+    assert isinstance(cursor, (int, float)), (
+        f"source_artefact_cell extracted a non-numeric value: {cursor!r}"
+    )
+
+    diff = abs(float(cursor) - float(reference_payload["reference_value"]))
+    tolerance = float(reference_payload["tolerance"])
+    assert diff <= tolerance, (
+        f"pinned reference_value {reference_payload['reference_value']} drifted "
+        f"from the source artefact cell value {cursor} by {diff:.6f} "
+        f"(tolerance {tolerance}); re-pin the reference or investigate the "
+        "sweep change"
+    )


### PR DESCRIPTION
Closes #335

## Summary

- New `reproduce-smoke` workflow runs a 1-seed x 1-fold dual-head smoke on every push to `dev` plus manual dispatch
- Pinned reference cell at `regime_f1_macro = 0.419 +/- 0.005` sourced from `summary.dual.regime_f1_macro.mean`
- Assertion script exits 1 with an `observed / reference / tolerance / diff` block on drift
- Makefile target gates on `TRAINING_PACKAGE_ID` and avoids docker compose so the CPU runner can call it directly
- Schema test pins the reference JSON shape and extracts the source-artefact cell cleanly when on disk
- Wiki §6.15 subsection documents the workflow, tolerance, and reference paths

## Test plan

- `docker run --rm -v $(pwd):/app -w /app -e PYTHONPATH=/app/backend fed-pulse-backend:latest python -m pytest tests/regression/test_reproducibility_reference.py -q`
- `PYTHONPATH=backend python -m scripts.assert_reproducibility_smoke --observed-value 0.420`
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/reproduce-smoke.yml'))"`