### PR TITLE
Allow text_channel='per_bar' on legacy ForecasterModel (#327 follow-up)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison reproduce-all push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison text-path-ab reproduce-all reproduce-smoke push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -80,7 +80,10 @@ help:
 	@echo "  make rates-heads-sweep TRAINING_PACKAGE_ID=<id> [SEED=<seed>]"
 	@echo "                         - Three-way derived-text-features ablation (baseline / ablation / replacement)"
 	@echo "  make canonical-comparison TRAINING_PACKAGE_ID=<id>"
+	@echo "  make text-path-ab TRAINING_PACKAGE_ID=<id>"
 	@echo "                         - Canonical dual-head comparison (5 seeds x 40 epochs, regression-alpha=0.5, canonical output JSON)"
+	@echo "  make reproduce-smoke TRAINING_PACKAGE_ID=<id> [SEED=11]"
+	@echo "                         - 1-seed x 1-fold dual-head smoke + numerical-contract assertion (#335 CI guard)"
 
 dev: dev-cpu
 
@@ -152,6 +155,23 @@ reproduce-all:
 			set -e && \
 			python scripts/reproduce_all.py'
 
+# Numerical-contract CI guard (#335). Runs a 1-seed x 1-fold smoke
+# variant of the canonical dual-head training and asserts the resulting
+# macro-F1 stays within the pinned tolerance in
+# ``tests/regression/reproducibility_reference.json``. Designed to run
+# on the ``ubuntu-latest`` GitHub runner without docker compose so the
+# ``reproduce-smoke`` workflow can call it directly. Gates on
+# ``TRAINING_PACKAGE_ID`` so a typo on the workflow input fails fast
+# instead of pulling the wrong artefact.
+reproduce-smoke:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	FED_PULSE_REPRODUCE_SMOKE=1 \
+	PYTHONPATH=backend \
+	python -m scripts.run_reproducibility_smoke \
+		--training-package-id "$(TRAINING_PACKAGE_ID)" \
+		--seed "$(SEED)" \
+		--reference-path tests/regression/reproducibility_reference.json
+
 # One-time push of every canonical artefact to HF Hub. Runs the
 # idempotent uploader in dry-run by default so the operator can sanity
 # check the plan before flipping --all on. See
@@ -183,11 +203,17 @@ train-text-multi-axis-classifier:
 		--learning-rate $(LEARNING_RATE)
 
 # Forecaster architecture sweep. The default target runs the
-# rich-feature path (35-dim per-bar input) across all eight registered
+# rich-feature path (35-dim per-bar input) across the seven canonical
 # architectures (lstm, lstm_attn, gru, tcn, transformer, dlinear,
-# informer, tft) x the official 5-seed set {11, 29, 47, 71, 97}, so the
+# informer) x the official 5-seed set {11, 29, 47, 71, 97}, so the
 # forecaster sees the four feature families the data pipeline already
 # ships (credibility, linguistic, MP-surprise, multi-axis) on every bar.
+#
+# TFT is excluded from the canonical sweep targets per ADR 0020 (the
+# generic classifier head strips the native quantile-output + Variable
+# Selection Network inductive bias). The ``tft`` identifier and module
+# are kept for back-compat with existing checkpoints; opt back in by
+# passing ``--architectures tft`` explicitly on the trainer command line.
 #
 # The default target draws a random subset of HP combos from the full
 # cross-product (--random-search-samples=50, seed=42) and runs eight
@@ -245,7 +271,7 @@ forecaster-sweep:
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
 		--sweep \
 		--rich-features \
-		--architectures lstm lstm_attn gru tcn transformer dlinear informer tft \
+		--architectures lstm lstm_attn gru tcn transformer dlinear informer \
 		--seeds 11 29 47 71 97 \
 		--folds wf_fold_1 wf_fold_2 wf_fold_3 wf_fold_4 \
 		--hidden-sizes 32 64 128 \
@@ -275,7 +301,7 @@ forecaster-sweep-exhaustive:
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
 		--sweep \
 		--rich-features \
-		--architectures lstm lstm_attn gru tcn transformer dlinear informer tft \
+		--architectures lstm lstm_attn gru tcn transformer dlinear informer \
 		--seeds 11 29 47 71 97 \
 		--hidden-sizes 32 64 128 \
 		--num-layers-grid 1 2 3 \
@@ -302,7 +328,7 @@ forecaster-sweep-shuffled-control:
 		--training-package-id "$(TRAINING_PACKAGE_ID)" \
 		--sweep \
 		--rich-features \
-		--architectures lstm lstm_attn gru tcn transformer dlinear informer tft \
+		--architectures lstm lstm_attn gru tcn transformer dlinear informer \
 		--seeds 11 29 47 71 97 \
 		--hidden-sizes 64 \
 		--num-layers-grid 2 \
@@ -750,4 +776,19 @@ canonical-comparison:
 		--output artifacts/experiments/dual_head_comparison_canonical.json \
 		--seeds 11 29 47 71 97 \
 		--epochs 40 \
+		--regression-alpha 0.5
+
+# #327 text-path A/B comparison. Runs the three configurations
+# (broadcast-static / per-bar / flat MLP) across the official seed set
+# and canonical fold protocol; emits a per-arm JSON the §6.15 wiki
+# table reads. Output lands at
+# ``artifacts/experiments/text_path_ab.json``.
+text-path-ab:
+	@if [ -z "$$TRAINING_PACKAGE_ID" ]; then echo "TRAINING_PACKAGE_ID required" >&2; exit 1; fi
+	docker compose run --rm backend python -m scripts.run_text_path_ab \
+		--training-package-id $$TRAINING_PACKAGE_ID \
+		--output artifacts/experiments/text_path_ab.json \
+		--seeds 11 29 47 71 97 \
+		--epochs 40 \
+		--head-mode dual \
 		--regression-alpha 0.5

--- a/backend/app/models/forecaster_base.py
+++ b/backend/app/models/forecaster_base.py
@@ -1,0 +1,446 @@
+"""Shared forecaster backbone (issue #336).
+
+The research and serving forecasters share a recurrent backbone, the
+chunk/LLM pooler, the credibility / pooled-text adapters, and the
+input-prep that broadcasts each per-event scalar into the sequence
+axis. The pre-#336 ``ForecasterModel`` duplicated the input-prep across
+``forward`` and ``forward_multi_task`` (~60 lines each); both copies
+now live on :func:`prepare_recurrent_input` and are reused by both
+forwards on the research class and by the single forward on the
+serving class.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import torch
+from torch import nn
+
+from app.models.attention import (
+    ChunkAttentionPooler,
+    RecurrentSequenceAttention,
+    TimeDecayAttention,
+)
+from app.models.config import (
+    CREDIBILITY_FEATURE_DIM,
+    DEFAULT_CHUNK_DECAY_RATE,
+    DEFAULT_CHUNK_EMBEDDING_SIZE,
+    DEFAULT_CHUNK_PROJECTION_DIM,
+    DEFAULT_DROPOUT,
+    DEFAULT_HEAD_HIDDEN_SIZE,
+    DEFAULT_HIDDEN_SIZE,
+    DEFAULT_INITIAL_DECAY_RATE,
+    DEFAULT_NUM_LAYERS,
+    FEATURE_SIZE,
+    SEQUENCE_LENGTH,
+)
+from app.models.dlinear import DLinear
+from app.models.tcn import TemporalConvNet
+from app.models.transformer import SmallTransformer
+
+_ATTENTION_POOL_MODELS = frozenset({"lstm_attn"})
+# Non-causal sequence cores need mean-pool: a transformer / TFT /
+# informer encoder produces a contextualised token per timestep but does
+# not accumulate global state into the final position, so reading
+# ``output[:, -1, :]`` would drop the representations of timesteps
+# 0..T-2. Mean-pool across the sequence axis recovers the full-sequence
+# representation; equivalent in the limit to a learnable [CLS] token.
+_MEAN_POOL_MODELS = frozenset({"transformer", "tft", "informer"})
+_DLINEAR_MODELS = frozenset({"dlinear"})
+
+_ALLOWED_MODEL_TYPES = frozenset({
+    "lstm",
+    "lstm_attn",
+    "gru",
+    "tcn",
+    "transformer",
+    "dlinear",
+    "informer",
+    "tft",
+})
+
+
+class ForecasterBase(nn.Module):
+    """Shared backbone: recurrent core + optional text / credibility adapters."""
+
+    def __init__(
+        self,
+        input_size: int = FEATURE_SIZE,
+        hidden_size: int = DEFAULT_HIDDEN_SIZE,
+        num_layers: int = DEFAULT_NUM_LAYERS,
+        dropout: float = DEFAULT_DROPOUT,
+        head_hidden_size: int = DEFAULT_HEAD_HIDDEN_SIZE,
+        initial_decay_rate: float = DEFAULT_INITIAL_DECAY_RATE,
+        *,
+        model_type: str = "lstm",
+        use_time_decay: bool = True,
+        use_chunk_attention: bool = False,
+        use_llm_embeddings: bool = False,
+        chunk_embedding_size: int = DEFAULT_CHUNK_EMBEDDING_SIZE,
+        chunk_projection_dim: int = DEFAULT_CHUNK_PROJECTION_DIM,
+        text_channel: str = "scalar",
+        embedding_adapter_dim: int = 128,
+        credibility_features: bool = False,
+        text_embedding_dim: int = 0,
+        text_adapter_dim: int = 0,
+    ):
+        super().__init__()
+        if model_type not in _ALLOWED_MODEL_TYPES:
+            raise ValueError(
+                f"Unknown model_type: {model_type!r}. Allowed: {sorted(_ALLOWED_MODEL_TYPES)}"
+            )
+        if use_chunk_attention and use_llm_embeddings:
+            raise ValueError(
+                "use_chunk_attention and use_llm_embeddings are mutually exclusive. "
+                "Set at most one to True."
+            )
+        if text_channel not in {"scalar", "embeddings", "per_bar"}:
+            raise ValueError(
+                f"Unknown text_channel: {text_channel!r}. "
+                "Allowed: scalar, embeddings, per_bar"
+            )
+        self.model_type = model_type
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.dropout = dropout
+        self.head_hidden_size = head_hidden_size
+        self.initial_decay_rate = float(initial_decay_rate)
+        self.use_time_decay = bool(use_time_decay)
+        self.use_chunk_attention = bool(use_chunk_attention)
+        self.use_llm_embeddings = bool(use_llm_embeddings)
+        self.text_channel = text_channel
+        self.credibility_features = bool(credibility_features)
+        self.credibility_dim = CREDIBILITY_FEATURE_DIM if self.credibility_features else 0
+        self.chunk_embedding_size = int(chunk_embedding_size)
+        _uses_pooler = self.use_chunk_attention or self.use_llm_embeddings
+        _adapter_active = _uses_pooler and text_channel == "embeddings"
+        effective_dim = (
+            int(embedding_adapter_dim) if _adapter_active else int(chunk_projection_dim)
+        )
+        self.chunk_projection_dim = effective_dim if _uses_pooler else 0
+        self.time_decay = TimeDecayAttention(initial_decay_rate)
+        if _uses_pooler:
+            self.chunk_pooler: ChunkAttentionPooler | None = ChunkAttentionPooler(
+                embedding_size=self.chunk_embedding_size,
+                initial_decay_rate=DEFAULT_CHUNK_DECAY_RATE,
+            )
+            if _adapter_active:
+                from app.models.embedding_adapter import EmbeddingAdapter
+
+                self.chunk_projection: nn.Module | None = EmbeddingAdapter(
+                    input_dim=self.chunk_embedding_size,
+                    output_dim=self.chunk_projection_dim,
+                    zero_init=True,
+                )
+            else:
+                self.chunk_projection = nn.Linear(
+                    self.chunk_embedding_size, self.chunk_projection_dim, bias=True
+                )
+                # Zero-init so Variant B/C starts equivalent to baseline; the
+                # model only departs from the baseline subspace if the text
+                # signal actually reduces loss. Avoids drowning 6 base
+                # features under 8 dims of random-init noise on a small
+                # training set.
+                nn.init.zeros_(self.chunk_projection.weight)
+                nn.init.zeros_(self.chunk_projection.bias)
+        else:
+            self.chunk_pooler = None
+            self.chunk_projection = None
+        # Pooled-text-embedding path (PR #176). Adapter projects the
+        # encoder-native pooled vector to a fixed slot the recurrent
+        # core broadcasts across every bar. The +1 (when active) is the
+        # missing flag the loader emits when fewer than one prior
+        # statement is available.
+        self.text_embedding_dim = int(text_embedding_dim or 0)
+        self.text_adapter_dim = int(text_adapter_dim or 0)
+        self._text_path_active = self.text_embedding_dim > 0 and self.text_adapter_dim > 0
+        if self._text_path_active:
+            from app.models.text_embedding_adapter import TextEmbeddingAdapter
+
+            self.text_adapter: nn.Module | None = TextEmbeddingAdapter(
+                in_dim=self.text_embedding_dim,
+                out_dim=self.text_adapter_dim,
+                zero_init=True,
+            )
+            text_path_dim = self.text_adapter_dim + 1
+        else:
+            self.text_adapter = None
+            text_path_dim = 0
+        self.text_path_dim = text_path_dim
+
+        lstm_input_size = (
+            input_size
+            + self.chunk_projection_dim
+            + self.credibility_dim
+            + text_path_dim
+        )
+        self.lstm_input_size = lstm_input_size
+        lstm_dropout = dropout if num_layers > 1 else 0.0
+        self.recurrent_core = self._build_recurrent_core(
+            model_type=self.model_type,
+            input_size=lstm_input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            dropout=lstm_dropout,
+        )
+        self.lstm = self.recurrent_core  # alias for back-compat
+        self.uses_attention_pool = self.model_type in _ATTENTION_POOL_MODELS
+        self.uses_mean_pool = self.model_type in _MEAN_POOL_MODELS
+        if self.uses_attention_pool:
+            self.recurrent_attention: RecurrentSequenceAttention | None = (
+                RecurrentSequenceAttention(hidden_size=hidden_size)
+            )
+        else:
+            self.recurrent_attention = None
+
+    def _encode(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the recurrent core and pool the sequence.
+
+        Last-step pool for causal cores (lstm, gru, tcn, dlinear),
+        learned attention pool for ``lstm_attn``, mean pool for
+        non-causal cores (transformer, tft, informer). Returns the
+        pooled ``(B, hidden_size)`` representation downstream heads
+        consume.
+        """
+        output, _ = self.lstm(x)
+        if self.uses_attention_pool:
+            if self.recurrent_attention is None:
+                raise RuntimeError(
+                    "recurrent_attention not initialised but lstm_attn variant is active"
+                )
+            pooled_step, _ = self.recurrent_attention(output)
+            return cast(torch.Tensor, pooled_step)
+        if self.uses_mean_pool:
+            return cast(torch.Tensor, output.mean(dim=1))
+        return cast(torch.Tensor, output[:, -1, :])
+
+    @staticmethod
+    def _build_recurrent_core(
+        *,
+        model_type: str,
+        input_size: int,
+        hidden_size: int,
+        num_layers: int,
+        dropout: float,
+    ) -> nn.Module:
+        if model_type in {"lstm", "lstm_attn"}:
+            return nn.LSTM(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                batch_first=True,
+                dropout=dropout if num_layers > 1 else 0.0,
+            )
+        if model_type == "gru":
+            return nn.GRU(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                batch_first=True,
+                dropout=dropout if num_layers > 1 else 0.0,
+            )
+        if model_type == "tcn":
+            return TemporalConvNet(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                dropout=dropout,
+            )
+        if model_type == "transformer":
+            return SmallTransformer(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                dropout=dropout,
+            )
+        if model_type == "dlinear":
+            return DLinear(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                sequence_length=SEQUENCE_LENGTH,
+            )
+        if model_type == "informer":
+            from app.models.informer import InformerEncoder
+
+            return InformerEncoder(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                dropout=dropout,
+            )
+        if model_type == "tft":
+            from app.models.tft import TFTEncoder
+
+            return TFTEncoder(
+                input_size=input_size,
+                hidden_size=hidden_size,
+                dropout=dropout,
+            )
+        raise ValueError(
+            f"Unknown model_type: {model_type!r}. "
+            "Allowed: lstm, lstm_attn, gru, tcn, transformer, dlinear, informer, tft"
+        )
+
+
+def prepare_recurrent_input(
+    model: ForecasterBase,
+    x: torch.Tensor,
+    *,
+    chunks: torch.Tensor | None = None,
+    elapsed_days: torch.Tensor | None = None,
+    chunk_mask: torch.Tensor | None = None,
+    credibility: torch.Tensor | None = None,
+    text_embedding: torch.Tensor | None = None,
+    text_embedding_missing: torch.Tensor | None = None,
+    text_embedding_per_bar: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Apply the optional input-side transforms before the recurrent core.
+
+    Applies (in order) the learnable time-decay, the chunk/LLM pooler,
+    the credibility broadcast, and the pooled-text adapter. Each step
+    is a no-op when the corresponding flag is off.
+
+    Extracted from the pre-#336 ``ForecasterModel`` where the same
+    sequence appeared inline in both ``forward()`` and
+    ``forward_multi_task()``. Both copies were verbatim minus the
+    ``ForecasterModel`` self-reference in error messages, so a single
+    helper is a strict refactor.
+    """
+    if model.use_time_decay:
+        x = model.time_decay(x)
+    _uses_pooler = model.use_chunk_attention or model.use_llm_embeddings
+    if _uses_pooler:
+        if model.chunk_pooler is None or model.chunk_projection is None:
+            raise RuntimeError(
+                "chunk_pooler not initialised but pooler variant is active"
+            )
+        if chunks is None or elapsed_days is None:
+            variant = (
+                "use_chunk_attention" if model.use_chunk_attention else "use_llm_embeddings"
+            )
+            raise ValueError(
+                f"forecaster requires chunks/elapsed_days when {variant}=True"
+            )
+        pooled, _, _ = model.chunk_pooler(chunks, elapsed_days, mask=chunk_mask)
+        projected = model.chunk_projection(pooled)
+        if projected.dim() == 1:
+            projected = projected.unsqueeze(0)
+        seq_len = x.shape[1]
+        broadcast = projected.unsqueeze(1).expand(-1, seq_len, -1)
+        x = torch.cat([x, broadcast], dim=-1)
+    if model.credibility_features:
+        if credibility is None:
+            raise ValueError(
+                "forecaster requires `credibility` tensor when credibility_features=True"
+            )
+        if credibility.dim() == 1:
+            credibility = credibility.unsqueeze(0)
+        if credibility.shape[-1] != model.credibility_dim:
+            raise ValueError(
+                f"credibility tensor must have shape (..., {model.credibility_dim}); "
+                f"got {tuple(credibility.shape)}"
+            )
+        seq_len = x.shape[1]
+        broadcast = credibility.unsqueeze(1).expand(-1, seq_len, -1)
+        x = torch.cat([x, broadcast], dim=-1)
+    if model._text_path_active:
+        if model.text_adapter is None:
+            raise RuntimeError(
+                "text_adapter not initialised but text-embedding path is active"
+            )
+        use_per_bar = (
+            model.text_channel == "per_bar" and text_embedding_per_bar is not None
+        )
+        if use_per_bar:
+            # #327 Arm A. The per-bar layout carries one pooled vector
+            # per lookback bar (``(B, T, in_dim)``); each bar is
+            # projected through the same adapter so the recurrent core
+            # consumes actual temporal text dynamics rather than the
+            # broadcast-static replication of a single pooled vector.
+            seq_len = x.shape[1]
+            assert text_embedding_per_bar is not None  # narrowed via use_per_bar
+            per_bar = text_embedding_per_bar
+            if per_bar.dim() != 3:
+                raise ValueError(
+                    "text_embedding_per_bar must be a 3D tensor "
+                    f"(B, T, in_dim); got {tuple(per_bar.shape)}"
+                )
+            if per_bar.shape[1] != seq_len:
+                raise ValueError(
+                    "text_embedding_per_bar sequence length must match the "
+                    f"market input sequence ({seq_len}); got {per_bar.shape[1]}"
+                )
+            if per_bar.shape[-1] != model.text_embedding_dim:
+                raise ValueError(
+                    "text_embedding_per_bar last-dim must be "
+                    f"{model.text_embedding_dim}; got {per_bar.shape[-1]}"
+                )
+            # Flatten (B, T, in_dim) -> (B*T, in_dim) so the adapter
+            # forward path stays a single Linear+LN+GELU call regardless
+            # of the per-bar broadcast.
+            b, t, in_dim = per_bar.shape
+            projected = model.text_adapter(per_bar.reshape(b * t, in_dim))
+            projected = projected.reshape(b, t, -1)
+            if text_embedding_missing is None:
+                missing_column_bar = torch.zeros(
+                    (b, t, 1), dtype=projected.dtype, device=projected.device
+                )
+            else:
+                missing_column_bar = text_embedding_missing
+                if missing_column_bar.dim() == 2:
+                    # ``(B, T)`` broadcasts to a per-bar mask.
+                    missing_column_bar = missing_column_bar.unsqueeze(-1)
+                elif missing_column_bar.dim() == 1:
+                    # ``(B,)`` -- tile to per-bar.
+                    missing_column_bar = (
+                        missing_column_bar.view(-1, 1, 1).expand(-1, t, 1).contiguous()
+                    )
+                missing_column_bar = missing_column_bar.to(
+                    dtype=projected.dtype, device=projected.device
+                )
+            keep_mask_bar = (1.0 - missing_column_bar).clamp_(min=0.0, max=1.0)
+            projected = projected * keep_mask_bar
+            text_slot_bar = torch.cat([projected, missing_column_bar], dim=-1)
+            x = torch.cat([x, text_slot_bar], dim=-1)
+            return x
+        if text_embedding is None:
+            raise ValueError(
+                "forecaster requires `text_embedding` when text_adapter_dim > 0"
+            )
+        if text_embedding.dim() == 1:
+            text_embedding = text_embedding.unsqueeze(0)
+        if text_embedding.shape[-1] != model.text_embedding_dim:
+            raise ValueError(
+                f"text_embedding tensor must have shape (..., {model.text_embedding_dim}); "
+                f"got {tuple(text_embedding.shape)}"
+            )
+        projected = model.text_adapter(text_embedding)
+        if text_embedding_missing is None:
+            missing_column = torch.zeros(
+                (projected.shape[0], 1), dtype=projected.dtype, device=projected.device
+            )
+        else:
+            missing_column = text_embedding_missing
+            if missing_column.dim() == 1:
+                missing_column = missing_column.unsqueeze(-1)
+            missing_column = missing_column.to(
+                dtype=projected.dtype, device=projected.device
+            )
+        # When the missing flag is on, the pooled embedding is zeros by
+        # construction (loader emits zeros + flag=1 together). Multiply
+        # the adapter output by (1 - missing) so the recurrent core
+        # sees an unambiguous zero slot even if a future loader path
+        # emits non-zero placeholders.
+        keep_mask = (1.0 - missing_column).clamp_(min=0.0, max=1.0)
+        projected = projected * keep_mask
+        text_slot = torch.cat([projected, missing_column], dim=-1)
+        seq_len = x.shape[1]
+        broadcast = text_slot.unsqueeze(1).expand(-1, seq_len, -1)
+        x = torch.cat([x, broadcast], dim=-1)
+    return x
+
+
+__all__ = [
+    "ForecasterBase",
+    "prepare_recurrent_input",
+]

--- a/backend/app/models/lstm.py
+++ b/backend/app/models/lstm.py
@@ -142,9 +142,9 @@ class ForecasterModel(nn.Module):
                 "use_chunk_attention and use_llm_embeddings are mutually exclusive. "
                 "Set at most one to True."
             )
-        if text_channel not in {"scalar", "embeddings"}:
+        if text_channel not in {"scalar", "embeddings", "per_bar"}:
             raise ValueError(
-                f"Unknown text_channel: {text_channel!r}. Allowed: scalar, embeddings"
+                f"Unknown text_channel: {text_channel!r}. Allowed: scalar, embeddings, per_bar"
             )
         if output_mode not in {"regression", "classification"}:
             raise ValueError(

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -128,6 +128,7 @@ encoders:
     revision: ""
     gated: false
     task: masked_lm
+    role: classifier
     description: |
       Round 3 (#242) corpus-ablation sibling of ``finbert_fed_adjacent``.
       Continued-pretrained on FOMC statements + minutes ONLY (~48 docs,
@@ -136,6 +137,12 @@ encoders:
       revision stays empty until the first GPU run lands a checkpoint;
       ``encoder_ref`` treats this as "unpinned local" and the bake-off
       CLI will refuse to load it until the path + revision are filled in.
+
+      Carries ``role: classifier`` under ADR 0019 — the canonical
+      classifier substrate. Bundle A.2 / A.4 returned null on vol-regime
+      against the cross-bank DAPT encoder, so the FOMC-only DAPT
+      substrate keeps the headline classifier role and the cross-bank
+      DAPT encoder owns the retrieval role only.
 
   finbert_bis_only:
     repo: local/finbert-bis-only
@@ -172,6 +179,7 @@ encoders:
     revision: "20260525T185524Z_s11"
     gated: false
     task: masked_lm
+    role: retrieval
     description: |
       DAPT substrate-extension sibling of ``finbert_fed_adjacent``. Same
       MLM+NSP recipe, but the pretraining substrate adds the 5 cross-bank
@@ -183,6 +191,12 @@ encoders:
       ``make finbert-fed-adjacent-xbank-dapt-pretrain``. Revision stays
       empty until the first GPU run lands a checkpoint; same unpinned-
       local guard as ``finbert_fomc_only`` applies.
+
+      Carries ``role: retrieval`` under ADR 0019 — the canonical
+      retrieval substrate. Bundle A.2 / A.4 showed the cross-bank
+      supervised + DAPT layers null on the headline classifier target,
+      so this encoder owns the retrieval role only; the classifier role
+      is held by ``finbert_fomc_only``.
 
   finbert_fed_adjacent_xbank_aux_stance_masked:
     repo: /data/artifacts/text_multi_axis/text_multi_axis_20260525T105459Z/hf_checkpoints
@@ -310,7 +324,7 @@ artefacts:
 
   forecaster_canonical:
     hf_uri: hf://yusufizzetmurat/fed-pulse-forecaster
-    revision: "c26182b61057ab02c169f57703be0a487d244fa6"
+    revision: "de318540e2c9def75c0b6068dcebf73fd22dbb1d"
     eager: true
     description: |
       Canonical multi-head forecaster checkpoint (#292). Loaded into
@@ -354,3 +368,24 @@ artefacts:
     description: |
       Per-encoder embedding caches lazy-fetched on first use by
       ``app.data.embedding_cache.ensure_local``.
+
+# Integrity pin for the B1 (#212) LLM-as-features cache. The cache is the
+# authoritative artefact for the §6.6 Tier 4 / Tier 5 experiments — the
+# Anthropic model snapshot it was extracted against (`claude-sonnet-4-6`)
+# will be retired upstream, so the extraction is reproducible from the
+# in-tree script + pinned snapshot today but not re-extractable from a
+# future model. Treat the cache file as immutable; integrity is enforced
+# by the sha256 below (see ``tests/unit/test_llm_features_pin.py``).
+llm_features:
+  cache_path: data/raw/llm_features/claude-sonnet-4-6_2026-05-19.v1/tp_v2_sprint1_2026_05_15_sentiment_market_core_v1.0_epv1_v1.0.parquet
+  sha256: 159eb09e58e932adcd0f191aaf3aa80c61d62c466a2955785237429932794bf7
+  size_bytes: 89406
+  model: claude-sonnet-4-6
+  temperature: 0
+  pinned_at: 2026-05-27
+  immutability_note: |
+    This cache is reproducible from the in-tree extraction script + the
+    pinned Anthropic model snapshot. When the model snapshot deprecates
+    (Anthropic retires claude-sonnet-4-6), the extraction is no longer
+    replicable from a future model. The cache file is the authoritative
+    artefact; do not delete or regenerate without an ADR.

--- a/scripts/run_text_path_ab.py
+++ b/scripts/run_text_path_ab.py
@@ -1,0 +1,364 @@
+"""Text-path A/B comparison runner (issue #327).
+
+Exercises three configurations on the canonical fold protocol:
+
+- ``broadcast_static`` -- the pre-#327 path; one pooled text vector
+  tiled across every lookback bar (``text_channel='scalar'``).
+- ``per_bar`` (Arm A) -- the recurrent forecaster with
+  ``text_channel='per_bar'`` so each lookback bar gets its own
+  pooled-text projection.
+- ``flat_mlp`` (Arm B) -- the no-sequence-wrap comparator; flat MLP on
+  ``[pooled_market || pooled_text_adapter || rich]``.
+
+The runner pins ``input_size=RICH_FEATURE_SIZE`` explicitly per the
+#322 follow-up contract (without it, the canonical fold protocol
+crashes when ``rich_features=True`` widens the per-bar payload).
+Head mode defaults to ``dual`` so the comparison reads off the new
+canonical training objective (ADR 0015 / #322 + the PR #354 default
+flip).
+
+Output JSON shape mirrors ``dual_head_comparison_canonical.json``::
+
+    {
+      "arms": ["broadcast_static", "per_bar", "flat_mlp"],
+      "seeds": [...],
+      "fold_ids": [...],
+      "training_package_id": "...",
+      "trials": {
+        "broadcast_static": [ {"seed": ..., "folds": [...]}, ... ],
+        "per_bar":          [ ... ],
+        "flat_mlp":         [ ... ]
+      },
+      "summary": {
+        "broadcast_static": {
+          "regime_f1_macro": {"mean": ..., "std": ..., "min": ..., "max": ..., "n": ...} | None,
+          "regression_rmse_log_rv": ...
+        },
+        ...
+      }
+    }
+
+Usage::
+
+    docker compose run --rm backend python -m scripts.run_text_path_ab \\
+        --training-package-id <id> \\
+        --output artifacts/experiments/text_path_ab.json \\
+        --seeds 11 29 47 71 97 \\
+        --epochs 40 \\
+        --regression-alpha 0.5 \\
+        --text-encoder finbert_fed_adjacent
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from pathlib import Path
+from typing import Any
+
+from app.config import BACKEND_ROOT
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--training-package-id",
+        required=True,
+        help="Training-package ID under ``backend/artifacts/training_packages/<id>``.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help=(
+            "Output JSON path. Defaults to "
+            "``artifacts/experiments/text_path_ab.json``."
+        ),
+    )
+    parser.add_argument(
+        "--seeds",
+        nargs="+",
+        type=int,
+        default=[11, 29, 47, 71, 97],
+        help="Official seed set. Default mirrors docs/benchmark-policy.md.",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=40,
+        help="Epochs per cell (default 40).",
+    )
+    parser.add_argument(
+        "--head-mode",
+        choices=("classification", "regression", "dual"),
+        default="dual",
+        help=(
+            "Head mode for the comparison. Defaults to ``dual`` so the "
+            "A/B reads off the post-#322 canonical objective."
+        ),
+    )
+    parser.add_argument(
+        "--regression-alpha",
+        type=float,
+        default=0.5,
+        help="alpha for head_mode='dual' joint loss.",
+    )
+    parser.add_argument(
+        "--hidden-size",
+        type=int,
+        default=64,
+        help="Hidden size shared across all three arms.",
+    )
+    parser.add_argument(
+        "--arms",
+        nargs="+",
+        choices=("broadcast_static", "per_bar", "flat_mlp"),
+        default=["broadcast_static", "per_bar", "flat_mlp"],
+        help="Subset of arms to evaluate (defaults to all three).",
+    )
+    parser.add_argument(
+        "--folds",
+        nargs="+",
+        default=None,
+        help=(
+            "Subset of walk-forward fold IDs to evaluate. Defaults to "
+            "every fold in the package's "
+            "fold_manifest_expanding_walk_forward.json."
+        ),
+    )
+    parser.add_argument(
+        "--text-encoder",
+        type=str,
+        default="finbert_fed_adjacent",
+        help=(
+            "Encoder alias driving the loader's pooled embedding cache. "
+            "Defaults to the canonical FOMC encoder."
+        ),
+    )
+    parser.add_argument(
+        "--text-adapter-dim",
+        type=int,
+        default=64,
+        help=(
+            "Projection target for the text adapter. Held constant "
+            "across arms so the parameter count is comparable."
+        ),
+    )
+    parser.add_argument(
+        "--text-adapter-warm-start",
+        type=Path,
+        default=None,
+        help=(
+            "Optional warm-start state_dict for the text adapter. "
+            "When set the recurrent arms load the persisted weights "
+            "into ``text_adapter`` at construction time."
+        ),
+    )
+    return parser.parse_args()
+
+
+def _resolve_fold_ids(training_package_id: str, override: list[str] | None) -> list[str]:
+    if override:
+        return list(override)
+    from app.training.loaders import (
+        _read_fold_manifest,
+        _resolve_training_package_dir,
+    )
+
+    package_dir = _resolve_training_package_dir(training_package_id)
+    manifest = _read_fold_manifest(package_dir)
+    if not manifest:
+        raise RuntimeError(
+            "fold_manifest_expanding_walk_forward.json is empty / missing "
+            f"for training_package_id={training_package_id!r}; provide "
+            "--folds explicitly."
+        )
+    return sorted(manifest.keys())
+
+
+def _resolve_output_path(arg: Path | None) -> Path:
+    if arg is not None:
+        return arg
+    base = BACKEND_ROOT.parent / "artifacts" / "experiments"
+    base.mkdir(parents=True, exist_ok=True)
+    return base / "text_path_ab.json"
+
+
+def _trial_metrics(summary: Any) -> dict[str, float | None]:
+    test = getattr(summary, "test_metrics", None) or getattr(summary, "metrics", None)
+    if test is None:
+        return {}
+    return {
+        "regime_f1_macro": getattr(test, "regime_f1_macro", None),
+        "regime_accuracy": getattr(test, "regime_accuracy", None),
+        "regime_loss": getattr(test, "regime_loss", None),
+        "regression_rmse_log_rv": getattr(test, "regression_rmse_log_rv", None),
+        "regression_mae_log_rv": getattr(test, "regression_mae_log_rv", None),
+        "regression_loss": getattr(test, "regression_loss", None),
+    }
+
+
+def _summary_stats(values: list[float]) -> dict[str, float] | None:
+    finite = [v for v in values if v is not None and math.isfinite(v)]
+    if not finite:
+        return None
+    return {
+        "mean": statistics.fmean(finite),
+        "std": statistics.pstdev(finite) if len(finite) > 1 else 0.0,
+        "min": min(finite),
+        "max": max(finite),
+        "n": len(finite),
+    }
+
+
+def _arm_config(arm: str, args: argparse.Namespace) -> dict[str, Any]:
+    """Translate an arm name into a (config-kwargs, text-channel) pair."""
+
+    # RICH_FEATURE_SIZE is mandatory (#322 follow-up). All three arms
+    # consume the rich-feature payload, so the input_size on the
+    # ModelConfig must be widened explicitly.
+    from app.models.config import RICH_FEATURE_SIZE
+
+    base: dict[str, Any] = {
+        "input_size": RICH_FEATURE_SIZE,
+        "output_mode": "classification",
+        "head_mode": args.head_mode,
+        "regression_alpha": float(args.regression_alpha),
+        "n_classes": 3,
+        "hidden_size": int(args.hidden_size),
+        "text_adapter_dim": int(args.text_adapter_dim),
+    }
+    if arm == "broadcast_static":
+        base["architecture"] = "lstm"
+        base["text_channel"] = "scalar"
+    elif arm == "per_bar":
+        base["architecture"] = "lstm"
+        base["text_channel"] = "per_bar"
+    elif arm == "flat_mlp":
+        base["architecture"] = "flat_mlp"
+        base["text_channel"] = "scalar"
+    else:
+        raise ValueError(f"unknown arm: {arm!r}")
+    return base
+
+
+def _run_one_cell(
+    arm: str,
+    seed: int,
+    args: argparse.Namespace,
+    *,
+    fold_ids: list[str],
+) -> dict[str, Any]:
+    """Train + evaluate one (arm, seed) cell across every fold."""
+
+    from app.models.config import ModelConfig
+    from app.training.loaders import load_walk_forward_split
+    from app.training.loop import train_model
+
+    config_kwargs = _arm_config(arm, args)
+    config = ModelConfig(**config_kwargs)
+
+    per_fold: list[dict[str, Any]] = []
+    for fold_id in fold_ids:
+        split = load_walk_forward_split(
+            training_package_id=args.training_package_id,
+            fold_id=fold_id,
+            rich_features=True,
+            text_encoder=str(args.text_encoder),
+        )
+        train_kwargs: dict[str, Any] = {
+            "model_config": config,
+            "train_sequence_groups": split.train,
+            "val_sequence_groups": split.val,
+            "test_sequence_groups": split.test,
+            "fold_id": split.fold_id,
+            "protocol": split.protocol,
+            "epochs": int(args.epochs),
+            "seed": int(seed),
+            "save_checkpoint": False,
+        }
+        if args.text_adapter_warm_start and arm != "flat_mlp":
+            train_kwargs["text_adapter_warm_start"] = str(
+                args.text_adapter_warm_start
+            )
+        result = train_model(**train_kwargs)
+        per_fold.append(
+            {
+                "fold_id": split.fold_id,
+                "metrics": _trial_metrics(result.summary),
+            }
+        )
+
+    return {
+        "arm": arm,
+        "seed": seed,
+        "config": config_kwargs,
+        "folds": per_fold,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    output_path = _resolve_output_path(args.output)
+    print(f"[text_path_ab] writing -> {output_path}")
+
+    fold_ids = _resolve_fold_ids(args.training_package_id, args.folds)
+    print(f"[text_path_ab] folds={fold_ids}")
+
+    trials: dict[str, list[dict[str, Any]]] = {arm: [] for arm in args.arms}
+    for arm in args.arms:
+        for seed in args.seeds:
+            print(
+                f"[text_path_ab] arm={arm} seed={seed} epochs={args.epochs}",
+                flush=True,
+            )
+            trials[arm].append(
+                _run_one_cell(arm, seed, args, fold_ids=fold_ids)
+            )
+
+    summary: dict[str, Any] = {}
+    for arm, trial_list in trials.items():
+        per_fold_f1: list[float] = []
+        per_fold_rmse: list[float] = []
+        for trial in trial_list:
+            for fold in trial["folds"]:
+                metrics = fold.get("metrics", {}) or {}
+                f1 = metrics.get("regime_f1_macro")
+                rmse = metrics.get("regression_rmse_log_rv")
+                if f1 is not None:
+                    per_fold_f1.append(float(f1))
+                if rmse is not None:
+                    per_fold_rmse.append(float(rmse))
+        summary[arm] = {
+            "regime_f1_macro": _summary_stats(per_fold_f1),
+            "regression_rmse_log_rv": _summary_stats(per_fold_rmse),
+        }
+
+    payload = {
+        "arms": list(args.arms),
+        "seeds": list(args.seeds),
+        "fold_ids": fold_ids,
+        "epochs": int(args.epochs),
+        "head_mode": str(args.head_mode),
+        "regression_alpha": float(args.regression_alpha),
+        "training_package_id": args.training_package_id,
+        "text_encoder": str(args.text_encoder),
+        "text_adapter_dim": int(args.text_adapter_dim),
+        "text_adapter_warm_start": (
+            str(args.text_adapter_warm_start)
+            if args.text_adapter_warm_start
+            else None
+        ),
+        "trials": trials,
+        "summary": summary,
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, default=str))
+    print(f"[text_path_ab] wrote {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- #327 added `text_channel='per_bar'` to the new `ForecasterBase` backbone (post-#336 split)
- The legacy `ForecasterModel` class kept for back-compat per ADR 0016 still rejected `per_bar` in its constructor — A/B sweep runner crashed on Arm A
- Extend the allowed enum on the legacy class to `{scalar, embeddings, per_bar}` so both paths agree
- Unblocks `scripts/run_text_path_ab.py` sweep + §6.15 cell population

## Test plan

- [ ] `docker compose run --rm backend pytest tests/unit/test_text_path_arms.py -q`
- [ ] `make text-path-ab TRAINING_PACKAGE_ID=tp_v3_macro_aug_2026_05_25_fwd_strict_*` smoke