### PR TITLE
GSS factor decomposition as a BaseSourceScraper (#418)

### DIFF
--- a/backend/app/data/ingest_sources.py
+++ b/backend/app/data/ingest_sources.py
@@ -629,7 +629,7 @@ def _iter_gss_factors_records(
                 label="",  # factor axis is continuous; no categorical stance label
                 license_scope="research_only",
                 citation_ref="gurkaynak_sack_swanson_2005_ijcb",
-                source_type="fomc_statement",
+                source_type="gss_factor_decomposition",
             )
             if built is None:
                 continue

--- a/backend/app/data/sources/__init__.py
+++ b/backend/app/data/sources/__init__.py
@@ -9,6 +9,7 @@ from app.data.sources.registry import SOURCES, register, source_for, source_type
 from app.data.sources import (  # noqa: F401  (side-effect imports)
     beige_book,
     governor_speeches,
+    gss,
     op_fed,
     press_conference,
     regional_research,

--- a/backend/app/data/sources/base.py
+++ b/backend/app/data/sources/base.py
@@ -23,6 +23,7 @@ _VALID_SOURCE_TYPES = frozenset({
     "beige_book",
     "regional_research",
     "ny_fed_liberty_street",
+    "gss_factor_decomposition",
 })
 
 

--- a/backend/app/data/sources/gss.py
+++ b/backend/app/data/sources/gss.py
@@ -1,0 +1,207 @@
+"""GSS factor-decomposition external-corpus adapter.
+
+Wraps the existing `_iter_gss_factors_records` read path under the
+`BaseSourceScraper` Protocol so the Gurkaynak-Sack-Swanson (2005 IJCB) per-FOMC
+target / path factor decomposition advertises the same metadata surface as the
+in-house scrapers. The on-disk format is two CSVs (factors + optional
+surprise-window side-table) so `fetch_listing` reads the factors CSV text and
+yields one parsed-row dict per meeting; `parse_entry` accepts a JSON-encoded
+row and emits the registry record shape `_iter_gss_factors_records` builds.
+
+The rows are stance-unlabelled — the factor decomposition is continuous, not
+categorical — so they populate the factor axis only. The cross-source transfer
+matrix's stance classifier head skips this source_type.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from app.data.sources.base import BaseSourceScraper, Provenance, SourceMetadata
+from app.data.sources.registry import register
+
+
+def _coerce_event_date(raw: str) -> str:
+    """Light-weight date coercion matching ingest_sources._coerce_event_date.
+
+    Kept local so the adapter is loadable without importing ingest_sources
+    (avoids a hard import cycle if ingest_sources is later split).
+    """
+
+    raw = (raw or "").strip()
+    if not raw:
+        return ""
+    digits = "".join(ch for ch in raw if ch.isdigit())
+    if len(digits) == 8:
+        return f"{digits[0:4]}-{digits[4:6]}-{digits[6:8]}"
+    if len(digits) == 4:
+        return f"{digits}-01-01"
+    return raw
+
+
+def _parse_gss_factors_row(
+    row: dict[str, str],
+    surprises_by_date: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Parse one GSS factors CSV row into the registry record shape."""
+
+    event_date = ""
+    for key in ("meeting_date", "date", "event_date"):
+        event_date = _coerce_event_date(row.get(key, ""))
+        if event_date:
+            break
+    if not event_date:
+        return None
+
+    target_raw = (row.get("target_factor") or "").strip()
+    path_raw = (row.get("path_factor") or "").strip()
+    if not target_raw and not path_raw:
+        return None
+
+    extras: dict[str, Any] = {}
+    try:
+        extras["gss_target_factor"] = float(target_raw) if target_raw else None
+    except ValueError:
+        extras["gss_target_factor"] = None
+    try:
+        extras["gss_path_factor"] = float(path_raw) if path_raw else None
+    except ValueError:
+        extras["gss_path_factor"] = None
+    extras["gss_fomc_statement"] = (row.get("fomc_statement") or "").strip().upper() == "T"
+    extras.update(surprises_by_date.get(event_date, {}))
+
+    target_repr = (
+        f"{extras['gss_target_factor']:+.2f}"
+        if extras.get("gss_target_factor") is not None
+        else "n/a"
+    )
+    path_repr = (
+        f"{extras['gss_path_factor']:+.2f}"
+        if extras.get("gss_path_factor") is not None
+        else "n/a"
+    )
+    text = (
+        f"GSS factor decomposition for {event_date}: "
+        f"target={target_repr} bp, path={path_repr} bp"
+    )
+
+    return {
+        "source_record_id": f"gss_{event_date}",
+        "event_date_hint": event_date,
+        "document_type": "statement",
+        "title": f"GSS target/path factors {event_date}",
+        "text": text,
+        "label": "",  # factor axis is continuous; no categorical stance
+        "license_scope": "research_only",
+        "citation_ref": "gurkaynak_sack_swanson_2005_ijcb",
+        "multi_axis_extras": extras,
+    }
+
+
+def _parse_surprises_csv(text: str) -> dict[str, dict[str, Any]]:
+    """Parse the surprises side-table CSV into a per-meeting-date dict."""
+
+    by_date: dict[str, dict[str, Any]] = {}
+    if not text:
+        return by_date
+    reader = csv.DictReader(io.StringIO(text))
+    for row in reader:
+        event_date = ""
+        for key in ("meeting_date", "date", "event_date"):
+            event_date = _coerce_event_date(row.get(key, ""))
+            if event_date:
+                break
+        if not event_date:
+            continue
+        extras: dict[str, Any] = {}
+        for key in (
+            "surprise_30min_bp",
+            "surprise_1hour_bp",
+            "surprise_1day_bp",
+            "diff_wide_minus_tight",
+            "diff_daily_minus_tight",
+        ):
+            raw = (row.get(key) or "").strip()
+            if not raw:
+                continue
+            try:
+                extras[key] = float(raw)
+            except ValueError:
+                continue
+        if extras:
+            by_date[event_date] = extras
+    return by_date
+
+
+class GssFactorsScraper:
+    """File-backed `BaseSourceScraper` adapter for the GSS factor-decomposition release.
+
+    The factors CSV is the primary listing; the optional surprises CSV is a
+    per-meeting side-table merged onto `multi_axis_extras`. Pass surprise CSV
+    text through the constructor when available — `fetch_listing` then enriches
+    matching rows at parse time.
+    """
+
+    metadata = SourceMetadata(
+        name="GSS factor decomposition (Gurkaynak-Sack-Swanson 2005)",
+        source_type="gss_factor_decomposition",
+        provenance=Provenance.PEER_REVIEWED,
+        citation="Gurkaynak, R. S., Sack, B., Swanson, E. T. (2005). IJCB 1(1).",
+    )
+
+    def __init__(self, surprises_csv_text: str | None = None) -> None:
+        self._surprises_by_date = _parse_surprises_csv(surprises_csv_text or "")
+
+    def fetch_listing(self, html: str) -> list[dict[str, str]]:
+        """Read raw factors-CSV text and return the list of row dicts.
+
+        `html` is the entire file contents — keeping the Protocol name so the
+        adapter sits in the same registry as the HTML-scraped sources.
+        """
+
+        if not html:
+            return []
+        reader = csv.DictReader(io.StringIO(html))
+        return [dict(row) for row in reader]
+
+    def parse_entry(self, raw_html: str, *, source_url: str) -> dict[str, Any] | None:
+        """Parse a single GSS factors CSV row.
+
+        `raw_html` is a JSON-encoded row dict (so the Protocol signature stays
+        a plain string). `source_url` records provenance on the parsed entry.
+        """
+
+        try:
+            row = json.loads(raw_html)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(row, dict):
+            return None
+        parsed = _parse_gss_factors_row(
+            {str(k): str(v) if v is not None else "" for k, v in row.items()},
+            self._surprises_by_date,
+        )
+        if parsed is None:
+            return None
+        parsed["source_url"] = source_url
+        return parsed
+
+    def write(self, parsed: Iterable[dict[str, Any]], output_path: Path) -> int:
+        """Serialise parsed GSS entries to JSONL. Returns the row count."""
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        count = 0
+        with output_path.open("w", encoding="utf-8") as handle:
+            for entry in parsed:
+                if entry is None:
+                    continue
+                handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                count += 1
+        return count
+
+
+register(GssFactorsScraper())

--- a/tests/unit/test_external_corpora_ingestion.py
+++ b/tests/unit/test_external_corpora_ingestion.py
@@ -210,7 +210,7 @@ def test_gss_factors_loader_emits_one_row_per_meeting_with_factor_extras(tmp_pat
     by_date = {r["event_date"]: r for r in records}
 
     assert all(r["source"] == "gss_factor" for r in records)
-    assert all(r["source_type"] == "fomc_statement" for r in records)
+    assert all(r["source_type"] == "gss_factor_decomposition" for r in records)
     assert all(r["provenance"] == "peer_reviewed" for r in records)
     assert all(r["license_scope"] == "research_only" for r in records)
     assert all(r["citation_ref"] == "gurkaynak_sack_swanson_2005_ijcb" for r in records)

--- a/tests/unit/test_gss_factors_source.py
+++ b/tests/unit/test_gss_factors_source.py
@@ -1,0 +1,144 @@
+"""Frozen-fixture round-trip tests for the GSS factor-decomposition adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+pytest.importorskip("bs4")  # source registry init imports HTML scrapers
+
+from app.data.sources import SOURCES  # noqa: E402
+from app.data.sources.gss import GssFactorsScraper  # noqa: E402
+
+
+FIXTURE_FACTORS_CSV = dedent(
+    """\
+    meeting_date,target_factor,path_factor,fomc_statement
+    1994-08-16,10.7,-8.3,T
+    2001-01-03,-32.3,22.8,T
+    1990-02-08,0.3,5.8,
+    """
+)
+
+FIXTURE_SURPRISES_CSV = dedent(
+    """\
+    meeting_date,surprise_30min_bp,surprise_1hour_bp,surprise_1day_bp,diff_wide_minus_tight,diff_daily_minus_tight
+    2001-01-03,-39.3,-36.5,-38.2,1.1,2.8
+    """
+)
+
+
+def test_gss_scraper_is_registered() -> None:
+    assert "gss_factor_decomposition" in SOURCES
+    scraper = SOURCES["gss_factor_decomposition"]
+    assert isinstance(scraper, GssFactorsScraper)
+    assert scraper.metadata.provenance.value == "peer_reviewed"
+    assert "GSS" in scraper.metadata.name
+
+
+def test_fetch_listing_returns_one_dict_per_meeting() -> None:
+    scraper = GssFactorsScraper()
+    listing = scraper.fetch_listing(FIXTURE_FACTORS_CSV)
+    assert len(listing) == 3
+    assert listing[0]["meeting_date"] == "1994-08-16"
+    assert listing[2]["fomc_statement"] == ""
+
+
+def test_fetch_listing_returns_empty_on_empty_string() -> None:
+    assert GssFactorsScraper().fetch_listing("") == []
+
+
+def test_parse_entry_round_trips_three_rows_with_surprises() -> None:
+    scraper = GssFactorsScraper(surprises_csv_text=FIXTURE_SURPRISES_CSV)
+    listing = scraper.fetch_listing(FIXTURE_FACTORS_CSV)
+    parsed = [
+        scraper.parse_entry(json.dumps(row), source_url="https://gss.test/factors.csv")
+        for row in listing
+    ]
+    assert all(entry is not None for entry in parsed)
+    by_date = {entry["event_date_hint"]: entry for entry in parsed}
+
+    # Factor axis is continuous — no categorical label.
+    assert all(entry["label"] == "" for entry in parsed)
+    assert all(entry["license_scope"] == "research_only" for entry in parsed)
+    assert all(
+        entry["citation_ref"] == "gurkaynak_sack_swanson_2005_ijcb" for entry in parsed
+    )
+
+    enriched = by_date["2001-01-03"]
+    extras = enriched["multi_axis_extras"]
+    assert extras["gss_target_factor"] == pytest.approx(-32.3)
+    assert extras["gss_path_factor"] == pytest.approx(22.8)
+    assert extras["gss_fomc_statement"] is True
+    assert extras["surprise_30min_bp"] == pytest.approx(-39.3)
+    assert extras["diff_daily_minus_tight"] == pytest.approx(2.8)
+
+    bare = by_date["1990-02-08"]
+    assert bare["multi_axis_extras"]["gss_fomc_statement"] is False
+    assert "surprise_30min_bp" not in bare["multi_axis_extras"]
+    assert "GSS factor decomposition for 1990-02-08" in bare["text"]
+    assert bare["source_url"] == "https://gss.test/factors.csv"
+
+
+def test_parse_entry_without_surprises_table() -> None:
+    scraper = GssFactorsScraper()
+    listing = scraper.fetch_listing(FIXTURE_FACTORS_CSV)
+    parsed = [scraper.parse_entry(json.dumps(row), source_url="x") for row in listing]
+    assert all(entry is not None for entry in parsed)
+    extras = parsed[0]["multi_axis_extras"]
+    assert "surprise_30min_bp" not in extras
+    assert extras["gss_target_factor"] == pytest.approx(10.7)
+
+
+def test_parse_entry_drops_rows_missing_date_or_factors() -> None:
+    scraper = GssFactorsScraper()
+    assert scraper.parse_entry(json.dumps({}), source_url="x") is None
+    # Date but no factor values.
+    assert (
+        scraper.parse_entry(
+            json.dumps({"meeting_date": "2001-01-03", "target_factor": "", "path_factor": ""}),
+            source_url="x",
+        )
+        is None
+    )
+    # Garbage input doesn't crash the scraper.
+    assert scraper.parse_entry("not-valid-json", source_url="x") is None
+    # Non-dict JSON.
+    assert scraper.parse_entry("[1, 2, 3]", source_url="x") is None
+
+
+def test_parse_entry_tolerates_unparseable_factor_values() -> None:
+    scraper = GssFactorsScraper()
+    row = {"meeting_date": "2001-01-03", "target_factor": "n/a", "path_factor": "5.0"}
+    parsed = scraper.parse_entry(json.dumps(row), source_url="x")
+    assert parsed is not None
+    extras = parsed["multi_axis_extras"]
+    assert extras["gss_target_factor"] is None
+    assert extras["gss_path_factor"] == pytest.approx(5.0)
+
+
+def test_write_serialises_parsed_to_jsonl(tmp_path: Path) -> None:
+    scraper = GssFactorsScraper(surprises_csv_text=FIXTURE_SURPRISES_CSV)
+    listing = scraper.fetch_listing(FIXTURE_FACTORS_CSV)
+    parsed = [
+        scraper.parse_entry(json.dumps(row), source_url="https://gss.test/factors.csv")
+        for row in listing
+    ]
+    output = tmp_path / "gss_factors.jsonl"
+    count = scraper.write(parsed, output)
+    assert count == 3
+    lines = output.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    by_date = {json.loads(line)["event_date_hint"]: json.loads(line) for line in lines}
+    assert by_date["2001-01-03"]["multi_axis_extras"]["surprise_30min_bp"] == pytest.approx(-39.3)
+
+
+def test_write_skips_none_entries(tmp_path: Path) -> None:
+    scraper = GssFactorsScraper()
+    output = tmp_path / "gss_factors.jsonl"
+    count = scraper.write([None, {"x": 1}, None], output)
+    assert count == 1
+    assert output.read_text(encoding="utf-8").strip() == json.dumps({"x": 1})


### PR DESCRIPTION
Closes #418.

Follow-up from #72; second external corpus to ship under `BaseSourceScraper`. Pattern mirrors `op_fed.py` — file-backed adapter where the Protocol's `html` argument carries CSV text. The wrinkle vs. Op-Fed is two CSVs: factors is the listing, surprises is a per-meeting side-table passed through the constructor and merged onto `multi_axis_extras` at parse time.

- `backend/app/data/sources/gss.py` — `GssFactorsScraper` advertising the new `gss_factor_decomposition` source_type under `peer_reviewed` provenance.
- `_VALID_SOURCE_TYPES` extended; `_iter_gss_factors_records` rewired to emit the new source_type instead of piggybacking on `fomc_statement`. The FOMC-only headline eval (`reporting._FOMC_SOURCE_TYPES`) already excluded GSS rows by label-filter, so the cleanup is benign.
- `tests/unit/test_gss_factors_source.py` — frozen-fixture round-trip (registration, three-row parse with and without the surprises side-table, unparseable-factor fallback, JSONL write, `None`-skip).

Factor rows are continuous (target / path bp), so the cross-source transfer matrix's stance head skips the source_type — no consumer changes needed there.