### PR TITLE
Trajectory baselines + parameter-count cap (#332)

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -958,3 +958,36 @@ class TrajectoryResponse(BaseModel):
             "that the projection extrapolates beyond the fold."
         ),
     )
+    # Lift-vs-baseline badge fields (#332). Surface the verdict on
+    # whether the Transformer arm beats the strongest naive baseline
+    # (previous_stance / rolling_majority / small-LSTM) by >= 5pp
+    # directional accuracy on the canonical fold protocol. All three
+    # fields default to None / False so a bundle trained before #332
+    # remains back-compatible.
+    lift_vs_baseline: bool = Field(
+        default=False,
+        description=(
+            "True iff the Transformer arm beats the strongest naive "
+            "baseline (previous_stance / rolling_majority(3) / "
+            "small-LSTM) by >= 5pp directional accuracy on the "
+            "canonical fold protocol. False when the holdout slice is "
+            "empty, when the bundle predates #332, or when the lift "
+            "did not clear the threshold."
+        ),
+    )
+    delta_dir_acc: float | None = Field(
+        default=None,
+        description=(
+            "Transformer directional accuracy minus the strongest "
+            "naive baseline's directional accuracy. None when no "
+            "baseline comparison is available."
+        ),
+    )
+    baseline_used: str | None = Field(
+        default=None,
+        description=(
+            "Name of the strongest naive baseline the lift verdict "
+            "compared against. None when no baseline comparison is "
+            "available."
+        ),
+    )

--- a/backend/app/services/trajectory.py
+++ b/backend/app/services/trajectory.py
@@ -48,6 +48,7 @@ NPZ_NAME = "embedding_index.npz"
 MODEL_NAME = "model.pt"
 MANIFEST_NAME = "manifest.json"
 CONFORMAL_NAME = "conformal.json"
+METRICS_NAME = "metrics.json"
 
 MAX_HISTORY_LENGTH = 60
 MAX_TEXT_CHARS = 4096
@@ -71,6 +72,13 @@ class _TrajectoryState:
     conformal_quantile: float | None
     conformal_alpha: float | None
     market_provider: Callable[[str], dict[str, float | None]] | None = None
+    # Lift-vs-baseline verdict (#332). Persisted to ``metrics.json``
+    # by the trainer; surfaced on the API envelope so the UI can render
+    # the "lift / no-lift" badge. All three default to None so a
+    # bundle trained before #332 reads through cleanly.
+    lift_vs_baseline: bool = False
+    delta_dir_acc: float | None = None
+    baseline_used: str | None = None
 
     @property
     def size(self) -> int:
@@ -138,6 +146,41 @@ def _load_npz_arrays(
     return embeddings, feature_mean, feature_std
 
 
+def _load_lift_check(bundle_dir: Path) -> tuple[bool, float | None, str | None]:
+    """Read the lift / no-lift verdict from the bundle's metrics.json (#332).
+
+    Returns ``(lift_vs_baseline, delta_dir_acc, baseline_used)``. A
+    missing / unreadable file degrades to ``(False, None, None)`` so
+    bundles trained before #332 surface a no-lift badge by default
+    instead of crashing the worker.
+    """
+
+    metrics_path = bundle_dir / METRICS_NAME
+    if not metrics_path.exists():
+        return False, None, None
+    try:
+        payload = json.loads(metrics_path.read_text(encoding="utf-8"))
+    except Exception:  # pragma: no cover
+        return False, None, None
+    lift_check = payload.get("lift_check") if isinstance(payload, dict) else None
+    if not isinstance(lift_check, dict):
+        return False, None, None
+    raw_lift = lift_check.get("lift_vs_baseline")
+    raw_delta = lift_check.get("delta_dir_acc")
+    raw_baseline = lift_check.get("baseline_used")
+    lift = bool(raw_lift) if raw_lift is not None else False
+    delta: float | None
+    if raw_delta is None:
+        delta = None
+    else:
+        try:
+            delta = float(raw_delta)
+        except (TypeError, ValueError):
+            delta = None
+    baseline_used = str(raw_baseline) if raw_baseline is not None else None
+    return lift, delta, baseline_used
+
+
 def _load_conformal(bundle_dir: Path) -> tuple[float | None, float | None]:
     conformal_path = bundle_dir / CONFORMAL_NAME
     if not conformal_path.exists():
@@ -184,6 +227,7 @@ def _load_state() -> _TrajectoryState | None:
         manifest = {}
 
     conformal_quantile, conformal_alpha = _load_conformal(bundle_dir)
+    lift_vs_baseline, delta_dir_acc, baseline_used = _load_lift_check(bundle_dir)
 
     return _TrajectoryState(
         model=model,
@@ -199,6 +243,9 @@ def _load_state() -> _TrajectoryState | None:
         bundle_dir=bundle_dir,
         conformal_quantile=conformal_quantile,
         conformal_alpha=conformal_alpha,
+        lift_vs_baseline=lift_vs_baseline,
+        delta_dir_acc=delta_dir_acc,
+        baseline_used=baseline_used,
     )
 
 
@@ -255,6 +302,9 @@ def build_state_for_tests(  # noqa: PLR0913 — keyword-only fixture knobs.
     conformal_quantile: float | None = None,
     conformal_alpha: float | None = None,
     market_provider: Callable[[str], dict[str, float | None]] | None = None,
+    lift_vs_baseline: bool = False,
+    delta_dir_acc: float | None = None,
+    baseline_used: str | None = None,
 ) -> _TrajectoryState:
     """Convenience constructor for tests / smoke harnesses."""
 
@@ -278,6 +328,9 @@ def build_state_for_tests(  # noqa: PLR0913 — keyword-only fixture knobs.
         conformal_quantile=conformal_quantile,
         conformal_alpha=conformal_alpha,
         market_provider=market_provider,
+        lift_vs_baseline=lift_vs_baseline,
+        delta_dir_acc=delta_dir_acc,
+        baseline_used=baseline_used,
     )
 
 
@@ -471,6 +524,9 @@ def project_trajectory(  # noqa: C901 — keep the branches inline so the data f
             "as_of_date": as_of_iso,
             "available": False,
             "warning": warning,
+            "lift_vs_baseline": bool(state.lift_vs_baseline),
+            "delta_dir_acc": state.delta_dir_acc,
+            "baseline_used": state.baseline_used,
         }
 
     padded_inputs, mask = pad_sequence(
@@ -520,6 +576,9 @@ def project_trajectory(  # noqa: C901 — keep the branches inline so the data f
         "as_of_date": as_of_iso,
         "available": True,
         "warning": warning,
+        "lift_vs_baseline": bool(state.lift_vs_baseline),
+        "delta_dir_acc": state.delta_dir_acc,
+        "baseline_used": state.baseline_used,
     }
 
 

--- a/backend/app/trajectory/baselines.py
+++ b/backend/app/trajectory/baselines.py
@@ -100,7 +100,7 @@ def _coerce_index(value: Any) -> int | None:
 
     if value is None:
         return None
-    if isinstance(value, (int, np.integer)):
+    if isinstance(value, (int, np.integer)):  # noqa: UP038 — keep tuple form; numpy + builtin int via X | Y breaks isinstance on some numpy versions
         idx = int(value)
         if 0 <= idx < N_STANCE_CLASSES:
             return idx
@@ -453,7 +453,7 @@ def evaluate_rolling_majority(
     )
 
 
-def evaluate_small_lstm(
+def evaluate_small_lstm(  # noqa: PLR0913 — kw-only baseline-evaluation config; collapsing into a dataclass would obscure the (train / history / target / hidden_size / lr / epochs / seed / n_classes) contract
     train_stance_sequences: Sequence[Sequence[int]],
     history_label_lists: Sequence[Sequence[Any]],
     truths: Sequence[int],

--- a/backend/app/trajectory/baselines.py
+++ b/backend/app/trajectory/baselines.py
@@ -1,0 +1,587 @@
+"""Naive + small-LSTM baselines for the trajectory head (#332).
+
+The Transformer arm shipped in #296 runs at 4 layers x 64 d_model x 4 heads
+(~200k parameters) against ~250 historical statements. Stance sequences carry
+strong autocorrelation: hawkish meetings cluster, dovish meetings cluster, and
+the modal class accounts for a non-trivial share of the corpus. Predictors
+that simply echo the last stance or the rolling majority therefore score well
+by default — without a published comparison cell, an absolute Transformer
+directional-accuracy number does not tell the reviewer whether the arm
+extracted a real signal.
+
+This module publishes three baselines on the same fold protocol the train
+script uses (event-date sorted statements, history of length N, target is the
+next meeting's stance):
+
+* ``previous_stance(history)`` — predicts ``history[-1]``.
+* ``rolling_majority(history, n=3)`` — predicts the modal label over the last
+  ``n`` real meetings (ties broken by the most recent label).
+* ``small_lstm_baseline(history)`` — a 1-layer x 16-hidden LSTM trained on
+  stance-index sequences. Caps at <= 5k parameters so the comparison cell is
+  unambiguously "small honest baseline" rather than "transformer-lite".
+
+Each baseline ships a :func:`evaluate_baseline_*` helper that consumes the
+same ``TrainingSequence`` list the trainer carves out (so train / cal /
+holdout slices stay aligned with the Transformer arm) and emits a payload
+with directional accuracy + a 3x3 confusion matrix. The
+:func:`compare_against_transformer` helper assembles the "lift / no-lift"
+verdict per the >= 5pp threshold the issue spells out.
+
+Stance indices follow ``app.trajectory.model.STANCE_CLASSES`` so the integer
+labels match whatever the Transformer head emits.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+import numpy as np
+
+from app.trajectory.model import N_STANCE_CLASSES, STANCE_CLASSES
+
+_logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_ROLLING_WINDOW: int = 3
+DEFAULT_LSTM_HIDDEN: int = 16
+DEFAULT_LSTM_LAYERS: int = 1
+DEFAULT_LSTM_EPOCHS: int = 40
+DEFAULT_LSTM_LR: float = 1e-2
+DEFAULT_LSTM_SEED: int = 11
+DEFAULT_LSTM_PARAM_CAP: int = 5_000
+
+# Threshold (in directional-accuracy points) the Transformer arm must beat
+# the best naive baseline by before /analyze/trajectory drops the "no-lift"
+# badge. Spelled out in the issue (#332) as 5pp.
+LIFT_THRESHOLD_POINTS: float = 0.05
+
+
+@dataclass(frozen=True)
+class BaselineResult:
+    """Per-baseline metrics block + the integer predictions for each holdout row.
+
+    The frozen dataclass keeps the structure trivially serialisable into
+    ``metrics.json`` blocks without an extra ``to_dict`` plumbing layer —
+    callers can ``dataclasses.asdict(result)`` directly when they need a
+    JSON-friendly payload.
+    """
+
+    name: str
+    predictions: tuple[int, ...]
+    truths: tuple[int, ...]
+    directional_accuracy: float
+    confusion_matrix: tuple[tuple[int, ...], ...]
+    n: int
+
+
+# ---------------------------------------------------------------------------
+# Naive predictors
+# ---------------------------------------------------------------------------
+
+
+def _coerce_index(value: Any) -> int | None:
+    """Accept either ``"hawkish"`` (string) or ``0`` (int) and return the index.
+
+    Mixed-type inputs are common: the train script keeps history as
+    ``TrainingSequence.label_index`` (int) but the runtime singleton reads
+    stance strings off the parquet. A single helper means callers do not
+    have to branch on which path is producing the history list.
+    """
+
+    if value is None:
+        return None
+    if isinstance(value, (int, np.integer)):
+        idx = int(value)
+        if 0 <= idx < N_STANCE_CLASSES:
+            return idx
+        return None
+    if isinstance(value, str):
+        cleaned = value.strip().lower()
+        for i, label in enumerate(STANCE_CLASSES):
+            if cleaned == label:
+                return i
+    return None
+
+
+def previous_stance(history: Sequence[Any]) -> int | None:
+    """Predict the last observed stance in ``history``.
+
+    Returns ``None`` if the entire history is unrecognised — the caller is
+    expected to fall back to the train-slice modal class in that case. The
+    contract matches what the existing ``baseline_modal`` block in
+    ``train.evaluate_metrics`` does for the modal-class fallback.
+    """
+
+    for raw in reversed(list(history)):
+        idx = _coerce_index(raw)
+        if idx is not None:
+            return idx
+    return None
+
+
+def rolling_majority(
+    history: Sequence[Any], *, n: int = DEFAULT_ROLLING_WINDOW
+) -> int | None:
+    """Predict the modal label over the last ``n`` real meetings in ``history``.
+
+    Ties are broken by recency — the most recent stance wins, so this
+    degenerates to :func:`previous_stance` when every label in the window
+    is distinct. ``n`` clamps to the history length so a short prefix does
+    not return ``None`` purely because the window is wider than the
+    available data.
+    """
+
+    if n <= 0:
+        raise ValueError(f"rolling_majority window must be positive; got {n}")
+    indices: list[int] = []
+    for raw in reversed(list(history)):
+        idx = _coerce_index(raw)
+        if idx is not None:
+            indices.append(idx)
+        if len(indices) >= n:
+            break
+    if not indices:
+        return None
+    counts = Counter(indices)
+    top = counts.most_common()
+    best_freq = top[0][1]
+    # Recency tie-break: ``indices`` is ordered most-recent first, so the
+    # first label with the best frequency is the most recent winner.
+    for idx in indices:
+        if counts[idx] == best_freq:
+            return idx
+    return top[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Small-LSTM baseline (stance sequences only — no text embeddings)
+# ---------------------------------------------------------------------------
+
+
+def _stance_indices_from_history(history: Sequence[Any]) -> list[int]:
+    out: list[int] = []
+    for raw in history:
+        idx = _coerce_index(raw)
+        if idx is not None:
+            out.append(idx)
+    return out
+
+
+def build_small_lstm(
+    *,
+    hidden_size: int = DEFAULT_LSTM_HIDDEN,
+    num_layers: int = DEFAULT_LSTM_LAYERS,
+    n_classes: int = N_STANCE_CLASSES,
+) -> Any:
+    """Build a 1-layer x ``hidden_size`` LSTM over one-hot stance inputs.
+
+    Layout::
+
+        Input: (B, T, n_classes)  one-hot stance indices
+        LSTM:  hidden_size, num_layers
+        Head:  Linear(hidden_size, n_classes)
+
+    The module ships in eval mode. :func:`train_small_lstm` flips it to
+    train mode for the fit loop. Parameter count is verified against
+    ``DEFAULT_LSTM_PARAM_CAP`` by :func:`assert_param_count_within_cap`.
+    """
+
+    import torch  # type: ignore[import-not-found,unused-ignore]
+
+    nn = torch.nn
+
+    class _SmallLSTM(nn.Module):  # type: ignore[misc, name-defined]
+        def __init__(self) -> None:
+            super().__init__()
+            self.hidden_size = int(hidden_size)
+            self.n_classes = int(n_classes)
+            self.lstm = nn.LSTM(
+                input_size=n_classes,
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                batch_first=True,
+            )
+            self.head = nn.Linear(hidden_size, n_classes)
+
+        def forward(self, inputs: Any) -> Any:
+            outputs, _ = self.lstm(inputs)
+            # Read the final timestep — the trajectory head shares the same
+            # "decode from the last real position" convention so the two
+            # arms are wired the same way.
+            last = outputs[:, -1, :]
+            return self.head(last)
+
+    model = _SmallLSTM()
+    model.eval()
+    return model
+
+
+def assert_param_count_within_cap(model: Any, *, cap: int) -> int:
+    """Hard-fail when a baseline / arm exceeds the parameter-count cap.
+
+    Returns the actual parameter count so callers can record it in their
+    metrics payload. The error is an :class:`AssertionError` so the
+    failure mode is unmissable in CI and is straightforward to override
+    with ``-O`` only in adversarial test paths (the trainer surfaces a
+    ``--no-param-cap`` CLI flag for legitimate overrides).
+    """
+
+    actual = int(sum(p.numel() for p in model.parameters()))
+    if actual > int(cap):
+        raise AssertionError(
+            f"parameter count {actual} exceeds cap {cap}; "
+            "shrink the architecture or pass --no-param-cap to override"
+        )
+    return actual
+
+
+def _one_hot(indices: Sequence[int], *, n_classes: int) -> np.ndarray:
+    arr = np.zeros((len(indices), n_classes), dtype=np.float32)
+    for t, idx in enumerate(indices):
+        if 0 <= int(idx) < n_classes:
+            arr[t, int(idx)] = 1.0
+    return arr
+
+
+def _build_lstm_training_pairs(
+    stance_sequences: Iterable[Sequence[int]],
+) -> list[tuple[np.ndarray, int]]:
+    """Carve ``(history_one_hot, next_label)`` rows out of stance sequences.
+
+    Each input sequence ``[s0, s1, ..., sK]`` yields ``K`` training rows
+    of shape ``(t+1, n_classes)`` paired with label ``s_{t+1}``. Empty /
+    length-1 sequences contribute zero rows.
+    """
+
+    pairs: list[tuple[np.ndarray, int]] = []
+    for seq in stance_sequences:
+        indices = [int(s) for s in seq if 0 <= int(s) < N_STANCE_CLASSES]
+        if len(indices) < 2:
+            continue
+        for cut in range(1, len(indices)):
+            history = indices[:cut]
+            target = indices[cut]
+            pairs.append((_one_hot(history, n_classes=N_STANCE_CLASSES), target))
+    return pairs
+
+
+def _pad_right(
+    arrays: Sequence[np.ndarray], *, n_classes: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Right-pad variable-length one-hot histories into a dense ``(B, T, C)`` tensor.
+
+    Returns ``(padded, lengths)``. The small-LSTM forward pass reads the
+    final timestep, so the actual padded slots after the true history
+    end never propagate into the prediction.
+    """
+
+    if not arrays:
+        return (
+            np.zeros((0, 1, n_classes), dtype=np.float32),
+            np.zeros(0, dtype=np.int64),
+        )
+    lengths = np.asarray([arr.shape[0] for arr in arrays], dtype=np.int64)
+    max_len = int(lengths.max())
+    padded = np.zeros((len(arrays), max_len, n_classes), dtype=np.float32)
+    for i, arr in enumerate(arrays):
+        padded[i, : arr.shape[0], :] = arr
+    return padded, lengths
+
+
+def train_small_lstm(  # noqa: PLR0913 — keyword-only knobs mirror the CLI surface.
+    stance_sequences: Iterable[Sequence[int]],
+    *,
+    hidden_size: int = DEFAULT_LSTM_HIDDEN,
+    num_layers: int = DEFAULT_LSTM_LAYERS,
+    epochs: int = DEFAULT_LSTM_EPOCHS,
+    learning_rate: float = DEFAULT_LSTM_LR,
+    seed: int = DEFAULT_LSTM_SEED,
+    param_cap: int = DEFAULT_LSTM_PARAM_CAP,
+) -> tuple[Any, int]:
+    """Fit the small-LSTM baseline on a list of stance-only sequences.
+
+    Returns ``(model, parameter_count)``. The model is returned in eval
+    mode so the caller can run :func:`predict_small_lstm` directly. An
+    empty pair list short-circuits training and returns the untrained
+    module — the caller's evaluation path then falls back to the modal
+    class on the holdout slice.
+    """
+
+    import torch  # type: ignore[import-not-found,unused-ignore]
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+    model = build_small_lstm(hidden_size=hidden_size, num_layers=num_layers)
+    parameter_count = assert_param_count_within_cap(model, cap=param_cap)
+
+    pairs = _build_lstm_training_pairs(stance_sequences)
+    if not pairs:
+        return model, parameter_count
+
+    inputs, _lengths = _pad_right([p[0] for p in pairs], n_classes=N_STANCE_CLASSES)
+    labels = np.asarray([p[1] for p in pairs], dtype=np.int64)
+
+    inputs_t = torch.tensor(inputs, dtype=torch.float32)
+    labels_t = torch.tensor(labels, dtype=torch.long)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
+    loss_fn = torch.nn.CrossEntropyLoss()
+    model.train()
+    for _ in range(epochs):
+        optimizer.zero_grad()
+        logits = model(inputs_t)
+        loss = loss_fn(logits, labels_t)
+        loss.backward()
+        optimizer.step()
+    model.eval()
+    return model, parameter_count
+
+
+def predict_small_lstm(model: Any, history: Sequence[Any]) -> int | None:
+    """Run the trained small-LSTM on one history window.
+
+    Returns the predicted stance index or ``None`` when ``history``
+    carries no recognised labels.
+    """
+
+    import torch  # type: ignore[import-not-found,unused-ignore]
+
+    indices = _stance_indices_from_history(history)
+    if not indices:
+        return None
+    arr = _one_hot(indices, n_classes=N_STANCE_CLASSES)
+    inputs_t = torch.tensor(arr[np.newaxis, ...], dtype=torch.float32)
+    model.eval()
+    with torch.no_grad():
+        logits = model(inputs_t)
+        prediction = int(torch.argmax(logits, dim=-1).item())
+    return prediction
+
+
+# ---------------------------------------------------------------------------
+# Metrics + comparison
+# ---------------------------------------------------------------------------
+
+
+def directional_accuracy(
+    truths: Sequence[int], predictions: Sequence[int]
+) -> float:
+    if len(truths) == 0:
+        return float("nan")
+    matches = sum(1 for t, p in zip(truths, predictions) if int(t) == int(p))
+    return matches / len(truths)
+
+
+def confusion_matrix(
+    truths: Sequence[int], predictions: Sequence[int]
+) -> tuple[tuple[int, ...], ...]:
+    """Build a 3x3 confusion matrix indexed by ``STANCE_CLASSES``.
+
+    Rows are truth labels, columns are predictions — the standard
+    sklearn convention. Returns a tuple-of-tuples so the result is
+    hashable + immutable; callers serialise it as a list-of-lists in
+    JSON payloads.
+    """
+
+    rows: list[list[int]] = [
+        [0 for _ in range(N_STANCE_CLASSES)] for _ in range(N_STANCE_CLASSES)
+    ]
+    for t, p in zip(truths, predictions):
+        if 0 <= int(t) < N_STANCE_CLASSES and 0 <= int(p) < N_STANCE_CLASSES:
+            rows[int(t)][int(p)] += 1
+    return tuple(tuple(row) for row in rows)
+
+
+def evaluate_previous_stance(
+    history_label_lists: Sequence[Sequence[Any]],
+    truths: Sequence[int],
+    *,
+    fallback_modal: int | None = None,
+) -> BaselineResult:
+    """Run :func:`previous_stance` on a list of (history, truth) rows."""
+
+    predictions: list[int] = []
+    for history in history_label_lists:
+        pred = previous_stance(history)
+        if pred is None:
+            pred = int(fallback_modal) if fallback_modal is not None else 0
+        predictions.append(pred)
+    return BaselineResult(
+        name="previous_stance",
+        predictions=tuple(predictions),
+        truths=tuple(int(t) for t in truths),
+        directional_accuracy=directional_accuracy(truths, predictions),
+        confusion_matrix=confusion_matrix(truths, predictions),
+        n=len(truths),
+    )
+
+
+def evaluate_rolling_majority(
+    history_label_lists: Sequence[Sequence[Any]],
+    truths: Sequence[int],
+    *,
+    n: int = DEFAULT_ROLLING_WINDOW,
+    fallback_modal: int | None = None,
+) -> BaselineResult:
+    """Run :func:`rolling_majority` on a list of (history, truth) rows."""
+
+    predictions: list[int] = []
+    for history in history_label_lists:
+        pred = rolling_majority(history, n=n)
+        if pred is None:
+            pred = int(fallback_modal) if fallback_modal is not None else 0
+        predictions.append(pred)
+    return BaselineResult(
+        name=f"rolling_majority_n{n}",
+        predictions=tuple(predictions),
+        truths=tuple(int(t) for t in truths),
+        directional_accuracy=directional_accuracy(truths, predictions),
+        confusion_matrix=confusion_matrix(truths, predictions),
+        n=len(truths),
+    )
+
+
+def evaluate_small_lstm(
+    train_stance_sequences: Sequence[Sequence[int]],
+    history_label_lists: Sequence[Sequence[Any]],
+    truths: Sequence[int],
+    *,
+    hidden_size: int = DEFAULT_LSTM_HIDDEN,
+    num_layers: int = DEFAULT_LSTM_LAYERS,
+    epochs: int = DEFAULT_LSTM_EPOCHS,
+    learning_rate: float = DEFAULT_LSTM_LR,
+    seed: int = DEFAULT_LSTM_SEED,
+    fallback_modal: int | None = None,
+) -> BaselineResult:
+    """Fit + evaluate the small-LSTM baseline on the canonical fold protocol.
+
+    ``train_stance_sequences`` carries the stance-only history the LSTM
+    is fit on (one sequence per training sample — the trainer's
+    pre-train_end pool). ``history_label_lists`` + ``truths`` is the
+    holdout slice the baseline is evaluated on.
+    """
+
+    model, _params = train_small_lstm(
+        train_stance_sequences,
+        hidden_size=hidden_size,
+        num_layers=num_layers,
+        epochs=epochs,
+        learning_rate=learning_rate,
+        seed=seed,
+    )
+    predictions: list[int] = []
+    for history in history_label_lists:
+        pred = predict_small_lstm(model, history)
+        if pred is None:
+            pred = int(fallback_modal) if fallback_modal is not None else 0
+        predictions.append(pred)
+    return BaselineResult(
+        name=f"small_lstm_h{hidden_size}_l{num_layers}",
+        predictions=tuple(predictions),
+        truths=tuple(int(t) for t in truths),
+        directional_accuracy=directional_accuracy(truths, predictions),
+        confusion_matrix=confusion_matrix(truths, predictions),
+        n=len(truths),
+    )
+
+
+def compare_against_transformer(
+    transformer_dir_acc: float,
+    baselines: Sequence[BaselineResult],
+    *,
+    threshold: float = LIFT_THRESHOLD_POINTS,
+) -> dict[str, Any]:
+    """Assemble the lift / no-lift verdict the API surface ships.
+
+    The baseline the badge compares against is the strongest one (max
+    directional accuracy) — the issue is explicit that the Transformer
+    arm must clear the *best* naive baseline, not an average. Returns a
+    payload sized for the ``TrajectoryResponse`` extension fields:
+
+        {
+            "baseline_used": str,        # name of the strongest baseline
+            "baseline_dir_acc": float,   # its directional accuracy
+            "delta_dir_acc": float,      # transformer - baseline
+            "lift_vs_baseline": bool,    # delta >= threshold
+            "threshold": float,
+            "per_baseline": [BaselineResult-as-dict, ...]
+        }
+
+    All ``float`` values are emitted unconditionally so the JSON payload
+    has stable keys regardless of which baseline lands on top.
+    """
+
+    finite_baselines = [
+        b for b in baselines if not _is_nan(b.directional_accuracy)
+    ]
+    if not finite_baselines:
+        return {
+            "baseline_used": None,
+            "baseline_dir_acc": None,
+            "delta_dir_acc": None,
+            "lift_vs_baseline": False,
+            "threshold": float(threshold),
+            "per_baseline": [_baseline_to_dict(b) for b in baselines],
+        }
+    best = max(finite_baselines, key=lambda b: b.directional_accuracy)
+    delta = float(transformer_dir_acc) - float(best.directional_accuracy)
+    return {
+        "baseline_used": best.name,
+        "baseline_dir_acc": float(best.directional_accuracy),
+        "delta_dir_acc": float(delta),
+        "lift_vs_baseline": bool(delta >= float(threshold)),
+        "threshold": float(threshold),
+        "per_baseline": [_baseline_to_dict(b) for b in baselines],
+    }
+
+
+def _is_nan(value: float) -> bool:
+    try:
+        return value != value  # noqa: PLR0124 — standard nan check
+    except TypeError:
+        return False
+
+
+def _baseline_to_dict(result: BaselineResult) -> dict[str, Any]:
+    return {
+        "name": result.name,
+        "directional_accuracy": float(result.directional_accuracy)
+        if not _is_nan(result.directional_accuracy)
+        else None,
+        "confusion_matrix": [list(row) for row in result.confusion_matrix],
+        "n": int(result.n),
+    }
+
+
+__all__ = [
+    "BaselineResult",
+    "DEFAULT_LSTM_HIDDEN",
+    "DEFAULT_LSTM_LAYERS",
+    "DEFAULT_LSTM_PARAM_CAP",
+    "DEFAULT_ROLLING_WINDOW",
+    "LIFT_THRESHOLD_POINTS",
+    "assert_param_count_within_cap",
+    "build_small_lstm",
+    "compare_against_transformer",
+    "confusion_matrix",
+    "directional_accuracy",
+    "evaluate_previous_stance",
+    "evaluate_rolling_majority",
+    "evaluate_small_lstm",
+    "predict_small_lstm",
+    "previous_stance",
+    "rolling_majority",
+    "train_small_lstm",
+]

--- a/backend/app/trajectory/train.py
+++ b/backend/app/trajectory/train.py
@@ -1,10 +1,24 @@
-"""Walk-forward trainer for the trajectory model (#296).
+"""Walk-forward trainer for the trajectory model (#296, #332).
 
 Builds the per-meeting input panel from ``events.parquet``, applies
 the same strict-forward walk-forward cut as the retrieval encoder
 (:mod:`app.retrieval.train`), trains the architecture selected by
 ``--architecture {lstm,transformer}``, and persists the bundle under
 ``data/artifacts/trajectory/<run_name>/``.
+
+Parameter-count cap (#332). With ~250 historical statements, a 4-layer
+x 64-d_model x 4-head Transformer (the #296 default at ~250k parameters)
+sits at a poor data:parameter ratio. Per the lift-or-no-lift convention
+spelled out in the issue, the Transformer arm caps at 2 layers x 32
+d_model unless it beats the strongest naive baseline (previous_stance /
+rolling_majority(3) / small-LSTM) by >= 5pp directional accuracy on the
+canonical fold protocol. The cap is enforced via
+:func:`assert_parameter_count_within_cap` before the training loop
+starts; ``--no-param-cap`` opts out only when the lift threshold has
+already been demonstrated on a downstream sweep. The cap default
+(75_000) accommodates a 2x32 Transformer at the canonical 768-d DAPT
+embedding (~50k parameters) with comfortable headroom and rejects the
+historical 4x64 default (~250k parameters).
 
 Bundle layout (matches the §13 acceptance for #296)::
 
@@ -58,6 +72,13 @@ import pandas as pd
 from app.config import DATA_DIR
 from app.evaluation.conformal import calibrate_classification_conformal
 from app.evaluation.regression_metrics import with_block_bootstrap_ci
+from app.trajectory.baselines import (
+    DEFAULT_ROLLING_WINDOW,
+    compare_against_transformer,
+    evaluate_previous_stance,
+    evaluate_rolling_majority,
+    evaluate_small_lstm,
+)
 from app.trajectory.model import (
     DEFAULT_HISTORY_LENGTH,
     MARKET_FEATURE_DIM,
@@ -87,6 +108,13 @@ DEFAULT_HOLDOUT_SHARE = 0.2
 DEFAULT_CALIBRATION_SHARE = 0.15
 DEFAULT_BOOTSTRAP_RESAMPLES = 500
 DEFAULT_BOOTSTRAP_BLOCK_SIZE = 4
+
+# Default parameter-count cap (#332). Sized to comfortably admit the
+# 2 layers x 32 d_model Transformer arm at the canonical 768-d DAPT
+# embedding (~50.6k params) while rejecting the original 4 layers x 64
+# d_model default (~250k params). Lift threshold for an override is
+# >= 5pp directional-accuracy beat over the strongest naive baseline.
+DEFAULT_PARAMETER_COUNT_CAP: int = 75_000
 
 FOLD_MANIFEST_FILENAME = "fold_manifest_expanding_walk_forward.json"
 
@@ -440,6 +468,63 @@ def standardise_inputs(
 # ---------------------------------------------------------------------------
 # Training loop
 # ---------------------------------------------------------------------------
+
+
+def _history_label_lists(
+    sequences: Sequence[TrainingSequence],
+    meetings: Sequence[MeetingRow],
+) -> list[list[int]]:
+    """Build per-row stance-index history lists from the meetings panel.
+
+    The naive baselines (#332) consume stance-only history — the same
+    sequence of past meeting labels the Transformer arm sees, projected
+    down to the label space. Returns one history list per row in
+    ``sequences``, with unrecognised stances dropped. Used by the
+    trainer to feed ``evaluate_previous_stance`` /
+    ``evaluate_rolling_majority`` / ``evaluate_small_lstm``.
+    """
+
+    label_by_date: dict[str, int] = {}
+    for row in meetings:
+        if row.axis_stance is not None and row.axis_stance in STANCE_TO_INDEX:
+            label_by_date[row.event_date] = STANCE_TO_INDEX[row.axis_stance]
+    histories: list[list[int]] = []
+    for seq in sequences:
+        history: list[int] = []
+        for event_date in seq.history_event_dates:
+            idx = label_by_date.get(str(event_date))
+            if idx is not None:
+                history.append(idx)
+        histories.append(history)
+    return histories
+
+
+def assert_parameter_count_within_cap(
+    model: Any, *, cap: int = DEFAULT_PARAMETER_COUNT_CAP
+) -> int:
+    """Block oversized trajectory architectures from entering the train loop (#332).
+
+    With ~250 historical statements, even the 2x32 Transformer (~50k
+    params at the 768-d DAPT embedding) is data-starved; the 4x64
+    default (~250k) is the configuration this cap exists to reject.
+    Lifting the cap requires the lift-or-no-lift verdict on the
+    canonical fold protocol to already favour the larger architecture
+    by >= 5pp directional accuracy over the strongest naive baseline.
+
+    Returns the actual parameter count so the caller can record it in
+    the metrics payload.
+    """
+
+    actual = int(sum(p.numel() for p in model.parameters()))
+    if actual > int(cap):
+        raise AssertionError(
+            f"trajectory model parameter count {actual} exceeds cap {cap}; "
+            "shrink the architecture (e.g. transformer_layers=2, "
+            "transformer_d_model=32) or pass --no-param-cap when the "
+            ">=5pp lift threshold over the strongest naive baseline has "
+            "already been demonstrated on the canonical fold protocol."
+        )
+    return actual
 
 
 def _set_all_seeds(seed: int) -> None:
@@ -1019,6 +1104,8 @@ def train_and_persist(  # noqa: PLR0913, C901, PLR0912, PLR0915 — keyword-only
     calibration_share: float = DEFAULT_CALIBRATION_SHARE,
     conformal_alpha: float = 0.2,
     training_package_id: str | None = None,
+    enforce_param_cap: bool = True,
+    parameter_count_cap: int = DEFAULT_PARAMETER_COUNT_CAP,
 ) -> Path:
     """End-to-end: read events, train, evaluate, persist the bundle.
 
@@ -1187,6 +1274,15 @@ def train_and_persist(  # noqa: PLR0913, C901, PLR0912, PLR0915 — keyword-only
     )
     pca_mean, pca_components = fit_pca_axes(train_embeddings_slice)
 
+    # Parameter-count cap (#332) — runs BEFORE the training loop so a
+    # mis-configured architecture surfaces in seconds rather than after
+    # a multi-epoch fit. The cap is opt-out via ``enforce_param_cap``;
+    # the CLI exposes the override as ``--no-param-cap``.
+    if enforce_param_cap:
+        probe_model = build_model(config)
+        assert_parameter_count_within_cap(probe_model, cap=parameter_count_cap)
+        del probe_model
+
     model = train_model(
         train_sequences,
         config,
@@ -1213,6 +1309,7 @@ def train_and_persist(  # noqa: PLR0913, C901, PLR0912, PLR0915 — keyword-only
             ),
         }
         # Naive-prior baseline: predict the modal class of the train slice.
+        modal: int | None = None
         if train_sequences:
             train_labels = [seq.label_index for seq in train_sequences]
             modal = max(set(train_labels), key=train_labels.count)
@@ -1221,6 +1318,56 @@ def train_and_persist(  # noqa: PLR0913, C901, PLR0912, PLR0915 — keyword-only
                 evaluation["labels"].tolist(),
                 baseline_pred,
                 seed=seed,
+            )
+
+        # Naive baselines + small-LSTM (#332). Each consumes the stance
+        # sequence of the same history window the Transformer arm sees,
+        # so the comparison is on the canonical fold protocol. The
+        # results land both on ``metrics_payload['baselines']`` (for
+        # downstream reporting) and on ``metrics_payload['lift_check']``
+        # (the lift / no-lift verdict the API endpoint surfaces).
+        holdout_histories = _history_label_lists(holdout_sequences, meetings)
+        holdout_truths = evaluation["labels"].tolist()
+        train_histories = _history_label_lists(train_sequences, meetings)
+
+        prev_result = evaluate_previous_stance(
+            holdout_histories, holdout_truths, fallback_modal=modal
+        )
+        rolling_result = evaluate_rolling_majority(
+            holdout_histories,
+            holdout_truths,
+            n=DEFAULT_ROLLING_WINDOW,
+            fallback_modal=modal,
+        )
+        try:
+            lstm_result = evaluate_small_lstm(
+                train_histories,
+                holdout_histories,
+                holdout_truths,
+                seed=seed,
+                fallback_modal=modal,
+            )
+        except Exception:  # pragma: no cover — guarded so a torch import / fit failure never crashes the trainer
+            _logger.warning("trajectory_small_lstm_baseline_failed", exc_info=True)
+            lstm_result = None
+
+        baseline_results = [prev_result, rolling_result]
+        if lstm_result is not None:
+            baseline_results.append(lstm_result)
+        metrics_payload["baselines"] = {
+            b.name: {
+                "directional_accuracy": float(b.directional_accuracy)
+                if not (b.directional_accuracy != b.directional_accuracy)  # noqa: PLR0124 — nan check
+                else None,
+                "confusion_matrix": [list(row) for row in b.confusion_matrix],
+                "n": int(b.n),
+            }
+            for b in baseline_results
+        }
+        transformer_dir_acc = metrics_payload["holdout"]["directional_accuracy"]["point"]
+        if transformer_dir_acc == transformer_dir_acc:  # noqa: PLR0124 — finite check
+            metrics_payload["lift_check"] = compare_against_transformer(
+                transformer_dir_acc, baseline_results
             )
     if calibration_sequences:
         cal_eval = evaluate_model(model, calibration_sequences)
@@ -1317,6 +1464,22 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--conformal-alpha", type=float, default=0.2)
     parser.add_argument("--training-package-id", default=None)
+    parser.add_argument(
+        "--no-param-cap",
+        action="store_true",
+        help=(
+            "Bypass the trajectory parameter-count cap (#332). Use only "
+            "when the >=5pp lift threshold over the strongest naive "
+            "baseline has been demonstrated on the canonical fold "
+            "protocol."
+        ),
+    )
+    parser.add_argument(
+        "--parameter-count-cap",
+        type=int,
+        default=DEFAULT_PARAMETER_COUNT_CAP,
+        help="Override the default parameter-count cap (#332).",
+    )
     return parser.parse_args()
 
 
@@ -1344,6 +1507,8 @@ def main() -> int:
         calibration_share=args.calibration_share,
         conformal_alpha=args.conformal_alpha,
         training_package_id=args.training_package_id,
+        enforce_param_cap=not args.no_param_cap,
+        parameter_count_cap=args.parameter_count_cap,
     )
     print(f"[trajectory.train] saved bundle to {out_dir}")
     return 0

--- a/docs/adr/0022-trajectory-parameter-count-cap.md
+++ b/docs/adr/0022-trajectory-parameter-count-cap.md
@@ -1,0 +1,51 @@
+# ADR 0022 — Trajectory arm parameter-count cap + lift-vs-baseline gating
+
+Status: accepted, in production (as of merge).
+Date: 2026-05-27.
+References:
+- Issue #332.
+- `backend/app/trajectory/train.py` — `assert_parameter_count_within_cap`, `DEFAULT_PARAMETER_COUNT_CAP`, `--no-param-cap` CLI flag.
+- `backend/app/trajectory/baselines.py` — `previous_stance`, `rolling_majority`, `small_lstm_baseline`, `compare_against_transformer`, `LIFT_THRESHOLD_POINTS`.
+- `backend/app/services/trajectory.py` — `_load_lift_check`, `_TrajectoryState.lift_vs_baseline / delta_dir_acc / baseline_used`.
+- `backend/app/schemas.py` — `TrajectoryResponse.lift_vs_baseline / delta_dir_acc / baseline_used`.
+- `tests/unit/test_trajectory_baselines.py` — synthetic high-autocorrelation fixture + cap-trip guard.
+- `fed-pulse.wiki/06_Deep_Learning_Roadmap.md §6.16` — trajectory baselines + parameter-count cap row.
+- PR #296 — the trajectory arm this ADR amends.
+
+## Context
+
+The trajectory head shipped in #296 runs at 4 layers x 64 d_model x 4 attention heads against ~250 historical FOMC statements. At the canonical 768-d DAPT encoder embedding, the configuration lands around 250k trainable parameters. The data:parameter ratio is poor by construction, and the issue surfaced two compounding concerns:
+
+1. No published baseline comparison. FOMC stance sequences carry strong autocorrelation — meetings cluster in regime runs (a dovish meeting is overwhelmingly followed by another dovish meeting, and the modal class accounts for a non-trivial share of the corpus). Naive predictors that simply echo the last stance or take the rolling majority over the last few meetings score well by default. Without those baselines published on the same fold protocol, the Transformer arm's absolute directional-accuracy number tells the reviewer nothing about whether the arm extracted real signal versus tracking the autocorrelation a `previous_stance` predictor would have matched for free.
+2. Capacity overshoot. The 250k-parameter Transformer over 250 statements is the textbook "more parameters than rows" configuration. The model can fit the training noise even on a strict-forward walk-forward split, then read clean on the validation slice purely because the test labels share the autocorrelation structure of the train labels. A smaller arm (2 layers x 32 d_model, ~50k params at the canonical embedding) is the configuration the data warrants; the larger arm should be admitted only when a clean lift over the strongest naive baseline justifies the additional capacity.
+
+Two options were on the table:
+
+- **Option A — soft note.** Document the parameter-count concern in the §6.7 cell and leave the 4x64 default in place. Surface the baseline comparison as a follow-up paragraph in the wiki only. Zero risk of breaking existing bundles; zero structural change to the codebase.
+- **Option B — hard cap with override.** Cap the Transformer arm at the configuration the data warrants (2x32) by enforcing a parameter-count assertion in the trainer entry point, publish the three naive baselines (`previous_stance`, `rolling_majority(n=3)`, `small_lstm_baseline`) on the canonical fold protocol, ship a `lift_vs_baseline` badge on `/analyze/trajectory` so the UI can render the verdict, and document the >= 5pp directional-accuracy lift threshold the override requires. Bundles trained before this ADR continue to load (the new schema fields default to `None`/`False`).
+
+Option A leaves the same gap the issue surfaces. Option B is the path the issue spells out and is the option this ADR records.
+
+## Decision
+
+Option B. The trajectory arm ships with:
+
+1. **Parameter-count cap.** `app.trajectory.train.assert_parameter_count_within_cap` runs in `train_and_persist` before the fit loop starts. The default cap is `DEFAULT_PARAMETER_COUNT_CAP = 75_000`, sized to admit a 2-layer x 32-d_model Transformer at the canonical 768-d DAPT embedding (~50.6k params) with comfortable headroom while rejecting the historical 4-layer x 64-d_model default (~250k params). The CLI exposes the override as `--no-param-cap`; the function signature carries `enforce_param_cap: bool = True` so callers from inside the package can switch the cap off explicitly when they have a documented reason (the trainer-wiring tests pass `enforce_param_cap=False` because the 4-d toy embedder pushes the historical default out of the cap budget even when the issue's concern about real-world capacity overshoot does not apply).
+2. **Three baselines on the canonical fold protocol.**
+   - `previous_stance(history)` — predicts the last observed stance label. The lower bound of "did the Transformer extract anything?".
+   - `rolling_majority(history, n=3)` — predicts the modal label over the last three real meetings, with ties broken by recency. The standard moving-average naive baseline for autocorrelated classification.
+   - `small_lstm_baseline(history)` — a 1-layer x 16-hidden LSTM trained on stance-only sequences. The "small honest baseline" the issue references — capped at <= 5k parameters by `assert_param_count_within_cap(cap=DEFAULT_LSTM_PARAM_CAP)` so the comparison is unambiguously between the Transformer arm and a structurally-smaller LSTM, not between the Transformer arm and a Transformer-lite.
+
+   Each baseline emits a `BaselineResult` dataclass carrying directional accuracy + a 3x3 confusion matrix. `evaluate_previous_stance` / `evaluate_rolling_majority` / `evaluate_small_lstm` are the convenience helpers the trainer uses; `compare_against_transformer` is the helper that assembles the lift / no-lift verdict.
+
+3. **Lift threshold.** `LIFT_THRESHOLD_POINTS = 0.05`. The Transformer arm clears the threshold iff it beats the strongest baseline (max directional accuracy across the three) by `>= 5pp`. The verdict lands as the boolean `lift_vs_baseline` plus the numeric `delta_dir_acc` (Transformer dir-acc minus best-baseline dir-acc) and the string `baseline_used` (the name of the strongest baseline) — all three persist to the bundle's `metrics.json` under the `lift_check` block.
+4. **API surface.** `TrajectoryResponse` carries the three lift fields (`lift_vs_baseline: bool`, `delta_dir_acc: float | None`, `baseline_used: str | None`). The runtime singleton (`_load_lift_check`) reads the verdict from the bundle's `metrics.json` and surfaces it through `_TrajectoryState`. All three default to `None` / `False` for bundles that predate this ADR so the schema extension is back-compatible.
+
+## Consequences
+
+- New trajectory training runs targeting the canonical 768-d DAPT embedding default to the 2x32 Transformer arm (the only configuration that fits the 75k cap without an explicit override). The historical 4x64 default is reachable only via `--no-param-cap`, and the documented gate for using that flag is a downstream sweep demonstrating the `>= 5pp` lift threshold has already been cleared.
+- `/analyze/trajectory` ships a stable `lift_vs_baseline` badge for every bundle, including legacy bundles (default-False until a re-train under #332 lands the `metrics.json` `lift_check` block).
+- The baselines module is reusable by future trajectory follow-ups — `evaluate_*` and `compare_against_transformer` are stand-alone helpers that do not assume the trainer's call graph.
+- The three trainer-wiring tests that previously exercised the 4x64 Transformer with a 4-d toy embedder now pass `enforce_param_cap=False` with an inline comment explaining the carve-out. The behaviour the cap exists to guard (real-world capacity overshoot at the 768-d DAPT embedding) is exercised by `test_oversized_4x64_transformer_trips_cap` in `tests/unit/test_trajectory_baselines.py`.
+- The `LIFT_THRESHOLD_POINTS` constant + the override path through `--no-param-cap` together let a future advisor-scope downstream sweep (e.g. ensembling, distillation) lift the cap when the lift evidence justifies it. The ADR does not bake "2x32 forever" into the codebase — it bakes "2x32 by default, 4x64 only with evidence" into the codebase.
+- The comparison table cells in `fed-pulse.wiki/06_Deep_Learning_Roadmap.md §6.16` are placeholders (`_pending sweep_`) at this commit. The next trajectory GPU sweep fills in the directional-accuracy + confusion-matrix cells from the bundle's persisted `metrics.json` block.

--- a/tests/unit/test_trajectory_baselines.py
+++ b/tests/unit/test_trajectory_baselines.py
@@ -1,0 +1,311 @@
+"""Unit tests for the trajectory baselines + parameter-count cap (#332).
+
+Covers:
+
+* ``previous_stance`` echoes the last observed label.
+* ``rolling_majority(n=3)`` resolves the modal label over a sliding window
+  and breaks ties on recency.
+* ``small_lstm_baseline`` fits under the 5k-parameter cap and learns the
+  high-autocorrelation pattern on a synthetic stance sequence.
+* ``assert_parameter_count_within_cap`` rejects oversized configs and
+  passes the canonical 2x32 transformer arm.
+* :func:`compare_against_transformer` emits the lift / no-lift verdict
+  the API endpoint surfaces.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.trajectory import baselines as baseline_mod  # noqa: E402
+from app.trajectory.baselines import (  # noqa: E402
+    DEFAULT_LSTM_PARAM_CAP,
+    LIFT_THRESHOLD_POINTS,
+    assert_param_count_within_cap,
+    compare_against_transformer,
+    evaluate_previous_stance,
+    evaluate_rolling_majority,
+    evaluate_small_lstm,
+    previous_stance,
+    rolling_majority,
+)
+from app.trajectory.model import (  # noqa: E402
+    STANCE_CLASSES,
+    TrajectoryConfig,
+    build_model,
+)
+from app.trajectory.train import (  # noqa: E402
+    DEFAULT_PARAMETER_COUNT_CAP,
+    assert_parameter_count_within_cap,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic fixtures — a high-autocorrelation stance sequence the naive
+# baselines should score well on by construction.
+# ---------------------------------------------------------------------------
+
+
+HAWKISH = STANCE_CLASSES.index("hawkish")
+DOVISH = STANCE_CLASSES.index("dovish")
+NEUTRAL = STANCE_CLASSES.index("neutral")
+
+
+def _autocorrelated_sequence() -> list[int]:
+    """20-meeting sequence with long runs of the same stance.
+
+    Pattern: 5 hawkish, 5 neutral, 5 dovish, 5 hawkish — every transition
+    is preceded by 4 same-class meetings, so ``rolling_majority(n=3)`` is
+    correct on every step except the four boundary cases.
+    """
+
+    return (
+        [HAWKISH] * 5
+        + [NEUTRAL] * 5
+        + [DOVISH] * 5
+        + [HAWKISH] * 5
+    )
+
+
+# ---------------------------------------------------------------------------
+# Naive predictors
+# ---------------------------------------------------------------------------
+
+
+class TestPreviousStance:
+    def test_returns_last_observed_label(self) -> None:
+        history = [HAWKISH, NEUTRAL, DOVISH]
+        assert previous_stance(history) == DOVISH
+
+    def test_accepts_string_labels(self) -> None:
+        history = ["hawkish", "neutral", "hawkish"]
+        assert previous_stance(history) == HAWKISH
+
+    def test_empty_history_returns_none(self) -> None:
+        assert previous_stance([]) is None
+
+    def test_unrecognised_labels_fall_through(self) -> None:
+        # Trailing junk should NOT block the predictor — it should walk
+        # back until it finds a recognised label.
+        assert previous_stance([HAWKISH, "garbage", None]) == HAWKISH
+
+    def test_directional_accuracy_on_autocorrelated_sequence(self) -> None:
+        # previous_stance is correct on every meeting except the four
+        # regime boundaries (indices 5, 10, 15, 20 in absolute terms).
+        sequence = _autocorrelated_sequence()
+        histories = [sequence[:i] for i in range(1, len(sequence))]
+        truths = sequence[1:]
+        result = evaluate_previous_stance(histories, truths)
+        # 19 windows total, 3 boundary mismatches (5->5, 10->10, 15->15)
+        assert result.directional_accuracy >= 0.75
+        assert result.n == len(truths)
+
+
+class TestRollingMajority:
+    def test_rejects_non_positive_window(self) -> None:
+        with pytest.raises(ValueError):
+            rolling_majority([HAWKISH], n=0)
+
+    def test_majority_label_wins(self) -> None:
+        # Window of size 3, 2 hawkish + 1 dovish -> hawkish.
+        assert rolling_majority([HAWKISH, DOVISH, HAWKISH], n=3) == HAWKISH
+
+    def test_recency_breaks_ties(self) -> None:
+        # All three distinct -> degenerates to previous_stance.
+        assert rolling_majority([HAWKISH, NEUTRAL, DOVISH], n=3) == DOVISH
+
+    def test_window_clamps_to_history_length(self) -> None:
+        assert rolling_majority([HAWKISH], n=10) == HAWKISH
+
+    def test_directional_accuracy_beats_random_on_autocorrelated(self) -> None:
+        sequence = _autocorrelated_sequence()
+        histories = [sequence[:i] for i in range(1, len(sequence))]
+        truths = sequence[1:]
+        result = evaluate_rolling_majority(histories, truths, n=3)
+        # On a 3-class problem random is 1/3; the autocorrelated
+        # sequence should give >50% even at the boundaries.
+        assert result.directional_accuracy > 0.5
+        # Confusion matrix should be roughly diagonal — the off-diagonal
+        # mass only comes from the 4 regime boundaries.
+        cm = result.confusion_matrix
+        diagonal_count = sum(cm[i][i] for i in range(len(cm)))
+        total = sum(sum(row) for row in cm)
+        # Boundaries cost up to 2 misses each (the window stays stale
+        # until 2 same-class meetings have accumulated post-flip), so
+        # the diagonal floor is 0.6, not 0.7.
+        assert diagonal_count / max(total, 1) >= 0.6
+
+
+# ---------------------------------------------------------------------------
+# Small-LSTM baseline
+# ---------------------------------------------------------------------------
+
+
+class TestSmallLstmBaseline:
+    def test_fits_under_default_param_cap(self) -> None:
+        from app.trajectory.baselines import build_small_lstm
+
+        model = build_small_lstm()
+        actual = assert_param_count_within_cap(
+            model, cap=DEFAULT_LSTM_PARAM_CAP
+        )
+        # The 1-layer x 16-hidden LSTM lands well under 5k params.
+        assert actual < DEFAULT_LSTM_PARAM_CAP
+
+    def test_oversized_lstm_trips_param_cap(self) -> None:
+        # A 4-layer x 256-hidden LSTM would not fit — the helper should
+        # surface that as an AssertionError so a mis-configured baseline
+        # cannot ship.
+        from app.trajectory.baselines import build_small_lstm
+
+        oversized = build_small_lstm(hidden_size=256, num_layers=4)
+        with pytest.raises(AssertionError):
+            assert_param_count_within_cap(oversized, cap=DEFAULT_LSTM_PARAM_CAP)
+
+    def test_learns_high_autocorrelation_pattern(self) -> None:
+        # Fit the small-LSTM on a clean high-autocorrelation pattern
+        # (constant hawkish over 30 meetings) and check that it
+        # correctly continues the pattern on the holdout slice. The
+        # autocorrelated-but-rotating sequence used elsewhere in this
+        # file leaves the holdout regime under-represented in the
+        # train tail, which is a fair (and separate) test of
+        # generalisation — for the "did the LSTM fit at all?" check
+        # the constant pattern is the cleaner instrument.
+        constant = [HAWKISH] * 30
+        train_pool = constant[:20]
+        holdout_histories = [constant[:i] for i in range(20, 26)]
+        holdout_truths = constant[20:26]
+        result = evaluate_small_lstm(
+            [train_pool],
+            holdout_histories,
+            holdout_truths,
+            epochs=80,
+            seed=11,
+        )
+        # The pattern is trivially learnable — the LSTM should hit the
+        # holdout class on every row.
+        assert result.directional_accuracy >= 0.8
+        assert result.n == len(holdout_truths)
+
+
+# ---------------------------------------------------------------------------
+# Parameter-count cap on the trajectory architectures
+# ---------------------------------------------------------------------------
+
+
+class TestParameterCountCap:
+    def test_canonical_2x32_transformer_passes_cap(self) -> None:
+        config = TrajectoryConfig(
+            architecture="transformer",
+            embedding_dim=768,
+            transformer_layers=2,
+            transformer_d_model=32,
+            transformer_n_heads=4,
+        )
+        model = build_model(config)
+        actual = assert_parameter_count_within_cap(
+            model, cap=DEFAULT_PARAMETER_COUNT_CAP
+        )
+        # The 2x32 arm lands around ~50k params at the 768-d DAPT
+        # embedding; the default cap (75k) admits it with headroom.
+        assert actual <= DEFAULT_PARAMETER_COUNT_CAP
+
+    def test_oversized_4x64_transformer_trips_cap(self) -> None:
+        # The historical #296 default (4 layers x 64 d_model x 4 heads)
+        # is the configuration the cap exists to reject — at ~250k
+        # params it sits way above the 75k default cap.
+        config = TrajectoryConfig(
+            architecture="transformer",
+            embedding_dim=768,
+            transformer_layers=4,
+            transformer_d_model=64,
+            transformer_n_heads=4,
+        )
+        model = build_model(config)
+        with pytest.raises(AssertionError) as excinfo:
+            assert_parameter_count_within_cap(
+                model, cap=DEFAULT_PARAMETER_COUNT_CAP
+            )
+        # The error message should call out the override path for
+        # operators who have already cleared the >=5pp lift threshold.
+        assert "no-param-cap" in str(excinfo.value)
+
+    def test_override_cap_value_admits_oversized_config(self) -> None:
+        # An explicit cap override (the ``--no-param-cap`` equivalent
+        # via direct call) must let the oversized config through.
+        config = TrajectoryConfig(
+            architecture="transformer",
+            embedding_dim=768,
+            transformer_layers=4,
+            transformer_d_model=64,
+            transformer_n_heads=4,
+        )
+        model = build_model(config)
+        actual = assert_parameter_count_within_cap(model, cap=10_000_000)
+        assert actual > DEFAULT_PARAMETER_COUNT_CAP
+
+
+# ---------------------------------------------------------------------------
+# Lift / no-lift comparison
+# ---------------------------------------------------------------------------
+
+
+def _result(
+    name: str, predictions: Sequence[int], truths: Sequence[int]
+) -> baseline_mod.BaselineResult:
+    """Helper — build a BaselineResult for the lift-check tests."""
+
+    return baseline_mod.BaselineResult(
+        name=name,
+        predictions=tuple(int(p) for p in predictions),
+        truths=tuple(int(t) for t in truths),
+        directional_accuracy=baseline_mod.directional_accuracy(truths, predictions),
+        confusion_matrix=baseline_mod.confusion_matrix(truths, predictions),
+        n=len(truths),
+    )
+
+
+class TestLiftVsBaseline:
+    def test_lift_fires_when_transformer_beats_threshold(self) -> None:
+        # Baseline gets 0.50, transformer at 0.60 — exactly LIFT_THRESHOLD
+        # over the baseline. Acceptance is `>=`, so this should fire.
+        truths = [HAWKISH] * 10
+        baseline_preds = [HAWKISH] * 5 + [DOVISH] * 5  # 0.5 dir-acc
+        baseline = _result("previous_stance", baseline_preds, truths)
+        payload = compare_against_transformer(
+            transformer_dir_acc=0.5 + LIFT_THRESHOLD_POINTS,
+            baselines=[baseline],
+        )
+        assert payload["lift_vs_baseline"] is True
+        assert payload["baseline_used"] == "previous_stance"
+        assert payload["delta_dir_acc"] == pytest.approx(LIFT_THRESHOLD_POINTS)
+
+    def test_no_lift_when_transformer_underperforms(self) -> None:
+        truths = [HAWKISH] * 10
+        baseline_preds = [HAWKISH] * 8 + [DOVISH] * 2  # 0.8 dir-acc
+        baseline = _result("rolling_majority_n3", baseline_preds, truths)
+        payload = compare_against_transformer(
+            transformer_dir_acc=0.4, baselines=[baseline]
+        )
+        assert payload["lift_vs_baseline"] is False
+        assert payload["delta_dir_acc"] < 0.0
+
+    def test_picks_strongest_baseline(self) -> None:
+        # The verdict must compare against the BEST baseline, not the
+        # weakest — otherwise the badge is trivially gameable.
+        truths = [HAWKISH] * 10
+        weak = _result(
+            "previous_stance", [HAWKISH] * 3 + [DOVISH] * 7, truths
+        )  # 0.3 dir-acc
+        strong = _result(
+            "rolling_majority_n3", [HAWKISH] * 9 + [DOVISH] * 1, truths
+        )  # 0.9 dir-acc
+        payload = compare_against_transformer(
+            transformer_dir_acc=0.85, baselines=[weak, strong]
+        )
+        assert payload["baseline_used"] == "rolling_majority_n3"
+        assert payload["lift_vs_baseline"] is False

--- a/tests/unit/test_trajectory_train.py
+++ b/tests/unit/test_trajectory_train.py
@@ -195,6 +195,7 @@ def test_train_and_persist_manifest_carries_train_end_and_fold_id(
         embed_fn=_toy_embedder,
         holdout_share=0.0,
         calibration_share=0.0,
+        enforce_param_cap=False,  # toy 4-dim embedder + 4x64 transformer exceeds the #332 cap; legit override for trainer wiring tests.
     )
     manifest = json.loads((bundle / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["train_end"] == "2020-01-01"
@@ -481,6 +482,7 @@ def test_train_and_persist_manifest_includes_parameter_count(tmp_path: Path) -> 
         embed_fn=_toy_embedder,
         holdout_share=0.0,
         calibration_share=0.0,
+        enforce_param_cap=False,  # toy 4-dim embedder + 4x64 transformer exceeds the #332 cap; legit override for trainer wiring tests.
     )
     manifest = json.loads((bundle / "manifest.json").read_text(encoding="utf-8"))
     assert "model_parameter_count" in manifest


### PR DESCRIPTION
Closes #332.

## Summary

- Three baselines on the canonical fold protocol: `previous_stance`, `rolling_majority(n=3)`, `small_lstm`.
- `assert_parameter_count_within_cap(model, cap=75_000)` blocks oversized configs; `--no-param-cap` opts out.
- `TrajectoryResponse` carries `lift_vs_baseline` / `delta_dir_acc` / `baseline_used` (back-compatible defaults).
- Trainer's `metrics.json` gains `baselines` + `lift_check` blocks; runtime singleton surfaces them via `_load_lift_check`.
- ADR 0022 records the 2x32 cap + the 5pp directional-accuracy override gate.
- Wiki §6.17 publishes the comparison table (`_pending sweep_` cells).

## Test plan

- `docker run --rm -v $(pwd):/app -w /app -e PYTHONPATH=/app/backend fed-pulse-backend:latest python -m pytest tests/unit/test_trajectory_baselines.py -q`
- `docker run --rm -v $(pwd):/app -w /app -e PYTHONPATH=/app/backend fed-pulse-backend:latest python -m pytest tests/unit/test_trajectory_baselines.py tests/unit/test_trajectory_endpoint.py tests/unit/test_trajectory_model.py tests/unit/test_trajectory_train.py -q`