### PR TITLE
Cold-start file lock + restore --workers 2 (#383)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,11 @@
 import asyncio
+import fcntl
 import io
 import json
 import logging
+import os
 import time
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -112,7 +114,54 @@ COLD_START_HISTORY_LENGTH = 252
 # "no Access-Control-Allow-Origin". Serialising the cold-start with an
 # asyncio lock + a checkpoint re-check inside the critical section keeps
 # only one bootstrap in flight per process.
+#
+# #383: the asyncio lock only serialises within one process. Prod runs
+# uvicorn with multiple workers, so we also wrap the bootstrap in an
+# OS-level ``fcntl.flock`` (see ``_bootstrap_cold_start``). The asyncio
+# lock stays as the cheap in-process guard; the file lock is the
+# cross-process safety net.
 _cold_start_lock = asyncio.Lock()
+
+
+def _bootstrap_lock_path() -> Path:
+    """Sentinel-file path for the cross-process bootstrap lock.
+
+    Resolved lazily because ``BEST_MODEL_PATH`` is imported from a
+    config module that some test paths monkeypatch.
+    """
+
+    from app.services.forecaster import BEST_MODEL_PATH
+
+    return Path(str(BEST_MODEL_PATH) + ".bootstrap.lock")
+
+
+@contextmanager
+def _bootstrap_file_lock(lock_path: Path):
+    """Acquire an exclusive ``fcntl.flock`` on a sentinel file.
+
+    Contract:
+      * Only one process at a time holds the lock; runners-up block
+        until the leader releases it, then observe the checkpoint and
+        skip the bootstrap on the re-check.
+      * The lock file is a dedicated sentinel — not the checkpoint
+        itself — so a half-written checkpoint can never masquerade as
+        "already bootstrapped".
+      * ``try/finally`` releases the lock on every path, including
+        exceptions raised inside the bootstrap.
+      * POSIX-only (``fcntl`` exists on macOS and Linux). The s6
+        deploy is POSIX, so this matches the prod runtime.
+    """
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
 
 
 async def _ensure_cold_start(payload: "AnalyzeRequest") -> None:
@@ -812,6 +861,16 @@ def _bootstrap_cold_start(payload: AnalyzeRequest) -> None:
     Synchronous — invoked via ``run_in_threadpool`` from the async
     handler so the long-running fit does not block the event loop.
 
+    #383: the body runs under an exclusive ``fcntl.flock`` on a
+    sentinel file next to ``BEST_MODEL_PATH``. Composes with the
+    process-local ``_cold_start_lock``: the asyncio lock is the cheap
+    in-process guard; the file lock is the cross-process safety net so
+    uvicorn can run with ``--workers > 1`` without two workers racing
+    on the same checkpoint write. We re-check ``checkpoint_exists``
+    inside the file lock so the runner-up (which blocked on
+    ``LOCK_EX`` until the leader finished) observes the freshly
+    written checkpoint and returns without re-training.
+
     #342: once the bootstrap writes a fresh checkpoint, we drop the
     in-process singleton + re-invoke the same loader the /analyze path
     uses (``_get_model`` -> ``_validate_serving_contract``). That way a
@@ -825,46 +884,52 @@ def _bootstrap_cold_start(payload: AnalyzeRequest) -> None:
     binds normally.
     """
 
-    warmup_sentiment = analyze_text(payload.text)
-    warmup_history = fetch_market_history(
-        target_date=payload.date,
-        symbol=payload.symbol,
-        history_length=COLD_START_HISTORY_LENGTH,
-    )
-    warmup_vectors = build_feature_vectors(
-        warmup_history,
-        sentiment_score=float(warmup_sentiment["score"]),
-        document_date=payload.date,
-    )
-    bootstrap_checkpoint(
-        vectors=warmup_vectors,
-        epochs=60,
-        batch_size=64,
-        learning_rate=4e-4,
-        early_stopping_patience=8,
-    )
-    # #342: drop the post-train singleton + force a cold load through
-    # the canonical loader so the contract validation actually runs on
-    # the freshly written sidecar. ``_set_singleton_after_train`` writes
-    # ``_model`` directly without crossing ``_validate_serving_contract``
-    # — without this reset the cold-start path would silently bind a
-    # checkpoint whose sidecar declares an unknown kwarg.
-    try:
-        from app.services.forecaster import (
-            _get_model as _forecaster_get_model,
-            reset_singleton_for_revalidation,
-        )
+    with _bootstrap_file_lock(_bootstrap_lock_path()):
+        # Runner-up path: the leader wrote the checkpoint while we
+        # waited on ``LOCK_EX``. Skip the retrain entirely.
+        if checkpoint_exists():
+            return
 
-        reset_singleton_for_revalidation()
-        _forecaster_get_model()
-    except RuntimeError:
-        # Re-raise so the /analyze caller surfaces the contract failure
-        # rather than swallowing it. ``/health`` already exposes the
-        # structured reason via ``get_serving_contract_status``.
-        raise
-    except Exception:  # pragma: no cover -- defensive
-        logger.warning("cold_start_contract_revalidation_failed", exc_info=True)
-        raise
+        warmup_sentiment = analyze_text(payload.text)
+        warmup_history = fetch_market_history(
+            target_date=payload.date,
+            symbol=payload.symbol,
+            history_length=COLD_START_HISTORY_LENGTH,
+        )
+        warmup_vectors = build_feature_vectors(
+            warmup_history,
+            sentiment_score=float(warmup_sentiment["score"]),
+            document_date=payload.date,
+        )
+        bootstrap_checkpoint(
+            vectors=warmup_vectors,
+            epochs=60,
+            batch_size=64,
+            learning_rate=4e-4,
+            early_stopping_patience=8,
+        )
+        # #342: drop the post-train singleton + force a cold load through
+        # the canonical loader so the contract validation actually runs on
+        # the freshly written sidecar. ``_set_singleton_after_train`` writes
+        # ``_model`` directly without crossing ``_validate_serving_contract``
+        # — without this reset the cold-start path would silently bind a
+        # checkpoint whose sidecar declares an unknown kwarg.
+        try:
+            from app.services.forecaster import (
+                _get_model as _forecaster_get_model,
+                reset_singleton_for_revalidation,
+            )
+
+            reset_singleton_for_revalidation()
+            _forecaster_get_model()
+        except RuntimeError:
+            # Re-raise so the /analyze caller surfaces the contract failure
+            # rather than swallowing it. ``/health`` already exposes the
+            # structured reason via ``get_serving_contract_status``.
+            raise
+        except Exception:  # pragma: no cover -- defensive
+            logger.warning("cold_start_contract_revalidation_failed", exc_info=True)
+            raise
 
 
 def _record_history(request: AnalyzeRequest, response: dict[str, Any]) -> None:

--- a/deploy/s6-services/backend/run
+++ b/deploy/s6-services/backend/run
@@ -3,13 +3,14 @@
 # file the backend writes into the /data bind mount or /home/fedpulse
 # HF cache then lands under UID 10001 on the host rather than root.
 cd /app/backend
-# Single worker: the #379 cold-start lock is ``asyncio.Lock`` and only
-# serialises within one process. Multi-worker bootstrap coordination
-# needs an OS-level file lock (tracked as a follow-up); pin
-# ``--workers 1`` until then so the race the lock guards stays in one
-# process.
+# Multi-worker safe: the #379 asyncio lock serialises within one
+# process; the #383 ``fcntl.flock`` on the bootstrap sentinel file
+# (``forecaster_best.pt.bootstrap.lock``) serialises across processes
+# so two uvicorn workers cannot race on the cold-start checkpoint
+# write. Keep ``--workers`` modest -- the forecaster checkpoint is
+# loaded per-process so each worker is its own RAM footprint.
 exec s6-setuidgid fedpulse /opt/venv/bin/uvicorn app.main:app \
     --host 0.0.0.0 \
     --port 8000 \
-    --workers 1 \
+    --workers 2 \
     --no-access-log

--- a/tests/unit/test_cold_start_file_lock.py
+++ b/tests/unit/test_cold_start_file_lock.py
@@ -1,0 +1,141 @@
+"""Cross-process cold-start regression (#383).
+
+PR #382 serialised the bootstrap within one process via
+``asyncio.Lock``; that's why ``deploy/s6-services/backend/run``
+temporarily pinned ``--workers 1``. #383 wraps the bootstrap body in
+an OS-level ``fcntl.flock`` on a sentinel file next to
+``BEST_MODEL_PATH`` so the prod deploy can scale back to
+``--workers > 1`` without two workers racing on the same checkpoint
+write.
+
+This test forks ``multiprocessing.Process`` children that each call
+the file-lock + re-check pattern from ``_bootstrap_cold_start``
+against a shared temp directory. Exactly one child must do the
+"bootstrap" work; the other must block on ``LOCK_EX``, observe the
+freshly written checkpoint on the re-check, and return.
+
+POSIX-only: ``fcntl.flock`` does not exist on Windows. The s6 deploy
+is POSIX so this matches the prod runtime.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+# Windows lacks ``fcntl``; skip the whole module on non-POSIX hosts.
+if sys.platform == "win32":  # pragma: no cover -- repo is POSIX-only
+    pytest.skip("fcntl.flock is POSIX-only", allow_module_level=True)
+
+
+def _bootstrap_worker(
+    checkpoint_path: str,
+    lock_path: str,
+    counter_path: str,
+    barrier_path: str,
+    bootstrap_sleep_s: float,
+) -> None:
+    """Subprocess entrypoint.
+
+    Mirrors the file-lock + re-check shape of ``_bootstrap_cold_start``
+    without dragging the real ML training stack into the test:
+
+      1. Spin on the barrier file so both children enter the lock
+         contention window at the same time.
+      2. Acquire the shared ``_bootstrap_file_lock``.
+      3. Re-check the checkpoint inside the lock; return if present.
+      4. Sleep briefly to widen the race window, then write the
+         checkpoint + bump the "did real work" counter.
+    """
+
+    # Force-import via the same path layout ``tests/conftest.py`` uses
+    # (the conftest is not auto-loaded inside a fresh subprocess).
+    here = Path(__file__).resolve()
+    repo_root = here.parents[2]
+    backend_dir = repo_root / "backend"
+    for entry in (str(backend_dir), str(repo_root)):
+        if entry not in sys.path:
+            sys.path.insert(0, entry)
+
+    from app.main import _bootstrap_file_lock  # noqa: E402
+
+    barrier = Path(barrier_path)
+    while not barrier.exists():
+        time.sleep(0.01)
+
+    with _bootstrap_file_lock(Path(lock_path)):
+        if Path(checkpoint_path).exists():
+            return
+        time.sleep(bootstrap_sleep_s)
+        Path(checkpoint_path).write_bytes(b"bootstrap-payload")
+        with open(counter_path, "a", encoding="utf-8") as fh:
+            fh.write(f"{os.getpid()}\n")
+
+
+def test_bootstrap_file_lock_serialises_across_processes(tmp_path: Path) -> None:
+    """Two processes hit the bootstrap concurrently. The file lock plus
+    the in-lock checkpoint re-check must mean exactly one writes."""
+
+    checkpoint = tmp_path / "forecaster_best.pt"
+    lock_file = tmp_path / "forecaster_best.pt.bootstrap.lock"
+    counter = tmp_path / "bootstrap_calls.log"
+    barrier = tmp_path / "go"
+
+    ctx = multiprocessing.get_context("spawn")
+    workers = [
+        ctx.Process(
+            target=_bootstrap_worker,
+            args=(str(checkpoint), str(lock_file), str(counter), str(barrier), 0.5),
+        )
+        for _ in range(2)
+    ]
+    for w in workers:
+        w.start()
+
+    # Give both children time to reach the barrier wait, then release
+    # them simultaneously. Without the file lock both would proceed
+    # into the bootstrap body together and both would write the
+    # checkpoint -- which is exactly the regression #383 fixes.
+    time.sleep(0.3)
+    barrier.write_bytes(b"go")
+
+    for w in workers:
+        w.join(timeout=30)
+        assert w.exitcode == 0, f"worker pid={w.pid} exited with {w.exitcode}"
+
+    assert checkpoint.exists(), "leader must have written the checkpoint"
+    assert lock_file.exists(), "sentinel lock file must survive the run"
+
+    lines = [ln for ln in counter.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 1, (
+        "exactly one process should run the bootstrap body; "
+        f"got {len(lines)} entries: {lines!r}"
+    )
+
+
+def test_bootstrap_file_lock_released_on_exception(tmp_path: Path) -> None:
+    """A raise inside the ``with`` block must still release the lock so
+    the next process can acquire it. Guards against the regression where
+    a missing ``try/finally`` would leave a stuck sentinel and wedge
+    every subsequent worker."""
+
+    from app.main import _bootstrap_file_lock
+
+    lock_file = tmp_path / "stuck.lock"
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with _bootstrap_file_lock(lock_file):
+            raise RuntimeError("boom")
+
+    # If the lock were leaked we'd deadlock here -- the second acquire
+    # would block forever on ``LOCK_EX``. A successful re-entry proves
+    # the ``try/finally`` actually released the kernel-level lock.
+    with _bootstrap_file_lock(lock_file):
+        pass


### PR DESCRIPTION
Closes #383.

PR #382 closed the cold-start race within one process via `asyncio.Lock` and pinned `--workers 1` because the asyncio lock is in-process only. This adds an OS-level `fcntl.flock` on a sentinel file next to `BEST_MODEL_PATH` so the bootstrap is serialised across uvicorn workers, then bumps the s6 entrypoint back to `--workers 2`.

- File lock acquired inside `_bootstrap_cold_start`; asyncio lock stays as the cheap in-process outer guard.
- Sentinel is `<BEST_MODEL_PATH>.bootstrap.lock`, not the checkpoint itself, so a half-written checkpoint can't masquerade as "already bootstrapped".
- Re-checks `checkpoint_exists()` inside the lock so the runner-up that blocked on `LOCK_EX` observes the leader's write and returns.
- `try/finally` releases the lock on every path including exceptions.
- New `tests/unit/test_cold_start_file_lock.py` forks two `multiprocessing.Process` workers against a shared tmp dir; without the lock both would write (verified locally), with the lock exactly one does.

## Reviewer focus
- Sentinel-file choice vs. locking the checkpoint directly.
- `try/finally` lock release on the exception path (`test_bootstrap_file_lock_released_on_exception`).
- Subprocess regression test asserts exactly-one bootstrap.
- macOS + Linux portability via `fcntl.flock`; module-level `sys.platform == "win32"` skip on the test (POSIX-only, matches the s6 deploy).
- `--workers 2` bump on `deploy/s6-services/backend/run` plus the updated comment.