### PR TITLE
Thread multi_task_loss + axis lambdas through _coerce_payload_config (#423)

### DIFF
--- a/backend/app/training/checkpoint.py
+++ b/backend/app/training/checkpoint.py
@@ -152,6 +152,26 @@ def _coerce_payload_config(payload: dict[str, Any] | None) -> ModelConfig:
                 raw.get("rates_head_mode", "regression") or "regression"
             ),
             rates_alpha=float(raw.get("rates_alpha", 0.5)),
+            # #423: mirror the #292 rates-fields landing for the #273
+            # multi-task loss knob + the four per-axis lambda fields.
+            # Pre-#273 checkpoints leave these absent and the defaults
+            # collapse to the single-task CE path. Without this,
+            # eval_checkpoint_directional / calibrate_regime_classifier
+            # silently rebuild a multi_task_loss=False config from a
+            # --multi-task-loss=on checkpoint.
+            multi_task_loss=bool(raw.get("multi_task_loss", False)),
+            multi_task_lambda_stance=float(
+                raw.get("multi_task_lambda_stance", 1.0)
+            ),
+            multi_task_lambda_factor=float(
+                raw.get("multi_task_lambda_factor", 0.3)
+            ),
+            multi_task_lambda_certainty=float(
+                raw.get("multi_task_lambda_certainty", 0.3)
+            ),
+            multi_task_lambda_topic=float(
+                raw.get("multi_task_lambda_topic", 0.3)
+            ),
         )
     return ModelConfig()
 

--- a/tests/unit/test_multi_task_checkpoint_persistence.py
+++ b/tests/unit/test_multi_task_checkpoint_persistence.py
@@ -125,6 +125,55 @@ def test_checkpoint_carries_per_axis_class_weights_and_lambdas(tmp_path: Path) -
     assert persisted["topic"] == mt["topic"]
 
 
+def test_coerce_payload_config_threads_multi_task_fields() -> None:
+    """`_coerce_payload_config` rebuilds the multi-task knob + lambdas (#423).
+
+    Pre-#423 the helper rebuilt a ``multi_task_loss=False`` config from a
+    checkpoint dict regardless of what the run trained under, so
+    ``eval_checkpoint_directional`` / ``calibrate_regime_classifier``
+    silently saw a single-task config on every multi-task checkpoint.
+    Mirror the #292 rates-fields landing and round-trip the four knobs
+    through the coercion path.
+    """
+
+    from app.training.checkpoint import _coerce_payload_config
+
+    config = ModelConfig(
+        output_mode="classification",
+        multi_task_loss=True,
+        multi_task_lambda_stance=1.0,
+        multi_task_lambda_factor=0.25,
+        multi_task_lambda_certainty=0.35,
+        multi_task_lambda_topic=0.40,
+        n_classes=3,
+    )
+
+    rebuilt = _coerce_payload_config({"model_config": config.to_dict()})
+
+    assert rebuilt.multi_task_loss is True
+    assert rebuilt.multi_task_lambda_stance == 1.0
+    assert rebuilt.multi_task_lambda_factor == 0.25
+    assert rebuilt.multi_task_lambda_certainty == 0.35
+    assert rebuilt.multi_task_lambda_topic == 0.40
+
+
+def test_coerce_payload_config_defaults_when_multi_task_absent() -> None:
+    """Pre-#273 checkpoints leave the keys absent; the rebuilt config
+    must collapse to the single-task CE path so the legacy contract
+    stays byte-identical.
+    """
+
+    from app.training.checkpoint import _coerce_payload_config
+
+    rebuilt = _coerce_payload_config({"model_config": {"input_size": 6}})
+
+    assert rebuilt.multi_task_loss is False
+    assert rebuilt.multi_task_lambda_stance == 1.0
+    assert rebuilt.multi_task_lambda_factor == 0.3
+    assert rebuilt.multi_task_lambda_certainty == 0.3
+    assert rebuilt.multi_task_lambda_topic == 0.3
+
+
 def test_checkpoint_omits_multi_task_weights_when_flag_off(tmp_path: Path) -> None:
     """Default (multi_task_loss=False): no per-axis payload, no contract
     drift for every pre-#273 checkpoint.


### PR DESCRIPTION
Closes #423.

`_coerce_payload_config` rebuilt the ModelConfig off the checkpoint dict but dropped `multi_task_loss` and the four per-axis lambda fields. `eval_checkpoint_directional` / `calibrate_regime_classifier` silently saw `multi_task_loss=False` on every multi-task checkpoint.

- Mirror the #292 rates-fields landing (`rates_heads` / `rates_head_mode` / `rates_alpha`) -- forward `multi_task_loss` + `multi_task_lambda_{stance,factor,certainty,topic}` on the same coercion path.
- Pre-#273 checkpoints leave the keys absent; the defaults collapse to the single-task CE branch byte-identical to the legacy path.
- New `_coerce_payload_config` unit tests in `test_multi_task_checkpoint_persistence.py` lock both directions: flag-on round-trips the four lambdas verbatim, flag-absent rebuilds the default single-task config.

Refs #273, #422.