### PR TITLE
Surprise decomposition: FOMC-attributable rates target (#305)

### DIFF
--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -406,6 +406,15 @@ class ModelConfig:
     # base; the ablation sweep can drive the boundary cases for the
     # parity test.
     rates_alpha: float = 0.5
+    # #305 rates-head target derivation. ``raw`` (default, byte-identical
+    # to the pre-#305 path) predicts the observed
+    # ``yield_<tenor>_change_5d`` move in bps. ``fomc_attributable``
+    # predicts the 1-D projection of the observed move onto the
+    # strict-prior policy-surprise direction ``sign(mp_surprise_level)``.
+    # The mode applies uniformly to every mounted rates head; per-head
+    # mode-mixing was deferred so the CLI stays one knob deep. See ADR
+    # 0027 and :mod:`app.training.rates_targets`.
+    rates_target_mode: str = "raw"
 
     @classmethod
     def from_model(cls, model: "Any") -> "ModelConfig":
@@ -465,6 +474,9 @@ class ModelConfig:
                 getattr(model, "rates_head_mode", "regression") or "regression"
             ),
             rates_alpha=float(getattr(model, "rates_alpha", 0.5)),
+            rates_target_mode=str(
+                getattr(model, "rates_target_mode", "raw") or "raw"
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -672,6 +684,19 @@ class FeatureVector:
     target_yield_2y_change_5d: float | None = None
     target_yield_5y_change_5d: float | None = None
     target_terminal_rate_change_5d: float | None = None
+    # #305 FOMC-attributable rates targets. Strict-forward 5-day yield
+    # change projected onto the strict-prior policy-surprise direction
+    # ``sign(mp_surprise_level)``. ``None`` on no-change meetings (where
+    # the surprise magnitude is below ``SURPRISE_DIRECTION_EPSILON_BPS``
+    # and the direction is ill-defined); ``None`` on every legacy /
+    # non-rates path so the dataclass shape round-trips clean through
+    # the determinism regression contract. Populated by the
+    # training-package loader on the target row alongside the raw
+    # ``target_yield_*_change_5d`` columns; the per-fold target builder
+    # reads one or the other based on ``ModelConfig.rates_target_mode``.
+    target_yield_2y_change_5d_fomc_attributable: float | None = None
+    target_yield_5y_change_5d_fomc_attributable: float | None = None
+    target_terminal_rate_change_5d_fomc_attributable: float | None = None
     # Pooled text-embedding payload (PR #176 onward). Carries the
     # variable-length encoder-output vector (FinBERT 768, voyage-finance-2
     # 1024, BGE 1024, ...) materialised by the loader's softmax(-Delta t /

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -158,6 +158,7 @@ def build_forecaster(
             "use_derived_text_features",
             "rates_head_mode",
             "rates_alpha",
+            "rates_target_mode",
         ):
             flat_kwargs.pop(drop, None)
         flat_rates_heads = tuple(

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -190,6 +190,12 @@ def build_forecaster(
         flat.rates_heads = flat_rates_heads  # type: ignore[assignment]
         flat.rates_head_mode = str(resolved.rates_head_mode or "regression")  # type: ignore[assignment]
         flat.rates_alpha = float(resolved.rates_alpha)  # type: ignore[assignment]
+        # #305 round-trip the rates target derivation onto the persisted
+        # run summary so the checkpoint records which target the heads
+        # were trained against.
+        flat.rates_target_mode = str(
+            getattr(resolved, "rates_target_mode", "raw") or "raw"
+        )  # type: ignore[assignment]
         return flat
 
     kwargs = resolved.to_dict()
@@ -235,6 +241,9 @@ def build_forecaster(
         kwargs.pop("rates_head_mode", "regression") or "regression"
     )
     rates_alpha_value = float(kwargs.pop("rates_alpha", 0.5))
+    rates_target_mode_value = str(
+        kwargs.pop("rates_target_mode", "raw") or "raw"
+    )
     # #317 finding #8: fail fast at the factory rather than silently
     # zeroing rates_heads when output_mode='regression'. The operator
     # gets a clear error message instead of a checkpoint that
@@ -314,6 +323,9 @@ def build_forecaster(
     model.rates_heads = rates_heads_tuple  # type: ignore[assignment]
     model.rates_head_mode = rates_head_mode_value  # type: ignore[assignment]
     model.rates_alpha = rates_alpha_value  # type: ignore[assignment]
+    # #305 round-trip the rates target derivation onto the built module
+    # so ``ModelConfig.from_model`` recovers it on resume / inference.
+    model.rates_target_mode = rates_target_mode_value  # type: ignore[assignment]
     return model
 
 

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -681,6 +681,24 @@ def _parse_args() -> argparse.Namespace:
             "level; ``0.0`` collapses to classification-only."
         ),
     )
+    parser.add_argument(
+        "--rates-target-mode",
+        type=str,
+        choices=("raw", "fomc_attributable"),
+        default="raw",
+        help=(
+            "Rates-head target derivation (#305). ``raw`` (default) "
+            "keeps the observed ``yield_<tenor>_change_5d`` bps move "
+            "as the supervised target, byte-identical to the pre-#305 "
+            "path. ``fomc_attributable`` predicts the 1-D projection "
+            "of the observed move onto the strict-prior policy-surprise "
+            "direction ``sign(mp_surprise_level)`` — the FOMC-"
+            "attributable component of the move (Kuttner-style, post-"
+            "#350 strict-prior construction). No-change meetings (where "
+            "the surprise magnitude is below the 1-bp epsilon) mark "
+            "the target as missing rather than zero. See ADR 0027."
+        ),
+    )
     # #309 derived-text-features ablation. Default ``on`` is byte-
     # identical to the pre-#309 path; ``off`` zeros the FeatureVector
     # slots populated by the per-sentence multi-axis classifier so the
@@ -1155,6 +1173,9 @@ def _build_model_config(args: argparse.Namespace) -> ModelConfig:
         rates_heads=_resolve_rates_heads_from_args(args),
         rates_head_mode=str(getattr(args, "rates_head_mode", "regression") or "regression"),
         rates_alpha=float(getattr(args, "rates_alpha", 0.5)),
+        rates_target_mode=str(
+            getattr(args, "rates_target_mode", "raw") or "raw"
+        ),
     )
 
 
@@ -1408,6 +1429,9 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                                 rates_heads=_resolve_rates_heads_from_args(args),
                                 rates_head_mode=str(getattr(args, "rates_head_mode", "regression") or "regression"),
                                 rates_alpha=float(getattr(args, "rates_alpha", 0.5)),
+                                rates_target_mode=str(
+                                    getattr(args, "rates_target_mode", "raw") or "raw"
+                                ),
                             ),
                             "learning_rate": float(hp["learning_rate"]),
                             "epochs": int(hp["epochs"]),
@@ -1517,6 +1541,9 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                         rates_heads=_resolve_rates_heads_from_args(args),
                         rates_head_mode=str(getattr(args, "rates_head_mode", "regression") or "regression"),
                         rates_alpha=float(getattr(args, "rates_alpha", 0.5)),
+                        rates_target_mode=str(
+                            getattr(args, "rates_target_mode", "raw") or "raw"
+                        ),
                     ),
                     "learning_rate": float(learning_rate),
                     "epochs": int(epochs),

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -1581,6 +1581,29 @@ def _load_package_sequences_with_metadata(
         rates_terminal_value = _coerce_finite_float(
             row.get("terminal_rate_change_5d")
         )
+        # #305 FOMC-attributable rates targets. Compute the 1-D
+        # projection of each observed bps move onto the strict-prior
+        # surprise direction ``sign(mp_surprise_level)``. The level is
+        # read off the strict-prior mp_surprises lookup so the target
+        # is leak-clean by construction (ADR 0024 / #350). No-change
+        # meetings (|surprise| < epsilon) emit ``None`` so the
+        # partition builder masks the row instead of writing a zero
+        # label. See ADR 0027 for the projection definition.
+        from app.training.rates_targets import fomc_attributable_projection
+
+        mp_level_lookup = mp_surprise_lookup.get(event_date_str[:10], {})
+        mp_level_for_projection = _coerce_finite_float(
+            mp_level_lookup.get("mp_surprise_level")
+        )
+        rates_2y_attributable = fomc_attributable_projection(
+            rates_2y_value, mp_level_for_projection
+        )
+        rates_5y_attributable = fomc_attributable_projection(
+            rates_5y_value, mp_level_for_projection
+        )
+        rates_terminal_attributable = fomc_attributable_projection(
+            rates_terminal_value, mp_level_for_projection
+        )
         # B1 (#212) LLM-features lookup -- one-hot block + missing flag
         # per event row. Lookup is built once per package outside the
         # loop. Hashes absent from the lookup (failed extraction or
@@ -1593,6 +1616,11 @@ def _load_package_sequences_with_metadata(
             vector.target_yield_2y_change_5d = rates_2y_value
             vector.target_yield_5y_change_5d = rates_5y_value
             vector.target_terminal_rate_change_5d = rates_terminal_value
+            vector.target_yield_2y_change_5d_fomc_attributable = rates_2y_attributable
+            vector.target_yield_5y_change_5d_fomc_attributable = rates_5y_attributable
+            vector.target_terminal_rate_change_5d_fomc_attributable = (
+                rates_terminal_attributable
+            )
             if llm_vector is not None:
                 vector.llm_features = list(llm_vector)
                 vector.llm_features_missing = 0.0
@@ -2191,6 +2219,23 @@ def load_training_sequences_from_package(
         rates_terminal_value = _coerce_finite_float(
             row.get("terminal_rate_change_5d")
         )
+        # #305 FOMC-attributable projections (see ADR 0027 + the matched
+        # block above on the walk-forward loader path).
+        from app.training.rates_targets import fomc_attributable_projection
+
+        mp_level_lookup = mp_surprise_lookup.get(event_date_str[:10], {})
+        mp_level_for_projection = _coerce_finite_float(
+            mp_level_lookup.get("mp_surprise_level")
+        )
+        rates_2y_attributable = fomc_attributable_projection(
+            rates_2y_value, mp_level_for_projection
+        )
+        rates_5y_attributable = fomc_attributable_projection(
+            rates_5y_value, mp_level_for_projection
+        )
+        rates_terminal_attributable = fomc_attributable_projection(
+            rates_terminal_value, mp_level_for_projection
+        )
         # B1 (#212) LLM-features lookup -- one-hot block + missing flag
         # per event row. Lookup is built once per package outside the
         # loop. Hashes absent from the lookup (failed extraction or
@@ -2203,6 +2248,11 @@ def load_training_sequences_from_package(
             vector.target_yield_2y_change_5d = rates_2y_value
             vector.target_yield_5y_change_5d = rates_5y_value
             vector.target_terminal_rate_change_5d = rates_terminal_value
+            vector.target_yield_2y_change_5d_fomc_attributable = rates_2y_attributable
+            vector.target_yield_5y_change_5d_fomc_attributable = rates_5y_attributable
+            vector.target_terminal_rate_change_5d_fomc_attributable = (
+                rates_terminal_attributable
+            )
             if llm_vector is not None:
                 vector.llm_features = list(llm_vector)
                 vector.llm_features_missing = 0.0

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -1419,11 +1419,19 @@ def _load_package_sequences_with_metadata(
         )
 
     linguistic_lookup: dict[str, list[float]] = {}
-    mp_surprise_lookup: dict[str, dict[str, float]] = {}
+    # The mp_surprise lookup feeds two consumers: rich-feature input
+    # columns (gated by ``rich_features``) AND the fomc-attributable
+    # rates-target projection (always computed; the trainer reads it
+    # off the FeatureVector only when ``rates_target_mode`` opts in).
+    # Loading it unconditionally costs one cheap parquet read and
+    # prevents the silent all-None projection that would otherwise
+    # fire under ``--no-rich-features --rates-target-mode=fomc_attributable``.
+    mp_surprise_lookup: dict[str, dict[str, float]] = _read_mp_surprise_lookup(
+        package_dir
+    )
     llm_lookup: dict[str, list[float]] = {}
     if rich_features:
         linguistic_lookup = _read_linguistic_lookup(package_dir)
-        mp_surprise_lookup = _read_mp_surprise_lookup(package_dir)
         if use_llm_features:
             llm_lookup = _load_llm_feature_lookup(training_package_id)
 
@@ -2028,11 +2036,17 @@ def load_training_sequences_from_package(
     # left empty -- ``_attach_rich_features`` is skipped entirely so
     # the legacy 6-dim path is undisturbed.
     linguistic_lookup: dict[str, list[float]] = {}
-    mp_surprise_lookup: dict[str, dict[str, float]] = {}
+    # See the matching note on `_load_package_sequences_with_metadata`:
+    # the mp_surprise lookup feeds both rich-feature input columns
+    # (gated) and the fomc-attributable rates-target projection (always
+    # computed). Load unconditionally so `--no-rich-features` does not
+    # silently null every projection.
+    mp_surprise_lookup: dict[str, dict[str, float]] = _read_mp_surprise_lookup(
+        package_dir
+    )
     llm_lookup: dict[str, list[float]] = {}
     if rich_features:
         linguistic_lookup = _read_linguistic_lookup(package_dir)
-        mp_surprise_lookup = _read_mp_surprise_lookup(package_dir)
         if use_llm_features:
             llm_lookup = _load_llm_feature_lookup(training_package_id)
 

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -2464,6 +2464,12 @@ def train_model(
         or "regression"
     )
     active_rates_alpha = float(getattr(active_model_config, "rates_alpha", 0.5))
+    # #305 per-head target derivation. ``raw`` (default) keeps the
+    # observed bps move; ``fomc_attributable`` reads the strict-prior
+    # surprise-projected scalar from the matching FeatureVector field.
+    active_rates_target_mode = str(
+        getattr(active_model_config, "rates_target_mode", "raw") or "raw"
+    )
     rates_heads_active = bool(active_rates_heads)
     train_rates_targets: RatesPartitionTensors | None = None
     val_rates_targets: RatesPartitionTensors | None = None
@@ -2595,6 +2601,7 @@ def train_model(
             ) = build_partition_rates_targets(
                 train_groups,
                 head_names=active_rates_heads,
+                target_mode=active_rates_target_mode,
             )
             train_rates_targets = RatesPartitionTensors(
                 per_head={
@@ -2656,6 +2663,7 @@ def train_model(
                 head_names=active_rates_heads,
                 scalers=rates_scalers,
                 edges_by_head=rates_edges,
+                target_mode=active_rates_target_mode,
             )
             val_rates_targets = RatesPartitionTensors(
                 per_head={
@@ -2704,6 +2712,7 @@ def train_model(
                 head_names=active_rates_heads,
                 scalers=rates_scalers,
                 edges_by_head=rates_edges,
+                target_mode=active_rates_target_mode,
             )
             test_rates_targets = RatesPartitionTensors(
                 per_head={

--- a/backend/app/training/rates_targets.py
+++ b/backend/app/training/rates_targets.py
@@ -1,4 +1,4 @@
-"""Per-fold rates-head target / scaler helpers (#292).
+"""Per-fold rates-head target / scaler helpers (#292, #305).
 
 The three rates heads (``2y`` / ``5y`` / ``terminal``) consume a strict-
 forward 5-day yield change in basis points read off the FeatureVector
@@ -6,6 +6,18 @@ target row. Each fold fits an independent per-head standardiser on the
 train slice (a ``(mean, std)`` pair); val and test partitions reuse the
 train-fitted scaler so no look-ahead leaks into the standardisation
 step.
+
+Two target modes are wired (#305):
+
+- ``raw`` (default, byte-identical to the pre-#305 path): the head
+  predicts the observed ``yield_<tenor>_change_5d`` move in bps.
+- ``fomc_attributable``: the head predicts the FOMC-attributable
+  component of the observed move, defined as the 1-D projection of the
+  observed move onto the strict-prior policy-surprise direction
+  ``sign(mp_surprise_level)``. When the surprise magnitude is below
+  :data:`SURPRISE_DIRECTION_EPSILON_BPS` (no-change meeting; direction
+  ill-defined) the target is marked missing rather than coerced to zero.
+  See :func:`fomc_attributable_projection` and ADR 0027.
 
 The aux 3-class classification surface (easing / neutral / tightening)
 is bucketed against per-fold tertile edges fitted on the same train
@@ -41,6 +53,66 @@ from app.models.rates_heads import (
 )
 
 
+# Canonical literal for the per-head target derivation. ``raw`` keeps the
+# pre-#305 contract (predict the observed bps move); ``fomc_attributable``
+# projects the observed move onto the strict-prior policy-surprise
+# direction (see :func:`fomc_attributable_projection` + ADR 0027).
+RATES_TARGET_MODES: tuple[str, ...] = ("raw", "fomc_attributable")
+DEFAULT_RATES_TARGET_MODE: str = "raw"
+
+# Minimum absolute mp_surprise_level (in bps) below which the surprise
+# direction is treated as ill-defined and the FOMC-attributable target
+# is marked missing. 1 bp is well below the FOMC's 25-bp standard move
+# and an order of magnitude above floating-point noise in the strict-
+# prior implied-move proxy that anchors the level construction.
+SURPRISE_DIRECTION_EPSILON_BPS: float = 1.0
+
+
+def fomc_attributable_projection(
+    observed_move_bps: float | None,
+    mp_surprise_level_bps: float | None,
+    *,
+    epsilon_bps: float = SURPRISE_DIRECTION_EPSILON_BPS,
+) -> float | None:
+    """Project the observed rates move onto the policy-surprise direction.
+
+    The Kuttner-style 1-D projection:
+
+    - ``u = sign(mp_surprise_level)`` is the strict-prior surprise
+      direction (post-#350 / ADR 0024 construction; the surprise is the
+      actual policy decision minus the implied next-move proxy at
+      ``T-1``).
+    - ``projected = observed_move_bps * u`` is the scalar coefficient
+      of the projection in bps, signed positive when the observed move
+      agrees with the surprise direction and negative when it opposes
+      it.
+
+    Returns ``None`` (target missing) when:
+
+    - either input is ``None`` / non-finite, or
+    - ``|mp_surprise_level| < epsilon_bps`` (no-change meeting; the
+      direction is ill-defined and zero would be a label, not a no-op).
+
+    The missing case is the load-bearing edge — coercing it to zero
+    would inject a fake "no-attributable-move" label on every pause
+    meeting and bias the regression toward the origin.
+    """
+
+    if observed_move_bps is None or mp_surprise_level_bps is None:
+        return None
+    try:
+        obs = float(observed_move_bps)
+        surp = float(mp_surprise_level_bps)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(obs) or not math.isfinite(surp):
+        return None
+    if abs(surp) < float(epsilon_bps):
+        return None
+    sign = 1.0 if surp > 0.0 else -1.0
+    return obs * sign
+
+
 @dataclass(frozen=True)
 class RatesHeadScaler:
     """Standardiser (``mean`` / ``std`` in bps) for one rates head.
@@ -59,6 +131,8 @@ class RatesHeadScaler:
 def _gather_rates_values_for_group(
     group: Sequence[FeatureVector],
     head_name: str,
+    *,
+    target_mode: str = DEFAULT_RATES_TARGET_MODE,
 ) -> list[float]:
     """Walk a sequence group and emit every supervised row's rates value.
 
@@ -68,6 +142,12 @@ def _gather_rates_values_for_group(
     target's ``forward_realized_vol_10d`` is null; for every kept group
     emit one value per row at index >= ``SEQUENCE_LENGTH`` whose
     forward-vol survives the filter.
+
+    ``target_mode`` selects between the raw observed move
+    (``target_<column>`` field) and the FOMC-attributable projection
+    (``target_<column>_fomc_attributable`` field). Missing values
+    (``None`` or non-finite) emit ``math.nan`` so the partition builder
+    can mask them out row-by-row.
     """
 
     if len(group) < SEQUENCE_LENGTH + 1:
@@ -78,7 +158,7 @@ def _gather_rates_values_for_group(
         isinstance(leading_vol, float) and leading_vol != leading_vol
     ):
         return []
-    field = _rates_field_for(head_name)
+    field = _rates_field_for(head_name, target_mode=target_mode)
     out: list[float] = []
     for idx in range(SEQUENCE_LENGTH, len(group)):
         target_row = group[idx]
@@ -103,8 +183,18 @@ def _gather_rates_values_for_group(
     return out
 
 
-def _rates_field_for(head_name: str) -> str:
-    """Return the FeatureVector field carrying the bps target."""
+def _rates_field_for(
+    head_name: str,
+    *,
+    target_mode: str = DEFAULT_RATES_TARGET_MODE,
+) -> str:
+    """Return the FeatureVector field carrying the per-head bps target.
+
+    ``target_mode='raw'`` returns ``target_<column>`` (the observed
+    bps move). ``target_mode='fomc_attributable'`` returns
+    ``target_<column>_fomc_attributable`` (the surprise-projected
+    scalar). Anything else raises ``ValueError``.
+    """
 
     name = str(head_name).lower()
     if name not in RATES_HEAD_TARGET_COLUMNS:
@@ -112,7 +202,16 @@ def _rates_field_for(head_name: str) -> str:
             f"unknown rates head name {head_name!r}; "
             f"expected one of {RATES_HEAD_NAMES}"
         )
-    return f"target_{RATES_HEAD_TARGET_COLUMNS[name]}"
+    mode = str(target_mode).lower()
+    if mode not in RATES_TARGET_MODES:
+        raise ValueError(
+            f"unsupported rates_target_mode={target_mode!r}; "
+            f"expected one of {RATES_TARGET_MODES}"
+        )
+    base = f"target_{RATES_HEAD_TARGET_COLUMNS[name]}"
+    if mode == "fomc_attributable":
+        return f"{base}_fomc_attributable"
+    return base
 
 
 def fit_rates_scaler(values: Sequence[float]) -> RatesHeadScaler:
@@ -144,6 +243,7 @@ def build_partition_rates_targets(
     head_names: Sequence[str],
     scalers: dict[str, RatesHeadScaler] | None = None,
     edges_by_head: dict[str, QuantileBinEdges] | None = None,
+    target_mode: str = DEFAULT_RATES_TARGET_MODE,
 ) -> tuple[
     dict[str, torch.Tensor],
     dict[str, torch.Tensor],
@@ -187,6 +287,12 @@ def build_partition_rates_targets(
                 f"unknown rates head name {name!r}; "
                 f"expected one of {RATES_HEAD_NAMES}"
             )
+    mode = str(target_mode).lower()
+    if mode not in RATES_TARGET_MODES:
+        raise ValueError(
+            f"unsupported rates_target_mode={target_mode!r}; "
+            f"expected one of {RATES_TARGET_MODES}"
+        )
 
     # Per-head row-wise raw values, with NaN holes for missing rows.
     raw_by_head: dict[str, list[float]] = {name: [] for name in head_list}
@@ -195,7 +301,7 @@ def build_partition_rates_targets(
         # the same row position for head B, keeping the per-head tensors
         # row-aligned with each other and with ``y``.
         per_head_rows: dict[str, list[float]] = {
-            name: _gather_rates_values_for_group(group, name)
+            name: _gather_rates_values_for_group(group, name, target_mode=mode)
             for name in head_list
         }
         if not per_head_rows:
@@ -280,8 +386,12 @@ def inverse_standardise_bps(
 
 
 __all__ = (
+    "DEFAULT_RATES_TARGET_MODE",
+    "RATES_TARGET_MODES",
     "RatesHeadScaler",
+    "SURPRISE_DIRECTION_EPSILON_BPS",
     "build_partition_rates_targets",
     "fit_rates_scaler",
+    "fomc_attributable_projection",
     "inverse_standardise_bps",
 )

--- a/docs/adr/0027-fomc-attributable-rates-target.md
+++ b/docs/adr/0027-fomc-attributable-rates-target.md
@@ -1,0 +1,110 @@
+# ADR 0027 — FOMC-attributable rates target (surprise decomposition)
+
+Status: accepted, code path live; canonical sweep deferred to operator.
+Date: 2026-05-27.
+References:
+- Issue #305 (closes).
+- Issue #291 (pre-meeting expectation features; the strict-prior implied-move proxy that anchors the surprise direction).
+- Issue #350 / ADR 0024 (strict-prior reformulation of `mp_surprise_level`; the leak-clean direction this projection consumes).
+- `backend/app/training/rates_targets.py` — `fomc_attributable_projection`, `RATES_TARGET_MODES`, target-mode-aware `_rates_field_for` + `build_partition_rates_targets`.
+- `backend/app/training/loaders.py` — per-event projection wired into both training-package loader sites.
+- `backend/app/models/config.py` — `ModelConfig.rates_target_mode`; new FeatureVector `target_yield_*_change_5d_fomc_attributable` fields.
+- Kuttner (2001), "Monetary policy surprises and interest rates: evidence from the Fed Funds futures market." J. Monetary Econ.
+- Gürkaynak, Sack, Swanson (2005), "Do actions speak louder than words?" Int. J. Central Banking.
+- Cieslak, Vissing-Jørgensen (2021), "The economics of the Fed put." Rev. Fin. Stud.
+
+## Context
+
+The rates heads landed in #292 supervise three forward 5-day yield changes (`yield_2y_change_5d`, `yield_5y_change_5d`, `terminal_rate_change_5d`) in basis points. The supervised target is the *raw* observed move over `[T, T+5]` — every basis point of yield change between the FOMC announcement close and five trading days later, regardless of what drove it.
+
+That raw quantity blends two signals:
+
+1. The FOMC-attributable component — the part of the move that responds to the policy decision (its surprise relative to the strictly-prior implied expectation).
+2. The non-FOMC component — data releases between `T+1` and `T+5` (jobs reports, CPI, PPI), cross-asset shocks, position unwind, and noise.
+
+For a forecaster sitting at `T-0` reading the FOMC statement text, only the first component is plausibly predictable from FOMC features. The second component is, by construction, orthogonal to anything the model can read off the statement and the strictly-prior market state. Training the head against the raw move therefore floors the achievable R²: even a perfect FOMC-reaction model can only explain the FOMC-attributable share of the variance.
+
+The literature pattern is to *decompose* the rates response into a surprise-driven component and a residual. Kuttner (2001) does this for the next-meeting Fed Funds futures contract; Gürkaynak–Sack–Swanson (2005) extends it across the curve with a two-factor PCA on the surprise window; Cieslak–Vissing-Jørgensen (2021) projects the response onto a policy-surprise axis to isolate the "Fed put" channel. The common construction is to project the observed move onto a policy-surprise direction estimated from the OIS / Fed Funds futures surprise at the announcement and report the projection scalar.
+
+#291 shipped the pre-meeting expectation feature block — `pre_meeting_implied_next_move_bps`, `pre_meeting_implied_hike_prob`, etc. — that supplies the strictly-prior "expected" leg. #350 (ADR 0024) reformulated `mp_surprise_level` against that strict-prior expected leg so the surprise quantity itself is leak-clean. The two prerequisites land the supply side for a Kuttner-style projection.
+
+This ADR records the decision to use the post-#350 `mp_surprise_level` as the policy-surprise direction and project each rates head's observed move onto its 1-D unit vector.
+
+## Decision
+
+Add a per-event-row supervised target
+
+```
+attributable_bps = observed_move_bps * sign(mp_surprise_level)     if |mp_surprise_level| >= 1.0 bp
+                 = MISSING                                          otherwise
+```
+
+for each of the three rates heads (2y / 5y / terminal). The construction is the 1-D Kuttner projection: the observed move `m` is projected onto the unit direction `u = surprise / |surprise|`, and the scalar projection coefficient `m · u = m * sign(surprise)` is taken as the supervised target. The sign convention follows the policy-surprise direction so a positive target means the observed move agreed with the surprise (hawkish surprise → yields up, dovish surprise → yields down).
+
+### Projection direction
+
+The surprise direction is the strict-prior `mp_surprise_level` from `data/external/fred/mp_surprises.parquet`, post-#350 / ADR 0024. That construction is
+
+```
+mp_surprise_level_bps = (ff_target_after − ff_target_prior) * 100 − pre_implied_next_move_bps
+                      = actual_target_change − strict_prior_expected_change
+```
+
+where `pre_implied_next_move_bps` is the FRED-only implied move proxy from `app.data.rates_event_features.implied_next_move_bps` at `T-1`. The expected leg is observable strictly before `event_date`; the actual leg is the announcement itself (the policy decision the surprise is defined *against*, not a market read of it). The direction is therefore leak-clean: the surprise is defined at the moment of the announcement, and `sign(surprise)` carries no information from the `[T, T+5]` window the target measures.
+
+### Edge case: |surprise| < epsilon
+
+Pause / no-change meetings where the FOMC matches the strictly-prior expectation exactly have `mp_surprise_level ≈ 0`. The projection direction is ill-defined (the unit vector divides by zero) and any signed projection would be a coin flip. We gate at `|mp_surprise_level| < 1.0 bp` (`SURPRISE_DIRECTION_EPSILON_BPS`) and mark the target *missing* rather than zero. Coercing to zero would inject a fake "no FOMC-attributable component" label on every pause meeting and bias the head's regression toward the origin; the existing `bps_mask` machinery in `build_partition_rates_targets` already handles missing rows row-by-row so the masking is free.
+
+The 1-bp threshold is well below the FOMC's 25-bp standard move and an order of magnitude above floating-point noise in the strict-prior implied-move proxy.
+
+### Wiring
+
+- A new `ModelConfig.rates_target_mode` field with values `"raw"` (default, byte-identical to pre-#305) and `"fomc_attributable"` selects the derivation. The mode applies uniformly to every mounted rates head; per-head mode-mixing was deferred so the CLI surface stays one knob deep.
+- Three new `FeatureVector.target_yield_*_change_5d_fomc_attributable` fields carry the projected target per event row, populated by the training-package loader alongside the existing raw targets. The loader computes the projection once per event from the strict-prior `mp_surprise_level` and writes the projected scalar (or `None` for ill-defined surprises) onto every per-bar vector in the supervised sequence; only the target row is read downstream.
+- `_rates_field_for(head, target_mode=...)` returns either `target_yield_<tenor>_change_5d` or `target_yield_<tenor>_change_5d_fomc_attributable`; `build_partition_rates_targets(..., target_mode=...)` plumbs the mode through to the gather step. The per-fold standardiser (`fit_rates_scaler`) fits on the projected values when the mode flips, and val / test partitions reuse the train-fitted scaler so no look-ahead leaks into the standardisation step.
+- A new `--rates-target-mode` CLI flag on `app.train_forecaster` forwards the choice into `ModelConfig`. The default `"raw"` keeps the pre-#305 path byte-identical for every caller that does not opt in.
+
+The evaluation surface (per-head `mae_bps` / `dir_acc` / `R²` with block-bootstrap CIs from `app.evaluation.regression_metrics`) does not change — the metrics still measure the head's prediction against the supervised target in bps, but the target itself is the FOMC-attributable component when the new mode is active. Side-by-side comparisons against the raw-mode headline live on the per-head metric block; the canonical comparison is the operator-run sweep against `--rates-target-mode=fomc_attributable`.
+
+## Alternatives considered
+
+**Raw move + post-hoc decomposition.** Keep training against the raw observed move, then decompose the prediction at inference time against the surprise direction. Rejected: the post-hoc decomposition is identity-on-the-output, so the head's loss surface and gradient flow stay tuned to the noisy raw move; the model has no incentive to focus on the FOMC-attributable component during training. The whole point of #305 is to *change the loss*, not the reporting frame.
+
+**Predict both heads jointly.** Mount two regression heads per tenor — one for the raw move, one for the projection — and train them jointly. Rejected: doubles the rates parameter count and the loss-mixing surface (every head now has its own alpha mixing with the joint loss). The methodology lift over picking one target is unclear, and the comparison sweep against `--rates-target-mode=raw` already gives the side-by-side numbers without the parameter blow-up.
+
+**Project onto the full 2-D surprise vector (level + path).** Use `(mp_surprise_level, mp_surprise_path_factor)` as a 2-D surprise direction and project the observed move onto it. Considered, but the observed move is a 1-D scalar per head (`yield_<tenor>_change_5d`), so a 2-D direction has no second axis to project onto without coupling the three heads. The natural multi-dimensional extension is the GSS-style "across the curve" projection, which would mount one head per surprise factor rather than one per tenor. That is a larger architectural change and is parked.
+
+**Use the standard CME-implied surprise window `(post − pre)` over a 30-minute window around the announcement.** Rejected: the post-#350 audit explicitly closed the `[T-1, T+1]` window in the surprise construction (ADR 0024). Using the 30-minute window would reintroduce a `T+ε` read into the surprise quantity and undo the strict-prior contract. The strict-prior version is the one a forecaster scoring at `T-0` can actually compute.
+
+**Sign the projection by `mp_surprise_path_factor` instead of `mp_surprise_level`.** The path factor captures curve-shape surprise; the level factor captures the immediate-policy surprise. Both could plausibly anchor the direction. We pick level because the literature (Kuttner) anchors there and because the 5-day forward horizon the heads supervise is dominated by the near-end of the curve where the level surprise has the bigger reaction. The path-anchored variant is a follow-up if the level variant ships.
+
+## Consequences
+
+### Methodology
+
+The headline framing shifts honestly. Pre-#305: "the model predicts the post-FOMC 5-day rates move." Post-#305 with `--rates-target-mode=fomc_attributable`: "the model predicts the FOMC-attributable component of the 5-day rates move — the part of the move that policy-watchers actually care about." That second framing is the one the literature uses and is the one a Fed-watcher product surface should lead with.
+
+The R² numbers between the two modes are not directly comparable. The fomc-attributable target has a smaller raw variance than the unprojected move (because the projection collapses any non-FOMC variance into a residual we discard), so R² values may be higher in the new mode without any actual lift in predictive power — the denominator changed. The mae-bps and dir-acc metrics remain comparable across modes (both in raw bps units), but the interpretation shifts: dir-acc in fomc-attributable mode is "did the model correctly predict whether the move agreed with the surprise direction?", not "did the model correctly predict the move sign."
+
+### Model + sweep
+
+The default `--rates-target-mode=raw` is byte-identical to the pre-#305 path. Existing callers, the canonical determinism regression, and the reproducibility-smoke CI smoke all stay green without changes. Opting in requires the explicit flag.
+
+A canonical-comparison sweep against `--rates-target-mode=fomc_attributable` is a Runpod job (operator-run via `make canonical-comparison TARGET_MODE=fomc_attributable` once code lands). This PR ships the code path, not the headline cell. The sweep is not a merge gate.
+
+### Reproducibility
+
+The new column lands on the `FeatureVector` dataclass with `None` defaults. The dataclass shape changes (three new fields), but `as_rich_list` does not include any of them — they ride on the target row only — so the rich-feature input tensor shape stays at 35 dims and the per-fold RobustScaler fit is byte-identical. Pre-#305 checkpoints deserialise into `rates_target_mode="raw"` via the `ModelConfig.from_model` fallback path (the new field has a default).
+
+The strict-prior contract on the projection direction is enforced upstream by ADR 0024 — this ADR consumes that contract rather than duplicating it. The post-#350 `feature-provenance-audit.md` documents `mp_surprise_level` as strict-prior; the new projected targets inherit that gate by construction and are themselves strictly `<` event_date in the sense that the *direction* is determined strictly before the event, with only the post-event observed move scaled by that direction.
+
+### Reviewer focus
+
+- Does the projection helper correctly mark the surprise-zero case as missing (not zero)? The unit test `test_fomc_attributable_projection_pause_meeting_marks_missing` pins this.
+- Does the per-fold standardiser fit on the train slice only when the new mode is active? Yes — `build_partition_rates_targets` accepts the `target_mode` argument and forwards it to the gather step, but the train/val/test scaler-reuse contract is identical to the raw-mode path. The unit test `test_build_partition_rates_targets_fomc_attributable_uses_train_scaler` pins this.
+- Is the default `--rates-target-mode=raw` byte-identical to the pre-#305 path? Yes — the default mode reads the same `target_yield_<tenor>_change_5d` field the pre-#305 build path read, and the per-fold builder takes the same code path. The smoke test `test_train_model_smoke_rates_target_mode_raw_byte_identical` would not be cheap to write as a true byte-identical assertion (the model weights diverge with seed micro-variation), so we settle for "default mode runs to completion and the persisted ModelConfig records rates_target_mode='raw'."
+
+### Submission-time framing
+
+The thesis framing is honest. This is a methodology contribution: a literature-mapped re-derivation of the supervised target so the head's loss is aligned with what a Fed-watcher actually wants to predict. It is *not* expected to beat the raw target on R² (the denominators differ); the case for it is interpretability and theoretical motivation, not headline accuracy. The §16 comparison table reports both modes side-by-side and lets the reader judge.

--- a/docs/feature-provenance-audit.md
+++ b/docs/feature-provenance-audit.md
@@ -66,6 +66,9 @@ itself a documented training target.
 | `target_yield_2y_change_5d` | `data.rates_event_features.forward_yield_change_bps` (t → t+5) | **`T+Δ`, future-derived** | none (target) | rates-head training target. Same broadcast-but-not-emitted pattern as `forward_realized_vol_10d`; not in `as_rich_list` output, only read off the target row by `app.training.rates_targets.build_partition_rates_targets`. |
 | `target_yield_5y_change_5d` | same as above (5y tenor) | **`T+Δ`, future-derived** | none (target) | rates-head training target; same storage / emission contract. |
 | `target_terminal_rate_change_5d` | same as above (terminal-rate proxy) | **`T+Δ`, future-derived** | none (target) | rates-head training target; same storage / emission contract. |
+| `target_yield_2y_change_5d_fomc_attributable` | 1-D projection of the observed 2y bps move onto `sign(mp_surprise_level)` (strict-prior, post-#350) | **`T+Δ`, future-derived** | none (target) | #305 surprise-decomposition target. Computed in `app.training.loaders` from the observed move scaled by the strict-prior surprise direction; `None` when `|mp_surprise_level| < 1.0 bp` (no-change meetings; direction ill-defined). Same broadcast-but-not-emitted contract as the raw siblings; only the target row is read by `build_partition_rates_targets`. See ADR 0027. |
+| `target_yield_5y_change_5d_fomc_attributable` | same as above (5y tenor) | **`T+Δ`, future-derived** | none (target) | #305 surprise-decomposition target; same storage / emission contract. |
+| `target_terminal_rate_change_5d_fomc_attributable` | same as above (terminal-rate proxy) | **`T+Δ`, future-derived** | none (target) | #305 surprise-decomposition target; same storage / emission contract. |
 | `text_embedding_pooled` | `loaders._compute_prior4_pooled_embedding` (softmax-weighted mean of the four most recent statements with date strictly `< T`) | `T-Δ` | none | the pool is the four prior statements only; the as-of document itself is excluded from the pool (`prior_text_hashes` are statement dates `< event_date`). |
 | `text_embedding_missing` | loader flag on the pooled-embedding lookup | n/a | none | structural mask, no leakage surface. |
 | `text_per_bar` | `loaders.build_per_bar_text_tensor` (per-bar pooled-text payload aligned to each lookback bar's date; falls back to tile-replicating `text_embedding_pooled` when no per-bar pool is attached) | `T-Δ` (prior FOMC docs only) | none | issue #327 Arm A. Each bar's row reads from the prior-N FOMC documents aligned to that bar's calendar date; bars are emitted on calendar dates strictly `< T` and the fallback reuses the pooled vector that is itself a function of prior statements only. Default `None` collapses the per-bar slot to the broadcast-zero path. |
@@ -132,7 +135,8 @@ keep-with-caveat alternative.
 No other `FeatureVector` column reads from a source post-dating
 `row.event_date` beyond the documented training-target columns
 (`forward_realized_vol_10d`, `target_yield_2y_change_5d`,
-`target_yield_5y_change_5d`, `target_terminal_rate_change_5d`).
+`target_yield_5y_change_5d`, `target_terminal_rate_change_5d`, and the
+three `_fomc_attributable` projections added under #305).
 
 ## Regression test
 

--- a/tests/regression/test_feature_provenance_as_of.py
+++ b/tests/regression/test_feature_provenance_as_of.py
@@ -78,6 +78,12 @@ _TARGET_ONLY_COLUMNS: tuple[str, ...] = (
     "target_yield_2y_change_5d",
     "target_yield_5y_change_5d",
     "target_terminal_rate_change_5d",
+    # #305 FOMC-attributable projections of the three forward 5d rates
+    # moves. Same target-only contract as the raw siblings; only the
+    # event row carries the projected scalar.
+    "target_yield_2y_change_5d_fomc_attributable",
+    "target_yield_5y_change_5d_fomc_attributable",
+    "target_terminal_rate_change_5d_fomc_attributable",
 )
 
 # Columns declared `T (snapshot)` — document-level signals broadcast to

--- a/tests/unit/test_rates_target_fomc_attributable.py
+++ b/tests/unit/test_rates_target_fomc_attributable.py
@@ -428,3 +428,59 @@ def test_train_model_smoke_rates_target_mode_raw_default() -> None:
     assert result.summary.epochs_completed == 1
     persisted_config = ModelConfig.from_model(result.model)
     assert persisted_config.rates_target_mode == "raw"
+
+
+def test_loader_mp_surprise_lookup_loaded_regardless_of_rich_features(
+    monkeypatch,
+) -> None:
+    """The mp_surprise lookup feeds the fomc-attributable rates-target
+    projection on every event, not just on rich-feature input columns.
+    A pre-#305-style guard that only loaded the lookup under
+    ``rich_features=True`` would silently null every projection when
+    a caller passed ``--no-rich-features --rates-target-mode=fomc_attributable``,
+    leaving the rates heads to train on zero rows with no error. Pin
+    the contract so a future loader refactor cannot regress it.
+    """
+
+    import app.training.loaders as loaders
+
+    call_log: list[str] = []
+
+    original = loaders._read_mp_surprise_lookup
+
+    def _spy(package_dir):
+        call_log.append(str(package_dir))
+        return original(package_dir)
+
+    monkeypatch.setattr(loaders, "_read_mp_surprise_lookup", _spy)
+
+    # Inspect both loader entry points by AST -- a full end-to-end
+    # invocation needs a real training package on disk. The contract
+    # we are pinning is "the lookup load site is outside the
+    # rich_features guard", which is statically observable in the
+    # source. The spy above is here so a future test that swaps in a
+    # fixture package can drop the source-string assertion and rely
+    # on the call log instead.
+    src = (
+        __import__("pathlib").Path(loaders.__file__).read_text(encoding="utf-8")
+    )
+    # The unconditional lookup call must appear in both
+    # `_load_package_sequences_with_metadata` and the legacy
+    # `load_training_sequences_from_package` loader, NOT inside an
+    # `if rich_features:` block above them.
+    assert src.count("_read_mp_surprise_lookup(") >= 3, (
+        "expected at least 3 references to _read_mp_surprise_lookup "
+        "(definition + two unconditional loader call sites)"
+    )
+    # Heuristic guard: there must NOT be a sequence where the
+    # rich_features block contains a `_read_mp_surprise_lookup` call.
+    rich_blocks = src.split("if rich_features:")
+    for block in rich_blocks[1:]:
+        # only inspect the block immediately following the guard
+        snippet = block.split("\n\n", 1)[0]
+        assert "_read_mp_surprise_lookup" not in snippet, (
+            "_read_mp_surprise_lookup must not live inside an "
+            "`if rich_features:` block -- the fomc-attributable target "
+            "projection depends on the lookup being loaded "
+            "unconditionally"
+        )

--- a/tests/unit/test_rates_target_fomc_attributable.py
+++ b/tests/unit/test_rates_target_fomc_attributable.py
@@ -1,0 +1,411 @@
+"""FOMC-attributable rates target wiring (#305).
+
+The new ``rates_target_mode='fomc_attributable'`` path projects the
+observed 5d rates move onto the strict-prior policy-surprise direction
+``sign(mp_surprise_level)`` and supervises the rates heads against the
+projected scalar. These tests pin the surface at four layers:
+
+- the projection helper (hand-computable fixture; pause-meeting edge
+  case marks the target missing);
+- the per-fold target builder (the new mode reads the
+  ``_fomc_attributable`` FeatureVector field and standardises on the
+  train slice only; val / test reuse the train scaler);
+- ``ModelConfig.rates_target_mode`` round-trips through the dataclass
+  field-name machinery in ``_coerce_model_config``;
+- a 1-epoch smoke through ``train_model`` runs to completion with
+  ``rates_target_mode='fomc_attributable'`` and persists the mode on
+  the run summary's ``ModelConfig``.
+
+See ADR 0027 for the projection definition.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import math
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.config import FeatureVector, ModelConfig  # noqa: E402
+from app.training.loop import train_model  # noqa: E402
+from app.training.rates_targets import (  # noqa: E402
+    DEFAULT_RATES_TARGET_MODE,
+    RATES_TARGET_MODES,
+    SURPRISE_DIRECTION_EPSILON_BPS,
+    _rates_field_for,
+    build_partition_rates_targets,
+    fomc_attributable_projection,
+)
+
+
+# ---------------------------------------------------------------------------
+# Projection helper
+# ---------------------------------------------------------------------------
+
+
+def test_projection_hawkish_surprise_signs_positive() -> None:
+    """Observed +10 bps move with +25 bps hawkish surprise -> +10 bps target.
+
+    The 1-D projection keeps the magnitude and signs it relative to the
+    surprise direction. A positive scalar means the observed move agreed
+    with the surprise (hawkish surprise -> yields up was the agreement).
+    """
+
+    assert fomc_attributable_projection(10.0, 25.0) == pytest.approx(10.0)
+
+
+def test_projection_dovish_surprise_signs_observation() -> None:
+    """Observed +10 bps move with -25 bps dovish surprise -> -10 bps target.
+
+    The model now predicts a negative attributable component, encoding
+    "yields rose but the surprise was dovish -> the move opposed the
+    surprise direction."
+    """
+
+    assert fomc_attributable_projection(10.0, -25.0) == pytest.approx(-10.0)
+
+
+def test_projection_negative_observation_dovish_surprise() -> None:
+    """Observed -8 bps move with -12 bps dovish surprise -> +8 bps target.
+
+    Both factors flip sign; the projection magnitude survives unchanged
+    and the sign agrees with the surprise direction (negative move,
+    negative surprise -> positive attributable component).
+    """
+
+    assert fomc_attributable_projection(-8.0, -12.0) == pytest.approx(8.0)
+
+
+def test_projection_pause_meeting_marks_missing() -> None:
+    """No-change meeting (|surprise| < epsilon) returns None, not zero.
+
+    Coercing the pause-meeting target to zero would inject a fake
+    "no FOMC-attributable component" label across every pause and bias
+    the regression toward the origin. The gate fires below the 1-bp
+    epsilon.
+    """
+
+    assert SURPRISE_DIRECTION_EPSILON_BPS == 1.0
+    # |surprise| = 0 -> direction ill-defined.
+    assert fomc_attributable_projection(15.0, 0.0) is None
+    # Below the epsilon -> still missing.
+    assert fomc_attributable_projection(15.0, 0.5) is None
+    assert fomc_attributable_projection(15.0, -0.5) is None
+    # At the epsilon boundary the gate releases (>= 1.0 bp passes).
+    assert fomc_attributable_projection(15.0, 1.0) == pytest.approx(15.0)
+
+
+def test_projection_none_inputs_propagate_missing() -> None:
+    """Either None input collapses to None so the loader masks the row."""
+
+    assert fomc_attributable_projection(None, 25.0) is None
+    assert fomc_attributable_projection(10.0, None) is None
+    assert fomc_attributable_projection(None, None) is None
+
+
+def test_projection_non_finite_inputs_collapse_to_missing() -> None:
+    """NaN / inf surprises or moves emit None rather than propagating."""
+
+    assert fomc_attributable_projection(float("nan"), 25.0) is None
+    assert fomc_attributable_projection(10.0, float("nan")) is None
+    assert fomc_attributable_projection(float("inf"), 25.0) is None
+    assert fomc_attributable_projection(10.0, float("inf")) is None
+
+
+def test_rates_field_for_dispatch_on_target_mode() -> None:
+    """``_rates_field_for`` returns the right FeatureVector attribute name."""
+
+    assert _rates_field_for("2y") == "target_yield_2y_change_5d"
+    assert _rates_field_for("2y", target_mode="raw") == "target_yield_2y_change_5d"
+    assert (
+        _rates_field_for("2y", target_mode="fomc_attributable")
+        == "target_yield_2y_change_5d_fomc_attributable"
+    )
+    assert (
+        _rates_field_for("terminal", target_mode="fomc_attributable")
+        == "target_terminal_rate_change_5d_fomc_attributable"
+    )
+
+
+def test_rates_target_modes_canonical_tuple() -> None:
+    """The literal vocabulary is pinned at the module level."""
+
+    assert RATES_TARGET_MODES == ("raw", "fomc_attributable")
+    assert DEFAULT_RATES_TARGET_MODE == "raw"
+
+
+def test_build_partition_rates_targets_rejects_unknown_target_mode() -> None:
+    """A typo in target_mode raises rather than silently dropping the head."""
+
+    with pytest.raises(ValueError, match="rates_target_mode"):
+        build_partition_rates_targets(
+            sequence_groups=[],
+            head_names=("2y",),
+            target_mode="kuttner",
+        )
+
+
+def test_rates_field_for_rejects_unknown_target_mode() -> None:
+    with pytest.raises(ValueError, match="rates_target_mode"):
+        _rates_field_for("2y", target_mode="kuttner")
+
+
+# ---------------------------------------------------------------------------
+# Per-fold target builder
+# ---------------------------------------------------------------------------
+
+
+def _dummy_feature_vector(
+    *,
+    day: int,
+    vol: float,
+    raw_2y: float = 0.0,
+    raw_5y: float = 0.0,
+    raw_terminal: float = 0.0,
+    fomc_2y: float | None = None,
+    fomc_5y: float | None = None,
+    fomc_terminal: float | None = None,
+) -> FeatureVector:
+    fv = FeatureVector(
+        date=str(_dt.date(2025, 1, 1) + _dt.timedelta(days=day - 1)),
+        sentiment_score=0.0,
+        market_close=100.0,
+        market_volatility=0.01,
+        close_change_pct=0.0,
+        volatility_change=0.0,
+        elapsed_time=0.0,
+        forward_realized_vol_10d=vol,
+    )
+    fv.target_yield_2y_change_5d = raw_2y
+    fv.target_yield_5y_change_5d = raw_5y
+    fv.target_terminal_rate_change_5d = raw_terminal
+    fv.target_yield_2y_change_5d_fomc_attributable = fomc_2y
+    fv.target_yield_5y_change_5d_fomc_attributable = fomc_5y
+    fv.target_terminal_rate_change_5d_fomc_attributable = fomc_terminal
+    return fv
+
+
+def _make_walk_forward_groups(
+    n: int = 30,
+    *,
+    populate_fomc: bool = True,
+) -> list[list[FeatureVector]]:
+    return [
+        [
+            _dummy_feature_vector(
+                day=i + 1,
+                vol=0.01 + 0.001 * i,
+                raw_2y=float(2 * i - 20),
+                raw_5y=float(1.5 * i - 15),
+                raw_terminal=float(i - 10),
+                fomc_2y=float(abs(2 * i - 20)) if populate_fomc else None,
+                fomc_5y=float(abs(1.5 * i - 15)) if populate_fomc else None,
+                fomc_terminal=float(abs(i - 10)) if populate_fomc else None,
+            )
+            for i in range(n)
+        ]
+    ]
+
+
+def test_build_partition_rates_targets_fomc_attributable_reads_projected_field() -> None:
+    """The new mode pulls supervised values off the ``_fomc_attributable`` field.
+
+    Builds two side-by-side partitions from the same group fixture, one
+    in raw mode and one in fomc-attributable mode. The fixture's
+    ``_fomc_attributable`` values are the absolute value of the raw
+    ones, so the per-fold scaler fitted under the new mode picks up a
+    different mean than the raw-mode fit and the standardised tensor
+    diverges.
+    """
+
+    groups = _make_walk_forward_groups(n=30, populate_fomc=True)
+    raw_bps, _, _, _, raw_scalers, _ = build_partition_rates_targets(
+        groups, head_names=("2y",), target_mode="raw"
+    )
+    fomc_bps, _, _, _, fomc_scalers, _ = build_partition_rates_targets(
+        groups, head_names=("2y",), target_mode="fomc_attributable"
+    )
+    # Mean of the raw 2y series is ~9.0 (signed); mean of |raw| is ~10.5.
+    # The two scalers must therefore differ.
+    assert raw_scalers["2y"].mean != fomc_scalers["2y"].mean
+    # The standardised tensors must agree on row count (the row filter
+    # is the same -- forward_realized_vol_10d gate).
+    assert raw_bps["2y"].shape == fomc_bps["2y"].shape
+
+
+def test_build_partition_rates_targets_fomc_attributable_uses_train_scaler() -> None:
+    """Val / test partitions reuse the train-fitted scaler under the new mode."""
+
+    train_groups = _make_walk_forward_groups(n=30, populate_fomc=True)
+    val_groups = _make_walk_forward_groups(n=20, populate_fomc=True)
+    _, _, _, _, train_scalers, train_edges = build_partition_rates_targets(
+        train_groups,
+        head_names=("2y",),
+        target_mode="fomc_attributable",
+    )
+    _, _, _, _, val_scalers, val_edges = build_partition_rates_targets(
+        val_groups,
+        head_names=("2y",),
+        scalers=train_scalers,
+        edges_by_head=train_edges,
+        target_mode="fomc_attributable",
+    )
+    assert val_scalers["2y"] == train_scalers["2y"]
+    assert val_edges["2y"].lower == train_edges["2y"].lower
+
+
+def test_build_partition_rates_targets_fomc_attributable_masks_missing_rows() -> None:
+    """Rows whose projected target is None are masked out, not coerced to zero.
+
+    Builds a group whose first half carries a valid projection and
+    whose second half has no surprise direction (None); the resulting
+    bps_mask must be True only on the populated rows.
+    """
+
+    groups = [
+        [
+            _dummy_feature_vector(
+                day=i + 1,
+                vol=0.01 + 0.001 * i,
+                raw_2y=float(2 * i - 20),
+                fomc_2y=float(abs(2 * i - 20)) if i < 25 else None,
+            )
+            for i in range(30)
+        ]
+    ]
+    _, bps_mask, _, _, _, _ = build_partition_rates_targets(
+        groups, head_names=("2y",), target_mode="fomc_attributable"
+    )
+    mask = bps_mask["2y"]
+    # First N rows populated; remaining masked False.
+    populated = int(mask.sum().item())
+    assert populated > 0
+    assert populated < mask.numel()
+
+
+# ---------------------------------------------------------------------------
+# ModelConfig round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_model_config_default_rates_target_mode_is_raw() -> None:
+    """Pre-#305 defaults persist; explicit opt-in only flips the flag."""
+
+    config = ModelConfig()
+    assert config.rates_target_mode == "raw"
+
+
+def test_model_config_rates_target_mode_round_trip_through_coerce() -> None:
+    """A dict-payload checkpoint round-trips the new field via the field-name machinery."""
+
+    from app.training.loop import _coerce_model_config
+
+    payload = {
+        "rates_heads": ["2y"],
+        "rates_head_mode": "regression",
+        "rates_alpha": 0.5,
+        "rates_target_mode": "fomc_attributable",
+        "output_mode": "classification",
+        "head_mode": "classification",
+    }
+    rebuilt = _coerce_model_config(payload)
+    assert rebuilt.rates_target_mode == "fomc_attributable"
+    assert rebuilt.rates_heads == ("2y",)
+
+
+# ---------------------------------------------------------------------------
+# Smoke training run
+# ---------------------------------------------------------------------------
+
+
+def test_train_model_smoke_rates_target_mode_fomc_attributable() -> None:
+    """1-epoch training run with the new mode completes and records the mode.
+
+    The smoke uses an in-memory fixture (no parquet I/O) so it runs
+    under a second on CPU. The `_fomc_attributable` fields are
+    pre-populated on the FeatureVectors; the per-fold target builder
+    must pick them up and the run must complete without crashing on
+    the new code path.
+    """
+
+    groups = _make_walk_forward_groups(n=40, populate_fomc=True)
+    config = ModelConfig(
+        output_mode="classification",
+        n_classes=3,
+        hidden_size=16,
+        head_hidden_size=8,
+        rates_heads=("2y",),
+        rates_head_mode="regression",
+        rates_alpha=0.5,
+        rates_target_mode="fomc_attributable",
+    )
+    result = train_model(
+        model_config=config,
+        train_sequence_groups=groups,
+        val_sequence_groups=groups,
+        test_sequence_groups=groups,
+        epochs=1,
+        batch_size=8,
+        seed=11,
+        save_checkpoint=False,
+        use_compile=False,
+        use_amp=False,
+    )
+    assert result.summary.epochs_completed == 1
+    # The persisted ModelConfig must record the active target mode so
+    # downstream consumers (the §16 comparison table, the checkpoint
+    # auditor) can verify which target the head trained against.
+    persisted_config = ModelConfig.from_model(result.model)
+    assert persisted_config.rates_target_mode == "fomc_attributable"
+    # Per-head metrics still emit -- the surface is unchanged, only the
+    # supervised target shifted.
+    metrics = result.summary.metrics
+    assert metrics is not None
+    assert metrics.rates_metrics is not None
+    assert "2y" in metrics.rates_metrics
+    payload = metrics.rates_metrics["2y"]
+    # The mae_bps panel must have a finite point estimate; if every
+    # row got masked the panel would be None and the per-head metric
+    # block on the comparison sweep would be empty.
+    assert payload["n_rows"] > 0
+    mae = payload["mae_bps"]
+    assert mae is not None
+    assert math.isfinite(mae["point"])
+
+
+def test_train_model_smoke_rates_target_mode_raw_default() -> None:
+    """Default ``rates_target_mode='raw'`` runs the pre-#305 path.
+
+    Verifies the default opt-out semantics: an unset / 'raw' flag
+    reads the raw observed-move target, and the persisted config
+    records ``raw`` so an auditor can tell raw runs from opt-in runs.
+    """
+
+    groups = _make_walk_forward_groups(n=40, populate_fomc=False)
+    config = ModelConfig(
+        output_mode="classification",
+        n_classes=3,
+        hidden_size=16,
+        head_hidden_size=8,
+        rates_heads=("2y",),
+        rates_head_mode="regression",
+        rates_alpha=0.5,
+        # rates_target_mode defaults to 'raw'.
+    )
+    result = train_model(
+        model_config=config,
+        train_sequence_groups=groups,
+        val_sequence_groups=groups,
+        test_sequence_groups=groups,
+        epochs=1,
+        batch_size=8,
+        seed=11,
+        save_checkpoint=False,
+        use_compile=False,
+        use_amp=False,
+    )
+    assert result.summary.epochs_completed == 1
+    persisted_config = ModelConfig.from_model(result.model)
+    assert persisted_config.rates_target_mode == "raw"

--- a/tests/unit/test_rates_target_fomc_attributable.py
+++ b/tests/unit/test_rates_target_fomc_attributable.py
@@ -192,17 +192,33 @@ def _make_walk_forward_groups(
     *,
     populate_fomc: bool = True,
 ) -> list[list[FeatureVector]]:
+    """Build a walk-forward group whose supervised rows (i >= 20) span
+    both signs of the raw bps move, so the standardiser fit under
+    ``raw`` and ``fomc_attributable`` modes lands on materially different
+    means (abs() collapses the negatives onto positives).
+    """
+
+    def _raw_2y(i: int) -> float:
+        # i in [20, 29] -> values [-9, -7, ..., 9]; mean 0, mean(|.|) = 5.
+        return float(2 * (i - 24) - 1)
+
+    def _raw_5y(i: int) -> float:
+        return float(1.5 * (i - 24) - 2)
+
+    def _raw_terminal(i: int) -> float:
+        return float((i - 24) - 1)
+
     return [
         [
             _dummy_feature_vector(
                 day=i + 1,
                 vol=0.01 + 0.001 * i,
-                raw_2y=float(2 * i - 20),
-                raw_5y=float(1.5 * i - 15),
-                raw_terminal=float(i - 10),
-                fomc_2y=float(abs(2 * i - 20)) if populate_fomc else None,
-                fomc_5y=float(abs(1.5 * i - 15)) if populate_fomc else None,
-                fomc_terminal=float(abs(i - 10)) if populate_fomc else None,
+                raw_2y=_raw_2y(i),
+                raw_5y=_raw_5y(i),
+                raw_terminal=_raw_terminal(i),
+                fomc_2y=abs(_raw_2y(i)) if populate_fomc else None,
+                fomc_5y=abs(_raw_5y(i)) if populate_fomc else None,
+                fomc_terminal=abs(_raw_terminal(i)) if populate_fomc else None,
             )
             for i in range(n)
         ]
@@ -259,9 +275,10 @@ def test_build_partition_rates_targets_fomc_attributable_uses_train_scaler() -> 
 def test_build_partition_rates_targets_fomc_attributable_masks_missing_rows() -> None:
     """Rows whose projected target is None are masked out, not coerced to zero.
 
-    Builds a group whose first half carries a valid projection and
-    whose second half has no surprise direction (None); the resulting
-    bps_mask must be True only on the populated rows.
+    Builds a group whose first 5 emitted rows carry a valid projection
+    and whose last 5 emitted rows have no surprise direction (None);
+    the resulting bps_mask must be True only on the populated rows so
+    the per-fold scaler ignores the missing entries.
     """
 
     groups = [
@@ -270,6 +287,8 @@ def test_build_partition_rates_targets_fomc_attributable_masks_missing_rows() ->
                 day=i + 1,
                 vol=0.01 + 0.001 * i,
                 raw_2y=float(2 * i - 20),
+                # Supervised rows are i in [20, 29]; populate the first
+                # five (i in [20, 24]) and leave the rest as None.
                 fomc_2y=float(abs(2 * i - 20)) if i < 25 else None,
             )
             for i in range(30)
@@ -279,10 +298,10 @@ def test_build_partition_rates_targets_fomc_attributable_masks_missing_rows() ->
         groups, head_names=("2y",), target_mode="fomc_attributable"
     )
     mask = bps_mask["2y"]
-    # First N rows populated; remaining masked False.
     populated = int(mask.sum().item())
-    assert populated > 0
-    assert populated < mask.numel()
+    # Five rows populated, five masked False.
+    assert populated == 5
+    assert int(mask.numel()) == 10
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #305.

Ships the code path for a Kuttner-style surprise-decomposition target on the rates heads. A new `--rates-target-mode={raw,fomc_attributable}` CLI flag on `app.train_forecaster` flips the supervised target from the observed 5d move in bps to its 1-D projection onto the strict-prior policy-surprise direction `sign(mp_surprise_level)` (post-#350 / ADR 0024). Pause meetings where `|surprise| < 1.0 bp` mark the target missing rather than zero so the regression is not biased toward the origin. Default mode is `raw` so the pre-#305 path is byte-identical for every caller that does not opt in.

- Projection helper + per-fold target builder + ModelConfig field + CLI flag + loader wiring across both training-package loader sites.
- Unit tests on the projection helper (hand-computable fixtures + pause-meeting edge), per-fold builder reuse of train-fitted scaler, and a 1-epoch smoke training run that asserts the persisted `ModelConfig.rates_target_mode` round-trips.
- ADR 0027 records the projection definition, the literature mapping (Kuttner 2001 / GSS 2005 / Cieslak-Vissing-Jorgensen 2021), and alternatives considered.
- Wiki §6.21 added; §13 row #305 flipped to in progress.

The canonical-comparison sweep against `--rates-target-mode=fomc_attributable` is an operator hand-off on Runpod (`make canonical-comparison TARGET_MODE=fomc_attributable`); the §16 table populates once the JSON lands. PR ships the code path, not the headline cell.

## Reviewer focus

- Surprise direction near-zero (no-change meetings) returns missing, not zero — `test_projection_pause_meeting_marks_missing` pins this.
- Per-fold standardisation fits on train slice only under the new mode — `test_build_partition_rates_targets_fomc_attributable_uses_train_scaler` pins this.
- Default `--rates-target-mode=raw` is byte-identical to the pre-#305 path — `test_train_model_smoke_rates_target_mode_raw_default` runs the legacy code path and asserts the persisted mode comes back as `raw`.
- The new column is documented as strictly < event_date by construction: the surprise direction comes from the post-#350 strict-prior `mp_surprise_level` (already audited in `docs/feature-provenance-audit.md`), and only the post-event observed move is scaled by that direction.