### PR TITLE
Auto-activate rates heads when --rates-target-mode != raw (#305 / #401 follow-up)

### DIFF
--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -215,6 +215,32 @@ def _summary_stats(values: list[float]) -> dict[str, float] | None:
     }
 
 
+def _resolve_auto_rates_heads(
+    rates_target_mode: str,
+    rates_heads: tuple[str, ...] | None,
+) -> tuple[str, ...]:
+    """Auto-activate the canonical rates-head set under FOMC-attributable.
+
+    ``--rates-target-mode`` only steers the rates heads' supervised
+    target; it has no observable effect unless at least one rates head
+    is mounted. The canonical-comparison sweep does not expose a
+    ``--rates-heads`` flag (it sweeps head_modes, not rates heads), so
+    when the operator opts the runner into ``fomc_attributable`` we
+    mount the same canonical set (``2y``, ``5y``, ``terminal``) the
+    ``make rates-heads-sweep`` target uses. ``raw`` (default) keeps
+    ``rates_heads=()`` so the pre-#401 canonical sweep stays
+    byte-identical.
+    """
+
+    from app.models.rates_heads import RATES_HEAD_NAMES
+
+    if rates_heads:
+        return tuple(rates_heads)
+    if rates_target_mode != "raw":
+        return tuple(RATES_HEAD_NAMES)
+    return ()
+
+
 def _run_one_cell(
     head_mode: str,
     seed: int,
@@ -234,6 +260,7 @@ def _run_one_cell(
     from app.training.loaders import load_walk_forward_split
     from app.training.loop import train_model
 
+    rates_heads = _resolve_auto_rates_heads(rates_target_mode, rates_heads=None)
     config = ModelConfig(
         input_size=RICH_FEATURE_SIZE,
         output_mode="classification",
@@ -241,6 +268,7 @@ def _run_one_cell(
         regression_alpha=regression_alpha,
         n_classes=3,
         hidden_size=hidden_size,
+        rates_heads=rates_heads,
         rates_target_mode=rates_target_mode,
         use_regime_conditioning=use_regime_conditioning,
     )
@@ -289,6 +317,11 @@ def main() -> int:
 
     fold_ids = _resolve_fold_ids(args.training_package_id, args.folds)
     print(f"[dual_head_comparison] folds={fold_ids}")
+    if str(args.rates_target_mode) != "raw":
+        print(
+            "[dual_head_comparison] auto-activating rates heads for "
+            f"rates_target_mode={args.rates_target_mode}"
+        )
 
     trials: dict[str, list[dict[str, Any]]] = {mode: [] for mode in args.head_modes}
     for head_mode in args.head_modes:
@@ -339,6 +372,9 @@ def main() -> int:
         "regression_alpha": args.regression_alpha,
         "training_package_id": args.training_package_id,
         "rates_target_mode": str(args.rates_target_mode),
+        "rates_heads": list(
+            _resolve_auto_rates_heads(str(args.rates_target_mode), rates_heads=None)
+        ),
         "use_retrieval_analogs": bool(args.use_retrieval_analogs),
         "use_regime_conditioning": bool(args.use_regime_conditioning),
         "trials": trials,

--- a/scripts/run_per_family_ablation.py
+++ b/scripts/run_per_family_ablation.py
@@ -311,6 +311,23 @@ def _resolve_output_path(arg: Path | None) -> Path:
     return base / "per_family_ablation.json"
 
 
+def _resolved_rates_heads_for_payload(rates_target_mode: str) -> list[str]:
+    """Surface the auto-activated rates-head set in the output JSON.
+
+    Mirrors the auto-activation policy inside ``_run_one_cell``: when
+    ``--rates-target-mode != raw`` we mount the canonical rates head set
+    so the per-family ablation actually exercises the flag. The payload
+    records the resolved tuple so readers can confirm the run was
+    distinct from the ``raw`` baseline.
+    """
+
+    from app.models.rates_heads import RATES_HEAD_NAMES
+
+    if rates_target_mode != "raw":
+        return list(RATES_HEAD_NAMES)
+    return []
+
+
 def _resolve_fold_ids(training_package_id: str, override: list[str] | None) -> list[str]:
     if override:
         return list(override)
@@ -470,10 +487,22 @@ def _run_one_cell(
     """Train + evaluate one (cell, seed) cell across every fold."""
 
     from app.models.config import ModelConfig, RICH_FEATURE_SIZE
+    from app.models.rates_heads import RATES_HEAD_NAMES
     from app.training.loaders import load_walk_forward_split
     from app.training.loop import train_model
 
     flags = _cell_flags(zero_set)
+
+    rates_target_mode = str(getattr(args, "rates_target_mode", "raw"))
+    # #401 follow-up: ``--rates-target-mode`` is a no-op unless at least
+    # one rates head is mounted. The per-family ablation runner does not
+    # expose a ``--rates-heads`` flag (it sweeps rich-feature families,
+    # not rates heads), so we auto-activate the canonical set when the
+    # operator opts into ``fomc_attributable``. ``raw`` (default) leaves
+    # ``rates_heads=()`` so the pre-#401 ablation stays byte-identical.
+    rates_heads = (
+        tuple(RATES_HEAD_NAMES) if rates_target_mode != "raw" else ()
+    )
 
     config = ModelConfig(
         input_size=RICH_FEATURE_SIZE,
@@ -482,7 +511,8 @@ def _run_one_cell(
         regression_alpha=float(args.regression_alpha),
         n_classes=3,
         hidden_size=int(args.hidden_size),
-        rates_target_mode=str(getattr(args, "rates_target_mode", "raw")),
+        rates_heads=rates_heads,
+        rates_target_mode=rates_target_mode,
         use_regime_conditioning=bool(
             getattr(args, "use_regime_conditioning", False)
         ),
@@ -564,6 +594,11 @@ def main() -> int:
 
     cells = _resolve_cells(args.cells)
     print(f"[per_family_ablation] cells={[c[0] for c in cells]}")
+    if str(args.rates_target_mode) != "raw":
+        print(
+            "[per_family_ablation] auto-activating rates heads for "
+            f"rates_target_mode={args.rates_target_mode}"
+        )
 
     trials: dict[str, list[dict[str, Any]]] = {}
     for cell_label, zero_set in cells:
@@ -630,6 +665,9 @@ def main() -> int:
         "training_package_id": args.training_package_id,
         "text_encoder": str(args.text_encoder),
         "rates_target_mode": str(args.rates_target_mode),
+        "rates_heads": _resolved_rates_heads_for_payload(
+            str(args.rates_target_mode)
+        ),
         "use_retrieval_analogs": bool(args.use_retrieval_analogs),
         "use_regime_conditioning": bool(args.use_regime_conditioning),
         "post_350_status": str(args.post_350_status),

--- a/tests/unit/test_run_dual_head_comparison.py
+++ b/tests/unit/test_run_dual_head_comparison.py
@@ -250,6 +250,127 @@ def test_dual_head_runner_opt_in_threads_through(monkeypatch):
     assert model_config.use_regime_conditioning is True
 
 
+# ---------------------------------------------------------------------------
+# #401 follow-up: auto-activate rates heads when rates_target_mode != raw.
+# Without rates heads mounted, --rates-target-mode is a no-op and the
+# canonical-comparison sweep produces byte-identical output to the default.
+# ---------------------------------------------------------------------------
+
+
+def test_dual_head_runner_default_off_leaves_rates_heads_empty(monkeypatch):
+    """Default ``rates_target_mode='raw'`` must keep ``rates_heads=()``.
+
+    Pre-#401 canonical sweep is byte-identical -- no auto-activation.
+    """
+
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from scripts import run_dual_head_comparison as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    runner._run_one_cell(
+        "dual",
+        seed=11,
+        training_package_id="tp_dummy",
+        fold_ids=["fold_001"],
+        epochs=1,
+        regression_alpha=0.5,
+        hidden_size=64,
+    )
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.rates_heads == ()
+
+
+def test_dual_head_runner_fomc_attributable_auto_activates_rates_heads(monkeypatch):
+    """``rates_target_mode='fomc_attributable'`` must mount canonical heads."""
+
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from app.models.rates_heads import RATES_HEAD_NAMES
+    from scripts import run_dual_head_comparison as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    runner._run_one_cell(
+        "dual",
+        seed=11,
+        training_package_id="tp_dummy",
+        fold_ids=["fold_001"],
+        epochs=1,
+        regression_alpha=0.5,
+        hidden_size=64,
+        rates_target_mode="fomc_attributable",
+    )
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.rates_heads == tuple(RATES_HEAD_NAMES)
+    assert model_config.rates_target_mode == "fomc_attributable"
+
+
+def test_per_family_runner_default_off_leaves_rates_heads_empty(monkeypatch):
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from scripts import run_per_family_ablation as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    args = SimpleNamespace(
+        training_package_id="tp_dummy",
+        text_encoder="finbert_fed_adjacent",
+        head_mode="dual",
+        regression_alpha=0.5,
+        hidden_size=64,
+        epochs=1,
+        rates_target_mode="raw",
+        use_retrieval_analogs=False,
+        use_regime_conditioning=False,
+    )
+    runner._run_one_cell(
+        "baseline",
+        frozenset(),
+        11,
+        args,
+        fold_ids=["fold_001"],
+    )
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.rates_heads == ()
+
+
+def test_per_family_runner_fomc_attributable_auto_activates_rates_heads(monkeypatch):
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from app.models.rates_heads import RATES_HEAD_NAMES
+    from scripts import run_per_family_ablation as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    args = SimpleNamespace(
+        training_package_id="tp_dummy",
+        text_encoder="finbert_fed_adjacent",
+        head_mode="dual",
+        regression_alpha=0.5,
+        hidden_size=64,
+        epochs=1,
+        rates_target_mode="fomc_attributable",
+        use_retrieval_analogs=False,
+        use_regime_conditioning=False,
+    )
+    runner._run_one_cell(
+        "baseline",
+        frozenset(),
+        11,
+        args,
+        fold_ids=["fold_001"],
+    )
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.rates_heads == tuple(RATES_HEAD_NAMES)
+    assert model_config.rates_target_mode == "fomc_attributable"
+
+
 def test_per_family_runner_default_off_byte_identity(monkeypatch):
     pytest.importorskip("torch", reason="train_model import path needs torch")
     from scripts import run_per_family_ablation as runner


### PR DESCRIPTION
Refs #305, #401.

`--rates-target-mode` only steers the rates heads' supervised target. The canonical-comparison sweep and the per-family ablation runner never mount rates heads themselves, so `make canonical-comparison-fomc-attributable` produced byte-identical output to the default canonical sweep. Both runners now auto-activate the canonical (`2y`, `5y`, `terminal`) set when the operator opts into `fomc_attributable`; `raw` keeps `rates_heads=()` so the pre-#401 sweep stays byte-identical.

- `_resolve_auto_rates_heads` in `scripts/run_dual_head_comparison.py` mounts the canonical set under non-raw modes and prints a single info line at sweep start.
- `scripts/run_per_family_ablation.py` gets the same auto-activation (and surfaces the resolved set in the payload).
- Regression tests cover default-off (`rates_heads == ()`) and opt-in (`rates_heads == RATES_HEAD_NAMES`) on both runners.

Reviewer focus:
- Default `--rates-target-mode=raw` (unset) keeps the canonical-comparison sweep byte-identical to pre-fix; auto-activation fires only when the operator opts into `fomc_attributable`.
- The auto-activated set matches the `make rates-heads-sweep` canonical tuple (`RATES_HEAD_NAMES = ("2y", "5y", "terminal")`).
- Per-family ablation runner gets the same treatment for symmetry — same flag, same gap; the runner's payload now records the resolved `rates_heads` so the artefact differs from the `raw` baseline.
- No new `--rates-heads` CLI flag on either runner; option (a) keeps the sweep contract one knob deep. If a future sweep needs a different rates-head subset under FOMC-attributable, that knob can land then.