### PR TITLE
Arm registry inference_features cross-check on fresh checkpoints (#374)

### DIFF
--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -219,17 +219,18 @@ def _record_contract_status(
 
 
 def _validate_serving_contract(
-    payload: Any,
     checkpoint_path: Path,
 ) -> tuple[bool, str]:
     """Cross-check the sidecar against the serving signature + registry.
 
     Returns ``(ok, status)``. ``ok=False`` means the serving loader
-    must refuse to bind the checkpoint. Falsy payload / missing
-    sidecar degrades to ``ok=True`` with status ``"sidecar_absent"``
-    so pre-#341 checkpoints continue to load -- the contract is a soft
-    surface for legacy artefacts and a hard surface for any checkpoint
-    written under the #341 contract.
+    must refuse to bind the checkpoint. A missing sidecar degrades to
+    ``ok=True`` with status ``"sidecar_absent"`` so pre-#341
+    checkpoints continue to load -- the contract is a soft surface for
+    legacy artefacts and a hard surface for any checkpoint written
+    under the #341 contract. (#374: the prior ``payload`` parameter
+    was never read; the sidecar is what we validate, not the .pt
+    payload.)
     """
 
     from app.training.inference_contract import (
@@ -321,7 +322,7 @@ def _get_model() -> ForecasterServingModel:
             # partial bind + a later RuntimeError on /analyze. Pre-#341
             # checkpoints with no sidecar degrade to "sidecar_absent"
             # + ok=True so the legacy serving fleet keeps working.
-            ok, _status = _validate_serving_contract(payload, BEST_MODEL_PATH)
+            ok, _status = _validate_serving_contract(BEST_MODEL_PATH)
             if not ok:
                 raise RuntimeError(
                     "checkpoint inference contract incompatible with serving "

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -65,6 +65,39 @@ def _resolve_device(device: str | torch.device | None = None) -> torch.device:
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
+def resolve_sidecar_registry_handle(
+    text_encoder: str | None,
+) -> tuple[str | None, tuple[str, ...]]:
+    """Resolve the alias + ``inference_features`` tuple for the sidecar.
+
+    #374 arms the loader's ``contract.inference_features ⊆ registry``
+    cross-check by threading the live encoder alias + its registry-
+    pinned ``inference_features`` through to the freshly written
+    sidecar. Without this hand-off every fresh checkpoint shipped with
+    ``inference_features=()`` and the cross-check passed trivially.
+
+    The CLI normalises ``"none"`` to ``None`` upstream, but direct
+    ``train_model`` callers can pass the sentinel through. Treat both
+    as "no text encoder" so the sidecar carries ``encoder_alias=None``
+    rather than the literal ``"none"`` (which would silently re-
+    disable the cross-check at load time). An alias unknown to the
+    registry falls back to an empty feature tuple.
+    """
+
+    if text_encoder is None or str(text_encoder) == "none":
+        return None, ()
+    alias = str(text_encoder)
+    try:
+        from app.models.registry import encoder_ref
+
+        ref = encoder_ref(alias)
+    except Exception:  # pragma: no cover -- defensive
+        return alias, ()
+    if ref is None:
+        return alias, ()
+    return alias, tuple(ref.inference_features)
+
+
 def _resolve_validation_fraction(
     validation_fraction: float | None,
     validation_split: float | None,
@@ -3787,27 +3820,9 @@ def train_model(
     if save_checkpoint:
         from app.training.checkpoint import _save_model_checkpoint
 
-        # #374: thread the active encoder alias + its registry-pinned
-        # ``inference_features`` tuple through to the sidecar. Without
-        # this the loader's ``contract.inference_features ⊆ registry``
-        # cross-check was ``∅ ⊆ ∅`` on every fresh checkpoint -- the
-        # arm was shipping documentation-only. ``text_encoder`` is the
-        # alias the trainer was driven against; the empty tuple
-        # fallback covers runs that do not register against the
-        # registry (legacy 6-feature only paths).
-        sidecar_encoder_alias: str | None = (
-            str(text_encoder) if text_encoder else None
+        sidecar_encoder_alias, sidecar_inference_features = (
+            resolve_sidecar_registry_handle(text_encoder)
         )
-        sidecar_inference_features: tuple[str, ...] = ()
-        if sidecar_encoder_alias:
-            try:
-                from app.models.registry import encoder_ref
-
-                ref = encoder_ref(sidecar_encoder_alias)
-                if ref is not None:
-                    sidecar_inference_features = tuple(ref.inference_features)
-            except Exception:  # pragma: no cover -- defensive
-                sidecar_inference_features = ()
 
         # `close_scale` was fitted on this fold's training rows in
         # `_build_training_tensors`; persisting it on the checkpoint is what

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -3787,6 +3787,28 @@ def train_model(
     if save_checkpoint:
         from app.training.checkpoint import _save_model_checkpoint
 
+        # #374: thread the active encoder alias + its registry-pinned
+        # ``inference_features`` tuple through to the sidecar. Without
+        # this the loader's ``contract.inference_features ⊆ registry``
+        # cross-check was ``∅ ⊆ ∅`` on every fresh checkpoint -- the
+        # arm was shipping documentation-only. ``text_encoder`` is the
+        # alias the trainer was driven against; the empty tuple
+        # fallback covers runs that do not register against the
+        # registry (legacy 6-feature only paths).
+        sidecar_encoder_alias: str | None = (
+            str(text_encoder) if text_encoder else None
+        )
+        sidecar_inference_features: tuple[str, ...] = ()
+        if sidecar_encoder_alias:
+            try:
+                from app.models.registry import encoder_ref
+
+                ref = encoder_ref(sidecar_encoder_alias)
+                if ref is not None:
+                    sidecar_inference_features = tuple(ref.inference_features)
+            except Exception:  # pragma: no cover -- defensive
+                sidecar_inference_features = ()
+
         # `close_scale` was fitted on this fold's training rows in
         # `_build_training_tensors`; persisting it on the checkpoint is what
         # lets inference (`services.forecaster._predict_next_point`) recover
@@ -3798,6 +3820,8 @@ def train_model(
             summary,
             close_scale=close_scale,
             rich_feature_scaler=rich_feature_scaler,
+            encoder_alias=sidecar_encoder_alias,
+            inference_features=sidecar_inference_features,
         )
         # Conformal calibration sidecar (#216). Classification-mode runs
         # write a manifest with the APS softmax_quantile fitted on the

--- a/tests/unit/test_inference_contract.py
+++ b/tests/unit/test_inference_contract.py
@@ -345,3 +345,58 @@ def test_loader_binds_when_contract_matches_registry(
 
     status = forecaster_service.get_serving_contract_status()
     assert status["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# #374: trainer-side resolution helper. The previous two tests bypassed
+# the resolution and hand-fed ``encoder_alias`` + ``inference_features``
+# straight into ``_save_model_checkpoint``. These cover the helper that
+# the live trainer call site uses so a regression in the resolution
+# logic (e.g. the ``"none"`` sentinel leaking into the sidecar) trips
+# at unit-test time instead of inside a real training run.
+
+
+def test_resolve_sidecar_registry_handle_returns_registry_features() -> None:
+    """A registered encoder alias resolves to ``(alias, tuple(features))``."""
+
+    from app.training.loop import resolve_sidecar_registry_handle
+
+    alias, features = resolve_sidecar_registry_handle("finbert")
+    assert alias == "finbert"
+    assert "text_embedding" in features
+
+
+def test_resolve_sidecar_registry_handle_none_returns_empty() -> None:
+    """``None`` and the sentinel ``"none"`` collapse to ``(None, ())``."""
+
+    from app.training.loop import resolve_sidecar_registry_handle
+
+    assert resolve_sidecar_registry_handle(None) == (None, ())
+    assert resolve_sidecar_registry_handle("none") == (None, ())
+
+
+def test_resolve_sidecar_registry_handle_unknown_alias_returns_empty_tuple() -> None:
+    """An alias unknown to the registry keeps the alias but empties features."""
+
+    from app.training.loop import resolve_sidecar_registry_handle
+
+    alias, features = resolve_sidecar_registry_handle("not_a_real_encoder")
+    assert alias == "not_a_real_encoder"
+    assert features == ()
+
+
+def test_resolve_sidecar_registry_handle_handles_registry_exception(
+    monkeypatch,
+) -> None:
+    """A raising ``encoder_ref`` falls back to an empty feature tuple."""
+
+    import app.models.registry as registry_module
+    from app.training.loop import resolve_sidecar_registry_handle
+
+    def _boom(_alias: str):
+        raise RuntimeError("registry on fire")
+
+    monkeypatch.setattr(registry_module, "encoder_ref", _boom)
+    alias, features = resolve_sidecar_registry_handle("finbert")
+    assert alias == "finbert"
+    assert features == ()

--- a/tests/unit/test_inference_contract.py
+++ b/tests/unit/test_inference_contract.py
@@ -233,3 +233,115 @@ def test_loader_refuses_bind_on_contract_mismatch(tmp_path: Path, monkeypatch) -
     status = forecaster_service.get_serving_contract_status()
     assert status["status"] == "serving_signature_missing_kwargs"
     assert "nonexistent_kwarg" in status["missing_kwargs"]
+
+
+def test_loader_refuses_bind_on_registry_feature_mismatch(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """#374: a checkpoint declaring an inference_feature the registry's
+    pinned encoder slot does not pin must be refused by ``_get_model``.
+
+    The pre-#374 trainer left ``inference_features=()`` on every fresh
+    sidecar, so the loader's ``contract ⊆ registry`` cross-check passed
+    trivially. With the trainer now threading the registry-resolved
+    tuple through, a sidecar whose ``inference_features`` add a feature
+    not pinned in ``registry.yaml::encoders[<alias>].inference_features``
+    is a wiring mismatch and must hard-refuse to bind."""
+
+    from app.evaluation.metrics import TrainingRunSummary
+    from app.training.checkpoint import _save_model_checkpoint
+    from app.services import forecaster as forecaster_service
+
+    model = _toy_serving_model()
+    ckpt_path = tmp_path / "forecaster.pt"
+    summary = TrainingRunSummary(
+        model_config=ModelConfig(input_size=FEATURE_SIZE, architecture="lstm"),
+        device="cpu",
+        epochs_requested=1,
+        epochs_completed=1,
+        batch_size=1,
+        learning_rate=1e-3,
+        validation_split=0.2,
+        early_stopping_patience=1,
+        sequence_groups=1,
+        total_windows=1,
+        train_windows=1,
+        validation_windows=0,
+        checkpoint_path=str(ckpt_path),
+        checkpoint_saved=True,
+        best_epoch=1,
+        metrics=None,
+    )
+    # ``bert_base`` declares ``inference_features: []`` in
+    # registry.yaml. A contract claiming ``text_embedding`` against
+    # that alias is the canonical wiring drift case.
+    _save_model_checkpoint(
+        model,
+        ckpt_path,
+        summary,
+        encoder_alias="bert_base",
+        inference_features=("text_embedding",),
+    )
+
+    monkeypatch.setattr(forecaster_service, "BEST_MODEL_PATH", ckpt_path)
+    monkeypatch.setattr(forecaster_service, "_model", None)
+    monkeypatch.setattr(forecaster_service, "_model_artifact_metadata", None)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        forecaster_service._get_model()
+    assert "inference contract" in str(excinfo.value).lower()
+
+    status = forecaster_service.get_serving_contract_status()
+    assert status["status"] == "registry_inference_features_mismatch"
+    assert "text_embedding" in status["extra_kwargs"]
+
+
+def test_loader_binds_when_contract_matches_registry(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """#374 positive path: contract.inference_features ⊆ registry pinned
+    set must bind cleanly. ``finbert`` pins ``text_embedding`` +
+    ``text_embedding_missing`` in registry.yaml; a contract declaring a
+    strict subset (or the full set) is valid."""
+
+    from app.evaluation.metrics import TrainingRunSummary
+    from app.training.checkpoint import _save_model_checkpoint
+    from app.services import forecaster as forecaster_service
+
+    model = _toy_serving_model()
+    ckpt_path = tmp_path / "forecaster.pt"
+    summary = TrainingRunSummary(
+        model_config=ModelConfig(input_size=FEATURE_SIZE, architecture="lstm"),
+        device="cpu",
+        epochs_requested=1,
+        epochs_completed=1,
+        batch_size=1,
+        learning_rate=1e-3,
+        validation_split=0.2,
+        early_stopping_patience=1,
+        sequence_groups=1,
+        total_windows=1,
+        train_windows=1,
+        validation_windows=0,
+        checkpoint_path=str(ckpt_path),
+        checkpoint_saved=True,
+        best_epoch=1,
+        metrics=None,
+    )
+    _save_model_checkpoint(
+        model,
+        ckpt_path,
+        summary,
+        encoder_alias="finbert",
+        inference_features=("text_embedding",),
+    )
+
+    monkeypatch.setattr(forecaster_service, "BEST_MODEL_PATH", ckpt_path)
+    monkeypatch.setattr(forecaster_service, "_model", None)
+    monkeypatch.setattr(forecaster_service, "_model_artifact_metadata", None)
+
+    bound = forecaster_service._get_model()
+    assert bound is not None
+
+    status = forecaster_service.get_serving_contract_status()
+    assert status["status"] == "ok"


### PR DESCRIPTION
Closes #374.

The trainer's `_save_model_checkpoint` call site was dropping `encoder_alias` and `inference_features` on the floor, so every fresh sidecar landed with `encoder_alias=None` and `inference_features=()`. That made the loader's `contract.inference_features ⊆ encoder_ref(encoder_alias).inference_features` guard pass trivially (∅ ⊆ ∅) on every fresh checkpoint -- the registry cross-check shipped in #341 was documentation-only. This PR threads the active encoder alias (from `text_encoder`) and its registry-pinned `inference_features` tuple through to the sidecar, drops the dead `payload` param on `_validate_serving_contract`, and extends the loader regression test to cover both the refusal and the matched path end-to-end.

- `backend/app/training/loop.py`: resolve `encoder_alias` from `text_encoder` and `inference_features` from `encoder_ref(...).inference_features` before calling `_save_model_checkpoint`.
- `backend/app/services/forecaster.py`: drop the unused `payload: Any` parameter on `_validate_serving_contract`; update the single call site in `_get_model`.
- `tests/unit/test_inference_contract.py`: add `test_loader_refuses_bind_on_registry_feature_mismatch` (sidecar declares `text_embedding` against `bert_base` which pins `[]`; loader hard-refuses) and `test_loader_binds_when_contract_matches_registry` (sidecar declares a subset of what `finbert` pins; loader binds).

No canonical `forecaster_best.pt` exists in the repo, so there is no in-place sidecar backfill to ship here -- the next training run will emit a properly populated sidecar via the patched code path, and the existing promotion contract in `scripts/promote_checkpoint` is what bakes the published artefact. To regenerate locally: `make train-smoke` (or any `train_model(..., text_encoder=<alias>)` invocation) will write `forecaster_best.inference_contract.json` with the populated fields.

Reviewer focus: confirm the alias resolution from `text_encoder` is the right registry handle in every active call path -- `encoder_lora_bundle.encoder_alias` (which is what already lands on the LoRA adapter sidecar at line 3849) is the obvious adjacent source if `text_encoder` ever diverges from the registry alias on a sweep cell.