### PR TITLE
Thread #305/#306/#307 flags through canonical sweep runners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison text-path-ab per-family-ablation reproduce-all reproduce-smoke push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation reproduce-all reproduce-smoke push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -779,6 +779,44 @@ canonical-comparison:
 		--seeds 11 29 47 71 97 \
 		--epochs 40 \
 		--regression-alpha 0.5
+
+# #305 opt-in variant. Same canonical sweep with the FOMC-attributable
+# rates target. Output path is distinct so a #305 sweep can run
+# concurrently with the canonical sweep without overwriting it.
+canonical-comparison-fomc-attributable:
+	@if [ -z "$$TRAINING_PACKAGE_ID" ]; then echo "TRAINING_PACKAGE_ID required" >&2; exit 1; fi
+	docker compose run --rm backend python -m scripts.run_dual_head_comparison \
+		--training-package-id $$TRAINING_PACKAGE_ID \
+		--output artifacts/experiments/dual_head_comparison_post_305.json \
+		--seeds 11 29 47 71 97 \
+		--epochs 40 \
+		--regression-alpha 0.5 \
+		--rates-target-mode fomc_attributable
+
+# #306 opt-in variant. Attaches the 5-dim retrieval-analog summary
+# block to every supervised event. Distinct output path.
+canonical-comparison-retrieval-analogs:
+	@if [ -z "$$TRAINING_PACKAGE_ID" ]; then echo "TRAINING_PACKAGE_ID required" >&2; exit 1; fi
+	docker compose run --rm backend python -m scripts.run_dual_head_comparison \
+		--training-package-id $$TRAINING_PACKAGE_ID \
+		--output artifacts/experiments/dual_head_comparison_post_306.json \
+		--seeds 11 29 47 71 97 \
+		--epochs 40 \
+		--regression-alpha 0.5 \
+		--use-retrieval-analogs
+
+# #307 opt-in variant. Attaches the 3-scalar macro-regime block and
+# mounts the multiplicative gate over the rich-feature slice. Distinct
+# output path.
+canonical-comparison-regime-conditioning:
+	@if [ -z "$$TRAINING_PACKAGE_ID" ]; then echo "TRAINING_PACKAGE_ID required" >&2; exit 1; fi
+	docker compose run --rm backend python -m scripts.run_dual_head_comparison \
+		--training-package-id $$TRAINING_PACKAGE_ID \
+		--output artifacts/experiments/dual_head_comparison_post_307.json \
+		--seeds 11 29 47 71 97 \
+		--epochs 40 \
+		--regression-alpha 0.5 \
+		--use-regime-conditioning
 
 # #327 text-path A/B comparison. Runs the three configurations
 # (broadcast-static / per-bar / flat MLP) across the official seed set

--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -104,6 +104,60 @@ def _parse_args() -> argparse.Namespace:
             "fold_manifest_expanding_walk_forward.json."
         ),
     )
+    # #305 rates-head target derivation. Mirrors the same flag on
+    # ``app.train_forecaster`` (name + choices + default). ``raw`` keeps
+    # this runner byte-identical to the pre-#305 canonical sweep.
+    parser.add_argument(
+        "--rates-target-mode",
+        type=str,
+        choices=("raw", "fomc_attributable"),
+        default="raw",
+        help=(
+            "Rates-head target derivation. ``raw`` (default) keeps the "
+            "observed ``yield_<tenor>_change_5d`` bps move; "
+            "``fomc_attributable`` predicts the 1-D projection onto the "
+            "strict-prior policy-surprise direction. See ADR 0027."
+        ),
+    )
+    # #306 retrieval-augmented input features. Off by default so the
+    # canonical sweep stays byte-identical.
+    parser.add_argument(
+        "--use-retrieval-analogs",
+        dest="use_retrieval_analogs",
+        action="store_true",
+        help=(
+            "Attach the 5-dim retrieval-analog summary block to every "
+            "supervised event. Default off."
+        ),
+    )
+    parser.add_argument(
+        "--no-retrieval-analogs",
+        dest="use_retrieval_analogs",
+        action="store_false",
+        help="Disable the retrieval-analog block (default).",
+    )
+    # #307 macro-regime conditioning. Off by default so the canonical
+    # sweep stays byte-identical.
+    parser.add_argument(
+        "--use-regime-conditioning",
+        dest="use_regime_conditioning",
+        action="store_true",
+        help=(
+            "Attach the 3-scalar macro-regime indicator block and mount "
+            "the multiplicative gate over the rich-feature slice. "
+            "Default off."
+        ),
+    )
+    parser.add_argument(
+        "--no-regime-conditioning",
+        dest="use_regime_conditioning",
+        action="store_false",
+        help="Disable the macro-regime block + gate (default).",
+    )
+    parser.set_defaults(
+        use_retrieval_analogs=False,
+        use_regime_conditioning=False,
+    )
     return parser.parse_args()
 
 
@@ -169,6 +223,9 @@ def _run_one_cell(
     epochs: int,
     regression_alpha: float,
     hidden_size: int,
+    rates_target_mode: str = "raw",
+    use_retrieval_analogs: bool = False,
+    use_regime_conditioning: bool = False,
 ) -> dict[str, Any]:
     # Imports happen here so the script is importable without a torch
     # install (useful for doc-only environments).
@@ -183,6 +240,8 @@ def _run_one_cell(
         regression_alpha=regression_alpha,
         n_classes=3,
         hidden_size=hidden_size,
+        rates_target_mode=rates_target_mode,
+        use_regime_conditioning=use_regime_conditioning,
     )
 
     per_fold: list[dict[str, Any]] = []
@@ -191,6 +250,8 @@ def _run_one_cell(
             training_package_id=training_package_id,
             fold_id=fold_id,
             rich_features=True,
+            use_retrieval_analogs=use_retrieval_analogs,
+            use_regime_conditioning=use_regime_conditioning,
         )
         result = train_model(
             model_config=config,
@@ -244,6 +305,9 @@ def main() -> int:
                     epochs=args.epochs,
                     regression_alpha=args.regression_alpha,
                     hidden_size=args.hidden_size,
+                    rates_target_mode=str(args.rates_target_mode),
+                    use_retrieval_analogs=bool(args.use_retrieval_analogs),
+                    use_regime_conditioning=bool(args.use_regime_conditioning),
                 )
             )
 
@@ -272,6 +336,9 @@ def main() -> int:
         "epochs": args.epochs,
         "regression_alpha": args.regression_alpha,
         "training_package_id": args.training_package_id,
+        "rates_target_mode": str(args.rates_target_mode),
+        "use_retrieval_analogs": bool(args.use_retrieval_analogs),
+        "use_regime_conditioning": bool(args.use_regime_conditioning),
         "trials": trials,
         "summary": summary,
     }

--- a/scripts/run_per_family_ablation.py
+++ b/scripts/run_per_family_ablation.py
@@ -240,6 +240,65 @@ def _parse_args() -> argparse.Namespace:
             "Defaults to the canonical FOMC encoder."
         ),
     )
+    # #305 rates-head target derivation. Mirrors the flag on
+    # ``app.train_forecaster``; default ``raw`` keeps the per-family
+    # ablation byte-identical to the pre-#305 path.
+    parser.add_argument(
+        "--rates-target-mode",
+        type=str,
+        choices=("raw", "fomc_attributable"),
+        default="raw",
+        help=(
+            "Rates-head target derivation. ``raw`` (default) keeps the "
+            "observed yield change in bps; ``fomc_attributable`` "
+            "projects onto the strict-prior policy-surprise direction. "
+            "See ADR 0027."
+        ),
+    )
+    # #306 retrieval-augmented input features. The per-family ablation
+    # zeros document-level rich-feature families directly on the loaded
+    # FeatureVector slices; the retrieval-analog block lives in a
+    # separate per-bar slot, so the families and the analog block are
+    # orthogonal -- a cell that zeros ``linguistic`` does NOT zero the
+    # analog summary scalars, and ``zero_llm`` likewise leaves the
+    # analog block intact. Enabling the flag widens the per-bar feature
+    # surface for every cell in the sweep.
+    parser.add_argument(
+        "--use-retrieval-analogs",
+        dest="use_retrieval_analogs",
+        action="store_true",
+        help=(
+            "Attach the 5-dim retrieval-analog summary block. Default "
+            "off; the block is orthogonal to per-family zeroing."
+        ),
+    )
+    parser.add_argument(
+        "--no-retrieval-analogs",
+        dest="use_retrieval_analogs",
+        action="store_false",
+        help="Disable the retrieval-analog block (default).",
+    )
+    # #307 macro-regime conditioning. Off by default so the per-family
+    # ablation stays byte-identical to the pre-#307 path.
+    parser.add_argument(
+        "--use-regime-conditioning",
+        dest="use_regime_conditioning",
+        action="store_true",
+        help=(
+            "Attach the 3-scalar macro-regime block and mount the "
+            "multiplicative gate over the rich-feature slice. Default off."
+        ),
+    )
+    parser.add_argument(
+        "--no-regime-conditioning",
+        dest="use_regime_conditioning",
+        action="store_false",
+        help="Disable the macro-regime block + gate (default).",
+    )
+    parser.set_defaults(
+        use_retrieval_analogs=False,
+        use_regime_conditioning=False,
+    )
     return parser.parse_args()
 
 
@@ -422,6 +481,10 @@ def _run_one_cell(
         regression_alpha=float(args.regression_alpha),
         n_classes=3,
         hidden_size=int(args.hidden_size),
+        rates_target_mode=str(getattr(args, "rates_target_mode", "raw")),
+        use_regime_conditioning=bool(
+            getattr(args, "use_regime_conditioning", False)
+        ),
     )
 
     per_fold: list[dict[str, Any]] = []
@@ -431,6 +494,12 @@ def _run_one_cell(
             fold_id=fold_id,
             rich_features=True,
             text_encoder=str(args.text_encoder),
+            use_retrieval_analogs=bool(
+                getattr(args, "use_retrieval_analogs", False)
+            ),
+            use_regime_conditioning=bool(
+                getattr(args, "use_regime_conditioning", False)
+            ),
             **flags["loader"],
         )
         # Pre-scaler-fit zeroing for the per-bar families that the
@@ -558,6 +627,9 @@ def main() -> int:
         "bootstrap_seed": int(args.bootstrap_seed),
         "training_package_id": args.training_package_id,
         "text_encoder": str(args.text_encoder),
+        "rates_target_mode": str(args.rates_target_mode),
+        "use_retrieval_analogs": bool(args.use_retrieval_analogs),
+        "use_regime_conditioning": bool(args.use_regime_conditioning),
         "post_350_status": str(args.post_350_status),
         "cumulative_chain": [
             {"label": label, "families": list(families)}

--- a/tests/unit/test_run_dual_head_comparison.py
+++ b/tests/unit/test_run_dual_head_comparison.py
@@ -1,0 +1,327 @@
+"""Regression tests for the canonical sweep runners.
+
+Covers the #305 / #306 / #307 flag-threading contract:
+
+- The three new flags appear on both runners' argparsers with the same
+  names + choices + defaults as ``app.train_forecaster``.
+- The default-off path constructs the same ``ModelConfig`` + calls
+  ``load_walk_forward_split`` with the same kwargs as the pre-PR
+  canonical sweep (reproducibility-smoke #335 stays byte-identical).
+- The opt-in path forwards each flag through to the trainer call.
+
+The tests stub ``load_walk_forward_split`` and ``train_model`` so the
+runner can be exercised end-to-end without GPU or a real training
+package on disk.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# argparser surface contract
+# ---------------------------------------------------------------------------
+
+
+def test_dual_head_runner_exposes_new_flags(monkeypatch):
+    """The three new flags ship on the canonical sweep runner."""
+
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+        ],
+    )
+    args = _parse_args()
+    assert args.rates_target_mode == "raw"
+    assert args.use_retrieval_analogs is False
+    assert args.use_regime_conditioning is False
+
+
+def test_dual_head_runner_accepts_opt_in_flags(monkeypatch):
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+            "--rates-target-mode",
+            "fomc_attributable",
+            "--use-retrieval-analogs",
+            "--use-regime-conditioning",
+        ],
+    )
+    args = _parse_args()
+    assert args.rates_target_mode == "fomc_attributable"
+    assert args.use_retrieval_analogs is True
+    assert args.use_regime_conditioning is True
+
+
+def test_dual_head_runner_rejects_unknown_rates_target_mode(monkeypatch):
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+            "--rates-target-mode",
+            "definitely_not_a_mode",
+        ],
+    )
+    with pytest.raises(SystemExit):
+        _parse_args()
+
+
+def test_per_family_runner_exposes_new_flags(monkeypatch):
+    from scripts.run_per_family_ablation import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_per_family_ablation",
+            "--training-package-id",
+            "tp_dummy",
+        ],
+    )
+    args = _parse_args()
+    assert args.rates_target_mode == "raw"
+    assert args.use_retrieval_analogs is False
+    assert args.use_regime_conditioning is False
+
+
+def test_per_family_runner_accepts_opt_in_flags(monkeypatch):
+    from scripts.run_per_family_ablation import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_per_family_ablation",
+            "--training-package-id",
+            "tp_dummy",
+            "--rates-target-mode",
+            "fomc_attributable",
+            "--use-retrieval-analogs",
+            "--use-regime-conditioning",
+        ],
+    )
+    args = _parse_args()
+    assert args.rates_target_mode == "fomc_attributable"
+    assert args.use_retrieval_analogs is True
+    assert args.use_regime_conditioning is True
+
+
+# ---------------------------------------------------------------------------
+# trainer-call kwargs contract
+# ---------------------------------------------------------------------------
+
+
+class _StubSplit:
+    fold_id = "fold_001"
+    protocol = "walk_forward"
+    train: list[Any] = []
+    val: list[Any] = []
+    test: list[Any] = []
+
+
+def _capture_calls(monkeypatch, runner_module):
+    """Stub the heavyweight calls inside one runner module.
+
+    Returns a dict that the test populates: ``loader_calls`` collects
+    kwargs passed to ``load_walk_forward_split``; ``train_calls``
+    collects kwargs passed to ``train_model``; ``config_calls`` collects
+    the ``ModelConfig`` instance the runner builds (via the kwarg
+    captured on the trainer call).
+    """
+
+    captured: dict[str, list[Any]] = {
+        "loader_calls": [],
+        "train_calls": [],
+    }
+
+    def _fake_load_walk_forward_split(**kwargs):
+        captured["loader_calls"].append(kwargs)
+        return _StubSplit()
+
+    def _fake_train_model(**kwargs):
+        captured["train_calls"].append(kwargs)
+        return SimpleNamespace(
+            summary=SimpleNamespace(
+                test_metrics=SimpleNamespace(
+                    regime_f1_macro=0.5,
+                    regime_accuracy=0.5,
+                    regime_loss=1.0,
+                    regression_rmse_log_rv=1.0,
+                    regression_mae_log_rv=0.8,
+                    regression_loss=1.0,
+                ),
+            ),
+        )
+
+    # The runner imports these lazily inside _run_one_cell, so we
+    # monkeypatch on the *source* modules they import from.
+    from app.training import loaders as loaders_module
+    from app.training import loop as loop_module
+
+    monkeypatch.setattr(
+        loaders_module,
+        "load_walk_forward_split",
+        _fake_load_walk_forward_split,
+    )
+    monkeypatch.setattr(loop_module, "train_model", _fake_train_model)
+    return captured
+
+
+def test_dual_head_runner_default_off_byte_identity(monkeypatch):
+    """Default invocation matches the pre-PR canonical loader kwargs."""
+
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from scripts import run_dual_head_comparison as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    result = runner._run_one_cell(
+        "dual",
+        seed=11,
+        training_package_id="tp_dummy",
+        fold_ids=["fold_001"],
+        epochs=1,
+        regression_alpha=0.5,
+        hidden_size=64,
+    )
+
+    assert result["head_mode"] == "dual"
+    assert len(captured["loader_calls"]) == 1
+    loader_kwargs = captured["loader_calls"][0]
+    # Default-off contract: both opt-in loader flags pass False.
+    assert loader_kwargs["use_retrieval_analogs"] is False
+    assert loader_kwargs["use_regime_conditioning"] is False
+    assert loader_kwargs["rich_features"] is True
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.rates_target_mode == "raw"
+    assert model_config.use_regime_conditioning is False
+
+
+def test_dual_head_runner_opt_in_threads_through(monkeypatch):
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from scripts import run_dual_head_comparison as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    runner._run_one_cell(
+        "dual",
+        seed=11,
+        training_package_id="tp_dummy",
+        fold_ids=["fold_001"],
+        epochs=1,
+        regression_alpha=0.5,
+        hidden_size=64,
+        rates_target_mode="fomc_attributable",
+        use_retrieval_analogs=True,
+        use_regime_conditioning=True,
+    )
+
+    loader_kwargs = captured["loader_calls"][0]
+    assert loader_kwargs["use_retrieval_analogs"] is True
+    assert loader_kwargs["use_regime_conditioning"] is True
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.rates_target_mode == "fomc_attributable"
+    assert model_config.use_regime_conditioning is True
+
+
+def test_per_family_runner_default_off_byte_identity(monkeypatch):
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from scripts import run_per_family_ablation as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    args = SimpleNamespace(
+        training_package_id="tp_dummy",
+        text_encoder="finbert_fed_adjacent",
+        head_mode="dual",
+        regression_alpha=0.5,
+        hidden_size=64,
+        epochs=1,
+        rates_target_mode="raw",
+        use_retrieval_analogs=False,
+        use_regime_conditioning=False,
+    )
+    runner._run_one_cell(
+        "baseline",
+        frozenset(),
+        11,
+        args,
+        fold_ids=["fold_001"],
+    )
+
+    loader_kwargs = captured["loader_calls"][0]
+    assert loader_kwargs["use_retrieval_analogs"] is False
+    assert loader_kwargs["use_regime_conditioning"] is False
+    # Per-family default-off must also still pass the pre-PR loader
+    # family flags (baseline keeps every family on).
+    assert loader_kwargs["use_credibility"] is True
+    assert loader_kwargs["use_linguistic"] is True
+    assert loader_kwargs["use_mp_surprise"] is True
+    assert loader_kwargs["use_multi_axis"] is True
+    assert loader_kwargs["use_llm_features"] is True
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.rates_target_mode == "raw"
+    assert model_config.use_regime_conditioning is False
+
+
+def test_per_family_runner_opt_in_threads_through(monkeypatch):
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from scripts import run_per_family_ablation as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    args = SimpleNamespace(
+        training_package_id="tp_dummy",
+        text_encoder="finbert_fed_adjacent",
+        head_mode="dual",
+        regression_alpha=0.5,
+        hidden_size=64,
+        epochs=1,
+        rates_target_mode="fomc_attributable",
+        use_retrieval_analogs=True,
+        use_regime_conditioning=True,
+    )
+    runner._run_one_cell(
+        "baseline",
+        frozenset(),
+        11,
+        args,
+        fold_ids=["fold_001"],
+    )
+
+    loader_kwargs = captured["loader_calls"][0]
+    assert loader_kwargs["use_retrieval_analogs"] is True
+    assert loader_kwargs["use_regime_conditioning"] is True
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.rates_target_mode == "fomc_attributable"
+    assert model_config.use_regime_conditioning is True


### PR DESCRIPTION
Three flags ship on `app.train_forecaster` (#305 / #306 / #307) but the canonical sweep runners do not forward them, so Runpod cannot exercise the new code paths through the JSONs the §6 wiki tables read. Adds the flags to both runners and the matching Makefile targets.

- `scripts/run_dual_head_comparison.py` + `scripts/run_per_family_ablation.py` now expose `--rates-target-mode`, `--use-retrieval-analogs`, `--use-regime-conditioning` with the same names + defaults as the trainer; the values thread through to the `ModelConfig` + the `load_walk_forward_split` kwargs the runner builds per fold.
- Four named Makefile targets: `canonical-comparison` (unchanged), `canonical-comparison-fomc-attributable`, `canonical-comparison-retrieval-analogs`, `canonical-comparison-regime-conditioning`. Each writes to a distinct path under `artifacts/experiments/` so concurrent sweeps cannot overwrite each other.
- Regression test under `tests/unit/test_run_dual_head_comparison.py` pins the argparser surface on both runners and verifies the trainer-call kwargs on default-off + opt-in paths.

Reviewer focus:
- Default-off byte-identity: a runner invocation with no new flags constructs the same `ModelConfig` + loader kwargs as the pre-PR canonical sweep. Test `test_dual_head_runner_default_off_byte_identity` pins this.
- Output paths differentiated per variant: `dual_head_comparison_canonical.json` stays the default; the three opt-ins land at `_post_305.json` / `_post_306.json` / `_post_307.json`.
- Reproducibility-smoke contract (#335) keeps passing because the smoke drives the default-off path.
- Per-family runner: the retrieval-analog block lives in a separate per-bar slot from the document-level families the runner zeros, so `--use-retrieval-analogs` is orthogonal to `zero_*` cells (commented in-line).