### PR TITLE
Wire trajectory panel into build_panel_attributions (#385)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -567,7 +567,9 @@ def _build_analyze_response(
         # structured-degrade try/except). Guard the dispatch defensively
         # so an IG runtime failure cannot break /analyze.
         try:
-            panel_attributions = build_panel_attributions(history_vectors)
+            panel_attributions = build_panel_attributions(
+                history_vectors, as_of_date=payload.date
+            )
         except Exception:  # noqa: BLE001 -- defensive: never break /analyze
             logger.warning("xai_panel_attribution_failed", exc_info=True)
             panel_attributions = []

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -677,6 +677,7 @@ def build_panel_attributions(
     sequence: list[FeatureVector],
     *,
     n_steps: int | None = None,
+    as_of_date: _date_cls | str | None = None,
 ) -> list[dict[str, Any]]:
     """Compute integrated-gradients attribution for every active panel (#297).
 
@@ -741,7 +742,103 @@ def build_panel_attributions(
         )
         panels.append(rates.to_dict())
 
+    # #385: dispatch through the trajectory IG runner. The trajectory
+    # model lives in a sibling singleton with its own bundle + input
+    # contract; we resolve the bundle here, build the model's forward
+    # inputs via the shared helper, then call the runner. Any failure
+    # surface (missing bundle, no eligible history, kernel error)
+    # degrades into an ``unavailable`` PanelAttribution rather than
+    # bubbling out.
+    trajectory_panel = _build_trajectory_panel(
+        as_of_date=as_of_date, steps=steps
+    )
+    panels.append(trajectory_panel.to_dict())
+
     return panels
+
+
+def _build_trajectory_panel(
+    *,
+    as_of_date: "_date_cls | str | None",
+    steps: int,
+) -> "Any":
+    """Resolve the trajectory bundle + run the IG runner, with structured
+    degrade for every failure mode. Returns a :class:`PanelAttribution`.
+    """
+
+    from app.services.xai_attribution import (
+        PanelAttribution,
+        attribute_trajectory_panel,
+    )
+
+    panel = "trajectory"
+    target = "next_stance_argmax"
+
+    def _unavailable(reason: str) -> "PanelAttribution":
+        return PanelAttribution(
+            panel=panel,
+            target=target,
+            families=[],
+            n_steps=steps,
+            unavailable=True,
+            reason=reason,
+        )
+
+    try:
+        from app.services import trajectory as trajectory_service
+    except Exception as exc:  # noqa: BLE001 -- defensive
+        logger.warning(
+            "xai_trajectory_import_failed exception_class=%s",
+            type(exc).__name__,
+            exc_info=True,
+        )
+        return _unavailable("bundle_not_loaded")
+
+    try:
+        state = trajectory_service.get_state()
+    except Exception as exc:  # noqa: BLE001 -- defensive
+        logger.warning(
+            "xai_trajectory_get_state_failed exception_class=%s",
+            type(exc).__name__,
+            exc_info=True,
+        )
+        return _unavailable("bundle_not_loaded")
+
+    if state is None:
+        return _unavailable("bundle_not_loaded")
+
+    # Resolve as_of_date. Prefer the explicit kwarg threaded from the
+    # /analyze handler; otherwise fall back to today so the helper is
+    # callable standalone (and the trajectory state's strict-backward
+    # slice still selects a meaningful window).
+    if as_of_date is None:
+        resolved_date = _date_cls.today()
+    elif isinstance(as_of_date, _date_cls):
+        resolved_date = as_of_date
+    else:
+        try:
+            resolved_date = _date_cls.fromisoformat(str(as_of_date)[:10])
+        except ValueError:
+            return _unavailable("invalid_as_of_date")
+
+    try:
+        _, inputs_tensor, mask_tensor, _, _ = trajectory_service.build_trajectory_inputs(
+            state, as_of_date=resolved_date
+        )
+    except Exception as exc:  # noqa: BLE001 -- defensive
+        logger.warning(
+            "xai_trajectory_input_build_failed exception_class=%s",
+            type(exc).__name__,
+            exc_info=True,
+        )
+        return _unavailable("trajectory_input_unavailable")
+
+    if inputs_tensor is None or mask_tensor is None:
+        return _unavailable("trajectory_history_empty")
+
+    return attribute_trajectory_panel(
+        state.model, inputs_tensor, mask=mask_tensor, n_steps=steps
+    )
 
 
 @torch.no_grad()

--- a/backend/app/services/trajectory.py
+++ b/backend/app/services/trajectory.py
@@ -434,20 +434,23 @@ def _standardise_embedding(
     )
 
 
-def project_trajectory(  # noqa: C901 — keep the branches inline so the data flow stays readable.
+def build_trajectory_inputs(
     state: _TrajectoryState,
     *,
     as_of_date: date_type,
     history_length: int = DEFAULT_HISTORY_LENGTH,
-) -> dict[str, Any]:
-    """Run inference + assemble the response payload.
+) -> tuple[list[dict[str, Any]], "Any | None", "Any | None", str, str | None]:
+    """Slice + pad the trajectory history into the model's forward inputs.
 
-    Returns a dict matching the API shape — the FastAPI handler wraps
-    it with the typed response model. ``history`` is the most-recent
-    ``history_length`` real meetings with their 2D anchors and stance
-    labels; ``projected_next`` carries the predicted class
-    distribution + a confidence band derived from the conformal
-    softmax quantile (when the bundle ships one).
+    Extracted from :func:`project_trajectory` so callers that only need
+    the inputs tensor (e.g. the XAI panel-attribution dispatcher in
+    :mod:`app.services.forecaster`) do not have to re-implement the
+    history-slice + scaler + pad pipeline.
+
+    Returns ``(history_markers, inputs_tensor, mask_tensor, as_of_iso,
+    warning)``. ``inputs_tensor`` and ``mask_tensor`` are ``None`` when
+    the strict-backward window contains no eligible meetings — the
+    caller then surfaces a "no history" payload.
     """
 
     import torch
@@ -514,6 +517,46 @@ def project_trajectory(  # noqa: C901 — keep the branches inline so the data f
         )
 
     if not embeddings_window:
+        return history_markers, None, None, as_of_iso, warning
+
+    padded_inputs, mask = pad_sequence(
+        embeddings_window,
+        market_blocks,
+        history_length=history_length,
+    )
+    inputs_tensor = torch.tensor(
+        padded_inputs[np.newaxis, ...], dtype=torch.float32
+    )
+    mask_tensor = torch.tensor(mask[np.newaxis, ...], dtype=torch.bool)
+    return history_markers, inputs_tensor, mask_tensor, as_of_iso, warning
+
+
+def project_trajectory(
+    state: _TrajectoryState,
+    *,
+    as_of_date: date_type,
+    history_length: int = DEFAULT_HISTORY_LENGTH,
+) -> dict[str, Any]:
+    """Run inference + assemble the response payload.
+
+    Returns a dict matching the API shape — the FastAPI handler wraps
+    it with the typed response model. ``history`` is the most-recent
+    ``history_length`` real meetings with their 2D anchors and stance
+    labels; ``projected_next`` carries the predicted class
+    distribution + a confidence band derived from the conformal
+    softmax quantile (when the bundle ships one).
+    """
+
+    import torch
+
+    history_length = max(1, min(int(history_length), MAX_HISTORY_LENGTH))
+    history_markers, inputs_tensor, mask_tensor, as_of_iso, warning = (
+        build_trajectory_inputs(
+            state, as_of_date=as_of_date, history_length=history_length
+        )
+    )
+
+    if inputs_tensor is None or mask_tensor is None:
         return {
             "history": history_markers,
             "projected_next": None,
@@ -528,17 +571,6 @@ def project_trajectory(  # noqa: C901 — keep the branches inline so the data f
             "delta_dir_acc": state.delta_dir_acc,
             "baseline_used": state.baseline_used,
         }
-
-    padded_inputs, mask = pad_sequence(
-        embeddings_window,
-        market_blocks,
-        history_length=history_length,
-    )
-
-    inputs_tensor = torch.tensor(
-        padded_inputs[np.newaxis, ...], dtype=torch.float32
-    )
-    mask_tensor = torch.tensor(mask[np.newaxis, ...], dtype=torch.bool)
 
     state.model.eval()
     with torch.no_grad():
@@ -600,6 +632,7 @@ __all__ = [
     "MAX_HISTORY_LENGTH",
     "STANCE_CLASSES",
     "build_state_for_tests",
+    "build_trajectory_inputs",
     "bundle_available",
     "get_state",
     "install_state",

--- a/docs/adr/0026-xai-attribution-across-panels.md
+++ b/docs/adr/0026-xai-attribution-across-panels.md
@@ -39,14 +39,15 @@ Integrated gradients (Sundararajan et al. 2017) over the per-bar feature tensor,
 
 One target per panel, picked so the IG run explains the scalar the panel actually renders on the UI:
 
-| Panel       | Target                                  | Forward call            |
-| ----------- | --------------------------------------- | ----------------------- |
-| `regime`    | argmax-class stance logit (scalar)      | `forward_multi_task`    |
-| `rates_2y`  | `rates_2y_bps` regression scalar        | `forward_multi_task`    |
-| `rates_5y`  | `rates_5y_bps` regression scalar        | `forward_multi_task`    |
-| `rates_terminal` | `rates_terminal_bps` regression scalar | `forward_multi_task` |
+| Panel        | Target                                       | Forward call                            |
+| ------------ | -------------------------------------------- | --------------------------------------- |
+| `regime`     | argmax-class stance logit (scalar)           | `forward_multi_task`                    |
+| `rates_2y`   | `rates_2y_bps` regression scalar             | `forward_multi_task`                    |
+| `rates_5y`   | `rates_5y_bps` regression scalar             | `forward_multi_task`                    |
+| `rates_terminal` | `rates_terminal_bps` regression scalar   | `forward_multi_task`                    |
+| `trajectory` | argmax next-stance logit (scalar)            | trajectory bundle `model(inputs, mask)` |
 
-Trajectory is deferred — see non-goals.
+The trajectory dispatch reads the runtime singleton (`app.services.trajectory.get_state`), reuses `build_trajectory_inputs` to assemble the model's `(B, T, embedding_dim + market_dim)` input tensor + boolean mask, then runs `attribute_trajectory_panel`. A missing bundle, an empty strict-backward history window, or an invalid `as_of_date` all degrade into structured `unavailable` payloads (`bundle_not_loaded`, `trajectory_history_empty`, `invalid_as_of_date`) so the trajectory entry is always present on the panel list, even when the model could not be exercised.
 
 The argmax index is resolved once on the clean input under `torch.no_grad` so the integration tracks a stable target across alpha steps. Targeting a stance class index that flipped mid-integration would emit attribution against a moving target and the per-family bars would be uninterpretable.
 
@@ -99,6 +100,5 @@ Each branch logs at WARNING with `exception_class=…` (no `str(exc)` on the cli
 
 ## Punts / explicit non-goals
 
-* **Trajectory panel attribution.** `attribute_trajectory_panel` is implemented and tested in isolation but the live route does not dispatch through it — the trajectory singleton lives in a sibling service (`app.services.trajectory`) with its own bundle + input contract, and wiring the dispatch end-to-end is out of scope for this PR. The kernel stays on disk so the follow-up only needs to add the dispatch + an integration test. Filed for #297 follow-up.
 * **SHAP value calibration story.** The IG magnitudes are not directly comparable across panels (each panel's target has a different scale: stance logits ~ O(1), bps predictions ~ O(10²)). The frontend normalises each panel chart independently; a cross-panel normalisation would need a calibration pass we do not have time to ship under #297. The per-panel bars are interpretable in isolation, which is the use case the surface supports.
 * **Gradient-through-encoder text attribution.** As above; the keyword salience continues to drive the sentence-highlight surface. A future ADR may revisit if the trained encoder shrinks enough to make a per-request backward pass feasible.

--- a/tests/unit/test_xai_panels_in_analyze_response.py
+++ b/tests/unit/test_xai_panels_in_analyze_response.py
@@ -1,4 +1,4 @@
-"""Smoke test for the /analyze panel-attribution wire-up (#297).
+"""Smoke test for the /analyze panel-attribution wire-up (#297, #385).
 
 The full /analyze route is exercised under tests/integration; here we
 just verify that ``build_panel_attributions`` produces a list-of-dicts
@@ -9,13 +9,22 @@ The function is also expected to never raise — it must surface
 structured-degrade payloads for any panel that cannot be explained on
 the active checkpoint. This test forces that contract by stubbing
 ``_get_model`` to a minimal classification-mode model.
+
+The #385 coverage stubs the trajectory singleton with a known-good
+bundle and asserts the trajectory panel surfaces alongside regime +
+rates on the returned panel list.
 """
 
 from __future__ import annotations
 
+from datetime import date
+
+import numpy as np
+import pandas as pd
 import torch
 
 from app.services import forecaster as forecaster_service
+from app.services import trajectory as trajectory_service
 from app.services.xai_attribution import PanelAttribution
 
 
@@ -57,22 +66,30 @@ def test_build_panel_attributions_emits_serialisable_dicts(monkeypatch):
     monkeypatch.setattr(
         forecaster_service, "build_lookback_sequence", lambda sequence: sequence
     )
+    # No trajectory bundle installed; the trajectory panel should still
+    # surface but as a structured ``unavailable`` payload.
+    monkeypatch.setattr(trajectory_service, "get_state", lambda: None)
 
     # The sequence arg is opaque here -- the stubbed builders ignore it.
     panels = forecaster_service.build_panel_attributions([], n_steps=4)
     assert isinstance(panels, list)
-    assert len(panels) == 2
+    assert len(panels) == 3
     by_panel = {item["panel"]: item for item in panels}
     assert "regime" in by_panel
     assert "rates_2y" in by_panel
+    assert "trajectory" in by_panel
     # Each entry has the schema-mandated keys.
     for payload in panels:
         assert {"panel", "target", "families", "n_steps", "unavailable", "reason"} <= payload.keys()
         assert isinstance(payload["families"], list)
-        assert payload["unavailable"] is False
         # Each family carries the magnitude + signed pair.
         for fam in payload["families"]:
             assert {"family", "magnitude", "signed"} <= fam.keys()
+    # Regime + rates ran against the stub model; trajectory degrades.
+    assert by_panel["regime"]["unavailable"] is False
+    assert by_panel["rates_2y"]["unavailable"] is False
+    assert by_panel["trajectory"]["unavailable"] is True
+    assert by_panel["trajectory"]["reason"] == "bundle_not_loaded"
 
 
 def test_build_panel_attributions_degrades_when_model_get_fails(monkeypatch):
@@ -110,10 +127,141 @@ def test_build_panel_attributions_skips_regime_on_regression_checkpoint(monkeypa
     monkeypatch.setattr(
         forecaster_service, "build_lookback_sequence", lambda sequence: sequence
     )
+    monkeypatch.setattr(trajectory_service, "get_state", lambda: None)
     panels = forecaster_service.build_panel_attributions([], n_steps=4)
     by_panel = {item["panel"]: item for item in panels}
     assert "regime" not in by_panel
     assert "rates_2y" in by_panel
+
+
+class _TrajStubModel(torch.nn.Module):
+    """Minimal trajectory model that matches the (inputs, mask) forward."""
+
+    def __init__(self, feature_dim: int, n_classes: int = 3) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(feature_dim, n_classes)
+
+    def forward(self, inputs: torch.Tensor, mask=None):  # noqa: ARG002
+        pooled = inputs.mean(dim=1)
+        logits = self.linear(pooled)
+        return logits, pooled
+
+
+def _install_known_good_trajectory_state(monkeypatch):
+    """Install a known-good trajectory bundle on the singleton.
+
+    Builds a 3-meeting history with non-zero embeddings + market blocks
+    so the IG kernel sees a non-zero integration path, then wires the
+    state via ``trajectory_service.get_state``. Returns the stubbed
+    model so callers can assert against it if needed.
+    """
+
+    from app.trajectory.model import TrajectoryConfig
+
+    embedding_dim = 4
+    market_dim = 3  # MARKET_FEATURE_DIM
+    feature_dim = embedding_dim + market_dim
+    history_length = 3
+
+    config = TrajectoryConfig(
+        architecture="lstm",
+        embedding_dim=embedding_dim,
+        history_length=history_length,
+        market_feature_dim=market_dim,
+    )
+    model = _TrajStubModel(feature_dim=feature_dim, n_classes=3)
+    embeddings = np.array(
+        [
+            [0.3, -0.1, 0.2, 0.4],
+            [0.1, 0.2, -0.3, 0.5],
+            [0.4, 0.0, 0.1, -0.2],
+        ],
+        dtype=np.float32,
+    )
+    metadata = pd.DataFrame(
+        {
+            "event_date": ["2024-01-31", "2024-03-20", "2024-05-01"],
+            "axis_stance": ["dovish", "neutral", "hawkish"],
+            "embedding_2d_x": [0.0, 0.1, 0.2],
+            "embedding_2d_y": [0.0, 0.1, 0.2],
+            "text_hash": ["h0", "h1", "h2"],
+            "pre_meeting_trailing_2y_yield_change_5d_bps": [1.0, -2.0, 0.5],
+            "vix_close": [18.0, 22.0, 20.0],
+        }
+    )
+    state = trajectory_service.build_state_for_tests(
+        model=model,
+        config=config,
+        embeddings=embeddings,
+        metadata=metadata,
+        train_end="2024-12-31",
+    )
+    monkeypatch.setattr(trajectory_service, "get_state", lambda: state)
+    return state
+
+
+def test_build_panel_attributions_dispatches_trajectory_panel(monkeypatch):
+    """#385: with a known-good trajectory bundle on the singleton, the
+    helper must dispatch through ``attribute_trajectory_panel`` and
+    surface the trajectory entry on the returned panel list with the
+    coarse ``trajectory_input`` family bar."""
+
+    stub = _StubModel()
+    monkeypatch.setattr(forecaster_service, "_get_model", lambda: stub)
+    monkeypatch.setattr(
+        forecaster_service,
+        "_build_inference_tensor",
+        lambda sequence, model, device: torch.randn((1, 4, 6)),
+    )
+    monkeypatch.setattr(
+        forecaster_service, "build_lookback_sequence", lambda sequence: sequence
+    )
+    _install_known_good_trajectory_state(monkeypatch)
+
+    panels = forecaster_service.build_panel_attributions(
+        [], n_steps=4, as_of_date=date(2024, 6, 15)
+    )
+    by_panel = {item["panel"]: item for item in panels}
+    assert "trajectory" in by_panel
+    trajectory_panel = by_panel["trajectory"]
+    assert trajectory_panel["unavailable"] is False
+    assert trajectory_panel["reason"] is None
+    # The trajectory IG runner aggregates per-bar magnitudes into a
+    # single coarse family bar per ADR 0026 lines 95-101.
+    assert len(trajectory_panel["families"]) == 1
+    family = trajectory_panel["families"][0]
+    assert family["family"] == "trajectory_input"
+    assert family["magnitude"] > 0.0
+    # The dict must serialise into the pydantic schema without coercion.
+    from app.schemas import XaiPanelAttribution
+
+    parsed = XaiPanelAttribution.model_validate(trajectory_panel)
+    assert parsed.panel == "trajectory"
+
+
+def test_build_panel_attributions_trajectory_history_empty(monkeypatch):
+    """When the strict-backward window selects no meetings (as_of_date
+    falls before every metadata row), the trajectory panel still
+    surfaces but with a structured ``trajectory_history_empty`` reason."""
+
+    stub = _StubModel()
+    monkeypatch.setattr(forecaster_service, "_get_model", lambda: stub)
+    monkeypatch.setattr(
+        forecaster_service,
+        "_build_inference_tensor",
+        lambda sequence, model, device: torch.randn((1, 4, 6)),
+    )
+    monkeypatch.setattr(
+        forecaster_service, "build_lookback_sequence", lambda sequence: sequence
+    )
+    _install_known_good_trajectory_state(monkeypatch)
+
+    panels = forecaster_service.build_panel_attributions(
+        [], n_steps=4, as_of_date=date(2000, 1, 1)
+    )
+    by_panel = {item["panel"]: item for item in panels}
+    assert by_panel["trajectory"]["unavailable"] is True
+    assert by_panel["trajectory"]["reason"] == "trajectory_history_empty"
 
 
 def test_panel_attribution_serialises_into_pydantic_schema():


### PR DESCRIPTION
Closes #385.

PR #384 shipped the `attribute_trajectory_panel` kernel but `build_panel_attributions` never dispatched through it. This wires the trajectory singleton end-to-end so `/analyze?include_xai=true` actually surfaces a trajectory panel.

- Factor the trajectory history-slice + scaler + pad pipeline out of `project_trajectory` into `build_trajectory_inputs` so the dispatcher reuses the model's forward-input contract instead of reimplementing it.
- Resolve the trajectory state inside `build_panel_attributions`, build the `(B, T, embedding_dim + market_dim)` input tensor, and call the IG runner; every failure surface (missing bundle, empty history window, invalid as_of_date) degrades into a structured `PanelAttribution`.
- Thread `payload.date` through `/analyze` so the strict-backward history slice keys off the request's reference date rather than today.
- Extend the #297 wire-up suite with a known-good trajectory bundle stub asserting the panel entry carries the coarse `trajectory_input` family bar per ADR 0026 lines 95-101, plus a history-empty degrade case.
- ADR 0026: move trajectory back into the attribution-targets table and drop the deferral non-goal.

Reviewer focus: the `_build_trajectory_panel` failure-surface enumeration (every branch returns a `PanelAttribution` so the dispatcher never raises and the panel list always carries an entry for trajectory), and the `build_trajectory_inputs` extraction matching the live `project_trajectory` data flow.