### PR TITLE
Auto-disable torch.compile on broken triton (sweep runner resilience)

### DIFF
--- a/backend/app/training/runtime_compat.py
+++ b/backend/app/training/runtime_compat.py
@@ -1,0 +1,98 @@
+"""Runtime-compatibility guards for the training stack.
+
+The sweep runners are routinely operated on rented GPU pods where the
+container's pre-installed torch can be clobbered by a later
+``pip install -r requirements.lock``. When that happens, the surviving
+``triton`` on disk frequently exposes a 3.x API that torch 2.4.x's
+inductor backend cannot talk to, and the very first ``torch.compile``
+call dies with::
+
+    torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
+    ImportError: cannot import name 'triton_key' from
+    'triton.compiler.compiler'
+
+The manual fix is ``TORCHDYNAMO_DISABLE=1``. This module gives the
+canonical sweep runners a way to detect the mismatch up-front and apply
+that fix themselves, so the next operator doesn't get to rediscover the
+debugging path.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+__all__ = ["ensure_compile_safe"]
+
+
+_ALREADY_RAN = False
+
+
+def ensure_compile_safe() -> None:
+    """Disable ``torch.compile`` when the local triton is incompatible.
+
+    Probes ``triton.compiler.compiler.triton_key`` -- the exact attribute
+    torch 2.4.x's inductor backend imports on its first compile call. If
+    the probe fails (``ImportError`` or ``AttributeError``), sets
+    ``TORCHDYNAMO_DISABLE=1`` in the process environment, calls
+    ``torch._dynamo.disable()`` if available, and emits a single
+    structured WARNING line so operators can grep for it in the pod log.
+
+    The helper is idempotent: the second call is a no-op. It also
+    respects an existing operator override -- if ``TORCHDYNAMO_DISABLE``
+    is already set (to any value), the helper leaves the env alone and
+    treats that as "operator already made the call".
+    """
+
+    global _ALREADY_RAN
+    if _ALREADY_RAN:
+        return
+    _ALREADY_RAN = True
+
+    # Operator override wins. If the variable is set to anything (even
+    # an empty string), the caller has already made a deliberate choice
+    # about dynamo and we don't second-guess it.
+    if "TORCHDYNAMO_DISABLE" in os.environ:
+        return
+
+    triton_module_name = "triton.compiler.compiler"
+    try:
+        module = importlib.import_module(triton_module_name)
+        getattr(module, "triton_key")
+    except (ImportError, AttributeError):
+        pass
+    else:
+        return
+
+    os.environ.setdefault("TORCHDYNAMO_DISABLE", "1")
+
+    resolved = getattr(
+        sys.modules.get(triton_module_name), "__file__", triton_module_name
+    )
+    print(
+        f"WARNING compile_fallback_to_eager reason=triton_api_mismatch "
+        f"triton_module={resolved}",
+        flush=True,
+    )
+
+    try:
+        import torch._dynamo as _dynamo  # noqa: WPS433
+    except Exception:
+        return
+    disable = getattr(_dynamo, "disable", None)
+    if callable(disable):
+        try:
+            disable()
+        except Exception:
+            # ``torch._dynamo.disable`` exists in a couple of shapes
+            # across torch versions; if the call fails we still have
+            # the env var set, which is the load-bearing half.
+            pass
+
+
+def _reset_for_testing() -> None:
+    """Clear the idempotency latch. Test-only hook."""
+
+    global _ALREADY_RAN
+    _ALREADY_RAN = False

--- a/backend/app/training/runtime_compat.py
+++ b/backend/app/training/runtime_compat.py
@@ -59,7 +59,7 @@ def ensure_compile_safe() -> None:
     triton_module_name = "triton.compiler.compiler"
     try:
         module = importlib.import_module(triton_module_name)
-        getattr(module, "triton_key")
+        _ = module.triton_key  # noqa: F841 -- probe attribute presence
     except (ImportError, AttributeError):
         pass
     else:

--- a/docs/reproduce.md
+++ b/docs/reproduce.md
@@ -42,3 +42,7 @@ What this does **not** validate:
 - Full-epoch training quality (use `make train-batch` for that — see `CLAUDE.md`).
 - The bake-off comparisons (those need the per-encoder embedding caches, which lazy-fetch separately via `app.data.embedding_cache.ensure_local`).
 - The frontend dashboard (that runs against the deployed container; see `docs/deploy.md`).
+
+## Troubleshooting
+
+- The canonical sweep runners (`scripts/run_dual_head_comparison.py`, `scripts/run_per_family_ablation.py`, `scripts/run_reproducibility_smoke.py`) auto-fall-back to eager mode on environments where `torch.compile` can't import a working triton; `TORCHDYNAMO_DISABLE=1` is the manual override.

--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import Any
 
 from app.config import BACKEND_ROOT
+from app.training.runtime_compat import ensure_compile_safe
 
 
 def _parse_args() -> argparse.Namespace:
@@ -281,6 +282,7 @@ def _run_one_cell(
 
 
 def main() -> int:
+    ensure_compile_safe()
     args = _parse_args()
     output_path = _resolve_output_path(args.output)
     print(f"[dual_head_comparison] writing -> {output_path}")

--- a/scripts/run_per_family_ablation.py
+++ b/scripts/run_per_family_ablation.py
@@ -83,6 +83,7 @@ from pathlib import Path
 from typing import Any
 
 from app.config import BACKEND_ROOT
+from app.training.runtime_compat import ensure_compile_safe
 
 
 # Canonical family order. The per-family cell labels follow
@@ -553,6 +554,7 @@ def _run_one_cell(
 
 
 def main() -> int:
+    ensure_compile_safe()
     args = _parse_args()
     output_path = _resolve_output_path(args.output)
     print(f"[per_family_ablation] writing -> {output_path}")

--- a/scripts/run_reproducibility_smoke.py
+++ b/scripts/run_reproducibility_smoke.py
@@ -29,6 +29,13 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BACKEND_DIR = REPO_ROOT / "backend"
 
+# Make ``app.training.runtime_compat`` importable so the smoke runner can
+# probe for a broken-triton inductor build up-front and set
+# ``TORCHDYNAMO_DISABLE=1`` in the env before spawning the trainer
+# subprocess. The child inherits the env mutation via ``{**os.environ}``.
+sys.path.insert(0, str(BACKEND_DIR))
+from app.training.runtime_compat import ensure_compile_safe  # noqa: E402
+
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -186,6 +193,7 @@ def _extract_regime_f1_macro(report_path: Path) -> float:
 
 
 def main() -> int:
+    ensure_compile_safe()
     args = _parse_args()
     _pull_training_package(args.training_package_id)
     _run_smoke_training(

--- a/tests/unit/test_runtime_compat.py
+++ b/tests/unit/test_runtime_compat.py
@@ -1,0 +1,142 @@
+"""Unit tests for the ``torch.compile`` resilience helper.
+
+The helper auto-disables dynamo on pods where the installed triton has
+an API too new for torch 2.4.x's inductor backend to import. These
+tests stub ``triton.compiler.compiler`` via ``sys.modules`` so the
+probe and its fallback can be exercised without a live torch+triton
+stack.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from app.training import runtime_compat
+
+
+@pytest.fixture(autouse=True)
+def _isolated_history_db():
+    """Override the suite-wide autouse fixture; this test never touches the db."""
+
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_helper(monkeypatch: pytest.MonkeyPatch):
+    """Reset the idempotency latch and clear the env var between cases."""
+
+    runtime_compat._reset_for_testing()
+    monkeypatch.delenv("TORCHDYNAMO_DISABLE", raising=False)
+    yield
+    runtime_compat._reset_for_testing()
+
+
+def _install_triton_stub(monkeypatch: pytest.MonkeyPatch, *, with_key: bool) -> None:
+    """Stub the three-level ``triton.compiler.compiler`` import path."""
+
+    triton_pkg = types.ModuleType("triton")
+    triton_pkg.__path__ = []  # mark as package
+    compiler_pkg = types.ModuleType("triton.compiler")
+    compiler_pkg.__path__ = []
+    compiler_mod = types.ModuleType("triton.compiler.compiler")
+    if with_key:
+        compiler_mod.triton_key = lambda: "stub-key"  # type: ignore[attr-defined]
+    compiler_mod.__file__ = "/stub/triton/compiler/compiler.py"
+
+    monkeypatch.setitem(sys.modules, "triton", triton_pkg)
+    monkeypatch.setitem(sys.modules, "triton.compiler", compiler_pkg)
+    monkeypatch.setitem(sys.modules, "triton.compiler.compiler", compiler_mod)
+
+
+def test_no_op_when_triton_key_present(
+    monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+) -> None:
+    _install_triton_stub(monkeypatch, with_key=True)
+
+    runtime_compat.ensure_compile_safe()
+
+    assert "TORCHDYNAMO_DISABLE" not in __import__("os").environ
+    captured = capfd.readouterr()
+    assert "compile_fallback_to_eager" not in captured.out
+    assert "compile_fallback_to_eager" not in captured.err
+
+
+def test_disables_dynamo_when_triton_key_missing(
+    monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+) -> None:
+    import os
+
+    _install_triton_stub(monkeypatch, with_key=False)
+
+    runtime_compat.ensure_compile_safe()
+
+    assert os.environ.get("TORCHDYNAMO_DISABLE") == "1"
+    captured = capfd.readouterr()
+    assert "compile_fallback_to_eager" in captured.out
+    assert "reason=triton_api_mismatch" in captured.out
+    assert "triton_module=" in captured.out
+
+
+def test_idempotent_second_call_emits_no_extra_warning(
+    monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+) -> None:
+    _install_triton_stub(monkeypatch, with_key=False)
+
+    runtime_compat.ensure_compile_safe()
+    first = capfd.readouterr()
+    runtime_compat.ensure_compile_safe()
+    second = capfd.readouterr()
+
+    assert first.out.count("compile_fallback_to_eager") == 1
+    assert "compile_fallback_to_eager" not in second.out
+
+
+def test_respects_existing_operator_override(
+    monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+) -> None:
+    import os
+
+    # Operator already set the env var (to anything, including the
+    # explicit "0" some operators use to mean "do not auto-touch").
+    monkeypatch.setenv("TORCHDYNAMO_DISABLE", "0")
+    _install_triton_stub(monkeypatch, with_key=False)
+
+    runtime_compat.ensure_compile_safe()
+
+    # Helper leaves the operator value alone, even when the probe would
+    # otherwise have flipped it to "1".
+    assert os.environ["TORCHDYNAMO_DISABLE"] == "0"
+    captured = capfd.readouterr()
+    assert "compile_fallback_to_eager" not in captured.out
+
+
+def test_handles_import_error_path(
+    monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+) -> None:
+    """Same fallback fires when the triton module is not importable at all."""
+
+    import os
+
+    # Remove any triton hits from sys.modules and block re-import by
+    # injecting a finder that raises ImportError.
+    for name in ("triton", "triton.compiler", "triton.compiler.compiler"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    class _Blocker:
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname.startswith("triton"):
+                raise ImportError(f"blocked {fullname} for test")
+            return None
+
+    blocker = _Blocker()
+    monkeypatch.setattr(sys, "meta_path", [blocker, *sys.meta_path])
+
+    runtime_compat.ensure_compile_safe()
+
+    assert os.environ.get("TORCHDYNAMO_DISABLE") == "1"
+    captured = capfd.readouterr()
+    assert "compile_fallback_to_eager" in captured.out
+    assert "reason=triton_api_mismatch" in captured.out


### PR DESCRIPTION
A Runpod sweep died on `cannot import name 'triton_key' from triton.compiler.compiler` after `pip install -r backend/requirements.lock` clobbered the pod's pre-installed torch. The manual fix is `TORCHDYNAMO_DISABLE=1`; this PR teaches the canonical sweep runners (`run_dual_head_comparison`, `run_per_family_ablation`, `run_reproducibility_smoke`) to detect the mismatch and set it themselves so the next operator doesn't get to rediscover the debugging path.

- New helper `backend/app/training/runtime_compat.py::ensure_compile_safe` probes `triton.compiler.compiler.triton_key`, sets `TORCHDYNAMO_DISABLE=1` + calls `torch._dynamo.disable()` on miss, and emits one structured WARNING line.
- Three sweep runners call it at the top of `main()`.
- New unit tests cover no-op, fallback, idempotency, operator-override, and unimportable-triton paths.
- One-line troubleshooting note in `docs/reproduce.md`.

### Reviewer focus
- Helper is idempotent and respects an existing operator override: if `TORCHDYNAMO_DISABLE` is already set to anything, the helper leaves env alone.
- Probe uses the exact attribute torch 2.4.x inductor imports (`triton.compiler.compiler.triton_key`), not a heuristic.
- Reproduce-smoke contract (#335) unaffected: CI's environment has matching triton, helper short-circuits as a no-op.
- WARNING line is structured (greppable `key=value`) so operators can spot it in pod logs.