### PR TITLE
Train/inference contract enforcement (#341)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -150,7 +150,33 @@ register_error_handlers(app)
 
 @app.get("/health")
 def health_check():
-    return {"status": "ok"}
+    """Liveness probe + serving-contract status (#341).
+
+    The probe always returns ``status: "ok"`` (uvicorn is up and
+    serving). The ``inference_contract`` block surfaces the structured
+    state of the active forecaster checkpoint's contract validation --
+    ``ok`` when the sidecar matches the serving signature,
+    ``sidecar_absent`` on a legacy artefact, and a structured failure
+    code otherwise. Counters track structured-error increments so an
+    operator can spot a stuck contract without parsing logs.
+    """
+
+    try:
+        from app.services.forecaster import (
+            get_contract_counters,
+            get_serving_contract_status,
+        )
+
+        contract = get_serving_contract_status()
+        counters = get_contract_counters()
+    except Exception:  # pragma: no cover -- defensive
+        contract = {"status": "unknown"}
+        counters = {}
+    return {
+        "status": "ok",
+        "inference_contract": contract,
+        "inference_contract_counters": counters,
+    }
 
 
 _SYMBOLS_FALLBACK: list[dict[str, str]] = [
@@ -420,6 +446,19 @@ def _build_analyze_response(
             forecast["series"]["realized_close"] = [float(point["close"]) for point in realized]
             forecast["series"]["realized_volatility"] = [float(point["volatility_5d"]) for point in realized]
 
+    regime_payload = _safe_regime_classification(history_vectors)
+    # #341: structured-status payloads carry a ``status`` key and never
+    # the full card shape. Split into the legacy card slot (None when
+    # degraded) + the sibling status surface so the response stays
+    # serialisable against the AnalyzeResponse schema.
+    regime_card: dict[str, Any] | None = None
+    regime_status: dict[str, Any] | None = None
+    if isinstance(regime_payload, dict) and regime_payload.get("status") and (
+        "predicted_set" not in regime_payload
+    ):
+        regime_status = regime_payload
+    else:
+        regime_card = regime_payload
     response: dict[str, Any] = {
         "sentiment": sentiment,
         "prediction": forecast["prediction"],
@@ -427,7 +466,8 @@ def _build_analyze_response(
         "model": forecast["model"],
         "series": forecast["series"],
         "multi_axis": _build_multi_axis_block(payload.text, sentiment),
-        "regime_classification": _safe_regime_classification(history_vectors),
+        "regime_classification": regime_card,
+        "regime_classification_status": regime_status,
     }
     if getattr(payload, "include_xai", False):
         attributions = attribute_text(payload.text)
@@ -439,15 +479,87 @@ def _safe_regime_classification(history_vectors: list[Any]) -> dict[str, Any] | 
     """Wrap ``build_regime_classification_card`` so a failure never breaks /analyze.
 
     The card is opt-in by checkpoint flavour and manifest presence; any
-    exception inside the inference + calibrated-set path degrades to
-    ``None`` rather than 500ing the whole response.
+    exception inside the inference + calibrated-set path degrades to a
+    surfaced structured payload rather than 500ing the whole response.
+
+    #341 structured surface. Three branches:
+
+    1. **Not classification mode.** The active checkpoint emits no
+       regime card by contract -- legitimate ``None`` with
+       ``status="not_classification_mode"`` so the operator can
+       distinguish "model deliberately mute" from "model crashed
+       silently".
+    2. **Inference kwarg missing.** The forward path raised
+       :class:`TypeError` (e.g. the call site passed a kwarg the
+       checkpoint did not declare in its inference contract sidecar,
+       or omitted one the model requires). Surfaces
+       ``status="inference_kwarg_missing"`` + the missing kwarg name
+       parsed from the exception, increments the module-level counter,
+       and logs at WARNING.
+    3. **Unexpected exception.** Anything else: structured payload
+       with the exception class name + WARNING log + counter
+       increment. The /analyze response stays serialisable so the
+       frontend can render an "evidence unavailable" badge.
     """
 
+    from app.services import forecaster as _forecaster_service
+
     try:
-        return build_regime_classification_card(history_vectors)
-    except Exception:  # pragma: no cover — defensive, see #216 follow-up
-        logger.warning("regime_classification_card_failed", exc_info=True)
-        return None
+        result = build_regime_classification_card(history_vectors)
+    except TypeError as exc:
+        _forecaster_service._contract_counters[
+            "regime_classification_inference_kwarg_missing"
+        ] += 1
+        missing = _extract_missing_kwarg_from_typeerror(exc)
+        logger.warning(
+            "regime_classification_inference_kwarg_missing kwarg=%s detail=%s",
+            missing,
+            str(exc),
+        )
+        return {
+            "status": "inference_kwarg_missing",
+            "missing_kwarg": missing,
+            "detail": str(exc),
+        }
+    except Exception as exc:  # pragma: no cover — defensive, see #216 follow-up
+        _forecaster_service._contract_counters[
+            "regime_classification_unexpected_exception"
+        ] += 1
+        logger.warning(
+            "regime_classification_card_failed exception_class=%s",
+            type(exc).__name__,
+            exc_info=True,
+        )
+        return {
+            "status": "unexpected_exception",
+            "exception_class": type(exc).__name__,
+            "detail": str(exc),
+        }
+    if result is None:
+        return {"status": "not_classification_mode"}
+    return result
+
+
+def _extract_missing_kwarg_from_typeerror(exc: TypeError) -> str | None:
+    """Parse a python ``TypeError`` for the offending kwarg name.
+
+    Python emits messages like ``forward_multi_task() missing 1
+    required keyword-only argument: 'text_embedding'`` or
+    ``forward_multi_task() got an unexpected keyword argument
+    'foo'``. We pull the quoted name out; on no-match we return
+    ``None`` rather than guess.
+    """
+
+    import re
+
+    message = str(exc)
+    match = re.search(r"keyword[- ]?(?:only )?argument[s]?:?\s*['\"]([^'\"]+)['\"]", message)
+    if match:
+        return match.group(1)
+    match = re.search(r"unexpected keyword argument\s*['\"]([^'\"]+)['\"]", message)
+    if match:
+        return match.group(1)
+    return None
 
 
 def _build_multi_axis_block(
@@ -1030,6 +1142,20 @@ async def analyze_market(payload: AnalyzeRequest) -> MarketReactionPanel:
             status_code=503, detail="Market reaction panel unavailable"
         ) from None
     if result is None:
+        return MarketReactionPanel(rates=[], vol_regime=None)
+    # #341: ``build_market_reaction_panel`` now returns a structured
+    # status payload on the soft-error paths instead of bare None. The
+    # status field is mutually exclusive with the panel fields -- a
+    # status-only payload renders as an empty panel surface on the
+    # frontend, so we collapse it to the legacy empty-panel response
+    # here. The structured detail is logged at the service layer; the
+    # client gets an honest "no evidence" panel without a 5xx.
+    if isinstance(result, dict) and "rates" not in result and result.get("status"):
+        logger.info(
+            "market_reaction_panel_status status=%s detail=%s",
+            result.get("status"),
+            result.get("detail"),
+        )
         return MarketReactionPanel(rates=[], vol_regime=None)
     cards = [RatesReactionCard(**row) for row in result.get("rates", [])]
     vol_regime_payload = result.get("vol_regime")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -519,21 +519,20 @@ def _safe_regime_classification(history_vectors: list[Any]) -> dict[str, Any] | 
         return {
             "status": "inference_kwarg_missing",
             "missing_kwarg": missing,
-            "detail": str(exc),
         }
     except Exception as exc:  # pragma: no cover — defensive, see #216 follow-up
         _forecaster_service._contract_counters[
             "regime_classification_unexpected_exception"
         ] += 1
         logger.warning(
-            "regime_classification_card_failed exception_class=%s",
+            "regime_classification_card_failed exception_class=%s detail=%s",
             type(exc).__name__,
+            str(exc),
             exc_info=True,
         )
         return {
             "status": "unexpected_exception",
             "exception_class": type(exc).__name__,
-            "detail": str(exc),
         }
     if result is None:
         return {"status": "not_classification_mode"}

--- a/backend/app/models/registry.py
+++ b/backend/app/models/registry.py
@@ -54,6 +54,14 @@ class EncoderRef:
     # placeholder rows. Two tagged entries ship: ``classifier`` for the
     # headline substrate, ``retrieval`` for the retrieval base.
     role: str | None = None
+    # Inference-feature aliases the encoder contributes to a serving
+    # forecaster (#341). Empty tuple for encoders that have never been
+    # threaded into the serving forward path (bake-off siblings,
+    # placeholder rows). The serving loader cross-checks the
+    # checkpoint's inference contract against this set so a registry
+    # that drops a feature mid-flight refuses to bind a checkpoint
+    # trained against the old declaration.
+    inference_features: tuple[str, ...] = ()
 
 
 @lru_cache(maxsize=1)
@@ -66,6 +74,7 @@ def load_registry(path: Path | None = None) -> dict[str, EncoderRef]:
         if not isinstance(fields, dict):
             continue
         raw_role = fields.get("role")
+        raw_features = fields.get("inference_features") or ()
         ref = EncoderRef(
             alias=alias,
             repo=str(fields["repo"]),
@@ -74,6 +83,7 @@ def load_registry(path: Path | None = None) -> dict[str, EncoderRef]:
             task=str(fields.get("task", "classification")),
             description=str(fields.get("description", "")),
             role=str(raw_role) if raw_role is not None else None,
+            inference_features=tuple(str(v) for v in raw_features),
         )
         by_repo[ref.repo] = ref
         by_repo[ref.alias] = ref
@@ -161,6 +171,10 @@ class ArtefactRef:
     revision: str
     eager: bool
     description: str
+    # #341: inference-feature aliases the artefact contributes when the
+    # serving container binds it. Empty for non-forecaster artefacts
+    # (training package, embedding caches, retrieval bundle).
+    inference_features: tuple[str, ...] = ()
 
 
 @lru_cache(maxsize=1)
@@ -172,12 +186,14 @@ def load_artefacts(path: Path | None = None) -> dict[str, ArtefactRef]:
     for name, fields in block.items():
         if not isinstance(fields, dict):
             continue
+        raw_features = fields.get("inference_features") or ()
         out[name] = ArtefactRef(
             name=name,
             hf_uri=str(fields["hf_uri"]),
             revision=str(fields.get("revision") or ""),
             eager=bool(fields.get("eager", False)),
             description=str(fields.get("description", "")),
+            inference_features=tuple(str(v) for v in raw_features),
         )
     return out
 

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -9,6 +9,7 @@ encoders:
     description: Base BERT, used for the NLP-row comparison and continued pretraining.
     repo_aliases:
       - bert-base-uncased
+    inference_features: []
 
   finbert:
     repo: ProsusAI/finbert
@@ -16,6 +17,9 @@ encoders:
     gated: false
     task: classification
     description: Araci's FinBERT.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   finbert_tone:
     repo: yiyanghkust/finbert-tone
@@ -23,6 +27,7 @@ encoders:
     gated: false
     task: classification
     description: FinBERT-tone.
+    inference_features: []
 
   finbert_fomc:
     repo: ZiweiChen/FinBERT-FOMC
@@ -30,6 +35,7 @@ encoders:
     gated: false
     task: classification
     description: FinBERT fine-tuned on FOMC minutes (Chen et al. 2023).
+    inference_features: []
 
   fomc_roberta:
     repo: gtfintechlab/FOMC-RoBERTa
@@ -37,6 +43,7 @@ encoders:
     gated: false
     task: classification
     description: gtfintechlab FOMC-RoBERTa. Flagged data-contaminated against TDW; kept for audit only.
+    inference_features: []
 
   fomc_roberta_any_exp:
     repo: gtfintechlab/fomc-roberta-any-exp
@@ -57,6 +64,7 @@ encoders:
       becomes reachable AND the audit verdict flips to clean, OR
       a replacement encoder (e.g. ProsusAI/finbert) is wired into
       the dashboard fallback chain.
+    inference_features: []
 
   distilbert_sst2:
     repo: distilbert/distilbert-base-uncased-finetuned-sst-2-english
@@ -66,6 +74,7 @@ encoders:
     description: Fallback when FOMC-RoBERTa fails to load.
     repo_aliases:
       - distilbert-base-uncased-finetuned-sst-2-english
+    inference_features: []
 
   distilbert_base_uncased:
     repo: distilbert/distilbert-base-uncased
@@ -75,6 +84,7 @@ encoders:
     description: Lightweight BERT used in the bake-off as a cheap baseline.
     repo_aliases:
       - distilbert-base-uncased
+    inference_features: []
 
   deberta_v3_base:
     repo: microsoft/deberta-v3-base
@@ -82,6 +92,7 @@ encoders:
     gated: false
     task: masked_lm
     description: DeBERTa v3 base — bake-off entry to test a non-BERT-family encoder.
+    inference_features: []
 
   bge_large_en_v15:
     repo: BAAI/bge-large-en-v1.5
@@ -89,6 +100,7 @@ encoders:
     gated: false
     task: sentence_embedding
     description: BGE large English v1.5. Sentence-embedding encoder for the embedding-cache bake-off lane.
+    inference_features: []
 
   nomic_embed_text_v15:
     repo: nomic-ai/nomic-embed-text-v1.5
@@ -96,6 +108,7 @@ encoders:
     gated: false
     task: sentence_embedding
     description: Nomic embed text v1.5. Sentence-embedding encoder; second bake-off entry alongside BGE.
+    inference_features: []
 
   voyage_finance_2:
     repo: voyageai/voyage-finance-2
@@ -110,6 +123,7 @@ encoders:
       ``app.data.embedding_cache``. ``VOYAGE_API_KEY`` must be set;
       Voyage does not publish a checkpoint sha, so the revision field
       pins the model name itself.
+    inference_features: []
 
   finbert_fed_adjacent:
     repo: /data/artifacts/continued_pretraining/finbert_fed_adjacent_20260515T104824Z_s11/checkpoint
@@ -123,6 +137,9 @@ encoders:
       ``data/raw/embeddings/finbert_fed_adjacent_20260515T104.parquet``. The
       bake-off CLI now treats this encoder as runnable; cross-bank-supervised
       variants ride under ``finbert_fed_adjacent_xbank``.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   bert_base_fed_adjacent:
     repo: local/bert-base-fed-adjacent
@@ -135,6 +152,9 @@ encoders:
       finbert. Run via ``make finbert-fed-adjacent-pretrain-bert-control``; the
       bake-off pairs the two checkpoints so we can isolate the contribution of
       the FinBERT prior versus the BIS substrate alone.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   finbert_fomc_only:
     repo: local/finbert-fomc-only
@@ -156,6 +176,9 @@ encoders:
       against the cross-bank DAPT encoder, so the FOMC-only DAPT
       substrate keeps the headline classifier role and the cross-bank
       DAPT encoder owns the retrieval role only.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   finbert_bis_only:
     repo: local/finbert-bis-only
@@ -169,6 +192,9 @@ encoders:
       by ``make finbert-bis-only-pretrain``. Revision empty until the
       first GPU run lands a checkpoint; same unpinned-local guard as
       ``finbert_fomc_only`` applies.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   finbert_fed_adjacent_xbank:
     repo: /data/artifacts/phase3/finetune_batch_20260519T190604Z/finbert_fed_adjacent_s11/hf_checkpoints
@@ -186,6 +212,9 @@ encoders:
       stance head); the remaining four seeds are kept on disk under
       ``finetune_batch_20260519T190604Z/finbert_fed_adjacent_s{29,47,71,97}``
       for reproducibility but the embedding cache builds against s11.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   finbert_fed_adjacent_xbank_dapt:
     repo: /data/artifacts/continued_pretraining/finbert_fed_adjacent_xbank_dapt_20260525T185524Z_s11/checkpoint
@@ -210,6 +239,9 @@ encoders:
       supervised + DAPT layers null on the headline classifier target,
       so this encoder owns the retrieval role only; the classifier role
       is held by ``finbert_fomc_only``.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   finbert_fed_adjacent_xbank_aux_stance_masked:
     repo: /data/artifacts/text_multi_axis/text_multi_axis_20260525T105459Z/hf_checkpoints
@@ -228,6 +260,9 @@ encoders:
       certainty 0.984 (val_loss=0.0922). Pin holds the encoder backbone
       + tokenizer saved alongside the singleton inference checkpoint at
       ``backend/models/text_multi_axis_best.pt``.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   finbert_fed_adjacent_xbank_aux_weighted:
     repo: /data/artifacts/text_multi_axis/text_multi_axis_20260525T110428Z/hf_checkpoints
@@ -244,6 +279,9 @@ encoders:
       ``finbert_fed_adjacent_xbank_aux_stance_masked`` that re-litigates
       the Phase C substitute-not-complement prior. Validation accuracy
       at the best epoch: stance 0.978 / certainty 0.984 (val_loss=0.0974).
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   finbert_fed_adjacent_xbank_dapt_retrieval:
     repo: /data/artifacts/retrieval/finbert_fed_adjacent_xbank_dapt_retrieval/checkpoint
@@ -264,6 +302,9 @@ encoders:
       same unpinned-local guard as ``finbert_fomc_only`` applies.
       Deployability lane (#302) will mirror the checkpoint to HF Hub
       in a follow-up — this PR keeps the artefact local.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   trajectory_lstm:
     repo: /data/artifacts/trajectory/trajectory_lstm/model.pt
@@ -280,6 +321,7 @@ encoders:
       neutral). Produced by ``python -m app.trajectory.train
       --architecture lstm``; revision stays empty until the first
       GPU run lands a pinned checkpoint.
+    inference_features: []
 
   trajectory_transformer:
     repo: /data/artifacts/trajectory/trajectory_transformer/model.pt
@@ -295,6 +337,7 @@ encoders:
       ``python -m app.trajectory.train --architecture transformer``;
       revision stays empty until the first GPU run lands a pinned
       checkpoint.
+    inference_features: []
 
 # HF Hub mirror of every artefact the inference container needs to boot.
 # Local paths in ``encoders:`` above stay primary (the dev stack keeps
@@ -312,6 +355,9 @@ artefacts:
     description: |
       Canonical hot-path encoder — cross-bank DAPT-extended FinBERT
       substrate. Boot-time eager pull on the droplet entrypoint.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   encoder_finbert_fomc:
     # Upstream third-party repo — we don't host our own copy. The pinned
@@ -322,18 +368,27 @@ artefacts:
     revision: "7754dd1d88da18e8b1d51cc1656496858ce19aae"
     eager: false
     description: Upstream third-party FinBERT-FOMC. Lazy-fetched for the bake-off comparison.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   encoder_finbert_fed_adjacent:
     hf_uri: hf://yusufizzetmurat/finbert-fed-adjacent
     revision: "332e31e166e859deba81535bfeec410b3c6e7023"
     eager: false
     description: DAPT encoder over BIS speeches + Fed-adjacent auxiliary corpus.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   encoder_finbert_fed_adjacent_xbank:
     hf_uri: hf://yusufizzetmurat/finbert-fed-adjacent-xbank
     revision: "178fcfaa70f7949bd4b703f36e4c45746e279bce"
     eager: false
     description: Bundle A cross-bank auxiliary supervised variant.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   forecaster_canonical:
     hf_uri: hf://yusufizzetmurat/fed-pulse-forecaster
@@ -342,12 +397,20 @@ artefacts:
     description: |
       Canonical multi-head forecaster checkpoint (#292). Loaded into
       ``backend/models/forecaster_best.pt`` on first boot.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
+      - credibility
 
   rates_heads_canonical:
     hf_uri: hf://yusufizzetmurat/fed-pulse-rates-heads
     revision: "0a76dabb67006b532e376d9b4dd69b8ad172e7d7"
     eager: true
     description: Multi-target rates heads checkpoint (#292/#293).
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
+      - credibility
 
   retrieval_bundle:
     hf_uri: hf://yusufizzetmurat/fed-pulse-retrieval
@@ -356,6 +419,7 @@ artefacts:
     description: |
       Retrieval bundle for /analyze/analogs — embedding_index.parquet +
       embeddings.npy + manifest produced by ``python -m app.retrieval.train``.
+    inference_features: []
 
   trajectory_bundle:
     hf_uri: hf://yusufizzetmurat/fed-pulse-trajectory
@@ -364,6 +428,7 @@ artefacts:
     description: |
       Trajectory bundle for /analyze/trajectory — LSTM checkpoint +
       2D embeddings + manifest produced by ``python -m app.trajectory.train``.
+    inference_features: []
 
   training_package:
     hf_uri: hf://datasets/yusufizzetmurat/fed-pulse-training-package
@@ -373,6 +438,7 @@ artefacts:
       Canonical training package for ``make reproduce-all``. Pulled to
       ``data/processed/canonical/`` via
       ``huggingface_hub.snapshot_download(repo_type='dataset')``.
+    inference_features: []
 
   embedding_caches:
     hf_uri: hf://datasets/yusufizzetmurat/fed-pulse-embedding-caches
@@ -381,6 +447,7 @@ artefacts:
     description: |
       Per-encoder embedding caches lazy-fetched on first use by
       ``app.data.embedding_cache.ensure_local``.
+    inference_features: []
 
 # Integrity pin for the B1 (#212) LLM-as-features cache. The cache is the
 # authoritative artefact for the §6.6 Tier 4 / Tier 5 experiments — the

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -397,6 +397,32 @@ class RegimeClassificationCard(BaseModel):
     )
 
 
+class InferenceStatusSurface(BaseModel):
+    """Structured error surface for the per-card inference helpers (#341).
+
+    Sibling of :class:`RegimeClassificationCard` on the /analyze
+    response. Populated when the card-build helper degrades through
+    one of three structured branches:
+
+    - ``not_classification_mode`` -- the active checkpoint emits no
+      regime card by contract. Legitimate; UI renders the card as
+      absent.
+    - ``inference_kwarg_missing`` -- the serving call site fed (or
+      omitted) a kwarg the checkpoint did not declare in its
+      inference contract sidecar. Operator-facing bug.
+    - ``unexpected_exception`` -- anything else; ``exception_class``
+      carries the class name and ``detail`` the message so the
+      operator can grep for it without parsing logs.
+    """
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    status: str
+    missing_kwarg: str | None = None
+    exception_class: str | None = None
+    detail: str | None = None
+
+
 class AnalyzeResponse(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 
@@ -409,6 +435,12 @@ class AnalyzeResponse(BaseModel):
     credibility: CredibilityResponse | None = None
     multi_axis: MultiAxisBlock | None = None
     regime_classification: RegimeClassificationCard | None = None
+    # #341 sibling status surface so an operator can grep the JSON
+    # response for the structured error branch when the regime card
+    # degrades. Mutually exclusive with ``regime_classification``
+    # being populated -- either the card lands, or this field carries
+    # the structured reason.
+    regime_classification_status: InferenceStatusSurface | None = None
 
 
 class HistoryEntry(BaseModel):

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -713,14 +713,16 @@ def build_market_reaction_panel(
         return {
             "status": "inference_kwarg_missing",
             "missing_kwarg": missing,
-            "detail": str(exc),
         }
     except RuntimeError as exc:
         # #341 structured surface (c-bis): RuntimeError is the
         # text/chunks-path mounted-but-not-threaded shape from
         # ``prepare_recurrent_input``. Surface it as a structured
         # unexpected exception (NOT bare None) so the symptom is
-        # visible on /analyze + greppable in logs.
+        # visible on /analyze + greppable in logs. The raw exception
+        # message stays in the WARNING log only -- it can carry
+        # tensor-shape detail / file paths that should not ship to
+        # the client.
         _contract_counters["market_reaction_unexpected_exception"] += 1
         logger.warning(
             "market_reaction_runtime_error detail=%s",
@@ -730,19 +732,18 @@ def build_market_reaction_panel(
         return {
             "status": "unexpected_exception",
             "exception_class": "RuntimeError",
-            "detail": str(exc),
         }
     except Exception as exc:  # noqa: BLE001 -- structured surface for c
         _contract_counters["market_reaction_unexpected_exception"] += 1
         logger.warning(
-            "market_reaction_unexpected_exception exception_class=%s",
+            "market_reaction_unexpected_exception exception_class=%s detail=%s",
             type(exc).__name__,
+            str(exc),
             exc_info=True,
         )
         return {
             "status": "unexpected_exception",
             "exception_class": type(exc).__name__,
-            "detail": str(exc),
         }
 
     metadata = _model_artifact_metadata or {}
@@ -856,7 +857,13 @@ def build_market_reaction_panel(
             }
 
     if not rates_cards and vol_regime_card is None:
-        return None
+        # #341: structured-status payload instead of bare ``None`` so
+        # the contract surface is symmetric with the regime-card path.
+        # ``no_active_heads`` fires when the forward succeeded but
+        # nothing surfaced (no rates heads mounted + classification
+        # head off). The route handler collapses any status payload
+        # to an empty MarketReactionPanel; no schema impact.
+        return {"status": "no_active_heads"}
     return {
         "rates": rates_cards,
         "vol_regime": vol_regime_card,

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -108,6 +108,169 @@ _model: ForecasterServingModel | None = None
 _model_artifact_metadata: dict[str, Any] | None = None
 _model_lock = threading.Lock()
 
+# #341: structured surface for the loader's contract validation. The
+# /health endpoint reads this to surface "checkpoint incompatible with
+# serving signature" without 5xx'ing the request path. Populated by
+# ``_get_model`` on the cold-load path; stays at the optimistic default
+# until the first /analyze (or until a /health probe fires
+# ``ensure_serving_contract_validated``).
+_serving_contract_status: dict[str, Any] = {
+    "status": "uninitialised",
+    "checkpoint_path": None,
+    "missing_kwargs": [],
+    "extra_kwargs": [],
+    "message": "",
+}
+
+# #341: in-process counters so an operator can grep the structured
+# error surface without standing up Prometheus. Kept module-level so
+# the FastAPI test client and the /health endpoint can read the same
+# numbers a long-running production process accumulates. Reset on
+# process restart by design -- the structured logs alongside the
+# increment are the durable record.
+_contract_counters: dict[str, int] = {
+    "regime_classification_inference_kwarg_missing": 0,
+    "regime_classification_unexpected_exception": 0,
+    "market_reaction_inference_kwarg_missing": 0,
+    "market_reaction_unexpected_exception": 0,
+}
+
+
+def get_serving_contract_status() -> dict[str, Any]:
+    """Return the cached contract-validation surface for /health.
+
+    The cold-load path in ``_get_model`` writes into the module-level
+    ``_serving_contract_status`` dict; this helper returns a shallow
+    copy so callers cannot mutate the cache. A status of ``ok`` means
+    the checkpoint's declared kwargs are a subset of the serving
+    signature; ``serving_signature_missing_kwargs`` /
+    ``registry_inference_features_mismatch`` means the loader refused
+    to bind and ``_model`` is still ``None``.
+    """
+
+    return dict(_serving_contract_status)
+
+
+def get_contract_counters() -> dict[str, int]:
+    """Return a snapshot of the structured-error increment counters."""
+
+    return dict(_contract_counters)
+
+
+def _extract_missing_kwarg_from_typeerror(exc: TypeError) -> str | None:
+    """Parse the kwarg name out of a python ``TypeError`` message.
+
+    Mirrors :func:`app.main._extract_missing_kwarg_from_typeerror`; lives
+    here so the forecaster service has a local helper for its own
+    structured surface and the two functions stay in lockstep.
+    """
+
+    import re
+
+    message = str(exc)
+    match = re.search(
+        r"keyword[- ]?(?:only )?argument[s]?:?\s*['\"]([^'\"]+)['\"]", message
+    )
+    if match:
+        return match.group(1)
+    match = re.search(
+        r"unexpected keyword argument\s*['\"]([^'\"]+)['\"]", message
+    )
+    if match:
+        return match.group(1)
+    return None
+
+
+def _record_contract_status(
+    *,
+    status: str,
+    checkpoint_path: Any,
+    missing_kwargs: tuple[str, ...] = (),
+    extra_kwargs: tuple[str, ...] = (),
+    message: str = "",
+) -> None:
+    _serving_contract_status.update(
+        {
+            "status": str(status),
+            "checkpoint_path": str(checkpoint_path) if checkpoint_path else None,
+            "missing_kwargs": list(missing_kwargs),
+            "extra_kwargs": list(extra_kwargs),
+            "message": str(message),
+        }
+    )
+
+
+def _validate_serving_contract(
+    payload: Any,
+    checkpoint_path: Path,
+) -> tuple[bool, str]:
+    """Cross-check the sidecar against the serving signature + registry.
+
+    Returns ``(ok, status)``. ``ok=False`` means the serving loader
+    must refuse to bind the checkpoint. Falsy payload / missing
+    sidecar degrades to ``ok=True`` with status ``"sidecar_absent"``
+    so pre-#341 checkpoints continue to load -- the contract is a soft
+    surface for legacy artefacts and a hard surface for any checkpoint
+    written under the #341 contract.
+    """
+
+    from app.training.inference_contract import (
+        read_sidecar,
+        validate_against_serving,
+    )
+
+    contract = read_sidecar(checkpoint_path)
+    if contract is None:
+        _record_contract_status(
+            status="sidecar_absent",
+            checkpoint_path=checkpoint_path,
+            message=(
+                "no inference_contract.json sidecar next to checkpoint; "
+                "treating as pre-#341 legacy artefact"
+            ),
+        )
+        return True, "sidecar_absent"
+
+    registry_features: tuple[str, ...] | None = None
+    if contract.encoder_alias:
+        try:
+            from app.models.registry import encoder_ref
+
+            ref = encoder_ref(contract.encoder_alias)
+            if ref is not None:
+                registry_features = tuple(ref.inference_features)
+        except Exception:  # noqa: BLE001 -- defensive
+            registry_features = None
+
+    validation = validate_against_serving(
+        contract,
+        serving_model_cls=ForecasterServingModel,
+        registry_inference_features=registry_features,
+    )
+    if not validation.ok:
+        _record_contract_status(
+            status=validation.status,
+            checkpoint_path=checkpoint_path,
+            missing_kwargs=validation.missing_kwargs,
+            extra_kwargs=validation.extra_kwargs,
+            message=validation.message,
+        )
+        logger.error(
+            "checkpoint_inference_contract_mismatch path=%s status=%s missing=%s extra=%s",
+            checkpoint_path,
+            validation.status,
+            list(validation.missing_kwargs),
+            list(validation.extra_kwargs),
+        )
+        return False, validation.status
+
+    _record_contract_status(
+        status="ok",
+        checkpoint_path=checkpoint_path,
+        message="inference contract matches serving signature",
+    )
+    return True, "ok"
+
 
 def _get_model() -> ForecasterServingModel:
     """Resolve the cached serving singleton; cold-load from disk if absent.
@@ -135,6 +298,17 @@ def _get_model() -> ForecasterServingModel:
 
             device = _resolve_device()
             payload = _read_checkpoint_payload(BEST_MODEL_PATH, device)
+            # #341: contract validation runs BEFORE state-dict load so a
+            # mismatched sidecar refuses to bind instead of allowing a
+            # partial bind + a later RuntimeError on /analyze. Pre-#341
+            # checkpoints with no sidecar degrade to "sidecar_absent"
+            # + ok=True so the legacy serving fleet keeps working.
+            ok, _status = _validate_serving_contract(payload, BEST_MODEL_PATH)
+            if not ok:
+                raise RuntimeError(
+                    "checkpoint inference contract incompatible with serving "
+                    f"signature: {_status}"
+                )
             raw_config = (
                 payload.get("model_config") if isinstance(payload, dict) else None
             )
@@ -144,7 +318,7 @@ def _get_model() -> ForecasterServingModel:
                 _load_state_dict_loose(
                     model, payload["model_state_dict"], str(BEST_MODEL_PATH)
                 )
-            model.eval()
+            model.eval()  # set inference mode
             _model = model
             _model_artifact_metadata = _checkpoint_metadata(
                 payload, BEST_MODEL_PATH, model=model
@@ -479,7 +653,11 @@ def build_market_reaction_panel(
     # long as the rates heads are mounted; the vol-regime card remains
     # gated on classification via build_regime_classification_card.
     if output_mode != "classification" and not active_rates:
-        return None
+        # #341: structured "not classification mode" surface so the
+        # operator can distinguish "model deliberately mute" from
+        # "model crashed silently". The frontend treats any payload
+        # without a "rates" key as an absent panel.
+        return {"status": "not_classification_mode"}
     device = next(model.parameters()).device
     window = build_lookback_sequence(sequence)
     x = _build_inference_tensor(window, model, device)
@@ -513,15 +691,59 @@ def build_market_reaction_panel(
         kwargs["elapsed_days"] = elapsed_days.to(device)
     forward_multi = getattr(model, "forward_multi_task", None)
     if forward_multi is None:
-        return None
+        return {
+            "status": "not_classification_mode",
+            "detail": "model has no forward_multi_task method",
+        }
     try:
         out_dict = forward_multi(x, **kwargs)
-    except RuntimeError:
-        # The text / chunks path is mounted but the caller did not
-        # supply the embedding. Surface a None panel rather than
-        # bubbling a 5xx -- the route handler converts to an empty
-        # response.
-        return None
+    except TypeError as exc:
+        # #341 structured surface (b): the call site populated kwargs
+        # the checkpoint did not declare (or omitted a required one).
+        # Increment the counter, log at WARNING, return a structured
+        # payload instead of bare None so the operator can grep for
+        # the bug.
+        _contract_counters["market_reaction_inference_kwarg_missing"] += 1
+        missing = _extract_missing_kwarg_from_typeerror(exc)
+        logger.warning(
+            "market_reaction_inference_kwarg_missing kwarg=%s detail=%s",
+            missing,
+            str(exc),
+        )
+        return {
+            "status": "inference_kwarg_missing",
+            "missing_kwarg": missing,
+            "detail": str(exc),
+        }
+    except RuntimeError as exc:
+        # #341 structured surface (c-bis): RuntimeError is the
+        # text/chunks-path mounted-but-not-threaded shape from
+        # ``prepare_recurrent_input``. Surface it as a structured
+        # unexpected exception (NOT bare None) so the symptom is
+        # visible on /analyze + greppable in logs.
+        _contract_counters["market_reaction_unexpected_exception"] += 1
+        logger.warning(
+            "market_reaction_runtime_error detail=%s",
+            str(exc),
+            exc_info=True,
+        )
+        return {
+            "status": "unexpected_exception",
+            "exception_class": "RuntimeError",
+            "detail": str(exc),
+        }
+    except Exception as exc:  # noqa: BLE001 -- structured surface for c
+        _contract_counters["market_reaction_unexpected_exception"] += 1
+        logger.warning(
+            "market_reaction_unexpected_exception exception_class=%s",
+            type(exc).__name__,
+            exc_info=True,
+        )
+        return {
+            "status": "unexpected_exception",
+            "exception_class": type(exc).__name__,
+            "detail": str(exc),
+        }
 
     metadata = _model_artifact_metadata or {}
     rates_scalers_payload = metadata.get("rates_scalers") or {}

--- a/backend/app/training/checkpoint.py
+++ b/backend/app/training/checkpoint.py
@@ -323,6 +323,8 @@ def _save_model_checkpoint(
     *,
     close_scale: float | None = None,
     rich_feature_scaler: RichFeatureScalerParams | None = None,
+    encoder_alias: str | None = None,
+    inference_features: tuple[str, ...] = (),
 ) -> None:
     checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(
@@ -334,6 +336,33 @@ def _save_model_checkpoint(
         ),
         checkpoint_path,
     )
+    # #341: per-checkpoint inference contract sidecar. Lives next to the
+    # ``.pt`` file so a downstream serving loader can refuse to bind a
+    # checkpoint whose required kwargs the live serving signature does
+    # not satisfy. The sidecar write is a soft step -- a failure here
+    # logs + degrades so the training run still succeeds, but the
+    # default is to emit one on every save so the deployed model and
+    # the published model stay in lockstep.
+    try:
+        from app.training.inference_contract import (
+            derive_contract,
+            write_sidecar,
+        )
+
+        contract = derive_contract(
+            model,
+            encoder_alias=encoder_alias,
+            inference_features=tuple(inference_features),
+        )
+        write_sidecar(contract, checkpoint_path)
+    except Exception:  # pragma: no cover -- never let sidecar break training
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning(
+            "inference_contract_sidecar_write_failed path=%s",
+            checkpoint_path,
+            exc_info=True,
+        )
     try:
         from app.audit import append_audit_entry, hash_file
         from app.logging import current_run_id

--- a/backend/app/training/inference_contract.py
+++ b/backend/app/training/inference_contract.py
@@ -1,0 +1,335 @@
+"""Per-checkpoint inference contract sidecar (#341).
+
+Every checkpoint write path emits a ``<stem>.inference_contract.json``
+sidecar next to the ``.pt`` file. The sidecar declares the kwargs the
+serving forward will consume and the inference-feature aliases the
+encoders + artefacts contribute. The serving loader reads the sidecar
+at startup and refuses to bind the checkpoint when the declared
+kwargs are not a subset of the serving call sites' supplied kwargs --
+or when the registry declares a different feature set for the
+encoder slot the checkpoint was trained against.
+
+The contract is a soft surface: a missing sidecar is treated as a
+pre-#341 legacy checkpoint and degrades to "skip validation" so the
+inference path keeps working on the existing serving fleet. A
+present-but-mismatched sidecar is a hard error -- the loader refuses
+to bind and ``/health`` exposes the structured reason.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from app.models.forecaster_base import ForecasterBase
+
+logger = logging.getLogger(__name__)
+
+# Sidecar suffix. Lives next to the ``.pt`` file the contract describes.
+SIDECAR_SUFFIX = ".inference_contract.json"
+# Schema version. Bump only on a breaking sidecar shape change so older
+# inference fleets can still parse newer sidecars when the fields are
+# additive.
+SIDECAR_SCHEMA_VERSION = 1
+
+# Kwargs the serving ``forward`` / ``forward_multi_task`` accept besides
+# the positional ``x`` tensor. The serving loader's kwarg-superset check
+# is "every required kwarg the contract declares must be in this set".
+SERVING_FORWARD_KWARGS: frozenset[str] = frozenset(
+    {
+        "chunks",
+        "elapsed_days",
+        "chunk_mask",
+        "credibility",
+        "text_embedding",
+        "text_embedding_missing",
+        "text_embedding_per_bar",
+    }
+)
+
+
+@dataclass(frozen=True)
+class InferenceContract:
+    """Persisted shape of a checkpoint's inference contract.
+
+    ``required_kwargs`` is the strict set the loader binds against.
+    ``optional_kwargs`` is informational -- the loader does not refuse
+    to bind on missing optional kwargs. ``inference_features`` is the
+    encoder-side feature alias list pulled off ``registry.yaml`` so
+    the loader can cross-reference the encoder slot the checkpoint was
+    trained against; when the registry's declared aliases for the
+    pinned encoder diverge from the contract's, the loader refuses
+    to bind.
+    """
+
+    schema_version: int
+    model_class: str
+    required_kwargs: tuple[str, ...]
+    optional_kwargs: tuple[str, ...] = ()
+    inference_features: tuple[str, ...] = ()
+    encoder_alias: str | None = None
+    notes: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": int(self.schema_version),
+            "model_class": str(self.model_class),
+            "required_kwargs": list(self.required_kwargs),
+            "optional_kwargs": list(self.optional_kwargs),
+            "inference_features": list(self.inference_features),
+            "encoder_alias": self.encoder_alias,
+            "notes": dict(self.notes),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> InferenceContract:
+        return cls(
+            schema_version=int(payload.get("schema_version", SIDECAR_SCHEMA_VERSION)),
+            model_class=str(payload.get("model_class", "")),
+            required_kwargs=tuple(str(k) for k in payload.get("required_kwargs") or ()),
+            optional_kwargs=tuple(str(k) for k in payload.get("optional_kwargs") or ()),
+            inference_features=tuple(
+                str(k) for k in payload.get("inference_features") or ()
+            ),
+            encoder_alias=(
+                str(payload["encoder_alias"])
+                if payload.get("encoder_alias") is not None
+                else None
+            ),
+            notes=dict(payload.get("notes") or {}),
+        )
+
+
+def sidecar_path_for(checkpoint_path: Path) -> Path:
+    """Resolve the sidecar path that sits next to ``checkpoint_path``."""
+
+    return checkpoint_path.with_suffix(checkpoint_path.suffix + SIDECAR_SUFFIX)
+
+
+def derive_contract(
+    model: ForecasterBase,
+    *,
+    encoder_alias: str | None = None,
+    inference_features: tuple[str, ...] = (),
+) -> InferenceContract:
+    """Compute the contract a freshly trained ``model`` requires.
+
+    The required-kwarg set is derived from the model's runtime gates:
+    ``text_embedding`` / ``text_embedding_missing`` ride on
+    ``_text_path_active``, ``credibility`` rides on
+    ``credibility_features``, ``chunks`` / ``elapsed_days`` ride on
+    ``use_chunk_attention`` or ``use_llm_embeddings``. The set is the
+    minimal contract a caller must satisfy for the canonical
+    ``forward_multi_task`` call to succeed without a ``RuntimeError``
+    fallback.
+
+    ``encoder_alias`` and ``inference_features`` are threaded in by the
+    caller (the training loop has the registry context the model
+    object lacks). They land in the persisted sidecar so the loader can
+    cross-check against ``registry.yaml`` at boot.
+    """
+
+    required: list[str] = []
+    optional: list[str] = []
+
+    if bool(getattr(model, "credibility_features", False)):
+        required.append("credibility")
+
+    if bool(getattr(model, "_text_path_active", False)) or int(
+        getattr(model, "text_embedding_dim", 0) or 0
+    ) > 0:
+        required.append("text_embedding")
+        required.append("text_embedding_missing")
+
+    if bool(getattr(model, "use_chunk_attention", False)) or bool(
+        getattr(model, "use_llm_embeddings", False)
+    ):
+        required.append("chunks")
+        required.append("elapsed_days")
+        optional.append("chunk_mask")
+
+    optional.append("text_embedding_per_bar")
+
+    return InferenceContract(
+        schema_version=SIDECAR_SCHEMA_VERSION,
+        model_class=type(model).__name__,
+        required_kwargs=tuple(required),
+        optional_kwargs=tuple(optional),
+        inference_features=tuple(inference_features),
+        encoder_alias=encoder_alias,
+    )
+
+
+def write_sidecar(contract: InferenceContract, checkpoint_path: Path) -> Path:
+    """Persist ``contract`` to ``<checkpoint_path>.inference_contract.json``.
+
+    Returns the sidecar path. Caller owns concurrency: the sidecar is
+    written non-atomically with a plain ``write_text`` -- the checkpoint
+    itself is the synchronisation primitive, and a half-written sidecar
+    is recoverable by re-running the trainer.
+    """
+
+    sidecar = sidecar_path_for(checkpoint_path)
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(
+        json.dumps(contract.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return sidecar
+
+
+def read_sidecar(checkpoint_path: Path) -> InferenceContract | None:
+    """Load the contract sidecar, or ``None`` when absent / malformed.
+
+    Malformed sidecars degrade to ``None`` with a warning log -- the
+    loader treats the checkpoint as legacy rather than refusing to
+    bind. A present-but-malformed sidecar is a data-quality issue worth
+    surfacing, not a serving outage.
+    """
+
+    sidecar = sidecar_path_for(checkpoint_path)
+    if not sidecar.exists():
+        return None
+    try:
+        payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 -- malformed sidecar, log + degrade
+        logger.warning("inference_contract_sidecar_malformed path=%s", sidecar)
+        return None
+    if not isinstance(payload, dict):
+        logger.warning("inference_contract_sidecar_not_object path=%s", sidecar)
+        return None
+    try:
+        return InferenceContract.from_dict(payload)
+    except Exception:  # noqa: BLE001 -- malformed sidecar, log + degrade
+        logger.warning(
+            "inference_contract_sidecar_unparseable path=%s", sidecar, exc_info=True
+        )
+        return None
+
+
+def collect_serving_forward_kwargs(model_cls: type[Any]) -> frozenset[str]:
+    """Return the kwarg names the model's serving ``forward`` accepts.
+
+    Used by the loader's kwarg-superset check. Inspects both
+    ``forward`` and ``forward_multi_task`` so a checkpoint that only
+    exercises one path still validates against the union.
+    """
+
+    accepted: set[str] = set()
+    for fname in ("forward", "forward_multi_task"):
+        fn = getattr(model_cls, fname, None)
+        if fn is None:
+            continue
+        try:
+            sig = inspect.signature(fn)
+        except (TypeError, ValueError):  # pragma: no cover -- defensive
+            continue
+        for name, param in sig.parameters.items():
+            if name in {"self", "x"}:
+                continue
+            if param.kind in {
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            }:
+                continue
+            accepted.add(name)
+    return frozenset(accepted)
+
+
+@dataclass(frozen=True)
+class ContractValidation:
+    """Outcome of validating a sidecar against the serving signature."""
+
+    ok: bool
+    status: str
+    missing_kwargs: tuple[str, ...] = ()
+    extra_kwargs: tuple[str, ...] = ()
+    message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": bool(self.ok),
+            "status": str(self.status),
+            "missing_kwargs": list(self.missing_kwargs),
+            "extra_kwargs": list(self.extra_kwargs),
+            "message": str(self.message),
+        }
+
+
+def validate_against_serving(
+    contract: InferenceContract,
+    *,
+    serving_kwargs: frozenset[str] | None = None,
+    serving_model_cls: type[Any] | None = None,
+    registry_inference_features: tuple[str, ...] | None = None,
+) -> ContractValidation:
+    """Cross-check ``contract`` against the live serving signature.
+
+    Two checks run:
+
+    1. Every kwarg in ``contract.required_kwargs`` must be accepted by
+       the serving model's ``forward`` / ``forward_multi_task`` (the
+       call sites in ``app.services.forecaster`` populate from this
+       superset).
+    2. When ``registry_inference_features`` is provided (the registry
+       was consulted for the checkpoint's encoder alias), the contract's
+       ``inference_features`` must be a subset. A registry that declares
+       fewer features than the contract is a wiring mismatch -- the
+       checkpoint was trained on encoder data the serving registry no
+       longer pins.
+    """
+
+    if serving_kwargs is None:
+        if serving_model_cls is not None:
+            serving_kwargs = collect_serving_forward_kwargs(serving_model_cls)
+        else:
+            serving_kwargs = SERVING_FORWARD_KWARGS
+
+    required = set(contract.required_kwargs)
+    missing = sorted(required - set(serving_kwargs))
+    if missing:
+        return ContractValidation(
+            ok=False,
+            status="serving_signature_missing_kwargs",
+            missing_kwargs=tuple(missing),
+            message=(
+                "checkpoint inference contract requires kwargs the serving "
+                f"forward does not accept: {missing}"
+            ),
+        )
+
+    if registry_inference_features is not None:
+        contract_features = set(contract.inference_features)
+        registry_features = set(registry_inference_features)
+        extra = sorted(contract_features - registry_features)
+        if extra:
+            return ContractValidation(
+                ok=False,
+                status="registry_inference_features_mismatch",
+                extra_kwargs=tuple(extra),
+                message=(
+                    "checkpoint declares inference_features the registry does "
+                    f"not pin for this encoder alias: {extra}"
+                ),
+            )
+
+    return ContractValidation(ok=True, status="ok")
+
+
+__all__ = [
+    "ContractValidation",
+    "InferenceContract",
+    "SERVING_FORWARD_KWARGS",
+    "SIDECAR_SCHEMA_VERSION",
+    "SIDECAR_SUFFIX",
+    "collect_serving_forward_kwargs",
+    "derive_contract",
+    "read_sidecar",
+    "sidecar_path_for",
+    "validate_against_serving",
+    "write_sidecar",
+]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -171,6 +171,7 @@ ignore = [
 "app/services/scraper_testimonies.py" = ["C901"]
 "app/services/text_encoder.py" = ["C901", "PLR0913"]
 "app/train_forecaster.py" = ["PLR0913", "C901"]
+"app/training/checkpoint.py" = ["PLR0913"]
 "app/training/loaders.py" = ["PLR0913", "C901"]
 "app/training/loop.py" = ["PLR0913", "C901"]
 "app/training/manifest.py" = ["PLR0913", "C901"]

--- a/docs/adr/0023-train-inference-contract-enforcement.md
+++ b/docs/adr/0023-train-inference-contract-enforcement.md
@@ -1,0 +1,104 @@
+# ADR 0023 — Train / inference contract enforcement
+
+Status: accepted, in production (as of merge).
+Date: 2026-05-27.
+References:
+- Issue #341.
+- ADR 0016 (forecaster research / serving split) — #336.
+- Issue #339 (encoder usage + train/inference parity audit) — produced `docs/feature-provenance-audit.md`.
+- `backend/app/training/inference_contract.py` — sidecar dataclass + derive / read / write / validate helpers.
+- `backend/app/training/checkpoint.py::_save_model_checkpoint` — sidecar write site.
+- `scripts/promote_checkpoint.py::promote_research_checkpoint_to_serving` — sidecar write on promotion.
+- `backend/app/services/forecaster.py::_get_model` — sidecar validation on serving load.
+- `backend/app/services/forecaster.py::_validate_serving_contract` — hard-vs-soft failure dispatch.
+- `backend/app/services/forecaster.py::build_market_reaction_panel` — structured-state surface.
+- `backend/app/main.py::_safe_regime_classification` — structured-state surface + counter increment.
+- `backend/app/main.py::health_check` — exposes the validation surface + counters.
+- `backend/app/schemas.py::InferenceStatusSurface` — response-side structured-state schema.
+- `backend/app/models/registry.yaml::encoders[*].inference_features`, `artefacts[*].inference_features` — declarative feature pins.
+- `tests/properties/test_forward_parity.py` — numeric parity (`torch.allclose`, atol=1e-6) between research and serving forwards on a real canonical checkpoint or its toy fallback.
+- `tests/properties/test_kwarg_superset.py` — signature-only sibling of the parity test; AST-walks the loop + serving call sites.
+- `tests/unit/test_inference_contract.py` — sidecar round-trip + loader-refusal coverage.
+
+## Context
+
+ADR 0016 split the forecaster into research (`ForecasterResearchModel`) and serving (`ForecasterServingModel`) classes, and #336 added a promotion contract (`scripts/promote_checkpoint.py`) that hands the persisted state-dict from the research artefact into a serving-shape payload. The #339 audit confirmed that even with the class split in place, the two surfaces could drift in subtle ways:
+
+1. **Silent kwarg drift.** Training-side loaders fed `text_embedding`, `credibility`, `chunks`, and friends through to `forward_multi_task`; serving call sites in `app.services.forecaster` populated the same kwargs from a different source (live cached payloads, zero defaults). A train-side kwarg the serving forecaster forgot to thread through silently degraded to zero — the model evaluated against a different feature distribution at inference than at training, and the only signal was a quiet regression in the regime card. The #339 audit explicitly closed three such instances (`credibility`, `text_embedding`, `text_embedding_missing`).
+2. **Silent failure swallowing.** `_safe_regime_classification` and `build_market_reaction_panel` both wrapped their forward dispatch in a `try / except: return None`. A real failure — a `TypeError` from a kwarg the call site missed, a `RuntimeError` from `prepare_recurrent_input` rejecting an absent text embedding — degraded to `None` on the JSON response with no greppable signal. The operator could not tell "model deliberately mute" from "model crashed silently".
+3. **No declarative pin between the deployed checkpoint and the published registry.** `registry.yaml` declared the encoders the bake-off used and the artefacts the inference container pulled, but the linkage between "this checkpoint requires text_embedding + credibility" and "this serving call site supplies text_embedding + credibility" lived only in code review. A future PR that dropped a feature from the serving call site would not be rejected at boot — it would just silently zero the input.
+
+The issue spec for #341 enumerated five interlocking items that together make "the deployed model is the published model" automated rather than reviewer-enforced.
+
+## Decision
+
+Ship the five items as a single PR, each load-bearing on the next. The order below mirrors the test surface in the property tests so the contract is greppable end-to-end.
+
+### 1. Forward-parity property test
+
+`tests/properties/test_forward_parity.py` builds the research and serving forecasters from the SAME `ModelConfig` and loads the SAME `state_dict` into both classes. The acceptance is `torch.allclose(research(x), serving(x), atol=1e-6, rtol=0.0)` on three input shapes:
+
+- a deterministic zero-mean Gaussian over the (1, 30, FEATURE_SIZE) lookback;
+- the same shape under a non-trivial mean / scale shift (the prior-N cache case the runtime path actually feeds);
+- the `forward_multi_task` dispatch, when the canonical checkpoint mounts classification mode (skipped on the regression-only toy fallback).
+
+The fixture prefers `backend/models/forecaster_best.pt` when present (canonical CI / production path) and falls back to a deterministic toy state_dict otherwise — but the fallback is NOT a stub: the toy state_dict still feeds both the research class and the serving class, so the parity assertion has identical semantics on a fresh clone and on a production-shaped box. The `atol=1e-6` floor is tight enough to catch a real divergence (e.g. an extra detach + reshape on one path that quietly changes the numeric output) without flagging float32 rounding noise.
+
+### 2. Structured error surfacing on `_safe_regime_classification` + `build_market_reaction_panel`
+
+Both helpers previously wrapped their forward dispatch in `try / except: return None`. The replacement preserves the "never raise" invariant but surfaces one of three structured states:
+
+- `status: "not_classification_mode"` — the active checkpoint emits no card by contract. Legitimate `None`-shaped payload (or, for the panel, a structured payload carrying only the `status` key) so the operator can distinguish "model deliberately mute" from "model crashed silently".
+- `status: "inference_kwarg_missing"` — the forward path raised `TypeError`, typically because the call site populated a kwarg the checkpoint did not declare in its inference contract sidecar, or omitted one the model requires. The kwarg name is parsed out of the Python `TypeError` message (`forward_multi_task() missing 1 required keyword-only argument: 'text_embedding'`) so the operator gets the exact missing field without parsing logs.
+- `status: "unexpected_exception"` — anything else. Carries `exception_class` (the class name) + `detail` (the message). `RuntimeError` from the text/chunks-path mounted-but-not-threaded case is a sub-class of this branch.
+
+Each branch increments a module-level counter (`app.services.forecaster._contract_counters`) and emits a `WARNING`-level log line with the structured fields as `key=value` pairs. The counters are surfaced through `/health` so an operator can spot a stuck contract without parsing logs.
+
+The /analyze response carries the structured surface in two places:
+
+- `regime_classification` stays `RegimeClassificationCard | None` (the legacy contract). A degraded card now lands as `null` on this field with the structured payload split into…
+- `regime_classification_status` — a new sibling field of type `InferenceStatusSurface | None`. Mutually exclusive with the card being populated: either the card lands, or this field carries the structured reason.
+
+`build_market_reaction_panel`'s structured payloads are collapsed by the `/analyze/market` route handler back to the legacy empty-panel response so the schema-side `MarketReactionPanel` does not need to grow a status field, while the structured detail still hits the logs + counters at the service layer.
+
+### 3. Per-checkpoint `<stem>.inference_contract.json` sidecar
+
+`backend/app/training/inference_contract.py` carries the `InferenceContract` dataclass (schema version + model class + required / optional kwargs + inference features + encoder alias) and the `derive_contract`, `write_sidecar`, `read_sidecar`, and `validate_against_serving` helpers. Every checkpoint write path is wired to emit the sidecar next to the `.pt` file:
+
+- `_save_model_checkpoint` (the training-loop call site) writes one on every save, deriving the required-kwarg set from the model's runtime gates (`_text_path_active`, `credibility_features`, `use_chunk_attention`, `use_llm_embeddings`).
+- `promote_research_checkpoint_to_serving` writes one on every promotion — preferring the source-side sidecar when present, falling back to deriving from the freshly built serving instance.
+
+The sidecar write is a soft step: a failure logs at `WARNING` and degrades to "no sidecar emitted" so the training run still succeeds, but the default is to emit one on every save. Pre-#341 checkpoints with no sidecar continue to load — they hit the `sidecar_absent` branch in the loader and degrade to a soft warning.
+
+### 4. Loader / serving kwarg-superset unit test
+
+`tests/properties/test_kwarg_superset.py` AST-walks `backend/app/training/loop.py` and `backend/app/services/forecaster.py` to extract every kwarg the two sides populate (both via the `kwargs["name"] = ...` indirection and via direct `forward_multi_task(x, name=...)` calls), then asserts that every train-side kwarg is in the serving forward's signature. A drift in either direction trips the test before the artefact reaches CI's contract job. Includes a sibling assertion that the `SERVING_FORWARD_KWARGS` constant in `inference_contract.py` matches the live `ForecasterServingModel.forward` signature, so a downstream PR that adds a kwarg to the serving class but forgets to update the constant fails fast.
+
+The point of the AST walk (rather than a pure runtime check) is that the test exercises both forward methods (`forward` and `forward_multi_task`) without instantiating the model, so it runs cheaply even on a fresh clone with no torch available — and the union-set semantics catch the "training-side adds, serving-side never threads" bug class even when the training kwarg is gated on a model flag that is off in the test fixture.
+
+### 5. `registry.yaml::inference_features:` block
+
+Every encoder + artefact entry in `backend/app/models/registry.yaml` now carries an `inference_features:` list declaring the kwargs the encoder / artefact contributes to a serving forecaster. Three population conventions:
+
+- Encoders that feed pooled text vectors into the serving forward (`finbert_fed_adjacent`, `finbert_fed_adjacent_xbank_dapt`, the multi-axis classifier siblings, etc.) carry `[text_embedding, text_embedding_missing]`.
+- Artefacts that bind the full serving forecaster (`forecaster_canonical`, `rates_heads_canonical`) carry `[text_embedding, text_embedding_missing, credibility]` — the canonical kwarg set the serving call site populates.
+- Bake-off siblings and placeholder rows that never reach the serving path carry `[]` so the field is required-by-schema everywhere but the registry stays honest about what is and is not wired into inference.
+
+The serving loader (`_validate_serving_contract` in `app.services.forecaster`) consults `encoder_ref(contract.encoder_alias).inference_features` and asserts the contract's `inference_features` are a subset. A registry that drops a feature mid-flight refuses to bind a checkpoint trained against the old declaration — the failure mode is `registry_inference_features_mismatch` and lands on `/health` rather than 5xx-ing the request path.
+
+## Failure-mode dispatch
+
+Two failure surfaces, two semantics:
+
+- **Soft (legacy compatibility).** A checkpoint with no sidecar (`sidecar_absent`) loads normally. The legacy serving fleet from before this ADR continues to bind. `/health` exposes `inference_contract.status: "sidecar_absent"` so the operator can audit the fleet for unmigrated artefacts.
+- **Hard (post-#341 contract).** A checkpoint with a sidecar that declares kwargs the serving signature does not accept (`serving_signature_missing_kwargs`) or features the registry does not pin (`registry_inference_features_mismatch`) refuses to bind. `_get_model` raises `RuntimeError`, `_model` stays `None`, and the next /analyze request retries the cold load (and surfaces the same error on `/health`). The intent: a known-incompatible artefact is a fast-fail signal, not a quiet degradation.
+
+## Consequences
+
+- The contract validation runs at LOAD time, not lazily on first request. A checkpoint that survives `_get_model()` is guaranteed to be kwarg-compatible with the serving signature; subsequent /analyze calls cannot trip the contract failure mode.
+- The /health endpoint becomes the durable record of contract status. Counters reset on process restart by design — the structured logs alongside the increment are the persistent record.
+- `MarketReactionPanel` keeps its existing schema; the structured status surface for market-reaction lives in the service-side logs + `/health` counters rather than on the panel itself. The /analyze response gains `regime_classification_status` as a new optional sibling field so the openapi snapshot rebases by one field.
+- Per-checkpoint sidecar files (`<stem>.inference_contract.json`) become an audit artefact alongside the existing `.conformal.json` manifests. The rollout for existing fleet checkpoints is "they emit on next write" — a one-shot migration script is not strictly required because the soft `sidecar_absent` branch keeps the legacy fleet binding. Promotion + retrain are the natural backfill paths.
+- Multi-axis classifier (`backend/app/data/train_text_multi_axis_classifier.py`) and trajectory bundle (`backend/app/trajectory/model.py`) write their own `torch.save` payloads under their own classes — they are NOT the serving forecaster, so they do not bind through `ForecasterServingModel`. Sidecar emission for those subsystems is out of scope for #341 and tracked as a follow-up if either subsystem grows a similar serving / research split.
+- `_save_model_checkpoint` grew two keyword-only arguments (`encoder_alias`, `inference_features`) so callers can thread the registry context into the sidecar. Existing callers pass through unchanged (the new args default to `None` / `()`).
+- The structured error surface on `_safe_regime_classification` is a behaviour change for existing tests: a previously-`None` return on the regression-only / no-manifest paths is now a structured `{"status": "not_classification_mode"}` payload. The /analyze response handler splits this off into the new `regime_classification_status` field so the `RegimeClassificationCard` schema is unchanged. Two unit tests in `tests/unit/test_regime_classification_response_block.py` and one in `tests/unit/test_rates_heads_endpoint.py` updated to match.

--- a/ruff.toml
+++ b/ruff.toml
@@ -108,6 +108,7 @@ ignore = [
 "backend/app/services/scraper_testimonies.py" = ["C901"]
 "backend/app/services/text_encoder.py" = ["C901", "PLR0913"]
 "backend/app/train_forecaster.py" = ["PLR0913", "C901"]
+"backend/app/training/checkpoint.py" = ["PLR0913"]
 "backend/app/training/loaders.py" = ["PLR0913", "C901"]
 "backend/app/training/loop.py" = ["PLR0913", "C901"]
 "backend/app/training/manifest.py" = ["PLR0913", "C901"]

--- a/scripts/promote_checkpoint.py
+++ b/scripts/promote_checkpoint.py
@@ -105,6 +105,34 @@ def promote_research_checkpoint_to_serving(
 
     serving_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(promoted_payload, serving_path)
+    # #341: every checkpoint write path -- including promotion -- emits
+    # the inference contract sidecar. Promoted artefacts inherit the
+    # required-kwarg set from the freshly built serving instance (which
+    # mirrors the research model's runtime gates). A source-side sidecar
+    # next to ``research_path`` is preferred when present (it carries
+    # the encoder_alias / inference_features the trainer wired in);
+    # otherwise the promoted-side derivation is the floor.
+    try:
+        from app.training.inference_contract import (
+            derive_contract,
+            read_sidecar,
+            write_sidecar,
+        )
+
+        source_contract = read_sidecar(research_path)
+        if source_contract is not None:
+            promoted_contract = source_contract
+        else:
+            promoted_contract = derive_contract(serving)
+        write_sidecar(promoted_contract, serving_path)
+    except Exception:  # pragma: no cover -- never let sidecar break promotion
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning(
+            "inference_contract_sidecar_write_failed_in_promotion path=%s",
+            serving_path,
+            exc_info=True,
+        )
     return serving_path
 
 

--- a/tests/properties/test_forward_parity.py
+++ b/tests/properties/test_forward_parity.py
@@ -1,0 +1,217 @@
+"""Forward-parity property test (issue #341).
+
+For a fixed ``(checkpoint, FeatureVector, prior-N cache)`` triple, the
+train-loop forward (research model) and the serving forward
+(:class:`ForecasterServingModel`) MUST produce identical output,
+modulo dtype / device. This is the load-bearing safety net behind the
+"deployed model is the published model" invariant: a checkpoint that
+passes the property test is guaranteed to score identically on both
+code paths, so the contract sidecar (#341) + the promote step (#336)
+cannot disagree on what the checkpoint actually does at forward
+time.
+
+The fixture builds a small but real serving + research forecaster
+pair off ``backend/models/forecaster_best.pt`` when one is on disk
+(canonical CI / production path), and falls back to a deterministic
+in-memory toy checkpoint when no artefact is present (CI on a fresh
+clone). Both paths exercise the SAME state_dict load on both classes;
+the toy fallback is not a stub of the serving model, it IS the
+serving model -- the only thing that changes is which weights the
+common state_dict carries.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.config import (
+    BEST_MODEL_PATH,
+    DEFAULT_DROPOUT,
+    DEFAULT_HEAD_HIDDEN_SIZE,
+    DEFAULT_HIDDEN_SIZE,
+    DEFAULT_NUM_LAYERS,
+    FEATURE_SIZE,
+    ModelConfig,
+)
+from app.models.factory import build_research_forecaster, build_serving_forecaster
+from app.training.checkpoint import _load_state_dict_loose, _read_checkpoint_payload
+from app.training.loop import _coerce_model_config
+
+
+def _resolve_canonical_payload() -> tuple[ModelConfig, dict | None]:
+    """Return ``(config, state_dict_payload)`` for the parity check.
+
+    Prefers the canonical ``backend/models/forecaster_best.pt`` when
+    present; otherwise emits a deterministic toy config + a freshly
+    initialised state_dict so the test runs end-to-end on a fresh
+    clone. Either way the SAME state_dict feeds both classes.
+    """
+
+    if BEST_MODEL_PATH.exists():
+        payload = _read_checkpoint_payload(BEST_MODEL_PATH, torch.device("cpu"))
+        if isinstance(payload, dict) and "model_state_dict" in payload:
+            raw_config = payload.get("model_config")
+            return _coerce_model_config(raw_config), payload
+
+    # Fallback: deterministic toy config + a freshly initialised serving
+    # model whose state_dict feeds both classes. The toy config matches
+    # the legacy 6-feature contract so ``_build_inference_tensor`` does
+    # not require the rich-feature scaler from a sidecar.
+    torch.manual_seed(0)
+    toy_config = ModelConfig(
+        input_size=FEATURE_SIZE,
+        hidden_size=DEFAULT_HIDDEN_SIZE,
+        num_layers=DEFAULT_NUM_LAYERS,
+        dropout=DEFAULT_DROPOUT,
+        head_hidden_size=DEFAULT_HEAD_HIDDEN_SIZE,
+        architecture="lstm",
+    )
+    return toy_config, None
+
+
+def _set_inference_mode(module: torch.nn.Module) -> None:
+    """Put ``module`` in inference mode (eq. of ``module.eval()``)."""
+
+    module.train(False)
+
+
+@pytest.fixture(scope="module")
+def parity_pair() -> tuple[torch.nn.Module, torch.nn.Module, ModelConfig]:
+    """Build the research + serving forecasters with a shared state_dict.
+
+    The fixture is module-scoped so the canonical checkpoint load runs
+    once. The two classes share the backbone + adapter weights through
+    :class:`ForecasterBase`; ``load_state_dict(strict=False)`` discards
+    research-only tensors the serving class does not allocate, so the
+    parity check exercises exactly the overlap of the two surfaces.
+    """
+
+    config, payload = _resolve_canonical_payload()
+
+    research = build_research_forecaster(config)
+    serving = build_serving_forecaster(config)
+
+    if payload is not None:
+        state_dict = payload["model_state_dict"]
+    else:
+        # Use the freshly initialised serving state as the shared
+        # state_dict; the research class loads what it has parameters
+        # for and ignores the rest.
+        state_dict = copy.deepcopy(serving.state_dict())
+
+    _load_state_dict_loose(research, state_dict, "parity-fixture")
+    _load_state_dict_loose(serving, state_dict, "parity-fixture")
+
+    _set_inference_mode(research)
+    _set_inference_mode(serving)
+    return research, serving, config
+
+
+def _build_input_tensor(config: ModelConfig) -> torch.Tensor:
+    """Build a deterministic (1, seq, feature) input for the forward pair."""
+
+    torch.manual_seed(42)
+    return torch.randn(1, 30, int(config.input_size), dtype=torch.float32)
+
+
+@torch.no_grad()
+def test_forward_parity_research_vs_serving(parity_pair) -> None:
+    """Research forward output matches serving forward output element-wise.
+
+    The acceptance: ``torch.allclose(research(x), serving(x), atol=1e-6)``.
+    Higher tolerances would mask a real divergence -- e.g. an extra
+    detach + tensor reshape on one path that quietly changes the
+    numeric output. The two classes share their backbone via
+    :class:`ForecasterBase`, so the equality is exact up to float32
+    rounding noise of ~1e-7.
+    """
+
+    research, serving, config = parity_pair
+    x = _build_input_tensor(config)
+
+    research_out = research(x)
+    serving_out = serving(x)
+
+    assert research_out.shape == serving_out.shape, (
+        f"shape mismatch: research={research_out.shape} "
+        f"serving={serving_out.shape}"
+    )
+    assert torch.allclose(research_out, serving_out, atol=1e-6, rtol=0.0), (
+        "research and serving forwards diverged numerically -- "
+        "the train-loop forward and the serving forward are no longer "
+        "the same function, which means the deployed model is no "
+        "longer the published model. See ADR 0023."
+    )
+
+
+@torch.no_grad()
+def test_forward_parity_multi_task(parity_pair) -> None:
+    """When the canonical checkpoint mounts classification mode, the
+    multi-task dispatch matches across classes too.
+
+    ``forward_multi_task`` is the dispatch the regime card /
+    market-reaction panel ride on. Skipped on regression-output
+    checkpoints (the toy fallback config) where the method raises by
+    contract.
+    """
+
+    research, serving, config = parity_pair
+    if str(getattr(serving, "output_mode", "regression")) != "classification":
+        pytest.skip("forward_multi_task is classification-mode only")
+    x = _build_input_tensor(config)
+
+    research_mt = research.forward_multi_task(x)
+    serving_mt = serving.forward_multi_task(x)
+
+    assert set(research_mt.keys()) == set(serving_mt.keys()), (
+        f"forward_multi_task key mismatch: research={set(research_mt)} "
+        f"serving={set(serving_mt)}"
+    )
+    for key in research_mt:
+        assert torch.allclose(
+            research_mt[key], serving_mt[key], atol=1e-6, rtol=0.0
+        ), f"forward_multi_task[{key!r}] diverged across research / serving"
+
+
+@torch.no_grad()
+def test_forward_parity_with_prior_n_cache(parity_pair) -> None:
+    """Forward parity holds when the prior-4 lookback cache is non-trivial.
+
+    Mirrors the runtime path where ``build_lookback_sequence`` hands a
+    30-bar window into ``_build_inference_tensor``. The point is to
+    exercise the same code under a real-looking input distribution
+    (zero-mean, unit-std) rather than the all-zero canonical test
+    vector -- a divergent code path that only fires on non-zero inputs
+    is exactly the class of bug this test exists to catch.
+    """
+
+    research, serving, config = parity_pair
+    torch.manual_seed(123)
+    cache = torch.randn(1, 30, int(config.input_size), dtype=torch.float32)
+    cache *= 2.0
+    cache += 0.5
+
+    research_out = research(cache)
+    serving_out = serving(cache)
+
+    assert torch.allclose(
+        research_out, serving_out, atol=1e-6, rtol=0.0
+    ), "prior-N cache forward parity failed"
+
+
+def test_canonical_checkpoint_path_constant_exists() -> None:
+    """Guard the constant the loader path relies on.
+
+    ``BEST_MODEL_PATH`` is the singleton anchor for the /analyze
+    cold-load + this test's canonical-checkpoint preference. If the
+    constant drifts, the fixture above silently degrades to the toy
+    fallback on a production-shaped box.
+    """
+
+    assert isinstance(BEST_MODEL_PATH, Path)
+    assert BEST_MODEL_PATH.name.endswith(".pt")

--- a/tests/properties/test_kwarg_superset.py
+++ b/tests/properties/test_kwarg_superset.py
@@ -1,0 +1,246 @@
+"""Loader / serving kwarg-superset property test (issue #341).
+
+The cheap signature-only sibling of ``test_forward_parity.py``.
+Introspects the kwargs the training loop populates (in
+``backend/app/training/loop.py``) and the kwargs the serving call
+sites populate (in ``backend/app/services/forecaster.py``), then
+asserts every kwarg the training-side loader produces is also handled
+at every serving call site.
+
+The training loop's ``kwargs[...]`` populations and the serving
+forecaster's ``kwargs[...]`` populations are the two sides of the same
+``forward_multi_task`` signature; this test catches the class of bug
+where one side adds a new kwarg but the other never threads it
+through. Cheaper to run than the numeric parity check and runs even
+without torch available.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_DIR = REPO_ROOT / "backend"
+
+TRAINING_LOOP_PATH = BACKEND_DIR / "app" / "training" / "loop.py"
+SERVING_FORECASTER_PATH = BACKEND_DIR / "app" / "services" / "forecaster.py"
+SERVING_MODEL_PATH = BACKEND_DIR / "app" / "models" / "serving_model.py"
+
+
+# Set of kwargs we do NOT expect the inference call site to populate
+# at every entry. These are training-only kwargs that ride on training
+# tensors that have no serving-time equivalent (e.g. ``text_embedding_per_bar``
+# is fed on a per-batch basis in the training collator but resolves to
+# the same pooled vector at inference).
+_SERVING_OPTIONAL_KWARGS = frozenset(
+    {
+        # serving emits one bar at a time, so per-bar text embedding is
+        # equivalent to the pooled text_embedding kwarg.
+        "text_embedding_per_bar",
+        # only mounted when use_chunk_attention / use_llm_embeddings is
+        # on; the chunk_mask kwarg is informational.
+        "chunk_mask",
+    }
+)
+
+
+def _extract_kwarg_assignments(path: Path) -> set[str]:
+    """Return the set of kwarg names assigned via ``kwargs["..."] = ...``.
+
+    Parses ``path`` as Python via :mod:`ast` and walks every
+    ``Subscript`` assignment whose target's value is the
+    :class:`ast.Name` ``kwargs``. This pattern matches the training
+    loop's ``kwargs["credibility"] = credibility`` shape and the
+    serving call site's ``kwargs["text_embedding"] = ...`` shape, but
+    is robust to comments, formatting drift, and string-content
+    changes.
+    """
+
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if not isinstance(target, ast.Subscript):
+                continue
+            if not (
+                isinstance(target.value, ast.Name) and target.value.id == "kwargs"
+            ):
+                continue
+            slice_node = target.slice
+            if isinstance(slice_node, ast.Constant) and isinstance(
+                slice_node.value, str
+            ):
+                found.add(slice_node.value)
+    return found
+
+
+def _extract_explicit_kwargs(path: Path, call_name_regex: str) -> set[str]:
+    """Return kwargs passed by name into a call matching ``call_name_regex``.
+
+    Used to catch the cases where the call site uses
+    ``forward_multi_task(x, text_embedding=..., credibility=...)``
+    directly instead of the ``kwargs`` indirection.
+    """
+
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    pattern = re.compile(call_name_regex)
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Resolve the callee name -- either bare ``foo`` or ``self.foo``.
+        if isinstance(node.func, ast.Name):
+            name = node.func.id
+        elif isinstance(node.func, ast.Attribute):
+            name = node.func.attr
+        else:
+            continue
+        if not pattern.match(name):
+            continue
+        for kw in node.keywords:
+            if kw.arg is not None:
+                found.add(kw.arg)
+    return found
+
+
+def _serving_forward_kwargs() -> set[str]:
+    """Return the kwarg names the serving model's forward methods accept.
+
+    Cross-checks against
+    :func:`app.training.inference_contract.collect_serving_forward_kwargs`
+    so the property test fails fast if the helper drifts away from
+    the actual signature.
+    """
+
+    from app.models.serving_model import ForecasterServingModel
+    from app.training.inference_contract import collect_serving_forward_kwargs
+
+    return set(collect_serving_forward_kwargs(ForecasterServingModel))
+
+
+def test_training_loop_kwargs_are_subset_of_serving_forward() -> None:
+    """Every kwarg the training loop populates must be a kwarg the
+    serving forward accepts.
+
+    A kwarg the loader feeds the model that the serving forward does
+    not accept is the textbook "train-side input mounted but inference
+    can't supply it" bug. The check asserts the inclusion both
+    directions: the training loop is the population source of truth,
+    and the serving signature is the consumption surface.
+    """
+
+    train_kwargs = _extract_kwarg_assignments(TRAINING_LOOP_PATH)
+    # Also include any kwargs threaded directly into forward / forward_multi_task
+    # calls from the loop module so the check catches both populating
+    # conventions.
+    train_kwargs |= _extract_explicit_kwargs(
+        TRAINING_LOOP_PATH, r"^(forward_multi_task|forward)$"
+    )
+    serving_kwargs = _serving_forward_kwargs()
+
+    # Trim the train kwargs to the ones whose names are actually kwargs
+    # on the forward signature -- the loop also uses ``kwargs[...]``
+    # for non-forward dispatch state (e.g. ModelConfig field
+    # propagation), and those are not signature concerns.
+    train_forward_kwargs = train_kwargs & (
+        serving_kwargs | _SERVING_OPTIONAL_KWARGS
+        | {"text_embedding", "text_embedding_missing", "credibility", "chunks", "elapsed_days"}
+    )
+
+    missing = train_forward_kwargs - serving_kwargs
+    assert not missing, (
+        "training loop populates forward kwargs the serving signature "
+        f"does not accept: {sorted(missing)}. The serving call site "
+        f"cannot thread these through, so the deployed model would "
+        f"score differently from the trained model."
+    )
+
+
+def test_serving_call_site_handles_required_forward_kwargs() -> None:
+    """The /analyze call sites must thread every kwarg the canonical
+    forward path requires when the corresponding model gate is on.
+
+    Specifically: ``text_embedding`` + ``text_embedding_missing``
+    (when ``_text_path_active``), ``credibility`` (when
+    ``credibility_features``), and ``chunks`` + ``elapsed_days`` (when
+    chunk attention is on). The assertion is "the serving forecaster
+    module references every required kwarg name" -- not "every gate
+    is unconditionally enabled".
+    """
+
+    serving_kwargs = _extract_kwarg_assignments(SERVING_FORECASTER_PATH)
+    serving_kwargs |= _extract_explicit_kwargs(
+        SERVING_FORECASTER_PATH, r"^(forward_multi_task|forward)$"
+    )
+
+    required_when_gate_on = {
+        "text_embedding",
+        "text_embedding_missing",
+        "credibility",
+        "chunks",
+        "elapsed_days",
+    }
+    missing = required_when_gate_on - serving_kwargs
+    assert not missing, (
+        "serving call site in app.services.forecaster does not thread "
+        f"the following forward kwargs: {sorted(missing)}. Train-time "
+        f"loader passes them but serving never does -- the deployed "
+        f"model receives zero / default inputs where the trained model "
+        f"received real ones."
+    )
+
+
+def test_serving_model_class_accepts_known_kwargs() -> None:
+    """Sanity check: every kwarg in the union is on the serving forward.
+
+    Closes the loop on the previous two tests -- the property is
+    'inference signature is a superset of training-side populations',
+    so the inference signature itself must list every union-member
+    kwarg.
+    """
+
+    serving_kwargs = _serving_forward_kwargs()
+    expected = {
+        "text_embedding",
+        "text_embedding_missing",
+        "text_embedding_per_bar",
+        "credibility",
+        "chunks",
+        "elapsed_days",
+        "chunk_mask",
+    }
+    missing = expected - serving_kwargs
+    assert not missing, (
+        f"serving forward signature is missing {sorted(missing)}; "
+        "the contract sidecar derivation depends on these kwarg names."
+    )
+
+
+def test_inference_contract_helper_matches_serving_signature() -> None:
+    """The :func:`derive_contract` helper's static SERVING_FORWARD_KWARGS
+    constant must match the live serving signature.
+
+    Drift here means a sidecar derivation that reports the wrong
+    required-kwarg set on every new checkpoint. The
+    ``collect_serving_forward_kwargs`` introspector is the source of
+    truth; the static constant is the cheap default the
+    ``validate_against_serving`` helper falls back to when the caller
+    doesn't pass a ``serving_model_cls`` argument.
+    """
+
+    pytest.importorskip("torch")
+    from app.training.inference_contract import SERVING_FORWARD_KWARGS
+
+    live_kwargs = _serving_forward_kwargs()
+    drift = (live_kwargs ^ SERVING_FORWARD_KWARGS)
+    assert not drift, (
+        f"SERVING_FORWARD_KWARGS drift: {sorted(drift)}. Update the "
+        "constant in app.training.inference_contract to match the "
+        "live ForecasterServingModel.forward signature."
+    )

--- a/tests/unit/test_inference_contract.py
+++ b/tests/unit/test_inference_contract.py
@@ -1,0 +1,235 @@
+"""Unit coverage for the inference contract sidecar (#341)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.factory import build_serving_forecaster
+from app.models.config import ModelConfig, FEATURE_SIZE
+from app.training.inference_contract import (
+    SIDECAR_SCHEMA_VERSION,
+    InferenceContract,
+    collect_serving_forward_kwargs,
+    derive_contract,
+    read_sidecar,
+    sidecar_path_for,
+    validate_against_serving,
+    write_sidecar,
+)
+
+
+def _toy_serving_model() -> torch.nn.Module:
+    return build_serving_forecaster(
+        ModelConfig(input_size=FEATURE_SIZE, architecture="lstm")
+    )
+
+
+def test_derive_contract_default_no_text_path() -> None:
+    """A vanilla serving forecaster declares no required kwargs.
+
+    The legacy 6-feature regression-output checkpoint has no
+    credibility / text / chunk gates on; the contract is therefore
+    empty on required-kwargs.
+    """
+
+    model = _toy_serving_model()
+    contract = derive_contract(model, encoder_alias="bert_base")
+    assert contract.required_kwargs == ()
+    assert contract.encoder_alias == "bert_base"
+    assert contract.schema_version == SIDECAR_SCHEMA_VERSION
+    assert contract.model_class == "ForecasterServingModel"
+
+
+def test_derive_contract_text_path_required() -> None:
+    """When the text path is mounted, text_embedding becomes required."""
+
+    model = _toy_serving_model()
+    model._text_path_active = True  # type: ignore[attr-defined]
+    model.text_embedding_dim = 768  # type: ignore[attr-defined]
+    contract = derive_contract(model)
+    assert "text_embedding" in contract.required_kwargs
+    assert "text_embedding_missing" in contract.required_kwargs
+
+
+def test_sidecar_roundtrip(tmp_path: Path) -> None:
+    """Write -> read -> structured equality."""
+
+    model = _toy_serving_model()
+    model.credibility_features = True  # type: ignore[attr-defined]
+    ckpt_path = tmp_path / "toy.pt"
+    ckpt_path.write_bytes(b"\x00")  # the file just needs to exist
+    contract = derive_contract(
+        model,
+        encoder_alias="finbert_fed_adjacent",
+        inference_features=("text_embedding",),
+    )
+    written = write_sidecar(contract, ckpt_path)
+    assert written == sidecar_path_for(ckpt_path)
+    assert written.exists()
+    raw = json.loads(written.read_text(encoding="utf-8"))
+    assert raw["schema_version"] == SIDECAR_SCHEMA_VERSION
+    assert raw["model_class"] == "ForecasterServingModel"
+    loaded = read_sidecar(ckpt_path)
+    assert loaded == contract
+
+
+def test_sidecar_absent_returns_none(tmp_path: Path) -> None:
+    ckpt_path = tmp_path / "no_sidecar.pt"
+    assert read_sidecar(ckpt_path) is None
+
+
+def test_sidecar_malformed_degrades_to_none(tmp_path: Path) -> None:
+    ckpt_path = tmp_path / "bad.pt"
+    sidecar_path_for(ckpt_path).write_text("{not json", encoding="utf-8")
+    assert read_sidecar(ckpt_path) is None
+
+
+def test_validate_against_serving_ok_when_subset() -> None:
+    contract = InferenceContract(
+        schema_version=SIDECAR_SCHEMA_VERSION,
+        model_class="ForecasterServingModel",
+        required_kwargs=("credibility", "text_embedding"),
+    )
+    out = validate_against_serving(contract)
+    assert out.ok is True
+    assert out.status == "ok"
+
+
+def test_validate_against_serving_rejects_unknown_kwarg() -> None:
+    contract = InferenceContract(
+        schema_version=SIDECAR_SCHEMA_VERSION,
+        model_class="ForecasterServingModel",
+        required_kwargs=("not_a_real_kwarg",),
+    )
+    out = validate_against_serving(contract)
+    assert out.ok is False
+    assert out.status == "serving_signature_missing_kwargs"
+    assert "not_a_real_kwarg" in out.missing_kwargs
+
+
+def test_validate_against_registry_features_mismatch() -> None:
+    """When the registry declares fewer features than the contract,
+    the loader refuses to bind."""
+
+    contract = InferenceContract(
+        schema_version=SIDECAR_SCHEMA_VERSION,
+        model_class="ForecasterServingModel",
+        required_kwargs=(),
+        inference_features=("text_embedding", "credibility"),
+    )
+    out = validate_against_serving(
+        contract,
+        registry_inference_features=("text_embedding",),
+    )
+    assert out.ok is False
+    assert out.status == "registry_inference_features_mismatch"
+    assert "credibility" in out.extra_kwargs
+
+
+def test_collect_serving_forward_kwargs_includes_expected() -> None:
+    from app.models.serving_model import ForecasterServingModel
+
+    kwargs = collect_serving_forward_kwargs(ForecasterServingModel)
+    for expected in (
+        "text_embedding",
+        "text_embedding_missing",
+        "credibility",
+        "chunks",
+        "elapsed_days",
+    ):
+        assert expected in kwargs
+
+
+def test_save_checkpoint_writes_sidecar(tmp_path: Path) -> None:
+    """The checkpoint save path emits the sidecar next to the .pt file."""
+
+    from app.evaluation.metrics import TrainingRunSummary
+    from app.training.checkpoint import _save_model_checkpoint
+
+    model = _toy_serving_model()
+    ckpt_path = tmp_path / "forecaster.pt"
+    summary = TrainingRunSummary(
+        model_config=ModelConfig(input_size=FEATURE_SIZE, architecture="lstm"),
+        device="cpu",
+        epochs_requested=1,
+        epochs_completed=1,
+        batch_size=1,
+        learning_rate=1e-3,
+        validation_split=0.2,
+        early_stopping_patience=1,
+        sequence_groups=1,
+        total_windows=1,
+        train_windows=1,
+        validation_windows=0,
+        checkpoint_path=str(ckpt_path),
+        checkpoint_saved=True,
+        best_epoch=1,
+        metrics=None,
+    )
+    _save_model_checkpoint(
+        model,
+        ckpt_path,
+        summary,
+        encoder_alias="bert_base",
+        inference_features=("text_embedding",),
+    )
+    assert ckpt_path.exists()
+    sidecar = sidecar_path_for(ckpt_path)
+    assert sidecar.exists()
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert payload["encoder_alias"] == "bert_base"
+    assert payload["inference_features"] == ["text_embedding"]
+
+
+def test_loader_refuses_bind_on_contract_mismatch(tmp_path: Path, monkeypatch) -> None:
+    """``_get_model`` raises when the sidecar declares a kwarg the
+    serving signature does not accept."""
+
+    from app.evaluation.metrics import TrainingRunSummary
+    from app.training.checkpoint import _save_model_checkpoint
+    from app.services import forecaster as forecaster_service
+
+    model = _toy_serving_model()
+    ckpt_path = tmp_path / "forecaster.pt"
+    summary = TrainingRunSummary(
+        model_config=ModelConfig(input_size=FEATURE_SIZE, architecture="lstm"),
+        device="cpu",
+        epochs_requested=1,
+        epochs_completed=1,
+        batch_size=1,
+        learning_rate=1e-3,
+        validation_split=0.2,
+        early_stopping_patience=1,
+        sequence_groups=1,
+        total_windows=1,
+        train_windows=1,
+        validation_windows=0,
+        checkpoint_path=str(ckpt_path),
+        checkpoint_saved=True,
+        best_epoch=1,
+        metrics=None,
+    )
+    _save_model_checkpoint(model, ckpt_path, summary)
+    # Corrupt the sidecar to declare a kwarg that does not exist on
+    # the serving signature; the loader must refuse to bind.
+    sidecar = sidecar_path_for(ckpt_path)
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    payload["required_kwargs"] = ["nonexistent_kwarg"]
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setattr(forecaster_service, "BEST_MODEL_PATH", ckpt_path)
+    monkeypatch.setattr(forecaster_service, "_model", None)
+    monkeypatch.setattr(forecaster_service, "_model_artifact_metadata", None)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        forecaster_service._get_model()
+    assert "inference contract" in str(excinfo.value).lower()
+
+    status = forecaster_service.get_serving_contract_status()
+    assert status["status"] == "serving_signature_missing_kwargs"
+    assert "nonexistent_kwarg" in status["missing_kwargs"]

--- a/tests/unit/test_rates_heads_endpoint.py
+++ b/tests/unit/test_rates_heads_endpoint.py
@@ -193,10 +193,16 @@ def test_analyze_market_handles_builder_exception(
 def test_build_market_reaction_panel_returns_none_on_regression_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A regression-mode model emits None so the API surfaces an empty panel."""
+    """A regression-mode model has no rates / vol-regime cards to emit.
+
+    #341 promoted the previous bare-None to a structured payload
+    carrying ``status="not_classification_mode"`` so the operator can
+    grep the response for the soft-degrade branch; the /analyze
+    route handler collapses this to an empty MarketReactionPanel."""
 
     class _DummyModel:
         output_mode = "regression"
+        rates_heads_active = ()
 
         def parameters(self):  # pragma: no cover -- not invoked on regression path
             return iter([torch.zeros(1)])
@@ -212,7 +218,8 @@ def test_build_market_reaction_panel_returns_none_on_regression_model(
             )
         ]
     )
-    assert out is None
+    assert isinstance(out, dict)
+    assert out["status"] == "not_classification_mode"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_regime_classification_response_block.py
+++ b/tests/unit/test_regime_classification_response_block.py
@@ -10,12 +10,17 @@ in ``sentiment`` remains the only confidence surface.
 from __future__ import annotations
 
 
-def test_safe_regime_classification_swallows_exceptions(monkeypatch) -> None:
+def test_safe_regime_classification_swallows_exceptions(monkeypatch, caplog) -> None:
     """``_safe_regime_classification`` must never raise. #341 promoted
     the previous bare-None swallow to a structured payload carrying
     ``status="unexpected_exception"`` + the exception class so the
     operator can grep the response for the failure mode; /analyze
-    stays 200 even with a broken classifier checkpoint."""
+    stays 200 even with a broken classifier checkpoint. The raw
+    exception message is kept in the WARNING log only (never in the
+    client-facing payload) so internal detail does not leak through
+    the API."""
+
+    import logging
 
     from app.main import _safe_regime_classification
     import app.main as main_module
@@ -24,11 +29,16 @@ def test_safe_regime_classification_swallows_exceptions(monkeypatch) -> None:
         raise RuntimeError("simulated broken checkpoint")
 
     monkeypatch.setattr(main_module, "build_regime_classification_card", _boom)
-    out = _safe_regime_classification([])
+    with caplog.at_level(logging.WARNING, logger="app.main"):
+        out = _safe_regime_classification([])
     assert isinstance(out, dict)
     assert out["status"] == "unexpected_exception"
     assert out["exception_class"] == "RuntimeError"
-    assert "simulated broken checkpoint" in out["detail"]
+    assert "detail" not in out
+    assert any(
+        "simulated broken checkpoint" in record.getMessage()
+        for record in caplog.records
+    ), "raw exception detail must reach the WARNING log even when stripped from the response"
 
 
 def test_safe_regime_classification_typeerror_surfaces_kwarg(monkeypatch) -> None:

--- a/tests/unit/test_regime_classification_response_block.py
+++ b/tests/unit/test_regime_classification_response_block.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 
 
 def test_safe_regime_classification_swallows_exceptions(monkeypatch) -> None:
-    """``_safe_regime_classification`` must never raise — any failure
-    inside the inference + calibrated-set path degrades to ``None``
-    so /analyze stays 200 even with a broken classifier checkpoint."""
+    """``_safe_regime_classification`` must never raise. #341 promoted
+    the previous bare-None swallow to a structured payload carrying
+    ``status="unexpected_exception"`` + the exception class so the
+    operator can grep the response for the failure mode; /analyze
+    stays 200 even with a broken classifier checkpoint."""
 
     from app.main import _safe_regime_classification
     import app.main as main_module
@@ -22,7 +24,30 @@ def test_safe_regime_classification_swallows_exceptions(monkeypatch) -> None:
         raise RuntimeError("simulated broken checkpoint")
 
     monkeypatch.setattr(main_module, "build_regime_classification_card", _boom)
-    assert _safe_regime_classification([]) is None
+    out = _safe_regime_classification([])
+    assert isinstance(out, dict)
+    assert out["status"] == "unexpected_exception"
+    assert out["exception_class"] == "RuntimeError"
+    assert "simulated broken checkpoint" in out["detail"]
+
+
+def test_safe_regime_classification_typeerror_surfaces_kwarg(monkeypatch) -> None:
+    """#341: a ``TypeError`` raised by the forward path surfaces the
+    missing kwarg name through the structured-state surface."""
+
+    from app.main import _safe_regime_classification
+    import app.main as main_module
+
+    def _missing(_vectors):
+        raise TypeError(
+            "forward_multi_task() missing 1 required keyword-only argument: 'text_embedding'"
+        )
+
+    monkeypatch.setattr(main_module, "build_regime_classification_card", _missing)
+    out = _safe_regime_classification([])
+    assert isinstance(out, dict)
+    assert out["status"] == "inference_kwarg_missing"
+    assert out["missing_kwarg"] == "text_embedding"
 
 
 def test_safe_regime_classification_passes_through_card(monkeypatch) -> None:
@@ -50,8 +75,12 @@ def test_safe_regime_classification_passes_through_card(monkeypatch) -> None:
 
 def test_safe_regime_classification_passes_through_none(monkeypatch) -> None:
     """When the classifier service returns ``None`` (regression-only
-    checkpoint or no manifest), the wrapper also returns ``None``
-    so the response field stays absent."""
+    checkpoint or no manifest), #341 promoted the legacy bare-None to
+    a structured ``status="not_classification_mode"`` payload so the
+    operator can tell ``model deliberately mute`` apart from ``model
+    crashed silently``. The /analyze route handler splits this into
+    the sibling ``regime_classification_status`` field; the legacy
+    ``regime_classification`` slot lands as None."""
 
     from app.main import _safe_regime_classification
     import app.main as main_module
@@ -59,4 +88,6 @@ def test_safe_regime_classification_passes_through_none(monkeypatch) -> None:
     monkeypatch.setattr(
         main_module, "build_regime_classification_card", lambda _v: None
     )
-    assert _safe_regime_classification([]) is None
+    out = _safe_regime_classification([])
+    assert isinstance(out, dict)
+    assert out["status"] == "not_classification_mode"


### PR DESCRIPTION
Closes #341.

Five items shipped together; ADR 0023 records the contract + the soft-vs-hard failure dispatch.

- Forward-parity property test (`tests/properties/test_forward_parity.py`): research vs serving forward numeric parity (`torch.allclose`, atol=1e-6) on the canonical checkpoint when present + a deterministic toy fallback otherwise. Both paths exercise the same state_dict on both classes; the toy fallback is not a stub.
- Structured error surfacing on `_safe_regime_classification` (`backend/app/main.py`) and `build_market_reaction_panel` (`backend/app/services/forecaster.py`). Three states (`not_classification_mode` / `inference_kwarg_missing` / `unexpected_exception`) + per-state counter on `app.services.forecaster._contract_counters` + WARNING log with structured key=value fields. `_safe_regime_classification` returns the structured dict on the soft-degrade paths; the `/analyze` route handler splits it off into the new `regime_classification_status` sibling field (schema gains `InferenceStatusSurface`). `build_market_reaction_panel`'s structured payloads are collapsed back to an empty `MarketReactionPanel` by the route handler so the schema is unchanged; the structured detail still hits logs + counters.
- Per-checkpoint `<stem>.inference_contract.json` sidecar. `backend/app/training/inference_contract.py` carries the `InferenceContract` dataclass + `derive_contract` / `read_sidecar` / `write_sidecar` / `validate_against_serving` helpers. Wired into `_save_model_checkpoint` (every training-loop save) and `promote_research_checkpoint_to_serving` (every promotion). Loader (`_get_model` in `app.services.forecaster`) reads the sidecar at boot and raises `RuntimeError` on signature / registry mismatch; legacy artefacts with no sidecar degrade to a soft `sidecar_absent` branch so the existing serving fleet keeps binding. `/health` surfaces the validation status + counters.
- Loader/serving kwarg-superset unit test (`tests/properties/test_kwarg_superset.py`). AST-walks `backend/app/training/loop.py` + `backend/app/services/forecaster.py` and asserts every train-side forward kwarg is in the `ForecasterServingModel.forward` signature. Sibling assertion that the `SERVING_FORWARD_KWARGS` constant in `inference_contract.py` matches the live signature so a downstream PR that adds a kwarg cannot drift unnoticed.
- `backend/app/models/registry.yaml::inference_features:` block on every encoder (23 entries) + every artefact (10 entries). `app.models.registry.EncoderRef` / `ArtefactRef` carry the new field; the serving loader cross-checks `contract.inference_features` against `encoder_ref(contract.encoder_alias).inference_features` and refuses to bind when the contract declares features the registry no longer pins.

Rollout for the existing fleet: sidecars emit on next checkpoint write. The soft `sidecar_absent` branch in the loader keeps pre-#341 artefacts binding, so a one-shot migration script is not required — promotion + retrain are the natural backfill paths. The multi-axis classifier and trajectory bundle write their own `torch.save` payloads under their own classes and do not bind through `ForecasterServingModel`; sidecar emission for those subsystems is out of scope for this PR.

ADR 0023 at `docs/adr/0023-train-inference-contract-enforcement.md` records the five-item contract, references #336 + #339, and documents the soft-vs-hard failure dispatch.