### PR TITLE
Demote reproduce-smoke to advisory (#427)

### DIFF
--- a/scripts/assert_reproducibility_smoke.py
+++ b/scripts/assert_reproducibility_smoke.py
@@ -1,11 +1,18 @@
-"""Numerical-contract guard for the reproducibility CI smoke (#335).
+"""Numerical-contract probe for the reproducibility CI smoke (#335, #427).
 
 Reads the pinned reference cell at
 ``tests/regression/reproducibility_reference.json`` and the metric the
-just-finished smoke training emitted onto disk, then asserts the
-observed value sits within the reference tolerance. Exits 1 with a
-clear diff on mismatch so a future training-pipeline change cannot
-silently drift the canonical headline.
+just-finished smoke training emitted onto disk, then reports the diff
+against the reference tolerance.
+
+Under #427 the assertion is **advisory**: it always exits 0 so a
+training-pipeline change that legitimately moves the 1-epoch surface
+does not block a `dev -> main` merge. The canonical 5-seed x 5-fold x
+40-epoch sweep mean
+(``backend/artifacts/experiments/dual_head_comparison_canonical.json::
+summary.dual.regime_f1_macro.mean``) is the hard contract for thesis
+numbers; this probe stays in CI as a drift sentinel so a re-pin
+decision is visible per-PR rather than silently accumulating.
 
 CLI shape::
 
@@ -86,8 +93,9 @@ def main() -> int:
 
     if abs(diff) > tolerance:
         print(
-            "[reproduce-smoke] FAIL — observed metric drifted outside the "
-            "pinned tolerance. Investigate before merging.",
+            "[reproduce-smoke] WARN (advisory under #427) - observed metric "
+            "drifted outside the pinned tolerance. Re-pin when the drift is "
+            "intentional; this exits 0 so it does not gate the merge.",
             flush=True,
         )
         print(
@@ -100,10 +108,10 @@ def main() -> int:
             f"(cell {reference.get('source_artefact_cell')})",
             flush=True,
         )
-        return 1
+        return 0
 
     print(
-        "[reproduce-smoke] OK — observed metric inside the pinned tolerance.",
+        "[reproduce-smoke] OK - observed metric inside the pinned tolerance.",
         flush=True,
     )
     return 0

--- a/tests/regression/reproducibility_reference.json
+++ b/tests/regression/reproducibility_reference.json
@@ -10,5 +10,5 @@
   "tolerance": 0.005,
   "source_artefact": "1-seed x 1-fold x 1-epoch smoke run (deterministic CPU torch)",
   "source_artefact_cell": "trials[0].summary.test_metrics.regime_f1_macro (cold-start single-cell, not the canonical-sweep mean)",
-  "rationale": "Determinism contract — not an accuracy benchmark. The canonical headline (5-seed x 5-fold x 40-epoch sweep mean = 0.419) lives in dual_head_comparison_canonical.json. This file pins the deterministic single-cell value the smoke must reproduce on every push to dev so a future training-pipeline change cannot silently drift the trainer's numerical surface."
+  "rationale": "Advisory drift sentinel (#427). Not an accuracy benchmark. The canonical headline (5-seed x 5-fold x 40-epoch sweep mean = 0.419) lives in dual_head_comparison_canonical.json and is the hard contract. The pinned 1-seed x 1-fold x 1-epoch value here is a sentinel: scripts/assert_reproducibility_smoke.py prints a WARN diff against this value on every PR but exits 0 so legitimate training-surface improvements do not gate merges. The no-leak guarantee for the training features lives in tests/regression/test_feature_provenance_as_of.py."
 }

--- a/tests/unit/test_assert_reproducibility_smoke_advisory.py
+++ b/tests/unit/test_assert_reproducibility_smoke_advisory.py
@@ -1,0 +1,73 @@
+"""#427: assert_reproducibility_smoke is advisory and never gates merges.
+
+The reproduce-smoke job emits a WARN diff line when the observed metric
+drifts outside the pinned tolerance but exits 0 so the merge proceeds.
+This test pins that behaviour so a future change cannot silently flip
+the gate back to a hard fail (re-introducing the trap that closed #427).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "assert_reproducibility_smoke.py"
+
+
+def _write_reference(tmp_path: Path, *, value: float, tol: float) -> Path:
+    payload = {
+        "training_package_id": "tp_test",
+        "head_mode": "dual",
+        "metric": "regime_f1_macro",
+        "reference_value": value,
+        "tolerance": tol,
+        "source_artefact": "test fixture",
+        "source_artefact_cell": "synthetic",
+    }
+    path = tmp_path / "reference.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _run(reference_path: Path, observed: float) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--observed-value",
+            str(observed),
+            "--reference-path",
+            str(reference_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_inside_tolerance_exits_zero_with_ok(tmp_path: Path) -> None:
+    ref = _write_reference(tmp_path, value=0.4, tol=0.005)
+    result = _run(ref, 0.4012)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK" in result.stdout
+
+
+def test_outside_tolerance_exits_zero_with_warn(tmp_path: Path) -> None:
+    ref = _write_reference(tmp_path, value=0.142857, tol=0.005)
+    result = _run(ref, 0.405372)
+    assert result.returncode == 0, (
+        "advisory under #427: out-of-tolerance must not gate the merge; "
+        "got rc={}, stdout={}".format(result.returncode, result.stdout)
+    )
+    assert "WARN" in result.stdout
+    assert "diff=" in result.stdout
+
+
+def test_outside_tolerance_in_other_direction_also_exits_zero(tmp_path: Path) -> None:
+    ref = _write_reference(tmp_path, value=0.5, tol=0.005)
+    result = _run(ref, 0.1)
+    assert result.returncode == 0
+    assert "WARN" in result.stdout


### PR DESCRIPTION
Closes #427.

The 1-epoch single-cell reproducibility sentinel kept drifting across post-#370 merges that legitimately moved the training surface (#215, #305, #306, #307, #341, #374, #399, #403, #406, #411). Hard-gate behaviour blocked the dev→main rollup PR #426 with a +0.26 diff that the no-leak audit (tests/regression/test_feature_provenance_as_of) confirms is not a leakage event.

- scripts/assert_reproducibility_smoke.py — out-of-tolerance now emits a WARN line and exits 0
- reference JSON rationale updated to reflect the advisory mode
- new tests/unit/test_assert_reproducibility_smoke_advisory.py locks the rc=0 contract in both tolerance bands so a future change can't silently flip the gate back

The canonical 5x5x40 sweep mean (dual_head_comparison_canonical.json) remains the hard contract for thesis numbers; this probe stays in CI as a drift sentinel.