### PR TITLE
Main merge: post_307 LSTM shape + post_305 sweep contract + triton fallback

### DIFF
--- a/backend/app/models/forecaster_base.py
+++ b/backend/app/models/forecaster_base.py
@@ -35,6 +35,7 @@ from app.models.config import (
     FEATURE_SIZE,
     RICH_FEATURE_SIZE,
     RICH_MACRO_REGIME_DIM,
+    RICH_MACRO_REGIME_MISSING_DIM,
     SEQUENCE_LENGTH,
 )
 from app.models.dlinear import DLinear
@@ -176,8 +177,21 @@ class ForecasterBase(nn.Module):
             )
             nn.init.zeros_(self.regime_gate.weight)
             nn.init.zeros_(self.regime_gate.bias)
+            # The loader appends ``RICH_MACRO_REGIME_DIM + RICH_MACRO_REGIME_MISSING_DIM``
+            # extra scalars past ``RICH_FEATURE_SIZE`` on every per-bar
+            # tensor when conditioning is on (see ``FeatureVector.as_rich_list``).
+            # The gate modulates the legacy rich-feature slice in place,
+            # but the regime tail itself flows past unchanged into the
+            # recurrent core so the temporal dynamics still see the
+            # indicator that triggered the modulation. The LSTM width
+            # therefore widens by the regime tail; without this the core
+            # would be built at ``RICH_FEATURE_SIZE`` and reject the
+            # 91-wide tensor the loader actually produces.
+            regime_tail_dim = RICH_MACRO_REGIME_DIM + RICH_MACRO_REGIME_MISSING_DIM
         else:
             self.regime_gate = None
+            regime_tail_dim = 0
+        self.regime_tail_dim = regime_tail_dim
         self.text_embedding_dim = int(text_embedding_dim or 0)
         self.text_adapter_dim = int(text_adapter_dim or 0)
         self._text_path_active = self.text_embedding_dim > 0 and self.text_adapter_dim > 0
@@ -200,6 +214,7 @@ class ForecasterBase(nn.Module):
             + self.chunk_projection_dim
             + self.credibility_dim
             + text_path_dim
+            + regime_tail_dim
         )
         self.lstm_input_size = lstm_input_size
         lstm_dropout = dropout if num_layers > 1 else 0.0

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -1128,20 +1128,17 @@ def _resolved_input_size(args: argparse.Namespace) -> int:
     ``--data-dir`` code path is unaffected. The text-embedding adapter
     slot is widened separately inside ``ForecasterModel`` via
     ``text_adapter_dim`` so this scalar size stays at 35 even when
-    text embeddings are on.
+    text embeddings are on. The #307 macro-regime tail is added at the
+    model layer (``ForecasterBase`` widens ``lstm_input_size`` by the
+    regime tail when ``use_regime_conditioning=True``), mirroring the
+    text-adapter convention; this helper returns ``RICH_FEATURE_SIZE``
+    regardless of the regime flag so the two paths never double-widen.
     """
 
     rich_on = bool(getattr(args, "rich_features", False))
     use_package_path = bool(getattr(args, "training_package_id", None))
     if rich_on and use_package_path:
-        # #307 widens the per-bar scalar slice past RICH_FEATURE_SIZE
-        # when ``--use-regime-conditioning`` is wired, so the model
-        # input projection mounts wide enough to consume the regime
-        # block + missing flag the loader appends past the legacy tail.
-        from app.models.config import rich_feature_size_with_regime
-        return rich_feature_size_with_regime(
-            bool(getattr(args, "use_regime_conditioning", False))
-        )
+        return RICH_FEATURE_SIZE
     return FEATURE_SIZE
 
 

--- a/backend/app/training/runtime_compat.py
+++ b/backend/app/training/runtime_compat.py
@@ -1,0 +1,98 @@
+"""Runtime-compatibility guards for the training stack.
+
+The sweep runners are routinely operated on rented GPU pods where the
+container's pre-installed torch can be clobbered by a later
+``pip install -r requirements.lock``. When that happens, the surviving
+``triton`` on disk frequently exposes a 3.x API that torch 2.4.x's
+inductor backend cannot talk to, and the very first ``torch.compile``
+call dies with::
+
+    torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
+    ImportError: cannot import name 'triton_key' from
+    'triton.compiler.compiler'
+
+The manual fix is ``TORCHDYNAMO_DISABLE=1``. This module gives the
+canonical sweep runners a way to detect the mismatch up-front and apply
+that fix themselves, so the next operator doesn't get to rediscover the
+debugging path.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+__all__ = ["ensure_compile_safe"]
+
+
+_ALREADY_RAN = False
+
+
+def ensure_compile_safe() -> None:
+    """Disable ``torch.compile`` when the local triton is incompatible.
+
+    Probes ``triton.compiler.compiler.triton_key`` -- the exact attribute
+    torch 2.4.x's inductor backend imports on its first compile call. If
+    the probe fails (``ImportError`` or ``AttributeError``), sets
+    ``TORCHDYNAMO_DISABLE=1`` in the process environment, calls
+    ``torch._dynamo.disable()`` if available, and emits a single
+    structured WARNING line so operators can grep for it in the pod log.
+
+    The helper is idempotent: the second call is a no-op. It also
+    respects an existing operator override -- if ``TORCHDYNAMO_DISABLE``
+    is already set (to any value), the helper leaves the env alone and
+    treats that as "operator already made the call".
+    """
+
+    global _ALREADY_RAN
+    if _ALREADY_RAN:
+        return
+    _ALREADY_RAN = True
+
+    # Operator override wins. If the variable is set to anything (even
+    # an empty string), the caller has already made a deliberate choice
+    # about dynamo and we don't second-guess it.
+    if "TORCHDYNAMO_DISABLE" in os.environ:
+        return
+
+    triton_module_name = "triton.compiler.compiler"
+    try:
+        module = importlib.import_module(triton_module_name)
+        _ = module.triton_key  # noqa: F841 -- probe attribute presence
+    except (ImportError, AttributeError):
+        pass
+    else:
+        return
+
+    os.environ.setdefault("TORCHDYNAMO_DISABLE", "1")
+
+    resolved = getattr(
+        sys.modules.get(triton_module_name), "__file__", triton_module_name
+    )
+    print(
+        f"WARNING compile_fallback_to_eager reason=triton_api_mismatch "
+        f"triton_module={resolved}",
+        flush=True,
+    )
+
+    try:
+        import torch._dynamo as _dynamo  # noqa: WPS433
+    except Exception:
+        return
+    disable = getattr(_dynamo, "disable", None)
+    if callable(disable):
+        try:
+            disable()
+        except Exception:
+            # ``torch._dynamo.disable`` exists in a couple of shapes
+            # across torch versions; if the call fails we still have
+            # the env var set, which is the load-bearing half.
+            pass
+
+
+def _reset_for_testing() -> None:
+    """Clear the idempotency latch. Test-only hook."""
+
+    global _ALREADY_RAN
+    _ALREADY_RAN = False

--- a/docs/reproduce.md
+++ b/docs/reproduce.md
@@ -42,3 +42,7 @@ What this does **not** validate:
 - Full-epoch training quality (use `make train-batch` for that — see `CLAUDE.md`).
 - The bake-off comparisons (those need the per-encoder embedding caches, which lazy-fetch separately via `app.data.embedding_cache.ensure_local`).
 - The frontend dashboard (that runs against the deployed container; see `docs/deploy.md`).
+
+## Troubleshooting
+
+- The canonical sweep runners (`scripts/run_dual_head_comparison.py`, `scripts/run_per_family_ablation.py`, `scripts/run_reproducibility_smoke.py`) auto-fall-back to eager mode on environments where `torch.compile` can't import a working triton; `TORCHDYNAMO_DISABLE=1` is the manual override.

--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -215,6 +215,32 @@ def _summary_stats(values: list[float]) -> dict[str, float] | None:
     }
 
 
+def _resolve_auto_rates_heads(
+    rates_target_mode: str,
+    rates_heads: tuple[str, ...] | None,
+) -> tuple[str, ...]:
+    """Auto-activate the canonical rates-head set under FOMC-attributable.
+
+    ``--rates-target-mode`` only steers the rates heads' supervised
+    target; it has no observable effect unless at least one rates head
+    is mounted. The canonical-comparison sweep does not expose a
+    ``--rates-heads`` flag (it sweeps head_modes, not rates heads), so
+    when the operator opts the runner into ``fomc_attributable`` we
+    mount the same canonical set (``2y``, ``5y``, ``terminal``) the
+    ``make rates-heads-sweep`` target uses. ``raw`` (default) keeps
+    ``rates_heads=()`` so the pre-#401 canonical sweep stays
+    byte-identical.
+    """
+
+    from app.models.rates_heads import RATES_HEAD_NAMES
+
+    if rates_heads:
+        return tuple(rates_heads)
+    if rates_target_mode != "raw":
+        return tuple(RATES_HEAD_NAMES)
+    return ()
+
+
 def _run_one_cell(
     head_mode: str,
     seed: int,
@@ -234,6 +260,7 @@ def _run_one_cell(
     from app.training.loaders import load_walk_forward_split
     from app.training.loop import train_model
 
+    rates_heads = _resolve_auto_rates_heads(rates_target_mode, rates_heads=None)
     config = ModelConfig(
         input_size=RICH_FEATURE_SIZE,
         output_mode="classification",
@@ -241,6 +268,7 @@ def _run_one_cell(
         regression_alpha=regression_alpha,
         n_classes=3,
         hidden_size=hidden_size,
+        rates_heads=rates_heads,
         rates_target_mode=rates_target_mode,
         use_regime_conditioning=use_regime_conditioning,
     )
@@ -289,6 +317,11 @@ def main() -> int:
 
     fold_ids = _resolve_fold_ids(args.training_package_id, args.folds)
     print(f"[dual_head_comparison] folds={fold_ids}")
+    if str(args.rates_target_mode) != "raw":
+        print(
+            "[dual_head_comparison] auto-activating rates heads for "
+            f"rates_target_mode={args.rates_target_mode}"
+        )
 
     trials: dict[str, list[dict[str, Any]]] = {mode: [] for mode in args.head_modes}
     for head_mode in args.head_modes:
@@ -339,6 +372,9 @@ def main() -> int:
         "regression_alpha": args.regression_alpha,
         "training_package_id": args.training_package_id,
         "rates_target_mode": str(args.rates_target_mode),
+        "rates_heads": list(
+            _resolve_auto_rates_heads(str(args.rates_target_mode), rates_heads=None)
+        ),
         "use_retrieval_analogs": bool(args.use_retrieval_analogs),
         "use_regime_conditioning": bool(args.use_regime_conditioning),
         "trials": trials,

--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import Any
 
 from app.config import BACKEND_ROOT
+from app.training.runtime_compat import ensure_compile_safe
 
 
 def _parse_args() -> argparse.Namespace:
@@ -281,6 +282,7 @@ def _run_one_cell(
 
 
 def main() -> int:
+    ensure_compile_safe()
     args = _parse_args()
     output_path = _resolve_output_path(args.output)
     print(f"[dual_head_comparison] writing -> {output_path}")

--- a/scripts/run_per_family_ablation.py
+++ b/scripts/run_per_family_ablation.py
@@ -83,6 +83,7 @@ from pathlib import Path
 from typing import Any
 
 from app.config import BACKEND_ROOT
+from app.training.runtime_compat import ensure_compile_safe
 
 
 # Canonical family order. The per-family cell labels follow
@@ -553,6 +554,7 @@ def _run_one_cell(
 
 
 def main() -> int:
+    ensure_compile_safe()
     args = _parse_args()
     output_path = _resolve_output_path(args.output)
     print(f"[per_family_ablation] writing -> {output_path}")

--- a/scripts/run_per_family_ablation.py
+++ b/scripts/run_per_family_ablation.py
@@ -311,6 +311,23 @@ def _resolve_output_path(arg: Path | None) -> Path:
     return base / "per_family_ablation.json"
 
 
+def _resolved_rates_heads_for_payload(rates_target_mode: str) -> list[str]:
+    """Surface the auto-activated rates-head set in the output JSON.
+
+    Mirrors the auto-activation policy inside ``_run_one_cell``: when
+    ``--rates-target-mode != raw`` we mount the canonical rates head set
+    so the per-family ablation actually exercises the flag. The payload
+    records the resolved tuple so readers can confirm the run was
+    distinct from the ``raw`` baseline.
+    """
+
+    from app.models.rates_heads import RATES_HEAD_NAMES
+
+    if rates_target_mode != "raw":
+        return list(RATES_HEAD_NAMES)
+    return []
+
+
 def _resolve_fold_ids(training_package_id: str, override: list[str] | None) -> list[str]:
     if override:
         return list(override)
@@ -470,10 +487,22 @@ def _run_one_cell(
     """Train + evaluate one (cell, seed) cell across every fold."""
 
     from app.models.config import ModelConfig, RICH_FEATURE_SIZE
+    from app.models.rates_heads import RATES_HEAD_NAMES
     from app.training.loaders import load_walk_forward_split
     from app.training.loop import train_model
 
     flags = _cell_flags(zero_set)
+
+    rates_target_mode = str(getattr(args, "rates_target_mode", "raw"))
+    # #401 follow-up: ``--rates-target-mode`` is a no-op unless at least
+    # one rates head is mounted. The per-family ablation runner does not
+    # expose a ``--rates-heads`` flag (it sweeps rich-feature families,
+    # not rates heads), so we auto-activate the canonical set when the
+    # operator opts into ``fomc_attributable``. ``raw`` (default) leaves
+    # ``rates_heads=()`` so the pre-#401 ablation stays byte-identical.
+    rates_heads = (
+        tuple(RATES_HEAD_NAMES) if rates_target_mode != "raw" else ()
+    )
 
     config = ModelConfig(
         input_size=RICH_FEATURE_SIZE,
@@ -482,7 +511,8 @@ def _run_one_cell(
         regression_alpha=float(args.regression_alpha),
         n_classes=3,
         hidden_size=int(args.hidden_size),
-        rates_target_mode=str(getattr(args, "rates_target_mode", "raw")),
+        rates_heads=rates_heads,
+        rates_target_mode=rates_target_mode,
         use_regime_conditioning=bool(
             getattr(args, "use_regime_conditioning", False)
         ),
@@ -564,6 +594,11 @@ def main() -> int:
 
     cells = _resolve_cells(args.cells)
     print(f"[per_family_ablation] cells={[c[0] for c in cells]}")
+    if str(args.rates_target_mode) != "raw":
+        print(
+            "[per_family_ablation] auto-activating rates heads for "
+            f"rates_target_mode={args.rates_target_mode}"
+        )
 
     trials: dict[str, list[dict[str, Any]]] = {}
     for cell_label, zero_set in cells:
@@ -630,6 +665,9 @@ def main() -> int:
         "training_package_id": args.training_package_id,
         "text_encoder": str(args.text_encoder),
         "rates_target_mode": str(args.rates_target_mode),
+        "rates_heads": _resolved_rates_heads_for_payload(
+            str(args.rates_target_mode)
+        ),
         "use_retrieval_analogs": bool(args.use_retrieval_analogs),
         "use_regime_conditioning": bool(args.use_regime_conditioning),
         "post_350_status": str(args.post_350_status),

--- a/scripts/run_reproducibility_smoke.py
+++ b/scripts/run_reproducibility_smoke.py
@@ -29,6 +29,13 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BACKEND_DIR = REPO_ROOT / "backend"
 
+# Make ``app.training.runtime_compat`` importable so the smoke runner can
+# probe for a broken-triton inductor build up-front and set
+# ``TORCHDYNAMO_DISABLE=1`` in the env before spawning the trainer
+# subprocess. The child inherits the env mutation via ``{**os.environ}``.
+sys.path.insert(0, str(BACKEND_DIR))
+from app.training.runtime_compat import ensure_compile_safe  # noqa: E402
+
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -186,6 +193,7 @@ def _extract_regime_f1_macro(report_path: Path) -> float:
 
 
 def main() -> int:
+    ensure_compile_safe()
     args = _parse_args()
     _pull_training_package(args.training_package_id)
     _run_smoke_training(

--- a/tests/unit/test_macro_regime_features.py
+++ b/tests/unit/test_macro_regime_features.py
@@ -630,7 +630,10 @@ def _dummy_feature_vector(*, day: int, vol: float) -> FeatureVector:
     """In-memory FeatureVector with a populated regime block.
 
     Mirrors the retrieval-features smoke fixture so the training loop
-    runs against an in-memory group with no parquet I/O.
+    runs against an in-memory group with no parquet I/O. ``rich_payload``
+    is set so the tensoriser routes through ``as_rich_list`` and the
+    regime tail actually reaches the recurrent core -- the post-#307
+    follow-up regression below depends on that wiring.
     """
 
     fv = FeatureVector(
@@ -642,6 +645,7 @@ def _dummy_feature_vector(*, day: int, vol: float) -> FeatureVector:
         volatility_change=0.0,
         elapsed_time=0.0,
         forward_realized_vol_10d=vol,
+        rich_payload=True,
     )
     fv.macro_regime_features = [1.0, 0.0, -1.0]
     fv.macro_regime_features_missing = 0.0
@@ -659,6 +663,7 @@ def test_train_model_smoke_with_regime_conditioning_gate() -> None:
 
     groups = [[_dummy_feature_vector(day=i + 1, vol=0.01 + 0.001 * i) for i in range(40)]]
     config = ModelConfig(
+        input_size=RICH_FEATURE_SIZE,
         output_mode="classification",
         n_classes=3,
         hidden_size=16,
@@ -725,3 +730,162 @@ def test_no_gate_mounts_without_flag() -> None:
     )
     model = build_research_forecaster(config)
     assert getattr(model, "regime_gate", None) is None
+
+
+# ---------------------------------------------------------------------------
+# Post-#307 shape-contract regression: the LSTM width must absorb the
+# regime tail the loader appends on every per-bar tensor when the flag
+# is on. The pre-fix path mounted the recurrent core at
+# ``RICH_FEATURE_SIZE`` and crashed at ``self.lstm(x)`` with
+# ``RuntimeError: input.size(-1) must be equal to input_size. Expected
+# 87, got 91`` on the canonical sweep (``run_dual_head_comparison.py``).
+# These tests instantiate the model the same way the sweep runner does
+# -- not via stubbing -- so the contract is verified end-to-end.
+# ---------------------------------------------------------------------------
+
+
+def test_research_model_lstm_width_includes_regime_tail() -> None:
+    """The recurrent core widens by the regime tail when the flag is on.
+
+    The loader's ``as_rich_list`` appends ``RICH_MACRO_REGIME_DIM + 1``
+    extra scalars past ``RICH_FEATURE_SIZE`` on every per-bar tensor
+    when conditioning is on; the LSTM constructor must accept that
+    widened input, otherwise the canonical sweep crashes with the
+    87-vs-91 shape mismatch reported on top of #307.
+    """
+
+    from app.models.config import ModelConfig
+    from app.models.factory import build_research_forecaster
+
+    config = ModelConfig(
+        input_size=RICH_FEATURE_SIZE,
+        output_mode="classification",
+        n_classes=3,
+        hidden_size=16,
+        head_hidden_size=8,
+        use_regime_conditioning=True,
+    )
+    model = build_research_forecaster(config)
+    expected_width = (
+        RICH_FEATURE_SIZE
+        + RICH_MACRO_REGIME_DIM
+        + RICH_MACRO_REGIME_MISSING_DIM
+    )
+    assert model.lstm_input_size == expected_width
+    # The recurrent core must consume the widened width; reading the
+    # ``input_size`` off the LSTM (``nn.LSTM`` exposes it directly) and
+    # off the TCN / Informer / DLinear cores (``self.input_size``)
+    # covers every architecture wired through ``ForecasterBase``.
+    core = model.recurrent_core
+    core_width = getattr(core, "input_size", None)
+    assert core_width == expected_width
+
+
+def test_research_model_lstm_width_unchanged_when_flag_off() -> None:
+    """Default OFF byte-identity: LSTM width stays at ``input_size``.
+
+    Pins the deliberate #307 design that the recurrent core sees
+    exactly the legacy ``RICH_FEATURE_SIZE`` width when conditioning
+    is off; flipping the flag on must never widen any other path.
+    """
+
+    from app.models.config import ModelConfig
+    from app.models.factory import build_research_forecaster
+
+    config = ModelConfig(
+        input_size=RICH_FEATURE_SIZE,
+        output_mode="classification",
+        n_classes=3,
+        hidden_size=16,
+        head_hidden_size=8,
+    )
+    model = build_research_forecaster(config)
+    assert model.lstm_input_size == RICH_FEATURE_SIZE
+    assert getattr(model.recurrent_core, "input_size", None) == RICH_FEATURE_SIZE
+
+
+def _rich_feature_vector(
+    *,
+    day: int,
+    vol: float,
+    regime_block: list[float] | None = (1.0, 0.0, -1.0),  # type: ignore[assignment]
+) -> FeatureVector:
+    """In-memory FeatureVector matching the loader's rich-payload shape.
+
+    Sets ``rich_payload=True`` so ``_build_training_tensors`` routes
+    through ``as_rich_list`` (the 91-wide path when the regime block is
+    populated) -- mirrors the per-bar tensor the canonical training
+    package emits via ``load_walk_forward_split``. The previous #307
+    smoke test mounted ``as_list`` instead (6 dims, regime stripped),
+    which is why the LSTM width mismatch never surfaced.
+    """
+
+    fv = FeatureVector(
+        date=str(_dt.date(2025, 1, 1) + _dt.timedelta(days=day - 1)),
+        sentiment_score=0.0,
+        market_close=100.0 + day * 0.5,
+        market_volatility=0.01,
+        close_change_pct=0.0,
+        volatility_change=0.0,
+        elapsed_time=0.0,
+        forward_realized_vol_10d=vol,
+        rich_payload=True,
+    )
+    if regime_block is not None:
+        fv.macro_regime_features = list(regime_block)
+        fv.macro_regime_features_missing = 0.0
+    return fv
+
+
+def test_train_model_forward_does_not_raise_on_regime_tail() -> None:
+    """Canonical-sweep reproduction: rich + regime tensors flow through train_model.
+
+    Reproduces the crash reported on top of #307 (``RuntimeError:
+    input.size(-1) must be equal to input_size. Expected 87, got 91``)
+    on the pre-fix code path. Constructs the model with
+    ``input_size=RICH_FEATURE_SIZE`` -- exactly what
+    ``scripts/run_dual_head_comparison.py`` passes -- and pipes the
+    91-wide rich+regime per-bar tensors through ``train_model``. With
+    the fix the LSTM widens by the regime tail and the forward pass
+    runs to completion; without it the call would raise the shape
+    mismatch.
+    """
+
+    groups = [
+        [
+            _rich_feature_vector(day=i + 1, vol=0.01 + 0.001 * i)
+            for i in range(40)
+        ]
+    ]
+    # Confirm the fixture actually emits the 91-wide per-bar tensor the
+    # sweep loader produces; without this guard a regression that
+    # silently strips the regime block would still pass the train_model
+    # call below.
+    expected_per_bar_width = (
+        RICH_FEATURE_SIZE
+        + RICH_MACRO_REGIME_DIM
+        + RICH_MACRO_REGIME_MISSING_DIM
+    )
+    assert len(groups[0][0].as_rich_list()) == expected_per_bar_width
+
+    config = ModelConfig(
+        input_size=RICH_FEATURE_SIZE,
+        output_mode="classification",
+        n_classes=3,
+        hidden_size=16,
+        head_hidden_size=8,
+        use_regime_conditioning=True,
+    )
+    result = train_model(
+        model_config=config,
+        train_sequence_groups=groups,
+        val_sequence_groups=groups,
+        test_sequence_groups=groups,
+        epochs=1,
+        batch_size=8,
+        seed=13,
+        save_checkpoint=False,
+        use_compile=False,
+        use_amp=False,
+    )
+    assert result.summary.epochs_completed == 1

--- a/tests/unit/test_run_dual_head_comparison.py
+++ b/tests/unit/test_run_dual_head_comparison.py
@@ -250,6 +250,127 @@ def test_dual_head_runner_opt_in_threads_through(monkeypatch):
     assert model_config.use_regime_conditioning is True
 
 
+# ---------------------------------------------------------------------------
+# #401 follow-up: auto-activate rates heads when rates_target_mode != raw.
+# Without rates heads mounted, --rates-target-mode is a no-op and the
+# canonical-comparison sweep produces byte-identical output to the default.
+# ---------------------------------------------------------------------------
+
+
+def test_dual_head_runner_default_off_leaves_rates_heads_empty(monkeypatch):
+    """Default ``rates_target_mode='raw'`` must keep ``rates_heads=()``.
+
+    Pre-#401 canonical sweep is byte-identical -- no auto-activation.
+    """
+
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from scripts import run_dual_head_comparison as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    runner._run_one_cell(
+        "dual",
+        seed=11,
+        training_package_id="tp_dummy",
+        fold_ids=["fold_001"],
+        epochs=1,
+        regression_alpha=0.5,
+        hidden_size=64,
+    )
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.rates_heads == ()
+
+
+def test_dual_head_runner_fomc_attributable_auto_activates_rates_heads(monkeypatch):
+    """``rates_target_mode='fomc_attributable'`` must mount canonical heads."""
+
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from app.models.rates_heads import RATES_HEAD_NAMES
+    from scripts import run_dual_head_comparison as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    runner._run_one_cell(
+        "dual",
+        seed=11,
+        training_package_id="tp_dummy",
+        fold_ids=["fold_001"],
+        epochs=1,
+        regression_alpha=0.5,
+        hidden_size=64,
+        rates_target_mode="fomc_attributable",
+    )
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.rates_heads == tuple(RATES_HEAD_NAMES)
+    assert model_config.rates_target_mode == "fomc_attributable"
+
+
+def test_per_family_runner_default_off_leaves_rates_heads_empty(monkeypatch):
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from scripts import run_per_family_ablation as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    args = SimpleNamespace(
+        training_package_id="tp_dummy",
+        text_encoder="finbert_fed_adjacent",
+        head_mode="dual",
+        regression_alpha=0.5,
+        hidden_size=64,
+        epochs=1,
+        rates_target_mode="raw",
+        use_retrieval_analogs=False,
+        use_regime_conditioning=False,
+    )
+    runner._run_one_cell(
+        "baseline",
+        frozenset(),
+        11,
+        args,
+        fold_ids=["fold_001"],
+    )
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.rates_heads == ()
+
+
+def test_per_family_runner_fomc_attributable_auto_activates_rates_heads(monkeypatch):
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from app.models.rates_heads import RATES_HEAD_NAMES
+    from scripts import run_per_family_ablation as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    args = SimpleNamespace(
+        training_package_id="tp_dummy",
+        text_encoder="finbert_fed_adjacent",
+        head_mode="dual",
+        regression_alpha=0.5,
+        hidden_size=64,
+        epochs=1,
+        rates_target_mode="fomc_attributable",
+        use_retrieval_analogs=False,
+        use_regime_conditioning=False,
+    )
+    runner._run_one_cell(
+        "baseline",
+        frozenset(),
+        11,
+        args,
+        fold_ids=["fold_001"],
+    )
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.rates_heads == tuple(RATES_HEAD_NAMES)
+    assert model_config.rates_target_mode == "fomc_attributable"
+
+
 def test_per_family_runner_default_off_byte_identity(monkeypatch):
     pytest.importorskip("torch", reason="train_model import path needs torch")
     from scripts import run_per_family_ablation as runner

--- a/tests/unit/test_runtime_compat.py
+++ b/tests/unit/test_runtime_compat.py
@@ -1,0 +1,142 @@
+"""Unit tests for the ``torch.compile`` resilience helper.
+
+The helper auto-disables dynamo on pods where the installed triton has
+an API too new for torch 2.4.x's inductor backend to import. These
+tests stub ``triton.compiler.compiler`` via ``sys.modules`` so the
+probe and its fallback can be exercised without a live torch+triton
+stack.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from app.training import runtime_compat
+
+
+@pytest.fixture(autouse=True)
+def _isolated_history_db():
+    """Override the suite-wide autouse fixture; this test never touches the db."""
+
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_helper(monkeypatch: pytest.MonkeyPatch):
+    """Reset the idempotency latch and clear the env var between cases."""
+
+    runtime_compat._reset_for_testing()
+    monkeypatch.delenv("TORCHDYNAMO_DISABLE", raising=False)
+    yield
+    runtime_compat._reset_for_testing()
+
+
+def _install_triton_stub(monkeypatch: pytest.MonkeyPatch, *, with_key: bool) -> None:
+    """Stub the three-level ``triton.compiler.compiler`` import path."""
+
+    triton_pkg = types.ModuleType("triton")
+    triton_pkg.__path__ = []  # mark as package
+    compiler_pkg = types.ModuleType("triton.compiler")
+    compiler_pkg.__path__ = []
+    compiler_mod = types.ModuleType("triton.compiler.compiler")
+    if with_key:
+        compiler_mod.triton_key = lambda: "stub-key"  # type: ignore[attr-defined]
+    compiler_mod.__file__ = "/stub/triton/compiler/compiler.py"
+
+    monkeypatch.setitem(sys.modules, "triton", triton_pkg)
+    monkeypatch.setitem(sys.modules, "triton.compiler", compiler_pkg)
+    monkeypatch.setitem(sys.modules, "triton.compiler.compiler", compiler_mod)
+
+
+def test_no_op_when_triton_key_present(
+    monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+) -> None:
+    _install_triton_stub(monkeypatch, with_key=True)
+
+    runtime_compat.ensure_compile_safe()
+
+    assert "TORCHDYNAMO_DISABLE" not in __import__("os").environ
+    captured = capfd.readouterr()
+    assert "compile_fallback_to_eager" not in captured.out
+    assert "compile_fallback_to_eager" not in captured.err
+
+
+def test_disables_dynamo_when_triton_key_missing(
+    monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+) -> None:
+    import os
+
+    _install_triton_stub(monkeypatch, with_key=False)
+
+    runtime_compat.ensure_compile_safe()
+
+    assert os.environ.get("TORCHDYNAMO_DISABLE") == "1"
+    captured = capfd.readouterr()
+    assert "compile_fallback_to_eager" in captured.out
+    assert "reason=triton_api_mismatch" in captured.out
+    assert "triton_module=" in captured.out
+
+
+def test_idempotent_second_call_emits_no_extra_warning(
+    monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+) -> None:
+    _install_triton_stub(monkeypatch, with_key=False)
+
+    runtime_compat.ensure_compile_safe()
+    first = capfd.readouterr()
+    runtime_compat.ensure_compile_safe()
+    second = capfd.readouterr()
+
+    assert first.out.count("compile_fallback_to_eager") == 1
+    assert "compile_fallback_to_eager" not in second.out
+
+
+def test_respects_existing_operator_override(
+    monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+) -> None:
+    import os
+
+    # Operator already set the env var (to anything, including the
+    # explicit "0" some operators use to mean "do not auto-touch").
+    monkeypatch.setenv("TORCHDYNAMO_DISABLE", "0")
+    _install_triton_stub(monkeypatch, with_key=False)
+
+    runtime_compat.ensure_compile_safe()
+
+    # Helper leaves the operator value alone, even when the probe would
+    # otherwise have flipped it to "1".
+    assert os.environ["TORCHDYNAMO_DISABLE"] == "0"
+    captured = capfd.readouterr()
+    assert "compile_fallback_to_eager" not in captured.out
+
+
+def test_handles_import_error_path(
+    monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+) -> None:
+    """Same fallback fires when the triton module is not importable at all."""
+
+    import os
+
+    # Remove any triton hits from sys.modules and block re-import by
+    # injecting a finder that raises ImportError.
+    for name in ("triton", "triton.compiler", "triton.compiler.compiler"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    class _Blocker:
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname.startswith("triton"):
+                raise ImportError(f"blocked {fullname} for test")
+            return None
+
+    blocker = _Blocker()
+    monkeypatch.setattr(sys, "meta_path", [blocker, *sys.meta_path])
+
+    runtime_compat.ensure_compile_safe()
+
+    assert os.environ.get("TORCHDYNAMO_DISABLE") == "1"
+    captured = capfd.readouterr()
+    assert "compile_fallback_to_eager" in captured.out
+    assert "reason=triton_api_mismatch" in captured.out


### PR DESCRIPTION
Three fixes from the Runpod sweep failure tonight: widen LSTM input by regime tail (#406, refs #307), auto-activate rates heads when --rates-target-mode != raw (#405, refs #305/#401), auto-disable torch.compile on broken triton (#403). Re-running the 3 broken sweeps after this lands.