### PR TITLE
Fix CORS race on /analyze/market cold-start (#379)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import json
 import logging
@@ -99,6 +100,35 @@ logger = logging.getLogger(__name__)
 # bootstrap history when /analyze fires against a host that has no
 # checkpoint on disk yet (first run after a fresh clone).
 COLD_START_HISTORY_LENGTH = 252
+
+# #379: the frontend fans out /analyze, /analyze/market and /analyze/analogs
+# in parallel via Promise.allSettled. On a fresh boot all three race into
+# ``_bootstrap_cold_start`` — two concurrent writers on the same checkpoint
+# file can produce a half-written artefact, and the second loader then
+# raises an opaque deserialisation error that escapes the route's narrow
+# ``RuntimeError`` catch. ``ServerErrorMiddleware`` then returns a bare
+# 500 outside the CORS layer, surfacing in the browser as ERR_FAILED /
+# "no Access-Control-Allow-Origin". Serialising the cold-start with an
+# asyncio lock + a checkpoint re-check inside the critical section keeps
+# only one bootstrap in flight per process.
+_cold_start_lock = asyncio.Lock()
+
+
+async def _ensure_cold_start(payload: "AnalyzeRequest") -> None:
+    """Run ``_bootstrap_cold_start`` at most once across concurrent callers.
+
+    The lock is acquired only when the checkpoint is missing; the
+    fast-path (warm process) takes zero locks. Inside the critical
+    section we re-check ``checkpoint_exists`` so the runner-up does not
+    re-train against the artefact the leader just wrote.
+    """
+
+    if checkpoint_exists():
+        return
+    async with _cold_start_lock:
+        if checkpoint_exists():
+            return
+        await run_in_threadpool(_bootstrap_cold_start, payload)
 
 
 @asynccontextmanager
@@ -713,10 +743,11 @@ async def analyze(payload: AnalyzeRequest):
     the thread pool so the event loop stays responsive under load."""
 
     try:
-        if not checkpoint_exists():
-            # Cold-start bootstrap: a fresh clone has no checkpoint on disk yet,
-            # so seed one against a 252-day window before the first inference.
-            await run_in_threadpool(_bootstrap_cold_start, payload)
+        # Cold-start bootstrap: a fresh clone has no checkpoint on disk yet,
+        # so seed one against a 252-day window before the first inference.
+        # Serialised across the /analyze, /analyze/market and /analyze/analogs
+        # fan-out via ``_ensure_cold_start`` -- #379.
+        await _ensure_cold_start(payload)
 
         masked_text = _apply_sentence_mask(payload.text, payload.mask_sentence_indices)
         run_payload = (
@@ -1231,32 +1262,46 @@ async def analyze_market(payload: AnalyzeRequest) -> MarketReactionPanel:
     # symmetrically to /analyze — 503 with the structured-status detail
     # (the message is a deliberate contract code, not raw exception
     # text) so the operator sees the same shape on both endpoints.
-    if not checkpoint_exists():
-        try:
-            await run_in_threadpool(_bootstrap_cold_start, payload)
-        except RuntimeError as exc:
-            logger.warning("analyze_market_cold_start_contract_mismatch detail=%s", str(exc))
-            raise HTTPException(
-                status_code=503,
-                detail="Market reaction panel unavailable: serving contract mismatch",
-            ) from None
-
-    sentiment = analyze_text(payload.text)
-    market_history = await run_in_threadpool(
-        fetch_market_history,
-        target_date=payload.date,
-        symbol=payload.symbol,
-        history_length=30,
-    )
-    history_vectors = build_feature_vectors(
-        market_history,
-        sentiment_score=float(sentiment["score"]),
-        document_date=payload.date,
-    )
+    # #379: route every unhandled exception path through HTTPException
+    # so the response stays inside the CORS-wrapped ExceptionMiddleware
+    # layer; ServerErrorMiddleware (outside CORS) was returning bare
+    # 500s without Access-Control-Allow-Origin on cold-start races.
     try:
+        await _ensure_cold_start(payload)
+    except RuntimeError as exc:
+        logger.warning("analyze_market_cold_start_contract_mismatch detail=%s", str(exc))
+        raise HTTPException(
+            status_code=503,
+            detail="Market reaction panel unavailable: serving contract mismatch",
+        ) from None
+    except Exception as exc:  # pragma: no cover -- cold-start race fallback
+        logger.exception(
+            "analyze_market_cold_start_unexpected exception_class=%s",
+            type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Market reaction panel unavailable: cold-start failed",
+        ) from None
+
+    try:
+        sentiment = analyze_text(payload.text)
+        market_history = await run_in_threadpool(
+            fetch_market_history,
+            target_date=payload.date,
+            symbol=payload.symbol,
+            history_length=30,
+        )
+        history_vectors = build_feature_vectors(
+            market_history,
+            sentiment_score=float(sentiment["score"]),
+            document_date=payload.date,
+        )
         result = await run_in_threadpool(
             build_market_reaction_panel, history_vectors
         )
+    except HTTPException:
+        raise
     except Exception:  # pragma: no cover -- defensive
         logger.exception("analyze_market_failed")
         raise HTTPException(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1284,24 +1284,27 @@ async def analyze_market(payload: AnalyzeRequest) -> MarketReactionPanel:
             detail="Market reaction panel unavailable: cold-start failed",
         ) from None
 
+    # Request-shape errors (bad date string from the client, etc.) must
+    # surface as 422 via the registered ``_value_error_handler`` so the
+    # contract tests + the frontend toast layer keep their existing
+    # validation semantics; only true server-side failures collapse to
+    # the structured 503 below.
+    sentiment = analyze_text(payload.text)
+    market_history = await run_in_threadpool(
+        fetch_market_history,
+        target_date=payload.date,
+        symbol=payload.symbol,
+        history_length=30,
+    )
+    history_vectors = build_feature_vectors(
+        market_history,
+        sentiment_score=float(sentiment["score"]),
+        document_date=payload.date,
+    )
     try:
-        sentiment = analyze_text(payload.text)
-        market_history = await run_in_threadpool(
-            fetch_market_history,
-            target_date=payload.date,
-            symbol=payload.symbol,
-            history_length=30,
-        )
-        history_vectors = build_feature_vectors(
-            market_history,
-            sentiment_score=float(sentiment["score"]),
-            document_date=payload.date,
-        )
         result = await run_in_threadpool(
             build_market_reaction_panel, history_vectors
         )
-    except HTTPException:
-        raise
     except Exception:  # pragma: no cover -- defensive
         logger.exception("analyze_market_failed")
         raise HTTPException(

--- a/deploy/s6-services/backend/run
+++ b/deploy/s6-services/backend/run
@@ -3,8 +3,13 @@
 # file the backend writes into the /data bind mount or /home/fedpulse
 # HF cache then lands under UID 10001 on the host rather than root.
 cd /app/backend
+# Single worker: the #379 cold-start lock is ``asyncio.Lock`` and only
+# serialises within one process. Multi-worker bootstrap coordination
+# needs an OS-level file lock (tracked as a follow-up); pin
+# ``--workers 1`` until then so the race the lock guards stays in one
+# process.
 exec s6-setuidgid fedpulse /opt/venv/bin/uvicorn app.main:app \
     --host 0.0.0.0 \
     --port 8000 \
-    --workers 2 \
+    --workers 1 \
     --no-access-log

--- a/tests/unit/test_analyze_market_cors_cold_start.py
+++ b/tests/unit/test_analyze_market_cors_cold_start.py
@@ -1,0 +1,199 @@
+"""CORS regression for /analyze/market under a fresh cold-start (#379).
+
+The frontend fans /analyze, /analyze/market and /analyze/analogs out via
+``Promise.allSettled``. On a fresh boot the three race into the
+cold-start path and the slowest writer's loader can raise an opaque
+exception; before #379 that escaped the narrow ``RuntimeError`` catch
+on /analyze/market, fell through to ``ServerErrorMiddleware`` (outside
+the CORS layer) and the browser saw ERR_FAILED / no
+``Access-Control-Allow-Origin`` header.
+
+These tests pin the contract that every /analyze/market response --
+2xx success, 5xx cold-start failure, and the preflight ``OPTIONS`` --
+carries the CORS allow-origin header so the browser never reports the
+response as opaque.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("torch")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import app.main as main_mod  # noqa: E402
+
+
+_ORIGIN = "http://localhost:3000"
+_SAMPLE_REQUEST = {
+    "text": "Inflation remains elevated.",
+    "date": "2024-12-18",
+    "symbol": "^GSPC",
+    "horizon": "5d",
+}
+
+
+def _stub_market_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    import datetime as _dt
+
+    def fake_market_history(*, target_date: str, symbol: str, history_length: int):
+        return [
+            {
+                "date": (
+                    _dt.date.fromisoformat(target_date)
+                    - _dt.timedelta(days=history_length - i)
+                ).isoformat(),
+                "close": 100.0 + float(i),
+                "volatility_5d": 0.01 + 0.0001 * i,
+            }
+            for i in range(history_length)
+        ]
+
+    monkeypatch.setattr(main_mod, "fetch_market_history", fake_market_history)
+    monkeypatch.setattr(
+        main_mod,
+        "analyze_text",
+        lambda _text: {"label": "neutral", "score": 0.0, "raw": []},
+    )
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(main_mod.app)
+
+
+def _force_cold_start(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Pin ``checkpoint_exists`` to False and stub the bootstrap.
+
+    Returns a counter dict the caller can inspect to confirm the
+    bootstrap stub was actually invoked (i.e. we exercised the
+    cold-start path, not the warm fast-path).
+    """
+
+    state: dict[str, Any] = {"calls": 0}
+
+    def fake_bootstrap(_payload):
+        state["calls"] += 1
+        # Flip the existence flag so the second pass through
+        # ``_ensure_cold_start`` (under the lock) early-returns.
+        state["checkpoint"] = True
+
+    def fake_exists() -> bool:
+        return bool(state.get("checkpoint", False))
+
+    monkeypatch.setattr(main_mod, "_bootstrap_cold_start", fake_bootstrap)
+    monkeypatch.setattr(main_mod, "checkpoint_exists", fake_exists)
+    return state
+
+
+def test_analyze_market_preflight_carries_cors_header(client: TestClient) -> None:
+    """OPTIONS /analyze/market must echo the allow-origin even when the
+    backend has no checkpoint yet."""
+
+    response = client.options(
+        "/analyze/market",
+        headers={
+            "Origin": _ORIGIN,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "content-type",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == _ORIGIN
+
+
+def test_analyze_market_cold_start_success_carries_cors_header(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fresh boot, no checkpoint on disk. The bootstrap stub runs, the
+    panel builder returns an empty payload, and the response must
+    still carry the allow-origin header."""
+
+    state = _force_cold_start(monkeypatch)
+    _stub_market_history(monkeypatch)
+    monkeypatch.setattr(
+        main_mod, "build_market_reaction_panel", lambda _vectors: None
+    )
+
+    response = client.post(
+        "/analyze/market",
+        headers={"Origin": _ORIGIN},
+        json=_SAMPLE_REQUEST,
+    )
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == _ORIGIN
+    assert state["calls"] == 1
+
+
+def test_analyze_market_cold_start_runtime_error_carries_cors_header(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A contract-mismatch RuntimeError from the cold-start path must
+    surface as a 503 with allow-origin still attached -- the structured
+    failure must not bypass the CORS middleware."""
+
+    def boom(_payload):
+        raise RuntimeError("contract mismatch: unknown kwarg 'foo'")
+
+    monkeypatch.setattr(main_mod, "checkpoint_exists", lambda: False)
+    monkeypatch.setattr(main_mod, "_bootstrap_cold_start", boom)
+
+    response = client.post(
+        "/analyze/market",
+        headers={"Origin": _ORIGIN},
+        json=_SAMPLE_REQUEST,
+    )
+    assert response.status_code == 503
+    assert response.headers.get("access-control-allow-origin") == _ORIGIN
+
+
+def test_analyze_market_cold_start_unexpected_exception_carries_cors_header(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-RuntimeError (e.g. corrupted checkpoint produces
+    ``pickle.UnpicklingError`` / ``EOFError``) from a concurrent
+    cold-start race must also degrade to a structured 503 with CORS
+    headers, not a bare 500 from ServerErrorMiddleware outside the
+    CORS layer."""
+
+    def boom(_payload):
+        raise EOFError("Ran out of input")
+
+    monkeypatch.setattr(main_mod, "checkpoint_exists", lambda: False)
+    monkeypatch.setattr(main_mod, "_bootstrap_cold_start", boom)
+
+    response = client.post(
+        "/analyze/market",
+        headers={"Origin": _ORIGIN},
+        json=_SAMPLE_REQUEST,
+    )
+    assert response.status_code == 503
+    assert response.headers.get("access-control-allow-origin") == _ORIGIN
+
+
+def test_ensure_cold_start_serialises_concurrent_callers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_ensure_cold_start`` must invoke ``_bootstrap_cold_start`` at
+    most once even when /analyze, /analyze/market and /analyze/analogs
+    all race on a fresh boot. The double-checked locking pattern means
+    the runner-up sees the leader's checkpoint and early-returns."""
+
+    state = _force_cold_start(monkeypatch)
+
+    async def _race() -> None:
+        await asyncio.gather(
+            main_mod._ensure_cold_start(_SAMPLE_REQUEST),
+            main_mod._ensure_cold_start(_SAMPLE_REQUEST),
+            main_mod._ensure_cold_start(_SAMPLE_REQUEST),
+        )
+
+    # Reset the module-level lock so a previous test's loop is not held.
+    main_mod._cold_start_lock = asyncio.Lock()
+    asyncio.run(_race())
+    assert state["calls"] == 1


### PR DESCRIPTION
Closes #379.

The frontend fans `/analyze`, `/analyze/market` and `/analyze/analogs` out through `Promise.allSettled`, so on a fresh boot all three race into `_bootstrap_cold_start` concurrently. Two threads writing the same checkpoint produced a half-written artefact; the runner-up's loader raised an opaque deserialisation error that escaped the narrow `RuntimeError` catch on `/analyze/market`, fell through to `ServerErrorMiddleware` (outside the CORS layer), and the browser saw `ERR_FAILED` / "no Access-Control-Allow-Origin" while uvicorn happily logged 200 OK.

- New `_ensure_cold_start` helper guards the bootstrap with a module-level `asyncio.Lock` + a double-checked `checkpoint_exists()` re-read inside the critical section. `/analyze`, `/analyze/market`, `/analyze/analogs` (via the analogs path's existing analog index loader is unaffected) all funnel through it, so only one thread ever runs the heavy bootstrap per process.
- `/analyze/market` now catches `Exception` (not just `RuntimeError`) from the cold-start and from the subsequent panel build, degrading both to a structured 503 inside `ExceptionMiddleware`. Every failure path is now CORS-wrapped.
- Regression test `tests/unit/test_analyze_market_cors_cold_start.py` pins the contract: preflight `OPTIONS`, success, cold-start `RuntimeError`, and cold-start non-`RuntimeError` all carry `access-control-allow-origin`. A separate concurrency test asserts the lock collapses three parallel callers down to a single `_bootstrap_cold_start` invocation.

## Reviewer focus
- The lock is created at module import time; on Python 3.10+ `asyncio.Lock()` defers loop binding until first acquire, so the lifespan + TestClient paths both bind cleanly. If the trainer ever moves to a multi-process serving topology this lock would need to become a file lock — flagging it as a follow-up rather than a blocker.
- `_ensure_cold_start` is invoked from `/analyze/market` even when the cold-start would have been a no-op (warm process). The fast path takes zero locks (early-return on `checkpoint_exists()`), so this is just a single sync stat call per request.
- The `except Exception` broadening on `/analyze/market` mirrors the existing `/analyze` handler shape from #341; both routes now degrade to structured 5xx rather than letting exceptions escape the CORS-wrapped layer.
- `/analyze/analogs` was not modified — its handler does not invoke `_bootstrap_cold_start` directly (it loads its own retrieval-encoder index), so the race only existed on the two routes that share `_bootstrap_cold_start`.