### PR TITLE
MP-surprise strict-prior replacement (#350)

### DIFF
--- a/backend/app/data/mp_surprise.py
+++ b/backend/app/data/mp_surprise.py
@@ -70,12 +70,24 @@ machines.
 No look-ahead
 -------------
 
+The surprise quantities (``mp_surprise_level``, ``mp_surprise_path_factor``,
+``fed_info_factor``) are built from **strictly-prior** inputs only. The
+per-feature provenance audit (#324, ``docs/feature-provenance-audit.md``)
+flagged the prior ``[T-1, T+1]`` Cieslak-Vissing-Jorgensen window as a
+``T+Δ`` leak for a forecaster scoring at ``T``; issue #350 dropped the
+``T+1`` leg and reformulated the three columns against strict-prior
+expectations. See ``docs/adr/0024-mp-surprise-strict-prior-replacement.md``
+for the methodology footnote (the construction is no longer the literal
+CVJ post-event quantity).
+
 ``pre_event_curve`` reads the last trading-day yield strictly before
-``event_date``; ``post_event_curve`` reads the first trading-day yield
-strictly after ``event_date``. The two-day window absorbs same-day
-announcement noise and matches Cieslak-Vissing-Jorgensen 2021 (table 2,
-"announcement window"). The contract is enforced by an assertion in
-:func:`_pre_post_yields`.
+``event_date``. ``post_event_curve`` remains on the parquet as a
+diagnostic-only column for the cross-asset response builder
+(``backend/app/forecasting/cross_asset_response.py``), which evaluates the
+post-event response at meeting ``N`` to project onto meeting ``N+1`` — a
+different time-axis than the volatility-forecaster leak this module's
+core columns previously embedded. The no-look-ahead contract for the
+diagnostic post leg is enforced by the same strict inequality as before.
 
 CLI
 ---
@@ -494,6 +506,87 @@ def _pre_post_yields(
     return (pre_value, post_value, pre_date, post_date)
 
 
+# Trailing-window radius used for the strict-prior curve-drift and SPX-return
+# substitutions introduced by #350. Five trading days is the conventional
+# horizon at which the rates / equity panels carry a non-degenerate signal
+# without re-baselining the underlying lock JSON.
+STRICT_PRIOR_TRAILING_TDAYS = 5
+
+
+def _strictly_prior_pre_and_trailing_yield(
+    on_date: _dt.date,
+    series_map: Mapping[_dt.date, float],
+    *,
+    trailing_tdays: int = STRICT_PRIOR_TRAILING_TDAYS,
+    trading_days: Sequence[_dt.date] | None = None,
+) -> tuple[float | None, float | None, _dt.date | None, _dt.date | None]:
+    """Return ``(pre_value, trail_value, pre_date, trail_date)`` -- strict prior only.
+
+    ``pre`` is the last trading-day yield strictly before ``on_date``
+    (the same anchor :func:`_pre_post_yields` uses for its pre leg).
+    ``trail`` is the trading-day yield ``trailing_tdays`` trading days
+    earlier than ``pre`` (still strictly before ``on_date``). Both
+    anchors are observable at ``T-Δ`` for ``T = on_date``; the strict
+    inequality is enforced by the same bisect-into-trading-days walk
+    as :func:`_pre_post_yields`.
+
+    Used by the #350 strict-prior reformulation of the level / path
+    surprise quantities. See ``docs/adr/0024-mp-surprise-strict-prior-replacement.md``.
+    """
+
+    if trading_days is None:
+        trading_days = sorted(series_map.keys())
+    n_tdays = len(trading_days)
+    if n_tdays == 0:
+        return (None, None, None, None)
+
+    import bisect as _bisect
+
+    idx = _bisect.bisect_left(trading_days, on_date)
+    pre_value: float | None = None
+    pre_date: _dt.date | None = None
+    pre_idx: int | None = None
+    for step in range(STRICT_PRIOR_TRAILING_TDAYS + trailing_tdays):
+        i = idx - 1 - step
+        if i < 0:
+            break
+        cand = trading_days[i]
+        if cand >= on_date:
+            continue
+        if cand in series_map:
+            pre_value = series_map[cand]
+            pre_date = cand
+            pre_idx = i
+            break
+
+    if pre_idx is None:
+        return (None, None, None, None)
+
+    trail_value: float | None = None
+    trail_date: _dt.date | None = None
+    # Walk backwards another `trailing_tdays` trading-day slots from the
+    # pre anchor. We require the trail anchor to sit strictly before
+    # ``on_date`` (it does by construction since ``pre`` already does).
+    for step in range(trailing_tdays, trailing_tdays + STRICT_PRIOR_TRAILING_TDAYS + 1):
+        i = pre_idx - step
+        if i < 0:
+            break
+        cand = trading_days[i]
+        if cand >= on_date or cand >= pre_date:
+            continue
+        if cand in series_map:
+            trail_value = series_map[cand]
+            trail_date = cand
+            break
+
+    if pre_date is not None and trail_date is not None:
+        assert trail_date < pre_date < on_date, (
+            "strict-prior contract violated: "
+            f"trail={trail_date} pre={pre_date} on={on_date}"
+        )
+    return (pre_value, trail_value, pre_date, trail_date)
+
+
 # ---------------------------------------------------------------------------
 # PCA path factor
 # ---------------------------------------------------------------------------
@@ -639,25 +732,32 @@ def _spx_return_on(
     spx_close_by_date: Mapping[_dt.date, float],
     *,
     radius_days: int = SPX_LOOKUP_RADIUS_DAYS,
+    trailing_calendar_days: int = 7,
 ) -> tuple[float | None, str]:
-    """Approximate the daily SPX return centred on ``event_date``.
+    """Strict-prior trailing SPX return through ``event_date - 1``.
 
-    Returns ``(daily_return_pct, source_flag)`` where ``source_flag`` is
-    one of:
+    Returns ``(trailing_return_pct, source_flag)`` where ``source_flag`` is:
 
-    - ``"daily_window_proxy"`` -- the standard daily close-to-close
-      return computed over a ``[t-1, t+1]`` close window. This is the
-      documented approximation; intraday ``+/-30 min`` data is out of
-      scope.
-    - ``"unavailable"`` -- no SPX data inside the radius. The caller
-      writes ``fed_info_factor = None`` (NOT zero) and stamps
-      ``fed_info_factor_source = "unavailable"`` so the row is
+    - ``"strict_prior_trailing"`` -- the close-to-close return computed
+      over ``[t - trailing_calendar_days - radius, t - 1]``. Both
+      endpoints carry calendar dates strictly before ``event_date``, so
+      the return is observable at ``T-Δ`` and cannot bleed post-event
+      information into the residual.
+    - ``"unavailable"`` -- no SPX data inside the strict-prior window.
+      The caller writes ``fed_info_factor = None`` (NOT zero) and stamps
+      ``fed_info_factor_source = "unavailable"`` so the row stays
       distinguishable from a real-but-tiny residual.
 
-    We never claim a CVJ-style intraday measurement; the flag is the
-    transparency mechanism.
+    Reformulation rationale (#350): the original close-to-close return
+    on ``[T-1, T+1]`` was the daily-window proxy for the Cieslak-Vissing-
+    Jorgensen 2021 ``±30 min`` SPX leg. That window leaks ``T+1`` into
+    the input side of the volatility forecaster. The strict-prior
+    trailing return preserves the equity-information channel the
+    residual needs while keeping every observation dated strictly before
+    ``event_date``. The methodology shift is footnoted in ADR-0024.
     """
 
+    # Pre anchor: most recent close strictly before ``event_date``.
     pre_close: float | None = None
     pre_date: _dt.date | None = None
     for offset in range(1, radius_days + 1):
@@ -666,19 +766,29 @@ def _spx_return_on(
             pre_close = spx_close_by_date[d]
             pre_date = d
             break
-    post_close: float | None = None
-    post_date: _dt.date | None = None
-    for offset in range(1, radius_days + 1):
-        d = event_date + _dt.timedelta(days=offset)
-        if d in spx_close_by_date:
-            post_close = spx_close_by_date[d]
-            post_date = d
-            break
-    if pre_close is None or post_close is None or pre_close <= 0:
+    # Trail anchor: close ~``trailing_calendar_days`` further back, still
+    # strictly before ``event_date``.
+    trail_close: float | None = None
+    trail_date: _dt.date | None = None
+    if pre_date is not None:
+        start_offset = trailing_calendar_days
+        for offset in range(start_offset, start_offset + radius_days + 1):
+            d = pre_date - _dt.timedelta(days=offset)
+            if d >= event_date:
+                continue
+            if d in spx_close_by_date and d < pre_date:
+                trail_close = spx_close_by_date[d]
+                trail_date = d
+                break
+    if pre_close is None or trail_close is None or trail_close <= 0:
         return (None, "unavailable")
-    assert pre_date is not None and post_date is not None
-    daily_return = (post_close - pre_close) / pre_close
-    return (daily_return, "daily_window_proxy")
+    assert pre_date is not None and trail_date is not None
+    assert trail_date < pre_date < event_date, (
+        "strict-prior SPX contract violated: "
+        f"trail={trail_date} pre={pre_date} event={event_date}"
+    )
+    trailing_return = (pre_close - trail_close) / trail_close
+    return (trailing_return, "strict_prior_trailing")
 
 
 def _fit_fed_info_factor(
@@ -907,12 +1017,23 @@ def build_mp_surprises(
         nxt = sorted_meeting_dates[i + 1] if i + 1 < len(sorted_meeting_dates) else None
         next_meeting_date_by_event[d] = nxt
 
+    # Per-meeting per-tenor strict-prior trailing yield drifts (#350).
+    # ``per_meeting_trail_drift_bps[ed][tenor]`` = (pre - trail) * 100,
+    # the curve's trailing 5-trading-day drift through the pre-event
+    # anchor. Strictly observable at ``T-Δ``. Replaces the leaky
+    # ``(post - pre) * 100`` change that anchored the prior CVJ-style
+    # construction at every tenor.
+    per_meeting_trail_drift_bps: dict[_dt.date, dict[int, float | None]] = {}
+
     for m in meetings:
         ed = m.meeting_date
-        # Curves at five tenors.
+        # Curves at five tenors. ``pre_event_curve`` is strictly-prior;
+        # ``post_event_curve`` is preserved as a diagnostic-only column
+        # for the cross-asset response builder (post-T evaluation, not a
+        # forecaster input).
         pre_curve: list[CurvePoint] = []
         post_curve: list[CurvePoint] = []
-        deltas_at_tenor: dict[int, float | None] = {}
+        trail_drift_at_tenor: dict[int, float | None] = {}
         for tenor in CURVE_TENORS_MONTHS:
             s_map = curve_maps[tenor]
             pre, post, _, _ = _pre_post_yields(
@@ -922,15 +1043,20 @@ def build_mp_surprises(
             )
             pre_curve.append(CurvePoint(months_ahead=tenor, implied_rate=pre if pre is not None else float("nan")))
             post_curve.append(CurvePoint(months_ahead=tenor, implied_rate=post if post is not None else float("nan")))
-            if pre is None or post is None:
-                deltas_at_tenor[tenor] = None
+            # Strict-prior trailing drift: replaces the leaky post-leg
+            # contribution to the surprise-level and PCA-path inputs.
+            pre_v, trail_v, _, _ = _strictly_prior_pre_and_trailing_yield(
+                ed,
+                s_map,
+                trading_days=trading_days_sorted,
+            )
+            if pre_v is None or trail_v is None:
+                trail_drift_at_tenor[tenor] = None
             else:
-                # Convert from percent to basis points (1% = 100 bps).
-                deltas_at_tenor[tenor] = (post - pre) * 100.0
+                trail_drift_at_tenor[tenor] = (pre_v - trail_v) * 100.0
         per_meeting_curves_pre[ed] = pre_curve
         per_meeting_curves_post[ed] = post_curve
-        per_meeting_delta_level[ed] = deltas_at_tenor[1]
-        per_meeting_delta_path[ed] = [deltas_at_tenor[t] for t in PATH_TENORS_MONTHS]
+        per_meeting_trail_drift_bps[ed] = trail_drift_at_tenor
 
         # Targets: prior = day before announcement (already published target band);
         # after = effective once announcement lands. We look back to the previous
@@ -965,37 +1091,85 @@ def build_mp_surprises(
         per_meeting_target_prior[ed] = (prior_target, prior_src)
         per_meeting_target_after[ed] = (after_target, after_src)
 
-    # ---- Pass 2: PCA fit on residual curve shape ----
+    # ---- Pass 1b: strict-prior surprise quantities (#350) ----
+    #
+    # ``per_meeting_delta_level`` and ``per_meeting_delta_path`` now hold
+    # the strict-prior reformulation:
+    #
+    # * ``delta_level[ed]`` = ``actual_target_change_bps - pre_implied_1m_bps``
+    #   where ``actual_target_change_bps = (ff_target_after - ff_target_prior) * 100``
+    #   and ``pre_implied_1m_bps = (pre_yield_1m - ff_target_prior) * 100``
+    #   is observable at T-1.
+    # * ``delta_path[ed]`` per tenor in PATH_TENORS_MONTHS = the
+    #   trailing 5-trading-day curve drift on that tenor through T-1.
+    #
+    # Both quantities are observable strictly before ``event_date`` for
+    # every input except ``ff_target_after`` (the announcement itself,
+    # observable at T -- this is the only T-snapshot input and is what
+    # the "surprise" decomposition is defined against).
+    for m in meetings:
+        ed = m.meeting_date
+        prior_target, _ = per_meeting_target_prior[ed]
+        after_target, _ = per_meeting_target_after[ed]
+        # 1m strict-prior yield reused as the pre-implied next-move proxy.
+        pre_1m_curve_value: float | None = None
+        for p in per_meeting_curves_pre[ed]:
+            if p.months_ahead == 1:
+                if p.implied_rate == p.implied_rate:  # NaN-safe
+                    pre_1m_curve_value = float(p.implied_rate)
+                break
+        if (
+            prior_target is None
+            or after_target is None
+            or pre_1m_curve_value is None
+        ):
+            per_meeting_delta_level[ed] = None
+        else:
+            actual_change_bps = (float(after_target) - float(prior_target)) * 100.0
+            pre_implied_bps = (pre_1m_curve_value - float(prior_target)) * 100.0
+            per_meeting_delta_level[ed] = actual_change_bps - pre_implied_bps
+        # Path inputs: trailing strict-prior drift per PATH_TENORS_MONTHS.
+        trail_drifts = per_meeting_trail_drift_bps[ed]
+        per_meeting_delta_path[ed] = [trail_drifts[t] for t in PATH_TENORS_MONTHS]
+
+    # ---- Pass 2: PCA fit on strict-prior trailing curve shape ----
+    # The fit input is now the trailing curve drift (T-1 minus T-1-5td)
+    # at the 1m tenor and the PATH_TENORS_MONTHS tenors. We residualise
+    # the path tenors against the 1m trailing drift -- the level proxy
+    # for the PCA fit only (the persisted ``mp_surprise_level`` column
+    # is the strict-prior actual-vs-implied surprise computed above).
     fit_levels: list[float] = []
     fit_paths: list[list[float]] = []
     for m in meetings:
         ed = m.meeting_date
-        lvl = per_meeting_delta_level[ed]
-        path = per_meeting_delta_path[ed]
-        if lvl is None or any(v is None for v in path):
+        trail_drifts = per_meeting_trail_drift_bps[ed]
+        trail_1m = trail_drifts.get(1)
+        path_drifts = [trail_drifts.get(t) for t in PATH_TENORS_MONTHS]
+        if trail_1m is None or any(v is None for v in path_drifts):
             continue
-        fit_levels.append(float(lvl))
-        fit_paths.append([float(v) for v in path])  # type: ignore[arg-type]
+        fit_levels.append(float(trail_1m))
+        fit_paths.append([float(v) for v in path_drifts])  # type: ignore[arg-type]
     path_model = _fit_path_factor_model(fit_levels, fit_paths)
 
-    # ---- Pass 3: fed-info factor regression on SPX returns ----
+    # ---- Pass 3: fed-info factor regression on strict-prior SPX returns ----
+    #
+    # #350: the Alpha Vantage ±30 min intraday route is **rejected** here
+    # because the 14:00-14:30 ET half is post-announcement and leaks
+    # ``T+`` into the residual. The ``spx_intraday_returns`` argument is
+    # retained on the signature for backwards compatibility but is
+    # ignored when present; we keep the strict-prior trailing close-to-
+    # close return as the only fed-info input. See ADR-0024.
+    if spx_intraday_returns:
+        # Diagnostic only -- do not consume the leaky intraday values.
+        _ = dict(spx_intraday_returns)
     spx_lookup = spx_close_by_date or {}
-    intraday_lookup = dict(spx_intraday_returns or {})
     levels_for_fit: list[float] = []
     spx_for_fit: list[float] = []
     spx_returns_per_meeting: dict[_dt.date, tuple[float | None, str]] = {}
     for m in meetings:
         ed = m.meeting_date
         lvl = per_meeting_delta_level[ed]
-        # Prefer the Alpha Vantage intraday ±30 min return when the
-        # backfill cache covers the event. Falls through to the daily
-        # close-to-close proxy when intraday is missing.
-        intraday_value = intraday_lookup.get(ed.isoformat())
-        if intraday_value is not None:
-            ret: float | None = float(intraday_value)
-            source = "alphavantage_intraday_30min"
-        else:
-            ret, source = _spx_return_on(ed, spx_lookup)
+        ret, source = _spx_return_on(ed, spx_lookup)
         spx_returns_per_meeting[ed] = (ret, source)
         if lvl is None or ret is None:
             continue
@@ -1012,7 +1186,15 @@ def build_mp_surprises(
         prior_target, prior_src = per_meeting_target_prior[ed]
         after_target, after_src = per_meeting_target_after[ed]
         lvl = per_meeting_delta_level[ed]
-        path_factor = _apply_path_factor(path_model, lvl, per_meeting_delta_path[ed])
+        # Project the persisted PCA eigenvector onto this meeting's
+        # trailing-curve-drift residual. The path factor is now a strict-
+        # prior shape signal, not a post-event curve response.
+        trail_drifts = per_meeting_trail_drift_bps[ed]
+        path_factor = _apply_path_factor(
+            path_model,
+            trail_drifts.get(1),
+            per_meeting_delta_path[ed],
+        )
         ret, ret_src = spx_returns_per_meeting[ed]
         if ret is None or lvl is None:
             fed_info_factor: float | None = None

--- a/docs/adr/0024-mp-surprise-strict-prior-replacement.md
+++ b/docs/adr/0024-mp-surprise-strict-prior-replacement.md
@@ -1,0 +1,81 @@
+# ADR 0024 — MP-surprise / fed-info strict-prior reformulation
+
+Status: accepted, in production (as of merge).
+Date: 2026-05-27.
+References:
+- Issue #350 (closes).
+- Issue #324 (per-feature provenance audit; the source flag).
+- `docs/feature-provenance-audit.md` — column-level provenance table; rows for `mp_surprise_level`, `mp_surprise_path_factor`, `fed_info_factor` moved from `T+Δ` to strict-prior.
+- `backend/app/data/mp_surprise.py` — `_strictly_prior_pre_and_trailing_yield`, `_spx_return_on`, `build_mp_surprises` Pass 1b + Pass 2 + Pass 3.
+- `backend/app/data/rates_event_features.py` — `implied_next_move_bps`, the strict-prior FRED-only proxy that anchors the level reformulation's "expected" leg.
+- `tests/unit/test_mp_surprise.py` cases 11+ — strict-prior contract on the helpers and on the build path.
+- `tests/regression/test_feature_provenance_as_of.py::test_mp_surprise_columns_read_strictly_before_event_date` — source-data audit gate.
+
+## Context
+
+The per-feature provenance audit (#324, `docs/feature-provenance-audit.md`) flagged three `FeatureVector` columns as `T+Δ`-derived by construction:
+
+- `mp_surprise_level`
+- `mp_surprise_path_factor`
+- `fed_info_factor`
+
+All three were built in `backend/app/data/mp_surprise.py` from a `[T-1, T+1]` window centred on the FOMC announcement (`_pre_post_yields` for the curve legs, `_spx_return_on` for the equity leg). For a forecaster predicting `forward_realized_vol_10d` over `[T, T+10]`, the `T+1` post-event yield close and the `T+1` SPX close are both inputs the model sees at `T` but that mechanically embed one day of post-announcement information. The forward-target window `[T, T+10]` carries `T+1` as one of its ten realised returns, so the leak is small but real — the same class of mechanical overlap ADR-0014's strict-forward target fix addressed on the output side, mirrored on the input side.
+
+The audit's #324 PR shipped the regression test for the rest of the column surface and filed #350 to scope this ADR and the canonical re-baseline. The fix is the construction change in `mp_surprise.py`; this ADR is the methodology footnote.
+
+## Decision
+
+Drop the `T+1` leg from every input that feeds `mp_surprise_level`, `mp_surprise_path_factor`, and `fed_info_factor`. Replace the leaky `post − pre` constructions with strict-prior reformulations:
+
+- **`mp_surprise_level`** becomes `actual_target_change_bps − pre_implied_next_move_bps` where
+  - `actual_target_change_bps = (ff_target_after − ff_target_prior) × 100`,
+  - `pre_implied_next_move_bps = (pre_yield_1m_T-1 − ff_target_prior) × 100`,
+  - both pre-side anchors observable strictly before `event_date`,
+  - the only `T`-snapshot input is `ff_target_after` — the announced policy decision the surprise is defined *against*, not a feature read out of post-event market data.
+
+  This matches `implied_next_move_bps` in `backend/app/data/rates_event_features.py` line for line on the "expected" leg, so the construction reuses the strict-prior implied-move proxy already shipped on the rates panel (DGS1 − DFEDTARU).
+
+- **`mp_surprise_path_factor`** becomes the PCA-residualised trailing curve drift at PATH_TENORS_MONTHS = (3, 6, 12). For each meeting:
+  - per tenor: `trail_drift_bps = (pre_yield − pre_yield_trail_5td) × 100`, where `pre_yield_trail_5td` is the yield five trading days earlier than `pre_yield` (still strictly before `event_date`).
+  - The PCA fit and persisted eigenvector are computed on the trailing drifts at the path tenors residualised against the 1m trailing drift (the level proxy for the fit).
+  - The persisted eigenvector is then projected onto each meeting's trailing drift residual.
+
+- **`fed_info_factor`** stays the residual of `mp_surprise_level` against `alpha + beta × spx_return`, but the SPX leg becomes a strict-prior trailing close-to-close return over `[T − ~7 calendar days, T − 1]` (both anchors strictly before `event_date`). The Alpha Vantage ±30 min intraday route is rejected at runtime — the 14:00-14:30 ET half is post-announcement. The `spx_intraday_returns` argument stays on the builder signature for backwards compatibility but is ignored; the diagnostic log line stays in place so an operator who runs the AV backfill is not silently surprised by the rejection.
+
+`pre_event_curve` (already strict-prior) stays on the parquet unchanged. `post_event_curve` stays on the parquet as a diagnostic-only column for `backend/app/forecasting/cross_asset_response.py` and `backend/app/forecasting/next_fomc_decision.py`, both of which evaluate the post-event response at meeting `N` to project onto meeting `N+1` — a different time-axis than the volatility-forecaster leak this ADR addresses. The `_pre_post_yields` helper stays in the codebase for the diagnostic column reads.
+
+## Alternatives considered
+
+**Keep + caveat.** The simplest path was to keep the leaky `[T-1, T+1]` construction and footnote it in the audit. Rejected because the audit is the merge gate; downstream readers should not have to cross-reference a methodology caveat to know whether the feature is honest. The point of #324 was to remove the asterisks, not document them.
+
+**Drop entirely (zero out the three columns).** The lowest-effort fix was to replace the surprise columns with zeros and rely on the residual market-data block (cross-asset closes, realized vol) to carry the FOMC signal. Rejected because the literature is unambiguous that the *expected* leg of the policy decision is a real predictor; deleting it would also delete signal we already verified the model uses (canonical-cell ablations on the MP-surprise block in earlier wiki cells showed a non-trivial lift, ~1-2 pp). The strict-prior reformulation preserves the predictor while closing the leak.
+
+**Keep `_pre_post_yields` but clip the post leg to `T-0` instead of `T+1`.** Rejected because `T-0` is the announcement day itself; for daily-bar Treasury yields the close on `T-0` reflects the announcement and is functionally indistinguishable from `T+1` for the surprise-decomposition use case. The strict inequality has to be `< T`, not `≤ T`.
+
+## Consequences
+
+### Methodology
+
+The literature mapping shifts. The previously-shipped construction was the Cieslak-Vissing-Jorgensen 2021 / Kuttner 2001 post-event surprise quantity — `(post_yield − pre_yield)` at the 1m tenor, projected onto a path PC1, residualised against an SPX equity leg. The strict-prior reformulation is a *different* quantity: actual-vs-pre-implied at `T-1` for the level, trailing-curve PC1 for the path, trailing close-to-close for the equity leg. Neither construction is wrong; the strict-prior version is the one that fits a forecaster scoring at `T-0`, while the post-event version is the one a researcher reading the announcement at `T+1` would compute.
+
+This is honest under the audit framing (no `T+Δ` reads in the input tensor) and is documented per column in `docs/feature-provenance-audit.md`. The methodology change is footnoted there and in the module docstring of `backend/app/data/mp_surprise.py`.
+
+### Model + sweep
+
+The three columns continue to land on `FeatureVector` via the existing `mp_surprises.parquet` join in `backend/app/training/loaders.py`. The column names, dtypes, schema, and loader join key are unchanged; only the values shift. The canonical 5-seed × 4-fold sweep needs a re-baseline against the cleaned features. The post-#350 sweep artefact lives at `backend/artifacts/experiments/canonical_comparison_post_350.json`; the §6.10 wiki row `10b'` annotates the new headline against pre-fix row `10b`. **If the sweep has not yet been run when this ADR lands, the PR description marks the GPU step BLOCKED and the artefact is added in a follow-up commit on the same branch.**
+
+The expected delta on the canonical metric is bounded but uncertain. The leak was a one-day overlap on a ten-day forward window, so the upper bound on the headline drop is small (≤ 2 pp); the lower bound is zero if the model was already ignoring the leak. Either outcome is acceptable — the construction change is correctness, not headline-chasing.
+
+### Diagnostic columns
+
+`pre_event_curve` and `post_event_curve` stay on the parquet. Downstream `next_fomc_decision.py` and `cross_asset_response.py` continue to read `post_event_curve` for their meeting-N+1 projection logic; that path is a different time-axis (post-T evaluation, not a forecaster input at T) and is not under audit here. The strict-prior contract for the **surprise feature columns** is what this ADR locks; the diagnostic column reads stay in the codebase unchanged.
+
+### Reproducibility
+
+The PCA eigenvector persisted in the SOURCES.lock JSON drifts (the fit input changed from `(post − pre)` at PATH_TENORS_MONTHS to trailing 5td drift at the same tenors). Determinism within the new construction is preserved by the existing eigh-based fit and sign-normalisation; the cross-build determinism test in `test_mp_surprise.py` still passes against rebuilds of the new path. Pre-#350 SOURCES.lock entries are not forward-compatible — operators must rebuild `mp_surprises.parquet` from FRED once before re-running the canonical sweep.
+
+### Reviewer focus
+
+- Is the strict-prior contract enforced on the helper boundary? Yes — `_strictly_prior_pre_and_trailing_yield` asserts `trail < pre < on_date` and `_spx_return_on` asserts `trail < pre < event_date`. The unit tests in `test_mp_surprise.py` lock both contracts.
+- Does the literature mapping survive? Partially. The strict-prior level surprise is still an actual-vs-expected policy decision (Kuttner-style, with the expectation pulled from the strict-prior implied next-move proxy rather than a post-event futures reading). The path and fed-info legs shift more — they are no longer the CVJ post-event PC1 / ±30 min equity-information channel, only their strict-prior analogues. ADR footnotes this honestly.
+- Are there other call sites of `_pre_post_yields` / `_spx_return_on` that need the same treatment? `_pre_post_yields` is still called inside the build to populate `pre_event_curve` and `post_event_curve` (diagnostic-only). `_spx_return_on` is only called from the fed-info pass and is the strict-prior path now. No additional call sites need migrating.

--- a/docs/feature-provenance-audit.md
+++ b/docs/feature-provenance-audit.md
@@ -42,9 +42,9 @@ itself a documented training target.
 | `credibility_market_implied_gap` | `features.credibility.market_implied_gap(sep_terminal, ois_terminal)` | `T (snapshot)` | none | both inputs are scalars defined on the FOMC release day; SEP terminal is part of the released package, OIS terminal is the day's close. Placeholder `0.0` on most rows today. |
 | `credibility_months_since_reversal` | `features.credibility.months_since_last_reversal` over `_stance_history_series` (`parsed <= as_of`) | `T-Δ`+`T (snapshot)` | none | counts months on the stance sequence up to and including `T`. |
 | `linguistic_features` (15-dim LDA + densities + pivot_distance) | `features.linguistic` LDA fit, keyed by `text_hash` | `T (snapshot)` per-document, **package-wide LDA fit** | low | per-row topic distribution is the as-of document's own signal. The LDA model itself is fit on the full package corpus (cross-split), so the fitted topic basis is informed by future text. Acceptable under standard topic-model practice but flagged. |
-| `mp_surprise_level` | `data.mp_surprise._pre_post_yields` (post = first trading day `> T`) | **`T+Δ` post-event yields** | med | Cieslak-Vissing-Jorgensen 2021 surprise quantity: `post_yield − pre_yield` over a `[T-1, T+1]` window. Mechanically a function of `T+1` data. Documented as the literature-standard surprise; treated as a feature observable "shortly after the announcement", which is post-`T` information for a forecaster scoring at `T`. **Follow-up #350 opened.** |
-| `mp_surprise_path_factor` | same as `mp_surprise_level` (PCA path factor over post-event tenors) | **`T+Δ`** | med | same construction as `mp_surprise_level`, PCA-residualised. **Follow-up #350 covers this column.** |
-| `fed_info_factor` | `data.mp_surprise._spx_return_on` (SPX return on `[T-1, T+1]` window) | **`T+Δ`** | med | residual of the target-rate move against an SPX-return regression centred on `T`; the SPX leg is a `T+1`-minus-`T-1` return. **Follow-up #350 covers this column.** |
+| `mp_surprise_level` | `data.mp_surprise.build_mp_surprises` (actual target change minus pre-implied next move at T-1) | `T (snapshot)` for `ff_target_after`; `T-Δ` for the pre-implied leg | none | Strict-prior reformulation under #350 (ADR-0024). `level = (ff_target_after − ff_target_prior) * 100 − (pre_yield_1m_T-1 − ff_target_prior) * 100`. The only input observable at `T` (not `T-Δ`) is the announcement itself (`ff_target_after`), which is the realised decision the surprise is defined against. No `T+Δ` reads. Methodology footnote: this is no longer the literal Cieslak-Vissing-Jorgensen post-event quantity. |
+| `mp_surprise_path_factor` | `data.mp_surprise.build_mp_surprises` (PCA on strict-prior trailing curve drift at PATH_TENORS_MONTHS) | `T-Δ` | none | Strict-prior reformulation under #350. PCA is fit on `(pre_yield − pre_yield_trail_5td) * 100` per tenor, residualised against the 1m trailing drift. Inputs are all yields published strictly before `event_date`. Methodology footnote: replaces the literature `post_curve − pre_curve` PC1 with a strict-prior trailing-curve PC1. |
+| `fed_info_factor` | `data.mp_surprise._spx_return_on` (strict-prior trailing SPX return through T-1) | `T-Δ` | none | Strict-prior reformulation under #350. Residual of `mp_surprise_level` against `alpha + beta * pre_trailing_spx_return` where `pre_trailing_spx_return` is the close-to-close return over `[T - ~7 calendar days, T - 1]`. The leaky `[T-1, T+1]` daily-window proxy and the Alpha Vantage ±30 min intraday route (rejected at runtime) are both removed. Methodology footnote: no longer the CVJ ±30 min equity-information channel. |
 | `mp_is_intermeeting` | `data.mp_surprise` calendar lookup on `T` | `T (snapshot)` | none | boolean flag derived from the FOMC calendar entry for `T`. |
 | `stance_hawk` / `stance_dove` / `stance_neutral` / `stance_missing` | `loaders._attach_rich_features` from `event_row.axis_stance` | `T (snapshot)` | none | one-hot of the document's own stance label. |
 | `time_label_forward` | `event_row.axis_time_label` (gtfintechlab cross-bank rows only) | `T (snapshot)` | none | document-level indicator from the released text. |
@@ -90,28 +90,44 @@ boundary.
 
 ## Leaks found
 
-Three columns read from post-event data by construction: `mp_surprise_level`,
-`mp_surprise_path_factor`, and `fed_info_factor`. All three are built from
-a `[T-1, T+1]` window centred on the announcement (`backend/app/data/mp_surprise.py`
-`_pre_post_yields` and `_spx_return_on`). They are the canonical
-Cieslak-Vissing-Jorgensen 2021 / Kuttner 2001 surprise quantities used as
-**features** in the existing FeatureVector layout.
+Originally three columns read from post-event data by construction:
+`mp_surprise_level`, `mp_surprise_path_factor`, and `fed_info_factor`.
+All three were built from a `[T-1, T+1]` window centred on the
+announcement (`backend/app/data/mp_surprise.py` `_pre_post_yields` and
+`_spx_return_on`). They were the canonical Cieslak-Vissing-Jorgensen
+2021 / Kuttner 2001 surprise quantities used as **features** in the
+FeatureVector layout.
 
 For a forecaster predicting `forward_realized_vol_10d` over `[T, T+10]`,
 treating these `T+1`-derived quantities as known-at-`T` features is the
 same class of leak the strict-forward target fix addressed on the
 output side: a small mechanical overlap that the model can latch onto.
-The overlap is one day (`T+1` post-window close, one of the ten forward
-returns the target integrates), not the full forward window, so the
-expected lift from closing this path is bounded but real.
 
-A follow-up issue has been filed to scope the ADR + canonical-cell
-re-baseline for the three MP-surprise columns. This audit PR does **not**
-re-baseline; it only flags the leak and ships the regression test for
-the rest of the column surface.
+**Resolved under #350 (ADR-0024).** All three columns now read from
+strictly-prior inputs:
 
-- Follow-up: **#350** — *#324 follow-up: mp_surprise / fed_info_factor
-  leak path needs ADR + canonical re-baseline.*
+- `mp_surprise_level` = `actual_target_change_bps - pre_implied_next_move_bps`
+  where the pre-implied leg is `(pre_yield_1m_T-1 - ff_target_prior) * 100`.
+  Only the announced policy decision (`ff_target_after`) is observable
+  at `T`; every other input is `T-Δ`.
+- `mp_surprise_path_factor` is the PCA-residualised trailing curve drift
+  (`pre_yield − pre_yield_trail_5td`) at PATH_TENORS_MONTHS, fit and
+  applied on strict-prior anchors only.
+- `fed_info_factor` is the residual of the strict-prior `mp_surprise_level`
+  against a strict-prior trailing SPX return (close-to-close over
+  `[T - ~7d, T - 1]`).
+
+The Alpha Vantage ±30 min intraday route is rejected at runtime under
+#350 because the 14:00-14:30 ET half is post-announcement. The
+`spx_intraday_returns` argument remains on the builder signature for
+backwards compatibility but is ignored.
+
+Methodology footnote: the literature mapping shifts. The original
+construction was the canonical CVJ post-event surprise; the strict-prior
+reformulation is a *different* quantity (actual-vs-pre-implied at T-1
+rather than post-pre across the announcement window). ADR-0024 records
+this decision and the rationale for choosing drop-T+1 over the
+keep-with-caveat alternative.
 
 No other `FeatureVector` column reads from a source post-dating
 `row.event_date` beyond the documented training-target columns
@@ -126,6 +142,14 @@ synthetic training package, loads the supervised sequences via
 column on every lookback row of every sequence: no scalar feature reads
 from a source post-dating `event_date`. The MP-surprise / fed-info
 columns are zeroed on the fixture (no `mp_surprises.parquet` shipped)
-so the contract holds package-wide; the leak path identified above is a
-methodology concern at the source-data level, not a per-row loader bug,
-and is tracked under the follow-up issue.
+so the per-bar contract holds package-wide.
+
+The source-data construction for `mp_surprise_level`,
+`mp_surprise_path_factor`, and `fed_info_factor` is exercised separately
+by `test_mp_surprise_columns_read_strictly_before_event_date` (added
+under #350) which builds a synthetic `mp_surprises` row through
+`app.data.mp_surprise.build_mp_surprises` and asserts the strict-prior
+contract on the pre/trail yield helper and the SPX return helper. The
+test also locks the rejection of the leaky Alpha Vantage intraday
+route. Per-unit-test coverage on the strict-prior construction lives in
+`tests/unit/test_mp_surprise.py` (cases 11+).

--- a/tests/regression/test_feature_provenance_as_of.py
+++ b/tests/regression/test_feature_provenance_as_of.py
@@ -11,7 +11,7 @@ target-row consumer but **never emitted** by `FeatureVector.as_rich_list`.
 
 The test materialises a synthetic training package (events.parquet +
 splits_train_val_test.parquet) under tmp_path, loads it through
-`load_walk_forward_split`, and verifies three guarantees:
+`load_walk_forward_split`, and verifies four guarantees:
 
 1. Every lookback bar's `date` is strictly less than the supervised
    `event_date` — the prior-window builder's core invariant.
@@ -21,6 +21,13 @@ splits_train_val_test.parquet) under tmp_path, loads it through
 3. The audit inventory in `docs/feature-provenance-audit.md` covers
    every FeatureVector field — any new field must be classified before
    merge.
+4. The MP-surprise / fed-info construction reads only strict-prior
+   inputs (issue #350 reformulation). The previously-leaking
+   `[T-1, T+1]` post-event window is replaced with an actual-vs-pre-
+   implied surprise and a strict-prior trailing SPX return; this test
+   builds a synthetic ``mp_surprises`` row through the production
+   builder and asserts the read window stays strictly before
+   ``event_date``.
 """
 
 from __future__ import annotations
@@ -368,13 +375,91 @@ def test_feature_provenance_as_of_contract(training_package_dir: Path) -> None:
                     )
 
                 # Snapshot columns are broadcast off the as-of row. The
-                # audit flags mp_surprise_* / fed_info_factor as a
-                # methodology-level leak path tracked under the #324
-                # follow-up issue, not a per-row loader bug, so the
-                # structural check here is shape only.
+                # audit previously flagged mp_surprise_* / fed_info_factor
+                # as a methodology-level leak path; #350 closed that path
+                # at the source-data level (see
+                # ``test_mp_surprise_columns_read_strictly_before_event_date``
+                # below for the strict-prior construction contract). The
+                # structural check here remains shape-only.
                 for column in _SNAPSHOT_COLUMNS:
                     value = getattr(vector, column)
                     assert isinstance(value, (int, float)), (
                         f"snapshot column {column!r} on bar {vector.date} "
                         f"is not a numeric scalar (got {type(value).__name__})"
                     )
+
+
+# Columns the #350 reformulation moved from ``T+Δ`` (post-event window)
+# to strict-prior. Listed here so the contract is grep-able alongside
+# the audit doc; the assertion below covers the source-data builder.
+_MP_SURPRISE_STRICT_PRIOR_COLUMNS: tuple[str, ...] = (
+    "mp_surprise_level",
+    "mp_surprise_path_factor",
+    "fed_info_factor",
+)
+
+
+def test_mp_surprise_columns_read_strictly_before_event_date(tmp_path) -> None:
+    """#350: ``mp_surprise.build_mp_surprises`` never reads ``T+Δ`` inputs.
+
+    Builds a synthetic ``mp_surprises`` row through the production
+    builder with a strictly-prior FRED panel and asserts:
+
+    1. The strict-prior pre/trail yield helper returns dates strictly
+       before ``event_date`` for every tenor in CURVE_TENORS_MONTHS.
+    2. The strict-prior SPX return helper rejects post-event closes
+       and degrades to ``unavailable`` when only ``T+1`` data is
+       supplied.
+    3. The intraday route (Alpha Vantage ±30 min) is ignored: the
+       ``spx_intraday_returns`` argument cannot bump any row to a
+       leaky source flag.
+
+    Together with the per-bar lookback assertion above, this closes the
+    audit's three remaining ``med`` leak rows
+    (``mp_surprise_level``, ``mp_surprise_path_factor``,
+    ``fed_info_factor``).
+    """
+
+    import datetime as _dt
+
+    from app.data import mp_surprise
+
+    base = _dt.date(2024, 1, 1)
+    trading_days = [
+        base + _dt.timedelta(days=i)
+        for i in range(120)
+        if (base + _dt.timedelta(days=i)).weekday() < 5
+    ]
+    series_map = {d: 0.10 + i * 0.001 for i, d in enumerate(trading_days)}
+    event_date = _dt.date(2024, 3, 6)
+
+    # 1. Trailing-yield helper: strict-prior contract on dates.
+    pre, trail, pre_d, trail_d = mp_surprise._strictly_prior_pre_and_trailing_yield(
+        event_date, series_map, trading_days=trading_days,
+    )
+    assert pre is not None and trail is not None
+    assert pre_d is not None and trail_d is not None
+    assert trail_d < pre_d < event_date, (
+        f"#350 strict-prior contract violated: trail={trail_d} "
+        f"pre={pre_d} event={event_date}"
+    )
+
+    # 2. SPX helper: rejects post-event-only closes.
+    leaky_closes = {event_date + _dt.timedelta(days=1): 5200.0}
+    ret_leaky, source_leaky = mp_surprise._spx_return_on(event_date, leaky_closes)
+    assert ret_leaky is None, (
+        "#350: SPX helper must NOT compute a return from post-event-only "
+        f"closes (got ret={ret_leaky}, source={source_leaky})"
+    )
+    assert source_leaky == "unavailable"
+
+    # 3. Strict-prior closes resolve to a non-null trailing return.
+    strict_closes = {
+        event_date - _dt.timedelta(days=10): 5000.0,
+        event_date - _dt.timedelta(days=1): 5100.0,
+    }
+    ret_ok, source_ok = mp_surprise._spx_return_on(event_date, strict_closes)
+    assert ret_ok is not None and source_ok == "strict_prior_trailing", (
+        "#350: strict-prior trailing SPX return failed to resolve from "
+        f"pre-event closes (ret={ret_ok}, source={source_ok})"
+    )

--- a/tests/unit/test_mp_surprise.py
+++ b/tests/unit/test_mp_surprise.py
@@ -239,17 +239,29 @@ def test_pandemic_emergency_cut_2020_03_15(
     )
     assert artifacts.rows_written == 2
     pandemic = artifacts.frame[artifacts.frame["event_date"] == "2020-03-15"].iloc[0]
-    # The level surprise should be a large negative bps move (we injected -50 bp at the 1m tenor).
+    # #350: ``mp_surprise_level`` is now the strict-prior surprise:
+    # ``actual_target_change_bps - pre_implied_next_move_bps`` where the
+    # pre-implied leg is ``(pre_yield_1m - ff_target_prior) * 100``. In
+    # this fixture the 1m yield sits at 0.10% on T-1 against a 0.375%
+    # mid-band, so the curve already priced a ~27.5 bp cut; the actual
+    # cut of 25 bp leaves a tiny residual near zero. The methodology
+    # change is locked here against the leaky -50 bp post-window reading
+    # the prior CVJ-style construction produced. See ADR-0024.
     level = float(pandemic["mp_surprise_level"])
-    assert level < -25.0, f"expected sharp negative level surprise, got {level} bps"
-    assert level > -100.0, f"expected ~-50 bp level surprise, got {level} bps"
+    assert -10.0 < level < 10.0, (
+        f"strict-prior level surprise should be near zero on a "
+        f"fully-priced cut, got {level} bps"
+    )
     assert bool(pandemic["is_intermeeting"]) is True
     assert pandemic["methodology"] == mp_surprise.METHODOLOGY_OIS_PROXY
     # Target after should fall to the 0.00-0.25 % band midpoint.
     assert float(pandemic["ff_target_after"]) == pytest.approx(0.125, abs=1e-6)
-    # Fed-info factor should be sign-consistent with the level (or null).
-    fi = pandemic["fed_info_factor"]
-    assert fi is not None
+    # Fed-info factor must derive from a strictly-prior SPX leg now.
+    src = pandemic["fed_info_factor_source"]
+    assert src in {"strict_prior_trailing", "unavailable", "level_missing"}, (
+        f"unexpected fed_info_factor_source {src!r} -- the #350 reformulation "
+        "rejects the leaky daily_window_proxy / alphavantage_intraday_30min routes."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -280,9 +292,14 @@ def test_2008_10_08_emergency_cut_documented_as_outside_default_range() -> None:
     start = _dt.date(2008, 9, 15)
     end = _dt.date(2008, 11, 30)
     payloads = _build_fred_payloads(start - _dt.timedelta(days=14), end + _dt.timedelta(days=7))
-    # Hand-craft single-target rates so 2008-10-07 = 2.0%, 2008-10-09 = 1.5%
-    # The 1m yield series we already built is flat across this range; we
-    # rewire it so 1m falls 50 bp across the cut.
+    # Hand-craft single-target rates so 2008-10-07 = 2.0%, 2008-10-08 = 1.5%.
+    # FRED's DFEDTAR series publishes the new target on the announcement
+    # day in the post-2003 schedule; the #350 strict-prior reformulation
+    # reads ``ff_target_after`` directly from ``event_date`` (preferring
+    # the on-day value over the lookahead). The 1m yield series stays at
+    # 1.80% through T-1 and falls only after the announcement, so the
+    # surprise is genuinely actual-vs-pre-implied. Path tenors mirror the
+    # 1m drop so the path factor stays near zero.
     days = (end - start + _dt.timedelta(days=22)).days
     base = start - _dt.timedelta(days=14)
     new_obs: list[tuple[str, float | None]] = []
@@ -291,7 +308,7 @@ def test_2008_10_08_emergency_cut_documented_as_outside_default_range() -> None:
         v = 1.80 if d < _dt.date(2008, 10, 9) else 1.30
         new_obs.append((d.isoformat(), v))
     payloads["DGS1MO"] = _series_response("DGS1MO", new_obs)
-    # Bump path tenors by the same -50 bp shift so the path factor stays near zero.
+    # Path tenors fall by the same -50 bp shift after the announcement.
     for sid, base_val in (("DGS3MO", 1.85), ("DGS6MO", 1.95), ("DGS1", 2.20), ("DGS2", 2.50)):
         obs2 = []
         for i in range(days):
@@ -299,11 +316,13 @@ def test_2008_10_08_emergency_cut_documented_as_outside_default_range() -> None:
             v = base_val if d < _dt.date(2008, 10, 9) else base_val - 0.50
             obs2.append((d.isoformat(), v))
         payloads[sid] = _series_response(sid, obs2)
-    # Single-target rate (pre-band era).
+    # Single-target rate (pre-band era): published target reads 2.0% up
+    # through 2008-10-07 (T-1) and 1.5% from 2008-10-08 (announcement
+    # day) onward.
     single_obs: list[tuple[str, float | None]] = []
     for i in range(days):
         d = base + _dt.timedelta(days=i)
-        v = 2.0 if d < _dt.date(2008, 10, 9) else 1.5
+        v = 2.0 if d < _dt.date(2008, 10, 8) else 1.5
         single_obs.append((d.isoformat(), v))
     payloads["DFEDTAR"] = _series_response("DFEDTAR", single_obs)
     payloads["DFEDTARU"] = _series_response("DFEDTARU", [])
@@ -331,8 +350,17 @@ def test_2008_10_08_emergency_cut_documented_as_outside_default_range() -> None:
     )
     row = artifacts.frame.iloc[0]
     level = float(row["mp_surprise_level"])
-    assert level == pytest.approx(-50.0, abs=10.0), (
-        f"2008-10-08 emergency cut should give ~-50 bp level surprise, got {level}"
+    # #350 strict-prior reformulation: ``mp_surprise_level`` is the
+    # actual-target-change minus the pre-implied next-move on T-1. The
+    # fixture leaves the 1m yield at 1.80% on T-1 against a 2.00% target
+    # (pre-implied = -20 bp), then the announcement moves the target to
+    # 1.50% (actual = -50 bp), so the surprise is -30 bp. Under the old
+    # construction this was -50 bp -- the literal post-event 1m yield
+    # change -- which leaked T+1 data. The methodology shift is locked
+    # here and footnoted in ADR-0024.
+    assert level == pytest.approx(-30.0, abs=10.0), (
+        f"2008-10-08 strict-prior level surprise should be ~-30 bp "
+        f"(actual -50 minus pre-implied -20), got {level}"
     )
     assert bool(row["is_intermeeting"]) is True
 
@@ -709,3 +737,123 @@ def test_dataframe_value_hash_roundtrips_through_parquet(
         spx_close_by_date=spx_map,
     )
     assert mp_surprise.dataframe_value_hash(artifacts_2.frame) == in_memory_hash
+
+
+# ---------------------------------------------------------------------------
+# 11. Strict-prior construction contract (#350)
+# ---------------------------------------------------------------------------
+
+
+def test_strictly_prior_pre_and_trailing_yield_enforces_strict_inequality() -> None:
+    """The new strict-prior helper must return dates strictly before ``on_date``.
+
+    The level/path surprise reformulation under #350 reads the pre-event
+    yield and a trailing anchor 5 trading days earlier. Both anchors are
+    observable at ``T-Δ`` for ``T = on_date``; the strict inequality
+    contract is the gate that closes the leaky ``T+1`` post-leg the
+    audit (#324) flagged.
+    """
+
+    base = _dt.date(2024, 1, 1)
+    trading_days = [
+        base + _dt.timedelta(days=i) for i in range(120) if (base + _dt.timedelta(days=i)).weekday() < 5
+    ]
+    series_map = {d: 0.10 + i * 0.001 for i, d in enumerate(trading_days)}
+    on = _dt.date(2024, 3, 6)
+    pre, trail, pre_d, trail_d = mp_surprise._strictly_prior_pre_and_trailing_yield(
+        on,
+        series_map,
+        trading_days=trading_days,
+    )
+    assert pre is not None and trail is not None
+    assert pre_d is not None and trail_d is not None
+    assert trail_d < pre_d < on, (
+        f"strict-prior contract violated: trail={trail_d} pre={pre_d} on={on}"
+    )
+    # The default trailing window is 5 trading days; assert the gap is
+    # at least that many calendar days (trading-day spacing varies
+    # across weekends but never drops below 5 calendar days for a 5td
+    # walk on a Mon-Fri schedule).
+    assert (pre_d - trail_d).days >= 5
+
+
+def test_spx_strict_prior_trailing_uses_only_pre_event_closes() -> None:
+    """``_spx_return_on`` must never read SPX closes dated >= event_date.
+
+    The strict-prior trailing return uses two anchors: ``pre`` (the
+    closest close < event_date) and ``trail`` (~7 calendar days earlier
+    than ``pre``, still < event_date). Both endpoints carry calendar
+    dates strictly before the announcement; the close-to-close return
+    is the strict-prior equity signal the fed-info residual is fit
+    against under the #350 reformulation.
+    """
+
+    event_date = _dt.date(2024, 3, 20)
+    # Strict-prior closes only; nothing post-event in the lookup map.
+    closes = {
+        event_date - _dt.timedelta(days=10): 5000.0,
+        event_date - _dt.timedelta(days=9): 5010.0,
+        event_date - _dt.timedelta(days=1): 5100.0,
+    }
+    ret, source = mp_surprise._spx_return_on(event_date, closes)
+    assert ret is not None
+    assert source == "strict_prior_trailing"
+    # If the post-event close is the *only* available "pre" anchor (which
+    # the old [T-1, T+1] construction relied on), the strict-prior path
+    # must NOT use it.
+    leaky_only = {event_date + _dt.timedelta(days=1): 5200.0}
+    ret_leaky, source_leaky = mp_surprise._spx_return_on(event_date, leaky_only)
+    assert ret_leaky is None
+    assert source_leaky == "unavailable"
+
+
+def test_intraday_returns_argument_is_ignored_under_strict_prior(
+    monkeypatch: pytest.MonkeyPatch,
+    small_calendar: Path,
+    fred_cache: Path,
+) -> None:
+    """The Alpha Vantage intraday route is rejected under #350.
+
+    The ``spx_intraday_returns`` mapping is retained on the
+    ``build_mp_surprises`` signature for backwards compatibility but is
+    ignored at runtime because the ±30 min window around the FOMC
+    announcement leaks ``T+`` data (the 14:00-14:30 ET half is post-
+    announcement). The contract here is: passing a non-empty intraday
+    map must NOT bump any ``fed_info_factor_source`` row to
+    ``alphavantage_intraday_30min``.
+    """
+
+    monkeypatch.setenv("FRED_API_KEY", "test-key")
+    start = _dt.date(2010, 1, 1)
+    end = _dt.date(2020, 12, 31)
+    payloads = _build_fred_payloads(start - _dt.timedelta(days=14), end + _dt.timedelta(days=7))
+    transport = _mock_transport(payloads)
+    responses = mp_surprise._hydrate_fred_responses(
+        start=start - _dt.timedelta(days=14),
+        end=end + _dt.timedelta(days=7),
+        cache_dir=fred_cache,
+        transport=transport,
+    )
+    # Strict-prior trailing SPX coverage for both meetings (T-7..T-1).
+    def _trailing_closes_for(d: _dt.date) -> dict[_dt.date, float]:
+        return {
+            d - _dt.timedelta(days=8): 4000.0,
+            d - _dt.timedelta(days=1): 4100.0,
+        }
+
+    spx_map: dict[_dt.date, float] = {}
+    for d in (_dt.date(2014, 3, 19), _dt.date(2020, 3, 15)):
+        spx_map.update(_trailing_closes_for(d))
+    intraday = {"2014-03-19": 0.01, "2020-03-15": -0.10}
+    artifacts = mp_surprise.build_mp_surprises(
+        start=start,
+        end=end,
+        fred_responses=responses,
+        fomc_calendar_path=small_calendar,
+        spx_close_by_date=spx_map,
+        spx_intraday_returns=intraday,
+    )
+    for source in artifacts.frame["fed_info_factor_source"].tolist():
+        assert source != "alphavantage_intraday_30min", (
+            f"#350: intraday route must be ignored, got {source!r}"
+        )


### PR DESCRIPTION
Closes #350.

- `backend/app/data/mp_surprise.py` — `build_mp_surprises` reads strict-prior inputs only for the three previously-leaking columns:
  - `mp_surprise_level` = `(ff_target_after − ff_target_prior) * 100 − (pre_yield_1m_T-1 − ff_target_prior) * 100`. Only `ff_target_after` is observed at T (the announcement itself); every other input is strict-prior.
  - `mp_surprise_path_factor` = PCA on strict-prior trailing curve drift `(pre_yield − pre_yield_trail_5td) * 100` at PATH_TENORS_MONTHS, residualised against the 1m trailing drift.
  - `fed_info_factor` = residual of `mp_surprise_level` against `alpha + beta * pre_trailing_spx_return` where the SPX leg is a strict-prior close-to-close return over `[T − ~7d, T − 1]`.
  - Alpha Vantage ±30 min intraday route is rejected at runtime (the 14:00–14:30 ET half is post-announcement). `spx_intraday_returns` kwarg retained for backwards compat but ignored.
  - New helper `_strictly_prior_pre_and_trailing_yield` enforces `trail < pre < on_date`. `_spx_return_on` rewritten with a `trail < pre < event_date` assertion and `strict_prior_trailing` source flag.
  - `_pre_post_yields` retained for diagnostic-only column reads (`pre_event_curve`, `post_event_curve`); these feed `cross_asset_response.py` and `next_fomc_decision.py` at meeting N+1, a different time-axis than the forecaster-input leak.
- `docs/adr/0024-mp-surprise-strict-prior-replacement.md` — methodology footnote. Records the construction change, the literature mapping shift (no longer the literal CVJ post-event quantity; closer to Kuttner-style actual-vs-pre-implied), and the alternatives considered (keep+caveat, drop-entirely, T-0 instead of T+1).
- `docs/feature-provenance-audit.md` — three rows moved from `T+Δ` band / `med` leak risk to strict-prior / `none`. "Leaks found" section rewritten to record the resolution.
- `tests/unit/test_mp_surprise.py` — pandemic + 2008 emergency-cut tests updated for the new semantics. Three new cases lock the strict-prior helper contracts and the intraday-route rejection.
- `tests/regression/test_feature_provenance_as_of.py` — new `test_mp_surprise_columns_read_strictly_before_event_date` exercises the strict-prior helpers as the source-data audit gate.
- Wiki §13 row #350 → `in progress`.

Schema is unchanged; downstream `mp_surprises.parquet` consumers (training loader, cross-asset-response, next-FOMC-decision panels) are unaffected. Pre-#350 SOURCES.lock entries are not forward-compatible because the persisted PCA eigenvector shifts under the new fit — rebuild `mp_surprises.parquet` from FRED once before re-running the canonical sweep.

§6.10 row `10b'` re-baseline lands as a follow-up commit on this branch once the canonical-comparison sweep artefact (`backend/artifacts/experiments/canonical_comparison_post_350.json`) is written; expected delta on the headline cell is small (upper bound ≤ 2pp).

## Reviewer focus

- Strict-prior contract on the helper boundary: `_strictly_prior_pre_and_trailing_yield` asserts `trail < pre < on_date`; `_spx_return_on` asserts `trail < pre < event_date`. Both locked by unit tests.
- `pre_meeting_implied_*` substitution preserves only part of the literature mapping; ADR-0024 footnotes the shift honestly (no longer the CVJ post-event PC1).
- Other call sites of `_pre_post_yields` / `_spx_return_on`: `_pre_post_yields` stays in use for diagnostic curve columns; `_spx_return_on` is only the fed-info pass and is now strict-prior. No additional sites need migrating.