### PR TITLE
Tighten garch_residual exception handling + convergence-failure tests (#436)

### DIFF
--- a/backend/app/data/garch_residual.py
+++ b/backend/app/data/garch_residual.py
@@ -49,7 +49,26 @@ import math
 from dataclasses import dataclass
 from typing import Sequence
 
+import numpy as np
+
 logger = logging.getLogger(__name__)
+
+
+# Exceptions the ``arch`` fit / forecast path actually raises on a
+# degenerate window (singular Hessian, non-finite scores, scipy
+# optimiser blow-up, malformed input). ``ConvergenceWarning`` is a
+# Warning subclass and never propagates as an exception, so it is
+# deliberately not in this tuple; the fit emits it via warnings.warn
+# and we suppress it at the call site via ``show_warning=False``. The
+# tuple is intentionally narrow: anything outside it (e.g. AttributeError
+# from a typo on a module constant) must surface in CI rather than be
+# silently swallowed and turned into a None column.
+_ARCH_FIT_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    np.linalg.LinAlgError,
+    ValueError,
+    RuntimeError,
+    OverflowError,
+)
 
 
 # Minimum strictly-prior returns required to fit GARCH(1,1). ~252
@@ -114,7 +133,7 @@ def _forecast_one_step_equiv_vol(model_result, *, horizon: int) -> float | None:
 
     try:
         forecast = model_result.forecast(horizon=horizon, reindex=False)
-    except Exception:  # arch raises a grab-bag of errors on degenerate fits
+    except _ARCH_FIT_EXCEPTIONS:
         return None
     variance_row = forecast.variance.iloc[-1].to_numpy()
     if variance_row.size == 0:
@@ -148,15 +167,13 @@ def _fit_garch_and_forecast(
         )
         return None
     try:
-        import numpy as np
-
         scaled = np.asarray(returns, dtype=float) * _PERCENT_SCALE
         # show_warning=False suppresses the per-fit "DataScaleWarning"
         # the optimiser emits on tail-heavy windows; we control the
         # scaling explicitly so the warning is noise.
         model = arch_model(scaled, mean="Zero", vol="Garch", p=1, q=1, rescale=False)
         result = model.fit(disp="off", show_warning=False)
-    except Exception:  # arch raises ConvergenceWarning, LinAlgError, ValueError, ...
+    except _ARCH_FIT_EXCEPTIONS:
         return None
     forecast_pct = _forecast_one_step_equiv_vol(result, horizon=horizon)
     if forecast_pct is None:

--- a/tests/unit/test_garch_residual.py
+++ b/tests/unit/test_garch_residual.py
@@ -229,3 +229,58 @@ def test_garch_forecast_horizon_constant_matches_target_window() -> None:
     """
 
     assert GARCH_FORECAST_HORIZON == 10
+
+
+def test_compute_garch_residual_fit_linalg_error_degrades_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``LinAlgError`` raised by ``arch_model().fit()`` degrades cleanly.
+
+    Mocks the QMLE fit to raise a singular-Hessian error (the canonical
+    convergence-failure surface on degenerate windows) and asserts both
+    baseline and residual come back as ``None`` instead of raising.
+    The raw target is left intact on the caller side.
+    """
+
+    import numpy as np
+    from arch.univariate.base import ARCHModel
+
+    def _raise_linalg(self: ARCHModel, *_args: object, **_kwargs: object) -> None:
+        raise np.linalg.LinAlgError("Singular matrix (mock)")
+
+    monkeypatch.setattr(ARCHModel, "fit", _raise_linalg, raising=True)
+
+    closes = _synth_lognormal_closes(MIN_FIT_RETURNS + 10, seed=101)
+    result = compute_garch_residual(
+        prior_closes=closes, forward_realized_vol_10d=0.015
+    )
+    assert result.baseline is None
+    assert result.residual is None
+    assert result.fit_returns_n == len(closes) - 1
+
+
+def test_compute_garch_residual_forecast_value_error_degrades_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``ValueError`` raised by ``model_result.forecast()`` degrades cleanly.
+
+    The fit converges normally; the failure surface is on the forecast
+    step (e.g. malformed reindex on a pathological calendar). The
+    baseline must still come back as ``None`` (we cannot synthesise a
+    forecast we never got) and the residual follows.
+    """
+
+    from arch.univariate.base import ARCHModelResult
+
+    def _raise_value(self: ARCHModelResult, *_args: object, **_kwargs: object) -> None:
+        raise ValueError("forecast failure (mock)")
+
+    monkeypatch.setattr(ARCHModelResult, "forecast", _raise_value, raising=True)
+
+    closes = _synth_lognormal_closes(MIN_FIT_RETURNS + 10, seed=102)
+    result = compute_garch_residual(
+        prior_closes=closes, forward_realized_vol_10d=0.015
+    )
+    assert result.baseline is None
+    assert result.residual is None
+    assert result.fit_returns_n == len(closes) - 1


### PR DESCRIPTION
Closes #436.

- `_fit_garch_and_forecast` and `_forecast_one_step_equiv_vol` now catch `(np.linalg.LinAlgError, ValueError, RuntimeError, OverflowError)` instead of bare `Exception`. Real bugs (constant typos, attribute errors) surface in CI instead of silently degrading the column to None.
- Two new mock-based tests: `LinAlgError` on fit and `ValueError` on forecast both degrade baseline + residual to None without raising. The existing iid / strict-prior / scale / horizon coverage stays intact.
- Lifted the inline `import numpy as np` to module level since the constant tuple needs `np.linalg.LinAlgError` at module import time.