### PR TITLE
PhraseBank as a supervised auxiliary task on B2 fine-tune (#33)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -86,6 +86,8 @@ help:
 	@echo "                         - Per-family rich-feature ablation (#334; backs the §6 substitution-finding table)"
 	@echo "  make finetune-pilot-b2 TRAINING_PACKAGE_ID=<id> [ENCODER_ALIAS=<alias>]"
 	@echo "                         - B2 end-to-end fine-tune on vol-regime (#213; AutoModelForSequenceClassification, 5 seeds x 4 folds x 5 epochs)"
+	@echo "  make finetune-pilot-b2-phrasebank TRAINING_PACKAGE_ID=<id> [PHRASEBANK_AUX_LAMBDA=0.3] [PHRASEBANK_SUBSET=sentences_allagree]"
+	@echo "                         - B2 fine-tune with the PhraseBank auxiliary 3-way sentiment CE on top (#33 Path B; ADR 0033)"
 	@echo "  make cross-source-transfer TRAINING_PACKAGE_ID=<id> ENCODER_CHECKPOINTS=alias=path[,alias=path]"
 	@echo "                         - Cross-source transfer matrix (#72 + #83; inference-only per source_type stratum)"
 	@echo "  make reproduce-smoke TRAINING_PACKAGE_ID=<id> [SEED=11]"
@@ -868,6 +870,27 @@ finetune-pilot-b2:
 		--train-batch-size 16 \
 		--learning-rate 2e-5 \
 		--weight-decay 0.01 \
+		$(if $(ENCODER_ALIAS),--encoder-alias $(ENCODER_ALIAS),)
+
+# #33 Path B — PhraseBank as a supervised auxiliary task on top of the
+# B2 fine-tune. Same harness as ``finetune-pilot-b2`` with
+# ``--enable-phrasebank-aux`` flipped on; output lands at a sibling
+# artefact so the §6.x tier table can compare the two cells head-to-head.
+# PHRASEBANK_AUX_LAMBDA defaults to 0.3 (per ADR 0033); sweep ``{0.1,
+# 0.3, 0.5, 1.0}`` to isolate the lambda knob.
+finetune-pilot-b2-phrasebank:
+	@if [ -z "$$TRAINING_PACKAGE_ID" ]; then echo "TRAINING_PACKAGE_ID required" >&2; exit 1; fi
+	docker compose run --rm backend python -m app.data.finetune_pilot_b2 \
+		--training-package-id $$TRAINING_PACKAGE_ID \
+		--output artifacts/experiments/finetune_pilot_b2_phrasebank.json \
+		--seeds 11 29 47 71 97 \
+		--epochs 5 \
+		--train-batch-size 16 \
+		--learning-rate 2e-5 \
+		--weight-decay 0.01 \
+		--enable-phrasebank-aux \
+		--phrasebank-aux-lambda $(if $(PHRASEBANK_AUX_LAMBDA),$(PHRASEBANK_AUX_LAMBDA),0.3) \
+		--phrasebank-subset $(if $(PHRASEBANK_SUBSET),$(PHRASEBANK_SUBSET),sentences_allagree) \
 		$(if $(ENCODER_ALIAS),--encoder-alias $(ENCODER_ALIAS),)
 
 cross-source-transfer:

--- a/backend/app/data/finetune_pilot_b2.py
+++ b/backend/app/data/finetune_pilot_b2.py
@@ -107,9 +107,12 @@ class FoldCell:
     classification_breakdown: dict[str, Any]
     train_runtime_s: float
     eval_runtime_s: float
+    phrasebank_aux_train_loss: float | None = None
+    phrasebank_aux_lambda: float = 0.0
+    phrasebank_aux_rows: int = 0
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload: dict[str, Any] = {
             "fold_id": self.fold_id,
             "metrics": {
                 "regime_f1_macro": self.macro_f1,
@@ -126,6 +129,13 @@ class FoldCell:
             "train_runtime_s": self.train_runtime_s,
             "eval_runtime_s": self.eval_runtime_s,
         }
+        if self.phrasebank_aux_lambda > 0.0:
+            payload["phrasebank_aux"] = {
+                "train_loss": self.phrasebank_aux_train_loss,
+                "aux_lambda": self.phrasebank_aux_lambda,
+                "n_rows": self.phrasebank_aux_rows,
+            }
+        return payload
 
 
 @dataclass
@@ -382,7 +392,7 @@ def _block_bootstrap_ci(
     return {"lower": lo, "upper": hi, "confidence": confidence, "n_resamples": n_resamples}
 
 
-def _train_and_eval_one_cell(
+def _train_and_eval_one_cell(  # noqa: PLR0913 — per-cell knobs surface as named kwargs by design
     *,
     train_texts: list[str],
     train_labels: list[int],
@@ -396,17 +406,37 @@ def _train_and_eval_one_cell(
     learning_rate: float,
     weight_decay: float,
     max_length: int,
+    phrasebank_rows: list[Any] | None = None,
+    phrasebank_aux_lambda: float = 0.0,
 ) -> dict[str, Any]:
-    """Run one fine-tune cell end-to-end and return its metrics dict."""
+    """Run one fine-tune cell end-to-end and return its metrics dict.
+
+    When ``phrasebank_rows`` is supplied and ``phrasebank_aux_lambda``
+    is strictly positive, the FOMC stance CE is augmented by an
+    auxiliary PhraseBank 3-way sentiment CE on a small linear head
+    over the encoder's pooled output (#33 Path B). The aux head reads
+    its rows from a separate DataLoader that round-robins one
+    PhraseBank batch per FOMC batch; the auxiliary loss is added to
+    the main loss as ``lambda * aux_ce`` so the aux gradient flows
+    through the same encoder as the main task. When the aux is off
+    the path stays byte-identical to pre-#33 B2.
+    """
 
     # Imports happen here so module import stays cheap on environments
     # without torch (the dataclass + helper surface is importable
     # standalone for the unit-test smoke).
     import torch
+    from torch import nn
     from torch.utils.data import DataLoader, Dataset
     from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
     _set_all_seeds(seed)
+
+    enable_aux = bool(
+        phrasebank_rows
+        and phrasebank_aux_lambda > 0.0
+        and len(phrasebank_rows) > 0
+    )
 
     hf_token = _hf_token()
     revision = revision_for(encoder_alias)
@@ -424,6 +454,20 @@ def _train_and_eval_one_cell(
         token=hf_token,
         revision=revision,
     )
+
+    # Auxiliary 3-class linear head over the encoder's pooled output.
+    # Only constructed when aux is on so the default-off path stays
+    # byte-identical to pre-#33 B2 — same module graph, same parameter
+    # set, same optimiser state.
+    aux_head: nn.Linear | None = None
+    if enable_aux:
+        hidden_size = int(getattr(model.config, "hidden_size", 0))
+        if hidden_size <= 0:
+            raise RuntimeError(
+                "Encoder model.config.hidden_size missing / non-positive; "
+                "auxiliary head needs a pooled-output dimension."
+            )
+        aux_head = nn.Linear(hidden_size, 3)
 
     class _TextDataset(Dataset[dict[str, "torch.Tensor"]]):
         def __init__(self, texts: list[str], labels: list[int]) -> None:
@@ -452,9 +496,14 @@ def _train_and_eval_one_cell(
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model.to(device)
+    if aux_head is not None:
+        aux_head.to(device)
 
+    optimizer_params: list[torch.nn.Parameter] = list(model.parameters())
+    if aux_head is not None:
+        optimizer_params.extend(list(aux_head.parameters()))
     optimizer = torch.optim.AdamW(
-        model.parameters(),
+        optimizer_params,
         lr=learning_rate,
         weight_decay=weight_decay,
     )
@@ -469,26 +518,84 @@ def _train_and_eval_one_cell(
     )
     eval_loader = DataLoader(test_ds, batch_size=eval_batch_size, shuffle=False)
 
+    # Auxiliary PhraseBank stream. A second DataLoader cycles over the
+    # PhraseBank rows independently of the FOMC fold split; aux batches
+    # are zipped one-for-one with FOMC batches inside the train step
+    # via ``itertools.cycle`` so the aux pool drives no extra epochs.
+    aux_loader: DataLoader | None = None
+    aux_iter: Any = None
+    if aux_head is not None and phrasebank_rows is not None:
+        aux_texts = [str(r.sentence) for r in phrasebank_rows]
+        aux_labels = [int(r.label_idx) for r in phrasebank_rows]
+        aux_ds = _TextDataset(aux_texts, aux_labels)
+        aux_generator = torch.Generator()
+        aux_generator.manual_seed(seed + 1)
+        aux_loader = DataLoader(
+            aux_ds,
+            batch_size=train_batch_size,
+            shuffle=True,
+            generator=aux_generator,
+        )
+
+    def _cycle(loader: DataLoader) -> Any:
+        while True:
+            yield from loader
+
     train_t0 = time.perf_counter()
     losses: list[float] = []
+    aux_losses: list[float] = []
     model.train()
+    if aux_head is not None:
+        aux_head.train()
+    if aux_loader is not None:
+        aux_iter = _cycle(aux_loader)
     for _ in range(epochs):
         for batch in train_loader:
             input_ids = batch["input_ids"].to(device)
             attention_mask = batch["attention_mask"].to(device)
             labels_t = batch["labels"].to(device)
             optimizer.zero_grad()
-            outputs = model(
-                input_ids=input_ids,
-                attention_mask=attention_mask,
-                labels=labels_t,
-            )
-            loss = outputs.loss
+            if aux_head is None:
+                outputs = model(
+                    input_ids=input_ids,
+                    attention_mask=attention_mask,
+                    labels=labels_t,
+                )
+                loss = outputs.loss
+            else:
+                # Recompute the main CE explicitly so the encoder
+                # forward also yields hidden states for the aux head.
+                # Going through ``output_hidden_states=True`` keeps
+                # the call signature on every BERT-family backbone.
+                outputs = model(
+                    input_ids=input_ids,
+                    attention_mask=attention_mask,
+                    labels=labels_t,
+                    output_hidden_states=True,
+                )
+                main_loss = outputs.loss
+
+                aux_batch = next(aux_iter)
+                aux_input_ids = aux_batch["input_ids"].to(device)
+                aux_attention_mask = aux_batch["attention_mask"].to(device)
+                aux_labels_t = aux_batch["labels"].to(device)
+                aux_outputs = model.base_model(
+                    input_ids=aux_input_ids,
+                    attention_mask=aux_attention_mask,
+                )
+                aux_pooled = _pooled_from_base_model_output(
+                    aux_outputs, aux_attention_mask
+                )
+                aux_logits = aux_head(aux_pooled)
+                aux_loss = nn.functional.cross_entropy(aux_logits, aux_labels_t)
+                aux_losses.append(float(aux_loss.detach().item()))
+                loss = main_loss + phrasebank_aux_lambda * aux_loss
             loss.backward()
             optimizer.step()
             losses.append(float(loss.detach().item()))
     train_runtime = time.perf_counter() - train_t0
     mean_train_loss = float(statistics.fmean(losses)) if losses else 0.0
+    mean_aux_loss = float(statistics.fmean(aux_losses)) if aux_losses else None
 
     eval_t0 = time.perf_counter()
     model.eval()
@@ -526,7 +633,38 @@ def _train_and_eval_one_cell(
         "classification_breakdown": breakdown.to_dict(),
         "train_runtime_s": train_runtime,
         "eval_runtime_s": eval_runtime,
+        "phrasebank_aux_train_loss": mean_aux_loss,
+        "phrasebank_aux_lambda": (
+            phrasebank_aux_lambda if aux_head is not None else 0.0
+        ),
+        "phrasebank_aux_rows": (
+            len(phrasebank_rows) if (aux_head is not None and phrasebank_rows) else 0
+        ),
     }
+
+
+def _pooled_from_base_model_output(
+    outputs: Any, attention_mask: "Any"
+) -> "Any":
+    """Extract a pooled vector from a HF base-model output.
+
+    BERT-family backbones expose ``pooler_output`` directly; backbones
+    without a pooler (e.g. RoBERTa configured without one, DistilBERT)
+    fall back to a masked-mean over ``last_hidden_state``. Mean-pool
+    keeps the gradient flowing through the encoder for the aux task
+    even when the pooler is absent.
+    """
+
+    import torch
+
+    pooled = getattr(outputs, "pooler_output", None)
+    if pooled is not None:
+        return pooled
+    last_hidden = outputs.last_hidden_state
+    mask = attention_mask.unsqueeze(-1).to(last_hidden.dtype)
+    summed = (last_hidden * mask).sum(dim=1)
+    denom = mask.sum(dim=1).clamp(min=torch.tensor(1.0, device=last_hidden.device))
+    return summed / denom
 
 
 def run_sweep(args: argparse.Namespace) -> dict[str, Any]:
@@ -543,6 +681,40 @@ def run_sweep(args: argparse.Namespace) -> dict[str, Any]:
         raise SystemExit(
             f"No folds resolved from {package_dir}; supply --folds explicitly."
         )
+
+    # PhraseBank auxiliary-task rows (#33 Path B). Loaded once and
+    # shared across every (seed, fold) cell so the aux pool is constant
+    # across the sweep; only the FOMC fold split varies. Cells never
+    # use PhraseBank text as their fine-tune validation slice — the
+    # aux loader is wholly separate from the FOMC fold's train / test
+    # slices, no row indexing crossover.
+    phrasebank_rows: list[Any] | None = None
+    phrasebank_meta: dict[str, Any] = {"enabled": False}
+    if getattr(args, "enable_phrasebank_aux", False):
+        from app.data.phrasebank import (
+            class_counts as _pb_class_counts,
+            load_phrasebank_rows,
+        )
+
+        subset = getattr(args, "phrasebank_subset", None) or "sentences_allagree"
+        local_jsonl = getattr(args, "phrasebank_jsonl", None)
+        cache_root = getattr(args, "phrasebank_cache_root", None)
+        phrasebank_rows = load_phrasebank_rows(
+            subset=subset,
+            local_jsonl=Path(local_jsonl) if local_jsonl else None,
+            cache_root=Path(cache_root) if cache_root else None,
+        )
+        phrasebank_meta = {
+            "enabled": True,
+            "subset": subset,
+            "n_rows": len(phrasebank_rows),
+            "class_counts": _pb_class_counts(phrasebank_rows),
+            "aux_lambda": float(getattr(args, "phrasebank_aux_lambda", 0.0)),
+        }
+        if not phrasebank_rows:
+            raise SystemExit(
+                "PhraseBank loader returned no rows; aux flag is on but pool is empty."
+            )
 
     seed_trials: list[SeedTrial] = []
     all_macro_f1: list[float] = []
@@ -593,6 +765,10 @@ def run_sweep(args: argparse.Namespace) -> dict[str, Any]:
                 learning_rate=args.learning_rate,
                 weight_decay=args.weight_decay,
                 max_length=args.max_length,
+                phrasebank_rows=phrasebank_rows,
+                phrasebank_aux_lambda=float(
+                    getattr(args, "phrasebank_aux_lambda", 0.0)
+                ),
             )
             cell = FoldCell(
                 seed=seed,
@@ -636,6 +812,7 @@ def run_sweep(args: argparse.Namespace) -> dict[str, Any]:
         "n_classes": N_CLASSES,
         "labels": list(VOL_REGIME_LABELS),
         "started_at_utc": datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
+        "phrasebank_aux": phrasebank_meta,
         "trials": [trial.to_dict() for trial in seed_trials],
         "summary": summary,
     }
@@ -716,6 +893,57 @@ def _parse_args() -> argparse.Namespace:
         help=(
             "Output JSON path. Defaults to "
             "artifacts/experiments/finetune_pilot_b2.json."
+        ),
+    )
+    # PhraseBank auxiliary-task knobs (#33 Path B). Default off so the
+    # CLI without these flags reproduces pre-#33 B2 byte-identically.
+    parser.add_argument(
+        "--enable-phrasebank-aux",
+        action="store_true",
+        help=(
+            "Enable the PhraseBank auxiliary 3-way sentiment CE on top "
+            "of the vol-regime CE during fine-tune (#33 Path B). Off by "
+            "default so the harness reproduces the existing B2 numerics."
+        ),
+    )
+    parser.add_argument(
+        "--phrasebank-aux-lambda",
+        type=float,
+        default=0.3,
+        help=(
+            "Auxiliary-loss weight applied to the PhraseBank CE term "
+            "when --enable-phrasebank-aux is on. Default 0.3 mirrors "
+            "the multi-task LSTM-stage default lambdas in "
+            "MultiTaskLoss (lambda_factor / lambda_certainty / "
+            "lambda_topic)."
+        ),
+    )
+    parser.add_argument(
+        "--phrasebank-subset",
+        default="sentences_allagree",
+        help=(
+            "PhraseBank subset name. Defaults to the strict 100%%-"
+            "agreement subset (2 264 rows); operator can override with "
+            "'sentences_50agree' for the full 4 840-row pool."
+        ),
+    )
+    parser.add_argument(
+        "--phrasebank-cache-root",
+        type=Path,
+        default=None,
+        help=(
+            "Override for the on-disk PhraseBank cache root. Defaults "
+            "to data/external/phrasebank/."
+        ),
+    )
+    parser.add_argument(
+        "--phrasebank-jsonl",
+        type=Path,
+        default=None,
+        help=(
+            "Optional local JSONL fixture path for PhraseBank rows. "
+            "When supplied the HF read path is skipped — used by tests "
+            "and air-gapped reproductions."
         ),
     )
     return parser.parse_args()

--- a/backend/app/data/phrasebank.py
+++ b/backend/app/data/phrasebank.py
@@ -107,7 +107,7 @@ def _coerce_label_idx(label: Any) -> int | None:
         if normalised in LABEL2ID:
             return LABEL2ID[normalised]
         return None
-    if isinstance(label, (int, bool)) and not isinstance(label, bool):
+    if isinstance(label, int) and not isinstance(label, bool):
         if 0 <= int(label) < N_CLASSES:
             return int(label)
         return None

--- a/backend/app/data/phrasebank.py
+++ b/backend/app/data/phrasebank.py
@@ -1,0 +1,292 @@
+"""Financial PhraseBank loader for the B2 auxiliary-task fine-tune (#33).
+
+PhraseBank (Malo et al. 2014) is a 4 840-sentence financial-sentiment
+corpus with 3-way labels (positive / negative / neutral). Path A (DAPT
+substrate) was rejected as noise-level against the 909k BIS NSP pair
+pool; this module supports Path B — PhraseBank rows feed an auxiliary
+3-way classification head during the encoder fine-tune so the encoder
+sees in-domain sentiment supervision alongside the FOMC vol-regime
+target.
+
+Loader contract:
+
+- :func:`load_phrasebank_rows` returns a list of
+  :class:`PhraseBankRow` (id, sentence, 3-class label index). Labels
+  follow the canonical order ``("negative", "neutral", "positive")``
+  so the auxiliary head's softmax index is reproducible across runs.
+- The on-wire source is the public HF mirror
+  ``takala/financial_phrasebank`` (``sentences_allagree`` subset by
+  default — 2 264 sentences with 100% annotator agreement). The
+  ``sentences_50agree`` subset is wired through as an opt-in for the
+  full 4 840-sentence pool.
+- Reads are cached under ``data/external/phrasebank/`` as a parquet
+  artefact so the loader is offline after the first hit. The cache
+  key includes the subset name + dataset revision (when pinned).
+- No write path. HF write tokens are revoked on this account; the
+  loader is read-only.
+
+The auxiliary head consumes the rows via
+:func:`app.data.finetune_pilot_b2._train_and_eval_one_cell` when
+``--enable-phrasebank-aux`` is set.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from app.config import DATA_DIR
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_DATASET_ID = "takala/financial_phrasebank"
+# `sentences_allagree` is the strict 100%-agreement subset (2 264
+# rows); the wider 50%-agreement subset (`sentences_50agree`, 4 840
+# rows) is opt-in via `subset=` for runs that prefer the higher row
+# count over the label-noise floor.
+DEFAULT_SUBSET = "sentences_allagree"
+VALID_SUBSETS: tuple[str, ...] = (
+    "sentences_allagree",
+    "sentences_75agree",
+    "sentences_66agree",
+    "sentences_50agree",
+)
+
+# Canonical label order. Pin the order so the auxiliary head's softmax
+# index is reproducible — HF's `ClassLabel` happens to expose the
+# labels in the same order today, but the harness must not depend on
+# that. The mapping below is the contract.
+PHRASEBANK_LABELS: tuple[str, ...] = ("negative", "neutral", "positive")
+LABEL2ID: dict[str, int] = {label: idx for idx, label in enumerate(PHRASEBANK_LABELS)}
+ID2LABEL: dict[int, str] = dict(enumerate(PHRASEBANK_LABELS))
+N_CLASSES = len(PHRASEBANK_LABELS)
+
+# HF dataset revision pin -- left None until the first run reports the
+# resolved sha. Mirrors the BIS-MLM pin pattern in
+# ``continued_pretraining.py``: pinning the revision is what makes the
+# DAPT manifest reproducible; the auxiliary head inherits the same
+# discipline so the row order + label assignment never drift silently.
+DEFAULT_REVISION: str | None = None
+
+DEFAULT_CACHE_ROOT = DATA_DIR / "external" / "phrasebank"
+
+
+@dataclass(frozen=True)
+class PhraseBankRow:
+    """One PhraseBank sentence + its 3-class label index.
+
+    ``label_idx`` follows :data:`PHRASEBANK_LABELS` ordering (0 =
+    negative, 1 = neutral, 2 = positive). ``row_id`` is the loader's
+    monotonically-assigned index per (subset, revision) so two loads
+    of the same subset round-trip to the same id.
+    """
+
+    row_id: str
+    sentence: str
+    label_idx: int
+
+    @property
+    def label(self) -> str:
+        return PHRASEBANK_LABELS[self.label_idx]
+
+
+def _coerce_label_idx(label: Any) -> int | None:
+    """Normalise an HF row's label field to the canonical index.
+
+    The HF mirror exposes the label either as an int (0/1/2 keyed on
+    its own `ClassLabel` order — which happens to be
+    `negative / neutral / positive` today) or as a string after a
+    `dataset.cast(...)` pass. Accept both; reject anything else.
+    """
+
+    if isinstance(label, str):
+        normalised = label.strip().lower()
+        if normalised in LABEL2ID:
+            return LABEL2ID[normalised]
+        return None
+    if isinstance(label, (int, bool)) and not isinstance(label, bool):
+        if 0 <= int(label) < N_CLASSES:
+            return int(label)
+        return None
+    try:
+        idx = int(label)
+    except (TypeError, ValueError):
+        return None
+    if 0 <= idx < N_CLASSES:
+        return idx
+    return None
+
+
+def _iter_local_rows(rows: Iterable[dict[str, Any]]) -> list[PhraseBankRow]:
+    """Adapt iter-of-dict rows into :class:`PhraseBankRow` objects.
+
+    Drops rows whose sentence is empty or whose label does not
+    normalise to a canonical 3-class index. Splits cleanly from the
+    HF read path so a local fixture (parquet or JSONL) can replay the
+    same parse contract during tests.
+    """
+
+    out: list[PhraseBankRow] = []
+    for idx, item in enumerate(rows):
+        if not isinstance(item, dict):
+            continue
+        sentence = str(item.get("sentence") or item.get("text") or "").strip()
+        if not sentence:
+            continue
+        label_idx = _coerce_label_idx(item.get("label"))
+        if label_idx is None:
+            continue
+        out.append(
+            PhraseBankRow(
+                row_id=str(item.get("row_id") or f"pb_{idx:05d}"),
+                sentence=sentence,
+                label_idx=label_idx,
+            )
+        )
+    return out
+
+
+def _cache_path(cache_root: Path, subset: str, revision: str | None) -> Path:
+    rev_tag = (revision or "head")[:12]
+    return cache_root / f"{subset}__{rev_tag}.parquet"
+
+
+def _read_cache(path: Path) -> list[PhraseBankRow] | None:
+    if not path.exists():
+        return None
+    try:
+        import pandas as pd
+    except ImportError:
+        return None
+    try:
+        frame = pd.read_parquet(path)
+    except Exception as exc:  # noqa: BLE001 -- cache miss is recoverable
+        _logger.warning("PhraseBank cache read failed at %s: %s", path, exc)
+        return None
+    return _iter_local_rows(frame.to_dict("records"))
+
+
+def _write_cache(path: Path, rows: list[PhraseBankRow]) -> None:
+    try:
+        import pandas as pd
+    except ImportError:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frame = pd.DataFrame(
+        [
+            {"row_id": r.row_id, "sentence": r.sentence, "label": r.label_idx}
+            for r in rows
+        ]
+    )
+    frame.to_parquet(path)
+
+
+def _download_from_hub(
+    dataset_id: str, subset: str, revision: str | None
+) -> list[PhraseBankRow]:
+    """Pull PhraseBank from the HF mirror — read-only.
+
+    Lazy import of :mod:`datasets` so the module is importable in CI
+    without the HF datasets dependency. Raises :class:`RuntimeError`
+    when the dependency is missing so the caller surfaces a clean
+    skip in tests.
+    """
+
+    try:
+        from datasets import load_dataset  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError(
+            "PhraseBank loader requires the `datasets` package; "
+            "install it via the backend requirements lock."
+        ) from exc
+
+    kwargs: dict[str, Any] = {"split": "train"}
+    if revision:
+        kwargs["revision"] = revision
+    # `trust_remote_code=True` is the HF default for legacy script-
+    # based loaders (PhraseBank ships one). The mirror is public so
+    # no token is needed; HF_TOKEN, when set, is forwarded transparently
+    # by the datasets library itself.
+    kwargs["trust_remote_code"] = True
+    ds = load_dataset(dataset_id, subset, **kwargs)
+    rows: list[dict[str, Any]] = []
+    for idx, row in enumerate(ds):
+        rows.append(
+            {
+                "row_id": f"pb_{subset}_{idx:05d}",
+                "sentence": row.get("sentence"),
+                "label": row.get("label"),
+            }
+        )
+    return _iter_local_rows(rows)
+
+
+def load_phrasebank_rows(
+    *,
+    subset: str = DEFAULT_SUBSET,
+    revision: str | None = DEFAULT_REVISION,
+    dataset_id: str = DEFAULT_DATASET_ID,
+    cache_root: Path | None = None,
+    local_jsonl: Path | None = None,
+) -> list[PhraseBankRow]:
+    """Load PhraseBank rows for the auxiliary head.
+
+    Parameters
+    ----------
+    subset
+        PhraseBank subset name — one of :data:`VALID_SUBSETS`.
+        Defaults to the strict 100%-agreement subset.
+    revision
+        Optional HF dataset revision pin. When ``None`` the loader
+        fetches HEAD; when pinned the cache key changes so two
+        revisions are stored side by side.
+    dataset_id
+        HF dataset id. Defaults to :data:`DEFAULT_DATASET_ID`.
+    cache_root
+        Optional override for the on-disk cache root. Defaults to
+        :data:`DEFAULT_CACHE_ROOT` under the configured data dir.
+    local_jsonl
+        Optional path to a local JSONL fixture. When supplied the
+        loader skips the HF read path entirely and parses the file
+        in place — used by tests + air-gapped reproductions.
+    """
+
+    if subset not in VALID_SUBSETS:
+        raise ValueError(
+            f"PhraseBank subset {subset!r} not in {VALID_SUBSETS!r}"
+        )
+
+    if local_jsonl is not None:
+        if not local_jsonl.exists():
+            raise FileNotFoundError(f"PhraseBank fixture missing: {local_jsonl}")
+        rows = []
+        for line in local_jsonl.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+        return _iter_local_rows(rows)
+
+    root = cache_root if cache_root is not None else DEFAULT_CACHE_ROOT
+    cache_path = _cache_path(root, subset, revision)
+    cached = _read_cache(cache_path)
+    if cached is not None:
+        return cached
+
+    rows = _download_from_hub(dataset_id, subset, revision)
+    if rows:
+        _write_cache(cache_path, rows)
+    return rows
+
+
+def class_counts(rows: Iterable[PhraseBankRow]) -> list[int]:
+    """Return the per-class row counts in canonical label order."""
+
+    counts = [0] * N_CLASSES
+    for row in rows:
+        if 0 <= row.label_idx < N_CLASSES:
+            counts[row.label_idx] += 1
+    return counts

--- a/docs/adr/0033-phrasebank-auxiliary-finetune.md
+++ b/docs/adr/0033-phrasebank-auxiliary-finetune.md
@@ -1,0 +1,69 @@
+# ADR 0033 — PhraseBank as a supervised auxiliary task on the B2 fine-tune
+
+Status: accepted, harness code path live; canonical sweep deferred to operator.
+Date: 2026-05-28.
+References:
+- Issue #33 (closes).
+- ADR 0019 — canonical encoder split (`role: classifier` resolves to `finbert_fomc_only`, fallback `finbert_fed_adjacent`).
+- ADR 0031 — B2 end-to-end fine-tune harness (this ADR extends the B2 entry point with an auxiliary-task knob).
+- `backend/app/data/phrasebank.py` — PhraseBank loader module.
+- `backend/app/data/finetune_pilot_b2.py` — fine-tune harness with the `--enable-phrasebank-aux` flag.
+- Malo, P. et al. (2014). *Good debt or bad debt: Detecting semantic orientations in economic texts.* — the PhraseBank dataset.
+- `takala/financial_phrasebank` — public HF mirror.
+
+## Context
+
+PhraseBank is a 4 840-sentence financial-sentiment corpus (3-way labels: positive / negative / neutral). The corpus first appeared in this codebase as a candidate continued-pretraining substrate (Path A in the original #33 framing); the 2026-05-23 review rejected that scoping as noise-level. The math: PhraseBank carries ~4 800 sentences against BIS-MLM's 909 877 NSP pairs (two orders of magnitude smaller); even a generous read of the SNR yields an expected lift under 0.005 macro-F1 on downstream stance — below the per-cell std on the canonical sweep (0.070 on fold 4, dual-head comparison). Adding it to the DAPT pool would change nothing measurable.
+
+Path B re-scopes PhraseBank as a *supervised auxiliary task* during the ENCODER fine-tune stage. The B2 harness (ADR 0031, PR #416) already fine-tunes the encoder end-to-end against the FOMC vol-regime target. Layering a second classification head over the same encoder — fed by PhraseBank sentiment labels — gives the encoder an in-domain supervised signal alongside the primary regime task. The auxiliary loss is added to the main loss with a per-axis weight knob (`phrasebank_aux_lambda`); when the knob is zero or the flag is off, the harness is byte-identical to pre-#33 B2.
+
+The two readings that B2 was designed to disambiguate (encoder freeze is the bottleneck vs LSTM detour is the bottleneck) are still in play; this auxiliary-task variant adds a third diagnostic axis:
+
+- *PhraseBank lifts B2 macro-F1 by +0.01 to +0.02.* The auxiliary supervision regularises the encoder away from the vol-regime label noise and toward a financial-sentiment manifold that overlaps the hawkish / dovish stance axis the §6 baselines target. The +0.01 to +0.02 band brackets what the literature on auxiliary classification heads typically shows on small downstream pools (Liu et al. 2019; Phang et al. 2018) — large enough to be visible on the 5-seed × 4-fold sweep CI, small enough not to redefine the headline.
+- *No lift / no change.* The label-space mismatch (PhraseBank is *financial sentiment* on company-level news, not *monetary-policy stance* on FOMC text) breaks the auxiliary's transfer. The encoder learns to discriminate sentiment in a context the FOMC pool never reaches, and the gradient on the main task is unchanged.
+- *Negative lift.* The auxiliary objective competes with the primary objective in the small-corpus regime; the encoder ends up worse on regime classification because half its capacity is allocated to a task with no downstream value.
+
+All three readings settle whether the in-domain supervised auxiliary signal helps, doesn't help, or hurts. The +0.01 to +0.02 band is the expectation the experiment fronts; the methodology contribution is the diagnostic itself.
+
+## Decision
+
+Add a `--enable-phrasebank-aux` flag (plus `--phrasebank-aux-lambda`, `--phrasebank-subset`, `--phrasebank-cache-root`, `--phrasebank-jsonl`) to `backend/app/data/finetune_pilot_b2.py`. Default off so the existing sweep is reproduced byte-identically. When on, the harness:
+
+- Loads PhraseBank rows via `backend/app/data/phrasebank.py::load_phrasebank_rows`. The loader reads from a local parquet cache under `data/external/phrasebank/<subset>__<rev>.parquet` and falls back to `datasets.load_dataset("takala/financial_phrasebank", subset)` on cache miss. The cache is read-only from this account; no write tokens are exercised. Tests pin a local JSONL fixture via `--phrasebank-jsonl` so the CI smoke is air-gapped.
+- Constructs a small linear head (`nn.Linear(hidden_size, 3)`) over the encoder's pooled output alongside the main `AutoModelForSequenceClassification` head. The pooled output comes from `model.base_model(...)` so the aux gradient flows through the shared encoder body.
+- Adds the PhraseBank batch to the optimiser step by zipping a second DataLoader (`_cycle(...)`) one-for-one with the FOMC batches. The aux pool drives no extra epochs; the FOMC fold's epoch count is the harness's epoch budget.
+- Computes the combined loss `L = main_ce + lambda * aux_ce` where `lambda = --phrasebank-aux-lambda` (default 0.3, matching the per-axis lambdas the LSTM-stage `MultiTaskLoss` ships with from #273).
+- Tracks the aux-loss mean per cell + reports it under `phrasebank_aux.train_loss` in the per-fold artefact row. The sweep payload's top-level `phrasebank_aux` meta block carries the subset name, row count, lambda, and per-class counts so downstream consumers can reproduce the auxiliary slice.
+- Leaves the FOMC fold split untouched. PhraseBank rows are loaded once and shared across every (seed, fold) cell; the aux loader and the FOMC loader index disjoint pools, so the auxiliary supervision can never bleed into a fold's test slice.
+
+### Default off — byte-identity contract
+
+Default-off path: `enable_phrasebank_aux=False` → `phrasebank_rows is None` → `enable_aux is False` → the harness skips the aux-head construction, the second DataLoader, and the combined-loss code path entirely. The main loss equals `model(...).loss` exactly as in pre-#33 B2. The unit test `test_default_off_metrics_have_zero_aux_fields` locks this; the metrics dict carries `phrasebank_aux_lambda = 0.0`, `phrasebank_aux_rows = 0`, `phrasebank_aux_train_loss = None`.
+
+The sweep artefact's per-fold rows omit the `phrasebank_aux` block when the flag is off — the JSON schema only grows when the operator opts in. The top-level `phrasebank_aux` meta block stays as `{"enabled": false}` on default-off runs.
+
+### Auxiliary loss — additive, lambda-weighted, separate CE
+
+The aux loss is plain cross-entropy on the linear head over the encoder's pooled output, weighted by `lambda` in the combined loss. The lambda default of 0.3 mirrors the `lambda_factor / lambda_certainty / lambda_topic` defaults the LSTM-stage `MultiTaskLoss` (#273) ships with — the canonical lambda for an auxiliary supervision axis that should regularise but not dominate the primary gradient. The headline stance/regime CE is the dominant signal at `lambda=1.0` implicitly (no scaling on the main term).
+
+The auxiliary head is a fresh `nn.Linear` with random init; the encoder forward sees the auxiliary backwards-pass only through the additive loss combination. No shared classifier weights, no logit summing across heads. This keeps the two tasks decoupled at the head level — the aux head learns the PhraseBank label space, the main head learns the regime label space, and the encoder body is the only shared substrate.
+
+### Label-space mismatch — explicit caveat
+
+PhraseBank labels are *financial sentiment* (positive / negative / neutral) on company-level news headlines. The B2 primary task labels are *forward-realised vol regime* (calm / normal / high) on FOMC document text. The two label spaces share three classes by accident; they do not align semantically. The expectation is that the encoder learns a finance-domain representation under the auxiliary signal that *transfers* to the regime task, not that the auxiliary labels themselves predict regime.
+
+This is the same theory of operation that motivates intermediate-task fine-tuning (Phang et al. 2018) and STILTs (Pruksachatkun et al. 2020) — the auxiliary task is the *vehicle*, not the *destination*. The +0.01 to +0.02 lift the experiment fronts is the level at which the literature reports transfer benefit on small downstream pools; deviations from that band are the diagnostic signal.
+
+### Acceptance — tier-table row
+
+A PhraseBank-augmented row sits alongside the existing B2 row in wiki §6.x once the GPU sweep populates `backend/artifacts/experiments/finetune_pilot_b2_phrasebank.json` (operator names the output file via `--output`). The acceptance assertion is whether the +0.01 to +0.02 macro-F1 lift materialises against the existing `finbert_fed_adjacent` B2 baseline on the same fold surface (same seeds, same fold manifest, same encoder alias). The §6 reporting frames the result as a methodology diagnostic: lift → in-domain auxiliary supervision helps the small-corpus encoder fine-tune; no lift → the label-space mismatch caps the benefit at noise; negative lift → the aux objective competes with the primary on this corpus size.
+
+The CI smoke (`tests/unit/test_finetune_pilot_b2_phrasebank.py`) covers the wire-up: loss flows, gradients reach both heads, default-off path is unchanged. The 5-seed × 4-fold sweep against the classifier-role encoder per ADR 0019 is a Runpod follow-up.
+
+## Consequences
+
+- PhraseBank is now a first-class loader in the B2 harness. The same loader can be reused as an auxiliary axis for any downstream fine-tune that wants in-domain financial-sentiment supervision.
+- `--phrasebank-aux-lambda` is a per-axis weight knob; sweeping it across `{0.1, 0.3, 0.5, 1.0}` would isolate the lambda where the auxiliary signal is maximally regularising. The default 0.3 is a thesis-defensible starting point; the sweep is operator follow-up.
+- The auxiliary path adds one extra forward + backward per step (~2x runtime per cell when aux is on). The 5-seed × 4-fold sweep at AdamW `lr=2e-5`, batch 16, 5 epochs runs ~20 GPU-hours instead of ~10. Operator budgets for this when planning the comparison run.
+- The label-space caveat documented above is the load-bearing limitation; the report frames the result honestly regardless of which reading wins.
+- HF write tokens are revoked; the loader reads PhraseBank from the public mirror without authentication. If the mirror disappears the loader fails closed (raises `RuntimeError`) rather than silently producing an empty pool.

--- a/tests/unit/test_finetune_pilot_b2_phrasebank.py
+++ b/tests/unit/test_finetune_pilot_b2_phrasebank.py
@@ -1,0 +1,329 @@
+"""Tests for the PhraseBank auxiliary-task path through B2 (#33).
+
+Covers four contracts:
+
+1. Default-off path through ``_train_and_eval_one_cell`` produces a
+   metrics dict whose phrasebank-aux fields are zero / None, so an
+   operator who never flips ``--enable-phrasebank-aux`` sees the
+   pre-#33 B2 behaviour byte-identically.
+2. PhraseBank-on path runs to completion, returns a finite aux-loss
+   trace, and reports the operator-supplied lambda.
+3. The aux head's parameters receive non-zero gradients during the
+   training step (proves the aux gradient actually flows into the
+   optimiser).
+4. ``run_sweep`` honours the ``--phrasebank-jsonl`` fixture without
+   reaching the HF Hub — sweep payloads carry a ``phrasebank_aux``
+   meta block.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.data import finetune_pilot_b2
+from app.data.phrasebank import PhraseBankRow
+
+
+def _torch_or_skip() -> Any:
+    return pytest.importorskip("torch")
+
+
+def _transformers_or_skip() -> Any:
+    return pytest.importorskip("transformers")
+
+
+def _stub_alias() -> str:
+    return "hf-internal-testing/tiny-random-bert"
+
+
+def _ensure_stub_loadable() -> None:
+    transformers = _transformers_or_skip()
+    try:
+        transformers.AutoTokenizer.from_pretrained(_stub_alias())
+    except Exception as exc:  # noqa: BLE001 -- cache flake on CI
+        pytest.skip(f"tiny-random-bert unavailable in test env: {exc}")
+
+
+def _make_phrasebank_rows() -> list[PhraseBankRow]:
+    return [
+        PhraseBankRow(row_id="pb_0", sentence="Revenue grew strongly.", label_idx=2),
+        PhraseBankRow(row_id="pb_1", sentence="Operating costs were flat.", label_idx=1),
+        PhraseBankRow(row_id="pb_2", sentence="Profit fell sharply.", label_idx=0),
+        PhraseBankRow(row_id="pb_3", sentence="Margins widened.", label_idx=2),
+    ]
+
+
+def _make_fomc_corpus() -> tuple[list[str], list[int], list[str], list[int]]:
+    train_texts = [
+        "Inflation remains elevated; further tightening is appropriate.",
+        "The committee judges that the policy stance is appropriate.",
+        "Conditions are softening; downside risks have increased.",
+        "Labour market remains tight; price pressures persist.",
+    ]
+    train_labels = [2, 1, 0, 2]
+    test_texts = [
+        "Risks to the outlook are roughly balanced.",
+        "Inflation is well above the committee's longer-run goal.",
+    ]
+    test_labels = [1, 2]
+    return train_texts, train_labels, test_texts, test_labels
+
+
+def test_default_off_metrics_have_zero_aux_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With aux off, the metrics dict reports zero rows + zero lambda.
+
+    The default-off path is the byte-identity contract: an operator
+    who never flips ``--enable-phrasebank-aux`` sees a B2 cell that
+    is equivalent to the pre-#33 harness.
+    """
+
+    torch = _torch_or_skip()
+    _ensure_stub_loadable()
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    train_texts, train_labels, test_texts, test_labels = _make_fomc_corpus()
+    cell = finetune_pilot_b2._train_and_eval_one_cell(
+        train_texts=train_texts,
+        train_labels=train_labels,
+        test_texts=test_texts,
+        test_labels=test_labels,
+        encoder_alias=_stub_alias(),
+        seed=11,
+        epochs=1,
+        train_batch_size=2,
+        eval_batch_size=2,
+        learning_rate=5e-5,
+        weight_decay=0.0,
+        max_length=32,
+        phrasebank_rows=None,
+        phrasebank_aux_lambda=0.0,
+    )
+    assert cell["phrasebank_aux_lambda"] == 0.0
+    assert cell["phrasebank_aux_rows"] == 0
+    assert cell["phrasebank_aux_train_loss"] is None
+    # Headline metric set unchanged from the pre-#33 contract.
+    assert 0.0 <= cell["macro_f1"] <= 1.0
+
+
+def test_aux_on_metrics_report_finite_aux_loss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With aux on, the cell returns a finite aux-loss trace + lambda."""
+
+    torch = _torch_or_skip()
+    _ensure_stub_loadable()
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    train_texts, train_labels, test_texts, test_labels = _make_fomc_corpus()
+    cell = finetune_pilot_b2._train_and_eval_one_cell(
+        train_texts=train_texts,
+        train_labels=train_labels,
+        test_texts=test_texts,
+        test_labels=test_labels,
+        encoder_alias=_stub_alias(),
+        seed=11,
+        epochs=1,
+        train_batch_size=2,
+        eval_batch_size=2,
+        learning_rate=5e-5,
+        weight_decay=0.0,
+        max_length=32,
+        phrasebank_rows=_make_phrasebank_rows(),
+        phrasebank_aux_lambda=0.3,
+    )
+    assert cell["phrasebank_aux_lambda"] == pytest.approx(0.3)
+    assert cell["phrasebank_aux_rows"] == 4
+    aux_loss = cell["phrasebank_aux_train_loss"]
+    assert aux_loss is not None
+    assert aux_loss == pytest.approx(aux_loss)  # finite (no NaN)
+    assert 0.0 <= cell["macro_f1"] <= 1.0
+
+
+def test_aux_gradient_flows_into_aux_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Aux-head parameters receive non-zero gradients.
+
+    Direct check: build the encoder + aux head, run one forward +
+    backward through the same code path as the harness, assert the
+    aux-head linear layer's weight grad is non-zero.
+    """
+
+    torch = _torch_or_skip()
+    transformers = _transformers_or_skip()
+    _ensure_stub_loadable()
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    stub = _stub_alias()
+    tokenizer = transformers.AutoTokenizer.from_pretrained(stub)
+    model = transformers.AutoModelForSequenceClassification.from_pretrained(
+        stub,
+        num_labels=finetune_pilot_b2.N_CLASSES,
+        ignore_mismatched_sizes=True,
+    )
+    hidden_size = int(model.config.hidden_size)
+    aux_head = torch.nn.Linear(hidden_size, 3)
+
+    rows = _make_phrasebank_rows()
+    encodings = tokenizer(
+        [r.sentence for r in rows],
+        truncation=True,
+        max_length=32,
+        padding="max_length",
+        return_tensors="pt",
+    )
+    aux_labels = torch.tensor([r.label_idx for r in rows], dtype=torch.long)
+
+    model.train()
+    aux_head.train()
+    outputs = model.base_model(
+        input_ids=encodings["input_ids"],
+        attention_mask=encodings["attention_mask"],
+    )
+    pooled = finetune_pilot_b2._pooled_from_base_model_output(
+        outputs, encodings["attention_mask"]
+    )
+    logits = aux_head(pooled)
+    loss = torch.nn.functional.cross_entropy(logits, aux_labels)
+    loss.backward()
+
+    # Aux head's linear weight grad is populated + non-zero somewhere.
+    assert aux_head.weight.grad is not None
+    assert aux_head.weight.grad.abs().sum().item() > 0.0
+    # The encoder body also receives gradient -- proves the aux loss
+    # flows back through the shared encoder, not just the new head.
+    encoder_grads = [
+        p.grad for p in model.base_model.parameters() if p.grad is not None
+    ]
+    assert any(g.abs().sum().item() > 0.0 for g in encoder_grads)
+
+
+def test_run_sweep_honours_phrasebank_jsonl_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``run_sweep`` reads PhraseBank from a local JSONL when supplied.
+
+    Tightly bounds the smoke: 1 seed, 1 fold, 1 epoch, batch 2 over a
+    tiny synthetic training-package fixture. The assertion is on the
+    sweep payload's ``phrasebank_aux`` meta block, not the macro-F1
+    (the random-init stub does not converge on 4 train rows).
+    """
+
+    pd = pytest.importorskip("pandas")
+    pytest.importorskip("pyarrow")
+    torch = _torch_or_skip()
+    _ensure_stub_loadable()
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    package_dir = tmp_path / "tp_phrasebank_smoke"
+    package_dir.mkdir()
+
+    # Five FOMC rows spanning a clean train window + one test event.
+    registry_rows = []
+    events_rows = []
+    for i in range(5):
+        ed = f"2020-0{i + 1}-15"
+        registry_rows.append(
+            {
+                "record_id": f"doc_{i}",
+                "text": f"FOMC statement {i}. Inflation remains a concern.",
+                "event_date": ed,
+                "source": "fomc_statement",
+                "sample_weight": 1.0,
+            }
+        )
+        events_rows.append(
+            {"event_date": ed, "forward_realized_vol_10d": 0.010 + 0.005 * i}
+        )
+    test_ed = "2021-01-15"
+    registry_rows.append(
+        {
+            "record_id": "doc_test",
+            "text": "FOMC test statement. Conditions softening.",
+            "event_date": test_ed,
+            "source": "fomc_statement",
+            "sample_weight": 1.0,
+        }
+    )
+    events_rows.append(
+        {"event_date": test_ed, "forward_realized_vol_10d": 0.035}
+    )
+
+    (package_dir / "registry_normalized.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in registry_rows), encoding="utf-8"
+    )
+    pd.DataFrame(events_rows).to_parquet(package_dir / "events.parquet")
+
+    fold_manifest = {
+        "folds": [
+            {
+                "fold_id": "fold_smoke",
+                "train_end": "2020-12-31",
+                "test_start": "2021-01-01",
+                "test_end": "2021-12-31",
+            }
+        ]
+    }
+    (package_dir / "fold_manifest_expanding_walk_forward.json").write_text(
+        json.dumps(fold_manifest), encoding="utf-8"
+    )
+
+    # PhraseBank fixture.
+    pb_fixture = tmp_path / "phrasebank_fixture.jsonl"
+    pb_rows = [
+        {"sentence": "Revenue grew sharply.", "label": "positive"},
+        {"sentence": "Profit fell sharply.", "label": "negative"},
+        {"sentence": "Costs were flat.", "label": "neutral"},
+        {"sentence": "Margins narrowed slightly.", "label": "negative"},
+    ]
+    pb_fixture.write_text(
+        "\n".join(json.dumps(r) for r in pb_rows), encoding="utf-8"
+    )
+
+    # Redirect the resolver so we don't depend on the global processed/
+    # directory inside the worktree.
+    monkeypatch.setattr(
+        finetune_pilot_b2,
+        "_resolve_training_package_dir",
+        lambda _id: package_dir,
+    )
+
+    args = type(
+        "Args",
+        (),
+        {
+            "training_package_id": "tp_phrasebank_smoke",
+            "encoder_alias": _stub_alias(),
+            "seeds": [11],
+            "folds": ["fold_smoke"],
+            "epochs": 1,
+            "train_batch_size": 2,
+            "eval_batch_size": 2,
+            "learning_rate": 5e-5,
+            "weight_decay": 0.0,
+            "max_length": 32,
+            "enable_phrasebank_aux": True,
+            "phrasebank_aux_lambda": 0.3,
+            "phrasebank_subset": "sentences_allagree",
+            "phrasebank_cache_root": None,
+            "phrasebank_jsonl": pb_fixture,
+        },
+    )()
+    payload = finetune_pilot_b2.run_sweep(args)
+    meta = payload["phrasebank_aux"]
+    assert meta["enabled"] is True
+    assert meta["n_rows"] == 4
+    assert meta["aux_lambda"] == pytest.approx(0.3)
+    assert meta["class_counts"] == [2, 1, 1]
+    # The sweep produced exactly one (seed, fold) cell with the aux
+    # payload populated.
+    cells = payload["trials"][0]["folds"]
+    assert len(cells) == 1
+    assert "phrasebank_aux" in cells[0]
+    assert cells[0]["phrasebank_aux"]["n_rows"] == 4

--- a/tests/unit/test_phrasebank_loader.py
+++ b/tests/unit/test_phrasebank_loader.py
@@ -1,0 +1,128 @@
+"""Loader contract tests for the PhraseBank auxiliary-task source (#33)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.data.phrasebank import (
+    ID2LABEL,
+    LABEL2ID,
+    N_CLASSES,
+    PHRASEBANK_LABELS,
+    PhraseBankRow,
+    _coerce_label_idx,
+    _iter_local_rows,
+    class_counts,
+    load_phrasebank_rows,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure-Python contract tests (no torch / HF datasets required).
+# ---------------------------------------------------------------------------
+
+
+def test_label_ordering_is_pinned() -> None:
+    """Canonical label order must be negative / neutral / positive."""
+
+    assert PHRASEBANK_LABELS == ("negative", "neutral", "positive")
+    assert N_CLASSES == 3
+    assert LABEL2ID == {"negative": 0, "neutral": 1, "positive": 2}
+    assert ID2LABEL == {0: "negative", 1: "neutral", 2: "positive"}
+
+
+def test_coerce_label_idx_accepts_canonical_strings() -> None:
+    assert _coerce_label_idx("negative") == 0
+    assert _coerce_label_idx("Neutral") == 1
+    assert _coerce_label_idx("POSITIVE") == 2
+
+
+def test_coerce_label_idx_accepts_canonical_ints() -> None:
+    assert _coerce_label_idx(0) == 0
+    assert _coerce_label_idx(1) == 1
+    assert _coerce_label_idx(2) == 2
+
+
+def test_coerce_label_idx_rejects_out_of_range() -> None:
+    assert _coerce_label_idx(-1) is None
+    assert _coerce_label_idx(3) is None
+    assert _coerce_label_idx("hawkish") is None
+    assert _coerce_label_idx(None) is None
+
+
+def test_iter_local_rows_drops_empty_and_invalid() -> None:
+    rows = [
+        {"sentence": "Net sales rose 12% on the year.", "label": "positive"},
+        {"sentence": "", "label": "negative"},  # empty sentence -> dropped
+        {"sentence": "Quarterly profit fell sharply.", "label": "bogus"},  # bad label -> dropped
+        {"sentence": "Revenue was flat.", "label": 1},
+    ]
+    parsed = _iter_local_rows(rows)
+    assert len(parsed) == 2
+    assert parsed[0].label == "positive"
+    assert parsed[1].label == "neutral"
+    # Row ids are monotonic.
+    assert parsed[0].row_id == "pb_00000"
+    assert parsed[1].row_id == "pb_00003"
+
+
+def test_class_counts_in_canonical_order() -> None:
+    rows = [
+        PhraseBankRow(row_id="r0", sentence="x", label_idx=0),
+        PhraseBankRow(row_id="r1", sentence="x", label_idx=2),
+        PhraseBankRow(row_id="r2", sentence="x", label_idx=2),
+        PhraseBankRow(row_id="r3", sentence="x", label_idx=1),
+    ]
+    assert class_counts(rows) == [1, 1, 2]
+
+
+def test_load_phrasebank_rows_from_local_jsonl(tmp_path: Path) -> None:
+    """Local JSONL fixture round-trips through the loader."""
+
+    fixture = tmp_path / "phrasebank_fixture.jsonl"
+    rows = [
+        {"sentence": "The company reported record earnings.", "label": "positive"},
+        {"sentence": "Operating costs declined modestly.", "label": "neutral"},
+        {"sentence": "Profit fell on weaker demand.", "label": "negative"},
+    ]
+    fixture.write_text(
+        "\n".join(json.dumps(r) for r in rows), encoding="utf-8"
+    )
+    loaded = load_phrasebank_rows(local_jsonl=fixture)
+    assert [r.label for r in loaded] == ["positive", "neutral", "negative"]
+    assert all(r.sentence for r in loaded)
+
+
+def test_load_phrasebank_rows_rejects_unknown_subset(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="not in"):
+        load_phrasebank_rows(subset="sentences_bogus", cache_root=tmp_path)
+
+
+def test_load_phrasebank_rows_missing_fixture_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_phrasebank_rows(local_jsonl=tmp_path / "absent.jsonl")
+
+
+def test_phrasebank_cache_round_trips(tmp_path: Path) -> None:
+    """Cache write -> read returns the same rows without hitting HF."""
+
+    pytest.importorskip("pandas")
+    pytest.importorskip("pyarrow")
+    from app.data.phrasebank import _cache_path, _read_cache, _write_cache
+
+    rows = [
+        PhraseBankRow(row_id="pb_00000", sentence="Net sales rose.", label_idx=2),
+        PhraseBankRow(row_id="pb_00001", sentence="Profit fell.", label_idx=0),
+    ]
+    cache_path = _cache_path(tmp_path, "sentences_allagree", None)
+    _write_cache(cache_path, rows)
+    assert cache_path.exists()
+    cached = _read_cache(cache_path)
+    assert cached is not None
+    assert [(r.sentence, r.label_idx) for r in cached] == [
+        ("Net sales rose.", 2),
+        ("Profit fell.", 0),
+    ]


### PR DESCRIPTION
Closes #33.

Path A — PhraseBank as a continued-pretraining substrate — was rejected as noise-level (4 800 sentences vs 909k BIS NSP pairs, expected lift < 0.005 macro-F1, below per-cell std on the canonical sweep). Path B re-scopes PhraseBank as a supervised auxiliary task on the B2 encoder fine-tune: a fresh 3-class linear head reads the encoder's pooled output and a per-axis lambda knob (`--phrasebank-aux-lambda`, default 0.3 to match LSTM-stage `MultiTaskLoss` defaults from #273) weights the auxiliary CE term into the combined loss. Default off → harness reproduces pre-#33 B2 byte-identically (locked by a unit test).

- `backend/app/data/phrasebank.py` — loader for `takala/financial_phrasebank` (defaults to `sentences_allagree`, 2 264 rows; opt-in `sentences_50agree` for the full 4 840-row pool). On-disk parquet cache under `data/external/phrasebank/`; local-JSONL fallback path for air-gapped tests. Read-only — HF write tokens are not exercised.
- `backend/app/data/finetune_pilot_b2.py` — `--enable-phrasebank-aux` + `--phrasebank-aux-lambda` (+ subset / cache / JSONL knobs). When on, second DataLoader cycles PhraseBank batches one-for-one with FOMC batches; combined loss `main_ce + lambda * aux_ce` flows back through the shared encoder body. Aux pool and FOMC fold index disjoint rows so the auxiliary supervision can never bleed into a fold's test slice.
- `make finetune-pilot-b2-phrasebank TRAINING_PACKAGE_ID=<id> [PHRASEBANK_AUX_LAMBDA=0.3]` wires the headline sweep.
- Tests: 10 loader contract tests (`tests/unit/test_phrasebank_loader.py`) + 4 harness tests (`tests/unit/test_finetune_pilot_b2_phrasebank.py`) covering default-off byte-identity, aux-on loss flow, aux-head gradient flow into both heads, and a JSONL-fixture sweep round-trip. All 20 pass on CPU < 60 s.
- `docs/adr/0033-phrasebank-auxiliary-finetune.md` — Path A rejection rationale, Path B scope, label-space mismatch caveat (PhraseBank is company-level financial sentiment, B2 target is FOMC vol-regime — three-class overlap is accidental, not semantic), expected lift band +0.01 to +0.02 macro-F1 per Phang et al. 2018 / Pruksachatkun et al. 2020.
- Wiki §13 burn-down row #33 in progress (separate commit in `fed-pulse.wiki`).

## Reviewer focus

- Default-off path: `--enable-phrasebank-aux` not set → `phrasebank_rows is None` → `_train_and_eval_one_cell` skips the aux head + second DataLoader + combined-loss code path entirely. `test_default_off_metrics_have_zero_aux_fields` locks the contract. No drift on the existing B2 numerics.
- No-leak: the aux loader and the FOMC fold loader index disjoint pools (PhraseBank rows are loaded once per sweep, shared across every cell; FOMC fold's train / test split is unchanged). No row-index crossover.
- Aux gradient: `test_aux_gradient_flows_into_aux_head` asserts both the aux-head linear weight grad AND the encoder body grads are non-zero after one backward — proves the aux loss reaches the shared substrate, not just the new head.
- ADR documents the label-space-mismatch caveat honestly; the +0.01 to +0.02 expected lift is the experimental front, not a marketing claim. The result is methodology-quality whichever way the GPU sweep settles.

BLOCKED: needs GPU fine-tune comparison.
The 5-seed × 4-fold sweep against `finbert_fed_adjacent` (`make finetune-pilot-b2-phrasebank TRAINING_PACKAGE_ID=<id>` against the baseline `make finetune-pilot-b2 TRAINING_PACKAGE_ID=<id>` on the same fold surface) is a Runpod follow-up. The CI smoke proves the wire-up; the GPU sweep populates the §6.x PhraseBank-augmented row.