### PR TITLE
Wire --vol-target-mode {raw,garch_residual} (#435)

### DIFF
--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -534,6 +534,17 @@ class ModelConfig:
     # mode-mixing was deferred so the CLI stays one knob deep. See ADR
     # 0027 and :mod:`app.training.rates_targets`.
     rates_target_mode: str = "raw"
+    # #435 forward-vol-target derivation. ``raw`` (default, byte-identical
+    # to the pre-#236 path) feeds the regression head the standardised
+    # ``log(forward_realized_vol_10d)`` scalar. ``garch_residual`` swaps
+    # in ``forward_realized_vol_10d_garch_residual`` (raw minus the
+    # GARCH(1,1) baseline; signed, no log) so the supervised target is
+    # the unanticipated component the classical conditional-variance
+    # model leaves on the table. Rows whose residual is ``None``
+    # (insufficient fit history per ``MIN_FIT_RETURNS`` or QMLE
+    # convergence failure) fall back to the raw target so row alignment
+    # with ``y`` is preserved. See #434 for the data side and ADR 0034.
+    vol_target_mode: str = "raw"
     # #307 macro-regime conditioning toggle. ``False`` (default) keeps
     # the pre-#307 path byte-identical: the loader leaves
     # ``FeatureVector.macro_regime_features`` at ``None`` and
@@ -613,6 +624,9 @@ class ModelConfig:
             rates_alpha=float(getattr(model, "rates_alpha", 0.5)),
             rates_target_mode=str(
                 getattr(model, "rates_target_mode", "raw") or "raw"
+            ),
+            vol_target_mode=str(
+                getattr(model, "vol_target_mode", "raw") or "raw"
             ),
             use_regime_conditioning=bool(
                 getattr(model, "use_regime_conditioning", False)

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -159,6 +159,7 @@ def build_forecaster(
             "rates_head_mode",
             "rates_alpha",
             "rates_target_mode",
+            "vol_target_mode",
             "use_regime_conditioning",
             "use_sep",
         ):
@@ -198,6 +199,12 @@ def build_forecaster(
         # were trained against.
         flat.rates_target_mode = str(
             getattr(resolved, "rates_target_mode", "raw") or "raw"
+        )  # type: ignore[assignment]
+        # #435 round-trip the forward-vol target derivation onto the
+        # persisted run summary so the checkpoint records which target
+        # the regression / dual head trained against.
+        flat.vol_target_mode = str(
+            getattr(resolved, "vol_target_mode", "raw") or "raw"
         )  # type: ignore[assignment]
         return flat
 
@@ -246,6 +253,13 @@ def build_forecaster(
     rates_alpha_value = float(kwargs.pop("rates_alpha", 0.5))
     rates_target_mode_value = str(
         kwargs.pop("rates_target_mode", "raw") or "raw"
+    )
+    # #435 forward-vol target derivation. Loop-side knob; the trainer
+    # reads it off the stashed module attribute when materialising the
+    # regression target tensor. Pop here so the ForecasterModel ctor
+    # does not see the unrecognised kwarg.
+    vol_target_mode_value = str(
+        kwargs.pop("vol_target_mode", "raw") or "raw"
     )
     # #317 finding #8: fail fast at the factory rather than silently
     # zeroing rates_heads when output_mode='regression'. The operator
@@ -345,6 +359,9 @@ def build_forecaster(
     # #305 round-trip the rates target derivation onto the built module
     # so ``ModelConfig.from_model`` recovers it on resume / inference.
     model.rates_target_mode = rates_target_mode_value  # type: ignore[assignment]
+    # #435 round-trip the forward-vol target derivation onto the built
+    # module so ``ModelConfig.from_model`` recovers it on resume.
+    model.vol_target_mode = vol_target_mode_value  # type: ignore[assignment]
     return model
 
 

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -780,6 +780,29 @@ def _parse_args() -> argparse.Namespace:
             "the target as missing rather than zero. See ADR 0027."
         ),
     )
+    parser.add_argument(
+        "--vol-target-mode",
+        type=str,
+        choices=("raw", "garch_residual"),
+        default="raw",
+        help=(
+            "Forward-vol regression-head target derivation (#435). "
+            "``raw`` (default, byte-identical to the pre-#236 path) "
+            "feeds the head the standardised "
+            "``log(forward_realized_vol_10d)`` scalar. "
+            "``garch_residual`` swaps in "
+            "``forward_realized_vol_10d_garch_residual`` (raw minus "
+            "the GARCH(1,1) 10-day-ahead 1-day-equivalent baseline; "
+            "signed, no log) so the supervised target is the "
+            "unanticipated component the classical conditional-"
+            "variance model leaves on the table. Rows whose residual "
+            "is missing (insufficient fit history per "
+            "``MIN_FIT_RETURNS`` or QMLE convergence failure) fall "
+            "back to the raw target with a log warning so row "
+            "alignment with ``y`` is preserved. See ADR 0034 and "
+            "#434 for the data side."
+        ),
+    )
     # #309 derived-text-features ablation. Default ``on`` is byte-
     # identical to the pre-#309 path; ``off`` zeros the FeatureVector
     # slots populated by the per-sentence multi-axis classifier so the
@@ -1261,6 +1284,9 @@ def _build_model_config(args: argparse.Namespace) -> ModelConfig:
         rates_target_mode=str(
             getattr(args, "rates_target_mode", "raw") or "raw"
         ),
+        vol_target_mode=str(
+            getattr(args, "vol_target_mode", "raw") or "raw"
+        ),
         use_regime_conditioning=bool(getattr(args, "use_regime_conditioning", False)),
         use_sep=bool(getattr(args, "use_sep", False)),
     )
@@ -1519,6 +1545,9 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                                 rates_target_mode=str(
                                     getattr(args, "rates_target_mode", "raw") or "raw"
                                 ),
+                                vol_target_mode=str(
+                                    getattr(args, "vol_target_mode", "raw") or "raw"
+                                ),
                                 use_regime_conditioning=bool(
                                     getattr(args, "use_regime_conditioning", False)
                                 ),
@@ -1634,6 +1663,9 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                         rates_alpha=float(getattr(args, "rates_alpha", 0.5)),
                         rates_target_mode=str(
                             getattr(args, "rates_target_mode", "raw") or "raw"
+                        ),
+                        vol_target_mode=str(
+                            getattr(args, "vol_target_mode", "raw") or "raw"
                         ),
                         use_regime_conditioning=bool(
                             getattr(args, "use_regime_conditioning", False)

--- a/backend/app/training/checkpoint.py
+++ b/backend/app/training/checkpoint.py
@@ -152,6 +152,12 @@ def _coerce_payload_config(payload: dict[str, Any] | None) -> ModelConfig:
                 raw.get("rates_head_mode", "regression") or "regression"
             ),
             rates_alpha=float(raw.get("rates_alpha", 0.5)),
+            # #435: forward the new vol-target-mode so a checkpoint trained
+            # under --vol-target-mode=garch_residual rehydrates with the
+            # right target column on eval / calibration paths. Pre-#435
+            # checkpoints leave the key absent and the default collapses
+            # to the raw column.
+            vol_target_mode=str(raw.get("vol_target_mode", "raw") or "raw"),
             # #423: mirror the #292 rates-fields landing for the #273
             # multi-task loss knob + the four per-axis lambda fields.
             # Pre-#273 checkpoints leave these absent and the defaults

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -59,6 +59,16 @@ _COMPILE_INCOMPATIBLE_ARCHITECTURES: frozenset[str] = frozenset({"informer", "tf
 _AMP_INCOMPATIBLE_ARCHITECTURES: frozenset[str] = frozenset({"informer", "tft"})
 
 
+# #435 forward-vol regression-target derivation modes. ``raw`` (default)
+# feeds the dual-head MSE branch ``log(forward_realized_vol_10d)``;
+# ``garch_residual`` swaps in ``forward_realized_vol_10d_garch_residual``
+# (raw minus the GARCH(1,1) baseline; signed, no log). The literal
+# vocabulary is pinned here so the CLI ``choices=`` tuple and the loop
+# resolver agree.
+VOL_TARGET_MODES: tuple[str, ...] = ("raw", "garch_residual")
+DEFAULT_VOL_TARGET_MODE: str = "raw"
+
+
 def _resolve_device(device: str | torch.device | None = None) -> torch.device:
     if device is not None:
         return torch.device(device)
@@ -1668,6 +1678,7 @@ def _build_partition_log_rv_target(
     *,
     vol_regime_quantiles: "Sequence[float]",
     log_rv_scaler: "tuple[float, float] | None" = None,
+    vol_target_mode: str = DEFAULT_VOL_TARGET_MODE,
 ) -> tuple[torch.Tensor | None, "tuple[float, float] | None"]:
     """Materialise per-partition log(forward_realized_vol_10d) targets (#304).
 
@@ -1694,12 +1705,32 @@ def _build_partition_log_rv_target(
     initial MSE ~16 while CE ~log(3); alpha=0.5 left MSE owning ~93%
     of the gradient) drops to MSE ~1 once the targets sit in unit
     variance, so the alpha knob behaves like a true mixing weight.
+
+    ``vol_target_mode`` (#435) selects between the raw
+    ``log(forward_realized_vol_10d)`` target (``"raw"``, default;
+    byte-identical to the pre-#236 path) and the GARCH(1,1) residual
+    ``forward_realized_vol_10d_garch_residual`` (``"garch_residual"``;
+    signed, no log). Rows whose residual is ``None`` (insufficient fit
+    history per ``MIN_FIT_RETURNS`` or QMLE convergence failure) fall
+    back to the raw ``log(forward_realized_vol_10d)`` so the per-row
+    count stays aligned with ``y``; the fallback emits a single log
+    warning at the partition boundary so the operator can grep the run
+    log for how many rows the data-side decomposition silently dropped.
     """
 
     from app.training.loaders import vol_regime_class_for
 
+    mode = str(vol_target_mode).lower()
+    if mode not in VOL_TARGET_MODES:
+        raise ValueError(
+            f"unsupported vol_target_mode={vol_target_mode!r}; "
+            f"expected one of {VOL_TARGET_MODES}"
+        )
+    residual_mode = mode == "garch_residual"
+
     values: list[float] = []
     rejected_non_finite = 0
+    residual_fallback_count = 0
     for sequence_group in sequence_groups:
         if len(sequence_group) < SEQUENCE_LENGTH + 1:
             continue
@@ -1732,7 +1763,35 @@ def _build_partition_log_rv_target(
             # ``_is_finite_positive_forward_vol`` narrowed the type
             # at runtime; mypy does not propagate the guard so the
             # explicit ``float(...)`` cast lands here.
-            values.append(math.log(float(forward_vol)))  # type: ignore[arg-type]
+            raw_value = math.log(float(forward_vol))  # type: ignore[arg-type]
+            if residual_mode:
+                residual = getattr(
+                    target_row,
+                    "forward_realized_vol_10d_garch_residual",
+                    None,
+                )
+                # The residual is signed (raw - baseline) and can be
+                # legitimately negative; only ``None`` / NaN / inf
+                # trigger the raw-target fallback. Pre-#236 parquets
+                # carry ``None`` on every row, so the fallback also
+                # covers the legacy training-package case.
+                if residual is None:
+                    residual_fallback_count += 1
+                    values.append(raw_value)
+                    continue
+                try:
+                    residual_value = float(residual)
+                except (TypeError, ValueError):
+                    residual_fallback_count += 1
+                    values.append(raw_value)
+                    continue
+                if not math.isfinite(residual_value):
+                    residual_fallback_count += 1
+                    values.append(raw_value)
+                    continue
+                values.append(residual_value)
+            else:
+                values.append(raw_value)
     if not values:
         return None, log_rv_scaler
 
@@ -1756,6 +1815,13 @@ def _build_partition_log_rv_target(
             "[dual-head] rejected %d row(s) with non-finite or non-positive "
             "forward_realized_vol_10d from the log_rv regression target",
             rejected_non_finite,
+        )
+    if residual_fallback_count:
+        _logger.warning(
+            "[dual-head] vol_target_mode='garch_residual': %d row(s) had "
+            "no GARCH residual (insufficient fit history or QMLE "
+            "convergence failure); fell back to log(forward_realized_vol_10d)",
+            residual_fallback_count,
         )
     return standardised, scaler_out
 
@@ -2470,6 +2536,15 @@ def train_model(
     active_rates_target_mode = str(
         getattr(active_model_config, "rates_target_mode", "raw") or "raw"
     )
+    # #435 forward-vol target derivation. ``raw`` (default) keeps the
+    # pre-#236 ``log(forward_realized_vol_10d)`` MSE target byte-
+    # identical; ``garch_residual`` swaps in the GARCH(1,1) residual
+    # (raw minus the conditional-variance baseline) so the regression
+    # head learns the unanticipated component.
+    active_vol_target_mode = str(
+        getattr(active_model_config, "vol_target_mode", DEFAULT_VOL_TARGET_MODE)
+        or DEFAULT_VOL_TARGET_MODE
+    )
     rates_heads_active = bool(active_rates_heads)
     train_rates_targets: RatesPartitionTensors | None = None
     val_rates_targets: RatesPartitionTensors | None = None
@@ -2585,7 +2660,9 @@ def train_model(
             )
         if dual_head_active and active_output_mode == "classification":
             train_log_rv, log_rv_scaler = _build_partition_log_rv_target(
-                train_groups, vol_regime_quantiles=fitted_quantiles
+                train_groups,
+                vol_regime_quantiles=fitted_quantiles,
+                vol_target_mode=active_vol_target_mode,
             )
         # #292 rates heads -- per-partition targets fitted on train.
         if rates_heads_active and active_output_mode == "classification":
@@ -2647,6 +2724,7 @@ def train_model(
                 val_groups,
                 vol_regime_quantiles=fitted_quantiles,
                 log_rv_scaler=log_rv_scaler,
+                vol_target_mode=active_vol_target_mode,
             )
         if rates_heads_active and active_output_mode == "classification":
             from app.training.rates_targets import build_partition_rates_targets
@@ -2696,6 +2774,7 @@ def train_model(
                 test_groups,
                 vol_regime_quantiles=fitted_quantiles,
                 log_rv_scaler=log_rv_scaler,
+                vol_target_mode=active_vol_target_mode,
             )
         if rates_heads_active and active_output_mode == "classification":
             from app.training.rates_targets import build_partition_rates_targets
@@ -2800,6 +2879,7 @@ def train_model(
             legacy_full_log_rv, log_rv_scaler = _build_partition_log_rv_target(
                 active_sequence_groups,
                 vol_regime_quantiles=legacy_fitted_quantiles,
+                vol_target_mode=active_vol_target_mode,
             )
         text_emb_tensor, text_missing_tensor, _text_emb_dim = _build_text_embedding_tensors(
             active_sequence_groups,

--- a/tests/unit/test_multi_task_checkpoint_persistence.py
+++ b/tests/unit/test_multi_task_checkpoint_persistence.py
@@ -174,6 +174,39 @@ def test_coerce_payload_config_defaults_when_multi_task_absent() -> None:
     assert rebuilt.multi_task_lambda_topic == 0.3
 
 
+def test_coerce_payload_config_threads_vol_target_mode() -> None:
+    """`_coerce_payload_config` rebuilds the vol-target-mode (#435).
+
+    A checkpoint trained under ``--vol-target-mode garch_residual`` must
+    rebuild a config that names the residual column on the eval /
+    calibration paths. Pre-#435 the helper silently dropped the key.
+    """
+
+    from app.training.checkpoint import _coerce_payload_config
+
+    config = ModelConfig(
+        output_mode="regression",
+        vol_target_mode="garch_residual",
+        n_classes=3,
+    )
+
+    rebuilt = _coerce_payload_config({"model_config": config.to_dict()})
+
+    assert rebuilt.vol_target_mode == "garch_residual"
+
+
+def test_coerce_payload_config_defaults_vol_target_mode_when_absent() -> None:
+    """Pre-#435 checkpoints leave the key absent; the rebuilt config
+    must collapse to ``raw`` so the legacy contract stays byte-identical.
+    """
+
+    from app.training.checkpoint import _coerce_payload_config
+
+    rebuilt = _coerce_payload_config({"model_config": {"input_size": 6}})
+
+    assert rebuilt.vol_target_mode == "raw"
+
+
 def test_checkpoint_omits_multi_task_weights_when_flag_off(tmp_path: Path) -> None:
     """Default (multi_task_loss=False): no per-axis payload, no contract
     drift for every pre-#273 checkpoint.

--- a/tests/unit/test_vol_target_mode.py
+++ b/tests/unit/test_vol_target_mode.py
@@ -1,0 +1,379 @@
+"""``--vol-target-mode {raw,garch_residual}`` switch wiring (#435).
+
+PR #434 landed the data side (events.parquet columns + audit + ADR
+0034 + tests) but the trainer always read from
+``forward_realized_vol_10d``. This wiring threads a CLI knob through
+``ModelConfig`` and ``_build_partition_log_rv_target`` so the canonical
+sweep can produce a §6 row against the GARCH-residual variant.
+
+The tests pin four layers:
+
+- ``ModelConfig.vol_target_mode`` defaults to ``raw`` and round-trips
+  through the dataclass field-name machinery (``_coerce_model_config``);
+- the default-off byte-identity guarantee: with ``vol_target_mode='raw'``
+  the per-partition log_rv tensor is bit-identical to the pre-#435
+  builder output;
+- ``vol_target_mode='garch_residual'`` reads the residual column and
+  fits the standardiser on residual values (the fixture's residual is
+  the absolute value of the raw target, so the fitted mean diverges
+  from the raw-mode fit and the standardised tensor diverges too);
+- the ``None``-residual fallback policy: rows with no residual fall
+  back to ``log(forward_realized_vol_10d)`` so row count stays aligned
+  with ``y``; a partition where the residual is populated on a strict
+  subset of rows produces a mixed tensor and emits a single log warning.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import math
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.config import FeatureVector, ModelConfig  # noqa: E402
+from app.training.loop import (  # noqa: E402
+    DEFAULT_VOL_TARGET_MODE,
+    VOL_TARGET_MODES,
+    _build_partition_log_rv_target,
+    train_model,
+)
+
+
+# ---------------------------------------------------------------------------
+# ModelConfig surface
+# ---------------------------------------------------------------------------
+
+
+def test_vol_target_modes_canonical_tuple() -> None:
+    assert VOL_TARGET_MODES == ("raw", "garch_residual")
+    assert DEFAULT_VOL_TARGET_MODE == "raw"
+
+
+def test_model_config_default_vol_target_mode_is_raw() -> None:
+    """Pre-#435 defaults persist; explicit opt-in only flips the flag."""
+
+    config = ModelConfig()
+    assert config.vol_target_mode == "raw"
+
+
+def test_model_config_vol_target_mode_round_trip_through_coerce() -> None:
+    """A dict-payload checkpoint round-trips the new field via the field-name machinery."""
+
+    from app.training.loop import _coerce_model_config
+
+    payload = {
+        "vol_target_mode": "garch_residual",
+        "output_mode": "classification",
+        "head_mode": "dual",
+    }
+    rebuilt = _coerce_model_config(payload)
+    assert rebuilt.vol_target_mode == "garch_residual"
+
+
+# ---------------------------------------------------------------------------
+# Per-partition log_rv builder
+# ---------------------------------------------------------------------------
+
+
+def _dummy_feature_vector(
+    *,
+    day: int,
+    vol: float,
+    residual: float | None = None,
+) -> FeatureVector:
+    fv = FeatureVector(
+        date=str(_dt.date(2025, 1, 1) + _dt.timedelta(days=day - 1)),
+        sentiment_score=0.0,
+        market_close=100.0,
+        market_volatility=0.01,
+        close_change_pct=0.0,
+        volatility_change=0.0,
+        elapsed_time=0.0,
+        forward_realized_vol_10d=vol,
+    )
+    fv.forward_realized_vol_10d_garch_residual = residual
+    return fv
+
+
+def _make_groups(
+    n: int = 30,
+    *,
+    populate_residual: bool = True,
+) -> list[list[FeatureVector]]:
+    """Synthetic walk-forward fold whose supervised rows (i >= 20) carry
+    a monotonic forward-vol curve. When ``populate_residual`` is True
+    the residual is set to ``abs(log(vol))`` so the per-fold scaler
+    fitted under ``garch_residual`` mode lands on a materially different
+    mean than the raw-mode fit (the absolute value collapses the
+    log-vol negatives onto positives).
+    """
+
+    def _vol(i: int) -> float:
+        return 0.01 + 0.001 * i
+
+    def _residual(i: int) -> float | None:
+        if not populate_residual:
+            return None
+        return abs(math.log(_vol(i)))
+
+    return [
+        [
+            _dummy_feature_vector(
+                day=i + 1,
+                vol=_vol(i),
+                residual=_residual(i),
+            )
+            for i in range(n)
+        ]
+    ]
+
+
+def test_log_rv_raw_mode_byte_identical_to_pre_435_path() -> None:
+    """Default ``vol_target_mode='raw'`` matches the unparameterised call.
+
+    The previous builder signature accepted ``(sequence_groups,
+    vol_regime_quantiles=, log_rv_scaler=)``; the new ``vol_target_mode``
+    kwarg defaults to ``'raw'`` so any caller that does not pass it
+    sees the identical tensor. Without the residual column populated
+    the explicit ``'garch_residual'`` mode would have fallen back to
+    raw row-by-row, also matching — this test pins the strict default
+    path (no fallback log line, no residual lookup) only.
+    """
+
+    groups = _make_groups(n=30, populate_residual=False)
+    quantiles = (0.012, 0.018)
+
+    default_tensor, default_scaler = _build_partition_log_rv_target(
+        groups, vol_regime_quantiles=quantiles
+    )
+    raw_tensor, raw_scaler = _build_partition_log_rv_target(
+        groups, vol_regime_quantiles=quantiles, vol_target_mode="raw"
+    )
+    assert default_tensor is not None
+    assert raw_tensor is not None
+    # Byte-identical: same shape, same values, same scaler.
+    assert default_tensor.shape == raw_tensor.shape
+    assert torch.equal(default_tensor, raw_tensor)
+    assert default_scaler == raw_scaler
+
+
+def test_log_rv_garch_residual_mode_reads_residual_column() -> None:
+    """``garch_residual`` mode fits the standardiser on the residual values."""
+
+    groups = _make_groups(n=30, populate_residual=True)
+    quantiles = (0.012, 0.018)
+
+    raw_tensor, raw_scaler = _build_partition_log_rv_target(
+        groups, vol_regime_quantiles=quantiles, vol_target_mode="raw"
+    )
+    residual_tensor, residual_scaler = _build_partition_log_rv_target(
+        groups,
+        vol_regime_quantiles=quantiles,
+        vol_target_mode="garch_residual",
+    )
+    assert raw_tensor is not None
+    assert residual_tensor is not None
+    assert raw_scaler is not None
+    assert residual_scaler is not None
+    # Row count is identical (same group filter) but the values diverge
+    # because the fixture's residual is the absolute value of log(vol)
+    # rather than log(vol) itself.
+    assert raw_tensor.shape == residual_tensor.shape
+    assert not torch.allclose(raw_tensor, residual_tensor)
+    # The two modes fit independent scalers; the residual fit centres on
+    # the absolute-value mean which is materially different from the
+    # raw log-vol mean. The raw log-vol mean sits around -4.4 (log of
+    # ~0.012); the residual mean equals abs(log) ≈ +4.4. So the fitted
+    # means must differ by a non-trivial amount.
+    assert abs(raw_scaler[0] - residual_scaler[0]) > 1.0
+
+
+def test_log_rv_garch_residual_missing_falls_back_to_raw(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Rows with ``residual=None`` fall back to log(raw) with a log line.
+
+    Row alignment with ``y`` is the load-bearing invariant: dropping
+    rows would break the TensorDataset row-count contract the dual-head
+    DataLoader rebuilds positionally. The fallback emits one warning at
+    the partition boundary so the operator can audit how many rows the
+    data-side decomposition silently lacked (insufficient fit history
+    or QMLE convergence failure per #434).
+    """
+
+    n = 30
+    groups: list[list[FeatureVector]] = []
+    sequence: list[FeatureVector] = []
+    for i in range(n):
+        # Populate the residual on the first half of the supervised
+        # range only; the second half falls back to raw.
+        if i >= 20 and i < 25:
+            residual: float | None = abs(math.log(0.01 + 0.001 * i))
+        else:
+            residual = None
+        sequence.append(
+            _dummy_feature_vector(
+                day=i + 1,
+                vol=0.01 + 0.001 * i,
+                residual=residual,
+            )
+        )
+    groups.append(sequence)
+    quantiles = (0.012, 0.018)
+
+    with caplog.at_level(logging.WARNING, logger="app.training.loop"):
+        residual_tensor, _scaler = _build_partition_log_rv_target(
+            groups,
+            vol_regime_quantiles=quantiles,
+            vol_target_mode="garch_residual",
+        )
+        raw_tensor, _ = _build_partition_log_rv_target(
+            groups,
+            vol_regime_quantiles=quantiles,
+            vol_target_mode="raw",
+        )
+    assert residual_tensor is not None
+    assert raw_tensor is not None
+    # Both tensors carry the same row count -- the fallback preserves
+    # row alignment with y.
+    assert residual_tensor.shape == raw_tensor.shape
+    # The warning fires exactly once at the partition boundary and
+    # records the fallback row count (5 rows populated, n - 5 fell back).
+    fallback_records = [
+        rec for rec in caplog.records
+        if "vol_target_mode='garch_residual'" in rec.getMessage()
+        and "fell back" in rec.getMessage()
+    ]
+    assert len(fallback_records) == 1
+    assert "row(s)" in fallback_records[0].getMessage()
+
+
+def test_log_rv_garch_residual_no_warning_when_every_row_has_residual(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Clean residual coverage -> no fallback log line."""
+
+    groups = _make_groups(n=30, populate_residual=True)
+    quantiles = (0.012, 0.018)
+
+    with caplog.at_level(logging.WARNING, logger="app.training.loop"):
+        residual_tensor, _scaler = _build_partition_log_rv_target(
+            groups,
+            vol_regime_quantiles=quantiles,
+            vol_target_mode="garch_residual",
+        )
+    assert residual_tensor is not None
+    fallback_records = [
+        rec for rec in caplog.records
+        if "fell back" in rec.getMessage()
+    ]
+    assert fallback_records == []
+
+
+def test_log_rv_unknown_vol_target_mode_raises() -> None:
+    """A typo in vol_target_mode raises rather than silently falling back."""
+
+    groups = _make_groups(n=5)
+    with pytest.raises(ValueError, match="vol_target_mode"):
+        _build_partition_log_rv_target(
+            groups,
+            vol_regime_quantiles=(0.012, 0.018),
+            vol_target_mode="not_a_mode",
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end smoke through train_model
+# ---------------------------------------------------------------------------
+
+
+def _make_walk_forward_groups_with_residual(
+    n: int = 40,
+    *,
+    populate_residual: bool = True,
+) -> list[list[FeatureVector]]:
+    def _vol(i: int) -> float:
+        return 0.01 + 0.001 * i
+
+    def _residual(i: int) -> float | None:
+        if not populate_residual:
+            return None
+        # Sign-flip half so the residual centres around zero rather
+        # than the all-positive log-vol value; this gives the
+        # standardiser a non-trivial std to fit on.
+        sign = 1.0 if i % 2 == 0 else -1.0
+        return sign * 0.005 * (i % 5 + 1)
+
+    return [
+        [
+            _dummy_feature_vector(
+                day=i + 1,
+                vol=_vol(i),
+                residual=_residual(i),
+            )
+            for i in range(n)
+        ]
+    ]
+
+
+def test_train_model_smoke_vol_target_mode_garch_residual() -> None:
+    """1-epoch training run with ``garch_residual`` completes and persists the mode."""
+
+    groups = _make_walk_forward_groups_with_residual(n=40, populate_residual=True)
+    config = ModelConfig(
+        output_mode="classification",
+        n_classes=3,
+        hidden_size=16,
+        head_hidden_size=8,
+        head_mode="dual",
+        regression_alpha=0.5,
+        vol_target_mode="garch_residual",
+    )
+    result = train_model(
+        model_config=config,
+        train_sequence_groups=groups,
+        val_sequence_groups=groups,
+        test_sequence_groups=groups,
+        epochs=1,
+        batch_size=8,
+        seed=11,
+        save_checkpoint=False,
+        use_compile=False,
+        use_amp=False,
+    )
+    assert result.summary.epochs_completed == 1
+    persisted_config = ModelConfig.from_model(result.model)
+    assert persisted_config.vol_target_mode == "garch_residual"
+
+
+def test_train_model_smoke_vol_target_mode_raw_default() -> None:
+    """Default ``vol_target_mode='raw'`` runs the pre-#435 path."""
+
+    groups = _make_walk_forward_groups_with_residual(n=40, populate_residual=False)
+    config = ModelConfig(
+        output_mode="classification",
+        n_classes=3,
+        hidden_size=16,
+        head_hidden_size=8,
+        head_mode="dual",
+        regression_alpha=0.5,
+        # vol_target_mode defaults to 'raw'.
+    )
+    result = train_model(
+        model_config=config,
+        train_sequence_groups=groups,
+        val_sequence_groups=groups,
+        test_sequence_groups=groups,
+        epochs=1,
+        batch_size=8,
+        seed=11,
+        save_checkpoint=False,
+        use_compile=False,
+        use_amp=False,
+    )
+    assert result.summary.epochs_completed == 1
+    persisted_config = ModelConfig.from_model(result.model)
+    assert persisted_config.vol_target_mode == "raw"


### PR DESCRIPTION
Closes #435.

- New ``--vol-target-mode {raw,garch_residual}`` on ``train_forecaster.py`` defaulting to ``raw``; mirrors the ``--rates-target-mode`` (#305) shape. ``ModelConfig.vol_target_mode`` rides through ``_coerce_model_config`` + ``ModelConfig.from_model`` (factory stash) so the active mode persists on the run summary.
- ``_build_partition_log_rv_target`` reads the mode off ``active_model_config`` and swaps in ``forward_realized_vol_10d_garch_residual`` when ``residual_mode`` is on. Rows with ``residual=None`` (insufficient fit history per ``MIN_FIT_RETURNS`` or QMLE convergence failure per #434) **fall back to ``log(raw)``** so row alignment with ``y`` is preserved — drop-row would break the TensorDataset row-count contract the dual-head DataLoader rebuilds positionally. A single warning fires at the partition boundary so the operator can grep the fallback count.
- Default ``--vol-target-mode raw`` stays byte-identical to the pre-#236 path: the new test pins the default-call output against the explicit raw-mode call (same shape, same values, same scaler).
- Smoke tests pin the residual-mode read + the ``None``-fallback policy + the unknown-mode ``ValueError``.

Refs #236, #434, #405.