### PR TITLE
Reporting honesty pass: per-family ablation + substitution finding (#334)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison text-path-ab reproduce-all reproduce-smoke push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison text-path-ab per-family-ablation reproduce-all reproduce-smoke push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -82,6 +82,8 @@ help:
 	@echo "  make canonical-comparison TRAINING_PACKAGE_ID=<id>"
 	@echo "  make text-path-ab TRAINING_PACKAGE_ID=<id>"
 	@echo "                         - Canonical dual-head comparison (5 seeds x 40 epochs, regression-alpha=0.5, canonical output JSON)"
+	@echo "  make per-family-ablation TRAINING_PACKAGE_ID=<id>"
+	@echo "                         - Per-family rich-feature ablation (#334; backs the §6 substitution-finding table)"
 	@echo "  make reproduce-smoke TRAINING_PACKAGE_ID=<id> [SEED=11]"
 	@echo "                         - 1-seed x 1-fold dual-head smoke + numerical-contract assertion (#335 CI guard)"
 
@@ -788,6 +790,21 @@ text-path-ab:
 	docker compose run --rm backend python -m scripts.run_text_path_ab \
 		--training-package-id $$TRAINING_PACKAGE_ID \
 		--output artifacts/experiments/text_path_ab.json \
+		--seeds 11 29 47 71 97 \
+		--epochs 40 \
+		--head-mode dual \
+		--regression-alpha 0.5
+
+# #334 per-family rich-feature ablation runner. Zeros each rich-feature
+# family one at a time (linguistic / credibility / mp_surprise /
+# multi_axis / realised_vol / cross_asset / llm_features) plus a
+# cumulative chain that drops text -> text+market-aux -> everything-
+# except-legacy-market. Backs the §6 substitution-finding table.
+per-family-ablation:
+	@if [ -z "$$TRAINING_PACKAGE_ID" ]; then echo "TRAINING_PACKAGE_ID required" >&2; exit 1; fi
+	docker compose run --rm backend python -m scripts.run_per_family_ablation \
+		--training-package-id $$TRAINING_PACKAGE_ID \
+		--output artifacts/experiments/per_family_ablation.json \
 		--seeds 11 29 47 71 97 \
 		--epochs 40 \
 		--head-mode dual \

--- a/scripts/run_per_family_ablation.py
+++ b/scripts/run_per_family_ablation.py
@@ -1,0 +1,576 @@
+"""Per-family rich-feature ablation runner (#334).
+
+Trains the forecaster under the canonical training package + walk-forward
+fold protocol while zeroing one rich-feature family at a time (and a
+cumulative chain that drops families in dominance order). The output JSON
+backs the §6 per-family ablation table and the substitution-finding
+narrative in the wiki.
+
+Seven rich-feature families are ablated:
+
+- ``linguistic``       -- 15-dim per-document linguistic block (joined
+                          on ``text_hash``)
+- ``credibility``      -- 4-vector sourced from the event row
+- ``mp_surprise``      -- 4-vector joined on ``event_date``
+- ``multi_axis``       -- 6-dim stance / time / certainty block
+- ``realised_vol``     -- per-bar 20d + 60d realised vol horizons
+- ``cross_asset``      -- per-bar VIX/DXY/TNX/Gold + VIX3M/IRX +
+                          VIX term-slope + 10y-3m curve slope (8-dim)
+- ``llm_features``     -- 35-dim B1 catalogue one-hot block + missing
+                          flag (off by default; the runner switches it
+                          on for the baseline so the ``zero_llm`` cell
+                          reads as a real ablation)
+
+Each ablation zeros the family **before** the per-fold scaler fit in
+``train_model``. The mechanism follows the #309 contract:
+
+- The first five families (linguistic / credibility / mp_surprise /
+  multi_axis / llm_features) are zeroed via the existing loader flags
+  on :func:`load_walk_forward_split` -- those flags already write
+  literal 0.0 into the FeatureVector slice before the scaler sees the
+  payload.
+- The realised-vol and cross-asset families have no loader flag because
+  PR #207 / #208 fanned them out as direct FeatureVector attributes.
+  The runner walks the loaded sequences in-place and zeros those
+  attributes before passing the split to ``train_model``; the same
+  pre-scaler ordering is preserved.
+
+Output JSON shape (``backend/artifacts/experiments/per_family_ablation.json``)::
+
+    {
+      "families": [...],
+      "cells": ["baseline", "zero_linguistic", ..., "cumulative_drop_*"],
+      "seeds": [...],
+      "fold_ids": [...],
+      "training_package_id": "...",
+      "epochs": 40,
+      "regression_alpha": 0.5,
+      "head_mode": "dual",
+      "trials": {
+        "<cell>": [ {"seed": ..., "folds": [{"fold_id": ..., "metrics": {...}}]}, ... ]
+      },
+      "summary": {
+        "<cell>": {
+          "regime_f1_macro": {"mean": ..., "lo": ..., "hi": ..., "n": ...} | None,
+          "regression_rmse_log_rv": {...} | None
+        }
+      },
+      "post_350_note": "..."     # caption marker
+    }
+
+Usage::
+
+    docker compose --profile gpu run --rm backend-gpu \\
+        python -m scripts.run_per_family_ablation \\
+        --training-package-id <id> \\
+        --output artifacts/experiments/per_family_ablation.json \\
+        --seeds 11 29 47 71 97 \\
+        --epochs 40 \\
+        --head-mode dual \\
+        --regression-alpha 0.5
+
+The runner is re-runnable; the output path is overwritten on each call.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+import statistics
+from pathlib import Path
+from typing import Any
+
+from app.config import BACKEND_ROOT
+
+
+# Canonical family order. The per-family cell labels follow
+# ``zero_<family>`` so the JSON keys sort stably. The cumulative chain
+# drops families in dominance order -- text first (smallest lift in the
+# §6.3 tier table), then the two market families that landed in the A2 /
+# A3 chunks, finishing on the credibility 4-vector that joins straight
+# off the event row. ``zero_cumulative_text`` is read as "drop the text
+# block entirely"; ``zero_cumulative_text_market_aux`` drops text + the
+# auxiliary market families; ``zero_cumulative_text_market_aux_cred``
+# drops everything except the legacy 6-feature market path. The chain
+# is intentionally short -- the table only needs three cumulative cells
+# to anchor the "rich market dominates" claim against the per-family
+# columns.
+_FAMILIES: tuple[str, ...] = (
+    "linguistic",
+    "credibility",
+    "mp_surprise",
+    "multi_axis",
+    "realised_vol",
+    "cross_asset",
+    "llm_features",
+)
+
+
+_CUMULATIVE_CHAIN: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "cumulative_drop_text",
+        ("linguistic", "multi_axis", "llm_features"),
+    ),
+    (
+        "cumulative_drop_text_market_aux",
+        (
+            "linguistic",
+            "multi_axis",
+            "llm_features",
+            "realised_vol",
+            "cross_asset",
+        ),
+    ),
+    (
+        "cumulative_drop_text_market_aux_cred_mp",
+        (
+            "linguistic",
+            "multi_axis",
+            "llm_features",
+            "realised_vol",
+            "cross_asset",
+            "credibility",
+            "mp_surprise",
+        ),
+    ),
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--training-package-id",
+        required=True,
+        help="Training-package ID under ``backend/artifacts/training_packages/<id>``.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help=(
+            "Output JSON path. Defaults to "
+            "``artifacts/experiments/per_family_ablation.json``."
+        ),
+    )
+    parser.add_argument(
+        "--seeds",
+        nargs="+",
+        type=int,
+        default=[11, 29, 47, 71, 97],
+        help="Official seed set. Default mirrors docs/benchmark-policy.md.",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=40,
+        help="Epochs per cell (default 40).",
+    )
+    parser.add_argument(
+        "--hidden-size",
+        type=int,
+        default=64,
+        help="Hidden size shared across every cell.",
+    )
+    parser.add_argument(
+        "--head-mode",
+        choices=("classification", "regression", "dual"),
+        default="dual",
+        help=(
+            "Head mode for every cell. Defaults to ``dual`` so the "
+            "table reads off the post-#322 canonical objective."
+        ),
+    )
+    parser.add_argument(
+        "--regression-alpha",
+        type=float,
+        default=0.5,
+        help="alpha for head_mode='dual' joint loss.",
+    )
+    parser.add_argument(
+        "--bootstrap-samples",
+        type=int,
+        default=500,
+        help="Block-bootstrap iterations for the CI columns.",
+    )
+    parser.add_argument(
+        "--bootstrap-seed",
+        type=int,
+        default=11,
+        help="Seed for the bootstrap RNG so the CI numbers reproduce.",
+    )
+    parser.add_argument(
+        "--folds",
+        nargs="+",
+        default=None,
+        help=(
+            "Subset of walk-forward fold IDs to evaluate. Defaults to "
+            "every fold in the package's "
+            "fold_manifest_expanding_walk_forward.json."
+        ),
+    )
+    parser.add_argument(
+        "--cells",
+        nargs="+",
+        default=None,
+        help=(
+            "Subset of cell labels to run (defaults to baseline + "
+            "every per-family cell + the cumulative chain). Useful for "
+            "resuming a partial sweep."
+        ),
+    )
+    parser.add_argument(
+        "--post-350-status",
+        type=str,
+        default="pre-#350",
+        help=(
+            "Caption-level marker recording whether the run was made "
+            "against the pre-#350 or post-#350 feature surface. Stored "
+            "verbatim on the output JSON so the wiki table can cite the "
+            "correct vintage."
+        ),
+    )
+    parser.add_argument(
+        "--text-encoder",
+        type=str,
+        default="finbert_fed_adjacent",
+        help=(
+            "Encoder alias driving the loader's pooled embedding cache. "
+            "Defaults to the canonical FOMC encoder."
+        ),
+    )
+    return parser.parse_args()
+
+
+def _resolve_output_path(arg: Path | None) -> Path:
+    if arg is not None:
+        return arg
+    base = BACKEND_ROOT.parent / "artifacts" / "experiments"
+    base.mkdir(parents=True, exist_ok=True)
+    return base / "per_family_ablation.json"
+
+
+def _resolve_fold_ids(training_package_id: str, override: list[str] | None) -> list[str]:
+    if override:
+        return list(override)
+    from app.training.loaders import _read_fold_manifest, _resolve_training_package_dir
+
+    package_dir = _resolve_training_package_dir(training_package_id)
+    manifest = _read_fold_manifest(package_dir)
+    if not manifest:
+        raise RuntimeError(
+            "fold_manifest_expanding_walk_forward.json is empty / missing "
+            f"for training_package_id={training_package_id!r}; provide "
+            "--folds explicitly."
+        )
+    return sorted(manifest.keys())
+
+
+def _zero_per_bar_market_aux(
+    sequences: list[list[Any]],
+    *,
+    zero_realised_vol: bool,
+    zero_cross_asset: bool,
+) -> None:
+    """Zero per-bar realised-vol / cross-asset FeatureVector attrs in place.
+
+    The loader has no flag for these families (they were fanned out as
+    direct ``FeatureVector`` attributes by PRs #207 / #208), so the
+    runner walks the loaded sequences and overwrites the slices before
+    the per-fold scaler in ``train_model`` sees them. Mirrors the #309
+    pre-scaler-fit pattern.
+    """
+
+    if not (zero_realised_vol or zero_cross_asset):
+        return
+    for sequence in sequences:
+        for fv in sequence:
+            if zero_realised_vol:
+                fv.realized_vol_20d = 0.0
+                fv.realized_vol_60d = 0.0
+            if zero_cross_asset:
+                fv.vix_close = 0.0
+                fv.dxy_close = 0.0
+                fv.tnx_close = 0.0
+                fv.gold_close = 0.0
+                fv.vix3m_close = 0.0
+                fv.irx_close = 0.0
+                fv.vix_term_slope = 0.0
+                fv.yield_curve_slope_10y_3m = 0.0
+
+
+def _trial_metrics(summary: Any) -> dict[str, float | None]:
+    test = getattr(summary, "test_metrics", None) or getattr(summary, "metrics", None)
+    if test is None:
+        return {}
+    return {
+        "regime_f1_macro": getattr(test, "regime_f1_macro", None),
+        "regime_accuracy": getattr(test, "regime_accuracy", None),
+        "regime_loss": getattr(test, "regime_loss", None),
+        "regression_rmse_log_rv": getattr(test, "regression_rmse_log_rv", None),
+        "regression_mae_log_rv": getattr(test, "regression_mae_log_rv", None),
+        "regression_loss": getattr(test, "regression_loss", None),
+    }
+
+
+def _bootstrap_ci(
+    values: list[float],
+    *,
+    samples: int,
+    seed: int,
+    confidence: float = 0.95,
+) -> dict[str, float] | None:
+    finite = [v for v in values if v is not None and math.isfinite(v)]
+    if not finite:
+        return None
+    if len(finite) < 2 or samples <= 0:
+        return {
+            "mean": statistics.fmean(finite),
+            "lo": min(finite),
+            "hi": max(finite),
+            "n": len(finite),
+        }
+    rng = random.Random(seed)
+    means: list[float] = []
+    for _ in range(samples):
+        resampled = [rng.choice(finite) for _ in finite]
+        means.append(statistics.fmean(resampled))
+    means.sort()
+    alpha = (1.0 - confidence) / 2.0
+    lo_idx = max(0, int(math.floor(alpha * len(means))))
+    hi_idx = min(len(means) - 1, int(math.ceil((1.0 - alpha) * len(means))) - 1)
+    return {
+        "mean": statistics.fmean(finite),
+        "lo": means[lo_idx],
+        "hi": means[hi_idx],
+        "n": len(finite),
+    }
+
+
+def _cell_flags(zero_set: frozenset[str]) -> dict[str, bool]:
+    """Translate a set of families-to-zero into loader + post-load flags.
+
+    Returns the kwargs for :func:`load_walk_forward_split` and the two
+    booleans that drive the in-place per-bar zeroing pass. The loader
+    accepts ``use_*`` flags for the document-level families;
+    ``realised_vol`` / ``cross_asset`` ride the post-load walker.
+    """
+
+    return {
+        "loader": {
+            "use_credibility": "credibility" not in zero_set,
+            "use_linguistic": "linguistic" not in zero_set,
+            "use_mp_surprise": "mp_surprise" not in zero_set,
+            "use_multi_axis": "multi_axis" not in zero_set,
+            # Baseline turns LLM features on so the zero_llm cell reads
+            # as a real ablation rather than a no-op (the default loader
+            # path emits llm_features=None on every cell).
+            "use_llm_features": "llm_features" not in zero_set,
+        },
+        "zero_realised_vol": "realised_vol" in zero_set,
+        "zero_cross_asset": "cross_asset" in zero_set,
+    }
+
+
+def _resolve_cells(
+    override: list[str] | None,
+) -> list[tuple[str, frozenset[str]]]:
+    """Build the canonical cell list.
+
+    Order: baseline -> per-family individual zeros (in ``_FAMILIES``
+    order) -> cumulative chain (in ``_CUMULATIVE_CHAIN`` order).
+    """
+
+    cells: list[tuple[str, frozenset[str]]] = [("baseline", frozenset())]
+    for family in _FAMILIES:
+        cells.append((f"zero_{family}", frozenset({family})))
+    for label, families in _CUMULATIVE_CHAIN:
+        cells.append((label, frozenset(families)))
+    if override:
+        allowed = set(override)
+        known_labels = [c[0] for c in cells]
+        cells = [c for c in cells if c[0] in allowed]
+        if not cells:
+            raise ValueError(
+                f"--cells={override!r} did not match any of the "
+                f"known labels: {known_labels}"
+            )
+    return cells
+
+
+def _run_one_cell(
+    cell_label: str,
+    zero_set: frozenset[str],
+    seed: int,
+    args: argparse.Namespace,
+    *,
+    fold_ids: list[str],
+) -> dict[str, Any]:
+    """Train + evaluate one (cell, seed) cell across every fold."""
+
+    from app.models.config import ModelConfig, RICH_FEATURE_SIZE
+    from app.training.loaders import load_walk_forward_split
+    from app.training.loop import train_model
+
+    flags = _cell_flags(zero_set)
+
+    config = ModelConfig(
+        input_size=RICH_FEATURE_SIZE,
+        output_mode="classification",
+        head_mode=str(args.head_mode),
+        regression_alpha=float(args.regression_alpha),
+        n_classes=3,
+        hidden_size=int(args.hidden_size),
+    )
+
+    per_fold: list[dict[str, Any]] = []
+    for fold_id in fold_ids:
+        split = load_walk_forward_split(
+            training_package_id=args.training_package_id,
+            fold_id=fold_id,
+            rich_features=True,
+            text_encoder=str(args.text_encoder),
+            **flags["loader"],
+        )
+        # Pre-scaler-fit zeroing for the per-bar families that the
+        # loader has no flag for. Same contract as #309's
+        # ``_zero_derived_text_features`` rewrite -- the scaler in
+        # ``train_model`` only sees zeros for those columns, so
+        # post-scaling values stay literal 0.
+        _zero_per_bar_market_aux(
+            split.train,
+            zero_realised_vol=flags["zero_realised_vol"],
+            zero_cross_asset=flags["zero_cross_asset"],
+        )
+        _zero_per_bar_market_aux(
+            split.val,
+            zero_realised_vol=flags["zero_realised_vol"],
+            zero_cross_asset=flags["zero_cross_asset"],
+        )
+        _zero_per_bar_market_aux(
+            split.test,
+            zero_realised_vol=flags["zero_realised_vol"],
+            zero_cross_asset=flags["zero_cross_asset"],
+        )
+
+        result = train_model(
+            model_config=config,
+            train_sequence_groups=split.train,
+            val_sequence_groups=split.val,
+            test_sequence_groups=split.test,
+            fold_id=split.fold_id,
+            protocol=split.protocol,
+            epochs=int(args.epochs),
+            seed=int(seed),
+            save_checkpoint=False,
+        )
+        per_fold.append(
+            {
+                "fold_id": split.fold_id,
+                "metrics": _trial_metrics(result.summary),
+            }
+        )
+
+    return {
+        "cell": cell_label,
+        "seed": seed,
+        "zeroed_families": sorted(zero_set),
+        "loader_flags": flags["loader"],
+        "zero_realised_vol": flags["zero_realised_vol"],
+        "zero_cross_asset": flags["zero_cross_asset"],
+        "folds": per_fold,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    output_path = _resolve_output_path(args.output)
+    print(f"[per_family_ablation] writing -> {output_path}")
+
+    fold_ids = _resolve_fold_ids(args.training_package_id, args.folds)
+    print(f"[per_family_ablation] folds={fold_ids}")
+
+    cells = _resolve_cells(args.cells)
+    print(f"[per_family_ablation] cells={[c[0] for c in cells]}")
+
+    trials: dict[str, list[dict[str, Any]]] = {}
+    for cell_label, zero_set in cells:
+        print(
+            f"[per_family_ablation] >>> cell={cell_label} "
+            f"zeroed={sorted(zero_set) or '[]'}",
+            flush=True,
+        )
+        cell_trials: list[dict[str, Any]] = []
+        for seed in args.seeds:
+            print(
+                f"[per_family_ablation] {cell_label} seed={seed} "
+                f"epochs={args.epochs}",
+                flush=True,
+            )
+            cell_trials.append(
+                _run_one_cell(
+                    cell_label,
+                    zero_set,
+                    seed,
+                    args,
+                    fold_ids=fold_ids,
+                )
+            )
+        trials[cell_label] = cell_trials
+
+    summary: dict[str, dict[str, Any]] = {}
+    for cell_label, cell_trials in trials.items():
+        f1_values: list[float] = []
+        rmse_values: list[float] = []
+        for trial in cell_trials:
+            for fold in trial["folds"]:
+                metrics = fold.get("metrics", {}) or {}
+                f1 = metrics.get("regime_f1_macro")
+                if f1 is not None:
+                    f1_values.append(float(f1))
+                rmse = metrics.get("regression_rmse_log_rv")
+                if rmse is not None:
+                    rmse_values.append(float(rmse))
+        summary[cell_label] = {
+            "regime_f1_macro": _bootstrap_ci(
+                f1_values,
+                samples=args.bootstrap_samples,
+                seed=args.bootstrap_seed,
+            ),
+            "regression_rmse_log_rv": _bootstrap_ci(
+                rmse_values,
+                samples=args.bootstrap_samples,
+                seed=args.bootstrap_seed,
+            ),
+        }
+
+    payload: dict[str, Any] = {
+        "families": list(_FAMILIES),
+        "cells": [c[0] for c in cells],
+        "seeds": list(args.seeds),
+        "fold_ids": fold_ids,
+        "epochs": int(args.epochs),
+        "hidden_size": int(args.hidden_size),
+        "head_mode": str(args.head_mode),
+        "regression_alpha": float(args.regression_alpha),
+        "bootstrap_samples": int(args.bootstrap_samples),
+        "bootstrap_seed": int(args.bootstrap_seed),
+        "training_package_id": args.training_package_id,
+        "text_encoder": str(args.text_encoder),
+        "post_350_status": str(args.post_350_status),
+        "cumulative_chain": [
+            {"label": label, "families": list(families)}
+            for label, families in _CUMULATIVE_CHAIN
+        ],
+        "trials": trials,
+        "summary": summary,
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, default=str))
+    print(f"[per_family_ablation] wrote {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #334.

- `scripts/run_per_family_ablation.py` + `make per-family-ablation` Make target. Runs the canonical training-package + walk-forward fold protocol under 11 cells: a baseline + seven per-family individual-zero cells (linguistic / credibility / mp_surprise / multi_axis / realised_vol / cross_asset / llm_features) + a three-step cumulative chain. Default head mode `dual` with `regression_alpha=0.5`, five official seeds, every fold from the package manifest.
- Pre-scaler-fit zeroing for every family — same ordering #309's `_zero_derived_text_features` used. Document-level families ride existing `use_*` flags on `load_walk_forward_split`; the two per-bar families (realised-vol horizons, cross-asset closes) ride an in-place per-sequence walker that overwrites those slots before the split is passed to `train_model`.
- Output JSON: `backend/artifacts/experiments/per_family_ablation.json` (pooled macro-F1 + 95% block-bootstrap CI per cell, regression-band RMSE on `log(RV)`, `post_350_status` marker for the table caption).
- Wiki §0 lead paragraph in `06_Deep_Learning_Roadmap.md`: rich market features dominate (~15pp Tier 1 → Tier 2), text contribution is small (~4pp) and substitutable, NLP + LLM stacked is -3pp negative interaction. Framed as methodology.
- Wiki §6.19 per-family ablation table scaffolded; cells populate from `summary.<cell>.regime_f1_macro` once the runner has emitted JSON against the canonical training package.
- Wiki §16 wording softened from "Fed-watcher product" → "small but real text lift on top of dominant market features." §12 ADR table untouched (no ADR; reporting/framing change only). §13 burn-down row #334 flipped to `in progress`.

## #350 coupling

The pre-#350 surface still has `mp_surprise_*` / `fed_info_factor` reading from a `[T-1, T+1]` window. The runner emits `post_350_status: "pre-#350"` on the payload by default; pass `--post-350-status post-#350` after #350 lands. If the post-#350 per-family direction flips materially, gate the §6.19 table on the post-#350 rerun.

## Reviewer focus

- Runner uses `load_walk_forward_split` + `train_model` on the same canonical training package and protocol as `canonical-comparison` / `text-path-ab`, so its numbers are comparable to §6.3 / §6.15.
- Zeroing happens before the per-fold scaler fit (loader flags emit literal 0.0 into the per-bar slice; in-place walker overwrites the `FeatureVector` attributes before the split is handed to `train_model`). Same contract #309 used.
- The substitution claim in §0 cites the §6.3 tier table directly and does not depend on the per-family numbers. The per-family table refines the framing; if directionally opposite, revise §0 lead.
- §16 wording: honest "small but real text lift" reading without underselling the methodological decomposition.