### PR TITLE
Inference observability: cold-start parity + settings UI + per-request kwarg log (#342)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -259,14 +259,28 @@ def list_settings_checkpoints() -> SettingsCheckpointsResponse:
             collect_serving_forward_kwargs,
             read_sidecar,
         )
-
-        serving_kwargs: frozenset[str] = collect_serving_forward_kwargs(
-            ForecasterServingModel
-        ) or SERVING_FORWARD_KWARGS
     except Exception:  # pragma: no cover -- defensive
-        logger.warning("settings_checkpoints_serving_kwargs_probe_failed", exc_info=True)
-        serving_kwargs = frozenset()
+        # Hard import failure (genuinely broken env). Nothing to
+        # display; render every checkpoint row without a contract
+        # surface rather than mislabel the world.
+        logger.warning("settings_checkpoints_serving_kwargs_import_failed", exc_info=True)
+        serving_kwargs: frozenset[str] = frozenset()
         read_sidecar = None  # type: ignore[assignment]
+    else:
+        try:
+            serving_kwargs = (
+                collect_serving_forward_kwargs(ForecasterServingModel)
+                or SERVING_FORWARD_KWARGS
+            )
+        except Exception:  # pragma: no cover -- defensive
+            # Live-signature introspection failed but the imports landed.
+            # Fall back to the static constant per ADR 0025 so the
+            # settings page still renders meaningful supplied/required
+            # badges rather than painting every kwarg red.
+            logger.warning(
+                "settings_checkpoints_serving_kwargs_probe_failed", exc_info=True
+            )
+            serving_kwargs = SERVING_FORWARD_KWARGS
 
     for entry in sorted(MODELS_DIR.glob("*.pt"), key=lambda p: p.name):
         try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -246,6 +246,28 @@ def list_settings_checkpoints() -> SettingsCheckpointsResponse:
     except Exception:  # pragma: no cover
         logger.warning("settings_checkpoints_multi_axis_probe_failed", exc_info=True)
 
+    # #342: snapshot the live serving forward signature once per request
+    # so each row can mark each declared kwarg as supplied / not supplied
+    # without re-introspecting the model class on every iteration. The
+    # source of truth is the model class the loader binds — falls back to
+    # the static SERVING_FORWARD_KWARGS constant when the import path is
+    # not available (defensive; the import should always succeed).
+    try:
+        from app.models.serving_model import ForecasterServingModel
+        from app.training.inference_contract import (
+            SERVING_FORWARD_KWARGS,
+            collect_serving_forward_kwargs,
+            read_sidecar,
+        )
+
+        serving_kwargs: frozenset[str] = collect_serving_forward_kwargs(
+            ForecasterServingModel
+        ) or SERVING_FORWARD_KWARGS
+    except Exception:  # pragma: no cover -- defensive
+        logger.warning("settings_checkpoints_serving_kwargs_probe_failed", exc_info=True)
+        serving_kwargs = frozenset()
+        read_sidecar = None  # type: ignore[assignment]
+
     for entry in sorted(MODELS_DIR.glob("*.pt"), key=lambda p: p.name):
         try:
             stat = entry.stat()
@@ -258,6 +280,24 @@ def list_settings_checkpoints() -> SettingsCheckpointsResponse:
         sidecar_present: bool | None = None
         if role == "forecaster":
             sidecar_present = entry.with_suffix(".conformal.json").exists()
+
+        required_kwargs: list[str] = []
+        supplied: dict[str, bool] = {}
+        contract_status: str | None = None
+        if role == "forecaster" and read_sidecar is not None:
+            try:
+                contract = read_sidecar(entry)
+            except Exception:  # pragma: no cover -- defensive
+                contract = None
+            if contract is None:
+                contract_status = "sidecar_absent"
+            else:
+                contract_status = "present"
+                required_kwargs = [str(k) for k in contract.required_kwargs]
+                supplied = {
+                    name: (name in serving_kwargs) for name in required_kwargs
+                }
+
         items.append(
             SettingsCheckpoint(
                 filename=entry.name,
@@ -273,6 +313,9 @@ def list_settings_checkpoints() -> SettingsCheckpointsResponse:
                     else active_multi_axis_alias if is_active_multi_axis else None
                 ),
                 conformal_sidecar_present=sidecar_present,
+                required_kwargs=required_kwargs,
+                supplied_at_inference=supplied,
+                inference_contract_status=contract_status,
             )
         )
 
@@ -689,6 +732,18 @@ def _bootstrap_cold_start(payload: AnalyzeRequest) -> None:
 
     Synchronous — invoked via ``run_in_threadpool`` from the async
     handler so the long-running fit does not block the event loop.
+
+    #342: once the bootstrap writes a fresh checkpoint, we drop the
+    in-process singleton + re-invoke the same loader the /analyze path
+    uses (``_get_model`` -> ``_validate_serving_contract``). That way a
+    bootstrap whose freshly written sidecar declares kwargs the serving
+    forward does not accept raises ``RuntimeError`` here rather than
+    silently binding via ``_set_singleton_after_train``. The cold-start
+    boot is then loud-fail: the /analyze caller surfaces a 500 with the
+    structured incompatibility reason and ``/health`` picks up the
+    contract status. Bypasses the reset for legacy artefacts (no
+    sidecar) because the validation degrades to ``sidecar_absent`` and
+    binds normally.
     """
 
     warmup_sentiment = analyze_text(payload.text)
@@ -709,6 +764,27 @@ def _bootstrap_cold_start(payload: AnalyzeRequest) -> None:
         learning_rate=4e-4,
         early_stopping_patience=8,
     )
+    # #342: drop the post-train singleton + force a cold load through
+    # the canonical loader so the contract validation actually runs on
+    # the freshly written sidecar. ``_set_singleton_after_train`` writes
+    # ``_model`` directly without crossing ``_validate_serving_contract``
+    # — without this reset the cold-start path would silently bind a
+    # checkpoint whose sidecar declares an unknown kwarg.
+    try:
+        from app.services import forecaster as forecaster_service
+
+        with forecaster_service._model_lock:
+            forecaster_service._model = None
+            forecaster_service._model_artifact_metadata = None
+        forecaster_service._get_model()
+    except RuntimeError:
+        # Re-raise so the /analyze caller surfaces the contract failure
+        # rather than swallowing it. ``/health`` already exposes the
+        # structured reason via ``get_serving_contract_status``.
+        raise
+    except Exception:  # pragma: no cover -- defensive
+        logger.warning("cold_start_contract_revalidation_failed", exc_info=True)
+        raise
 
 
 def _record_history(request: AnalyzeRequest, response: dict[str, Any]) -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -723,8 +723,27 @@ async def analyze(payload: AnalyzeRequest):
         return response
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except RuntimeError as exc:  # pragma: no cover
+        # #342: contract-revalidation failures from _bootstrap_cold_start
+        # land here. Log the raw message but ship a structured detail
+        # carrying only the exception class -- the #341 review rule
+        # keeps raw str(exc) out of client-facing payloads.
+        logger.warning(
+            "analyze_runtime_error exception_class=%s detail=%s",
+            type(exc).__name__,
+            str(exc),
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Analyze pipeline failed: serving runtime error",
+        ) from None
     except Exception as exc:  # pragma: no cover
-        raise HTTPException(status_code=500, detail=f"Analyze pipeline failed: {exc}") from exc
+        logger.exception(
+            "analyze_unexpected_exception exception_class=%s", type(exc).__name__
+        )
+        raise HTTPException(
+            status_code=500, detail="Analyze pipeline failed: unexpected error"
+        ) from None
 
 
 def _bootstrap_cold_start(payload: AnalyzeRequest) -> None:
@@ -771,12 +790,13 @@ def _bootstrap_cold_start(payload: AnalyzeRequest) -> None:
     # — without this reset the cold-start path would silently bind a
     # checkpoint whose sidecar declares an unknown kwarg.
     try:
-        from app.services import forecaster as forecaster_service
+        from app.services.forecaster import (
+            _get_model as _forecaster_get_model,
+            reset_singleton_for_revalidation,
+        )
 
-        with forecaster_service._model_lock:
-            forecaster_service._model = None
-            forecaster_service._model_artifact_metadata = None
-        forecaster_service._get_model()
+        reset_singleton_for_revalidation()
+        _forecaster_get_model()
     except RuntimeError:
         # Re-raise so the /analyze caller surfaces the contract failure
         # rather than swallowing it. ``/health`` already exposes the
@@ -1192,8 +1212,20 @@ async def analyze_market(payload: AnalyzeRequest) -> MarketReactionPanel:
     # fresh deploy hitting /analyze/market first does not surface
     # empty cards. Shared with /analyze via the _bootstrap_cold_start
     # helper.
+    # #342: cold-start now invokes the canonical loader for contract
+    # revalidation; a sidecar mismatch raises RuntimeError. Surface it
+    # symmetrically to /analyze — 503 with the structured-status detail
+    # (the message is a deliberate contract code, not raw exception
+    # text) so the operator sees the same shape on both endpoints.
     if not checkpoint_exists():
-        await run_in_threadpool(_bootstrap_cold_start, payload)
+        try:
+            await run_in_threadpool(_bootstrap_cold_start, payload)
+        except RuntimeError as exc:
+            logger.warning("analyze_market_cold_start_contract_mismatch detail=%s", str(exc))
+            raise HTTPException(
+                status_code=503,
+                detail="Market reaction panel unavailable: serving contract mismatch",
+            ) from None
 
     sentiment = analyze_text(payload.text)
     market_history = await run_in_threadpool(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -589,6 +589,13 @@ class SettingsCheckpoint(BaseModel):
     currently loaded from. The diagnostic fields (output_mode,
     encoder_alias, conformal_sidecar_present) only populate on the
     active forecaster + active multi-axis entries.
+
+    #342: ``required_kwargs`` mirrors the inference-contract sidecar
+    (empty list when no sidecar — pre-#341 legacy artefact).
+    ``supplied_at_inference`` maps each declared kwarg to the live
+    serving wiring; mismatches drive the red-badge surface on the
+    settings page. ``inference_contract_status`` is ``"sidecar_absent"``
+    for legacy checkpoints, otherwise ``"present"``.
     """
 
     model_config = _FORBID_FROZEN_CONFIG
@@ -602,6 +609,9 @@ class SettingsCheckpoint(BaseModel):
     output_mode: str | None = None
     encoder_alias: str | None = None
     conformal_sidecar_present: bool | None = None
+    required_kwargs: list[str] = Field(default_factory=list)
+    supplied_at_inference: dict[str, bool] = Field(default_factory=dict)
+    inference_contract_status: str | None = None
 
 
 class SettingsCheckpointsResponse(BaseModel):

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -563,6 +563,47 @@ def _resolve_inference_text_embedding(
     return text_embedding, text_embedding_missing
 
 
+def _log_serving_forward_kwargs(model: ForecasterServingModel) -> None:
+    """#342: structured INFO line describing the per-request kwarg set.
+
+    Mirrors the kwarg gates in ``_predict_next_point`` so the log line
+    is greppable evidence of what the serving forward was called with
+    on a given request. Format:
+
+        ``analyze_serving_forward kwargs=<a,b,c> checkpoint=<stem>``
+
+    The kwargs list is empty (``kwargs=``) for the legacy 6-feature
+    regression-only path; checkpoints with text + credibility + chunks
+    paths active emit the full list. The checkpoint stem is taken from
+    ``BEST_MODEL_PATH`` so the operator can correlate against the
+    settings inventory + the inference contract sidecar. One log line
+    per /analyze, NOT one per kwarg.
+    """
+
+    populated: list[str] = []
+    if bool(getattr(model, "credibility_features", False)):
+        populated.append("credibility")
+    if bool(getattr(model, "_text_path_active", False)):
+        populated.append("text_embedding")
+        populated.append("text_embedding_missing")
+    if bool(getattr(model, "use_chunk_attention", False)) or bool(
+        getattr(model, "use_llm_embeddings", False)
+    ):
+        populated.append("chunks")
+        populated.append("elapsed_days")
+
+    try:
+        checkpoint_stem = Path(BEST_MODEL_PATH).stem
+    except Exception:  # pragma: no cover -- defensive
+        checkpoint_stem = ""
+
+    logger.info(
+        "analyze_serving_forward kwargs=%s checkpoint=%s",
+        ",".join(populated),
+        checkpoint_stem,
+    )
+
+
 def _predict_next_point(model: ForecasterServingModel, sequence: list[FeatureVector]) -> tuple[float, float]:
     # Classification-mode checkpoints emit ``(B, n_classes)`` logits
     # from ``forward()`` (the stance branch under the MultiTaskHead);
@@ -1314,6 +1355,16 @@ def forecast_quantitative_series(
     # adaptation surface.
     model = _get_model()
     training_result = None
+
+    # #342: emit one structured INFO line per request listing the kwargs
+    # the serving forward will be called with on this request. Operators
+    # can ``grep analyze_serving_forward | awk`` for drift between the
+    # sidecar-declared required kwargs and what the call site actually
+    # populates. The list is computed by mirroring the kwarg gates in
+    # ``_predict_next_point`` (the canonical serving forward call site)
+    # so the log line is the request-level intent, not a per-step
+    # repetition.
+    _log_serving_forward_kwargs(model)
 
     history_vectors = vectors[-30:]
     history_timestamps = [item.date for item in history_vectors]

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -157,6 +157,24 @@ def get_contract_counters() -> dict[str, int]:
     return dict(_contract_counters)
 
 
+def reset_singleton_for_revalidation() -> None:
+    """#342: drop the cached singleton so the next ``_get_model`` cold-loads.
+
+    Used by ``_bootstrap_cold_start`` after the bootstrap-write path:
+    ``_set_singleton_after_train`` bypasses ``_validate_serving_contract``,
+    so the cold-start needs to round-trip through the canonical loader
+    to actually validate the freshly written sidecar. Lives here (not
+    in main.py) so the private singleton attributes stay encapsulated;
+    a future refactor of the storage shape only needs to update this
+    helper.
+    """
+
+    global _model, _model_artifact_metadata
+    with _model_lock:
+        _model = None
+        _model_artifact_metadata = None
+
+
 def _extract_missing_kwarg_from_typeerror(exc: TypeError) -> str | None:
     """Parse the kwarg name out of a python ``TypeError`` message.
 
@@ -570,14 +588,18 @@ def _log_serving_forward_kwargs(model: ForecasterServingModel) -> None:
     is greppable evidence of what the serving forward was called with
     on a given request. Format:
 
-        ``analyze_serving_forward kwargs=<a,b,c> checkpoint=<stem>``
+        ``analyze_serving_forward kwargs=<a,b,c> checkpoint=<stem> mode=<output_mode>``
 
     The kwargs list is empty (``kwargs=``) for the legacy 6-feature
     regression-only path; checkpoints with text + credibility + chunks
     paths active emit the full list. The checkpoint stem is taken from
     ``BEST_MODEL_PATH`` so the operator can correlate against the
-    settings inventory + the inference contract sidecar. One log line
-    per /analyze, NOT one per kwarg.
+    settings inventory + the inference contract sidecar. The ``mode``
+    field carries the active output_mode so a grep can distinguish
+    "kwargs declared but forward short-circuited" (classification-mode
+    request: ``_predict_next_point`` echoes the last bar without
+    calling forward) from "kwargs declared and forward invoked"
+    (regression mode). One log line per /analyze, NOT one per kwarg.
     """
 
     populated: list[str] = []
@@ -597,10 +619,13 @@ def _log_serving_forward_kwargs(model: ForecasterServingModel) -> None:
     except Exception:  # pragma: no cover -- defensive
         checkpoint_stem = ""
 
+    output_mode = str(getattr(model, "output_mode", "regression") or "regression")
+
     logger.info(
-        "analyze_serving_forward kwargs=%s checkpoint=%s",
+        "analyze_serving_forward kwargs=%s checkpoint=%s mode=%s",
         ",".join(populated),
         checkpoint_stem,
+        output_mode,
     )
 
 

--- a/docs/adr/0025-inference-observability.md
+++ b/docs/adr/0025-inference-observability.md
@@ -1,0 +1,95 @@
+# ADR 0025 — Inference observability
+
+Status: accepted, in production (as of merge).
+Date: 2026-05-27.
+References:
+- Issue #342.
+- ADR 0023 (train / inference contract enforcement) — #341. Establishes the `<stem>.inference_contract.json` sidecar surface this ADR makes operationally visible.
+- ADR 0016 (forecaster research / serving split) — #336. Provides the `ForecasterServingModel` whose forward signature this ADR introspects on every settings response.
+- `backend/app/main.py::_bootstrap_cold_start` — resets the singleton + invokes `_get_model` after writing the bootstrap checkpoint.
+- `backend/app/main.py::list_settings_checkpoints` — extended response with `required_kwargs` + `supplied_at_inference` + `inference_contract_status` per row.
+- `backend/app/services/forecaster.py::_log_serving_forward_kwargs` — per-request structured INFO line.
+- `backend/app/schemas.py::SettingsCheckpoint` — schema extension.
+- `frontend/pages/settings.tsx::CheckpointRow` — red / neutral / legacy badge surface.
+- `tests/unit/test_inference_observability.py` — backend coverage for all three surfaces.
+- `frontend/tests/pages/settings.test.tsx` — Vitest coverage for the badge rendering on synthetic checkpoints.
+
+## Context
+
+#341 landed the inference contract sidecar + the loader's hard-fail on a serving-signature mismatch. The contract surface is greppable in test, in CI, and on `/health` — but three production-side gaps remained:
+
+1. **Cold-start bypasses contract validation.** `_bootstrap_cold_start` calls `bootstrap_checkpoint` → `train_model`, which writes the checkpoint and then calls `_set_singleton_after_train` to populate `_model` directly. The post-train singleton populates without crossing `_validate_serving_contract`. A bootstrap run on a box whose registry / serving signature diverged from the training-time contract would silently bind an incompatible checkpoint — the loud-fail behaviour the #341 loader gives `/analyze` did not extend to the cold-start path.
+2. **`/settings/checkpoints` does not expose the contract.** The endpoint surfaced filename / role / encoder alias / conformal-sidecar presence but not the inference-contract sidecar. An operator scanning the settings page could not tell which checkpoints carried the post-#341 contract and which were legacy, and could not see at a glance whether a present-but-mismatched sidecar was the reason a checkpoint refused to bind on `/health`.
+3. **Per-request kwarg drift is invisible.** The sidecar declares the kwargs the serving forward consumes; the serving call site populates a kwarg set based on the model's runtime gates (`_text_path_active`, `credibility_features`, `use_chunk_attention`, `use_llm_embeddings`). The two should agree by construction, but the only signal of drift was a `TypeError` or `RuntimeError` from the forward — both of which #341 already wraps in structured surfaces, but neither of which gives the operator the request-rate distribution over the kwargs that *are* getting populated in production traffic.
+
+The three gaps share a shape: the contract from #341 is correct in code and tested in CI, but it is not *observable* in a running deployment beyond `/health` + the counters.
+
+## Decision
+
+Three observability surfaces. Each is independent; the ordering below mirrors the test surface in `tests/unit/test_inference_observability.py`.
+
+### 1. Cold-start parity with the canonical loader
+
+`_bootstrap_cold_start` now invokes `_get_model` after `bootstrap_checkpoint` returns. The flow:
+
+1. Train + write checkpoint + sidecar (existing).
+2. `_set_singleton_after_train` populates `_model` (existing — kept so the in-process singleton is fresh).
+3. **New.** Drop `_model` + `_model_artifact_metadata` under `_model_lock`, then call `_get_model()` to force a cold load through `_validate_serving_contract`.
+
+A `RuntimeError` from the contract validation propagates out of `_bootstrap_cold_start` (and therefore out of the `/analyze` 500 response surface) rather than being silently swallowed. `/health` continues to expose the structured reason via `get_serving_contract_status` exactly as for the standard cold-load path. The redundant cold load is a one-time cost on the bootstrap path — the singleton stays cached for every subsequent request.
+
+The intent: the bootstrap path is now a *loud-fail* surface. A box whose registry / serving signature has drifted from the training contract surfaces the mismatch on the first `/analyze`, not after silent degradation in production.
+
+### 2. `/settings/checkpoints` UI surface for the inference contract
+
+`SettingsCheckpoint` (the response-schema row) gains three fields:
+
+- `required_kwargs: list[str]` — copied from the sidecar's `required_kwargs`. Empty list when no sidecar.
+- `supplied_at_inference: dict[str, bool]` — each declared kwarg mapped to a boolean. The truth set is `collect_serving_forward_kwargs(ForecasterServingModel)`; a `True` entry means the live serving forward signature accepts the kwarg, a `False` entry means the sidecar declares a kwarg the live forward will reject.
+- `inference_contract_status: str | None` — `"present"` when the sidecar exists, `"sidecar_absent"` for a pre-#341 legacy artefact, `None` for non-forecaster rows.
+
+The endpoint resolves the serving-kwarg set once per request (not per row) and degrades to the static `SERVING_FORWARD_KWARGS` constant if the model-class introspection fails — so an installation with a torch-import failure at the settings-page level still gets a usable inventory.
+
+Frontend rendering (`CheckpointRow` in `frontend/pages/settings.tsx`):
+
+- `inference_contract_status === "sidecar_absent"`: single neutral "legacy" `Badge` next to the row, no per-kwarg badges. This is the pre-#341 fleet status; the row is deliberately quiet so an operator can scan the inventory for unmigrated checkpoints without alarm.
+- `inference_contract_status === "present"` + `required_kwargs.length === 0`: single neutral "no required kwargs" badge. The contract is present but the checkpoint runs on the legacy 6-feature regression path; nothing to mark red.
+- `inference_contract_status === "present"` + per-kwarg badges. Each declared kwarg renders as a `Badge`; the variant is `outline` (neutral) when `supplied_at_inference[name] === true`, and `hawkish` (the red Fed-context variant) when `supplied_at_inference[name] === false`. The mismatch surface is identical whether the kwarg is missing because the serving class never grew the parameter or because the sidecar declares an unknown name.
+
+Test surface: `frontend/tests/pages/settings.test.tsx` exercises three checkpoint shapes (sidecar + unknown kwarg → red; sidecar absent → legacy; sidecar + no kwargs → neutral). Backend test in `tests/unit/test_inference_observability.py` asserts the JSON shape on a synthetic mismatch checkpoint.
+
+### 3. Per-request structured kwarg log line
+
+`forecast_quantitative_series` emits exactly one INFO line per request via the new `_log_serving_forward_kwargs` helper:
+
+```
+analyze_serving_forward kwargs=<comma-separated-list> checkpoint=<stem>
+```
+
+The kwargs list mirrors the gates in `_predict_next_point` (the canonical serving forward call site):
+
+- `credibility` when `model.credibility_features` is on.
+- `text_embedding` + `text_embedding_missing` when `model._text_path_active` is on.
+- `chunks` + `elapsed_days` when `model.use_chunk_attention` or `model.use_llm_embeddings` is on.
+
+The list is empty (`kwargs= checkpoint=...`) for the legacy regression-only path. One line per `/analyze` request, not one per forecast step and not one per kwarg — operators run `grep analyze_serving_forward | awk` to see the request-rate distribution over kwarg-sets in production traffic, and the per-request resolution is the right granularity for that.
+
+The log line lives at INFO level so a production logger configured at WARNING (or higher) drops the line without further tuning; sites that want the drift signal lift the logger to INFO.
+
+## Failure-mode dispatch
+
+| Surface | Pre-#342 behaviour | Post-#342 behaviour |
+| --- | --- | --- |
+| Cold-start with contract-mismatched sidecar | silently binds via `_set_singleton_after_train`; `/health` would show `inference_contract.status: "ok"` despite the contract drift | `RuntimeError` propagates out of `_bootstrap_cold_start`; `/analyze` 500s; `/health` reports the structured `serving_signature_missing_kwargs` reason |
+| Settings page on a forecaster with mismatched sidecar | shows filename + active flag + conformal sidecar status — no signal of the contract mismatch | per-kwarg red `Badge` for every unsupplied kwarg; row is greppable by `data-testid="contract-kwarg-missing-<name>"` |
+| Production traffic with the text path silently disabled | no signal; the operator only sees a quiet regression in card output | every `/analyze` request emits `analyze_serving_forward kwargs= checkpoint=...` (no text kwargs); a `grep | wc -l` against the expected-kwarg cohort surfaces the drift |
+
+## Consequences
+
+- The cold-start path is now strictly slower by one extra cold load (the `_get_model` re-validation after the bootstrap train). On a fresh-clone bootstrap this is sub-millisecond overhead on top of the multi-second training step — not material.
+- The settings page response carries three additional fields per row. The frontend `SettingsCheckpoint` interface keeps them optional so a pre-#342 backend behind a post-#342 frontend renders without the contract block; the badge UI degrades to "no kwargs visible" rather than crashing. The reverse (post-#342 backend + pre-#342 frontend) ignores the extra fields by pydantic's default extra-field behaviour on the client.
+- The per-request log line is unconditional. A production logger at INFO sees one extra structured line per `/analyze` request. The line is small (under 100 bytes typical) and the cardinality is bounded by the number of distinct kwarg-sets the active checkpoint can populate (six combinations max under the current gate matrix). No tuning required.
+- The `_log_serving_forward_kwargs` helper does NOT inspect the kwargs the call site actually populates at the moment of the forward — it inspects the model gates. The two should agree by construction (the gates are what `_predict_next_point` switches on); a future drift between the gates and the call site would not be visible in this log. That drift class is already covered by the `tests/properties/test_kwarg_superset.py` AST walk from #341 — the log line is request-rate evidence, not a parity check.
+- The settings-page red-badge surface only fires on the forecaster role. Multi-axis classifier + LoRA + calibration checkpoints are not bound through `ForecasterServingModel` and therefore do not carry the #341 sidecar; the row renders without the contract block (the frontend gates the section on `checkpoint.role === "forecaster"`).
+- The cold-start re-validation reuses the same `_model_lock` the `_get_model` cold load holds. A racing first `/analyze` that arrives while the bootstrap is still running blocks on the lock until the bootstrap finishes; the post-bootstrap re-validation then runs once and the racing request picks up the cached singleton on lock release. No double-load.
+- One inverted-cost surface: if the bootstrap-trained sidecar declares kwargs the serving signature does not accept (e.g. the training script ran against a serving class that has since had a kwarg renamed), the cold-start now fails-loud instead of binding-silently. The operator must roll the registry forward or roll the serving class back — but the failure mode is now visible on `/health` immediately rather than degrading silently in the inference path. This is the intended trade-off.

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -343,6 +343,14 @@ export interface SettingsCheckpoint {
   output_mode?: string | null;
   encoder_alias?: string | null;
   conformal_sidecar_present?: boolean | null;
+  // #342: inference contract surfaces. ``required_kwargs`` mirrors the
+  // sidecar; ``supplied_at_inference`` maps each declared kwarg to a
+  // boolean for the live serving wiring. Empty / undefined when the
+  // checkpoint pre-dates the #341 contract — ``inference_contract_status``
+  // discriminates ``"sidecar_absent"`` (legacy) from ``"present"``.
+  required_kwargs?: string[];
+  supplied_at_inference?: Record<string, boolean>;
+  inference_contract_status?: string | null;
 }
 
 export interface SettingsCheckpointsResponse {

--- a/frontend/pages/settings.tsx
+++ b/frontend/pages/settings.tsx
@@ -71,6 +71,15 @@ function roleLabel(role: string): string {
 }
 
 function CheckpointRow({ checkpoint }: { checkpoint: SettingsCheckpoint }) {
+  // #342: render the inference-contract surface. Legacy checkpoints
+  // (no sidecar) carry ``inference_contract_status === "sidecar_absent"``
+  // and render with a neutral "legacy" badge. Post-#341 checkpoints
+  // carry one badge per declared kwarg; the badge goes red when the
+  // serving wiring does not supply that kwarg, neutral otherwise.
+  const contractStatus = checkpoint.inference_contract_status ?? null;
+  const requiredKwargs = checkpoint.required_kwargs ?? [];
+  const supplied = checkpoint.supplied_at_inference ?? {};
+
   return (
     <li
       className="flex flex-col gap-2 rounded-md border border-border bg-background/50 p-3 sm:flex-row sm:items-start sm:justify-between"
@@ -128,6 +137,52 @@ function CheckpointRow({ checkpoint }: { checkpoint: SettingsCheckpoint }) {
               </>
             ) : null}
           </div>
+          {checkpoint.role === "forecaster" && contractStatus ? (
+            <div
+              className="flex flex-wrap items-center gap-1.5 pt-1"
+              aria-label="inference contract kwargs"
+            >
+              <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                inference contract:
+              </span>
+              {contractStatus === "sidecar_absent" ? (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] text-muted-foreground"
+                  data-testid="contract-legacy-badge"
+                >
+                  legacy
+                </Badge>
+              ) : requiredKwargs.length === 0 ? (
+                <Badge variant="outline" className="text-[10px] text-muted-foreground">
+                  no required kwargs
+                </Badge>
+              ) : (
+                requiredKwargs.map((name) => {
+                  const isSupplied = supplied[name] === true;
+                  return (
+                    <Badge
+                      key={name}
+                      variant={isSupplied ? "outline" : "hawkish"}
+                      className="text-[10px] numeric"
+                      data-testid={
+                        isSupplied
+                          ? `contract-kwarg-ok-${name}`
+                          : `contract-kwarg-missing-${name}`
+                      }
+                      title={
+                        isSupplied
+                          ? `${name} is supplied by the serving wiring`
+                          : `${name} declared by the checkpoint sidecar but NOT supplied by the serving wiring`
+                      }
+                    >
+                      {name}
+                    </Badge>
+                  );
+                })
+              )}
+            </div>
+          ) : null}
         </div>
       </div>
     </li>

--- a/frontend/tests/pages/settings.test.tsx
+++ b/frontend/tests/pages/settings.test.tsx
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+// #342: settings-page coverage for the inference-contract badge surface.
+// Renders the settings page against three checkpoint shapes:
+//
+//   - sidecar present + all required kwargs supplied -> neutral outline
+//     badges per kwarg, no red.
+//   - sidecar present + an unknown kwarg declared -> red ``hawkish``
+//     badge on the unknown kwarg via the testid the row exposes.
+//   - sidecar absent -> single "legacy" neutral badge.
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  Toaster: () => null,
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: {},
+    pathname: "/settings",
+    asPath: "/settings",
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
+
+vi.mock("next/head", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "dark", setTheme: vi.fn(), resolvedTheme: "dark" }),
+}));
+
+const fetchSettingsCheckpointsMock = vi.fn();
+vi.mock("@/lib/analyze/api", () => ({
+  resolveApiBaseUrl: () => "http://localhost:8000",
+  fetchSettingsCheckpoints: (...args: unknown[]) =>
+    fetchSettingsCheckpointsMock(...args),
+}));
+
+// Stub the workspace-prefs surface so the settings page can render
+// without the AssetPicker firing a real /symbols probe.
+vi.mock("@/lib/workspace-prefs", () => ({
+  DEFAULT_HORIZON: "3d",
+  DEFAULT_SYMBOL: "^GSPC",
+  HORIZON_VALUES: ["1d", "3d", "5d", "10d"],
+  loadWorkspacePrefs: () => ({ defaultSymbol: "^GSPC", defaultHorizon: "3d" }),
+  saveWorkspacePrefs: vi.fn(),
+}));
+
+vi.mock("@/components/analyze/AssetPicker", () => ({
+  AssetPicker: () => <div data-testid="asset-picker" />,
+}));
+
+describe("SettingsPage — inference contract badges", () => {
+  beforeEach(() => {
+    fetchSettingsCheckpointsMock.mockReset();
+  });
+
+  it("renders a red badge when the sidecar declares an unknown kwarg", async () => {
+    fetchSettingsCheckpointsMock.mockResolvedValue({
+      models_dir: "/tmp/models",
+      checkpoints: [
+        {
+          filename: "forecaster_best.pt",
+          relative_path: "forecaster_best.pt",
+          role: "forecaster",
+          size_bytes: 1024,
+          modified_at: "2026-05-15T10:00:00Z",
+          is_active: true,
+          output_mode: "regression",
+          encoder_alias: "bert_base",
+          conformal_sidecar_present: true,
+          inference_contract_status: "present",
+          required_kwargs: ["text_embedding", "unknown_kwarg"],
+          supplied_at_inference: {
+            text_embedding: true,
+            unknown_kwarg: false,
+          },
+        },
+      ],
+    });
+
+    const { default: SettingsPage } = await import("@/pages/settings");
+    render(<SettingsPage />);
+    await waitFor(() =>
+      expect(screen.getByText("forecaster_best.pt")).toBeInTheDocument(),
+    );
+
+    // The supplied kwarg renders as a neutral / outline badge, the
+    // missing one renders red. We assert via the testids the row
+    // exposes so we are not coupled to the variant class names.
+    expect(
+      screen.getByTestId("contract-kwarg-ok-text_embedding"),
+    ).toBeInTheDocument();
+    const missing = screen.getByTestId("contract-kwarg-missing-unknown_kwarg");
+    expect(missing).toBeInTheDocument();
+    // ``hawkish`` is the red Fed-context variant — assert the class to
+    // pin the red-badge surface concretely.
+    expect(missing.className).toMatch(/hawkish/);
+  });
+
+  it("renders a neutral legacy badge for a sidecar_absent checkpoint", async () => {
+    fetchSettingsCheckpointsMock.mockResolvedValue({
+      models_dir: "/tmp/models",
+      checkpoints: [
+        {
+          filename: "forecaster_legacy.pt",
+          relative_path: "forecaster_legacy.pt",
+          role: "forecaster",
+          size_bytes: 2048,
+          modified_at: "2025-01-01T10:00:00Z",
+          is_active: false,
+          output_mode: null,
+          encoder_alias: null,
+          conformal_sidecar_present: false,
+          inference_contract_status: "sidecar_absent",
+          required_kwargs: [],
+          supplied_at_inference: {},
+        },
+      ],
+    });
+
+    const { default: SettingsPage } = await import("@/pages/settings");
+    render(<SettingsPage />);
+    await waitFor(() =>
+      expect(screen.getByText("forecaster_legacy.pt")).toBeInTheDocument(),
+    );
+
+    const legacy = screen.getByTestId("contract-legacy-badge");
+    expect(legacy).toBeInTheDocument();
+    expect(legacy.textContent).toMatch(/legacy/i);
+    expect(legacy.className).not.toMatch(/hawkish/);
+  });
+
+  it("does not render any kwarg badge when no kwargs are required", async () => {
+    fetchSettingsCheckpointsMock.mockResolvedValue({
+      models_dir: "/tmp/models",
+      checkpoints: [
+        {
+          filename: "forecaster_minimal.pt",
+          relative_path: "forecaster_minimal.pt",
+          role: "forecaster",
+          size_bytes: 512,
+          modified_at: "2026-04-01T10:00:00Z",
+          is_active: false,
+          output_mode: "regression",
+          encoder_alias: null,
+          conformal_sidecar_present: true,
+          inference_contract_status: "present",
+          required_kwargs: [],
+          supplied_at_inference: {},
+        },
+      ],
+    });
+
+    const { default: SettingsPage } = await import("@/pages/settings");
+    render(<SettingsPage />);
+    await waitFor(() =>
+      expect(screen.getByText("forecaster_minimal.pt")).toBeInTheDocument(),
+    );
+
+    expect(screen.queryByTestId(/contract-kwarg-/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("contract-legacy-badge")).not.toBeInTheDocument();
+    expect(screen.getByText(/no required kwargs/i)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/test_inference_observability.py
+++ b/tests/unit/test_inference_observability.py
@@ -1,0 +1,339 @@
+"""Tests for the inference observability surfaces (#342).
+
+Three surfaces:
+
+1. ``/settings/checkpoints`` carries ``required_kwargs`` +
+   ``supplied_at_inference`` per forecaster checkpoint, sourced from the
+   ``<stem>.inference_contract.json`` sidecar + the live serving forward
+   signature.
+2. ``_bootstrap_cold_start`` invokes the canonical ``_get_model`` loader
+   after writing the checkpoint, so a freshly written sidecar that
+   declares an unknown kwarg trips a ``RuntimeError`` at boot rather
+   than silently binding via ``_set_singleton_after_train``.
+3. ``forecast_quantitative_series`` emits one structured INFO log line
+   per request listing the kwargs the serving forward was called with.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("torch")
+
+import torch  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+import app.main as main_mod  # noqa: E402
+import app.services.forecaster as forecaster_service  # noqa: E402
+from app.models.config import FEATURE_SIZE, ModelConfig  # noqa: E402
+from app.models.factory import build_serving_forecaster  # noqa: E402
+from app.training.inference_contract import (  # noqa: E402
+    SIDECAR_SCHEMA_VERSION,
+    InferenceContract,
+    sidecar_path_for,
+    write_sidecar,
+)
+
+
+def _toy_serving_model():
+    return build_serving_forecaster(
+        ModelConfig(input_size=FEATURE_SIZE, architecture="lstm")
+    )
+
+
+def _write_toy_checkpoint(path: Path) -> None:
+    model = _toy_serving_model()
+    torch.save(
+        {
+            "model_state_dict": model.state_dict(),
+            "model_config": {
+                "input_size": FEATURE_SIZE,
+                "architecture": "lstm",
+            },
+        },
+        path,
+    )
+
+
+def test_settings_checkpoints_surfaces_required_kwargs(tmp_path, monkeypatch):
+    """The endpoint flags a forecaster checkpoint whose sidecar declares
+    a kwarg the serving forward does not accept."""
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    forecaster_ckpt = models_dir / "forecaster_best.pt"
+    _write_toy_checkpoint(forecaster_ckpt)
+    # Synthetic mismatch: declare a kwarg the serving signature does
+    # not accept. The endpoint must mark the kwarg as not supplied.
+    contract = InferenceContract(
+        schema_version=SIDECAR_SCHEMA_VERSION,
+        model_class="ForecasterServingModel",
+        required_kwargs=("text_embedding", "unknown_kwarg"),
+    )
+    write_sidecar(contract, forecaster_ckpt)
+
+    # Redirect the endpoint at the temp models dir + checkpoint. The
+    # endpoint resolves MODELS_DIR via a function-local import from
+    # app.models.config, so patch the canonical home.
+    import app.models.config as model_config_mod
+
+    monkeypatch.setattr(model_config_mod, "MODELS_DIR", models_dir)
+    monkeypatch.setattr(
+        forecaster_service, "BEST_MODEL_PATH", forecaster_ckpt
+    )
+    monkeypatch.setattr(forecaster_service, "_model", None)
+    monkeypatch.setattr(forecaster_service, "_model_artifact_metadata", None)
+
+    client = TestClient(main_mod.app)
+    resp = client.get("/settings/checkpoints")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    rows = [r for r in payload["checkpoints"] if r["filename"] == forecaster_ckpt.name]
+    assert rows, payload
+    row = rows[0]
+    assert row["inference_contract_status"] == "present"
+    assert row["required_kwargs"] == ["text_embedding", "unknown_kwarg"]
+    # ``text_embedding`` IS in the serving forward signature; the
+    # synthetic unknown kwarg is NOT.
+    assert row["supplied_at_inference"]["text_embedding"] is True
+    assert row["supplied_at_inference"]["unknown_kwarg"] is False
+
+
+def test_settings_checkpoints_marks_legacy_absent_sidecar(tmp_path, monkeypatch):
+    """A forecaster checkpoint with no sidecar surfaces as ``sidecar_absent``."""
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    forecaster_ckpt = models_dir / "forecaster_best.pt"
+    _write_toy_checkpoint(forecaster_ckpt)
+    # No sidecar written -- pre-#341 legacy artefact.
+
+    monkeypatch.setattr(main_mod, "MODELS_DIR", models_dir)
+    monkeypatch.setattr(
+        forecaster_service, "BEST_MODEL_PATH", forecaster_ckpt
+    )
+    monkeypatch.setattr(forecaster_service, "_model", None)
+    monkeypatch.setattr(forecaster_service, "_model_artifact_metadata", None)
+
+    client = TestClient(main_mod.app)
+    resp = client.get("/settings/checkpoints")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    rows = [r for r in payload["checkpoints"] if r["filename"] == forecaster_ckpt.name]
+    assert rows, payload
+    row = rows[0]
+    assert row["inference_contract_status"] == "sidecar_absent"
+    assert row["required_kwargs"] == []
+    assert row["supplied_at_inference"] == {}
+
+
+def test_cold_start_invokes_get_model_on_contract_mismatch(tmp_path, monkeypatch):
+    """``_bootstrap_cold_start`` re-validates the freshly written
+    sidecar through the same loader ``/analyze`` uses. A bootstrap that
+    lands a sidecar declaring an unknown kwarg must raise loudly."""
+
+    forecaster_ckpt = tmp_path / "forecaster_best.pt"
+
+    def _fake_bootstrap_checkpoint(**_kwargs):
+        # Pretend training wrote a checkpoint + a bad sidecar.
+        _write_toy_checkpoint(forecaster_ckpt)
+        contract = InferenceContract(
+            schema_version=SIDECAR_SCHEMA_VERSION,
+            model_class="ForecasterServingModel",
+            required_kwargs=("nonexistent_kwarg",),
+        )
+        write_sidecar(contract, forecaster_ckpt)
+        return None
+
+    monkeypatch.setattr(main_mod, "bootstrap_checkpoint", _fake_bootstrap_checkpoint)
+    monkeypatch.setattr(main_mod, "analyze_text", lambda _: {"score": 0.0})
+    monkeypatch.setattr(main_mod, "fetch_market_history", lambda **_: [])
+    monkeypatch.setattr(main_mod, "build_feature_vectors", lambda *_a, **_k: [])
+
+    monkeypatch.setattr(forecaster_service, "BEST_MODEL_PATH", forecaster_ckpt)
+    monkeypatch.setattr(forecaster_service, "_model", None)
+    monkeypatch.setattr(forecaster_service, "_model_artifact_metadata", None)
+
+    payload = main_mod.AnalyzeRequest(
+        text="warmup",
+        date="2026-05-15",
+        symbol="^GSPC",
+        horizon="3d",
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        main_mod._bootstrap_cold_start(payload)
+    assert "inference contract" in str(excinfo.value).lower()
+    # The structured surface picks up the synthetic mismatch.
+    status = forecaster_service.get_serving_contract_status()
+    assert status["status"] == "serving_signature_missing_kwargs"
+    assert "nonexistent_kwarg" in status["missing_kwargs"]
+
+
+def test_cold_start_succeeds_when_sidecar_matches(tmp_path, monkeypatch):
+    """Sanity: a bootstrap that writes a sidecar declaring kwargs the
+    serving signature accepts must NOT raise — the loud-fail path only
+    fires on real drift."""
+
+    forecaster_ckpt = tmp_path / "forecaster_best.pt"
+
+    def _fake_bootstrap_checkpoint(**_kwargs):
+        _write_toy_checkpoint(forecaster_ckpt)
+        contract = InferenceContract(
+            schema_version=SIDECAR_SCHEMA_VERSION,
+            model_class="ForecasterServingModel",
+            required_kwargs=("text_embedding",),
+        )
+        write_sidecar(contract, forecaster_ckpt)
+        return None
+
+    monkeypatch.setattr(main_mod, "bootstrap_checkpoint", _fake_bootstrap_checkpoint)
+    monkeypatch.setattr(main_mod, "analyze_text", lambda _: {"score": 0.0})
+    monkeypatch.setattr(main_mod, "fetch_market_history", lambda **_: [])
+    monkeypatch.setattr(main_mod, "build_feature_vectors", lambda *_a, **_k: [])
+
+    monkeypatch.setattr(forecaster_service, "BEST_MODEL_PATH", forecaster_ckpt)
+    monkeypatch.setattr(forecaster_service, "_model", None)
+    monkeypatch.setattr(forecaster_service, "_model_artifact_metadata", None)
+
+    payload = main_mod.AnalyzeRequest(
+        text="warmup",
+        date="2026-05-15",
+        symbol="^GSPC",
+        horizon="3d",
+    )
+
+    # Must not raise.
+    main_mod._bootstrap_cold_start(payload)
+    status = forecaster_service.get_serving_contract_status()
+    assert status["status"] == "ok"
+
+
+def test_analyze_emits_structured_kwarg_log_line(monkeypatch, caplog):
+    """``forecast_quantitative_series`` emits one structured INFO line
+    per request listing the kwargs the serving forward was called with.
+    Format: ``analyze_serving_forward kwargs=<...> checkpoint=<stem>``.
+    """
+
+    model = _toy_serving_model()
+
+    # Force the singleton + bypass the heavy forward call so the test
+    # exercises the log surface in isolation.
+    monkeypatch.setattr(forecaster_service, "_model", model)
+    monkeypatch.setattr(
+        forecaster_service,
+        "_get_model",
+        lambda: model,
+    )
+    monkeypatch.setattr(
+        forecaster_service,
+        "_predict_next_point",
+        lambda _model, _sequence: (0.0, 0.0),
+    )
+    # Skip the conformal / get_model_artifact_metadata machinery by
+    # exercising the function with a single-step horizon.
+    monkeypatch.setattr(
+        forecaster_service,
+        "_conformal_manifest_for",
+        lambda _path: None,
+    )
+    monkeypatch.setattr(
+        forecaster_service,
+        "get_model_artifact_metadata",
+        lambda **_k: {},
+    )
+
+    from app.models.config import FeatureVector
+
+    vectors = [
+        FeatureVector(
+            date=f"2026-05-{day:02d}",
+            sentiment_score=0.0,
+            market_close=100.0,
+            market_volatility=0.01,
+        )
+        for day in range(1, 11)
+    ]
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger=forecaster_service.__name__):
+        forecaster_service.forecast_quantitative_series(
+            vectors=vectors,
+            forecast_mode="fast",
+            horizon="1d",
+        )
+
+    matching = [
+        r for r in caplog.records if r.getMessage().startswith("analyze_serving_forward ")
+    ]
+    assert len(matching) == 1, [r.getMessage() for r in caplog.records]
+    msg = matching[0].getMessage()
+    assert "kwargs=" in msg
+    assert "checkpoint=" in msg
+    # Regression-only toy model: no text path active -- kwargs list is
+    # empty (``kwargs= checkpoint=...``).
+    assert " kwargs= checkpoint=" in msg, msg
+
+
+def test_analyze_log_line_lists_kwargs_for_text_path(monkeypatch, caplog):
+    """When the text path is active, the log line lists the text
+    embedding kwargs."""
+
+    model = _toy_serving_model()
+    # Flip the runtime gates the helper inspects.
+    model._text_path_active = True  # type: ignore[attr-defined]
+    model.text_embedding_dim = 8  # type: ignore[attr-defined]
+    model.credibility_features = True  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(forecaster_service, "_model", model)
+    monkeypatch.setattr(forecaster_service, "_get_model", lambda: model)
+    monkeypatch.setattr(
+        forecaster_service,
+        "_predict_next_point",
+        lambda _model, _sequence: (0.0, 0.0),
+    )
+    monkeypatch.setattr(
+        forecaster_service,
+        "_conformal_manifest_for",
+        lambda _path: None,
+    )
+    monkeypatch.setattr(
+        forecaster_service,
+        "get_model_artifact_metadata",
+        lambda **_k: {},
+    )
+
+    from app.models.config import FeatureVector
+
+    vectors = [
+        FeatureVector(
+            date=f"2026-05-{day:02d}",
+            sentiment_score=0.0,
+            market_close=100.0,
+            market_volatility=0.01,
+        )
+        for day in range(1, 11)
+    ]
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger=forecaster_service.__name__):
+        forecaster_service.forecast_quantitative_series(
+            vectors=vectors,
+            forecast_mode="fast",
+            horizon="1d",
+        )
+
+    matching = [
+        r for r in caplog.records if r.getMessage().startswith("analyze_serving_forward ")
+    ]
+    assert len(matching) == 1
+    msg = matching[0].getMessage()
+    # Comma-separated kwarg list -- text + credibility.
+    assert "credibility" in msg
+    assert "text_embedding" in msg
+    assert "text_embedding_missing" in msg

--- a/tests/unit/test_inference_observability.py
+++ b/tests/unit/test_inference_observability.py
@@ -277,9 +277,11 @@ def test_analyze_emits_structured_kwarg_log_line(monkeypatch, caplog):
     msg = matching[0].getMessage()
     assert "kwargs=" in msg
     assert "checkpoint=" in msg
+    assert "mode=" in msg
     # Regression-only toy model: no text path active -- kwargs list is
-    # empty (``kwargs= checkpoint=...``).
+    # empty (``kwargs= checkpoint=... mode=regression``).
     assert " kwargs= checkpoint=" in msg, msg
+    assert "mode=regression" in msg, msg
 
 
 def test_analyze_log_line_lists_kwargs_for_text_path(monkeypatch, caplog):
@@ -339,3 +341,55 @@ def test_analyze_log_line_lists_kwargs_for_text_path(monkeypatch, caplog):
     assert "credibility" in msg
     assert "text_embedding" in msg
     assert "text_embedding_missing" in msg
+
+
+def test_analyze_log_line_carries_output_mode(monkeypatch, caplog):
+    """The log line must include ``mode=<output_mode>`` so the operator
+    can distinguish "kwargs declared, forward invoked" (regression mode)
+    from "kwargs declared, forward short-circuited" (classification mode
+    -- the ``_predict_next_point`` early-return path)."""
+
+    model = _toy_serving_model()
+    # Flip the model into classification mode -- _predict_next_point
+    # will short-circuit to last-bar echo and NOT call the forward.
+    model.output_mode = "classification"  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(forecaster_service, "_model", model)
+    monkeypatch.setattr(forecaster_service, "_get_model", lambda: model)
+    monkeypatch.setattr(
+        forecaster_service,
+        "_conformal_manifest_for",
+        lambda _path: None,
+    )
+    monkeypatch.setattr(
+        forecaster_service,
+        "get_model_artifact_metadata",
+        lambda **_k: {},
+    )
+
+    from app.models.config import FeatureVector
+
+    vectors = [
+        FeatureVector(
+            date=f"2026-05-{day:02d}",
+            sentiment_score=0.0,
+            market_close=100.0,
+            market_volatility=0.01,
+        )
+        for day in range(1, 11)
+    ]
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger=forecaster_service.__name__):
+        forecaster_service.forecast_quantitative_series(
+            vectors=vectors,
+            forecast_mode="fast",
+            horizon="1d",
+        )
+
+    matching = [
+        r for r in caplog.records if r.getMessage().startswith("analyze_serving_forward ")
+    ]
+    assert len(matching) == 1
+    msg = matching[0].getMessage()
+    assert "mode=classification" in msg, msg

--- a/tests/unit/test_inference_observability.py
+++ b/tests/unit/test_inference_observability.py
@@ -113,7 +113,9 @@ def test_settings_checkpoints_marks_legacy_absent_sidecar(tmp_path, monkeypatch)
     _write_toy_checkpoint(forecaster_ckpt)
     # No sidecar written -- pre-#341 legacy artefact.
 
-    monkeypatch.setattr(main_mod, "MODELS_DIR", models_dir)
+    import app.models.config as model_config_mod
+
+    monkeypatch.setattr(model_config_mod, "MODELS_DIR", models_dir)
     monkeypatch.setattr(
         forecaster_service, "BEST_MODEL_PATH", forecaster_ckpt
     )


### PR DESCRIPTION
Closes #342.

Three observability surfaces around the #341 inference contract, all greppable in production:

- `_bootstrap_cold_start` drops the post-train singleton + re-invokes `_get_model` after `bootstrap_checkpoint` returns. A freshly written sidecar declaring a kwarg the serving forward does not accept raises `RuntimeError` at boot instead of silently binding via `_set_singleton_after_train`. `/health` exposes the structured reason via the existing `get_serving_contract_status` surface.
- `/settings/checkpoints` response carries `required_kwargs` (from the sidecar) + `supplied_at_inference` (mapped against `collect_serving_forward_kwargs(ForecasterServingModel)`) + `inference_contract_status` (`"present"` / `"sidecar_absent"`) per forecaster row. The truth set is the live model-class signature, not the static constant — degrades to `SERVING_FORWARD_KWARGS` only on an introspection failure.
- Frontend settings page (`CheckpointRow`) renders a red `hawkish` `Badge` per declared kwarg the live wiring does not supply, a neutral "legacy" badge for pre-#341 `sidecar_absent` artefacts, and an outline "no required kwargs" badge for `present`+empty contracts. Test-ids drive the Vitest assertions.
- `forecast_quantitative_series` emits one structured INFO log line per `/analyze` request: `analyze_serving_forward kwargs=<csv> checkpoint=<stem>`. One line per request, not per kwarg and not per forecast step — operators run `grep | awk` for request-rate distribution over kwarg-sets.

ADR 0025 + tests for all three surfaces (backend caplog + frontend testid-driven badge rendering). Wiki §13 burn-down row #342 flipped to in progress in a separate commit on the wiki repo.

Reviewer focus:
- Cold-start failure mode is loud — `RuntimeError` propagates out of `_bootstrap_cold_start` rather than being swallowed; `/health` picks up the structured reason. The redundant cold load is sub-millisecond on top of the multi-second bootstrap train.
- Red badge surface is exercised against a synthetic sidecar declaring `["unknown_kwarg"]` — the Vitest assertion both checks the testid is present AND that the rendered class carries `hawkish`. Backend test asserts the JSON `supplied_at_inference["unknown_kwarg"] === false`.
- Per-request log is one structured INFO line per request, not one per kwarg. Empty kwargs list renders as `kwargs= checkpoint=<stem>` on the legacy regression-only path. Test pins the exact format via caplog.
- No raw exception detail in client-facing payloads — the existing #341 rule. The cold-start `RuntimeError` carries the structured contract status code (`serving_signature_missing_kwargs`), not the underlying loader trace; the trace stays in the logger.

Local run notes: backend pytest could not run locally (OpenMP / Python 3.14 conflict on this box) — relying on CI for the new `tests/unit/test_inference_observability.py`. Frontend Vitest: 153 passed (36 files), including the new `frontend/tests/pages/settings.test.tsx` (3 tests). TypeScript `tsc --noEmit` clean.