### PR TITLE
Wire GSS into cross-source transfer matrix + adapter polish (#433)

### DIFF
--- a/backend/app/data/sources/gss.py
+++ b/backend/app/data/sources/gss.py
@@ -18,11 +18,14 @@ from __future__ import annotations
 import csv
 import io
 import json
+import logging
 from pathlib import Path
 from typing import Any, Iterable
 
 from app.data.sources.base import BaseSourceScraper, Provenance, SourceMetadata
 from app.data.sources.registry import register
+
+logger = logging.getLogger(__name__)
 
 
 def _coerce_event_date(raw: str) -> str:
@@ -72,7 +75,20 @@ def _parse_gss_factors_row(
     except ValueError:
         extras["gss_path_factor"] = None
     extras["gss_fomc_statement"] = (row.get("fomc_statement") or "").strip().upper() == "T"
-    extras.update(surprises_by_date.get(event_date, {}))
+    # Guard against future surprises columns that collide with a gss_*
+    # factor key — without this guard, dict.update silently overwrites the
+    # factor we just parsed. Per-collision warn so the misnamed column is
+    # visible without breaking the pipeline.
+    surprise_extras = surprises_by_date.get(event_date, {})
+    for key, value in surprise_extras.items():
+        if key in extras:
+            logger.warning(
+                "GSS surprises CSV key %r collides with factor key for %s; keeping factor value",
+                key,
+                event_date,
+            )
+            continue
+        extras[key] = value
 
     target_repr = (
         f"{extras['gss_target_factor']:+.2f}"
@@ -102,6 +118,39 @@ def _parse_gss_factors_row(
     }
 
 
+_SURPRISES_NUMERIC_COLUMNS: tuple[str, ...] = (
+    "surprise_30min_bp",
+    "surprise_1hour_bp",
+    "surprise_1day_bp",
+    "diff_wide_minus_tight",
+    "diff_daily_minus_tight",
+)
+
+
+def _extract_surprises_row(row: dict[str, str]) -> tuple[str, dict[str, Any]] | None:
+    """Pull the event_date + numeric extras off a single surprises CSV row."""
+
+    event_date = ""
+    for key in ("meeting_date", "date", "event_date"):
+        event_date = _coerce_event_date(row.get(key, ""))
+        if event_date:
+            break
+    if not event_date:
+        return None
+    extras: dict[str, Any] = {}
+    for key in _SURPRISES_NUMERIC_COLUMNS:
+        raw = (row.get(key) or "").strip()
+        if not raw:
+            continue
+        try:
+            extras[key] = float(raw)
+        except ValueError:
+            continue
+    if not extras:
+        return None
+    return event_date, extras
+
+
 def _parse_surprises_csv(text: str) -> dict[str, dict[str, Any]]:
     """Parse the surprises side-table CSV into a per-meeting-date dict."""
 
@@ -110,30 +159,19 @@ def _parse_surprises_csv(text: str) -> dict[str, dict[str, Any]]:
         return by_date
     reader = csv.DictReader(io.StringIO(text))
     for row in reader:
-        event_date = ""
-        for key in ("meeting_date", "date", "event_date"):
-            event_date = _coerce_event_date(row.get(key, ""))
-            if event_date:
-                break
-        if not event_date:
+        parsed = _extract_surprises_row(row)
+        if parsed is None:
             continue
-        extras: dict[str, Any] = {}
-        for key in (
-            "surprise_30min_bp",
-            "surprise_1hour_bp",
-            "surprise_1day_bp",
-            "diff_wide_minus_tight",
-            "diff_daily_minus_tight",
-        ):
-            raw = (row.get(key) or "").strip()
-            if not raw:
-                continue
-            try:
-                extras[key] = float(raw)
-            except ValueError:
-                continue
-        if extras:
-            by_date[event_date] = extras
+        event_date, extras = parsed
+        by_date[event_date] = extras
+    if not by_date:
+        # Non-empty input that produced zero parsed rows is almost always a
+        # schema drift (renamed date column, all-empty value cells). Surface
+        # it at debug so an operator running --log-level=DEBUG sees it
+        # without spamming a quiet run.
+        logger.debug(
+            "GSS surprises CSV parsed to zero rows; check date/value columns"
+        )
     return by_date
 
 
@@ -166,7 +204,12 @@ class GssFactorsScraper:
         if not html:
             return []
         reader = csv.DictReader(io.StringIO(html))
-        return [dict(row) for row in reader]
+        rows = [dict(row) for row in reader]
+        if not rows:
+            logger.debug(
+                "GSS factors CSV parsed to zero rows; check header / row format"
+            )
+        return rows
 
     def parse_entry(self, raw_html: str, *, source_url: str) -> dict[str, Any] | None:
         """Parse a single GSS factors CSV row.

--- a/backend/app/evaluation/cross_source_transfer.py
+++ b/backend/app/evaluation/cross_source_transfer.py
@@ -16,6 +16,18 @@ for.
 Output schema mirrors `cross_bank_transfer` so downstream aggregation can
 share code paths: ``matrix.csv`` with one row per ``(encoder, source)`` pair
 plus per-source ``support`` so under-populated cells are visible.
+
+Continuous-target arm
+---------------------
+A second dispatch arm handles ``source_type`` strata that ship continuous
+factor columns instead of categorical stance labels (today: GSS
+target/path factor decomposition, ``gss_factor_decomposition``). The arm
+runs the same stance checkpoint, derives a signed stance score
+``P(hawkish) - P(dovish)`` per row, and reports Pearson + Spearman rank
+correlation against the GSS target and path factors. Reported alongside is
+a z-scored RMSE so both factor columns sit on a comparable scale; the raw
+factor is in basis points and the stance score is in [-1, 1] so an
+un-scaled RMSE would be meaningless.
 """
 
 from __future__ import annotations
@@ -24,9 +36,10 @@ import argparse
 import csv
 import io
 import json
+import math
 import time
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
@@ -53,12 +66,34 @@ CROSS_SOURCE_TYPES: tuple[str, ...] = (
     "beige_book",
     "regional_research",
     "ny_fed_liberty_street",
+    "gss_factor_decomposition",
 )
+
+# Continuous-target strata: rows carry no categorical stance label, they
+# carry numeric factor columns lifted off ``multi_axis_extras``. The
+# harness dispatches these through ``evaluate_continuous_source`` instead
+# of the stance-classification path.
+CROSS_SOURCE_CONTINUOUS_TYPES: tuple[str, ...] = (
+    "gss_factor_decomposition",
+)
+
+# Per continuous source_type, the ``multi_axis_extras`` keys to score
+# the model's signed stance score against. Order matters only for the
+# CSV column layout downstream.
+CONTINUOUS_TARGETS: dict[str, tuple[str, ...]] = {
+    "gss_factor_decomposition": ("gss_target_factor", "gss_path_factor"),
+}
 
 
 @dataclass(frozen=True)
 class CrossSourceRow:
-    """A labelled registry row read for the cross-source eval."""
+    """A registry row read for the cross-source eval.
+
+    ``label`` is empty string for rows from a continuous-target source_type
+    (see ``CROSS_SOURCE_CONTINUOUS_TYPES``); the factor columns live on
+    ``multi_axis_extras`` and the continuous-arm evaluator reads them
+    directly.
+    """
 
     record_id: str
     text: str
@@ -67,6 +102,7 @@ class CrossSourceRow:
     source: str
     source_type: str
     provenance: str
+    multi_axis_extras: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -126,30 +162,37 @@ def load_cross_source_rows(
             payload = json.loads(line)
         except json.JSONDecodeError:
             continue
-        label = str(payload.get("mapped_label", "")).strip().lower()
-        if label not in LABELS:
+        source_type = str(payload.get("source_type", "")).strip()
+        if source_type not in CROSS_SOURCE_TYPES:
             continue
         text = str(payload.get("text", "")).strip()
         if not text:
+            continue
+        label = str(payload.get("mapped_label", "")).strip().lower()
+        is_continuous = source_type in CROSS_SOURCE_CONTINUOUS_TYPES
+        if not is_continuous and label not in LABELS:
             continue
         try:
             sample_weight = float(payload.get("sample_weight", 1.0))
         except (TypeError, ValueError):
             sample_weight = 1.0
-        if not include_zero_weight and sample_weight == 0.0:
+        # Continuous-arm rows carry sample_weight=0 by design (they sit
+        # in the registry for evaluation only, never enter training).
+        # Don't gate them on the zero-weight flag.
+        if not include_zero_weight and sample_weight == 0.0 and not is_continuous:
             continue
-        source_type = str(payload.get("source_type", "")).strip()
-        if source_type not in CROSS_SOURCE_TYPES:
-            continue
+        extras_raw = payload.get("multi_axis_extras") or {}
+        extras = extras_raw if isinstance(extras_raw, dict) else {}
         rows.append(
             CrossSourceRow(
                 record_id=str(payload.get("record_id", "")).strip(),
                 text=text,
-                label=label,
+                label=label if not is_continuous else "",
                 event_date=str(payload.get("event_date", "")).strip(),
                 source=str(payload.get("source", "")).strip(),
                 source_type=source_type,
                 provenance=str(payload.get("provenance", "")).strip(),
+                multi_axis_extras=dict(extras),
             )
         )
     return rows
@@ -267,6 +310,224 @@ def evaluate_source(
     )
 
 
+@dataclass(frozen=True)
+class CrossSourceContinuousResult:
+    """Continuous-arm result for a single (encoder, continuous source) cell.
+
+    The stance checkpoint emits a signed score ``P(hawkish) - P(dovish)``
+    per row; the harness scores that against each continuous target column
+    on ``multi_axis_extras`` via Pearson + Spearman correlation and a
+    z-scored RMSE (raw RMSE is meaningless cross-scale).
+    """
+
+    source_type: str
+    encoder_alias: str
+    checkpoint: str
+    support: int
+    targets: dict[str, dict[str, float]]
+    latency_ms_p50: float
+    latency_ms_p95: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_type": self.source_type,
+            "encoder_alias": self.encoder_alias,
+            "checkpoint": self.checkpoint,
+            "support": self.support,
+            "kind": "continuous",
+            "targets": self.targets,
+            "latency_ms": {"p50": self.latency_ms_p50, "p95": self.latency_ms_p95},
+        }
+
+
+def _pearson(xs: list[float], ys: list[float]) -> float | None:
+    """Pearson r over paired finite samples. Returns ``None`` if degenerate."""
+
+    n = len(xs)
+    if n < 2 or len(ys) != n:
+        return None
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    dx2 = sum((x - mx) ** 2 for x in xs)
+    dy2 = sum((y - my) ** 2 for y in ys)
+    if dx2 <= 0 or dy2 <= 0:
+        return None
+    return num / math.sqrt(dx2 * dy2)
+
+
+def _rank(values: list[float]) -> list[float]:
+    """Average-rank assignment, ties get the mean of their tied positions."""
+
+    indexed = sorted(range(len(values)), key=lambda i: values[i])
+    ranks = [0.0] * len(values)
+    i = 0
+    while i < len(indexed):
+        j = i
+        while j + 1 < len(indexed) and values[indexed[j + 1]] == values[indexed[i]]:
+            j += 1
+        avg = (i + j) / 2.0 + 1.0  # 1-indexed average
+        for k in range(i, j + 1):
+            ranks[indexed[k]] = avg
+        i = j + 1
+    return ranks
+
+
+def _spearman(xs: list[float], ys: list[float]) -> float | None:
+    """Spearman rank correlation via Pearson on rank-transformed inputs."""
+
+    if len(xs) < 2 or len(xs) != len(ys):
+        return None
+    return _pearson(_rank(xs), _rank(ys))
+
+
+def _zscore_rmse(xs: list[float], ys: list[float]) -> float | None:
+    """RMSE after z-scoring both vectors. Returns ``None`` if degenerate."""
+
+    n = len(xs)
+    if n < 2 or len(ys) != n:
+        return None
+
+    def _z(vs: list[float]) -> list[float] | None:
+        mean = sum(vs) / len(vs)
+        var = sum((v - mean) ** 2 for v in vs) / len(vs)
+        if var <= 0:
+            return None
+        sd = math.sqrt(var)
+        return [(v - mean) / sd for v in vs]
+
+    zx = _z(xs)
+    zy = _z(ys)
+    if zx is None or zy is None:
+        return None
+    return math.sqrt(sum((a - b) ** 2 for a, b in zip(zx, zy)) / n)
+
+
+def _predict_continuous_scores(
+    rows: list[CrossSourceRow],
+    *,
+    checkpoint: str,
+    max_length: int = 256,
+    batch_size: int = 32,
+) -> tuple[list[float], list[float]]:
+    """Return ``(signed_scores, per_row_latency_ms)`` for the continuous arm.
+
+    Signed score = ``softmax(logits)[hawkish_id] - softmax(logits)[dovish_id]``
+    per row — a single bipolar dim in [-1, 1] that's the natural projection
+    of a 3-class stance head onto the GSS factor axis.
+    """
+
+    import torch
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+    model = AutoModelForSequenceClassification.from_pretrained(checkpoint)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    model.eval()
+
+    label2id = {v: k for k, v in ID2LABEL.items()}
+    hawk = label2id["hawkish"]
+    dove = label2id["dovish"]
+
+    scores: list[float] = []
+    latencies: list[float] = []
+    with torch.no_grad():
+        for start in range(0, len(rows), batch_size):
+            batch_rows = rows[start : start + batch_size]
+            batch_texts = [r.text for r in batch_rows]
+            enc = tokenizer(
+                batch_texts,
+                truncation=True,
+                max_length=max_length,
+                padding=True,
+                return_tensors="pt",
+            ).to(device)
+            t0 = time.perf_counter()
+            logits = model(**enc).logits
+            elapsed_ms = (time.perf_counter() - t0) * 1000.0
+            per_item_ms = elapsed_ms / max(len(batch_rows), 1)
+            latencies.extend([per_item_ms] * len(batch_rows))
+            probs = torch.softmax(logits, dim=-1)
+            for prob in probs:
+                scores.append(float(prob[hawk] - prob[dove]))
+    return scores, latencies
+
+
+def evaluate_continuous_source(
+    rows: list[CrossSourceRow],
+    *,
+    source_type: str,
+    encoder_alias: str,
+    checkpoint: str,
+    max_length: int = 256,
+    batch_size: int = 32,
+    predict_fn: Any = None,
+) -> CrossSourceContinuousResult:
+    """Score a continuous-target source slice.
+
+    ``predict_fn(rows) -> (signed_scores, latencies_ms)`` is the test seam;
+    production calls fall through to ``_predict_continuous_scores``.
+    """
+
+    if not rows:
+        raise ValueError(
+            f"No continuous rows for source_type={source_type!r} in registry."
+        )
+    target_keys = CONTINUOUS_TARGETS.get(source_type, ())
+    if not target_keys:
+        raise ValueError(
+            f"No continuous targets configured for source_type={source_type!r}; "
+            "extend CONTINUOUS_TARGETS to register the factor columns."
+        )
+
+    if predict_fn is None:
+        scores, latencies = _predict_continuous_scores(
+            rows, checkpoint=checkpoint, max_length=max_length, batch_size=batch_size
+        )
+    else:
+        scores, latencies = predict_fn(rows)
+
+    if len(scores) != len(rows):
+        raise ValueError(
+            f"predict_fn returned {len(scores)} scores for {len(rows)} rows."
+        )
+
+    targets: dict[str, dict[str, float]] = {}
+    for key in target_keys:
+        paired_x: list[float] = []
+        paired_y: list[float] = []
+        for row, score in zip(rows, scores):
+            raw = row.multi_axis_extras.get(key)
+            if raw is None:
+                continue
+            try:
+                value = float(raw)
+            except (TypeError, ValueError):
+                continue
+            if math.isnan(value) or math.isinf(value):
+                continue
+            paired_x.append(score)
+            paired_y.append(value)
+        targets[key] = {
+            "support": len(paired_x),
+            "pearson_r": _pearson(paired_x, paired_y) if paired_x else None,
+            "spearman_r": _spearman(paired_x, paired_y) if paired_x else None,
+            "zscore_rmse": _zscore_rmse(paired_x, paired_y) if paired_x else None,
+        }
+
+    latency = _latency_summary(latencies)
+    return CrossSourceContinuousResult(
+        source_type=source_type,
+        encoder_alias=encoder_alias,
+        checkpoint=checkpoint,
+        support=len(rows),
+        targets=targets,
+        latency_ms_p50=latency["p50_ms"],
+        latency_ms_p95=latency["p95_ms"],
+    )
+
+
 def build_matrix(
     *,
     package_dir: Path,
@@ -275,6 +536,7 @@ def build_matrix(
     max_length: int = 256,
     batch_size: int = 32,
     predict_fn: Any = None,
+    continuous_predict_fn: Any = None,
 ) -> dict[str, Any]:
     """Build the per-(encoder, source_type) cross-source transfer payload.
 
@@ -282,6 +544,12 @@ def build_matrix(
     inference once per (alias, source_type) cell. Cells with zero rows are
     emitted as ``support=0`` with empty metrics so the under-populated
     sources stay visible in the CSV.
+
+    Continuous-target source_types (see ``CROSS_SOURCE_CONTINUOUS_TYPES``)
+    dispatch through ``evaluate_continuous_source`` and emit cells tagged
+    ``kind="continuous"``. ``continuous_predict_fn`` is the corresponding
+    test seam; production code passes ``None`` and lets the harness call
+    the HF inference path.
     """
 
     rows = load_cross_source_rows(package_dir)
@@ -301,6 +569,7 @@ def build_matrix(
     for encoder_alias, checkpoint in encoder_checkpoints.items():
         for source_type in targets:
             slice_rows = buckets.get(source_type, [])
+            is_continuous = source_type in CROSS_SOURCE_CONTINUOUS_TYPES
             if not slice_rows:
                 matrix["cells"].append(
                     {
@@ -309,19 +578,34 @@ def build_matrix(
                         "source_type": source_type,
                         "support": 0,
                         "status": "no_rows",
+                        "kind": "continuous" if is_continuous else "stance",
                     }
                 )
                 continue
             try:
-                result = evaluate_source(
-                    slice_rows,
-                    source_type=source_type,
-                    encoder_alias=encoder_alias,
-                    checkpoint=checkpoint,
-                    max_length=max_length,
-                    batch_size=batch_size,
-                    predict_fn=predict_fn,
-                )
+                if is_continuous:
+                    cont = evaluate_continuous_source(
+                        slice_rows,
+                        source_type=source_type,
+                        encoder_alias=encoder_alias,
+                        checkpoint=checkpoint,
+                        max_length=max_length,
+                        batch_size=batch_size,
+                        predict_fn=continuous_predict_fn,
+                    )
+                    cell = cont.to_dict()
+                else:
+                    result = evaluate_source(
+                        slice_rows,
+                        source_type=source_type,
+                        encoder_alias=encoder_alias,
+                        checkpoint=checkpoint,
+                        max_length=max_length,
+                        batch_size=batch_size,
+                        predict_fn=predict_fn,
+                    )
+                    cell = result.to_dict()
+                    cell["kind"] = "stance"
             except Exception as exc:  # noqa: BLE001 — surface per-cell failure
                 matrix["failures"].append(
                     {
@@ -332,7 +616,6 @@ def build_matrix(
                     }
                 )
                 continue
-            cell = result.to_dict()
             cell["status"] = "ok"
             matrix["cells"].append(cell)
 
@@ -340,6 +623,13 @@ def build_matrix(
 
 
 def render_csv(matrix: dict[str, Any]) -> str:
+    """Render the stance-arm matrix as a CSV.
+
+    Continuous-arm cells are skipped here so the stance CSV stays
+    well-typed (the per-class columns don't apply). Continuous cells are
+    emitted by ``render_continuous_csv``; both share ``matrix.json``.
+    """
+
     fieldnames = [
         "encoder_alias",
         "checkpoint",
@@ -359,6 +649,8 @@ def render_csv(matrix: dict[str, Any]) -> str:
     writer = csv.DictWriter(buffer, fieldnames=fieldnames)
     writer.writeheader()
     for cell in matrix.get("cells", []):
+        if cell.get("kind") == "continuous":
+            continue
         per_label = cell.get("label_support") or {}
         latency = cell.get("latency_ms") or {}
         writer.writerow(
@@ -378,6 +670,67 @@ def render_csv(matrix: dict[str, Any]) -> str:
                 "latency_ms_p95": _fmt(latency.get("p95")),
             }
         )
+    return buffer.getvalue()
+
+
+def render_continuous_csv(matrix: dict[str, Any]) -> str:
+    """Render the continuous-arm cells as a long-form CSV.
+
+    One row per ``(encoder, source_type, target_key)`` tuple, so the
+    Pearson / Spearman / z-RMSE numbers stay one-target-per-row regardless
+    of how many factor columns a source ships. Returns an empty string if
+    no continuous cells made it into the matrix (lets the caller skip the
+    artefact instead of writing a header-only file).
+    """
+
+    rows: list[dict[str, Any]] = []
+    for cell in matrix.get("cells", []):
+        if cell.get("kind") != "continuous":
+            continue
+        latency = cell.get("latency_ms") or {}
+        targets = cell.get("targets") or {}
+        if not targets:
+            rows.append(
+                {
+                    "encoder_alias": cell.get("encoder_alias", ""),
+                    "checkpoint": cell.get("checkpoint", ""),
+                    "source_type": cell.get("source_type", ""),
+                    "status": cell.get("status", ""),
+                    "support": cell.get("support", 0),
+                    "target_key": "",
+                    "paired_support": 0,
+                    "pearson_r": "",
+                    "spearman_r": "",
+                    "zscore_rmse": "",
+                    "latency_ms_p50": _fmt(latency.get("p50")),
+                    "latency_ms_p95": _fmt(latency.get("p95")),
+                }
+            )
+            continue
+        for target_key, stats in targets.items():
+            rows.append(
+                {
+                    "encoder_alias": cell.get("encoder_alias", ""),
+                    "checkpoint": cell.get("checkpoint", ""),
+                    "source_type": cell.get("source_type", ""),
+                    "status": cell.get("status", ""),
+                    "support": cell.get("support", 0),
+                    "target_key": target_key,
+                    "paired_support": stats.get("support", 0),
+                    "pearson_r": _fmt(stats.get("pearson_r")),
+                    "spearman_r": _fmt(stats.get("spearman_r")),
+                    "zscore_rmse": _fmt(stats.get("zscore_rmse")),
+                    "latency_ms_p50": _fmt(latency.get("p50")),
+                    "latency_ms_p95": _fmt(latency.get("p95")),
+                }
+            )
+    if not rows:
+        return ""
+    fieldnames = list(rows[0].keys())
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(rows)
     return buffer.getvalue()
 
 
@@ -493,18 +846,26 @@ def main() -> int:
         json.dumps(matrix, indent=2, allow_nan=False), encoding="utf-8"
     )
     (output_dir / "matrix.csv").write_text(render_csv(matrix), encoding="utf-8")
+    continuous_csv = render_continuous_csv(matrix)
+    if continuous_csv:
+        (output_dir / "matrix_continuous.csv").write_text(continuous_csv, encoding="utf-8")
     print(f"[cross_source_transfer] wrote artefacts to {output_dir}")
     return 0
 
 
 __all__ = [
+    "CONTINUOUS_TARGETS",
+    "CROSS_SOURCE_CONTINUOUS_TYPES",
     "CROSS_SOURCE_TYPES",
+    "CrossSourceContinuousResult",
     "CrossSourceResult",
     "CrossSourceRow",
     "build_matrix",
+    "evaluate_continuous_source",
     "evaluate_source",
     "group_by_source_type",
     "load_cross_source_rows",
+    "render_continuous_csv",
     "render_csv",
 ]
 

--- a/backend/app/evaluation/cross_source_transfer.py
+++ b/backend/app/evaluation/cross_source_transfer.py
@@ -324,7 +324,10 @@ class CrossSourceContinuousResult:
     encoder_alias: str
     checkpoint: str
     support: int
-    targets: dict[str, dict[str, float]]
+    # ``targets[target_key]`` carries ``support`` (int) plus ``pearson_r``,
+    # ``spearman_r``, ``zscore_rmse`` which are ``float | None`` — None for
+    # degenerate slices (zero variance, sub-2 pairs).
+    targets: dict[str, dict[str, float | int | None]]
     latency_ms_p50: float
     latency_ms_p95: float
 
@@ -493,7 +496,7 @@ def evaluate_continuous_source(
             f"predict_fn returned {len(scores)} scores for {len(rows)} rows."
         )
 
-    targets: dict[str, dict[str, float]] = {}
+    targets: dict[str, dict[str, float | int | None]] = {}
     for key in target_keys:
         paired_x: list[float] = []
         paired_y: list[float] = []

--- a/tests/unit/test_cross_source_transfer.py
+++ b/tests/unit/test_cross_source_transfer.py
@@ -240,3 +240,247 @@ def test_parse_encoder_spec_rejects_duplicate_aliases() -> None:
 def test_parse_source_types_rejects_unknown() -> None:
     with pytest.raises(ValueError, match="unknown source_type"):
         cst._parse_source_types("not_a_real_source")
+
+
+# ----- continuous-arm (GSS factor decomposition) ----------------------------
+
+
+@pytest.fixture
+def package_with_gss_rows(tmp_path: Path) -> Path:
+    package_dir = tmp_path / "processed" / "tp_gss"
+    _write_registry(
+        package_dir / "registry_normalized.jsonl",
+        [
+            # GSS rows ship sample_weight=0 by design (eval-only, never
+            # enter training) — the continuous arm must still pick them up.
+            {
+                "record_id": "gss_1994-08-16",
+                "text": "GSS factor decomposition for 1994-08-16: target=+10.70 bp, path=-8.30 bp",
+                "event_date": "1994-08-16",
+                "source_type": "gss_factor_decomposition",
+                "source": "gurkaynak_sack_swanson_2005",
+                "mapped_label": "",
+                "provenance": "peer_reviewed",
+                "sample_weight": 0.0,
+                "multi_axis_extras": {
+                    "gss_target_factor": 10.7,
+                    "gss_path_factor": -8.3,
+                    "gss_fomc_statement": True,
+                },
+            },
+            {
+                "record_id": "gss_2001-01-03",
+                "text": "GSS factor decomposition for 2001-01-03: target=-32.30 bp, path=+22.80 bp",
+                "event_date": "2001-01-03",
+                "source_type": "gss_factor_decomposition",
+                "source": "gurkaynak_sack_swanson_2005",
+                "mapped_label": "",
+                "provenance": "peer_reviewed",
+                "sample_weight": 0.0,
+                "multi_axis_extras": {
+                    "gss_target_factor": -32.3,
+                    "gss_path_factor": 22.8,
+                    "gss_fomc_statement": True,
+                },
+            },
+            {
+                "record_id": "gss_1990-02-08",
+                "text": "GSS factor decomposition for 1990-02-08: target=+0.30 bp, path=+5.80 bp",
+                "event_date": "1990-02-08",
+                "source_type": "gss_factor_decomposition",
+                "source": "gurkaynak_sack_swanson_2005",
+                "mapped_label": "",
+                "provenance": "peer_reviewed",
+                "sample_weight": 0.0,
+                "multi_axis_extras": {
+                    "gss_target_factor": 0.3,
+                    "gss_path_factor": 5.8,
+                    "gss_fomc_statement": False,
+                },
+            },
+        ],
+    )
+    return package_dir
+
+
+def test_load_cross_source_rows_picks_up_continuous_rows(
+    package_with_gss_rows: Path,
+) -> None:
+    rows = cst.load_cross_source_rows(package_with_gss_rows)
+    assert len(rows) == 3
+    assert all(r.source_type == "gss_factor_decomposition" for r in rows)
+    assert all(r.label == "" for r in rows)
+    by_id = {r.record_id: r for r in rows}
+    assert by_id["gss_2001-01-03"].multi_axis_extras["gss_target_factor"] == pytest.approx(-32.3)
+
+
+def test_evaluate_continuous_source_with_perfect_oracle(
+    package_with_gss_rows: Path,
+) -> None:
+    rows = cst.load_cross_source_rows(package_with_gss_rows)
+
+    def perfect_oracle(rs):
+        # Return the target factor itself as the "score". A perfect
+        # predictor must hit Pearson r = 1.0 and zero z-scored RMSE.
+        scores = [float(r.multi_axis_extras["gss_target_factor"]) for r in rs]
+        return scores, [0.5] * len(rs)
+
+    result = cst.evaluate_continuous_source(
+        rows,
+        source_type="gss_factor_decomposition",
+        encoder_alias="oracle",
+        checkpoint="oracle",
+        predict_fn=perfect_oracle,
+    )
+    assert result.support == 3
+    target = result.targets["gss_target_factor"]
+    assert target["support"] == 3
+    assert target["pearson_r"] == pytest.approx(1.0, abs=1e-9)
+    assert target["spearman_r"] == pytest.approx(1.0, abs=1e-9)
+    assert target["zscore_rmse"] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_evaluate_continuous_source_with_anti_correlated_predictor(
+    package_with_gss_rows: Path,
+) -> None:
+    rows = cst.load_cross_source_rows(package_with_gss_rows)
+
+    def anti(rs):
+        return [-float(r.multi_axis_extras["gss_target_factor"]) for r in rs], [0.4] * len(rs)
+
+    result = cst.evaluate_continuous_source(
+        rows,
+        source_type="gss_factor_decomposition",
+        encoder_alias="anti",
+        checkpoint="anti",
+        predict_fn=anti,
+    )
+    target = result.targets["gss_target_factor"]
+    assert target["pearson_r"] == pytest.approx(-1.0, abs=1e-9)
+    assert target["spearman_r"] == pytest.approx(-1.0, abs=1e-9)
+
+
+def test_evaluate_continuous_source_rejects_score_count_mismatch(
+    package_with_gss_rows: Path,
+) -> None:
+    rows = cst.load_cross_source_rows(package_with_gss_rows)
+    with pytest.raises(ValueError, match="scores for"):
+        cst.evaluate_continuous_source(
+            rows,
+            source_type="gss_factor_decomposition",
+            encoder_alias="x",
+            checkpoint="x",
+            predict_fn=lambda rs: ([0.1], [0.1]),
+        )
+
+
+def test_evaluate_continuous_source_rejects_empty_rows() -> None:
+    with pytest.raises(ValueError, match="No continuous rows"):
+        cst.evaluate_continuous_source(
+            [],
+            source_type="gss_factor_decomposition",
+            encoder_alias="x",
+            checkpoint="x",
+            predict_fn=lambda rs: ([], []),
+        )
+
+
+def test_evaluate_continuous_source_rejects_unconfigured_type(
+    package_with_gss_rows: Path,
+) -> None:
+    rows = cst.load_cross_source_rows(package_with_gss_rows)
+    with pytest.raises(ValueError, match="No continuous targets configured"):
+        cst.evaluate_continuous_source(
+            rows,
+            source_type="fomc_statement",  # not in CONTINUOUS_TARGETS
+            encoder_alias="x",
+            checkpoint="x",
+            predict_fn=lambda rs: ([0.0] * len(rs), [0.1] * len(rs)),
+        )
+
+
+def test_build_matrix_dispatches_continuous_arm(
+    package_with_gss_rows: Path,
+) -> None:
+    def oracle(rs):
+        return [float(r.multi_axis_extras["gss_target_factor"]) for r in rs], [0.3] * len(rs)
+
+    matrix = cst.build_matrix(
+        package_dir=package_with_gss_rows,
+        encoder_checkpoints={"oracle": "oracle"},
+        source_types=["gss_factor_decomposition", "fomc_statement"],
+        continuous_predict_fn=oracle,
+    )
+    counts = matrix["per_source_counts"]
+    assert counts["gss_factor_decomposition"] == 3
+    assert counts["fomc_statement"] == 0
+
+    by_type = {(c["source_type"], c["status"]): c for c in matrix["cells"]}
+    gss_cell = by_type[("gss_factor_decomposition", "ok")]
+    assert gss_cell["kind"] == "continuous"
+    assert gss_cell["support"] == 3
+    assert gss_cell["targets"]["gss_target_factor"]["pearson_r"] == pytest.approx(1.0, abs=1e-9)
+    # Empty stance source still emits a no_rows cell, tagged kind=stance.
+    stance_cell = by_type[("fomc_statement", "no_rows")]
+    assert stance_cell["kind"] == "stance"
+
+
+def test_render_continuous_csv_one_row_per_target(
+    package_with_gss_rows: Path,
+) -> None:
+    def oracle(rs):
+        return [float(r.multi_axis_extras["gss_target_factor"]) for r in rs], [0.3] * len(rs)
+
+    matrix = cst.build_matrix(
+        package_dir=package_with_gss_rows,
+        encoder_checkpoints={"oracle": "oracle"},
+        source_types=["gss_factor_decomposition"],
+        continuous_predict_fn=oracle,
+    )
+    csv_text = cst.render_continuous_csv(matrix)
+    header = csv_text.splitlines()[0].split(",")
+    assert header[:7] == [
+        "encoder_alias",
+        "checkpoint",
+        "source_type",
+        "status",
+        "support",
+        "target_key",
+        "paired_support",
+    ]
+    # Two rows: one for gss_target_factor, one for gss_path_factor.
+    body = csv_text.splitlines()[1:]
+    assert len(body) == 2
+    keys = {line.split(",")[5] for line in body}
+    assert keys == {"gss_target_factor", "gss_path_factor"}
+
+
+def test_render_csv_skips_continuous_cells(
+    package_with_gss_rows: Path,
+) -> None:
+    def oracle(rs):
+        return [float(r.multi_axis_extras["gss_target_factor"]) for r in rs], [0.3] * len(rs)
+
+    matrix = cst.build_matrix(
+        package_dir=package_with_gss_rows,
+        encoder_checkpoints={"oracle": "oracle"},
+        source_types=["gss_factor_decomposition"],
+        continuous_predict_fn=oracle,
+    )
+    # Stance CSV must NOT contain the continuous cell — its per-class
+    # columns don't apply and would render as zeros, masking the cell.
+    csv_text = cst.render_csv(matrix)
+    body_lines = [line for line in csv_text.splitlines()[1:] if line.strip()]
+    assert body_lines == []
+
+
+def test_pearson_and_spearman_helpers_handle_degenerate_inputs() -> None:
+    assert cst._pearson([1.0], [1.0]) is None
+    assert cst._pearson([1.0, 1.0, 1.0], [2.0, 3.0, 4.0]) is None
+    assert cst._spearman([], []) is None
+    assert cst._zscore_rmse([1.0, 1.0], [2.0, 3.0]) is None
+    # Monotone agreement -> Spearman 1, Pearson positive but < 1 on non-linear.
+    xs = [1.0, 2.0, 3.0, 4.0]
+    ys = [1.0, 4.0, 9.0, 16.0]
+    assert cst._spearman(xs, ys) == pytest.approx(1.0, abs=1e-9)
+    assert (cst._pearson(xs, ys) or 0.0) > 0.9

--- a/tests/unit/test_gss_factors_source.py
+++ b/tests/unit/test_gss_factors_source.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from textwrap import dedent
 
@@ -12,6 +13,7 @@ pytest.importorskip("bs4")  # source registry init imports HTML scrapers
 
 from app.data.sources import SOURCES  # noqa: E402
 from app.data.sources.gss import GssFactorsScraper  # noqa: E402
+from app.data.sources import gss as gss_module  # noqa: E402
 
 
 FIXTURE_FACTORS_CSV = dedent(
@@ -142,3 +144,68 @@ def test_write_skips_none_entries(tmp_path: Path) -> None:
     count = scraper.write([None, {"x": 1}, None], output)
     assert count == 1
     assert output.read_text(encoding="utf-8").strip() == json.dumps({"x": 1})
+
+
+# ----- log guards + collision guard (issue #433) ----------------------------
+
+
+def test_fetch_listing_debug_logs_when_non_empty_input_yields_zero_rows(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Header-only CSV: csv.DictReader gives zero rows but the input is
+    # non-empty. The previous adapter swallowed this silently.
+    scraper = GssFactorsScraper()
+    with caplog.at_level(logging.DEBUG, logger=gss_module.logger.name):
+        result = scraper.fetch_listing("meeting_date,target_factor,path_factor\n")
+    assert result == []
+    assert any("factors CSV parsed to zero rows" in rec.message for rec in caplog.records)
+
+
+def test_parse_surprises_csv_debug_logs_when_non_empty_yields_zero_rows(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Wrong date column name -> every row drops on the date-missing check.
+    bad = dedent(
+        """\
+        wrong_date_column,surprise_30min_bp
+        2001-01-03,-39.3
+        """
+    )
+    with caplog.at_level(logging.DEBUG, logger=gss_module.logger.name):
+        result = gss_module._parse_surprises_csv(bad)
+    assert result == {}
+    assert any("surprises CSV parsed to zero rows" in rec.message for rec in caplog.records)
+
+
+def test_parse_surprises_csv_does_not_log_when_input_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.DEBUG, logger=gss_module.logger.name):
+        result = gss_module._parse_surprises_csv("")
+    assert result == {}
+    # Empty input is the no-op path, not a parse failure — must not log.
+    assert not any(
+        "surprises CSV parsed to zero rows" in rec.message for rec in caplog.records
+    )
+
+
+def test_side_table_merge_does_not_overwrite_factor_keys_on_collision(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Synthesise a colliding surprises table: a (hypothetical, future)
+    # column named identically to a factor key. The merge must keep the
+    # factor value and warn.
+    scraper = GssFactorsScraper()
+    scraper._surprises_by_date = {
+        "2001-01-03": {"gss_target_factor": 999.0, "surprise_30min_bp": -1.0},
+    }
+    row = {"meeting_date": "2001-01-03", "target_factor": "-32.3", "path_factor": "22.8"}
+    with caplog.at_level(logging.WARNING, logger=gss_module.logger.name):
+        parsed = scraper.parse_entry(json.dumps(row), source_url="x")
+    assert parsed is not None
+    extras = parsed["multi_axis_extras"]
+    # Factor value preserved, not overwritten by the colliding side-table key.
+    assert extras["gss_target_factor"] == pytest.approx(-32.3)
+    # Non-colliding side-table column still merged through.
+    assert extras["surprise_30min_bp"] == pytest.approx(-1.0)
+    assert any("collides with factor key" in rec.message for rec in caplog.records)


### PR DESCRIPTION
Closes #433.

- Took path 1 (continuous-target arm). #418's adapter was already emitting `gss_target_factor` / `gss_path_factor` on `multi_axis_extras` — losing them to a sign projection would have wasted the work. The harness change came in around 360 LOC including the CSV split, comfortably under the 300-net-LOC threshold the scoping note set.
- New continuous arm: `gss_factor_decomposition` joins `CROSS_SOURCE_TYPES` plus a small `CROSS_SOURCE_CONTINUOUS_TYPES` set; `build_matrix` dispatches by type and tags cells `kind=stance|continuous`. Signed score = `P(hawkish) - P(dovish)` from the same stance checkpoint, scored against each registered target column via Pearson + Spearman + z-scored RMSE (raw RMSE makes no sense across a [-1,1] score and a basis-point factor).
- `load_cross_source_rows` now carries `multi_axis_extras` and lets continuous-type rows through the LABELS / zero-weight gates — GSS rows ship `sample_weight=0` by design so the existing gate was filtering them out before they could ever reach the dispatch.
- `render_csv` skips continuous cells (per-class columns don't apply); `render_continuous_csv` writes a long-form `matrix_continuous.csv` with one row per (encoder, source, target_key).
- Adapter polish in `gss.py`: debug log when a non-empty surprises / factors CSV parses to zero rows (catches schema drift), and the side-table merge no longer blindly `dict.update`s — colliding keys keep the factor value and emit a warning. Pulled the per-row surprises parser into a helper to stay under the ruff C901 cap.

## Test plan
- [x] `ruff check` clean on the four changed files
- [x] `pytest tests/unit/test_cross_source_transfer.py tests/unit/test_gss_factors_source.py` — 33 passed locally in container
- [x] `pytest tests/unit/test_external_corpora_ingestion.py -k gss` — 4 passed (no regression on the pre-existing GSS loader)
- [ ] CI green on the worktree branch