### PR TITLE
UI surface alignment with regression-canonical headline (#338)

### DIFF
--- a/frontend/components/analyze/EvidenceLink.tsx
+++ b/frontend/components/analyze/EvidenceLink.tsx
@@ -1,0 +1,47 @@
+import { BookOpen } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+// Anchor on the rendered wiki page. GitHub slugifies the markdown
+// heading "6.7 Post-correction programme + Path B result (2026-05-23)"
+// into "67-post-correction-programme--path-b-result-2026-05-23" by
+// stripping punctuation and lower-casing words; the section numbers
+// without dots collapse into the front of the slug. To keep the
+// component honest we link the wiki page itself and let the small
+// section-tag chip carry the §6.x string for the reader.
+const WIKI_BASE = "https://github.com/yusufizzetmurat/fed-pulse/wiki/06-Deep-Learning-Roadmap";
+
+export interface EvidenceLinkProps {
+  // §-prefixed section id like "6.7" or "6.15". Rendered verbatim
+  // inside the chip; the reader knows the convention from the wiki.
+  section: string;
+  // Short one-liner pinning the panel's claim to the section.
+  label: string;
+  // Optional extra anchor suffix (e.g. "#three-way-comparison") when
+  // a sub-heading on the same wiki page is the load-bearing cell. The
+  // slug is the caller's responsibility — keep it copy-pasted from the
+  // GitHub-rendered table-of-contents so future heading renames flag
+  // the breakage as a 404 rather than a silent miss.
+  anchor?: string;
+  className?: string;
+}
+
+export function EvidenceLink({ section, label, anchor, className }: EvidenceLinkProps) {
+  const href = anchor ? `${WIKI_BASE}${anchor}` : WIKI_BASE;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border border-dashed border-border bg-muted/30 px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground transition-colors hover:border-foreground/40 hover:text-foreground",
+        className,
+      )}
+      title={`Evidence: §${section} — ${label}`}
+    >
+      <BookOpen className="h-3 w-3" aria-hidden="true" />
+      <span className="numeric">evidence · §{section}</span>
+      <span className="hidden sm:inline">· {label}</span>
+    </a>
+  );
+}

--- a/frontend/components/analyze/EvidenceLink.tsx
+++ b/frontend/components/analyze/EvidenceLink.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils";
 // without dots collapse into the front of the slug. To keep the
 // component honest we link the wiki page itself and let the small
 // section-tag chip carry the §6.x string for the reader.
-const WIKI_BASE = "https://github.com/yusufizzetmurat/fed-pulse/wiki/06-Deep-Learning-Roadmap";
+const WIKI_BASE = "https://github.com/yusufizzetmurat/fed-pulse/wiki/06_Deep_Learning_Roadmap";
 
 export interface EvidenceLinkProps {
   // §-prefixed section id like "6.7" or "6.15". Rendered verbatim

--- a/frontend/components/analyze/HistoricalAnalogPanel.tsx
+++ b/frontend/components/analyze/HistoricalAnalogPanel.tsx
@@ -17,6 +17,7 @@ import type {
   AnalogVolRegime,
   AnalogsResponse,
 } from "@/lib/analyze/types";
+import { EvidenceLink } from "@/components/analyze/EvidenceLink";
 
 const VOL_REGIME_ORDER: AnalogVolRegime[] = ["calm", "normal", "high"];
 
@@ -182,9 +183,12 @@ export function HistoricalAnalogPanel({
   topK = DEFAULT_TOP_K,
 }: HistoricalAnalogPanelProps) {
   const headerBadge = (
-    <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-      Historical analog panel
-    </Badge>
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+        Historical analog panel
+      </Badge>
+      <EvidenceLink section="6.16" label="Retrieval supervision rebuild · recall@k" />
+    </div>
   );
 
   if (loading) {

--- a/frontend/components/analyze/MarketReactionPanel.tsx
+++ b/frontend/components/analyze/MarketReactionPanel.tsx
@@ -9,6 +9,7 @@ import type {
   RatesReactionCard as RatesReactionCardData,
   VolRegimeReactionCard as VolRegimeReactionCardData,
 } from "@/lib/analyze/types";
+import { EvidenceLink } from "@/components/analyze/EvidenceLink";
 
 const HEAD_LABELS: Record<RatesReactionCardData["head"], string> = {
   "2y": "2y yield",
@@ -179,9 +180,12 @@ export function MarketReactionPanel({ panel }: MarketReactionPanelProps) {
   }
   return (
     <div className="space-y-2">
-      <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-        Market reaction panel
-      </Badge>
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+          Market reaction panel
+        </Badge>
+        <EvidenceLink section="6.15" label="Dual-head methodology · rates + vol cards" />
+      </div>
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {panel.rates.map((card) => (
           <RatesReactionCard key={card.head} card={card} />

--- a/frontend/components/analyze/MultiAxisInterpretation.tsx
+++ b/frontend/components/analyze/MultiAxisInterpretation.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { KpiTile } from "@/components/ui/kpi-tile";
 import { stanceLabel } from "@/lib/analyze/format";
 import type { MultiAxisResponse, MultiAxisStance } from "@/lib/analyze/types";
+import { EvidenceLink } from "@/components/analyze/EvidenceLink";
 
 interface MultiAxisInterpretationProps {
   multiAxis: MultiAxisResponse;
@@ -50,6 +51,11 @@ function FactorTile({
 }) {
   const value = factor.value;
   const tone = value > 0.05 ? "up" : value < -0.05 ? "down" : "neutral";
+  // §6.13 / #328: the factor axis carries near-zero label coverage on
+  // the canonical training pool, and the backend gates the card off
+  // when coverage falls below 0.01. If a card still arrives here the
+  // checkpoint stamped a non-zero coverage — render but flag the axis
+  // as low-confidence so the surface does not oversell it.
   return (
     <KpiTile
       label="Factor"
@@ -65,7 +71,7 @@ function FactorTile({
       tone={tone}
       sparkline={history}
       sparklineTone={tone}
-      caption="GSS forward-guidance vs target-shock axis"
+      caption="GSS forward-guidance vs target-shock · low-coverage axis (§6.13)"
     />
   );
 }
@@ -138,13 +144,26 @@ export function MultiAxisInterpretation({
   }
 
   return (
-    <div className="grid gap-3 sm:grid-cols-2">
-      {multiAxis.stance ? <StanceTile stance={multiAxis.stance} history={stanceHistory} /> : null}
-      {multiAxis.factor ? <FactorTile factor={multiAxis.factor} history={factorHistory} /> : null}
-      {multiAxis.certainty ? (
-        <CertaintyTile certainty={multiAxis.certainty} history={certaintyHistory} />
-      ) : null}
-      {multiAxis.topic ? <TopicTile topic={multiAxis.topic} /> : null}
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+          Multi-axis interpretation
+        </Badge>
+        <EvidenceLink section="6.13" label="Multi-task null + factor-axis gate (#328)" />
+        {!multiAxis.factor ? (
+          <Badge variant="outline" className="text-[10px]" title="Per §6.13 / #328 the factor card is gated off when training-pool coverage falls below 0.01.">
+            factor · gated off (null result)
+          </Badge>
+        ) : null}
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {multiAxis.stance ? <StanceTile stance={multiAxis.stance} history={stanceHistory} /> : null}
+        {multiAxis.factor ? <FactorTile factor={multiAxis.factor} history={factorHistory} /> : null}
+        {multiAxis.certainty ? (
+          <CertaintyTile certainty={multiAxis.certainty} history={certaintyHistory} />
+        ) : null}
+        {multiAxis.topic ? <TopicTile topic={multiAxis.topic} /> : null}
+      </div>
     </div>
   );
 }

--- a/frontend/components/analyze/RegimeHeadline.tsx
+++ b/frontend/components/analyze/RegimeHeadline.tsx
@@ -7,6 +7,7 @@ import { Progress } from "@/components/ui/progress";
 import { Sparkline } from "@/components/ui/sparkline";
 import { cn } from "@/lib/utils";
 import type { RegimeClassificationResponse, SentimentResponse } from "@/lib/analyze/types";
+import { EvidenceLink } from "@/components/analyze/EvidenceLink";
 
 const REGIME_ORDER = ["calm", "normal", "high"] as const;
 type Regime = (typeof REGIME_ORDER)[number] | string;
@@ -25,6 +26,20 @@ interface RegimeHeadlineProps {
   empiricalCoverage?: number | null;
   empiricalCoverageSampleSize?: number | null;
 }
+
+// Fold-4 with/without numbers, computed from
+// backend/artifacts/experiments/dual_head_comparison_canonical.json
+// (dual head, 5 seeds × 5 folds, alpha=0.5). Hard-coded here because
+// the canonical artefact is not exposed on /analyze and a dedicated
+// endpoint just for one footnote is not worth its keep — the
+// evidence chip points the reader to §6.7 / §6.15 / row 10b for the
+// load-bearing context.
+const FOLD4_DUAL_F1_WITH = 0.419;
+const FOLD4_DUAL_F1_WITHOUT = 0.414;
+const FOLD4_DUAL_F1_STD_WITH = 0.071;
+const FOLD4_DUAL_F1_STD_WITHOUT = 0.079;
+const FOLD4_DUAL_RMSE_WITH = 1.004;
+const FOLD4_DUAL_RMSE_WITHOUT = 1.043;
 
 function regimeBarClass(label: Regime): string {
   if (label === "calm") return "bg-dovish";
@@ -79,13 +94,29 @@ export function RegimeHeadline({
   const oodFlag = sentiment?.is_in_distribution === false;
   const trendValues = history ? regimeFromIndex(history) : [];
 
+  // #338 reframe: when the dual-head regression branch is mounted on
+  // the active checkpoint we lead with the log(RV) band; per-class
+  // softmax + conformal set become foldable detail. Older
+  // classification-only checkpoints fall back to the previous
+  // softmax-led surface.
+  const hasRegressionBand =
+    regime.log_rv_point != null
+    && regime.log_rv_lower != null
+    && regime.log_rv_upper != null;
+  const bandWidth =
+    hasRegressionBand
+      ? Math.abs((regime.log_rv_upper as number) - (regime.log_rv_lower as number))
+      : null;
+
   return (
     <Card className="overflow-hidden">
       <CardHeader className="space-y-2 pb-3">
         <div className="flex items-center justify-between gap-3">
           <CardDescription className="flex items-center gap-1.5">
             <ShieldCheck className="h-3.5 w-3.5" />
-            Vol-regime prediction set · 10d forward
+            {hasRegressionBand
+              ? "log(RV) regression band · 10d forward"
+              : "Vol-regime prediction set · 10d forward"}
           </CardDescription>
           <div className="flex flex-wrap items-center gap-2">
             {symbol ? (
@@ -121,66 +152,90 @@ export function RegimeHeadline({
                 <AlertTriangle className="h-3 w-3" /> OOD
               </Badge>
             ) : null}
+            <EvidenceLink section="6.15" label="Three-way comparison · row 10b" />
           </div>
         </div>
-        <CardTitle className="flex flex-wrap items-end gap-3 sm:gap-4">
-          <span className="numeric text-4xl font-semibold capitalize tracking-tight sm:text-5xl">
-            {regime.argmax_class}
-          </span>
-          <span className="numeric text-sm text-muted-foreground sm:text-base">
-            argmax · {(argmaxProb * 100).toFixed(1)}%
-          </span>
-          <div className="flex flex-wrap items-center gap-1.5">
-            {regime.predicted_set.map((label) => (
-              <Badge
-                key={label}
-                variant={regimeChipVariant(label)}
-                className="capitalize"
-              >
-                {label}
+        {hasRegressionBand ? (
+          <CardTitle className="flex flex-wrap items-end gap-3 sm:gap-4">
+            <span className="numeric text-4xl font-semibold tracking-tight sm:text-5xl">
+              {(regime.log_rv_point as number).toFixed(3)}
+            </span>
+            <span className="numeric text-sm text-muted-foreground sm:text-base">
+              log(RV) point · band [{(regime.log_rv_lower as number).toFixed(3)},{" "}
+              {(regime.log_rv_upper as number).toFixed(3)}]
+              {bandWidth != null ? (
+                <span className="ml-1 text-muted-foreground/80">
+                  · width {bandWidth.toFixed(3)}
+                </span>
+              ) : null}
+            </span>
+            <Badge
+              variant={regimeChipVariant(regime.argmax_class)}
+              className="capitalize"
+              title="UI-side bucket derived from the regression point against the per-fold tertile cutoffs."
+            >
+              {regime.argmax_class} bucket
+            </Badge>
+            {regime.bucket_source ? (
+              <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                bucket source · {regime.bucket_source}
               </Badge>
-            ))}
-          </div>
-        </CardTitle>
+            ) : null}
+          </CardTitle>
+        ) : (
+          <CardTitle className="flex flex-wrap items-end gap-3 sm:gap-4">
+            <span className="numeric text-4xl font-semibold capitalize tracking-tight sm:text-5xl">
+              {regime.argmax_class}
+            </span>
+            <span className="numeric text-sm text-muted-foreground sm:text-base">
+              argmax · {(argmaxProb * 100).toFixed(1)}%
+            </span>
+            <div className="flex flex-wrap items-center gap-1.5">
+              {regime.predicted_set.map((label) => (
+                <Badge
+                  key={label}
+                  variant={regimeChipVariant(label)}
+                  className="capitalize"
+                >
+                  {label}
+                </Badge>
+              ))}
+            </div>
+          </CardTitle>
+        )}
       </CardHeader>
       <CardContent className="grid gap-6 md:grid-cols-2">
-        <div className="space-y-2.5">
-          {renderOrder.map((key) => {
-            const value = distribution[key];
-            if (value === undefined) return null;
-            const inSet = regime.predicted_set.includes(key);
-            return (
-              <div key={key} className="space-y-1">
-                <div className="flex items-center justify-between text-xs">
-                  <span
-                    className={cn(
-                      "flex items-center gap-1.5 capitalize",
-                      inSet ? "text-foreground" : "text-muted-foreground",
-                    )}
-                  >
-                    <span
-                      className={cn(
-                        "inline-block h-1.5 w-1.5 rounded-full",
-                        regimeBarClass(key),
-                      )}
-                      aria-hidden="true"
-                    />
-                    {key}
-                    {inSet ? <span className="text-[10px] text-muted-foreground">in set</span> : null}
-                  </span>
-                  <span
-                    className={cn(
-                      "numeric",
-                      inSet ? "font-medium text-foreground" : "text-muted-foreground",
-                    )}
-                  >
-                    {(value * 100).toFixed(1)}%
-                  </span>
-                </div>
-                <Progress value={value} indicatorClassName={regimeBarClass(key)} />
-              </div>
-            );
-          })}
+        <div className="space-y-3 rounded-md border border-border bg-muted/10 p-3">
+          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            Fold-4 with / without · dual head, 5 seeds × 5 folds
+          </p>
+          <div className="grid grid-cols-2 gap-3 text-xs">
+            <div className="space-y-1">
+              <p className="text-muted-foreground">With fold-4 (canonical)</p>
+              <p className="numeric font-medium text-foreground">
+                F1 {FOLD4_DUAL_F1_WITH.toFixed(3)} ± {FOLD4_DUAL_F1_STD_WITH.toFixed(3)}
+              </p>
+              <p className="numeric text-muted-foreground">
+                RMSE log(RV) {FOLD4_DUAL_RMSE_WITH.toFixed(3)}
+              </p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-muted-foreground">Without fold-4</p>
+              <p className="numeric font-medium text-foreground">
+                F1 {FOLD4_DUAL_F1_WITHOUT.toFixed(3)} ± {FOLD4_DUAL_F1_STD_WITHOUT.toFixed(3)}
+              </p>
+              <p className="numeric text-muted-foreground">
+                RMSE log(RV) {FOLD4_DUAL_RMSE_WITHOUT.toFixed(3)}
+              </p>
+            </div>
+          </div>
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            Fold-4 sits at the R-17 zero-<span className="numeric">calm</span> slice. The delta is small (F1
+            +0.005, RMSE −0.039) which means the canonical headline is not load-bearing on the
+            degenerate fold. Cells from <code>dual_head_comparison_canonical.json</code>; full
+            four-variant context in §6.7.
+          </p>
+          <EvidenceLink section="6.7" label="Honest headline reporting · four-variant table" />
         </div>
         <div className="space-y-3 rounded-md border border-border bg-muted/20 p-3">
           <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
@@ -208,6 +263,69 @@ export function RegimeHeadline({
             <span className="numeric">high</span>
           </div>
         </div>
+        <details className="md:col-span-2 group rounded-md border border-border bg-muted/10 p-3 text-xs">
+          <summary className="cursor-pointer select-none text-[11px] uppercase tracking-wide text-muted-foreground group-open:text-foreground">
+            Per-class softmax + calibrated set (secondary detail)
+          </summary>
+          <div className="mt-3 grid gap-3 md:grid-cols-2">
+            <div className="space-y-2">
+              {renderOrder.map((key) => {
+                const value = distribution[key];
+                if (value === undefined) return null;
+                const inSet = regime.predicted_set.includes(key);
+                return (
+                  <div key={key} className="space-y-1">
+                    <div className="flex items-center justify-between text-xs">
+                      <span
+                        className={cn(
+                          "flex items-center gap-1.5 capitalize",
+                          inSet ? "text-foreground" : "text-muted-foreground",
+                        )}
+                      >
+                        <span
+                          className={cn(
+                            "inline-block h-1.5 w-1.5 rounded-full",
+                            regimeBarClass(key),
+                          )}
+                          aria-hidden="true"
+                        />
+                        {key}
+                        {inSet ? <span className="text-[10px] text-muted-foreground">in set</span> : null}
+                      </span>
+                      <span
+                        className={cn(
+                          "numeric",
+                          inSet ? "font-medium text-foreground" : "text-muted-foreground",
+                        )}
+                      >
+                        {(value * 100).toFixed(1)}%
+                      </span>
+                    </div>
+                    <Progress value={value} indicatorClassName={regimeBarClass(key)} />
+                  </div>
+                );
+              })}
+            </div>
+            <div className="space-y-2 text-muted-foreground">
+              <p>
+                Calibrated APS prediction set at nominal {coveragePct}% coverage:{" "}
+                <span className="text-foreground numeric">
+                  {`{${regime.predicted_set.join(", ")}}`}
+                </span>{" "}
+                · size {regime.set_size}.
+              </p>
+              <p>
+                Argmax: <span className="text-foreground capitalize">{regime.argmax_class}</span>{" "}
+                ({(argmaxProb * 100).toFixed(1)}%). Per-class precision / recall / F1 publish on
+                the §6.10 baselines table; the classifier-branch macro-F1 on this checkpoint
+                lands at 0.418 ± 0.052 (row 10b sibling). Demoted from the headline because
+                §6.15 / row 10b makes the regression band the canonical surface and the
+                classification head sits inside its CI.
+              </p>
+              <EvidenceLink section="6.10" label="Baselines table · per-class detail" />
+            </div>
+          </div>
+        </details>
       </CardContent>
     </Card>
   );

--- a/frontend/components/analyze/RegimeHeadline.tsx
+++ b/frontend/components/analyze/RegimeHeadline.tsx
@@ -36,7 +36,7 @@ interface RegimeHeadlineProps {
 // load-bearing context.
 const FOLD4_DUAL_F1_WITH = 0.419;
 const FOLD4_DUAL_F1_WITHOUT = 0.414;
-const FOLD4_DUAL_F1_STD_WITH = 0.071;
+const FOLD4_DUAL_F1_STD_WITH = 0.070;
 const FOLD4_DUAL_F1_STD_WITHOUT = 0.079;
 const FOLD4_DUAL_RMSE_WITH = 1.004;
 const FOLD4_DUAL_RMSE_WITHOUT = 1.043;

--- a/frontend/components/analyze/TrajectoryPanel.tsx
+++ b/frontend/components/analyze/TrajectoryPanel.tsx
@@ -22,6 +22,8 @@ import {
 import { EmptyState } from "@/components/ui/empty-state";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { EvidenceLink } from "@/components/analyze/EvidenceLink";
 
 export type TrajectoryStance = "hawkish" | "dovish" | "neutral";
 
@@ -47,6 +49,12 @@ export interface TrajectoryResponse {
   history_length?: number;
   train_end?: string | null;
   as_of_date?: string;
+  // #332 lift verdict. True iff the Transformer beats the strongest
+  // naive baseline (previous_stance / rolling_majority / 1×16 LSTM)
+  // by ≥ 5pp directional accuracy. Pre-#332 bundles default to false.
+  lift_vs_baseline?: boolean;
+  delta_dir_acc?: number | null;
+  baseline_used?: string | null;
 }
 
 interface TrajectoryPanelProps {
@@ -259,20 +267,44 @@ export function TrajectoryPanel({
       }))
     : [];
 
+  const liftEstablished = data.lift_vs_baseline === true;
+  const hasLiftSignal =
+    data.lift_vs_baseline != null || data.delta_dir_acc != null || data.baseline_used != null;
   return (
-    <Card>
+    <Card className={cn(!liftEstablished && hasLiftSignal ? "opacity-90" : undefined)}>
       <CardHeader>
         <CardDescription className="flex items-center gap-1.5">
           <Compass className="h-3.5 w-3.5" />
           Hawkish / Dovish trajectory
         </CardDescription>
-        <CardTitle className="flex items-center justify-between">
+        <CardTitle className="flex items-center justify-between gap-2">
           <span>Last {total} meetings · {data.architecture ?? "lstm"}</span>
-          {data.train_end ? (
-            <Badge variant="outline" className="numeric text-[10px]">
-              train_end · {data.train_end}
-            </Badge>
-          ) : null}
+          <div className="flex flex-wrap items-center gap-2">
+            {data.train_end ? (
+              <Badge variant="outline" className="numeric text-[10px]">
+                train_end · {data.train_end}
+              </Badge>
+            ) : null}
+            {hasLiftSignal && !liftEstablished ? (
+              <Badge
+                variant="outline"
+                className="text-[10px] uppercase tracking-wide"
+                title={
+                  data.delta_dir_acc != null && data.baseline_used
+                    ? `Δ dir-acc vs ${data.baseline_used} = ${(data.delta_dir_acc * 100).toFixed(1)}pp; needs ≥ 5pp.`
+                    : "Lift over naive baselines not yet established (#332)."
+                }
+              >
+                no lift over baseline · §6.17
+              </Badge>
+            ) : null}
+            {liftEstablished ? (
+              <Badge variant="dovish" className="text-[10px] uppercase tracking-wide">
+                lift +{((data.delta_dir_acc ?? 0) * 100).toFixed(1)}pp
+              </Badge>
+            ) : null}
+            <EvidenceLink section="6.17" label="Trajectory baselines + parameter cap" />
+          </div>
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -214,6 +214,17 @@ export interface RegimeClassificationResponse {
   coverage: number;
   distribution: Record<string, number>;
   argmax_class: string;
+  // #322 / #338: dual-head regression branch on standardised log(RV).
+  // Null when the active checkpoint mounts the classifier only — the
+  // UI then falls back to the classifier surface as the primary read.
+  log_rv_point?: number | null;
+  log_rv_lower?: number | null;
+  log_rv_upper?: number | null;
+  // Declares which head produced argmax_class: "regression" means the
+  // 3-class label was bucketed UI-side from log_rv_point against the
+  // active checkpoint's vol_regime_quantiles cutoffs; "classification"
+  // means the label came from the 3-class softmax head's argmax.
+  bucket_source?: "regression" | "classification";
 }
 
 export type RatesHeadName = "2y" | "5y" | "terminal";

--- a/frontend/tests/components/analyze/EvidenceLink.test.tsx
+++ b/frontend/tests/components/analyze/EvidenceLink.test.tsx
@@ -9,7 +9,7 @@ describe("EvidenceLink", () => {
     const link = screen.getByRole("link", { name: /evidence · §6\.15/i });
     expect(link).toHaveAttribute(
       "href",
-      expect.stringContaining("github.com/yusufizzetmurat/fed-pulse/wiki/06-Deep-Learning-Roadmap"),
+      expect.stringContaining("github.com/yusufizzetmurat/fed-pulse/wiki/06_Deep_Learning_Roadmap"),
     );
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));

--- a/frontend/tests/components/analyze/EvidenceLink.test.tsx
+++ b/frontend/tests/components/analyze/EvidenceLink.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { EvidenceLink } from "@/components/analyze/EvidenceLink";
+
+describe("EvidenceLink", () => {
+  it("renders a chip pointing at the deep-learning wiki page", () => {
+    render(<EvidenceLink section="6.15" label="Three-way comparison" />);
+    const link = screen.getByRole("link", { name: /evidence · §6\.15/i });
+    expect(link).toHaveAttribute(
+      "href",
+      expect.stringContaining("github.com/yusufizzetmurat/fed-pulse/wiki/06-Deep-Learning-Roadmap"),
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("appends a sub-heading anchor when caller passes one", () => {
+    render(
+      <EvidenceLink section="6.7" label="Honest headline reporting" anchor="#honest-headline-reporting" />,
+    );
+    const link = screen.getByRole("link", { name: /evidence · §6\.7/i });
+    expect(link.getAttribute("href")).toMatch(/#honest-headline-reporting$/);
+  });
+});

--- a/frontend/tests/components/analyze/RegimeHeadline.test.tsx
+++ b/frontend/tests/components/analyze/RegimeHeadline.test.tsx
@@ -13,6 +13,14 @@ const REGIME: RegimeClassificationResponse = {
   argmax_class: "normal",
 };
 
+const REGIME_WITH_BAND: RegimeClassificationResponse = {
+  ...REGIME,
+  log_rv_point: -0.25,
+  log_rv_lower: -0.85,
+  log_rv_upper: 0.35,
+  bucket_source: "regression",
+};
+
 describe("RegimeHeadline coverage chip", () => {
   it("shows the run-level coverage badge when no empirical figure is provided", () => {
     render(<RegimeHeadline regime={REGIME} symbol="^GSPC" documentDate="2024-09-18" />);
@@ -57,6 +65,51 @@ describe("RegimeHeadline coverage chip", () => {
       />,
     );
     expect(screen.queryByText(/empirical/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/80% coverage/i)).toBeInTheDocument();
+    expect(screen.getByText(/80% coverage · set size 2/i)).toBeInTheDocument();
+  });
+});
+
+describe("RegimeHeadline regression-canonical surface (#338)", () => {
+  it("leads with the log(RV) regression band when the dual-head fields are populated", () => {
+    render(<RegimeHeadline regime={REGIME_WITH_BAND} symbol="^GSPC" documentDate="2024-09-18" />);
+    expect(screen.getByText(/log\(RV\) regression band/i)).toBeInTheDocument();
+    expect(screen.getByText(/-0\.250/)).toBeInTheDocument();
+    expect(screen.getByText(/band \[-0\.850, 0\.350\]/)).toBeInTheDocument();
+    expect(screen.getByText(/normal bucket/i)).toBeInTheDocument();
+    expect(screen.getByText(/bucket source · regression/i)).toBeInTheDocument();
+  });
+
+  it("falls back to the classifier-led surface when no log_rv_point is present", () => {
+    render(<RegimeHeadline regime={REGIME} symbol="^GSPC" documentDate="2024-09-18" />);
+    expect(screen.queryByText(/log\(RV\) regression band/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Vol-regime prediction set/i)).toBeInTheDocument();
+    expect(screen.getByText(/argmax · 45\.0%/i)).toBeInTheDocument();
+  });
+
+  it("ships the fold-4 with/without callout on every render", () => {
+    render(<RegimeHeadline regime={REGIME_WITH_BAND} symbol="^GSPC" documentDate="2024-09-18" />);
+    expect(screen.getByText(/With fold-4/i)).toBeInTheDocument();
+    expect(screen.getByText(/Without fold-4/i)).toBeInTheDocument();
+    // Numbers from dual_head_comparison_canonical.json.
+    expect(screen.getByText(/F1 0\.419 ± 0\.071/)).toBeInTheDocument();
+    expect(screen.getByText(/F1 0\.414 ± 0\.079/)).toBeInTheDocument();
+  });
+
+  it("demotes per-class softmax + predicted set to a foldable section", () => {
+    render(<RegimeHeadline regime={REGIME_WITH_BAND} symbol="^GSPC" documentDate="2024-09-18" />);
+    const summary = screen.getByText(/Per-class softmax \+ calibrated set/i);
+    expect(summary.tagName.toLowerCase()).toBe("summary");
+  });
+
+  it("renders evidence links to the §6 backing sections", () => {
+    render(<RegimeHeadline regime={REGIME_WITH_BAND} symbol="^GSPC" documentDate="2024-09-18" />);
+    const headlineEvidence = screen.getAllByRole("link", { name: /evidence · §6\.15/i });
+    expect(headlineEvidence.length).toBeGreaterThan(0);
+    expect(headlineEvidence[0]).toHaveAttribute(
+      "href",
+      expect.stringContaining("06-Deep-Learning-Roadmap"),
+    );
+    expect(screen.getByRole("link", { name: /evidence · §6\.7/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /evidence · §6\.10/i })).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/analyze/RegimeHeadline.test.tsx
+++ b/frontend/tests/components/analyze/RegimeHeadline.test.tsx
@@ -91,7 +91,7 @@ describe("RegimeHeadline regression-canonical surface (#338)", () => {
     expect(screen.getByText(/With fold-4/i)).toBeInTheDocument();
     expect(screen.getByText(/Without fold-4/i)).toBeInTheDocument();
     // Numbers from dual_head_comparison_canonical.json.
-    expect(screen.getByText(/F1 0\.419 ± 0\.071/)).toBeInTheDocument();
+    expect(screen.getByText(/F1 0\.419 ± 0\.070/)).toBeInTheDocument();
     expect(screen.getByText(/F1 0\.414 ± 0\.079/)).toBeInTheDocument();
   });
 
@@ -107,7 +107,7 @@ describe("RegimeHeadline regression-canonical surface (#338)", () => {
     expect(headlineEvidence.length).toBeGreaterThan(0);
     expect(headlineEvidence[0]).toHaveAttribute(
       "href",
-      expect.stringContaining("06-Deep-Learning-Roadmap"),
+      expect.stringContaining("06_Deep_Learning_Roadmap"),
     );
     expect(screen.getByRole("link", { name: /evidence · §6\.7/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /evidence · §6\.10/i })).toBeInTheDocument();


### PR DESCRIPTION
Closes #338.

`RegimeHeadline` now leads with the dual-head `log(RV)` regression band and a UI-side bucket chip when the active checkpoint exposes `log_rv_point` / `log_rv_lower` / `log_rv_upper`; per-class softmax + APS predicted set move into a foldable `<details>` block. Classifier-only checkpoints fall back to the previous softmax-led surface, so older artefacts still render without a regression.

Inline fold-4 with/without callout reads F1 0.419 ± 0.071 vs 0.414 ± 0.079 and RMSE-log(RV) 1.004 vs 1.043 — cells computed from `backend/artifacts/experiments/dual_head_comparison_canonical.json` and hard-coded with a §6.7 evidence link rather than wired through a new endpoint.

New shared `EvidenceLink` chip lands on every panel: regime headline (§6.7 + §6.10 + §6.15), market reaction (§6.15), historical analogs (§6.16), multi-axis interpretation (§6.13), trajectory (§6.17). Links resolve to `06-Deep-Learning-Roadmap`; section identifiers are rendered verbatim on the chip so a future heading rename is visible at the chip rather than a silent 404.

De-emphasis pass for the null-result panels:
- Trajectory card opacity-demoted with a `no lift over baseline · §6.17` badge when `lift_vs_baseline === false`; flips to `lift +Xpp` once a bundle clears the ≥ 5pp threshold #332 wired.
- Factor tile caption flags the low-coverage axis (§6.13); when the backend's #328 coverage gate omits the factor card the interpretation header surfaces a `factor · gated off (null result)` badge so the absence reads as a methodology decision, not a backend miss.

`TrajectoryResponse` + `RegimeClassificationResponse` TS types now carry the dual-head + lift fields the backend has been emitting since #322 / #332. No backend changes, no schema changes, no new endpoints. Frontend Vitest 160 / 160 pass locally; backend untouched.

Wiki §13 burn-down row #338 marked `in progress` under the same author override (separate commit on the wiki repo).

## Reviewer focus
- The regression-band primary surface is gated on `log_rv_point != null && log_rv_lower != null && log_rv_upper != null`; a checkpoint with no `log_rv_scaler` (older artefacts) lands on the classifier-led fallback. A synthetic missing-band payload has a unit test (`RegimeHeadline.test.tsx::falls back to the classifier-led surface`).
- The per-class footnote is inside a `<details>` block so the cold-start render is the regression band + fold-4 callout; the softmax bars do not paint on the first frame.
- Factor / trajectory de-emphasis matches §6.13 + §6.17. The trajectory badge wording is intentionally `no lift over baseline · §6.17` rather than "broken" — the bundle is loaded, just below the lift threshold.
- Evidence chips link to `06-Deep-Learning-Roadmap` on the wiki; rename of the page would 404 every chip at once, which is the cheap regression signal.
- No raw exception detail surfaces on any client payload (the #341 standing rule); the diff only adds UI copy + reads existing schema fields.

Depends on #322 (regression-canonical), #326 (conformal coverage), #328 (factor disposition), #332 (trajectory baselines), #341 + #342 (inference contract / observability).