### PR TITLE
GARCH(1,1)-residual variant of the forward-realised-vol target (#236)

### DIFF
--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -1345,6 +1345,25 @@ def _build_event_rows(
     # assigned here -- the per-fold quantile cutoffs are computed at
     # training time on the train slice to avoid look-ahead leakage.
     forward_vol_10d = _forward_realized_vol(asset_series, as_of_date, window=10)
+    # #236 GARCH(1,1)-residual decomposition of the same target. Fits
+    # GARCH(1,1) on log returns dated strictly before ``as_of_date`` and
+    # forecasts a 1-day-equivalent vol over the same 10-trading-day
+    # forward window. The residual = raw - baseline isolates the
+    # unanticipated component of realised vol given the standard
+    # conditional-variance model. Strict-prior contract: the fit reads
+    # only closes ``< as_of_date``; the forecast is conditional-on-fit
+    # and reads no close at or after ``as_of_date``. Below
+    # ``MIN_FIT_RETURNS`` (252 trading days) or on convergence failure
+    # both columns degrade to None and the supervised row keeps the raw
+    # target intact. See ADR 0034.
+    from app.data.garch_residual import compute_for_event as _garch_compute_for_event
+
+    garch_result = _garch_compute_for_event(
+        dates=asset_series.dates,
+        closes=asset_series.close,
+        event_date=as_of_date,
+        forward_realized_vol_10d=forward_vol_10d,
+    )
     concurrent_macro = _has_concurrent_macro_release(
         event_date,
         asset_series,
@@ -1440,6 +1459,21 @@ def _build_event_rows(
                 "volatility_shift": float(vol_shift) if vol_shift is not None else None,
                 "forward_realized_vol_10d": (
                     float(forward_vol_10d) if forward_vol_10d is not None else None
+                ),
+                # #236 GARCH(1,1)-residual decomposition. See
+                # ``app.data.garch_residual`` + ADR 0034. Both columns
+                # are nullable: ``baseline`` is None when GARCH did not
+                # converge or the strict-prior window is short, and the
+                # residual additionally requires a non-null raw target.
+                "forward_realized_vol_10d_garch_baseline": (
+                    float(garch_result.baseline)
+                    if garch_result.baseline is not None
+                    else None
+                ),
+                "forward_realized_vol_10d_garch_residual": (
+                    float(garch_result.residual)
+                    if garch_result.residual is not None
+                    else None
                 ),
                 "concurrent_macro_release": bool(concurrent_macro),
                 "intra_meeting_stance_shift": float(
@@ -1590,6 +1624,9 @@ COLUMN_ORDER = (
     "direction_t1d",
     "volatility_shift",
     "forward_realized_vol_10d",
+    # #236 GARCH(1,1)-residual variant of the forward-vol target.
+    "forward_realized_vol_10d_garch_baseline",
+    "forward_realized_vol_10d_garch_residual",
     "concurrent_macro_release",
     "intra_meeting_stance_shift",
     "intra_meeting_certainty_shift",

--- a/backend/app/data/garch_residual.py
+++ b/backend/app/data/garch_residual.py
@@ -1,0 +1,253 @@
+"""GARCH(1,1) baseline + residual on the forward 10-day realised vol target (#236).
+
+Fits a Zero-mean GARCH(1,1) on the asset's log returns dated *strictly
+before* ``event_date`` and forecasts the next 10 trading days' conditional
+volatility. The 10-day forecast is collapsed to a 1-day-equivalent std
+(mean of the per-step variances, square-rooted) so the scale matches the
+sample std of log returns over ``[T+1, T+10]`` that
+:func:`app.data.event_dataset_builder._forward_realized_vol` reports.
+
+The residual target is
+
+    forward_realized_vol_10d_garch_residual
+        = forward_realized_vol_10d - forward_realized_vol_10d_garch_baseline
+
+so the supervised quantity isolates the *unanticipated* component of the
+realised vol given a standard time-series model. Neural networks are
+known to be poor at the raw heteroskedastic level but reasonable at the
+residual once the classical conditional-variance baseline is stripped
+off; the hybrid GARCH-NN recipe is the textbook decomposition.
+
+Strict-prior contract: the fit consumes only returns whose ending close
+is dated ``< event_date``. The forecast is conditional-on-fit and never
+reads any close at or after ``event_date``. The leak surface is
+identical to the strict-backward windows
+:func:`app.data.event_dataset_builder._volatility_shift` uses on its
+pre-event leg.
+
+Convergence and edge cases:
+
+- ``arch`` is an optional import (already on ``backend/pyproject.toml``
+  as ``arch>=6.3``). Import is lazy so the module is importable in
+  test environments that strip the dep.
+- Below ``MIN_FIT_RETURNS`` strictly-prior returns the fit is skipped
+  and the baseline / residual are ``None``. ~252 trading days (a year)
+  is the documented floor for GARCH(1,1) convergence on equity returns.
+- Convergence failures (numerical, missing-data, ``arch.LinAlgError``)
+  degrade to ``None``; the supervised row keeps the raw target column
+  intact, only the residual is missing.
+- ``forward_realized_vol_10d`` itself is required to compute the
+  residual; if the target is ``None`` (event too close to end of price
+  series) the residual is also ``None``.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+
+# Minimum strictly-prior returns required to fit GARCH(1,1). ~252
+# trading days (one year) is the documented floor for stable
+# convergence on equity returns; below that the QMLE fit is dominated
+# by initial-condition noise. The events.parquet routinely carries
+# events dating back to 2010+ so the gate is rarely hit in practice;
+# it exists to fail gracefully on synthetic / truncated fixtures.
+MIN_FIT_RETURNS: int = 252
+
+# Forecast horizon in trading days. Matches the 10-day window the
+# raw target measures so the baseline and the realised quantity are
+# defined over the same forward span.
+GARCH_FORECAST_HORIZON: int = 10
+
+# Returns are scaled to percentage units (× 100) before the fit. The
+# ``arch`` optimiser is notoriously poorly-scaled on raw log returns
+# (~1e-2 magnitude); percentage scaling brings the parameter space
+# closer to unity and stabilises the QMLE step. The forecast variance
+# is then de-scaled back to log-return units before exposure.
+_PERCENT_SCALE: float = 100.0
+
+
+@dataclass(frozen=True)
+class GarchResidualResult:
+    """Baseline + residual scalars on the supervised target row.
+
+    All three fields carry log-return units (the same units the raw
+    ``forward_realized_vol_10d`` column reports). ``baseline`` is the
+    GARCH(1,1) 10-day-ahead 1-day-equivalent vol forecast; ``residual``
+    is the raw target minus the baseline. Both are ``None`` when the
+    fit was skipped (insufficient prior returns), failed to converge,
+    or the raw target was itself missing.
+    """
+
+    baseline: float | None
+    residual: float | None
+    fit_returns_n: int
+
+
+def _log_returns(closes: Sequence[float]) -> list[float]:
+    out: list[float] = []
+    for i in range(1, len(closes)):
+        prev = closes[i - 1]
+        cur = closes[i]
+        if prev <= 0 or cur <= 0:
+            continue
+        out.append(math.log(cur / prev))
+    return out
+
+
+def _forecast_one_step_equiv_vol(model_result, *, horizon: int) -> float | None:
+    """Mean per-step variance over the next ``horizon`` steps, square-rooted.
+
+    ``arch_model.forecast(horizon=h)`` returns a per-step variance path
+    ``[v_1, v_2, ..., v_h]`` in the fit's units (here, percentage
+    squared). Collapsing to the mean variance and square-rooting yields
+    the 1-day-equivalent std over the window, which is the same scale
+    the raw ``forward_realized_vol_10d`` column reports (sample std of
+    log returns over ``[T+1, T+horizon]``).
+    """
+
+    try:
+        forecast = model_result.forecast(horizon=horizon, reindex=False)
+    except Exception:  # arch raises a grab-bag of errors on degenerate fits
+        return None
+    variance_row = forecast.variance.iloc[-1].to_numpy()
+    if variance_row.size == 0:
+        return None
+    mean_var = float(variance_row.mean())
+    if mean_var <= 0.0 or not math.isfinite(mean_var):
+        return None
+    return math.sqrt(mean_var)
+
+
+def _fit_garch_and_forecast(
+    returns: Sequence[float],
+    *,
+    horizon: int = GARCH_FORECAST_HORIZON,
+) -> float | None:
+    """Fit Zero-mean GARCH(1,1) and return the 1-day-equivalent forecast vol.
+
+    Returns are expected in raw log-return units; the helper scales to
+    percentage internally, fits, forecasts ``horizon`` steps, then
+    de-scales the forecast back to log-return units. Returns ``None``
+    when the fit fails for any reason (numerical, missing arch, etc).
+    """
+
+    if len(returns) < MIN_FIT_RETURNS:
+        return None
+    try:
+        from arch import arch_model  # lazy import keeps the module importable without arch
+    except ImportError:  # pragma: no cover - dep is locked in pyproject
+        logger.warning(
+            "arch package not importable; GARCH residual target will be None for every event"
+        )
+        return None
+    try:
+        import numpy as np
+
+        scaled = np.asarray(returns, dtype=float) * _PERCENT_SCALE
+        # show_warning=False suppresses the per-fit "DataScaleWarning"
+        # the optimiser emits on tail-heavy windows; we control the
+        # scaling explicitly so the warning is noise.
+        model = arch_model(scaled, mean="Zero", vol="Garch", p=1, q=1, rescale=False)
+        result = model.fit(disp="off", show_warning=False)
+    except Exception:  # arch raises ConvergenceWarning, LinAlgError, ValueError, ...
+        return None
+    forecast_pct = _forecast_one_step_equiv_vol(result, horizon=horizon)
+    if forecast_pct is None:
+        return None
+    return forecast_pct / _PERCENT_SCALE
+
+
+def compute_garch_residual(
+    *,
+    prior_closes: Sequence[float],
+    forward_realized_vol_10d: float | None,
+    horizon: int = GARCH_FORECAST_HORIZON,
+) -> GarchResidualResult:
+    """Fit GARCH(1,1) on strict-prior closes and emit the baseline + residual.
+
+    ``prior_closes`` is the asset close series dated strictly before the
+    event (the caller slices it on ``index_strictly_before(event_date)``).
+    ``forward_realized_vol_10d`` is the raw realised-vol target for the
+    same supervised row.
+
+    The helper computes log returns over ``prior_closes`` (dropping any
+    non-positive closes), fits the GARCH(1,1), forecasts ``horizon``
+    steps, collapses to a 1-day-equivalent vol, and returns the baseline
+    + residual. Missing baseline (insufficient data or convergence
+    failure) propagates ``None`` to the residual.
+    """
+
+    returns = _log_returns(prior_closes)
+    baseline = _fit_garch_and_forecast(returns, horizon=horizon)
+    if baseline is None or forward_realized_vol_10d is None:
+        return GarchResidualResult(
+            baseline=baseline,
+            residual=None,
+            fit_returns_n=len(returns),
+        )
+    raw = float(forward_realized_vol_10d)
+    if not math.isfinite(raw):
+        return GarchResidualResult(
+            baseline=baseline,
+            residual=None,
+            fit_returns_n=len(returns),
+        )
+    return GarchResidualResult(
+        baseline=float(baseline),
+        residual=raw - float(baseline),
+        fit_returns_n=len(returns),
+    )
+
+
+def compute_for_event(
+    *,
+    dates: Sequence[_dt.date],
+    closes: Sequence[float],
+    event_date: _dt.date,
+    forward_realized_vol_10d: float | None,
+    horizon: int = GARCH_FORECAST_HORIZON,
+) -> GarchResidualResult:
+    """Per-event entry point used by :mod:`event_dataset_builder`.
+
+    Walks the (dates, closes) series, slices to the strict-prior window
+    (``dates[i] < event_date``), and delegates to
+    :func:`compute_garch_residual`. The strict-prior slice is the same
+    one ``_CloseSeries.index_strictly_before`` exposes; we replicate it
+    here to keep the helper testable without the full builder dependency.
+    """
+
+    if len(dates) != len(closes):
+        raise ValueError(
+            f"dates ({len(dates)}) and closes ({len(closes)}) length mismatch"
+        )
+    # Binary-search-style slice: dates are sorted ascending by contract.
+    # A linear scan is fine because the asset series in practice carries
+    # at most ~4000 daily bars and the slice is O(n) anyway in numpy land.
+    cutoff_idx = 0
+    for i, d in enumerate(dates):
+        if d < event_date:
+            cutoff_idx = i + 1
+    if cutoff_idx <= 0:
+        return GarchResidualResult(baseline=None, residual=None, fit_returns_n=0)
+    prior_closes = closes[:cutoff_idx]
+    return compute_garch_residual(
+        prior_closes=prior_closes,
+        forward_realized_vol_10d=forward_realized_vol_10d,
+        horizon=horizon,
+    )
+
+
+__all__ = (
+    "GARCH_FORECAST_HORIZON",
+    "GarchResidualResult",
+    "MIN_FIT_RETURNS",
+    "compute_for_event",
+    "compute_garch_residual",
+)

--- a/backend/app/data/schemas.py
+++ b/backend/app/data/schemas.py
@@ -570,6 +570,16 @@ _EVENT_ROW_COLUMNS: dict[str, Column] = {
     "forward_realized_vol_10d": Column(
         float, nullable=True, required=False, coerce=True
     ),
+    # #236 GARCH(1,1)-residual decomposition. Nullable for events whose
+    # strict-prior window is shorter than ``MIN_FIT_RETURNS`` (~252 td)
+    # or the QMLE fit failed to converge. required=False so older
+    # events.parquet files (pre #236) validate without the columns.
+    "forward_realized_vol_10d_garch_baseline": Column(
+        float, nullable=True, required=False, coerce=True
+    ),
+    "forward_realized_vol_10d_garch_residual": Column(
+        float, nullable=True, required=False, coerce=True
+    ),
     "concurrent_macro_release": Column(
         bool, nullable=False, required=True, coerce=True
     ),

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -850,6 +850,18 @@ class FeatureVector:
     # mapper consume the target-row value only. Default ``None`` so
     # regression-only callers stay byte-identical.
     forward_realized_vol_10d: float | None = None
+    # #236 GARCH(1,1)-residual decomposition of the same target. The
+    # baseline is the GARCH(1,1) 10-day-ahead 1-day-equivalent vol
+    # forecast (fitted on strict-prior log returns); the residual is
+    # ``forward_realized_vol_10d - baseline``. Both ride on the target
+    # row alongside the raw forward-vol target; lookback bars carry
+    # ``None`` so the per-fold builder can filter the leading target
+    # the same way the raw vol-regime helper does. ``None`` on every
+    # legacy / non-vol path keeps the dataclass shape round-trip clean
+    # against the determinism regression contract. See ADR 0034 and
+    # ``app.data.garch_residual.compute_for_event``.
+    forward_realized_vol_10d_garch_baseline: float | None = None
+    forward_realized_vol_10d_garch_residual: float | None = None
     # #292 rates-complex targets. Strict-forward 5-day yield change in
     # basis points (raw bps; the loader emits the value the
     # events.parquet column already carries). Populated by the

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -1800,6 +1800,17 @@ def _load_package_sequences_with_metadata(
         forward_vol_value = _coerce_finite_float(
             row.get("forward_realized_vol_10d")
         )
+        # #236 GARCH(1,1) baseline + residual. Frozen into the events
+        # parquet at build time (see ``app.data.garch_residual``);
+        # the loader only reads them off the row and broadcasts onto
+        # the target slot. Older events.parquet files without these
+        # columns degrade cleanly to ``None`` here.
+        garch_baseline_value = _coerce_finite_float(
+            row.get("forward_realized_vol_10d_garch_baseline")
+        )
+        garch_residual_value = _coerce_finite_float(
+            row.get("forward_realized_vol_10d_garch_residual")
+        )
         # #292 rates-complex strict-forward 5d yield change targets.
         # Each value rides on the same event row alongside
         # forward_realized_vol_10d; the per-fold target builder
@@ -1887,6 +1898,8 @@ def _load_package_sequences_with_metadata(
             sep_block_list = None
         for vector in vectors:
             vector.forward_realized_vol_10d = forward_vol_value
+            vector.forward_realized_vol_10d_garch_baseline = garch_baseline_value
+            vector.forward_realized_vol_10d_garch_residual = garch_residual_value
             vector.target_yield_2y_change_5d = rates_2y_value
             vector.target_yield_5y_change_5d = rates_5y_value
             vector.target_terminal_rate_change_5d = rates_terminal_value
@@ -2533,6 +2546,14 @@ def load_training_sequences_from_package(
         forward_vol_value = _coerce_finite_float(
             row.get("forward_realized_vol_10d")
         )
+        # #236 GARCH(1,1) baseline + residual (see matched walk-forward
+        # site above for the contract).
+        garch_baseline_value = _coerce_finite_float(
+            row.get("forward_realized_vol_10d_garch_baseline")
+        )
+        garch_residual_value = _coerce_finite_float(
+            row.get("forward_realized_vol_10d_garch_residual")
+        )
         # #292 rates-complex strict-forward 5d yield change targets.
         # Each value rides on the same event row alongside
         # forward_realized_vol_10d; the per-fold target builder
@@ -2600,6 +2621,8 @@ def load_training_sequences_from_package(
             sep_block_list = None
         for vector in vectors:
             vector.forward_realized_vol_10d = forward_vol_value
+            vector.forward_realized_vol_10d_garch_baseline = garch_baseline_value
+            vector.forward_realized_vol_10d_garch_residual = garch_residual_value
             vector.target_yield_2y_change_5d = rates_2y_value
             vector.target_yield_5y_change_5d = rates_5y_value
             vector.target_terminal_rate_change_5d = rates_terminal_value

--- a/docs/adr/0034-garch-residual-vol-target.md
+++ b/docs/adr/0034-garch-residual-vol-target.md
@@ -1,0 +1,61 @@
+# ADR 0034 — GARCH(1,1)-residual variant of the forward-realised-vol target
+
+Status: accepted, target column computed at build time; canonical sweep deferred to operator.
+Date: 2026-05-28.
+References:
+- Issue #236 (closes).
+- ADR 0027 — #305 surprise-decomposition target on the rates heads; the prior precedent for shipping an alternative target column alongside the raw target without disturbing the default path.
+- `backend/app/data/garch_residual.py` — GARCH fit + residual helper.
+- `backend/app/data/event_dataset_builder.py` — per-event invocation site; `forward_realized_vol_10d_garch_baseline` / `forward_realized_vol_10d_garch_residual` emitted on every row.
+- `backend/app/models/config.py` — `FeatureVector.forward_realized_vol_10d_garch_baseline` / `forward_realized_vol_10d_garch_residual`.
+- Bollerslev (1986), "Generalized autoregressive conditional heteroskedasticity." J. Econometrics.
+- Hansen, Lunde (2005), "A forecast comparison of volatility models: does anything beat a GARCH(1,1)?" J. Applied Econometrics.
+
+## Context
+
+The Phase 9 V2 vol-regime target (`forward_realized_vol_10d`, #195) supervises the raw sample std of log returns over `[T+1, T+10]`. The quantity is heteroskedastic and heavy-tailed — exactly the regime neural networks struggle on. The classical GARCH(1,1) baseline captures most of the conditional-variance dynamics on equity returns (Hansen-Lunde 2005 — "does anything beat a GARCH(1,1)?" is the canonical negative finding in the volatility-forecasting literature); a neural forecaster that predicts the raw target spends most of its capacity re-learning what GARCH already explains.
+
+The textbook hybrid is to subtract the GARCH baseline forecast from the raw target and supervise the residual instead. The residual isolates the *unanticipated* component of realised vol given the standard time-series model: the part the text + macro features can plausibly explain that GARCH cannot. The training surface is lower variance and closer to mean-zero, and the literature (Donaldson-Kamstra 1997; Engle-Patton 2001) reports consistent lift on equity vol forecasting when the decomposition is applied.
+
+This sits opposite the #305 surprise-decomposition target on the rates heads. #305 isolates the FOMC-attributable component of the 5-day rates move via a 1-D projection onto the policy-surprise direction; #236 isolates the GARCH-unanticipated component of the forward-realised vol via a subtraction against a strict-prior conditional-variance forecast. Together the two targets give the §6 narrative a paired "decompose the target, supervise the part the text actually predicts" methodology axis on both regression surfaces.
+
+## Decision
+
+Compute two new columns at events.parquet build time, alongside the raw `forward_realized_vol_10d` column:
+
+- `forward_realized_vol_10d_garch_baseline` — GARCH(1,1) 10-day-ahead 1-day-equivalent vol forecast, fitted on log returns of the asset's close series dated *strictly before* `event_date`.
+- `forward_realized_vol_10d_garch_residual` — `forward_realized_vol_10d − forward_realized_vol_10d_garch_baseline`.
+
+Both columns are frozen into the training package at build time (not computed at loader time) so the decomposition is reproducible byte-for-byte from the persisted parquet. The supervised target is the residual; the baseline is persisted alongside so the raw quantity is recoverable at inference (predicted vol = predicted residual + baseline).
+
+### GARCH fit
+
+Zero-mean GARCH(1,1) via `arch.arch_model(scaled, mean="Zero", vol="Garch", p=1, q=1)` from Kevin Sheppard's `arch` library (already on `backend/pyproject.toml` as `arch>=6.3`; the dep was added for `scripts/garch_baseline.py`'s §6.6 row). Returns are scaled to percentage units (× 100) before the fit because the QMLE optimiser is notoriously poorly-scaled on raw log returns of magnitude 1e-2; the forecast variance is de-scaled back to log-return units before the residual subtraction.
+
+The forecast is `horizon=10` per-step variances; we collapse to the mean variance and square-root to get a 1-day-equivalent vol, which matches the scale of the sample std `_forward_realized_vol` reports over the same window. The subtraction is only meaningful if both legs sit on the same scale — that is why we collapse the per-step forecast and de-scale the percentage units before differencing rather than leaving the GARCH output in its native cumulative-variance form.
+
+### Strict-prior contract
+
+The fit consumes only closes whose date is strictly less than `event_date`. The slice is replicated from `_CloseSeries.index_strictly_before` so the contract is the same one `_volatility_shift`'s pre-event leg enforces. The forecast is conditional-on-fit and reads no close at or after `event_date`. The leak surface is identical to the strict-backward windows already audited under #350.
+
+`tests/regression/test_feature_provenance_as_of.py` classifies both columns as target-only (lookback bars stay `None`, only the supervised event row carries the values). The audit doc `docs/feature-provenance-audit.md` documents the fit's strict-prior contract and the forecast's conditional-on-fit semantics; the regression test's inventory-coverage assertion gates any future addition.
+
+### Edge cases
+
+- `MIN_FIT_RETURNS = 252`. Below ~one trading year of strict-prior returns the GARCH(1,1) QMLE fit is dominated by initial-condition noise. Below the floor both columns degrade to `None` and the supervised row keeps the raw target intact. The events.parquet routinely carries events from 2010+, so the gate is rarely hit in practice; it exists for synthetic / truncated fixtures.
+- Convergence failures (numerical, `LinAlgError`, ValueError from the optimiser) degrade to `None` via a broad `except Exception` around the fit. The arch library raises a grab-bag of error types on degenerate windows and we treat any failure as "no baseline this event."
+- `forward_realized_vol_10d = None` (event within 10 td of the end of the price series) → residual is `None`; the baseline can still be computed and is persisted on its own.
+
+### Default-off equivalent
+
+There is no default-on / default-off knob on this PR. The columns land on every events.parquet built after this commit; older parquets validate cleanly against the schema because the columns are `required=False` (consistent with the #305 / #291 pattern). Downstream consumers that don't read the columns are byte-identical to the pre-#236 path — the FeatureVector dataclass has two new fields with `None` defaults and `as_rich_list` does not emit them.
+
+The supervised-target switch (predict residual vs predict raw) lives on the training loop's target-column knob, not on the events.parquet build. A future training-time flag analogous to #305's `--rates-target-mode` would dispatch between `forward_realized_vol_10d` and `forward_realized_vol_10d_garch_residual` as the classifier's regression head's supervised target; that flag is a follow-up.
+
+## Consequences
+
+- Events.parquet grows by two nullable float columns. The schema validation is `required=False` so pre-#236 parquets still validate without the columns.
+- The events.parquet build cost grows by ~50 ms per event (one GARCH(1,1) fit). Over ~150 FOMC events the marginal build time is ~8 s, negligible against the existing FRED / yfinance fetch latency.
+- The `arch>=6.3` dep was already on `backend/pyproject.toml` for `scripts/garch_baseline.py`. No new dependency was added.
+- The training-time switch (predict residual vs predict raw) is not wired in this PR. The §6.6 GARCH-residual row needs a canonical sweep against `forward_realized_vol_10d_garch_residual` as the supervised target, which is a Runpod follow-up.
+- The §6 narrative now has a paired methodology axis: #305 decomposes the rates target, #236 decomposes the vol target. Each isolates the component a text + macro forecaster can plausibly predict from the unconditional baseline.

--- a/docs/feature-provenance-audit.md
+++ b/docs/feature-provenance-audit.md
@@ -69,6 +69,8 @@ itself a documented training target.
 | `sep_features_missing` | loader flag on the SEP composer | `T (snapshot)` | none | per-row 0/1 mask. `1.0` when `--use-sep` is off (default) or when the SEP-projections parquet is absent on disk (graceful degrade — the code path stays live without the parquet). The conditional-emit contract on `as_rich_list` keeps the per-bar feature size byte-identical to pre-#215 in that case (the block + flag are not emitted at all). |
 | `rich_payload` | loader flag, set after rich-feature attachment | n/a | none | structural flag, not consumed as a numeric feature. |
 | `forward_realized_vol_10d` | `event_dataset_builder._forward_realized_vol` (closes `[T..T+10]`) | **`T+Δ`, future-derived** | none (target) | declared training target under the strict-forward ADR. The loader broadcasts the target-row value onto every bar of the sequence for convenience, but it is **not** emitted by `FeatureVector.as_rich_list` and therefore never enters the model input tensor. Downstream consumers (`collect_forward_vols`, `_build_training_tensors`) only read it off the target row at index `>= SEQUENCE_LENGTH`. Per-fold quantile cutoffs are fit on the train slice only. |
+| `forward_realized_vol_10d_garch_baseline` | `app.data.garch_residual.compute_for_event`: GARCH(1,1) fitted on strict-prior log returns of the asset's close series (closes dated `< event_date`), forecast `horizon=10` days ahead, mean per-step variance square-rooted to a 1-day-equivalent vol. | `T-Δ` (fit window) → 10-step-ahead forecast | none (target-side) | #236 GARCH baseline. The fit consumes only closes strictly before `event_date`; the forecast is conditional-on-fit and reads no close at or after `event_date`. The leak surface is identical to `_volatility_shift`'s pre-event leg. `None` when the strict-prior window is shorter than `MIN_FIT_RETURNS` (~252 td) or the QMLE step does not converge. Same broadcast-but-not-emitted contract as `forward_realized_vol_10d`; only the target row is read by the residual target consumer. See ADR 0034. |
+| `forward_realized_vol_10d_garch_residual` | `app.data.garch_residual.compute_for_event`: `forward_realized_vol_10d − forward_realized_vol_10d_garch_baseline` | **`T+Δ`, future-derived** | none (target) | #236 GARCH-residual variant of the forward-vol target. The residual isolates the unanticipated component of realised vol given the GARCH(1,1) conditional-variance model — the part a hybrid GARCH-NN forecaster predicts after the classical baseline is stripped off. `None` whenever either the raw target or the baseline is `None`. Stored on the events.parquet at build time so the target column is frozen in the training package; same broadcast-but-not-emitted contract as the raw sibling. See ADR 0034. |
 | `target_yield_2y_change_5d` | `data.rates_event_features.forward_yield_change_bps` (t → t+5) | **`T+Δ`, future-derived** | none (target) | rates-head training target. Same broadcast-but-not-emitted pattern as `forward_realized_vol_10d`; not in `as_rich_list` output, only read off the target row by `app.training.rates_targets.build_partition_rates_targets`. |
 | `target_yield_5y_change_5d` | same as above (5y tenor) | **`T+Δ`, future-derived** | none (target) | rates-head training target; same storage / emission contract. |
 | `target_terminal_rate_change_5d` | same as above (terminal-rate proxy) | **`T+Δ`, future-derived** | none (target) | rates-head training target; same storage / emission contract. |
@@ -141,8 +143,10 @@ keep-with-caveat alternative.
 No other `FeatureVector` column reads from a source post-dating
 `row.event_date` beyond the documented training-target columns
 (`forward_realized_vol_10d`, `target_yield_2y_change_5d`,
-`target_yield_5y_change_5d`, `target_terminal_rate_change_5d`, and the
-three `_fomc_attributable` projections added under #305).
+`target_yield_5y_change_5d`, `target_terminal_rate_change_5d`, the
+three `_fomc_attributable` projections added under #305, and the
+`forward_realized_vol_10d_garch_baseline` / `forward_realized_vol_10d_garch_residual`
+decomposition added under #236).
 
 ## Regression test
 

--- a/tests/regression/test_feature_provenance_as_of.py
+++ b/tests/regression/test_feature_provenance_as_of.py
@@ -75,6 +75,13 @@ _TRAINING_DELTA_COLUMNS: tuple[str, ...] = (
 # row of the sequence) may carry a non-None value.
 _TARGET_ONLY_COLUMNS: tuple[str, ...] = (
     "forward_realized_vol_10d",
+    # #236 GARCH(1,1)-residual decomposition of the forward-vol target.
+    # The baseline rides on the events.parquet row at build time and
+    # the residual = raw - baseline does too; both are target-only
+    # (lookback bars stay None) since they read from the strict-prior
+    # asset close series only on the supervised event row.
+    "forward_realized_vol_10d_garch_baseline",
+    "forward_realized_vol_10d_garch_residual",
     "target_yield_2y_change_5d",
     "target_yield_5y_change_5d",
     "target_terminal_rate_change_5d",
@@ -207,6 +214,8 @@ def _event_row(
         "intra_meeting_factor_shift": 0.0,
         "realized_date": realized_date,
         "forward_realized_vol_10d": 0.015,
+        "forward_realized_vol_10d_garch_baseline": 0.013,
+        "forward_realized_vol_10d_garch_residual": 0.002,
         "yield_2y_change_5d": -3.2,
         "yield_5y_change_5d": -2.1,
         "terminal_rate_change_5d": -1.0,

--- a/tests/unit/test_garch_residual.py
+++ b/tests/unit/test_garch_residual.py
@@ -1,0 +1,231 @@
+"""Unit tests for the GARCH(1,1) baseline + residual helper (#236)."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import math
+import random
+
+import pytest
+
+pytest.importorskip("arch")
+
+from app.data.garch_residual import (
+    GARCH_FORECAST_HORIZON,
+    GarchResidualResult,
+    MIN_FIT_RETURNS,
+    compute_for_event,
+    compute_garch_residual,
+)
+
+
+def _synth_lognormal_closes(n: int, *, seed: int, vol: float = 0.012) -> list[float]:
+    """Synthesise ``n`` closes from an iid log-normal return process.
+
+    iid log-returns are the simplest convergent regime for GARCH(1,1):
+    the fitted alpha + beta should land near zero (no persistence), the
+    omega should land near ``vol**2``, and the forecast should reduce
+    to the unconditional vol regardless of horizon. We use this to anchor
+    the helper's scale-handling without coupling the test to a specific
+    QMLE optimum.
+    """
+
+    rng = random.Random(seed)
+    closes = [100.0]
+    for _ in range(n - 1):
+        r = rng.gauss(0.0, vol)
+        closes.append(closes[-1] * math.exp(r))
+    return closes
+
+
+def _trading_dates(n: int, *, start: _dt.date) -> list[_dt.date]:
+    """Generate ``n`` consecutive weekday dates starting from ``start``."""
+
+    out: list[_dt.date] = []
+    cursor = start
+    while len(out) < n:
+        if cursor.weekday() < 5:
+            out.append(cursor)
+        cursor = cursor + _dt.timedelta(days=1)
+    return out
+
+
+def test_compute_garch_residual_returns_baseline_and_residual_on_iid_returns() -> None:
+    """On iid log-normal closes the GARCH fit converges and the residual is finite.
+
+    The exact baseline value depends on the QMLE optimum (which is
+    sensitive to numerical paths); we anchor on the contract: a non-None
+    baseline, a non-None residual matching raw - baseline, and a finite
+    fit_returns_n equal to the input length minus the dropped initial bar.
+    """
+
+    closes = _synth_lognormal_closes(MIN_FIT_RETURNS + 50, seed=11)
+    raw_target = 0.018  # arbitrary realised-vol target in log-return units
+
+    result = compute_garch_residual(
+        prior_closes=closes, forward_realized_vol_10d=raw_target
+    )
+
+    assert isinstance(result, GarchResidualResult)
+    assert result.baseline is not None
+    assert math.isfinite(result.baseline)
+    assert result.baseline > 0.0
+    assert result.residual is not None
+    assert math.isfinite(result.residual)
+    # residual = raw - baseline (within float-roundtrip tolerance)
+    assert abs(result.residual - (raw_target - result.baseline)) < 1e-12
+    # Initial bar drops out of the log-return series, so fit_returns_n
+    # is len(closes) - 1.
+    assert result.fit_returns_n == len(closes) - 1
+
+
+def test_compute_garch_residual_below_min_fit_returns_returns_none() -> None:
+    """Insufficient strict-prior returns -> baseline + residual both None.
+
+    The gate at ``MIN_FIT_RETURNS`` exists so synthetic / truncated
+    fixtures degrade gracefully instead of crashing on a singular
+    Hessian. The helper still reports the would-be fit length so the
+    caller can log the gate.
+    """
+
+    closes = _synth_lognormal_closes(MIN_FIT_RETURNS - 50, seed=7)
+    result = compute_garch_residual(
+        prior_closes=closes, forward_realized_vol_10d=0.020
+    )
+    assert result.baseline is None
+    assert result.residual is None
+    assert result.fit_returns_n == len(closes) - 1
+
+
+def test_compute_garch_residual_missing_raw_target_returns_none_residual() -> None:
+    """A None ``forward_realized_vol_10d`` propagates to the residual.
+
+    The baseline is still computed (it only depends on strict-prior
+    data, not on the forward target), but the residual is None because
+    we cannot subtract from a missing quantity. This matters for events
+    near the end of the price series where the 10-day forward window
+    is truncated.
+    """
+
+    closes = _synth_lognormal_closes(MIN_FIT_RETURNS + 30, seed=21)
+    result = compute_garch_residual(
+        prior_closes=closes, forward_realized_vol_10d=None
+    )
+    assert result.baseline is not None
+    assert result.residual is None
+
+
+def test_compute_garch_residual_non_finite_raw_target_returns_none_residual() -> None:
+    """NaN / inf raw target propagates to a None residual."""
+
+    closes = _synth_lognormal_closes(MIN_FIT_RETURNS + 30, seed=22)
+    nan_result = compute_garch_residual(
+        prior_closes=closes, forward_realized_vol_10d=float("nan")
+    )
+    assert nan_result.baseline is not None
+    assert nan_result.residual is None
+
+    inf_result = compute_garch_residual(
+        prior_closes=closes, forward_realized_vol_10d=float("inf")
+    )
+    assert inf_result.baseline is not None
+    assert inf_result.residual is None
+
+
+def test_compute_for_event_respects_strict_prior_slice() -> None:
+    """The strict-prior slice drops every close dated at or after event_date.
+
+    We seed a series of MIN_FIT_RETURNS + 20 closes ending past
+    ``event_date``, run the helper, and assert the helper saw only the
+    closes whose date is strictly less than the event. The test is
+    structural (fit_returns_n must equal the strict-prior length minus
+    the initial-bar drop), so we don't pin a specific baseline value.
+    """
+
+    total = MIN_FIT_RETURNS + 20
+    dates = _trading_dates(total, start=_dt.date(2018, 1, 1))
+    closes = _synth_lognormal_closes(total, seed=33)
+
+    # Event sits 15 bars before the end of the series so 15 closes
+    # post-date the event and must be excluded from the fit.
+    event_date = dates[total - 15]
+    expected_strict_prior_len = total - 15
+
+    result = compute_for_event(
+        dates=dates,
+        closes=closes,
+        event_date=event_date,
+        forward_realized_vol_10d=0.014,
+    )
+
+    assert result.baseline is not None
+    assert result.residual is not None
+    # Log-return series has length (strict-prior closes - 1); the helper
+    # reports that count.
+    assert result.fit_returns_n == expected_strict_prior_len - 1
+
+
+def test_compute_for_event_event_predates_series_returns_none() -> None:
+    """An event dated before the first close -> no strict-prior window.
+
+    The fit_returns_n is zero and both baseline / residual are None.
+    """
+
+    dates = _trading_dates(50, start=_dt.date(2020, 6, 1))
+    closes = _synth_lognormal_closes(50, seed=44)
+    early_event = _dt.date(2019, 1, 1)
+
+    result = compute_for_event(
+        dates=dates,
+        closes=closes,
+        event_date=early_event,
+        forward_realized_vol_10d=0.012,
+    )
+
+    assert result.baseline is None
+    assert result.residual is None
+    assert result.fit_returns_n == 0
+
+
+def test_compute_for_event_rejects_mismatched_input_lengths() -> None:
+    """``dates`` and ``closes`` must have the same length."""
+
+    with pytest.raises(ValueError, match="length mismatch"):
+        compute_for_event(
+            dates=[_dt.date(2020, 1, 1), _dt.date(2020, 1, 2)],
+            closes=[100.0],
+            event_date=_dt.date(2020, 6, 1),
+            forward_realized_vol_10d=0.01,
+        )
+
+
+def test_compute_garch_residual_baseline_units_match_log_return_std() -> None:
+    """The baseline lands in log-return units (same scale as the raw target).
+
+    Sanity check that the percentage rescaling round-trip is correct:
+    on an iid Gaussian process with std ~vol, the GARCH baseline should
+    sit within an order of magnitude of vol. Anything off by a factor of
+    100 would mean we forgot to de-scale.
+    """
+
+    vol = 0.010  # 1% daily std
+    closes = _synth_lognormal_closes(MIN_FIT_RETURNS + 100, seed=55, vol=vol)
+    result = compute_garch_residual(
+        prior_closes=closes, forward_realized_vol_10d=vol
+    )
+    assert result.baseline is not None
+    # Within 10x of the true vol (loose because the QMLE fit on 350
+    # samples carries non-trivial estimation noise).
+    assert vol / 10.0 < result.baseline < vol * 10.0
+
+
+def test_garch_forecast_horizon_constant_matches_target_window() -> None:
+    """The horizon constant matches the 10-day raw target window.
+
+    Pinning the constant locks the scale-matching contract: the
+    baseline must be forecast over the same window as
+    ``_forward_realized_vol`` reports for the subtraction to land in
+    consistent units.
+    """
+
+    assert GARCH_FORECAST_HORIZON == 10


### PR DESCRIPTION
Closes #236.

- New events.parquet columns frozen at build time: `forward_realized_vol_10d_garch_baseline` (GARCH(1,1) 10-day-ahead 1-day-equivalent vol forecast, fitted on log returns dated strictly before event_date) and `forward_realized_vol_10d_garch_residual = raw - baseline`. The residual isolates the unanticipated component of realised vol given the classical conditional-variance model.
- Strict-prior contract: the fit consumes only closes `< event_date`; the forecast is conditional-on-fit and reads no close at or after the event. Audit row added to `docs/feature-provenance-audit.md` and the inventory-coverage assertion in `tests/regression/test_feature_provenance_as_of.py` carries both columns.
- Below `MIN_FIT_RETURNS` (~252 td) or on QMLE convergence failure both columns degrade to `None` and the supervised row keeps the raw target intact. `arch>=6.3` was already on `backend/pyproject.toml` for `scripts/garch_baseline.py`; no new dep was added.
- `FeatureVector` gets two new target-only fields with `None` defaults; the loader broadcasts the target-row values onto every bar of the supervised sequence and `as_rich_list` does not emit them, so the input-tensor surface is byte-identical to the pre-#236 path.
- ADR 0034 records the decomposition. The training-time switch (predict residual vs predict raw) is a follow-up that wires the canonical sweep into the §6.6 row.

BLOCKED: needs GPU canonical sweep to populate §6 row.