### PR TITLE
Address Copilot review comments on #424 + #421

### DIFF
--- a/backend/app/data/finetune_pilot_b2.py
+++ b/backend/app/data/finetune_pilot_b2.py
@@ -563,15 +563,10 @@ def _train_and_eval_one_cell(  # noqa: PLR0913 — per-cell knobs surface as nam
                 )
                 loss = outputs.loss
             else:
-                # Recompute the main CE explicitly so the encoder
-                # forward also yields hidden states for the aux head.
-                # Going through ``output_hidden_states=True`` keeps
-                # the call signature on every BERT-family backbone.
                 outputs = model(
                     input_ids=input_ids,
                     attention_mask=attention_mask,
                     labels=labels_t,
-                    output_hidden_states=True,
                 )
                 main_loss = outputs.loss
 
@@ -655,15 +650,13 @@ def _pooled_from_base_model_output(
     even when the pooler is absent.
     """
 
-    import torch
-
     pooled = getattr(outputs, "pooler_output", None)
     if pooled is not None:
         return pooled
     last_hidden = outputs.last_hidden_state
     mask = attention_mask.unsqueeze(-1).to(last_hidden.dtype)
     summed = (last_hidden * mask).sum(dim=1)
-    denom = mask.sum(dim=1).clamp(min=torch.tensor(1.0, device=last_hidden.device))
+    denom = mask.sum(dim=1).clamp(min=1.0)
     return summed / denom
 
 
@@ -690,31 +683,44 @@ def run_sweep(args: argparse.Namespace) -> dict[str, Any]:
     # slices, no row indexing crossover.
     phrasebank_rows: list[Any] | None = None
     phrasebank_meta: dict[str, Any] = {"enabled": False}
+    aux_lambda = float(getattr(args, "phrasebank_aux_lambda", 0.0))
     if getattr(args, "enable_phrasebank_aux", False):
-        from app.data.phrasebank import (
-            class_counts as _pb_class_counts,
-            load_phrasebank_rows,
-        )
-
-        subset = getattr(args, "phrasebank_subset", None) or "sentences_allagree"
-        local_jsonl = getattr(args, "phrasebank_jsonl", None)
-        cache_root = getattr(args, "phrasebank_cache_root", None)
-        phrasebank_rows = load_phrasebank_rows(
-            subset=subset,
-            local_jsonl=Path(local_jsonl) if local_jsonl else None,
-            cache_root=Path(cache_root) if cache_root else None,
-        )
-        phrasebank_meta = {
-            "enabled": True,
-            "subset": subset,
-            "n_rows": len(phrasebank_rows),
-            "class_counts": _pb_class_counts(phrasebank_rows),
-            "aux_lambda": float(getattr(args, "phrasebank_aux_lambda", 0.0)),
-        }
-        if not phrasebank_rows:
-            raise SystemExit(
-                "PhraseBank loader returned no rows; aux flag is on but pool is empty."
+        if aux_lambda <= 0.0:
+            print(
+                f"[finetune-pilot-b2] WARN: --enable-phrasebank-aux is set "
+                f"but --phrasebank-aux-lambda={aux_lambda} <= 0; treating "
+                f"the run as aux-disabled.",
+                flush=True,
             )
+        else:
+            from app.data.phrasebank import (
+                class_counts as _pb_class_counts,
+                load_phrasebank_rows,
+            )
+
+            subset = (
+                getattr(args, "phrasebank_subset", None)
+                or "sentences_allagree"
+            )
+            local_jsonl = getattr(args, "phrasebank_jsonl", None)
+            cache_root = getattr(args, "phrasebank_cache_root", None)
+            phrasebank_rows = load_phrasebank_rows(
+                subset=subset,
+                local_jsonl=Path(local_jsonl) if local_jsonl else None,
+                cache_root=Path(cache_root) if cache_root else None,
+            )
+            if not phrasebank_rows:
+                raise SystemExit(
+                    "PhraseBank loader returned no rows; aux flag is on but "
+                    "pool is empty."
+                )
+            phrasebank_meta = {
+                "enabled": True,
+                "subset": subset,
+                "n_rows": len(phrasebank_rows),
+                "class_counts": _pb_class_counts(phrasebank_rows),
+                "aux_lambda": aux_lambda,
+            }
 
     seed_trials: list[SeedTrial] = []
     all_macro_f1: list[float] = []

--- a/backend/app/evaluation/cross_source_transfer.py
+++ b/backend/app/evaluation/cross_source_transfer.py
@@ -180,8 +180,9 @@ def _predict_with_model(
 
     tokenizer = AutoTokenizer.from_pretrained(checkpoint)
     model = AutoModelForSequenceClassification.from_pretrained(checkpoint)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
     model.eval()
-    device = next(model.parameters()).device
 
     # Honour the canonical TDW label order (dovish, hawkish, neutral) per the
     # cross_bank_transfer note — some legacy checkpoints carry an inverted

--- a/tests/unit/test_finetune_pilot_b2_phrasebank.py
+++ b/tests/unit/test_finetune_pilot_b2_phrasebank.py
@@ -28,6 +28,71 @@ from app.data import finetune_pilot_b2
 from app.data.phrasebank import PhraseBankRow
 
 
+def _build_synthetic_package(tmp_path: Path) -> Path:
+    """Build a minimal training-package fixture under ``tmp_path``.
+
+    Five train rows + one test row spanning a clean walk-forward fold,
+    plus a fold manifest. Shared between the JSONL-fixture happy-path
+    test and the lambda<=0 disable-the-aux footgun test.
+    """
+
+    pd = pytest.importorskip("pandas")
+    pytest.importorskip("pyarrow")
+
+    package_dir = tmp_path / "tp_phrasebank_smoke"
+    package_dir.mkdir()
+
+    registry_rows: list[dict[str, Any]] = []
+    events_rows: list[dict[str, Any]] = []
+    for i in range(5):
+        ed = f"2020-0{i + 1}-15"
+        registry_rows.append(
+            {
+                "record_id": f"doc_{i}",
+                "text": f"FOMC statement {i}. Inflation remains a concern.",
+                "event_date": ed,
+                "source": "fomc_statement",
+                "sample_weight": 1.0,
+            }
+        )
+        events_rows.append(
+            {"event_date": ed, "forward_realized_vol_10d": 0.010 + 0.005 * i}
+        )
+    test_ed = "2021-01-15"
+    registry_rows.append(
+        {
+            "record_id": "doc_test",
+            "text": "FOMC test statement. Conditions softening.",
+            "event_date": test_ed,
+            "source": "fomc_statement",
+            "sample_weight": 1.0,
+        }
+    )
+    events_rows.append(
+        {"event_date": test_ed, "forward_realized_vol_10d": 0.035}
+    )
+
+    (package_dir / "registry_normalized.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in registry_rows), encoding="utf-8"
+    )
+    pd.DataFrame(events_rows).to_parquet(package_dir / "events.parquet")
+
+    fold_manifest = {
+        "folds": [
+            {
+                "fold_id": "fold_smoke",
+                "train_end": "2020-12-31",
+                "test_start": "2021-01-01",
+                "test_end": "2021-12-31",
+            }
+        ]
+    }
+    (package_dir / "fold_manifest_expanding_walk_forward.json").write_text(
+        json.dumps(fold_manifest), encoding="utf-8"
+    )
+    return package_dir
+
+
 def _torch_or_skip() -> Any:
     return pytest.importorskip("torch")
 
@@ -215,64 +280,11 @@ def test_run_sweep_honours_phrasebank_jsonl_fixture(
     (the random-init stub does not converge on 4 train rows).
     """
 
-    pd = pytest.importorskip("pandas")
-    pytest.importorskip("pyarrow")
     torch = _torch_or_skip()
     _ensure_stub_loadable()
     monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
 
-    package_dir = tmp_path / "tp_phrasebank_smoke"
-    package_dir.mkdir()
-
-    # Five FOMC rows spanning a clean train window + one test event.
-    registry_rows = []
-    events_rows = []
-    for i in range(5):
-        ed = f"2020-0{i + 1}-15"
-        registry_rows.append(
-            {
-                "record_id": f"doc_{i}",
-                "text": f"FOMC statement {i}. Inflation remains a concern.",
-                "event_date": ed,
-                "source": "fomc_statement",
-                "sample_weight": 1.0,
-            }
-        )
-        events_rows.append(
-            {"event_date": ed, "forward_realized_vol_10d": 0.010 + 0.005 * i}
-        )
-    test_ed = "2021-01-15"
-    registry_rows.append(
-        {
-            "record_id": "doc_test",
-            "text": "FOMC test statement. Conditions softening.",
-            "event_date": test_ed,
-            "source": "fomc_statement",
-            "sample_weight": 1.0,
-        }
-    )
-    events_rows.append(
-        {"event_date": test_ed, "forward_realized_vol_10d": 0.035}
-    )
-
-    (package_dir / "registry_normalized.jsonl").write_text(
-        "\n".join(json.dumps(r) for r in registry_rows), encoding="utf-8"
-    )
-    pd.DataFrame(events_rows).to_parquet(package_dir / "events.parquet")
-
-    fold_manifest = {
-        "folds": [
-            {
-                "fold_id": "fold_smoke",
-                "train_end": "2020-12-31",
-                "test_start": "2021-01-01",
-                "test_end": "2021-12-31",
-            }
-        ]
-    }
-    (package_dir / "fold_manifest_expanding_walk_forward.json").write_text(
-        json.dumps(fold_manifest), encoding="utf-8"
-    )
+    package_dir = _build_synthetic_package(tmp_path)
 
     # PhraseBank fixture.
     pb_fixture = tmp_path / "phrasebank_fixture.jsonl"
@@ -327,3 +339,63 @@ def test_run_sweep_honours_phrasebank_jsonl_fixture(
     assert len(cells) == 1
     assert "phrasebank_aux" in cells[0]
     assert cells[0]["phrasebank_aux"]["n_rows"] == 4
+
+
+def test_run_sweep_treats_enable_aux_with_zero_lambda_as_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--enable-phrasebank-aux`` with ``--phrasebank-aux-lambda=0`` is a
+    footgun: PhraseBank would load (and emit ``enabled=true`` meta) while
+    the multiplier zeroed every aux gradient. We treat lambda<=0 as
+    aux-disabled, emit a WARN line, and never touch the loader.
+    """
+
+    torch = _torch_or_skip()
+    _ensure_stub_loadable()
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    package_dir = _build_synthetic_package(tmp_path)
+
+    # Sentinel: if the loader is reached we explode the test.
+    def _exploding_loader(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("PhraseBank loader must not be invoked when lambda<=0")
+
+    monkeypatch.setattr(
+        finetune_pilot_b2,
+        "_resolve_training_package_dir",
+        lambda _id: package_dir,
+    )
+    monkeypatch.setattr(
+        "app.data.phrasebank.load_phrasebank_rows",
+        _exploding_loader,
+    )
+
+    args = type(
+        "Args",
+        (),
+        {
+            "training_package_id": "tp_phrasebank_smoke",
+            "encoder_alias": _stub_alias(),
+            "seeds": [11],
+            "folds": ["fold_smoke"],
+            "epochs": 1,
+            "train_batch_size": 2,
+            "eval_batch_size": 2,
+            "learning_rate": 5e-5,
+            "weight_decay": 0.0,
+            "max_length": 32,
+            "enable_phrasebank_aux": True,
+            "phrasebank_aux_lambda": 0.0,
+            "phrasebank_subset": "sentences_allagree",
+            "phrasebank_cache_root": None,
+            "phrasebank_jsonl": None,
+        },
+    )()
+    payload = finetune_pilot_b2.run_sweep(args)
+    captured = capsys.readouterr()
+    assert "WARN" in captured.out
+    assert payload["phrasebank_aux"] == {"enabled": False}
+    # Per-cell schema is also aux-free.
+    cells = payload["trials"][0]["folds"]
+    assert "phrasebank_aux" not in cells[0]


### PR DESCRIPTION
Sweeps the Copilot review on PR #426 (which carries #421 + #424). Six findings total; this PR addresses five. The sixth (pin a \`DEFAULT_REVISION\` SHA for the PhraseBank dataset) is left for the canonical-sweep run since it needs the actual revision to pin against — tracked in #425.

- **lambda<=0 footgun (\`finetune_pilot_b2.py\`)**: \`--enable-phrasebank-aux\` with \`--phrasebank-aux-lambda<=0\` would load PhraseBank and mark the top-level meta \`enabled=true\` while the multiplier silently zeroed every aux gradient. Now warns and treats the run as aux-disabled; loader is never called.
- **Schema consistency (\`finetune_pilot_b2.py\`)**: top-level \`phrasebank_aux.enabled\` now aligns with the per-cell \`FoldCell.to_dict()\` emission (both gated on the same lambda>0 condition).
- **Unused flag (\`finetune_pilot_b2.py\`)**: drop \`output_hidden_states=True\` on the aux-on main forward; the aux pass uses a separate \`base_model()\` call.
- **Pooling clamp (\`finetune_pilot_b2.py\`)**: \`clamp(min=1.0)\` instead of \`clamp(min=torch.tensor(1.0, device=...))\` — no per-call tensor allocation.
- **CUDA selection (\`cross_source_transfer.py\`)**: explicit \`device = cuda if available\` + \`model.to(device)\`; \`from_pretrained()\` loads on CPU by default, which pinned the eval to CPU even on a GPU pod.

Tests: extracted \`_build_synthetic_package\` helper out of the existing happy-path sweep test and added one new test that asserts the lambda<=0 path warns, skips the loader (sentinel raises), and leaves the schema aux-free in both top-level and per-cell positions.

Refs #421, #424, #425.