### PR TITLE
Wire MultiTaskLoss through the training loop (#273)

### DIFF
--- a/backend/app/evaluation/metrics.py
+++ b/backend/app/evaluation/metrics.py
@@ -138,6 +138,17 @@ class TrainingRunSummary:
     # by the auxiliary classification surface).
     rates_scalers: dict[str, dict[str, float]] | None = None
     rates_quantile_edges: dict[str, dict[str, float | int | str]] | None = None
+    # #273 multi-task loss. ``None`` on every pre-#273 run and on
+    # multi_task_loss=False runs (the default). When the joint loss is
+    # active the dict carries the per-axis class-weight vectors fitted on
+    # the train slice plus the four lambda coefficients the
+    # ``MultiTaskLoss`` module was constructed with, so a resume from the
+    # checkpoint reads back the exact loss config the run trained under.
+    # Schema: ``{"stance": [...], "certainty": [...], "topic": [...],
+    # "lambdas": {"stance": float, "factor": float, "certainty": float,
+    # "topic": float}}``. The factor axis is a regression branch with no
+    # class weights, so it appears only under ``lambdas``.
+    multi_task_class_weights: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -3225,6 +3225,12 @@ def train_model(
     # identical to the single-task path on rows where only stance is
     # supervised.
     multi_task_loss_fn: nn.Module | None = None
+    # #273 per-axis class weights captured here so the run summary +
+    # checkpoint payload can persist them alongside the lambdas; resume
+    # then reads back the exact loss config the run trained under.
+    # ``None`` on multi_task_loss=False runs (the default) so the
+    # checkpoint contract on every pre-#273 caller stays byte-identical.
+    multi_task_class_weights_payload: dict[str, Any] | None = None
     if multi_task_loss_active and _active_output_mode == "classification":
         from app.models.config import (
             MULTI_TASK_CERTAINTY_CLASSES,
@@ -3261,6 +3267,26 @@ def train_model(
             lambda_certainty=float(getattr(active_model_config, "multi_task_lambda_certainty", 0.3)),
             lambda_topic=float(getattr(active_model_config, "multi_task_lambda_topic", 0.3)),
         ).to(device_obj)
+        # Stash the per-axis weights + lambdas on a plain dict so the
+        # TrainingRunSummary -> torch.save round-trip carries them onto
+        # the checkpoint payload. Tensors are detached to CPU so the
+        # serialised form is portable; the resume path can rebuild the
+        # MultiTaskLoss module by reading these back.
+        multi_task_class_weights_payload = {
+            "stance": (
+                class_weight_tensor.detach().cpu().tolist()
+                if class_weight_tensor is not None
+                else None
+            ),
+            "certainty": certainty_weight.detach().cpu().tolist(),
+            "topic": topic_weight.detach().cpu().tolist(),
+            "lambdas": {
+                "stance": float(multi_task_loss_fn.lambda_stance),
+                "factor": float(multi_task_loss_fn.lambda_factor),
+                "certainty": float(multi_task_loss_fn.lambda_certainty),
+                "topic": float(multi_task_loss_fn.lambda_topic),
+            },
+        }
         print(
             "[train_model] multi_task_loss active: "
             f"lambda_stance={multi_task_loss_fn.lambda_stance} "
@@ -3824,6 +3850,7 @@ def train_model(
             if rates_heads_active and rates_edges
             else None
         ),
+        multi_task_class_weights=multi_task_class_weights_payload,
     )
 
     if save_checkpoint:

--- a/tests/unit/test_multi_task_checkpoint_persistence.py
+++ b/tests/unit/test_multi_task_checkpoint_persistence.py
@@ -1,0 +1,157 @@
+"""Per-axis class weights + lambdas survive the checkpoint round-trip (#273).
+
+When ``multi_task_loss=True``, the training-loop builds per-axis class
+weights for stance / certainty / topic on the train slice and constructs
+a ``MultiTaskLoss`` with those weights plus the four lambda coefficients
+from the ModelConfig. The fitted weights + lambdas must land on the
+serialised checkpoint payload so a resume reads back the same loss
+config -- otherwise the post-resume gradient signal silently drifts.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+
+import torch
+
+from app.models.config import FeatureVector, ModelConfig
+from app.training.loop import train_model
+
+
+def _dummy_vec(
+    *,
+    day: int,
+    vol: float,
+    stance: int,
+    factor: float,
+    certainty: int,
+    topic: int,
+) -> FeatureVector:
+    return FeatureVector(
+        date=_dt.date(2025, 1, 1) + _dt.timedelta(days=day - 1),
+        sentiment_score=0.0,
+        market_close=100.0,
+        market_volatility=0.01,
+        close_change_pct=0.0,
+        volatility_change=0.0,
+        elapsed_time=0.0,
+        forward_realized_vol_10d=vol,
+        target_stance_idx=stance,
+        target_stance_present=True,
+        target_factor=factor,
+        target_factor_present=True,
+        target_certainty_idx=certainty,
+        target_certainty_present=True,
+        target_topic_idx=topic,
+        target_topic_present=True,
+    )
+
+
+def _make_groups(n: int = 40) -> list[list[FeatureVector]]:
+    return [
+        [
+            _dummy_vec(
+                day=i + 1,
+                vol=0.01 + 0.001 * i,
+                stance=i % 3,
+                factor=((i % 5) - 2) / 5.0,
+                certainty=i % 3,
+                topic=i % 4,
+            )
+            for i in range(n)
+        ]
+    ]
+
+
+def test_checkpoint_carries_per_axis_class_weights_and_lambdas(tmp_path: Path) -> None:
+    """One-epoch smoke: --multi-task-loss=on, then load the .pt and
+    assert the per-axis weights + lambdas round-trip into the payload.
+    """
+
+    config = ModelConfig(
+        output_mode="classification",
+        multi_task_loss=True,
+        multi_task_lambda_stance=1.0,
+        multi_task_lambda_factor=0.25,
+        multi_task_lambda_certainty=0.35,
+        multi_task_lambda_topic=0.40,
+        n_classes=3,
+    )
+    groups = _make_groups()
+    ckpt = tmp_path / "mt.pt"
+
+    result = train_model(
+        model_config=config,
+        train_sequence_groups=groups,
+        val_sequence_groups=groups,
+        test_sequence_groups=groups,
+        epochs=1,
+        batch_size=8,
+        seed=11,
+        save_checkpoint=True,
+        checkpoint_path=ckpt,
+        use_compile=False,
+        use_amp=False,
+    )
+
+    assert result.summary.epochs_completed == 1
+    # The summary itself carries the per-axis weights so a sweep
+    # aggregator can ingest them without re-loading the .pt file.
+    mt = result.summary.multi_task_class_weights
+    assert mt is not None
+    assert "certainty" in mt and "topic" in mt and "lambdas" in mt
+    assert isinstance(mt["certainty"], list) and len(mt["certainty"]) >= 2
+    assert isinstance(mt["topic"], list) and len(mt["topic"]) >= 2
+    lambdas = mt["lambdas"]
+    assert lambdas["stance"] == 1.0
+    assert lambdas["factor"] == 0.25
+    assert lambdas["certainty"] == 0.35
+    assert lambdas["topic"] == 0.40
+
+    # The on-disk checkpoint must also carry the same payload so a
+    # resume reads back the exact loss config the run trained under.
+    assert ckpt.exists(), "checkpoint .pt not written"
+    payload = torch.load(ckpt, map_location="cpu", weights_only=False)
+    ts = payload.get("training_summary")
+    assert isinstance(ts, dict)
+    persisted = ts.get("multi_task_class_weights")
+    assert persisted is not None, (
+        "multi_task_class_weights missing from serialised training_summary; "
+        "the resume path would silently rebuild a uniform-weighted loss."
+    )
+    assert persisted["lambdas"] == lambdas
+    assert persisted["certainty"] == mt["certainty"]
+    assert persisted["topic"] == mt["topic"]
+
+
+def test_checkpoint_omits_multi_task_weights_when_flag_off(tmp_path: Path) -> None:
+    """Default (multi_task_loss=False): no per-axis payload, no contract
+    drift for every pre-#273 checkpoint.
+    """
+
+    config = ModelConfig(output_mode="classification", n_classes=3)
+    groups = _make_groups()
+    ckpt = tmp_path / "single.pt"
+
+    result = train_model(
+        model_config=config,
+        train_sequence_groups=groups,
+        val_sequence_groups=groups,
+        test_sequence_groups=groups,
+        epochs=1,
+        batch_size=8,
+        seed=11,
+        save_checkpoint=True,
+        checkpoint_path=ckpt,
+        use_compile=False,
+        use_amp=False,
+    )
+
+    assert result.summary.multi_task_class_weights is None
+    payload = torch.load(ckpt, map_location="cpu", weights_only=False)
+    ts = payload.get("training_summary")
+    assert isinstance(ts, dict)
+    # Either the key is absent or it serialised as None -- both leave
+    # the resume path on the legacy single-task CE branch.
+    assert ts.get("multi_task_class_weights") is None

--- a/tests/unit/test_multi_task_class_weights_no_leak.py
+++ b/tests/unit/test_multi_task_class_weights_no_leak.py
@@ -1,0 +1,104 @@
+"""Per-axis class weights fit on the train slice only (#273).
+
+The multi-task loss path constructs a separate ``CrossEntropyLoss``
+weight tensor for stance / certainty / topic. The weights must be
+fitted strictly on the train partition's masked rows -- val or test
+labels must never inform the fit -- so the eval metrics are not
+inflated by class-prior leakage from the held-out partitions. This
+mirrors the existing single-task ``fit_class_weights`` protocol the
+loop has used since #206 for the stance head.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from app.training.loop import _fit_axis_class_weights_from_mask
+
+
+def test_axis_weights_only_see_masked_train_rows() -> None:
+    """Rows with mask=False contribute zero to the per-axis counts.
+
+    Construct a partition where the masked-out rows would heavily skew
+    the class prior if the helper ignored the mask. The fitted weights
+    must come from the masked-IN rows only.
+    """
+
+    # Masked-in distribution: balanced 1:1:1 across 3 classes (6 rows).
+    # Masked-out distribution: 100x class 0 (would dominate without mask).
+    n_classes = 3
+    masked_in_targets = [0, 0, 1, 1, 2, 2]
+    masked_out_targets = [0] * 100
+    targets = torch.tensor(masked_in_targets + masked_out_targets, dtype=torch.long)
+    mask = torch.tensor(
+        [True] * len(masked_in_targets) + [False] * len(masked_out_targets),
+        dtype=torch.bool,
+    )
+
+    weights = _fit_axis_class_weights_from_mask(targets, mask, n_classes)
+
+    # Balanced inverse-frequency on equal counts collapses to a
+    # near-uniform tensor that sums to n_classes (the helper's
+    # normalisation contract). A leaky implementation would emit
+    # something heavily skewed toward downweighting class 0.
+    assert weights.shape == (n_classes,)
+    assert weights.sum().item() == _approx(float(n_classes))
+    # Uniform within ~1% on this balanced subset; smoothing keeps it
+    # away from a hard equality but well below any leak-driven skew.
+    for w in weights.tolist():
+        assert abs(w - 1.0) < 0.05, weights
+
+
+def test_axis_weights_empty_mask_returns_uniform() -> None:
+    """An axis with zero supervised rows yields a uniform fallback.
+
+    Topic on FOMC-only training has 0% label coverage upstream; the
+    weight fit must still return a well-defined length-n_classes tensor
+    so MultiTaskLoss can construct a CrossEntropyLoss for that axis.
+    """
+
+    n_classes = 4
+    targets = torch.zeros(10, dtype=torch.long)
+    mask = torch.zeros(10, dtype=torch.bool)  # all False
+
+    weights = _fit_axis_class_weights_from_mask(targets, mask, n_classes)
+
+    assert weights.shape == (n_classes,)
+    assert torch.allclose(weights, torch.ones(n_classes))
+
+
+def test_axis_weights_rare_class_gets_higher_weight() -> None:
+    """Inverse-frequency: a rare class gets a larger weight than a common one.
+
+    The standard contract the stance ``fit_class_weights`` carries: the
+    minority class should pull more gradient per row than the majority.
+    """
+
+    n_classes = 3
+    # Heavily imbalanced: 90 rows of class 0, 9 of class 1, 1 of class 2.
+    targets = torch.tensor([0] * 90 + [1] * 9 + [2], dtype=torch.long)
+    mask = torch.ones(100, dtype=torch.bool)
+
+    weights = _fit_axis_class_weights_from_mask(targets, mask, n_classes)
+
+    # The minority class (2) must outweigh class 1 must outweigh
+    # the majority class (0).
+    assert weights[2].item() > weights[1].item() > weights[0].item()
+
+
+def _approx(expected: float, *, rel: float = 1e-4) -> object:
+    """Tiny inline approx so the test file stays free of pytest imports
+    beyond the assertion expression itself.
+    """
+
+    class _Approx:
+        def __eq__(self, other: object) -> bool:
+            try:
+                return abs(float(other) - expected) <= rel * max(1.0, abs(expected))
+            except (TypeError, ValueError):
+                return False
+
+        def __repr__(self) -> str:  # pragma: no cover - diag only
+            return f"approx({expected}, rel={rel})"
+
+    return _Approx()


### PR DESCRIPTION
Closes #273.

PR #282 landed the DataLoader → train-step wiring + the `MultiTaskLoss` swap on `train_model` when `multi_task_loss=True` (per-fold class weights fitted on the train slice for stance / certainty / topic; mask-aware so 0%-coverage axes contribute zero gradient). This pass closes the remaining gap on the issue body — persistence of the per-axis class weights + lambdas onto the checkpoint payload so a resume reads back the exact loss config the run trained under, plus the two new tests that cover the no-leak protocol and the round-trip. CLI flag `--multi-task-loss` stays opt-in (default off → stance F1 byte-identical to pre-#273).

- New `TrainingRunSummary.multi_task_class_weights` field carries `{"stance": [...], "certainty": [...], "topic": [...], "lambdas": {...}}` on multi-task runs; `None` on every pre-#273 / default-off run.
- `train_model` populates the field from the per-axis weights it already fits via `_fit_axis_class_weights_from_mask`, alongside the lambda coefficients pulled off `MultiTaskLoss`.
- New `tests/unit/test_multi_task_class_weights_no_leak.py` asserts the per-fold fit only sees the train slice's masked-in rows (rare classes outweigh majority, empty mask returns uniform).
- New `tests/unit/test_multi_task_checkpoint_persistence.py` runs a 1-epoch CPU smoke with `--multi-task-loss on` and asserts the on-disk `.pt` carries the per-axis vectors + the four lambda values; mirror test with the flag off asserts the payload key stays `None`.
- Wiki: §6.8 per-axis macro-F1 appendix scaffolded with placeholder rows; §13 burn-down row #273 added as in-progress.

Reviewer focus:

- Default `--multi-task-loss off` keeps stance F1 byte-identical to pre-#273 (no path through any of the new code on the legacy classification run).
- Per-axis class weights fit on the train slice only — same protocol as the existing stance head's `fit_class_weights`, no val/test leakage.
- Checkpoint persistence: per-axis weights + lambdas land in `payload["training_summary"]["multi_task_class_weights"]` so resume reads back the same loss config; new round-trip test covers it end-to-end.
- The headline sweep from the issue body (Transformer / seed 97 / 4 folds / stance F1 within ±0.005 of Path B 0.5225) is a Runpod follow-up; this PR ships the wire-up + persistence + tests.