### PR TITLE
Resolve text_path_ab arm parity (#390)

### DIFF
--- a/backend/artifacts/experiments/text_path_ab_canonical.README.md
+++ b/backend/artifacts/experiments/text_path_ab_canonical.README.md
@@ -1,0 +1,38 @@
+# `text_path_ab_canonical.json` — why `per_bar` and `broadcast_static` match byte-for-byte
+
+The `per_bar` and `broadcast_static` arms in this artefact have **identical** per-trial metric values across all 25 cells (5 seeds × 5 folds) and **identical** summary stats. This is the genuine output of the sweep, not a copy-paste bug. The two arms collapse to the same forward computation under the current loader wiring.
+
+## Why the collapse is exact (not "close")
+
+The `per_bar` adapter call is stateless (Linear → LayerNorm → GELU, no dropout, no per-position state). When the per-bar input tensor `(B, T, in_dim)` carries the *same* pooled vector at every bar `t ∈ [0, T)`, the adapter emits the *same* projected vector at every bar — which is exactly the `(B, out_dim)` slot that `broadcast_static` produces and then `unsqueeze(1).expand(-1, T, -1)`s across the sequence axis. The two `prepare_recurrent_input` branches produce bit-equivalent `(B, T, lstm_input_size)` tensors before the recurrent core ever runs.
+
+The math is pinned by `test_per_bar_parity_with_broadcast_static_when_constant_across_bars` in `tests/unit/test_text_path_arms.py` — that test loads the same `state_dict` into both arms, runs a forward with a tile-replicated per-bar tensor, and asserts `allclose(atol=1e-6)`.
+
+## Why this canonical sweep tile-replicates
+
+Per ADR 0017 §"Arm A — per-bar text features":
+
+> Default smoke path: tile-replicate the prior-N FOMC pool across the lookback so the contract holds without a new corpus ingestion. A future per-day loader populates `text_per_bar` directly and slots into the same tensor.
+
+The canonical training package (`tp_v3_macro_aug_2026_05_25_fwd_strict_sentiment_market_core_v1.1_epv1_v1.0`) does not carry a populated `FeatureVector.text_per_bar` field. The `build_per_bar_text_tensor` helper in `backend/app/training/loaders.py` consequently falls back to its tile-replicate branch (the anchor's `text_embedding_pooled` repeated across every bar). The per-bar wiring is exercised end-to-end — model constructor, forward path, loader payload shape — but the input variance the recurrent core consumes is zero across the sequence axis, so the per-bar projection collapses to the broadcast-static projection.
+
+## What this means for §6.15
+
+The A/B null between `per_bar` and `broadcast_static` is the expected outcome given the canonical training package's text-per-bar payload. It is **not** evidence that the `per_bar` code path is broken; it is evidence that the input signal feeding it is identical to the broadcast-static signal. The honest framing in §6.15 is: "Arm A is plumbed end-to-end and produces byte-identical output to `broadcast_static` when fed a tile-replicated per-bar payload (the canonical training package's current state); a real per-bar A/B requires a daily-frequency text corpus the package does not yet ingest."
+
+## Regenerating
+
+This artefact is GPU-bound and was produced by `scripts/run_text_path_ab.py` on Runpod. If a future training package carries a populated `text_per_bar` field, regenerate with:
+
+```
+make text-path-ab TRAINING_PACKAGE_ID=<id>
+```
+
+The same parity test (`test_per_bar_parity_with_broadcast_static_when_constant_across_bars`) will continue to hold for tile-replicated inputs; the `per_bar` row of the artefact will start diverging from `broadcast_static` once the loader emits non-constant per-bar payloads.
+
+## Cross-references
+
+- ADR 0017 — `docs/adr/0017-text-path-architecture-decision.md`
+- Issue #327 (original A/B), #389 (per_bar constructor regression test), #390 (this audit).
+- `tests/unit/test_text_path_arms.py::test_per_bar_parity_with_broadcast_static_when_constant_across_bars` — invariant test.
+- `tests/regression/test_text_path_ab_artefact_parity.py` — artefact-level guard (added with this change).

--- a/tests/regression/test_text_path_ab_artefact_parity.py
+++ b/tests/regression/test_text_path_ab_artefact_parity.py
@@ -1,0 +1,116 @@
+"""Artefact-level guard for the `text_path_ab_canonical.json` parity claim (#390).
+
+The canonical sweep records the `per_bar` arm as byte-identical to the
+`broadcast_static` arm. That is the expected outcome under the current
+loader wiring: `build_per_bar_text_tensor` tile-replicates the anchor's
+pooled embedding across every lookback bar (ADR 0017 §"Arm A — per-bar
+text features"), and the per-bar adapter (Linear → LayerNorm → GELU)
+is stateless, so a tile-replicated `(B, T, in_dim)` input collapses to
+the same `(B, T, out_dim)` slot `broadcast_static` produces. The
+forward-level invariant is pinned in `tests/unit/test_text_path_arms.py`
+(`test_per_bar_parity_with_broadcast_static_when_constant_across_bars`).
+
+This regression test pins the *artefact-level* property: every per-trial
+metric value and every summary stat in the `per_bar` block must match
+its `broadcast_static` counterpart byte-for-byte. A regeneration that
+silently produces a different `per_bar` row without also flipping the
+loader contract is either a corpus change worth re-captioning §6.15 or
+a data-integrity bug worth investigating. Either way the test forces
+the conversation to happen at PR review.
+
+See `backend/artifacts/experiments/text_path_ab_canonical.README.md`
+for the architectural reasoning. See issue #390 for the audit.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARTEFACT_PATH = (
+    REPO_ROOT
+    / "backend"
+    / "artifacts"
+    / "experiments"
+    / "text_path_ab_canonical.json"
+)
+
+
+@pytest.fixture(scope="module")
+def artefact() -> dict[str, object]:
+    if not ARTEFACT_PATH.exists():
+        pytest.skip(f"sweep artefact missing at {ARTEFACT_PATH}")
+    return json.loads(ARTEFACT_PATH.read_text())
+
+
+def test_artefact_shape(artefact: dict[str, object]) -> None:
+    trials = artefact["trials"]
+    assert isinstance(trials, dict)
+    assert "broadcast_static" in trials and "per_bar" in trials
+    bs = trials["broadcast_static"]
+    pb = trials["per_bar"]
+    assert isinstance(bs, list) and isinstance(pb, list)
+    assert len(bs) == len(pb), (len(bs), len(pb))
+    assert len(bs) == 5, "canonical sweep pins 5 seeds"
+
+
+def test_per_bar_trials_byte_identical_to_broadcast_static(
+    artefact: dict[str, object],
+) -> None:
+    """Per-trial metrics in `per_bar` must equal `broadcast_static`.
+
+    See module docstring for the architectural reason. If this fails,
+    either the loader started emitting a non-constant per-bar payload
+    (in which case the §6.15 caption + the README next to the artefact
+    need a refresh) or the sweep produced inconsistent output (in which
+    case the regeneration is the bug).
+    """
+
+    trials = artefact["trials"]
+    bs = trials["broadcast_static"]
+    pb = trials["per_bar"]
+    for i, (b_trial, p_trial) in enumerate(zip(bs, pb)):
+        assert b_trial["seed"] == p_trial["seed"], (i, b_trial["seed"], p_trial["seed"])
+        b_folds = b_trial["folds"]
+        p_folds = p_trial["folds"]
+        assert len(b_folds) == len(p_folds), (i, len(b_folds), len(p_folds))
+        for j, (b_fold, p_fold) in enumerate(zip(b_folds, p_folds)):
+            assert b_fold["fold_id"] == p_fold["fold_id"], (i, j)
+            assert b_fold["metrics"] == p_fold["metrics"], (
+                f"trial {i} seed={b_trial['seed']} fold {j} ({b_fold['fold_id']}): "
+                f"per_bar diverges from broadcast_static — see "
+                f"backend/artifacts/experiments/text_path_ab_canonical.README.md"
+            )
+
+
+def test_per_bar_summary_identical_to_broadcast_static(
+    artefact: dict[str, object],
+) -> None:
+    summary = artefact["summary"]
+    bs = summary["broadcast_static"]
+    pb = summary["per_bar"]
+    assert bs == pb, (
+        "per_bar summary stats diverge from broadcast_static — "
+        "see backend/artifacts/experiments/text_path_ab_canonical.README.md"
+    )
+
+
+def test_per_bar_config_marks_arm_correctly(artefact: dict[str, object]) -> None:
+    """The arms collapse mathematically but the configs must still be distinct.
+
+    The per-trial parity is the result of the loader feeding identical
+    inputs to the two arms, not of the runner mis-labelling cells. The
+    `text_channel` config key must reflect the arm name so a future
+    auditor can re-derive which cell was meant to be which.
+    """
+
+    trials = artefact["trials"]
+    for trial in trials["broadcast_static"]:
+        assert trial["arm"] == "broadcast_static"
+        assert trial["config"]["text_channel"] == "scalar"
+    for trial in trials["per_bar"]:
+        assert trial["arm"] == "per_bar"
+        assert trial["config"]["text_channel"] == "per_bar"


### PR DESCRIPTION
Closes #390.

The `per_bar` and `broadcast_static` arms in `text_path_ab_canonical.json` are byte-identical across all 25 cells. Audit confirms this is the deliberate output of the canonical sweep, not a copy-paste bug: the canonical training package does not populate `FeatureVector.text_per_bar`, so `build_per_bar_text_tensor` falls back to its ADR-0017 tile-replicate path, and the stateless adapter collapses a tile-replicated `(B, T, in_dim)` input to the same slot `broadcast_static` produces. The forward-level invariant is already pinned by `test_per_bar_parity_with_broadcast_static_when_constant_across_bars`.

- `backend/artifacts/experiments/text_path_ab_canonical.README.md` — explains the math + the loader fallback to a future auditor.
- `tests/regression/test_text_path_ab_artefact_parity.py` — pins the artefact-level parity so a regeneration that breaks the invariant fails CI immediately.
- Wiki §6.15 caption rewritten to drop the "loader bug to audit" framing in favour of the honest "tile-replicate is the documented default; a real per-bar A/B needs a daily-frequency corpus the canonical package does not ingest yet".

Reviewer focus: the regression test assertions in `tests/regression/test_text_path_ab_artefact_parity.py` (especially `test_per_bar_trials_byte_identical_to_broadcast_static`) — if the canonical training package ever starts emitting per-bar variance, the test fails loudly and the §6.15 caption + the README need a refresh in lockstep. No code paths changed; the unit-level parity test was already in tree.