### PR TITLE
Demo: skip market panel on timeout (#379 workaround)

### DIFF
--- a/scripts/demo_end_to_end.py
+++ b/scripts/demo_end_to_end.py
@@ -241,8 +241,15 @@ def run_demo(args: DemoArgs) -> int:
         _capture(page, output_dir, "statement_decomposition", timestamp)
 
         # ---- Step 3: market reaction. ---------------------------------
-        _wait_panel(page, "Market reaction", args.wait_timeout_ms)
-        _capture(page, output_dir, "market_reaction", timestamp)
+        # Cold-start dev backends produce a regression-only checkpoint;
+        # the market panel then collapses to an "evidence unavailable"
+        # state and the heading text never paints. Skip + log rather
+        # than hard-fail so the rest of the capture still runs.
+        try:
+            _wait_panel(page, "Market reaction", args.wait_timeout_ms)
+            _capture(page, output_dir, "market_reaction", timestamp)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[demo]   market_reaction panel skipped: {exc}")
 
         # ---- Step 4: historical analogs. ------------------------------
         try:


### PR DESCRIPTION
Refs #379. The script hard-fails on the empty market panel when the cold-start backend produces a regression-only checkpoint; the analog + trajectory panels already have the same skip-on-timeout pattern. Tolerate it the same way so the rest of the capture runs.