### PR TITLE
End-to-end demo flow + thesis report figures (#298)

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,82 @@
+# Demo + report figures
+
+Companion to `docs/reproduce.md`. Walks through driving the dashboard end-to-end, capturing the panel screenshots the report cites, and regenerating the per-head + cross-bank figure set. Both scripts are deterministic — the same backend state plus the same viewport gives diffable PNGs run-to-run.
+
+## Prerequisites
+
+- Docker + Compose v2 (for the local backend stack), or a reachable deployed origin.
+- Python 3.11 with `playwright` installed (`pip install playwright && playwright install chromium`).
+- Pillow on the host running `build_thesis_figures.py` — already a backend dep, so the script also works inside the backend container if you would rather not install on the host.
+
+## End-to-end demo (screenshots)
+
+```sh
+# 1. Backend + frontend on the default `make dev` ports.
+make dev
+# Wait for `http://localhost:3000` to respond and the backend `/health` to
+# go green (≈ 30 s once the image is built).
+
+# 2. Drive the dashboard, capture screenshots to ../fed-pulse.wiki/assets/demo/.
+python scripts/demo_end_to_end.py
+```
+
+The script captures five panels — statement decomposition, market reaction, historical analogs, trajectory, settings checkpoints — and writes one PNG per panel with a UTC timestamp suffix so a re-run does not overwrite the previous capture. Add `--headed` to watch the run; `--keep-open` pauses after the last capture so the live UI is inspectable before tear-down.
+
+Against the deployed droplet:
+
+```sh
+python scripts/demo_end_to_end.py \
+    --frontend-url https://fedpulse.yusufizzetmurat.com \
+    --backend-url https://fedpulse.yusufizzetmurat.com/api
+```
+
+The frontend resolves its API base URL at build time from `NEXT_PUBLIC_API_URL` (see `frontend/lib/analyze/api.ts`), so the `--backend-url` flag is informational against a prebuilt bundle. Pass `--in-repo` to write captures under `docs/demo-screenshots/` instead of the wiki repo.
+
+## Report figures
+
+```sh
+python -m scripts.figures.build_thesis_figures
+```
+
+Default output is `../fed-pulse.wiki/assets/figures/`. Pass `--in-repo` to write to `docs/figures/` instead. The script renders four figures:
+
+| Figure | Source |
+| --- | --- |
+| `architecture.png` | wiki §3 (system architecture) |
+| `dual_head_comparison.png` | `backend/artifacts/experiments/dual_head_comparison_canonical.json` |
+| `text_path_ab.png` | `backend/artifacts/experiments/text_path_ab_canonical.json` |
+| `cross_bank_ladder.png` | wiki §6.14 (transcribed; no JSON artefact on disk) |
+
+Each PNG ships a paired `.caption.txt` carrying the reproducibility header (commit SHA at render time, canonical training-package id, source artefact path). The report can drop the caption verbatim.
+
+To regenerate one figure rather than the full set:
+
+```sh
+python -m scripts.figures.build_thesis_figures --only dual-head
+```
+
+## Putting it together
+
+On a fresh checkout the full reproduce-from-scratch flow is:
+
+```sh
+# 1. Pull the canonical training package + run a 1-epoch smoke training pass.
+make reproduce-all
+
+# 2. Bring the dashboard up.
+make dev
+
+# 3. Capture the demo screenshots.
+python scripts/demo_end_to_end.py
+
+# 4. Rebuild the report figures.
+python -m scripts.figures.build_thesis_figures
+```
+
+The demo screenshots land under `../fed-pulse.wiki/assets/demo/` and the figures under `../fed-pulse.wiki/assets/figures/`. Commit both to the wiki repo separately from the main repo.
+
+## Troubleshooting
+
+- The screenshot script raises `TimeoutError: locator "Multi-axis interpretation" not found` if the backend has no multi-axis checkpoint mounted. The panel renders an empty-state card with that string anyway, so the timeout almost always means the backend has not finished cold-starting — re-run after `/health` reports `"status": "ready"`.
+- `make dev` builds the frontend bundle with `NEXT_PUBLIC_API_URL=http://localhost:8000`. Against the droplet the prod build bakes the public origin in instead; do not point a local frontend at a remote backend by changing the env var at runtime — rebuild the image.
+- Pillow's default fonts vary by host. The script falls back to PIL's bitmap default if no truetype font is found, which renders correctly but at lower legibility. Install the DejaVu or system Arial fonts to match the published figures.

--- a/scripts/demo_end_to_end.py
+++ b/scripts/demo_end_to_end.py
@@ -1,0 +1,295 @@
+"""Scripted end-to-end demo + screenshot capture (#298).
+
+Drives the live front-end through every panel the 2026-06-05 report
+cites and writes a stable set of PNG screenshots to the wiki repo
+under ``fed-pulse.wiki/assets/demo/``. The script assumes a backend
+listening on ``http://localhost:8000`` and a frontend on
+``http://localhost:3000`` — both default ``make dev`` ports.
+
+The capture is deterministic: a 1440×900 viewport, fixed FOMC statement,
+fixed symbol + horizon, and explicit waits per panel so screenshots are
+diffable run-to-run.
+
+Panels captured
+---------------
+
+1. ``statement_decomposition_<ts>.png`` — paste-and-analyse form,
+   regime headline, multi-axis interpretation, factor card (with the
+   #328 null-result framing).
+2. ``market_reaction_<ts>.png`` — rates cards (#292/#293) + vol-regime
+   card (#322/#326).
+3. ``historical_analogs_<ts>.png`` — top-3 hits (#294/#295).
+4. ``trajectory_<ts>.png`` — projected next stance with the
+   #332/#338 lift-vs-baseline badge.
+5. ``settings_checkpoints_<ts>.png`` — /settings page surface with
+   the #341/#342 sidecar contract + supplied_at_inference badges.
+
+CLI
+---
+
+::
+
+    # Backend + frontend up via `make dev`, then:
+    python scripts/demo_end_to_end.py
+
+    # Override the bases (e.g. against the deployed droplet):
+    python scripts/demo_end_to_end.py \\
+        --backend-url https://fedpulse.yusufizzetmurat.com/api \\
+        --frontend-url https://fedpulse.yusufizzetmurat.com
+
+The script writes to ``../fed-pulse.wiki/assets/demo/`` by default; pass
+``--output-dir`` to redirect or ``--in-repo`` to write under
+``docs/demo-screenshots/`` instead.
+
+Dependencies
+------------
+
+The Playwright Python package + a Chromium download. On a fresh
+checkout::
+
+    pip install playwright
+    playwright install chromium
+
+The script imports ``playwright.sync_api`` lazily so the module can
+still be imported (for ``--help`` etc.) without the dep installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FOMC_TEXT = (
+    "Recent indicators suggest economic activity has continued to expand at a "
+    "solid pace. Job gains have moderated since earlier in the year but remain "
+    "solid, and the unemployment rate has moved up slightly though it stays low. "
+    "Inflation has eased over the past year but remains somewhat elevated. The "
+    "Committee judges that the risks to achieving its employment and inflation "
+    "goals continue to move into better balance."
+)
+DEFAULT_BACKEND = "http://localhost:8000"
+DEFAULT_FRONTEND = "http://localhost:3000"
+VIEWPORT = {"width": 1440, "height": 900}
+
+
+@dataclass
+class DemoArgs:
+    backend_url: str
+    frontend_url: str
+    output_dir: Path
+    fomc_text: str
+    headless: bool
+    wait_timeout_ms: int
+    keep_open: bool
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> DemoArgs:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend-url", default=DEFAULT_BACKEND)
+    parser.add_argument("--frontend-url", default=DEFAULT_FRONTEND)
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Override the screenshot output directory. Defaults to ../fed-pulse.wiki/assets/demo/.",
+    )
+    parser.add_argument(
+        "--in-repo",
+        action="store_true",
+        help="Write screenshots under docs/demo-screenshots/ inside the main repo instead.",
+    )
+    parser.add_argument(
+        "--fomc-text",
+        default=DEFAULT_FOMC_TEXT,
+        help="Statement text pasted into the analyze form. Defaults to a sanitised FOMC excerpt.",
+    )
+    parser.add_argument(
+        "--headed",
+        action="store_true",
+        help="Run with the browser visible. Default is headless.",
+    )
+    parser.add_argument(
+        "--keep-open",
+        action="store_true",
+        help="Pause after capture so the operator can inspect the live UI before tear-down.",
+    )
+    parser.add_argument(
+        "--wait-timeout-ms",
+        type=int,
+        default=30_000,
+        help="Per-step wait timeout in milliseconds.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.output_dir is not None:
+        out = Path(args.output_dir).resolve()
+    elif args.in_repo:
+        out = REPO_ROOT / "docs" / "demo-screenshots"
+    else:
+        # Walk back from REPO_ROOT looking for a sibling `fed-pulse.wiki` dir
+        # so the demo works both from a top-level checkout and from a worktree.
+        candidates = [
+            REPO_ROOT.parent / "fed-pulse.wiki",
+            REPO_ROOT.parent.parent / "fed-pulse.wiki",
+            REPO_ROOT.parent.parent.parent / "fed-pulse.wiki",
+            REPO_ROOT.parent.parent.parent.parent / "fed-pulse.wiki",
+        ]
+        out = next(
+            (wiki / "assets" / "demo" for wiki in candidates if wiki.exists()),
+            REPO_ROOT.parent / "fed-pulse.wiki" / "assets" / "demo",
+        )
+
+    return DemoArgs(
+        backend_url=args.backend_url.rstrip("/"),
+        frontend_url=args.frontend_url.rstrip("/"),
+        output_dir=out,
+        fomc_text=args.fomc_text,
+        headless=not args.headed,
+        wait_timeout_ms=args.wait_timeout_ms,
+        keep_open=args.keep_open,
+    )
+
+
+def _import_playwright():
+    """Lazy-import so ``--help`` works without the dep installed."""
+
+    try:
+        from playwright.sync_api import sync_playwright  # noqa: WPS433 (intentional lazy import)
+    except ImportError as exc:
+        raise SystemExit(
+            "playwright is not installed. Run `pip install playwright && playwright install chromium`."
+        ) from exc
+    return sync_playwright
+
+
+def _timestamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _wait_panel(page, locator_text: str, timeout_ms: int) -> None:
+    """Scroll the panel with ``locator_text`` into view and let it settle."""
+
+    locator = page.get_by_text(locator_text, exact=False).first
+    locator.wait_for(timeout=timeout_ms)
+    locator.scroll_into_view_if_needed()
+    page.wait_for_timeout(400)  # give the chart libs a beat to paint
+
+
+def _capture(page, output_dir: Path, name: str, timestamp: str) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"{name}_{timestamp}.png"
+    page.screenshot(path=str(path), full_page=True)
+    print(f"[demo]   wrote {path}")
+    return path
+
+
+def run_demo(args: DemoArgs) -> int:
+    """Drive the demo end-to-end and capture the panel screenshots.
+
+    Returns 0 on success, 1 on any panel failure.
+    """
+
+    sync_playwright = _import_playwright()
+    timestamp = _timestamp()
+    output_dir = args.output_dir
+    print(f"[demo] frontend={args.frontend_url} backend={args.backend_url}")
+    print(f"[demo] output_dir={output_dir} timestamp={timestamp}")
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=args.headless)
+        context = browser.new_context(viewport=VIEWPORT)
+        # The frontend resolves its API base URL at build time from
+        # NEXT_PUBLIC_API_URL (see frontend/lib/analyze/api.ts). The
+        # --backend-url flag is therefore a documentation knob; capture
+        # against the deployed bundle by pointing --frontend-url at the
+        # public origin (the prod build already wires `/api` correctly).
+        page = context.new_page()
+        page.set_default_timeout(args.wait_timeout_ms)
+
+        # ---- Step 1: paste statement + analyse. -----------------------
+        page.goto(args.frontend_url, wait_until="domcontentloaded")
+        # The text area is rendered by AnalyzeForm with a placeholder; pasting
+        # via fill keeps the diff small and avoids per-character debounce.
+        textarea = page.locator("textarea").first
+        textarea.wait_for(timeout=args.wait_timeout_ms)
+        textarea.fill(args.fomc_text)
+
+        # The submit button is the only primary CTA in the form. Match by
+        # role rather than CSS so a className change does not break the demo.
+        analyse_button = page.get_by_role("button", name="Analyze")
+        if analyse_button.count() == 0:
+            # Older copy: "Run analysis" / "Analyse".
+            analyse_button = page.get_by_role("button").filter(
+                has_text="naly"
+            ).first
+        analyse_button.click()
+
+        # Wait for the regime headline to render (the first panel to settle).
+        _wait_panel(page, "Regime", args.wait_timeout_ms)
+
+        # ---- Step 2: statement decomposition screenshot. --------------
+        # The form + regime headline + multi-axis cards sit at the top of /
+        # so the full-page screenshot captures all three.
+        _wait_panel(page, "Multi-axis interpretation", args.wait_timeout_ms)
+        page.evaluate("window.scrollTo(0, 0)")
+        page.wait_for_timeout(300)
+        _capture(page, output_dir, "statement_decomposition", timestamp)
+
+        # ---- Step 3: market reaction. ---------------------------------
+        _wait_panel(page, "Market reaction", args.wait_timeout_ms)
+        _capture(page, output_dir, "market_reaction", timestamp)
+
+        # ---- Step 4: historical analogs. ------------------------------
+        try:
+            _wait_panel(page, "Historical analog", args.wait_timeout_ms)
+            _capture(page, output_dir, "historical_analogs", timestamp)
+        except Exception as exc:  # noqa: BLE001 - analog index may be absent on a fresh deploy
+            print(f"[demo]   historical_analogs panel skipped: {exc}")
+
+        # ---- Step 5: trajectory. --------------------------------------
+        try:
+            _wait_panel(page, "Trajectory", args.wait_timeout_ms)
+            _capture(page, output_dir, "trajectory", timestamp)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[demo]   trajectory panel skipped: {exc}")
+
+        # ---- Step 6: settings / checkpoint surface. -------------------
+        page.goto(f"{args.frontend_url}/settings", wait_until="domcontentloaded")
+        try:
+            _wait_panel(page, "Checkpoint", args.wait_timeout_ms)
+        except Exception:
+            # Older settings copy: "Settings" or "Inference contract".
+            page.wait_for_load_state("networkidle", timeout=args.wait_timeout_ms)
+        page.wait_for_timeout(300)
+        _capture(page, output_dir, "settings_checkpoints", timestamp)
+
+        if args.keep_open:
+            print("[demo] --keep-open set; press Enter to tear down...")
+            try:
+                input()
+            except EOFError:
+                pass
+
+        context.close()
+        browser.close()
+
+    print("[demo] OK")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    start = time.time()
+    rc = run_demo(args)
+    elapsed = time.time() - start
+    print(f"[demo] elapsed={elapsed:.1f}s exit={rc}")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/figures/__init__.py
+++ b/scripts/figures/__init__.py
@@ -1,0 +1,1 @@
+"""Thesis figure-generation scripts."""

--- a/scripts/figures/build_thesis_figures.py
+++ b/scripts/figures/build_thesis_figures.py
@@ -1,0 +1,646 @@
+"""Thesis figure-generation entry point (#298).
+
+Renders the figures the 2026-06-05 report cites into a single directory
+under the wiki repo (``fed-pulse.wiki/assets/figures/``). Every figure
+carries a reproducibility caption with the commit SHA at generation
+time, the canonical training-package id, and the source artefact path
+on disk.
+
+The script is pure-PIL on purpose. The backend image already ships
+Pillow as a transitive dep (see ``backend/app/evaluation/confusion_matrix_render.py``
+for the prior precedent); adding matplotlib would inflate the wheel
+weight by ~30 MB for a handful of tables. The per-cell rendering is
+the same convention the confusion-matrix module already uses.
+
+Figures produced
+----------------
+
+1. ``architecture.png`` — backend / frontend / external-data flow
+   diagram derived from the §3 system-architecture wiki C4 sketch.
+2. ``dual_head_comparison.png`` — three-way head-mode table from
+   ``backend/artifacts/experiments/dual_head_comparison_canonical.json``.
+3. ``text_path_ab.png`` — text-channel A/B table from
+   ``backend/artifacts/experiments/text_path_ab_canonical.json``.
+4. ``cross_bank_ladder.png`` — cross-bank transfer ladder transcribed
+   from wiki §6.14 (no JSON artefact on disk; the table is the
+   canonical source).
+
+Each PNG ships a paired ``.caption.txt`` with the reproducibility
+header so the report can drop the caption verbatim.
+
+CLI
+---
+
+::
+
+    python -m scripts.figures.build_thesis_figures \\
+        --output-dir ../fed-pulse.wiki/assets/figures
+
+Default output dir resolves to the wiki repo next to the main repo
+checkout. The script also supports ``--in-repo`` which writes the
+figures under ``docs/figures/`` instead — handy for previewing
+without touching the wiki repo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError as exc:  # pragma: no cover - import guard
+    raise SystemExit(
+        "Pillow is required to generate thesis figures. "
+        "Install via `pip install pillow` or run inside the backend container."
+    ) from exc
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARTEFACTS_DIR = REPO_ROOT / "backend" / "artifacts" / "experiments"
+CANONICAL_TP_ID = (
+    "tp_v3_macro_aug_2026_05_25_fwd_strict_sentiment_market_core_v1.1_epv1_v1.0"
+)
+
+# Tuned for legibility against the report's two-column layout. Cells stay
+# wide enough that the four-decimal metric strings fit without wrapping.
+_CELL_PAD_X = 18
+_CELL_PAD_Y = 12
+_ROW_HEIGHT = 36
+_HEADER_HEIGHT = 44
+_TITLE_HEIGHT = 56
+_CAPTION_HEIGHT = 72
+_BG = (255, 255, 255)
+_BORDER = (200, 206, 214)
+_HEADER_BG = (240, 244, 250)
+_TITLE_FG = (20, 30, 50)
+_BODY_FG = (40, 46, 58)
+_MUTED_FG = (96, 104, 118)
+_ACCENT = (32, 96, 196)
+
+
+def _load_font(size: int, *, bold: bool = False) -> ImageFont.ImageFont:
+    """Resolve a usable TTF; fall back to PIL's bitmap default."""
+
+    candidates: list[str] = []
+    if bold:
+        candidates.extend(
+            [
+                "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+                "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+                "/usr/share/fonts/dejavu/DejaVuSans-Bold.ttf",
+            ]
+        )
+    candidates.extend(
+        [
+            "/System/Library/Fonts/Supplemental/Arial.ttf",
+            "/System/Library/Fonts/Helvetica.ttc",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+        ]
+    )
+    for path in candidates:
+        if Path(path).exists():
+            try:
+                return ImageFont.truetype(path, size)
+            except OSError:
+                continue
+    return ImageFont.load_default()
+
+
+def _git_sha() -> str:
+    """Return the short commit SHA at script run time."""
+
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=REPO_ROOT,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "uncommitted"
+
+
+def _measure(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.ImageFont) -> tuple[int, int]:
+    """Width / height of ``text`` rendered with ``font``."""
+
+    bbox = draw.textbbox((0, 0), text, font=font)
+    return bbox[2] - bbox[0], bbox[3] - bbox[1]
+
+
+@dataclass
+class ReproducibilityHeader:
+    """Caption header carried by every figure."""
+
+    commit_sha: str
+    training_package_id: str
+    source_artefact: str
+
+    def render(self) -> str:
+        return (
+            f"Commit {self.commit_sha} · "
+            f"Training package: {self.training_package_id} · "
+            f"Source: {self.source_artefact}"
+        )
+
+
+def _wrap_caption(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    font: ImageFont.ImageFont,
+    max_width: int,
+) -> list[str]:
+    """Greedy word-wrap so the caption fits the figure width."""
+
+    words = text.split(" ")
+    lines: list[str] = []
+    current: list[str] = []
+    for word in words:
+        trial = (" ".join(current + [word])).strip()
+        width, _ = _measure(draw, trial, font)
+        if width > max_width and current:
+            lines.append(" ".join(current))
+            current = [word]
+        else:
+            current.append(word)
+    if current:
+        lines.append(" ".join(current))
+    return lines
+
+
+def _render_table(
+    *,
+    title: str,
+    headers: Sequence[str],
+    rows: Sequence[Sequence[str]],
+    caption: str,
+    output_path: Path,
+    align: Sequence[str] | None = None,
+) -> Path:
+    """Render a single titled table with caption to ``output_path``."""
+
+    if align is None:
+        align = ["left"] + ["right"] * (len(headers) - 1)
+    if len(align) != len(headers):
+        raise ValueError("align length must match headers")
+
+    title_font = _load_font(24, bold=True)
+    header_font = _load_font(15, bold=True)
+    body_font = _load_font(15)
+    caption_font = _load_font(13)
+
+    # First pass: measure widest cell per column.
+    probe = Image.new("RGB", (10, 10), _BG)
+    pdraw = ImageDraw.Draw(probe)
+    col_widths: list[int] = []
+    for c, header in enumerate(headers):
+        w, _ = _measure(pdraw, header, header_font)
+        col_widths.append(w)
+    for row in rows:
+        for c, cell in enumerate(row):
+            w, _ = _measure(pdraw, str(cell), body_font)
+            col_widths[c] = max(col_widths[c], w)
+    col_widths = [w + 2 * _CELL_PAD_X for w in col_widths]
+
+    table_width = sum(col_widths)
+    title_w, _ = _measure(pdraw, title, title_font)
+    width = max(table_width, title_w + 2 * _CELL_PAD_X, 720)
+
+    caption_lines = _wrap_caption(pdraw, caption, caption_font, width - 2 * _CELL_PAD_X)
+    caption_box_h = max(_CAPTION_HEIGHT, len(caption_lines) * 20 + 16)
+
+    table_height = _HEADER_HEIGHT + len(rows) * _ROW_HEIGHT
+    height = _TITLE_HEIGHT + table_height + caption_box_h + 16
+
+    img = Image.new("RGB", (width, height), _BG)
+    draw = ImageDraw.Draw(img)
+
+    # Title.
+    draw.text((_CELL_PAD_X, 16), title, fill=_TITLE_FG, font=title_font)
+
+    # Table origin centred horizontally.
+    table_x = (width - table_width) // 2
+    table_y = _TITLE_HEIGHT
+
+    # Header band.
+    draw.rectangle(
+        [table_x, table_y, table_x + table_width, table_y + _HEADER_HEIGHT],
+        fill=_HEADER_BG,
+        outline=_BORDER,
+    )
+    cx = table_x
+    for c, header in enumerate(headers):
+        text_w, text_h = _measure(draw, header, header_font)
+        if align[c] == "right":
+            tx = cx + col_widths[c] - _CELL_PAD_X - text_w
+        elif align[c] == "center":
+            tx = cx + (col_widths[c] - text_w) // 2
+        else:
+            tx = cx + _CELL_PAD_X
+        ty = table_y + (_HEADER_HEIGHT - text_h) // 2
+        draw.text((tx, ty), header, fill=_TITLE_FG, font=header_font)
+        cx += col_widths[c]
+
+    # Rows.
+    for r, row in enumerate(rows):
+        ry = table_y + _HEADER_HEIGHT + r * _ROW_HEIGHT
+        draw.rectangle(
+            [table_x, ry, table_x + table_width, ry + _ROW_HEIGHT],
+            fill=_BG,
+            outline=_BORDER,
+        )
+        cx = table_x
+        for c, cell in enumerate(row):
+            txt = str(cell)
+            text_w, text_h = _measure(draw, txt, body_font)
+            if align[c] == "right":
+                tx = cx + col_widths[c] - _CELL_PAD_X - text_w
+            elif align[c] == "center":
+                tx = cx + (col_widths[c] - text_w) // 2
+            else:
+                tx = cx + _CELL_PAD_X
+            ty = ry + (_ROW_HEIGHT - text_h) // 2
+            draw.text((tx, ty), txt, fill=_BODY_FG, font=body_font)
+            cx += col_widths[c]
+
+    # Caption.
+    cy = table_y + table_height + 12
+    for line in caption_lines:
+        draw.text((_CELL_PAD_X, cy), line, fill=_MUTED_FG, font=caption_font)
+        cy += 20
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    img.save(output_path, format="PNG", optimize=True)
+
+    caption_path = output_path.with_suffix(".caption.txt")
+    caption_path.write_text(caption + "\n", encoding="utf-8")
+    return output_path
+
+
+def _format_stat(stat: dict | None) -> str:
+    """Render ``{mean, std, n}`` as ``0.4190 ± 0.0697`` (or ``—`` when null)."""
+
+    if stat is None:
+        return "—"
+    mean = stat.get("mean")
+    std = stat.get("std")
+    if mean is None:
+        return "—"
+    if std is None:
+        return f"{mean:.4f}"
+    return f"{mean:.4f} ± {std:.4f}"
+
+
+def _read_json(path: Path) -> dict:
+    if not path.exists():
+        raise FileNotFoundError(
+            f"artefact missing on disk: {path} — run the corresponding sweep first"
+        )
+    with path.open() as fh:
+        return json.load(fh)
+
+
+def build_dual_head_table(header: ReproducibilityHeader, output_dir: Path) -> Path:
+    src = ARTEFACTS_DIR / "dual_head_comparison_canonical.json"
+    data = _read_json(src)
+    summary = data["summary"]
+
+    rows = []
+    for mode in data["head_modes"]:
+        block = summary[mode]
+        rows.append(
+            [
+                mode,
+                _format_stat(block.get("regime_f1_macro")),
+                _format_stat(block.get("regression_rmse_log_rv")),
+                str(block.get("regime_f1_macro", {}).get("n", "—") if block.get("regime_f1_macro") else "—"),
+            ]
+        )
+
+    caption = (
+        f"Three-way head-mode comparison on the canonical training package. "
+        f"Pooled across {len(data['seeds'])} seeds × {len(data['fold_ids'])} walk-forward folds "
+        f"({data.get('epochs', '?')} epochs, regression_alpha={data.get('regression_alpha', '?')}). "
+        f"{header.render()}"
+    )
+
+    return _render_table(
+        title="Dual-head methodology — three-way comparison",
+        headers=["Head mode", "regime macro-F1", "RMSE log(RV)", "n (seed × fold)"],
+        rows=rows,
+        caption=caption,
+        output_path=output_dir / "dual_head_comparison.png",
+        align=["left", "right", "right", "right"],
+    )
+
+
+def build_text_path_ab_table(header: ReproducibilityHeader, output_dir: Path) -> Path:
+    src = ARTEFACTS_DIR / "text_path_ab_canonical.json"
+    data = _read_json(src)
+    summary = data["summary"]
+
+    rows = []
+    for arm in data["arms"]:
+        block = summary[arm]
+        rows.append(
+            [
+                arm,
+                _format_stat(block.get("regime_f1_macro")),
+                _format_stat(block.get("regression_rmse_log_rv")),
+            ]
+        )
+
+    caption = (
+        f"Text-channel A/B sweep on the canonical training package. "
+        f"Pooled across {len(data['seeds'])} seeds × {len(data['fold_ids'])} walk-forward folds "
+        f"({data.get('epochs', '?')} epochs, head_mode={data.get('head_mode', '?')}, "
+        f"regression_alpha={data.get('regression_alpha', '?')}, "
+        f"encoder={data.get('text_encoder', '?')}). "
+        f"{header.render()}"
+    )
+
+    return _render_table(
+        title="Text-channel A/B — broadcast vs per-bar vs flat-MLP",
+        headers=["Arm", "regime macro-F1", "RMSE log(RV)"],
+        rows=rows,
+        caption=caption,
+        output_path=output_dir / "text_path_ab.png",
+        align=["left", "right", "right"],
+    )
+
+
+# Cross-bank ladder. No JSON artefact on disk — the canonical source is
+# wiki §6.14 ("Cross-bank ladder — final comparison"). Values transcribed
+# from that table verbatim. If §6.14 changes, update this block and
+# regenerate the figure.
+_CROSS_BANK_ROWS: list[list[str]] = [
+    ["FOMC-only (baseline)", "finbert_fed_adjacent", "0.4538", "[0.434, 0.469]", "5 × 4", "—"],
+    ["Bundle A.2 arm B (weighted aux)", "finbert_fed_adjacent_xbank_aux_weighted", "0.4297", "[0.414, 0.447]", "5 × 4", "−0.024"],
+    ["Bundle A.4 DAPT", "finbert_fed_adjacent_xbank_dapt", "0.4183", "σ 0.053", "1 × 4", "−0.036"],
+    ["Bundle A.2 arm A (stance-masked aux)", "finbert_fed_adjacent_xbank_aux_stance_masked", "0.4066", "[0.391, 0.424]", "5 × 4", "−0.047"],
+]
+
+
+def build_cross_bank_table(header: ReproducibilityHeader, output_dir: Path) -> Path:
+    caption = (
+        "Cross-bank transfer ladder. Same Transformer cell (h=128, layers=2, "
+        "dropout=0.2, lr=1e-3, weight-decay=1e-3, text-adapter-dim=128) on "
+        "tp_v3_macro_aug_2026_05_25_fwd_strict_v1.1_epv1_v1.0; encoder swapped "
+        "row-by-row. Every cross-bank-touched variant lands below the FOMC-only "
+        "baseline CI, replicating the substitute-not-complement prior. "
+        f"{header.render()}"
+    )
+    # Override the source artefact for this figure since it's transcribed
+    # from wiki §6.14 rather than from a JSON file.
+    caption = caption.replace(
+        f"Source: {header.source_artefact}",
+        "Source: fed-pulse.wiki/06_Deep_Learning_Roadmap.md §6.14",
+    )
+
+    return _render_table(
+        title="Cross-bank transfer ladder",
+        headers=["Variant", "Encoder alias", "macro-F1", "95% CI / Std", "Sample", "Δ vs baseline"],
+        rows=_CROSS_BANK_ROWS,
+        caption=caption,
+        output_path=output_dir / "cross_bank_ladder.png",
+        align=["left", "left", "right", "right", "right", "right"],
+    )
+
+
+def build_architecture_diagram(header: ReproducibilityHeader, output_dir: Path) -> Path:
+    """Render the system-architecture diagram as a box-and-arrow PNG.
+
+    Mirrors wiki §3 container diagram (Next.js dashboard / FastAPI
+    backend / external data sources) plus the §3.3 component layout
+    (forecaster + multi-axis classifier + analog retriever + trajectory
+    heads off the shared text encoder).
+    """
+
+    title_font = _load_font(24, bold=True)
+    box_font = _load_font(14, bold=True)
+    sub_font = _load_font(12)
+    caption_font = _load_font(13)
+
+    width, height = 1280, 760
+    img = Image.new("RGB", (width, height), _BG)
+    draw = ImageDraw.Draw(img)
+
+    draw.text(
+        (_CELL_PAD_X, 16),
+        "Fed Pulse — runtime architecture",
+        fill=_TITLE_FG,
+        font=title_font,
+    )
+
+    # Box layout. (x, y, w, h, title, subtitle, fill, outline)
+    boxes: list[tuple[int, int, int, int, str, str, tuple[int, int, int], tuple[int, int, int]]] = [
+        # Frontend column.
+        (40, 96, 240, 88, "Next.js dashboard", "/, /settings, /history", (235, 244, 255), _ACCENT),
+        # Backend column - API surface.
+        (340, 96, 240, 88, "FastAPI /analyze", "+ /analyze/market /analogs /trajectory", (240, 244, 250), _BORDER),
+        (340, 200, 240, 64, "/settings/checkpoints", "inference_contract sidecar", (240, 244, 250), _BORDER),
+        # Backend column - heads.
+        (640, 96, 280, 64, "Forecaster (dual head)", "regression(log RV) + 3-class CE", (250, 246, 240), (196, 128, 32)),
+        (640, 176, 280, 64, "Multi-axis classifier", "stance / time / certainty", (250, 246, 240), (196, 128, 32)),
+        (640, 256, 280, 64, "Analog retriever", "cross-bank DAPT encoder", (250, 246, 240), (196, 128, 32)),
+        (640, 336, 280, 64, "Trajectory head", "LSTM / Transformer + baselines", (250, 246, 240), (196, 128, 32)),
+        # Shared substrate.
+        (640, 432, 280, 72, "Shared text encoder", "FinBERT-FedAdjacent (classifier role)\n+ xbank-DAPT (retrieval role)", (248, 240, 250), (128, 64, 196)),
+        # External sources.
+        (980, 96, 240, 64, "Hugging Face Hub", "training packages + checkpoints", (244, 244, 244), _MUTED_FG),
+        (980, 176, 240, 64, "FRED + Yahoo", "macro-state + market series", (244, 244, 244), _MUTED_FG),
+        (980, 256, 240, 64, "FOMC archives", "statements + minutes", (244, 244, 244), _MUTED_FG),
+        # Storage.
+        (340, 296, 240, 64, "Run history (SQLite)", "+ FOMC calendar", (244, 244, 244), _MUTED_FG),
+    ]
+
+    def _box(x: int, y: int, w: int, h: int, title: str, subtitle: str, fill: tuple, outline: tuple) -> None:
+        draw.rectangle([x, y, x + w, y + h], fill=fill, outline=outline, width=2)
+        tx, ty = _measure(draw, title, box_font)
+        draw.text((x + (w - tx) // 2, y + 10), title, fill=_TITLE_FG, font=box_font)
+        # Sub line(s) — split on newline so we can keep two-line subtitles tight.
+        sub_y = y + 10 + ty + 6
+        for line in subtitle.split("\n"):
+            sx, _ = _measure(draw, line, sub_font)
+            draw.text((x + (w - sx) // 2, sub_y), line, fill=_BODY_FG, font=sub_font)
+            sub_y += 16
+
+    for box in boxes:
+        _box(*box)
+
+    # Edges. (x1, y1, x2, y2)
+    edges: list[tuple[int, int, int, int]] = [
+        # Frontend → API.
+        (280, 140, 340, 140),
+        # Frontend → settings.
+        (280, 160, 340, 220),
+        # API → each head.
+        (580, 130, 640, 128),
+        (580, 140, 640, 208),
+        (580, 150, 640, 288),
+        (580, 160, 640, 368),
+        # Heads → shared encoder.
+        (780, 160, 780, 432),
+        # API → run history.
+        (460, 184, 460, 296),
+        # API → HF Hub + FRED + FOMC.
+        (920, 128, 980, 128),
+        (920, 208, 980, 208),
+        (920, 288, 980, 288),
+    ]
+    for x1, y1, x2, y2 in edges:
+        draw.line([(x1, y1), (x2, y2)], fill=_MUTED_FG, width=2)
+        # tiny arrowhead at (x2,y2).
+        draw.polygon(
+            [(x2, y2), (x2 - 8, y2 - 4), (x2 - 8, y2 + 4)],
+            fill=_MUTED_FG,
+        )
+
+    # Legend.
+    legend_y = 560
+    draw.text((_CELL_PAD_X, legend_y), "Layers:", fill=_TITLE_FG, font=box_font)
+    legend_items = [
+        ("Frontend", (235, 244, 255), _ACCENT),
+        ("API + storage", (240, 244, 250), _BORDER),
+        ("Model heads", (250, 246, 240), (196, 128, 32)),
+        ("Shared encoder", (248, 240, 250), (128, 64, 196)),
+        ("External", (244, 244, 244), _MUTED_FG),
+    ]
+    lx = 110
+    for label, fill, outline in legend_items:
+        draw.rectangle([lx, legend_y - 4, lx + 18, legend_y + 14], fill=fill, outline=outline, width=2)
+        draw.text((lx + 26, legend_y - 2), label, fill=_BODY_FG, font=sub_font)
+        lw, _ = _measure(draw, label, sub_font)
+        lx += 26 + lw + 24
+
+    # Caption.
+    caption = (
+        "Runtime architecture (C4 container + component level). The Next.js "
+        "dashboard calls four /analyze* endpoints in parallel; each backend "
+        "head consumes the same shared text-encoder substrate (FinBERT-FedAdjacent "
+        "as the classifier role; cross-bank DAPT as the retrieval role per ADR 0019). "
+        f"{header.render()}"
+    )
+    caption = caption.replace(
+        f"Source: {header.source_artefact}",
+        "Source: fed-pulse.wiki/03_System_Architecture.md §1–§3",
+    )
+    caption_lines = _wrap_caption(draw, caption, caption_font, width - 2 * _CELL_PAD_X)
+    cy = 620
+    for line in caption_lines:
+        draw.text((_CELL_PAD_X, cy), line, fill=_MUTED_FG, font=caption_font)
+        cy += 20
+
+    output_path = output_dir / "architecture.png"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    img.save(output_path, format="PNG", optimize=True)
+    output_path.with_suffix(".caption.txt").write_text(caption + "\n", encoding="utf-8")
+    return output_path
+
+
+def _resolve_output_dir(args: argparse.Namespace) -> Path:
+    if args.output_dir is not None:
+        return Path(args.output_dir).resolve()
+    if args.in_repo:
+        return REPO_ROOT / "docs" / "figures"
+    # Default: wiki repo next to the main checkout. Try a few plausible
+    # parents — REPO_ROOT may resolve inside a worktree (`.claude/worktrees/<id>`)
+    # in which case the sibling lookup needs to walk back to the original
+    # checkout's parent before the wiki appears.
+    candidates = [
+        REPO_ROOT.parent / "fed-pulse.wiki",
+        REPO_ROOT.parent.parent / "fed-pulse.wiki",
+        REPO_ROOT.parent.parent.parent / "fed-pulse.wiki",
+        REPO_ROOT.parent.parent.parent.parent / "fed-pulse.wiki",
+    ]
+    for wiki in candidates:
+        if wiki.exists():
+            return wiki / "assets" / "figures"
+    # Fall back to the literal sibling path — the script will create it.
+    return REPO_ROOT.parent / "fed-pulse.wiki" / "assets" / "figures"
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Override the output directory (defaults to ../fed-pulse.wiki/assets/figures).",
+    )
+    parser.add_argument(
+        "--in-repo",
+        action="store_true",
+        help="Write figures to docs/figures/ inside the main repo instead of the wiki.",
+    )
+    parser.add_argument(
+        "--only",
+        choices=("architecture", "dual-head", "text-path-ab", "cross-bank"),
+        default=None,
+        help="Render only one figure (default: render all).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    output_dir = _resolve_output_dir(args)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    sha = _git_sha()
+    print(f"[figures] commit={sha} output_dir={output_dir}")
+
+    builders: list[tuple[str, str, callable]] = [
+        (
+            "architecture",
+            "fed-pulse.wiki/03_System_Architecture.md",
+            build_architecture_diagram,
+        ),
+        (
+            "dual-head",
+            "backend/artifacts/experiments/dual_head_comparison_canonical.json",
+            build_dual_head_table,
+        ),
+        (
+            "text-path-ab",
+            "backend/artifacts/experiments/text_path_ab_canonical.json",
+            build_text_path_ab_table,
+        ),
+        (
+            "cross-bank",
+            "fed-pulse.wiki/06_Deep_Learning_Roadmap.md §6.14",
+            build_cross_bank_table,
+        ),
+    ]
+
+    failures: list[tuple[str, BaseException]] = []
+    for name, source, builder in builders:
+        if args.only and args.only != name:
+            continue
+        header = ReproducibilityHeader(
+            commit_sha=sha,
+            training_package_id=CANONICAL_TP_ID,
+            source_artefact=source,
+        )
+        try:
+            path = builder(header, output_dir)
+        except Exception as exc:  # noqa: BLE001 - figure builders surface their own context
+            failures.append((name, exc))
+            print(f"[figures] {name}: FAILED — {exc}", file=sys.stderr)
+            continue
+        print(f"[figures] {name}: {path.relative_to(output_dir.parent) if path.is_relative_to(output_dir.parent) else path}")
+
+    if failures:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/figures/build_thesis_figures.py
+++ b/scripts/figures/build_thesis_figures.py
@@ -392,7 +392,7 @@ def build_cross_bank_table(header: ReproducibilityHeader, output_dir: Path) -> P
     caption = (
         "Cross-bank transfer ladder. Same Transformer cell (h=128, layers=2, "
         "dropout=0.2, lr=1e-3, weight-decay=1e-3, text-adapter-dim=128) on "
-        "tp_v3_macro_aug_2026_05_25_fwd_strict_v1.1_epv1_v1.0; encoder swapped "
+        f"{CANONICAL_TP_ID}; encoder swapped "
         "row-by-row. Every cross-bank-touched variant lands below the FOMC-only "
         "baseline CI, replicating the substitute-not-complement prior. "
         f"{header.render()}"


### PR DESCRIPTION
Closes #298. Closes out the §16 finalization roadmap.

- `scripts/figures/build_thesis_figures.py` renders four figures (runtime architecture, dual-head three-way comparison, text-channel A/B, cross-bank transfer ladder) from on-disk artefacts. Each PNG ships a paired `.caption.txt` with the commit SHA + canonical training-package id + source artefact path.
- `scripts/demo_end_to_end.py` drives the live front-end through every panel at a fixed 1440×900 viewport (lazy Playwright import). Screenshots write to `fed-pulse.wiki/assets/demo/`.
- `docs/demo.md` documents the reproduction commands.

Wiki: figures committed, §6.10 / §6.15 / §6.18 reference them, §13 row #298 flipped. Screenshot capture itself runs once before submission via `make dev && python scripts/demo_end_to_end.py` — no Docker on this box so the demo PNGs land in a separate wiki commit when the stack is up.