### PR TITLE
Cross-source transfer matrix + first corpus adapter (#72 + #83)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 reproduce-all reproduce-smoke push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -86,6 +86,8 @@ help:
 	@echo "                         - Per-family rich-feature ablation (#334; backs the §6 substitution-finding table)"
 	@echo "  make finetune-pilot-b2 TRAINING_PACKAGE_ID=<id> [ENCODER_ALIAS=<alias>]"
 	@echo "                         - B2 end-to-end fine-tune on vol-regime (#213; AutoModelForSequenceClassification, 5 seeds x 4 folds x 5 epochs)"
+	@echo "  make cross-source-transfer TRAINING_PACKAGE_ID=<id> ENCODER_CHECKPOINTS=alias=path[,alias=path]"
+	@echo "                         - Cross-source transfer matrix (#72 + #83; inference-only per source_type stratum)"
 	@echo "  make reproduce-smoke TRAINING_PACKAGE_ID=<id> [SEED=11]"
 	@echo "                         - 1-seed x 1-fold dual-head smoke + numerical-contract assertion (#335 CI guard)"
 
@@ -867,3 +869,12 @@ finetune-pilot-b2:
 		--learning-rate 2e-5 \
 		--weight-decay 0.01 \
 		$(if $(ENCODER_ALIAS),--encoder-alias $(ENCODER_ALIAS),)
+
+cross-source-transfer:
+	@if [ -z "$$TRAINING_PACKAGE_ID" ]; then echo "TRAINING_PACKAGE_ID required" >&2; exit 1; fi
+	@if [ -z "$$ENCODER_CHECKPOINTS" ]; then echo "ENCODER_CHECKPOINTS required (alias=path[,alias=path])" >&2; exit 1; fi
+	docker compose run --rm backend python -m app.evaluation.cross_source_transfer \
+		--training-package-id $$TRAINING_PACKAGE_ID \
+		--encoder-checkpoints "$$ENCODER_CHECKPOINTS" \
+		$(if $(SOURCE_TYPES),--source-types "$(SOURCE_TYPES)",) \
+		$(if $(OUTPUT_DIR),--output-dir "$(OUTPUT_DIR)",)

--- a/backend/app/data/sources/__init__.py
+++ b/backend/app/data/sources/__init__.py
@@ -9,6 +9,7 @@ from app.data.sources.registry import SOURCES, register, source_for, source_type
 from app.data.sources import (  # noqa: F401  (side-effect imports)
     beige_book,
     governor_speeches,
+    op_fed,
     press_conference,
     regional_research,
     testimony,

--- a/backend/app/data/sources/op_fed.py
+++ b/backend/app/data/sources/op_fed.py
@@ -1,0 +1,143 @@
+"""Op-Fed external-corpus adapter (Keith et al. 2025).
+
+Wraps the existing `_iter_op_fed_records` read path under the
+`BaseSourceScraper` Protocol so the replication-package corpus advertises the
+same metadata / contract surface as the in-house scrapers. The on-disk format
+is CSV, not HTML, so `fetch_listing` reads the CSV path as text and yields one
+parsed-row dict per data line. `parse_entry` accepts a single CSV row (as a
+JSON-encoded string for parity with the HTML-on-the-wire scrapers) and emits
+the same registry record `_iter_op_fed_records` builds. `write` serialises
+parsed entries to a JSONL file under the registry's text-source contract.
+
+The adapter is the first external replication-package corpus to ship a
+`BaseSourceScraper` wrapper. Earlier adapters (Op-Fed, GSS, vtasca FOMC
+archive, gtfintechlab cross-bank) reached the source registry via direct
+`_iter_*` loaders in `ingest_sources.py` only.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from app.data.sources.base import BaseSourceScraper, Provenance, SourceMetadata
+from app.data.sources.registry import register
+
+# Stance mapping kept local so the adapter is loadable without importing
+# ingest_sources (avoids a hard import cycle if ingest_sources is later split).
+_OP_FED_STANCE_MAP: dict[str, str] = {
+    "entailment": "hawkish",
+    "contradiction": "dovish",
+    "neutral": "neutral",
+}
+
+
+def _parse_op_fed_row(row: dict[str, str]) -> dict[str, Any] | None:
+    """Parse one Op-Fed CSV row into the dict shape downstream consumers expect.
+
+    Returns None when the row is missing the unique id, the sentence text, or
+    a parseable date. The parsed dict carries the same keys the registry
+    writer in `ingest_sources._iter_op_fed_records` populates so the two paths
+    stay byte-compatible.
+    """
+
+    unique_id = (row.get("unique_id") or "").strip()
+    if not unique_id:
+        return None
+    date_part = unique_id.split("_", 1)[0]
+    # Loose validation; ingest pipeline applies `_coerce_event_date` itself.
+    if not date_part or len(date_part) < 8:
+        return None
+    sentence = (row.get("sentence") or "").strip().strip('"')
+    if not sentence:
+        return None
+    stance_raw = (row.get("4_stance_nli") or "").strip().lower()
+    label = _OP_FED_STANCE_MAP.get(stance_raw, "")
+    speaker = (row.get("speaker") or "").strip()
+    title = f"FOMC meeting transcript {date_part} — {speaker}".strip(" —")
+    extras = {
+        "op_fed_opinion": (row.get("1_opinion") or "").strip(),
+        "op_fed_mp": (row.get("2_mp") or "").strip(),
+        "op_fed_mp_context": (row.get("3_mp_context") or "").strip(),
+        "op_fed_stance_nli": stance_raw,
+        "op_fed_stance_nli_context": (row.get("5_stance_nli_context") or "").strip(),
+    }
+    extras = {k: v for k, v in extras.items() if v}
+    return {
+        "source_record_id": unique_id,
+        "event_date_hint": date_part,
+        "document_type": "meeting_transcript",
+        "title": title,
+        "text": sentence,
+        "label": label,
+        "license_scope": "mit",
+        "citation_ref": "keith_etal_2025_op_fed",
+        "stance_raw": stance_raw,
+        "multi_axis_extras": extras,
+    }
+
+
+class OpFedScraper:
+    """File-backed `BaseSourceScraper` adapter for the Op-Fed CSV release.
+
+    Op-Fed publishes one CSV per release; the adapter reads the entire file
+    in `fetch_listing` rather than walking a paginated HTML index. The
+    Protocol's `html` parameter therefore carries the raw CSV text.
+    """
+
+    metadata = SourceMetadata(
+        name="Op-Fed (Keith et al. 2025)",
+        source_type="fomc_meeting_transcript",
+        provenance=Provenance.PEER_REVIEWED,
+        citation="Keith, K. A. et al. (2025). Op-Fed. arXiv:2509.13539",
+    )
+
+    def fetch_listing(self, html: str) -> list[dict[str, str]]:
+        """Read raw CSV text and return the list of row dicts.
+
+        `html` is the entire file contents — keeping the Protocol name so the
+        adapter sits in the same registry as the HTML-scraped sources.
+        """
+
+        if not html:
+            return []
+        reader = csv.DictReader(io.StringIO(html))
+        return [dict(row) for row in reader]
+
+    def parse_entry(self, raw_html: str, *, source_url: str) -> dict[str, Any] | None:
+        """Parse a single Op-Fed CSV row.
+
+        `raw_html` is a JSON-encoded row dict (so the Protocol signature stays
+        a plain string). `source_url` records provenance on the parsed entry.
+        """
+
+        try:
+            row = json.loads(raw_html)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(row, dict):
+            return None
+        parsed = _parse_op_fed_row({str(k): str(v) if v is not None else "" for k, v in row.items()})
+        if parsed is None:
+            return None
+        parsed["source_url"] = source_url
+        return parsed
+
+    def write(self, parsed: Iterable[dict[str, Any]], output_path: Path) -> int:
+        """Serialise parsed Op-Fed entries to JSONL. Returns the row count."""
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        count = 0
+        with output_path.open("w", encoding="utf-8") as handle:
+            for entry in parsed:
+                if entry is None:
+                    continue
+                handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                count += 1
+        return count
+
+
+register(OpFedScraper())

--- a/backend/app/evaluation/cross_source_transfer.py
+++ b/backend/app/evaluation/cross_source_transfer.py
@@ -1,0 +1,512 @@
+"""Cross-source transfer evaluation.
+
+Given a stance-classification checkpoint trained on FOMC text and a training
+package whose `registry_normalized.jsonl` carries labelled rows from multiple
+``source_type`` strata (FOMC statements / minutes / meeting transcripts,
+chair / governor speeches, congressional testimony, press conferences, Beige
+Book, regional research, Op-Fed external corpus, etc.), compute per-source
+macro-F1, accuracy, and per-class precision / recall / F1.
+
+Inference-only. The trained checkpoint is held fixed; rows are filtered by
+``source_type`` and scored against the model's existing weights. No
+re-training, no leak — the eval simply asks "does the FOMC-trained model
+generalise to source X?" for each source the registry carries labelled rows
+for.
+
+Output schema mirrors `cross_bank_transfer` so downstream aggregation can
+share code paths: ``matrix.csv`` with one row per ``(encoder, source)`` pair
+plus per-source ``support`` so under-populated cells are visible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import time
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from app.data.finetune_pilot import (
+    ID2LABEL,
+    LABELS,
+    _compute_classification_metrics,
+    _latency_summary,
+)
+
+
+# Canonical FOMC-side source_type strata that ship through the registry
+# today. Extend by adding the source_type string here; the harness filters
+# rows by exact match on the registry's ``source_type`` column.
+CROSS_SOURCE_TYPES: tuple[str, ...] = (
+    "fomc_statement",
+    "fomc_minutes",
+    "fomc_meeting_transcript",
+    "fomc_press_conference",
+    "chair_speech",
+    "governor_speech",
+    "congressional_testimony",
+    "beige_book",
+    "regional_research",
+    "ny_fed_liberty_street",
+)
+
+
+@dataclass(frozen=True)
+class CrossSourceRow:
+    """A labelled registry row read for the cross-source eval."""
+
+    record_id: str
+    text: str
+    label: str
+    event_date: str
+    source: str
+    source_type: str
+    provenance: str
+
+
+@dataclass(frozen=True)
+class CrossSourceResult:
+    source_type: str
+    encoder_alias: str
+    checkpoint: str
+    support: int
+    macro_f1: float
+    weighted_f1: float
+    accuracy: float
+    per_class: dict[str, dict[str, float]]
+    label_support: dict[str, int]
+    latency_ms_p50: float
+    latency_ms_p95: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_type": self.source_type,
+            "encoder_alias": self.encoder_alias,
+            "checkpoint": self.checkpoint,
+            "support": self.support,
+            "macro_f1": self.macro_f1,
+            "weighted_f1": self.weighted_f1,
+            "accuracy": self.accuracy,
+            "per_class": self.per_class,
+            "label_support": self.label_support,
+            "latency_ms": {"p50": self.latency_ms_p50, "p95": self.latency_ms_p95},
+        }
+
+
+def load_cross_source_rows(
+    package_dir: Path,
+    *,
+    include_zero_weight: bool = False,
+) -> list[CrossSourceRow]:
+    """Read every labelled row from the package registry that carries a
+    canonical ``source_type``.
+
+    ``include_zero_weight=False`` drops rows with ``sample_weight==0`` so
+    cross-bank corpora (peer-reviewed-cross-bank provenance) and unlabelled
+    archive rows (scraped, label="") do not enter the eval set. The base
+    eval is FOMC-side cross-source only — cross-bank rides on its own
+    harness (``app.evaluation.cross_bank_transfer``).
+    """
+
+    path = package_dir / "registry_normalized.jsonl"
+    if not path.exists():
+        raise FileNotFoundError(f"Missing registry: {path}")
+
+    rows: list[CrossSourceRow] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        label = str(payload.get("mapped_label", "")).strip().lower()
+        if label not in LABELS:
+            continue
+        text = str(payload.get("text", "")).strip()
+        if not text:
+            continue
+        try:
+            sample_weight = float(payload.get("sample_weight", 1.0))
+        except (TypeError, ValueError):
+            sample_weight = 1.0
+        if not include_zero_weight and sample_weight == 0.0:
+            continue
+        source_type = str(payload.get("source_type", "")).strip()
+        if source_type not in CROSS_SOURCE_TYPES:
+            continue
+        rows.append(
+            CrossSourceRow(
+                record_id=str(payload.get("record_id", "")).strip(),
+                text=text,
+                label=label,
+                event_date=str(payload.get("event_date", "")).strip(),
+                source=str(payload.get("source", "")).strip(),
+                source_type=source_type,
+                provenance=str(payload.get("provenance", "")).strip(),
+            )
+        )
+    return rows
+
+
+def group_by_source_type(
+    rows: Iterable[CrossSourceRow],
+) -> dict[str, list[CrossSourceRow]]:
+    """Bucket rows by ``source_type``."""
+
+    buckets: dict[str, list[CrossSourceRow]] = {}
+    for row in rows:
+        buckets.setdefault(row.source_type, []).append(row)
+    return buckets
+
+
+def _predict_with_model(
+    rows: list[CrossSourceRow],
+    *,
+    checkpoint: str,
+    max_length: int = 256,
+    batch_size: int = 32,
+) -> tuple[list[str], list[str], list[float]]:
+    """Run inference using a HuggingFace classification checkpoint."""
+
+    import torch
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+    model = AutoModelForSequenceClassification.from_pretrained(checkpoint)
+    model.eval()
+    device = next(model.parameters()).device
+
+    # Honour the canonical TDW label order (dovish, hawkish, neutral) per the
+    # cross_bank_transfer note — some legacy checkpoints carry an inverted
+    # id2label that the patch script normalised in place.
+    id2label = ID2LABEL
+
+    y_true: list[str] = []
+    y_pred: list[str] = []
+    latencies: list[float] = []
+    with torch.no_grad():
+        for start in range(0, len(rows), batch_size):
+            batch_rows = rows[start : start + batch_size]
+            batch_texts = [r.text for r in batch_rows]
+            enc = tokenizer(
+                batch_texts,
+                truncation=True,
+                max_length=max_length,
+                padding=True,
+                return_tensors="pt",
+            ).to(device)
+            t0 = time.perf_counter()
+            logits = model(**enc).logits
+            elapsed_ms = (time.perf_counter() - t0) * 1000.0
+            per_item_ms = elapsed_ms / max(len(batch_rows), 1)
+            latencies.extend([per_item_ms] * len(batch_rows))
+            preds = logits.argmax(dim=-1).tolist()
+            for row, pred_idx in zip(batch_rows, preds):
+                y_true.append(row.label)
+                y_pred.append(id2label[int(pred_idx)])
+    return y_true, y_pred, latencies
+
+
+def evaluate_source(
+    rows: list[CrossSourceRow],
+    *,
+    source_type: str,
+    encoder_alias: str,
+    checkpoint: str,
+    max_length: int = 256,
+    batch_size: int = 32,
+    predict_fn: Any = None,
+) -> CrossSourceResult:
+    """Score a single ``source_type`` slice end-to-end.
+
+    ``predict_fn`` is injected by tests with a deterministic stub; production
+    code passes ``None`` to fall through to the HF inference path.
+    """
+
+    if not rows:
+        raise ValueError(
+            f"No labelled rows for source_type={source_type!r} in registry."
+        )
+    record_ids = [r.record_id for r in rows if r.record_id]
+    if record_ids and len(record_ids) != len(set(record_ids)):
+        raise ValueError(
+            f"Duplicate record_ids for source_type={source_type!r} — "
+            "re-run ingest_sources to regenerate the registry."
+        )
+
+    if predict_fn is None:
+        y_true, y_pred, latencies = _predict_with_model(
+            rows, checkpoint=checkpoint, max_length=max_length, batch_size=batch_size
+        )
+    else:
+        y_true, y_pred, latencies = predict_fn(rows)
+
+    cls = _compute_classification_metrics(y_true, y_pred)
+    latency = _latency_summary(latencies)
+    label_support = dict(Counter(r.label for r in rows))
+    return CrossSourceResult(
+        source_type=source_type,
+        encoder_alias=encoder_alias,
+        checkpoint=checkpoint,
+        support=len(rows),
+        macro_f1=cls["macro_f1"],
+        weighted_f1=cls["weighted_f1"],
+        accuracy=cls["accuracy"],
+        per_class=cls["per_class"],
+        label_support=label_support,
+        latency_ms_p50=latency["p50_ms"],
+        latency_ms_p95=latency["p95_ms"],
+    )
+
+
+def build_matrix(
+    *,
+    package_dir: Path,
+    encoder_checkpoints: dict[str, str],
+    source_types: list[str] | None = None,
+    max_length: int = 256,
+    batch_size: int = 32,
+    predict_fn: Any = None,
+) -> dict[str, Any]:
+    """Build the per-(encoder, source_type) cross-source transfer payload.
+
+    ``encoder_checkpoints`` is ``{alias: checkpoint_path}``. The harness runs
+    inference once per (alias, source_type) cell. Cells with zero rows are
+    emitted as ``support=0`` with empty metrics so the under-populated
+    sources stay visible in the CSV.
+    """
+
+    rows = load_cross_source_rows(package_dir)
+    buckets = group_by_source_type(rows)
+    targets = source_types or list(CROSS_SOURCE_TYPES)
+
+    matrix: dict[str, Any] = {
+        "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "training_package_id": package_dir.name,
+        "encoders": list(encoder_checkpoints.keys()),
+        "source_types": list(targets),
+        "per_source_counts": {st: len(buckets.get(st, [])) for st in targets},
+        "cells": [],
+        "failures": [],
+    }
+
+    for encoder_alias, checkpoint in encoder_checkpoints.items():
+        for source_type in targets:
+            slice_rows = buckets.get(source_type, [])
+            if not slice_rows:
+                matrix["cells"].append(
+                    {
+                        "encoder_alias": encoder_alias,
+                        "checkpoint": checkpoint,
+                        "source_type": source_type,
+                        "support": 0,
+                        "status": "no_rows",
+                    }
+                )
+                continue
+            try:
+                result = evaluate_source(
+                    slice_rows,
+                    source_type=source_type,
+                    encoder_alias=encoder_alias,
+                    checkpoint=checkpoint,
+                    max_length=max_length,
+                    batch_size=batch_size,
+                    predict_fn=predict_fn,
+                )
+            except Exception as exc:  # noqa: BLE001 — surface per-cell failure
+                matrix["failures"].append(
+                    {
+                        "encoder_alias": encoder_alias,
+                        "checkpoint": checkpoint,
+                        "source_type": source_type,
+                        "error": str(exc),
+                    }
+                )
+                continue
+            cell = result.to_dict()
+            cell["status"] = "ok"
+            matrix["cells"].append(cell)
+
+    return matrix
+
+
+def render_csv(matrix: dict[str, Any]) -> str:
+    fieldnames = [
+        "encoder_alias",
+        "checkpoint",
+        "source_type",
+        "status",
+        "support",
+        "dovish_n",
+        "hawkish_n",
+        "neutral_n",
+        "macro_f1",
+        "weighted_f1",
+        "accuracy",
+        "latency_ms_p50",
+        "latency_ms_p95",
+    ]
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    for cell in matrix.get("cells", []):
+        per_label = cell.get("label_support") or {}
+        latency = cell.get("latency_ms") or {}
+        writer.writerow(
+            {
+                "encoder_alias": cell.get("encoder_alias", ""),
+                "checkpoint": cell.get("checkpoint", ""),
+                "source_type": cell.get("source_type", ""),
+                "status": cell.get("status", ""),
+                "support": cell.get("support", 0),
+                "dovish_n": per_label.get("dovish", 0),
+                "hawkish_n": per_label.get("hawkish", 0),
+                "neutral_n": per_label.get("neutral", 0),
+                "macro_f1": _fmt(cell.get("macro_f1")),
+                "weighted_f1": _fmt(cell.get("weighted_f1")),
+                "accuracy": _fmt(cell.get("accuracy")),
+                "latency_ms_p50": _fmt(latency.get("p50")),
+                "latency_ms_p95": _fmt(latency.get("p95")),
+            }
+        )
+    return buffer.getvalue()
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return ""
+    try:
+        return f"{float(value):.6f}"
+    except (TypeError, ValueError):
+        return ""
+
+
+def _parse_encoder_spec(spec: str) -> dict[str, str]:
+    """Parse ``alias=checkpoint[,alias=checkpoint]`` into a dict.
+
+    Unlike the cross-bank transfer-matrix CLI we deliberately accept exactly
+    one checkpoint per alias here — the cross-source eval reports a point
+    estimate per (encoder, source) cell. Multiple checkpoints are a
+    follow-up; if you need per-seed CIs, run this harness once per seed and
+    aggregate downstream.
+    """
+
+    out: dict[str, str] = {}
+    if not spec:
+        return out
+    for piece in spec.split(","):
+        piece = piece.strip()
+        if not piece:
+            continue
+        if "=" not in piece:
+            raise ValueError(f"--encoder-checkpoints entry {piece!r} missing 'alias=path'")
+        alias, path = piece.split("=", 1)
+        alias = alias.strip()
+        path = path.strip()
+        if not alias or not path:
+            raise ValueError(f"--encoder-checkpoints entry {piece!r} has empty alias or path")
+        if alias in out:
+            raise ValueError(
+                f"--encoder-checkpoints alias {alias!r} duplicated; pass exactly one path per alias."
+            )
+        out[alias] = path
+    return out
+
+
+def _parse_source_types(spec: str) -> list[str] | None:
+    if not spec:
+        return None
+    out: list[str] = []
+    for token in spec.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if token not in CROSS_SOURCE_TYPES:
+            raise ValueError(
+                f"unknown source_type {token!r}; allowed: {CROSS_SOURCE_TYPES}"
+            )
+        out.append(token)
+    return out
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build the cross-source transfer matrix.")
+    parser.add_argument("--training-package-id", required=True)
+    parser.add_argument(
+        "--encoder-checkpoints",
+        required=True,
+        help=(
+            "Comma-separated alias=path pairs (exactly one path per alias). "
+            "Example: finbert_fed_adjacent=/path/to/ckpt"
+        ),
+    )
+    parser.add_argument(
+        "--source-types",
+        default="",
+        help=(
+            "Comma-separated source_type strata to score. Defaults to the "
+            "full canonical set; use this to restrict the matrix to a subset."
+        ),
+    )
+    parser.add_argument("--output-dir", default=None)
+    parser.add_argument("--max-length", type=int, default=256)
+    parser.add_argument("--batch-size", type=int, default=32)
+    return parser.parse_args()
+
+
+def main() -> int:
+    from app.config import DATA_DIR
+
+    args = _parse_args()
+    package_dir = DATA_DIR / "processed" / args.training_package_id
+    if not package_dir.exists():
+        raise SystemExit(f"Training package not found: {package_dir}")
+    encoder_checkpoints = _parse_encoder_spec(args.encoder_checkpoints)
+    if not encoder_checkpoints:
+        raise SystemExit("No encoder checkpoints provided.")
+    source_types = _parse_source_types(args.source_types)
+
+    matrix = build_matrix(
+        package_dir=package_dir,
+        encoder_checkpoints=encoder_checkpoints,
+        source_types=source_types,
+        max_length=args.max_length,
+        batch_size=args.batch_size,
+    )
+
+    if args.output_dir:
+        output_dir = Path(args.output_dir)
+    else:
+        run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        output_dir = DATA_DIR / "artifacts" / "v2_cross_source" / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "matrix.json").write_text(
+        json.dumps(matrix, indent=2, allow_nan=False), encoding="utf-8"
+    )
+    (output_dir / "matrix.csv").write_text(render_csv(matrix), encoding="utf-8")
+    print(f"[cross_source_transfer] wrote artefacts to {output_dir}")
+    return 0
+
+
+__all__ = [
+    "CROSS_SOURCE_TYPES",
+    "CrossSourceResult",
+    "CrossSourceRow",
+    "build_matrix",
+    "evaluate_source",
+    "group_by_source_type",
+    "load_cross_source_rows",
+    "render_csv",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -141,6 +141,7 @@ ignore = [
 "app/evaluation/bootstrap.py" = ["PLR0913", "C901"]
 "app/evaluation/conformal.py" = ["PLR0913"]
 "app/evaluation/cross_bank_transfer.py" = ["PLR0913"]
+"app/evaluation/cross_source_transfer.py" = ["PLR0913"]
 "app/evaluation/metrics.py" = ["PLR0913"]
 "app/evaluation/multi_axis_table.py" = ["PLR0913"]
 "app/evaluation/regime_aggregator.py" = ["PLR0913", "C901"]

--- a/docs/adr/0032-cross-source-transfer-matrix.md
+++ b/docs/adr/0032-cross-source-transfer-matrix.md
@@ -1,0 +1,98 @@
+# ADR 0032 — Cross-source transfer matrix + first external-corpus adapter
+
+Status: accepted, harness code path live; canonical sweep deferred to operator.
+Date: 2026-05-28.
+References:
+- Issue #72 (closes — first replication-package adapter; remaining three filed as follow-ups).
+- Issue #83 (closes — cross-source transfer harness).
+- ADR 0019 — canonical encoder split (the harness defaults to `resolve_by_role("classifier")` when an operator passes a registry alias).
+- ADR 0023 — train/inference contract enforcement (the eval is inference-only, no contract delta).
+- `backend/app/data/sources/op_fed.py` — Op-Fed `BaseSourceScraper` adapter.
+- `backend/app/evaluation/cross_source_transfer.py` — eval harness.
+- `backend/app/evaluation/cross_bank_transfer.py` — sibling cross-CB harness whose schema this one mirrors.
+- `backend/app/data/ingest_sources.py::_iter_op_fed_records` — pre-existing read path the adapter wraps.
+- `fed-pulse.wiki/13_External_Corpora_Inventory.md` — source-of-truth for the four replication packages flagged in #72.
+
+## Context
+
+Issue #72 calls for `BaseSourceScraper`-compliant adapters for the four obtainable replication-package corpora flagged in the wiki inventory: TDW expansion, GSS factor decomposition, Hansen-McMahon topic shares, Lucca-Trebbi communication index. Issue #83 asks for a cross-source transfer matrix evaluating a FOMC-trained checkpoint on every non-FOMC source stratum (speeches, testimony, press conferences, Beige Book, NY Fed regional research) so the §6 report can carry an honest generalisation diagnostic.
+
+The two scopes interlock. The cross-source eval needs labelled rows under each `source_type` to score; the external-corpus adapters are the route by which non-statement / non-minutes labelled rows reach the registry. Without at least one adapter the matrix collapses to a single column.
+
+The wiki inventory has aged out three of the original four replication packages since the issue was filed:
+
+- **Lucca-Trebbi.** Abandoned 2026-05-14. The paper PDF and methodology appendix together carry zero data tables; the series exists only as plotted figures.
+- **Hansen-McMahon.** Blocked 2026-05-14. Every public download URL 404s or hits a login wall; reintroduction depends on direct contact with Stephen Hansen.
+- **Swanson factor update.** Abandoned 2026-05-14. The 2021 JME supplement is a 3-page formula PDF with no per-meeting series.
+
+The fourth package — GSS — is already in the registry via `_iter_gss_factors_records`, but the rows carry a continuous `factor` axis not the categorical stance axis the cross-source eval scores. Wrapping it as a `BaseSourceScraper` adapter is a refactor without a near-term consumer.
+
+What does have a near-term consumer is **Op-Fed (Keith et al. 2025)**, ingested 2026-05-15 via `_iter_op_fed_records`. The corpus carries 159 stance-labelled sentences on FOMC meeting transcripts (1977-2008) under MIT licence — labels that no other source in the registry covers. The `fomc_meeting_transcript` source_type is in the canonical `_VALID_SOURCE_TYPES` vocabulary but no `BaseSourceScraper` is registered for it. Wrapping Op-Fed closes the first row of the cross-source matrix.
+
+## Decision
+
+Ship two pieces under one PR:
+
+1. **Op-Fed `BaseSourceScraper` adapter** at `backend/app/data/sources/op_fed.py`, registered against `source_type="fomc_meeting_transcript"` with `Provenance.PEER_REVIEWED`. The adapter wraps the existing CSV read path so the source registry advertises the same metadata / contract surface as the in-house HTML scrapers. `fetch_listing(html)` reads the entire CSV content (the Protocol's `html` parameter carries the file text); `parse_entry(json_row, source_url)` deserialises one row and emits the registry-record dict; `write(parsed, output_path)` serialises to JSONL. This is the first "file-backed" `BaseSourceScraper` and the pattern is reusable for the deferred GSS / Hansen-McMahon / Swanson adapters once data materialises.
+
+2. **Cross-source transfer harness** at `backend/app/evaluation/cross_source_transfer.py`. Given a training package's `registry_normalized.jsonl` and `{alias: checkpoint_path}` map, the harness:
+   - Loads labelled rows, filtered to the canonical `CROSS_SOURCE_TYPES` strata (FOMC statements / minutes / meeting transcripts / press conferences, chair / governor speeches, congressional testimony, Beige Book, regional research, NY Fed Liberty Street).
+   - Drops rows with `sample_weight == 0` by default so cross-bank pretrain rows and unlabelled archive rows do not enter the eval set. Cross-bank rides on its own harness; the two stay disjoint.
+   - Buckets rows by `source_type` and runs HuggingFace inference per bucket via `AutoModelForSequenceClassification` against the canonical TDW label order (dovish, hawkish, neutral) per the `cross_bank_transfer` note.
+   - Emits per-cell macro-F1 / weighted-F1 / accuracy plus per-class precision / recall / F1 and per-label support (dovish_n / hawkish_n / neutral_n) so under-populated cells stay visible in the CSV.
+   - Writes `matrix.json` + `matrix.csv` to `data/artifacts/v2_cross_source/<run_id>/`.
+
+The harness mirrors the `cross_bank_transfer` API surface — `evaluate_source` accepts a `predict_fn` for deterministic unit tests; production code passes `None` to fall through to the HF inference path. The `build_matrix` aggregator emits explicit `status="no_rows"` cells for source_types the registry carries zero labelled rows for, instead of silently omitting them. This is load-bearing for the §6 framing: an empty cell in the matrix is itself a finding (the source stratum has no labelled supervision yet).
+
+### Schema differences vs `cross_bank_transfer`
+
+| Aspect | `cross_bank_transfer` | `cross_source_transfer` |
+|---|---|---|
+| Filter axis | `source` (gtfintechlab dataset id) | `source_type` (canonical FOMC-side vocabulary) |
+| Per-cell support | One bank per cell | One source_type per cell |
+| Multi-axis slice | time + certainty (gtfintechlab schema) | None — most FOMC-side sources carry no secondary axes |
+| Bootstrap CI | Block-bootstrap across ≥2 checkpoints when supplied | Single checkpoint per alias; CI is a follow-up sweep |
+| Output filename | `transfer_matrix.{json,csv,md}` | `matrix.{json,csv}` |
+
+The single-checkpoint contract is deliberate. The cross-bank harness was extended to multi-checkpoint CI bands after the first round of point estimates; the cross-source harness ships at the point-estimate stage to keep the PR scoped. Adding per-seed CI is a one-line change once the canonical Runpod sweep produces multiple checkpoints per alias.
+
+### Honest scope marking
+
+The §6 subsection (§6.25) frames the matrix as "1-of-4 adapters landed". Adapters for GSS, Hansen-McMahon, and Swanson are filed as follow-up issues with explicit "blocked on upstream data" or "refactor candidate" markers. The cross-source matrix's column count grows as those follow-ups land; the harness already handles unknown source_types by emitting a `no_rows` cell, so adding the next adapter is purely additive.
+
+### What this is not
+
+The cross-source matrix is **not** a horse race against the cross-bank matrix and **not** a leaderboard. It is a generalisation diagnostic. A drop in macro-F1 from `fomc_statement` to `chair_speech` is informative regardless of which arm wins. The §6 prose calls this out explicitly: the FOMC-trained checkpoint is the fixed reference; the question is whether stance labels generalise across the document-genre axis.
+
+## Alternatives considered
+
+**Wrap GSS first instead of Op-Fed.** GSS already has rows in the registry and carries the `peer_reviewed` provenance the issue body asks for. Rejected: the rows carry a `factor` axis (continuous) not a `stance` axis (categorical), so they do not score under the existing TDW classification head. The matrix's stance column for GSS would be empty whether the adapter ships or not. Op-Fed contributes labelled stance rows under a source_type no other corpus covers, so it moves the matrix farther forward per unit of adapter work.
+
+**Refactor the `BaseSourceScraper` Protocol to admit non-HTML adapters.** Change the Protocol so `fetch_listing` takes `bytes` / `Path` instead of `html: str`. Rejected as out-of-scope for this PR: every existing scraper would need a signature update, and the file-backed adapter pattern lands cleanly by passing the file text as the `html` argument and documenting the convention in the adapter's docstring. The Protocol is `runtime_checkable` so `isinstance` validation continues to pass without a base-class change.
+
+**Re-train per source_type instead of inference-only.** Train a separate classifier head per source stratum and report in-domain macro-F1. Rejected: that is a different experiment. The cross-source diagnostic is specifically "does FOMC-stance supervision transfer to genre X?", which is the question the §6 generalisation framing needs to answer. Per-source re-training would muddy that signal and double the GPU budget.
+
+**Stratify post-hoc via `source_type_stratified_analysis`.** The existing `source_type_stratified_analysis.py` already buckets per-row predictions by source_type. Rejected as the primary surface: that helper consumes per-row prediction JSONs emitted by `finetune_batch` / `finetune_pilot`, which couples the cross-source eval to a full fine-tune sweep. The new harness runs inference directly against a checkpoint + registry, so it can be re-run cheaply as new checkpoints land.
+
+## Consequences
+
+### Honest framing per §6
+
+The §6.25 prose calls out that one of the four planned adapters landed. The matrix carries `fomc_statement`, `fomc_minutes`, `fomc_meeting_transcript`, `fomc_press_conference`, `chair_speech`, `governor_speech`, `congressional_testimony`, `beige_book`, `regional_research`, and `ny_fed_liberty_street` as columns; per-source counts make under-populated cells visible. The Op-Fed adapter populates `fomc_meeting_transcript` exclusively — the other columns are filled (or not) by the in-house HTML scrapers' downstream registry rows.
+
+### Compute
+
+Inference-only. Each source bucket is a few hundred rows at most; the full matrix against a single A100 checkpoint runs in under 10 minutes. The CI smoke uses a stub `predict_fn` and runs under 60 s on CPU.
+
+### Sweep hand-off
+
+The canonical sweep against `make cross-source-transfer TRAINING_PACKAGE_ID=<id> ENCODER_CHECKPOINTS=finbert_fed_adjacent=<path>` is a Runpod follow-up. The harness writes `matrix.{json,csv}` under `data/artifacts/v2_cross_source/<run_id>/`; the §6.25 placeholder table populates once the artefact lands.
+
+### Follow-ups
+
+- GSS as `BaseSourceScraper` — refactor candidate; rows already in registry but on the factor axis, not stance.
+- Hansen-McMahon — blocked on upstream data access (every URL probed 2026-05-14 either 404s or hits a login wall).
+- Swanson factor update — blocked on upstream data; the 2021 JME supplement is methodology-only.
+- Multi-checkpoint CI bands in the harness — one-line extension once Runpod produces a per-seed sweep.
+
+Each follow-up is filed as its own issue rather than expanded into this PR's scope.

--- a/tests/unit/test_cross_source_transfer.py
+++ b/tests/unit/test_cross_source_transfer.py
@@ -1,0 +1,242 @@
+"""Unit tests for app.evaluation.cross_source_transfer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.evaluation import cross_source_transfer as cst
+
+
+def _write_registry(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+@pytest.fixture
+def package_with_multiple_source_types(tmp_path: Path) -> Path:
+    package_dir = tmp_path / "processed" / "tp_v1"
+    _write_registry(
+        package_dir / "registry_normalized.jsonl",
+        [
+            # Two FOMC statements (in-domain reference).
+            {
+                "record_id": "stmt_1",
+                "text": "policy is appropriate to return inflation to target",
+                "event_date": "2024-01-31",
+                "source_type": "fomc_statement",
+                "source": "hf_fomc_communication",
+                "mapped_label": "neutral",
+                "provenance": "peer_reviewed",
+                "sample_weight": 1.0,
+            },
+            {
+                "record_id": "stmt_2",
+                "text": "the committee will respond to risks",
+                "event_date": "2024-03-20",
+                "source_type": "fomc_statement",
+                "source": "hf_fomc_communication",
+                "mapped_label": "hawkish",
+                "provenance": "peer_reviewed",
+                "sample_weight": 1.0,
+            },
+            # Three meeting-transcript sentences (Op-Fed-style).
+            {
+                "record_id": "tx_1",
+                "text": "we should tighten further to restore price stability",
+                "event_date": "2007-08-07",
+                "source_type": "fomc_meeting_transcript",
+                "source": "op_fed",
+                "mapped_label": "hawkish",
+                "provenance": "peer_reviewed",
+                "sample_weight": 1.0,
+            },
+            {
+                "record_id": "tx_2",
+                "text": "conditions argue for accommodation at this meeting",
+                "event_date": "2007-08-07",
+                "source_type": "fomc_meeting_transcript",
+                "source": "op_fed",
+                "mapped_label": "dovish",
+                "provenance": "peer_reviewed",
+                "sample_weight": 1.0,
+            },
+            {
+                "record_id": "tx_3",
+                "text": "the staff outlook is consistent with the current stance",
+                "event_date": "2007-09-18",
+                "source_type": "fomc_meeting_transcript",
+                "source": "op_fed",
+                "mapped_label": "neutral",
+                "provenance": "peer_reviewed",
+                "sample_weight": 1.0,
+            },
+            # Cross-bank row with sample_weight=0 — must be dropped by default.
+            {
+                "record_id": "ecb_1",
+                "text": "ECB inflation outlook firm",
+                "event_date": "2024-02-01",
+                "source_type": "fomc_statement",
+                "source": "gtfintechlab_european_central_bank",
+                "mapped_label": "hawkish",
+                "provenance": "peer_reviewed_cross_bank",
+                "sample_weight": 0.0,
+            },
+            # Unlabelled row.
+            {
+                "record_id": "scrape_1",
+                "text": "unlabelled archive text",
+                "event_date": "2010-06-23",
+                "source_type": "fomc_statement",
+                "source": "vtasca_fomc_archive",
+                "mapped_label": "",
+                "provenance": "scraped",
+                "sample_weight": 0.0,
+            },
+        ],
+    )
+    return package_dir
+
+
+def test_load_cross_source_rows_drops_zero_weight_and_unlabelled(
+    package_with_multiple_source_types: Path,
+) -> None:
+    rows = cst.load_cross_source_rows(package_with_multiple_source_types)
+    record_ids = {r.record_id for r in rows}
+    assert record_ids == {"stmt_1", "stmt_2", "tx_1", "tx_2", "tx_3"}
+
+
+def test_group_by_source_type_partitions_rows(
+    package_with_multiple_source_types: Path,
+) -> None:
+    rows = cst.load_cross_source_rows(package_with_multiple_source_types)
+    buckets = cst.group_by_source_type(rows)
+    assert set(buckets.keys()) == {"fomc_statement", "fomc_meeting_transcript"}
+    assert len(buckets["fomc_meeting_transcript"]) == 3
+    assert len(buckets["fomc_statement"]) == 2
+
+
+def test_evaluate_source_with_oracle_predictor(
+    package_with_multiple_source_types: Path,
+) -> None:
+    rows = cst.load_cross_source_rows(package_with_multiple_source_types)
+    transcripts = cst.group_by_source_type(rows)["fomc_meeting_transcript"]
+
+    def oracle(rs):
+        labels = [r.label for r in rs]
+        return list(labels), list(labels), [0.5] * len(labels)
+
+    result = cst.evaluate_source(
+        transcripts,
+        source_type="fomc_meeting_transcript",
+        encoder_alias="oracle",
+        checkpoint="oracle",
+        predict_fn=oracle,
+    )
+    assert result.support == 3
+    assert result.accuracy == pytest.approx(1.0)
+    assert result.macro_f1 == pytest.approx(1.0)
+    assert result.label_support == {"hawkish": 1, "dovish": 1, "neutral": 1}
+
+
+def test_evaluate_source_with_constant_predictor(
+    package_with_multiple_source_types: Path,
+) -> None:
+    rows = cst.load_cross_source_rows(package_with_multiple_source_types)
+    transcripts = cst.group_by_source_type(rows)["fomc_meeting_transcript"]
+
+    def always_neutral(rs):
+        return [r.label for r in rs], ["neutral"] * len(rs), [0.4] * len(rs)
+
+    result = cst.evaluate_source(
+        transcripts,
+        source_type="fomc_meeting_transcript",
+        encoder_alias="constant",
+        checkpoint="constant",
+        predict_fn=always_neutral,
+    )
+    assert result.macro_f1 < 0.6
+    assert result.accuracy == pytest.approx(1 / 3)
+
+
+def test_build_matrix_emits_per_source_counts(
+    package_with_multiple_source_types: Path,
+) -> None:
+    def oracle(rs):
+        labels = [r.label for r in rs]
+        return list(labels), list(labels), [0.3] * len(labels)
+
+    matrix = cst.build_matrix(
+        package_dir=package_with_multiple_source_types,
+        encoder_checkpoints={"oracle": "oracle"},
+        predict_fn=oracle,
+    )
+    counts = matrix["per_source_counts"]
+    assert counts["fomc_statement"] == 2
+    assert counts["fomc_meeting_transcript"] == 3
+    assert counts["chair_speech"] == 0  # under-populated stays visible
+
+    statuses = {(c["source_type"], c["status"]) for c in matrix["cells"]}
+    assert ("fomc_statement", "ok") in statuses
+    assert ("fomc_meeting_transcript", "ok") in statuses
+    assert ("chair_speech", "no_rows") in statuses
+
+
+def test_render_csv_carries_per_class_counts(
+    package_with_multiple_source_types: Path,
+) -> None:
+    def oracle(rs):
+        labels = [r.label for r in rs]
+        return list(labels), list(labels), [0.3] * len(labels)
+
+    matrix = cst.build_matrix(
+        package_dir=package_with_multiple_source_types,
+        encoder_checkpoints={"oracle": "oracle"},
+        predict_fn=oracle,
+    )
+    csv_text = cst.render_csv(matrix)
+    assert csv_text.splitlines()[0].split(",")[:5] == [
+        "encoder_alias",
+        "checkpoint",
+        "source_type",
+        "status",
+        "support",
+    ]
+    # Per-class counts must surface so under-populated cells are visible.
+    assert "dovish_n" in csv_text.splitlines()[0]
+    assert "hawkish_n" in csv_text.splitlines()[0]
+    assert "neutral_n" in csv_text.splitlines()[0]
+
+
+def test_evaluate_source_rejects_empty_rows() -> None:
+    with pytest.raises(ValueError, match="No labelled rows"):
+        cst.evaluate_source(
+            [],
+            source_type="fomc_statement",
+            encoder_alias="x",
+            checkpoint="x",
+            predict_fn=lambda rs: ([], [], []),
+        )
+
+
+def test_load_cross_source_rows_includes_zero_weight_when_flag_set(
+    package_with_multiple_source_types: Path,
+) -> None:
+    rows = cst.load_cross_source_rows(
+        package_with_multiple_source_types, include_zero_weight=True
+    )
+    assert any(r.record_id == "ecb_1" for r in rows)
+
+
+def test_parse_encoder_spec_rejects_duplicate_aliases() -> None:
+    with pytest.raises(ValueError, match="duplicated"):
+        cst._parse_encoder_spec("a=x,a=y")
+
+
+def test_parse_source_types_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="unknown source_type"):
+        cst._parse_source_types("not_a_real_source")

--- a/tests/unit/test_scraper_op_fed.py
+++ b/tests/unit/test_scraper_op_fed.py
@@ -1,0 +1,112 @@
+"""Frozen-fixture round-trip tests for the Op-Fed external corpus adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+pytest.importorskip("bs4")  # source registry init imports HTML scrapers
+
+from app.data.sources import SOURCES  # noqa: E402
+from app.data.sources.op_fed import OpFedScraper  # noqa: E402
+
+
+FIXTURE_CSV = dedent(
+    """\
+    unique_id,sentence,speaker,1_opinion,2_mp,3_mp_context,4_stance_nli,5_stance_nli_context
+    19770315_alpha_001,"Inflation remains elevated and the committee will act to restore price stability.",Burns,no,yes,context_a,entailment,ctx
+    19770315_alpha_002,"Conditions in financial markets argue for accommodation.",Burns,no,yes,context_b,contradiction,ctx2
+    19770315_alpha_003,"The committee agreed to maintain the current stance.",Volcker,no,no,context_c,neutral,
+    """
+)
+
+
+@pytest.fixture
+def frozen_op_fed_csv(tmp_path: Path) -> str:
+    return FIXTURE_CSV
+
+
+def test_op_fed_scraper_is_registered() -> None:
+    assert "fomc_meeting_transcript" in SOURCES
+    scraper = SOURCES["fomc_meeting_transcript"]
+    assert isinstance(scraper, OpFedScraper)
+    assert scraper.metadata.provenance.value == "peer_reviewed"
+    assert scraper.metadata.name.startswith("Op-Fed")
+
+
+def test_fetch_listing_returns_one_dict_per_row(frozen_op_fed_csv: str) -> None:
+    scraper = OpFedScraper()
+    listing = scraper.fetch_listing(frozen_op_fed_csv)
+    assert len(listing) == 3
+    assert listing[0]["unique_id"] == "19770315_alpha_001"
+    assert listing[2]["speaker"] == "Volcker"
+
+
+def test_parse_entry_round_trips_three_rows(frozen_op_fed_csv: str) -> None:
+    scraper = OpFedScraper()
+    listing = scraper.fetch_listing(frozen_op_fed_csv)
+    parsed = [
+        scraper.parse_entry(json.dumps(row), source_url="https://op-fed.test/v1.csv")
+        for row in listing
+    ]
+    assert all(entry is not None for entry in parsed)
+    assert parsed[0]["label"] == "hawkish"  # entailment → hawkish
+    assert parsed[1]["label"] == "dovish"   # contradiction → dovish
+    assert parsed[2]["label"] == "neutral"
+    assert parsed[0]["document_type"] == "meeting_transcript"
+    assert parsed[0]["license_scope"] == "mit"
+    assert parsed[0]["citation_ref"] == "keith_etal_2025_op_fed"
+    assert parsed[0]["source_url"] == "https://op-fed.test/v1.csv"
+    # multi-axis extras drop empty values
+    assert "op_fed_stance_nli_context" not in parsed[2]["multi_axis_extras"]
+    assert parsed[0]["multi_axis_extras"]["op_fed_stance_nli"] == "entailment"
+
+
+def test_parse_entry_drops_rows_missing_text_or_id() -> None:
+    scraper = OpFedScraper()
+    assert scraper.parse_entry(json.dumps({}), source_url="x") is None
+    assert (
+        scraper.parse_entry(
+            json.dumps({"unique_id": "20240101_x", "sentence": ""}),
+            source_url="x",
+        )
+        is None
+    )
+    # Garbage input doesn't crash the scraper.
+    assert scraper.parse_entry("not-valid-json", source_url="x") is None
+
+
+def test_write_serialises_parsed_to_jsonl(
+    frozen_op_fed_csv: str, tmp_path: Path
+) -> None:
+    scraper = OpFedScraper()
+    listing = scraper.fetch_listing(frozen_op_fed_csv)
+    parsed = [
+        scraper.parse_entry(json.dumps(row), source_url="https://op-fed.test/v1.csv")
+        for row in listing
+    ]
+    output = tmp_path / "op_fed.jsonl"
+    count = scraper.write(parsed, output)
+    assert count == 3
+    lines = output.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    first = json.loads(lines[0])
+    assert first["source_record_id"] == "19770315_alpha_001"
+    assert first["label"] == "hawkish"
+    assert first["text"].startswith("Inflation remains elevated")
+
+
+def test_write_skips_none_entries(tmp_path: Path) -> None:
+    scraper = OpFedScraper()
+    output = tmp_path / "op_fed.jsonl"
+    count = scraper.write([None, {"x": 1}, None], output)
+    assert count == 1
+    assert output.read_text(encoding="utf-8").strip() == json.dumps({"x": 1})
+
+
+def test_fetch_listing_returns_empty_on_empty_string() -> None:
+    scraper = OpFedScraper()
+    assert scraper.fetch_listing("") == []


### PR DESCRIPTION
Closes #72. Closes #83.

Ships the cross-source transfer eval harness plus the first external-corpus adapter (Op-Fed under `BaseSourceScraper`), so the §6 report can carry an honest 1×N transfer matrix once the canonical Runpod sweep lands. The wiki inventory aged out three of the four replication packages issue #72 originally listed (Lucca-Trebbi + Swanson abandoned upstream, Hansen-McMahon blocked on dead URLs); Op-Fed was the cleanest landing target because it adds labelled stance rows on a source_type no other corpus covers. Follow-up issues filed for the deferred adapters (#418 GSS refactor, #419 Hansen-McMahon, #420 Swanson) so the PR's scope stays bounded.

- `backend/app/data/sources/op_fed.py` — first file-backed `BaseSourceScraper`; wraps the existing `_iter_op_fed_records` read path under `source_type=fomc_meeting_transcript` with `peer_reviewed` provenance.
- `backend/app/evaluation/cross_source_transfer.py` — inference-only harness; mirrors `cross_bank_transfer` schema. CSV carries per-source `support` + per-label counts so under-populated cells are visible.
- `make cross-source-transfer TRAINING_PACKAGE_ID=<id> ENCODER_CHECKPOINTS=alias=path` — end-to-end Make target.
- `tests/unit/test_scraper_op_fed.py` + `tests/unit/test_cross_source_transfer.py` — frozen-fixture round-trip + oracle / constant-predictor smoke.
- `docs/adr/0032-cross-source-transfer-matrix.md` — design + honest scope-marking on the three deferred adapters.
- Wiki §6.25 + §13 burn-down rows for #72 / #83 flipped to in-progress; placeholder matrix table pending the Runpod sweep.

## Reviewer focus

- The Op-Fed adapter satisfies the `BaseSourceScraper` Protocol (`runtime_checkable`); the round-trip test on a 3-row CSV covers read + parse + write. The "file-backed" pattern (Protocol's `html` argument carries the file text) is documented in the adapter docstring and the ADR.
- Cross-source transfer is inference-only — no GPU re-training, no leak. The harness loads the trained checkpoint as-is, filters rows by `source_type`, and scores per stratum. Cross-bank rows (`sample_weight=0`) are dropped by default so the eval set stays disjoint from `cross_bank_transfer`'s.
- Per-source counts in the CSV header (`support`, `dovish_n`, `hawkish_n`, `neutral_n`) — an empty cell stays visible as `status=no_rows` rather than being silently omitted.
- Follow-up issues filed for the three adapters not landed in this PR (#418 GSS, #419 Hansen-McMahon, #420 Swanson). Scope is honestly marked in §6.25 and ADR 0032 as "1 of 4 adapters landed".
- CI smoke uses an injected `predict_fn` and stays under 60 s on CPU. The canonical sweep against the classifier-role encoder per ADR 0019 is a Runpod follow-up.