### PR TITLE
Dual-head retrofit: regression card on /analyze + R^2 in eval (#304)

### DIFF
--- a/backend/app/evaluation/metrics.py
+++ b/backend/app/evaluation/metrics.py
@@ -65,6 +65,16 @@ class EvaluationMetrics:
     regression_rmse_log_rv: float | None = None
     regression_mae_log_rv: float | None = None
     regression_loss: float | None = None
+    # #304 acceptance: per-fold R^2 on log_rv joins the existing
+    # RMSE/MAE pair so the three-way comparison table (classification-
+    # only, regression-only, dual) can report a scale-free goodness-of-
+    # fit alongside the absolute-error metrics. ``1 - SSE / SST`` over
+    # the partition's standardised log(forward_realized_vol_10d)
+    # values; collapses to ``None`` on a partition where SST is 0
+    # (constant target — pathological fixture only) so the consumer
+    # can tell ``no head ran`` apart from ``head ran on a degenerate
+    # partition``.
+    regression_r2_log_rv: float | None = None
     # #292 rates-complex per-head metrics. Keyed on the head short
     # name (``2y`` / ``5y`` / ``terminal``); each value is a dict
     # mirroring the regression-metric panel from

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -622,6 +622,7 @@ def _build_analyze_response(
         "series": forecast["series"],
         "multi_axis": _build_multi_axis_block(payload.text, sentiment),
         "regime_classification": regime_card,
+        "regime_regression": _build_regime_regression_block(regime_card),
         "regime_classification_status": regime_status,
     }
     if getattr(payload, "include_xai", False):
@@ -644,6 +645,43 @@ def _build_analyze_response(
             xai_block["panels"] = panel_attributions
         response["xai"] = xai_block
     return response
+
+
+def _build_regime_regression_block(
+    regime_card: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Derive the sibling ``regime_regression`` block from the classification card (#304).
+
+    The dual-head retrofit keeps the classification card as the
+    product-facing surface and exposes the regression head's point
+    estimate + 90% conformal interval as a standalone sibling block so
+    a frontend can render it behind a "show details" toggle without
+    re-deriving the read out of the classification card. The block is
+    emitted only when the classification card carries a non-null
+    ``log_rv_point`` (i.e. ``head_mode`` in ``regression`` / ``dual``);
+    otherwise the field stays ``None`` on the response and the legacy
+    classification-only payload shape is byte-identical.
+    """
+
+    if not isinstance(regime_card, dict):
+        return None
+    log_rv_point = regime_card.get("log_rv_point")
+    if log_rv_point is None:
+        return None
+    block: dict[str, Any] = {
+        "log_rv_point": float(log_rv_point),
+        "log_rv_lower": regime_card.get("log_rv_lower"),
+        "log_rv_upper": regime_card.get("log_rv_upper"),
+    }
+    coverage = regime_card.get("coverage")
+    # Coverage on the classification card maps to the calibrated APS
+    # set's nominal coverage. The regression interval rides off the
+    # same conformal manifest (residual_quantile_volatility) so it
+    # inherits the same nominal coverage for now; when the regression
+    # head gets a dedicated quantile sidecar this read switches over.
+    if isinstance(coverage, int | float) and coverage > 0:
+        block["coverage"] = float(coverage)
+    return block
 
 
 def _safe_regime_classification(history_vectors: list[Any]) -> dict[str, Any] | None:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -443,6 +443,45 @@ class RegimeClassificationCard(BaseModel):
     )
 
 
+class RegimeRegressionCard(BaseModel):
+    """Regression-head sibling block on the /analyze response (#304).
+
+    The classification card stays the headline; this block carries the
+    same dual-head regression output (``log_rv_point`` + symmetric 90%
+    conformal band) as a standalone surface so a downstream consumer
+    can read the continuous prediction without parsing it out of the
+    classification card. Populated only when the active checkpoint
+    mounts the regression head (``head_mode`` in ``regression`` /
+    ``dual``) AND ``build_regime_classification_card`` returned a card
+    whose ``log_rv_point`` is non-null; otherwise the field stays
+    ``None`` on the response.
+
+    Units mirror :class:`RegimeClassificationCard`: ``log_rv_point`` is
+    in standardised log(forward realized vol) space (the per-fold
+    train-slice standardiser the dual-head trainer fits, see
+    ``log_rv_scaler`` on the run summary). ``log_rv_lower`` /
+    ``log_rv_upper`` are the symmetric conformal interval at
+    ``coverage`` nominal coverage; on a checkpoint without a conformal
+    sidecar the bounds collapse to ``None`` even when the point
+    estimate is populated.
+    """
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    log_rv_point: float
+    log_rv_lower: float | None = None
+    log_rv_upper: float | None = None
+    coverage: float | None = Field(
+        default=None,
+        description=(
+            "Nominal coverage on the conformal interval (0.9 by default; "
+            "matches the manifest's nominal_coverage when the sidecar "
+            "carries one). None when the regression head is mounted but "
+            "no conformal manifest is on disk."
+        ),
+    )
+
+
 class InferenceStatusSurface(BaseModel):
     """Structured error surface for the per-card inference helpers (#341).
 
@@ -481,6 +520,13 @@ class AnalyzeResponse(BaseModel):
     credibility: CredibilityResponse | None = None
     multi_axis: MultiAxisBlock | None = None
     regime_classification: RegimeClassificationCard | None = None
+    # #304 regression sibling. Populated when the active checkpoint
+    # mounts the dual-head regression head AND the classification card
+    # carried a non-null ``log_rv_point``. The classification card
+    # stays the headline; this block surfaces the continuous
+    # prediction + 90% conformal interval as a standalone read for the
+    # frontend's "show details" toggle on the regime panel.
+    regime_regression: RegimeRegressionCard | None = None
     # #341 sibling status surface so an operator can grep the JSON
     # response for the structured error branch when the regime card
     # degrades. Mutually exclusive with ``regime_classification``

--- a/backend/app/training/checkpoint.py
+++ b/backend/app/training/checkpoint.py
@@ -104,6 +104,13 @@ def _metrics_from_payload(payload: dict[str, Any] | None) -> EvaluationMetrics |
                 regime_loss=_opt_float("regime_loss"),
                 classification_breakdown=breakdown,
                 rates_metrics=rates_metrics,
+                # #304 dual-head regression surface. Pre-#304
+                # checkpoints leave these absent; the defaults give
+                # back ``None`` so the legacy contract holds.
+                regression_rmse_log_rv=_opt_float("regression_rmse_log_rv"),
+                regression_mae_log_rv=_opt_float("regression_mae_log_rv"),
+                regression_loss=_opt_float("regression_loss"),
+                regression_r2_log_rv=_opt_float("regression_r2_log_rv"),
             )
         except (KeyError, TypeError, ValueError):
             return None
@@ -158,6 +165,13 @@ def _coerce_payload_config(payload: dict[str, Any] | None) -> ModelConfig:
             # checkpoints leave the key absent and the default collapses
             # to the raw column.
             vol_target_mode=str(raw.get("vol_target_mode", "raw") or "raw"),
+            # #304 dual-head: forward head_mode + regression_alpha so a
+            # dual-head checkpoint rehydrates the same head config the
+            # run trained against. Pre-#304 checkpoints leave the keys
+            # absent and the defaults collapse to the canonical config
+            # the ModelConfig dataclass ships with.
+            head_mode=str(raw.get("head_mode", "dual") or "dual"),
+            regression_alpha=float(raw.get("regression_alpha", 0.5)),
             # #423: mirror the #292 rates-fields landing for the #273
             # multi-task loss knob + the four per-axis lambda fields.
             # Pre-#273 checkpoints leave these absent and the defaults

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -1887,6 +1887,14 @@ def _evaluate_model(
     log_rv_squared_error_sum = torch.zeros((), dtype=torch.float64, device=device)
     log_rv_abs_error_sum = torch.zeros((), dtype=torch.float64, device=device)
     log_rv_items = torch.zeros((), dtype=torch.int64, device=device)
+    # #304 acceptance: R^2 on log_rv joins MAE / RMSE. R^2 needs the
+    # target's variance over the partition (SST) so the loop also
+    # accumulates the partition-wide sum + sum-of-squares of the
+    # standardised log_rv target. SST is computed once at the end as
+    # ``sum(y^2) - sum(y)^2 / n``; the running-mean variant would
+    # accumulate float64 cancellation error on long val/test sweeps.
+    log_rv_target_sum = torch.zeros((), dtype=torch.float64, device=device)
+    log_rv_target_squared_sum = torch.zeros((), dtype=torch.float64, device=device)
     # Per-axis loss bookkeeping for the multi-task eval path (#273
     # follow-up). Each axis accumulates ``loss * batch_size`` so the
     # final mean matches the per-batch mean ``MultiTaskLoss`` emits
@@ -2067,6 +2075,8 @@ def _evaluate_model(
                     diff = log_rv_pred - log_rv_true
                     log_rv_squared_error_sum += torch.square(diff).sum()
                     log_rv_abs_error_sum += torch.abs(diff).sum()
+                    log_rv_target_sum += log_rv_true.sum()
+                    log_rv_target_squared_sum += torch.square(log_rv_true).sum()
                     log_rv_items += int(diff.shape[0])
             elif has_regression_head:
                 # #304 single-task dual-head eval. ``forward_multi_task``
@@ -2094,6 +2104,8 @@ def _evaluate_model(
                     diff = log_rv_pred - log_rv_true
                     log_rv_squared_error_sum += torch.square(diff).sum()
                     log_rv_abs_error_sum += torch.abs(diff).sum()
+                    log_rv_target_sum += log_rv_true.sum()
+                    log_rv_target_squared_sum += torch.square(log_rv_true).sum()
                     log_rv_items += int(diff.shape[0])
             elif multimodal_forward is not None:
                 modality_out = multimodal_forward(batch_x, **kwargs)
@@ -2239,6 +2251,7 @@ def _evaluate_model(
         regression_rmse_log_rv_value: float | None = None
         regression_mae_log_rv_value: float | None = None
         regression_loss_value: float | None = None
+        regression_r2_log_rv_value: float | None = None
         if has_regression_head and log_rv_items_int > 0:
             regression_loss_value = float(
                 log_rv_squared_error_sum.item() / log_rv_items_int
@@ -2247,6 +2260,18 @@ def _evaluate_model(
             regression_mae_log_rv_value = float(
                 log_rv_abs_error_sum.item() / log_rv_items_int
             )
+            # R^2 = 1 - SSE / SST. SST is the partition's sum of
+            # squared deviations from the mean target; we accumulate
+            # sum + sum-of-squares above so SST = sum(y^2) - sum(y)^2 / n.
+            # A constant-target partition (SST = 0) collapses R^2 to
+            # ``None`` so the consumer can tell ``no head ran`` apart
+            # from ``head ran on a degenerate partition``.
+            sse_value = float(log_rv_squared_error_sum.item())
+            sum_y = float(log_rv_target_sum.item())
+            sum_y_sq = float(log_rv_target_squared_sum.item())
+            sst_value = sum_y_sq - (sum_y * sum_y) / float(log_rv_items_int)
+            if sst_value > 0.0:
+                regression_r2_log_rv_value = 1.0 - sse_value / sst_value
 
         return EvaluationMetrics(
             loss=regime_loss,
@@ -2264,6 +2289,7 @@ def _evaluate_model(
             regression_rmse_log_rv=regression_rmse_log_rv_value,
             regression_mae_log_rv=regression_mae_log_rv_value,
             regression_loss=regression_loss_value,
+            regression_r2_log_rv=regression_r2_log_rv_value,
         )
 
     close_value = float(close_squared_error.item())

--- a/frontend/components/analyze/PreviewPanels.tsx
+++ b/frontend/components/analyze/PreviewPanels.tsx
@@ -11,6 +11,7 @@ import type {
   CredibilityResponse,
   MultiAxisResponse,
   RegimeClassificationResponse,
+  RegimeRegressionResponse,
   XaiResponse,
 } from "@/lib/analyze/types";
 
@@ -19,6 +20,9 @@ interface PreviewPanelsProps {
   xai?: XaiResponse;
   credibility?: CredibilityResponse;
   regimeClassification?: RegimeClassificationResponse | null;
+  // #304 dual-head sibling block; surfaces behind the regime card's
+  // "show regression details" toggle when populated.
+  regimeRegression?: RegimeRegressionResponse | null;
   slot: "cards" | "xai" | "credibility" | "regime";
 }
 
@@ -27,6 +31,7 @@ export default function PreviewPanels({
   xai,
   credibility,
   regimeClassification,
+  regimeRegression,
   slot,
 }: PreviewPanelsProps) {
   if (slot === "cards") {
@@ -34,7 +39,7 @@ export default function PreviewPanels({
   }
   if (slot === "regime") {
     if (!regimeClassification) return null;
-    return <RegimeClassificationCard regime={regimeClassification} />;
+    return <RegimeClassificationCard regime={regimeClassification} regression={regimeRegression} />;
   }
   if (slot === "xai") {
     return <XaiPanel xai={xai ?? SAMPLE_XAI} previewMode={!xai} />;

--- a/frontend/components/analyze/RegimeClassificationCard.tsx
+++ b/frontend/components/analyze/RegimeClassificationCard.tsx
@@ -1,12 +1,23 @@
-import { ShieldCheck } from "lucide-react";
+import { useState } from "react";
+import { ChevronDown, ChevronUp, ShieldCheck } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
-import type { RegimeClassificationResponse } from "@/lib/analyze/types";
+import type {
+  RegimeClassificationResponse,
+  RegimeRegressionResponse,
+} from "@/lib/analyze/types";
 
 interface RegimeClassificationCardProps {
   regime: RegimeClassificationResponse;
+  // #304 dual-head retrofit: optional sibling block carrying the
+  // regression head's point estimate + conformal interval. When
+  // provided, a "show details" toggle reveals it underneath the
+  // classification surface; absence keeps the pre-#304 visual
+  // language identical.
+  regression?: RegimeRegressionResponse | null;
 }
 
 const REGIME_ORDER = ["calm", "normal", "high"];
@@ -23,12 +34,25 @@ function regimeIndicatorClass(label: string): string {
   }
 }
 
-export function RegimeClassificationCard({ regime }: RegimeClassificationCardProps) {
+function formatLogRv(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return "—";
+  }
+  return value.toFixed(3);
+}
+
+export function RegimeClassificationCard({ regime, regression }: RegimeClassificationCardProps) {
+  const [showRegression, setShowRegression] = useState(false);
   const distribution = regime.distribution ?? {};
   const coveragePct = Math.round(regime.coverage * 100);
   const known = new Set(REGIME_ORDER);
   const extraLabels = Object.keys(distribution).filter((k) => !known.has(k));
   const renderOrder = [...REGIME_ORDER, ...extraLabels];
+  const hasRegression = regression != null && Number.isFinite(regression.log_rv_point);
+  const regressionCoveragePct =
+    regression?.coverage != null && Number.isFinite(regression.coverage)
+      ? Math.round(regression.coverage * 100)
+      : coveragePct;
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -73,6 +97,48 @@ export function RegimeClassificationCard({ regime }: RegimeClassificationCardPro
           Split-conformal prediction set at nominal {coveragePct}% coverage.
           Argmax: <span className="font-medium text-foreground capitalize">{regime.argmax_class}</span> · set size {regime.set_size}.
         </p>
+        {hasRegression && (
+          <div className="border-t pt-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+              onClick={() => setShowRegression((open) => !open)}
+              aria-expanded={showRegression}
+              aria-controls="regime-regression-details"
+            >
+              {showRegression ? (
+                <ChevronUp className="mr-1 h-3 w-3" />
+              ) : (
+                <ChevronDown className="mr-1 h-3 w-3" />
+              )}
+              {showRegression ? "Hide regression details" : "Show regression details"}
+            </Button>
+            {showRegression && regression && (
+              <div
+                id="regime-regression-details"
+                className="mt-2 space-y-1 rounded-md border bg-muted/40 px-3 py-2 text-xs text-muted-foreground"
+              >
+                <div className="flex items-center justify-between">
+                  <span>log(RV) point</span>
+                  <span className="font-mono text-foreground">{formatLogRv(regression.log_rv_point)}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>{regressionCoveragePct}% interval</span>
+                  <span className="font-mono text-foreground">
+                    [{formatLogRv(regression.log_rv_lower)}, {formatLogRv(regression.log_rv_upper)}]
+                  </span>
+                </div>
+                <p className="pt-1 text-[10px] leading-snug">
+                  Dual-head regression on standardised log(forward realized vol);
+                  conformal interval at nominal {regressionCoveragePct}% coverage.
+                  Classification surface above stays the headline.
+                </p>
+              </div>
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -226,6 +226,19 @@ export interface CredibilityResponse {
   months_since_reversal?: number | null;
 }
 
+// #304 sibling block: dual-head regression output on log(forward
+// realized vol). Surfaced alongside the classification card so the
+// "show details" toggle on the regime panel can render the
+// continuous prediction + 90% conformal interval without re-parsing
+// it out of RegimeClassificationResponse. Null on a classification-
+// only checkpoint where the regression head is not mounted.
+export interface RegimeRegressionResponse {
+  log_rv_point: number;
+  log_rv_lower: number | null;
+  log_rv_upper: number | null;
+  coverage: number | null;
+}
+
 export interface RegimeClassificationResponse {
   predicted_set: string[];
   set_label: string;
@@ -316,6 +329,8 @@ export interface AnalyzeResult {
   series?: SeriesResponse;
   multi_axis?: MultiAxisResponse;
   regime_classification?: RegimeClassificationResponse | null;
+  // #304 dual-head regression sibling block.
+  regime_regression?: RegimeRegressionResponse | null;
   xai?: XaiResponse;
   credibility?: CredibilityResponse;
 }

--- a/frontend/pages/history/[id].tsx
+++ b/frontend/pages/history/[id].tsx
@@ -170,7 +170,11 @@ export default function HistoryDetailPage() {
           ) : detail && result ? (
             <>
               {result.regime_classification ? (
-                <PreviewPanels slot="regime" regimeClassification={result.regime_classification} />
+                <PreviewPanels
+                  slot="regime"
+                  regimeClassification={result.regime_classification}
+                  regimeRegression={result.regime_regression}
+                />
               ) : null}
 
               {result.multi_axis ? (

--- a/tests/unit/test_regime_regression_response_block.py
+++ b/tests/unit/test_regime_regression_response_block.py
@@ -1,0 +1,303 @@
+"""Cover the /analyze ``regime_regression`` sibling block (#304).
+
+The dual-head retrofit keeps the classification card as the headline
+on the response and adds a sibling :class:`RegimeRegressionCard` so a
+downstream consumer can read the regression head's point estimate +
+90% conformal interval as a standalone surface. The block is
+populated only when the active checkpoint mounts the regression head
+(``head_mode`` in ``regression`` / ``dual``) AND the classification
+card carries a non-null ``log_rv_point``; otherwise the field stays
+``None`` and the legacy classification-only payload shape is byte-
+identical to pre-#304.
+
+These tests pin:
+
+- the schema field exists and validates against the new
+  :class:`RegimeRegressionCard`;
+- ``_build_regime_regression_block`` derives the block correctly from
+  a dual-head classification card;
+- the helper short-circuits to ``None`` on a classification-only card
+  (or one whose regression head did not run);
+- the checkpoint round-trip preserves the four new
+  ``EvaluationMetrics`` regression fields (RMSE / MAE / loss / R^2)
+  so an aggregator reading per-trial JSONs gets the full surface
+  back.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+
+# ---------------------------------------------------------------------------
+# Schema surface
+
+
+def test_analyze_response_carries_regime_regression_field() -> None:
+    """The :class:`AnalyzeResponse` schema must declare the new sibling field."""
+
+    from app.schemas import AnalyzeResponse
+
+    assert "regime_regression" in AnalyzeResponse.model_fields
+    field = AnalyzeResponse.model_fields["regime_regression"]
+    # Optional + defaults to None so the classification-only payload
+    # stays byte-identical to the pre-#304 shape on every legacy run.
+    assert field.default is None
+
+
+def test_regime_regression_card_validates_point_only() -> None:
+    """A point-only card (no conformal sidecar on disk) must validate."""
+
+    from app.schemas import RegimeRegressionCard
+
+    card = RegimeRegressionCard(log_rv_point=-3.5)
+    assert card.log_rv_point == pytest.approx(-3.5)
+    assert card.log_rv_lower is None
+    assert card.log_rv_upper is None
+    assert card.coverage is None
+
+
+def test_regime_regression_card_validates_full_interval() -> None:
+    """A populated conformal interval round-trips through the schema."""
+
+    from app.schemas import RegimeRegressionCard
+
+    card = RegimeRegressionCard(
+        log_rv_point=-3.5,
+        log_rv_lower=-3.8,
+        log_rv_upper=-3.2,
+        coverage=0.9,
+    )
+    assert card.log_rv_lower == pytest.approx(-3.8)
+    assert card.log_rv_upper == pytest.approx(-3.2)
+    assert card.coverage == pytest.approx(0.9)
+
+
+def test_regime_regression_card_rejects_missing_point() -> None:
+    """``log_rv_point`` is required — the block is meaningless without it."""
+
+    from app.schemas import RegimeRegressionCard
+
+    with pytest.raises(ValidationError):
+        RegimeRegressionCard()  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# /analyze block derivation
+
+
+def test_build_regime_regression_block_returns_none_for_classification_only() -> None:
+    """Classification-only card (no log_rv_point) yields ``None``."""
+
+    from app.main import _build_regime_regression_block
+
+    card = {
+        "predicted_set": ["normal", "high"],
+        "set_label": "{normal, high}",
+        "set_size": 2,
+        "coverage": 0.8,
+        "distribution": {"calm": 0.18, "normal": 0.52, "high": 0.30},
+        "argmax_class": "normal",
+        "log_rv_point": None,
+        "log_rv_lower": None,
+        "log_rv_upper": None,
+        "bucket_source": "classification",
+    }
+    assert _build_regime_regression_block(card) is None
+
+
+def test_build_regime_regression_block_returns_none_for_none_input() -> None:
+    """A degraded /analyze (no classification card) emits no sibling block."""
+
+    from app.main import _build_regime_regression_block
+
+    assert _build_regime_regression_block(None) is None
+
+
+def test_build_regime_regression_block_passes_through_dual_head_card() -> None:
+    """Dual-head card carries log_rv_point + conformal bounds onto the block."""
+
+    from app.main import _build_regime_regression_block
+
+    card = {
+        "predicted_set": ["normal"],
+        "set_label": "{normal}",
+        "set_size": 1,
+        "coverage": 0.9,
+        "distribution": {"calm": 0.10, "normal": 0.70, "high": 0.20},
+        "argmax_class": "normal",
+        "log_rv_point": -3.42,
+        "log_rv_lower": -3.71,
+        "log_rv_upper": -3.13,
+        "bucket_source": "regression",
+    }
+    block = _build_regime_regression_block(card)
+    assert block is not None
+    assert block["log_rv_point"] == pytest.approx(-3.42)
+    assert block["log_rv_lower"] == pytest.approx(-3.71)
+    assert block["log_rv_upper"] == pytest.approx(-3.13)
+    # Coverage rides off the classification card's nominal coverage
+    # because the regression interval re-uses the same conformal
+    # manifest (residual_quantile_volatility) today.
+    assert block["coverage"] == pytest.approx(0.9)
+
+
+def test_build_regime_regression_block_point_only_drops_coverage() -> None:
+    """A regression card without a conformal sidecar emits no coverage value."""
+
+    from app.main import _build_regime_regression_block
+
+    card = {
+        "predicted_set": ["normal"],
+        "set_label": "{normal}",
+        "set_size": 1,
+        "coverage": 0.0,  # cold-start checkpoint, no manifest
+        "distribution": {"calm": 0.10, "normal": 0.70, "high": 0.20},
+        "argmax_class": "normal",
+        "log_rv_point": -3.42,
+        "log_rv_lower": None,
+        "log_rv_upper": None,
+        "bucket_source": "regression",
+    }
+    block = _build_regime_regression_block(card)
+    assert block is not None
+    assert block["log_rv_point"] == pytest.approx(-3.42)
+    assert block["log_rv_lower"] is None
+    assert block["log_rv_upper"] is None
+    assert "coverage" not in block
+
+
+def test_build_regime_regression_block_card_round_trips_through_schema() -> None:
+    """The derived dict must hydrate cleanly into the pydantic card."""
+
+    from app.main import _build_regime_regression_block
+    from app.schemas import RegimeRegressionCard
+
+    card = {
+        "log_rv_point": -3.42,
+        "log_rv_lower": -3.71,
+        "log_rv_upper": -3.13,
+        "coverage": 0.9,
+        "argmax_class": "normal",
+        "predicted_set": ["normal"],
+        "set_label": "{normal}",
+        "set_size": 1,
+        "distribution": {"calm": 0.1, "normal": 0.7, "high": 0.2},
+        "bucket_source": "regression",
+    }
+    block = _build_regime_regression_block(card)
+    assert block is not None
+    hydrated = RegimeRegressionCard(**block)
+    assert hydrated.log_rv_point == pytest.approx(-3.42)
+    assert hydrated.coverage == pytest.approx(0.9)
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint round-trip on the dual-head metrics surface
+
+
+def test_evaluation_metrics_carries_regression_r2_log_rv_field() -> None:
+    """Per acceptance: R^2 on log_rv joins the existing RMSE / MAE pair."""
+
+    from app.evaluation.metrics import EvaluationMetrics
+
+    metrics = EvaluationMetrics(
+        loss=0.5,
+        close_rmse=float("inf"),
+        volatility_rmse=float("inf"),
+        combined_rmse=float("inf"),
+        regression_rmse_log_rv=0.42,
+        regression_mae_log_rv=0.31,
+        regression_loss=0.18,
+        regression_r2_log_rv=0.27,
+    )
+    assert metrics.regression_r2_log_rv == pytest.approx(0.27)
+    # Default stays None so the legacy contract holds on every pre-
+    # #304 caller that does not pass the kwarg.
+    default = EvaluationMetrics(
+        loss=0.0,
+        close_rmse=0.0,
+        volatility_rmse=0.0,
+        combined_rmse=0.0,
+    )
+    assert default.regression_r2_log_rv is None
+
+
+def test_metrics_from_payload_round_trips_regression_fields() -> None:
+    """The four #304 regression fields must rehydrate from a per-trial JSON."""
+
+    from app.training.checkpoint import _metrics_from_payload
+
+    payload = {
+        "metrics": {
+            "loss": 0.5,
+            "close_rmse": float("inf"),
+            "volatility_rmse": float("inf"),
+            "combined_rmse": float("inf"),
+            "regression_rmse_log_rv": 0.42,
+            "regression_mae_log_rv": 0.31,
+            "regression_loss": 0.18,
+            "regression_r2_log_rv": 0.27,
+        }
+    }
+    metrics = _metrics_from_payload(payload)
+    assert metrics is not None
+    assert metrics.regression_rmse_log_rv == pytest.approx(0.42)
+    assert metrics.regression_mae_log_rv == pytest.approx(0.31)
+    assert metrics.regression_loss == pytest.approx(0.18)
+    assert metrics.regression_r2_log_rv == pytest.approx(0.27)
+
+
+def test_metrics_from_payload_legacy_pre_304_returns_none_regression_fields() -> None:
+    """Pre-#304 per-trial JSONs (no regression keys) keep the contract."""
+
+    from app.training.checkpoint import _metrics_from_payload
+
+    payload = {
+        "metrics": {
+            "loss": 0.5,
+            "close_rmse": 0.1,
+            "volatility_rmse": 0.05,
+            "combined_rmse": 0.15,
+        }
+    }
+    metrics = _metrics_from_payload(payload)
+    assert metrics is not None
+    assert metrics.regression_rmse_log_rv is None
+    assert metrics.regression_mae_log_rv is None
+    assert metrics.regression_loss is None
+    assert metrics.regression_r2_log_rv is None
+
+
+def test_coerce_payload_config_round_trips_head_mode_and_alpha() -> None:
+    """A dual-head checkpoint must rehydrate ``head_mode`` + ``regression_alpha``."""
+
+    from app.training.checkpoint import _coerce_payload_config
+
+    payload = {
+        "model_config": {
+            "output_mode": "classification",
+            "head_mode": "dual",
+            "regression_alpha": 0.7,
+            "n_classes": 3,
+        }
+    }
+    config = _coerce_payload_config(payload)
+    assert config.head_mode == "dual"
+    assert config.regression_alpha == pytest.approx(0.7)
+
+
+def test_coerce_payload_config_legacy_pre_304_defaults_match_dataclass() -> None:
+    """Pre-#304 checkpoint (no head_mode key) inherits the dataclass default."""
+
+    from app.models.config import ModelConfig
+    from app.training.checkpoint import _coerce_payload_config
+
+    payload = {"model_config": {"output_mode": "regression"}}
+    config = _coerce_payload_config(payload)
+    # ModelConfig's dataclass default is 'dual' (ADR 0015 / #322); the
+    # coercion path must match so a legacy checkpoint rebuilds the
+    # same config the dataclass would emit cold.
+    assert config.head_mode == ModelConfig().head_mode
+    assert config.regression_alpha == pytest.approx(ModelConfig().regression_alpha)


### PR DESCRIPTION
Closes #304.

The dual-head regression surface was always emitted in training but never reached the response. This PR closes the gap:

- New `RegimeRegressionCard` pydantic schema + `regime_regression` field on `AnalyzeResponse`. Populated only when the active checkpoint's classification card carries a non-null `log_rv_point` (i.e. `head_mode` in `regression` / `dual`).
- `_build_regime_regression_block` helper reads the classification card's existing point + interval fields and emits the sibling block. Coverage rides off the same conformal manifest until the regression head gets its own quantile sidecar.
- Per-fold R^2 on log_rv now joins RMSE / MAE on `EvaluationMetrics`. Computed as `1 - SSE / SST` over the partition's standardised log-RV; collapses to `None` on a constant-target partition so consumers can tell "no head ran" apart from "head ran on a degenerate fixture".
- `_coerce_payload_config` forwards `head_mode` + `regression_alpha` so dual-head checkpoints rehydrate the same head config on `eval_checkpoint_directional` / `calibrate_regime_classifier`. Same gap pattern as #423 / #435.
- `_metrics_from_payload` threads the four regression fields off per-trial JSONs.
- Frontend: `RegimeClassificationCard` accepts an optional `regression` prop and renders a `ChevronDown` "show details" toggle exposing the point estimate + 90% interval. Pre-#304 visual language is byte-identical when the prop is absent.
- 14 new tests (`tests/unit/test_regime_regression_response_block.py`) cover the schema, the helper short-circuit on classification-only cards, the dual-head card population, and the checkpoint round-trip on the four regression metrics.

ADR follow-up — the methodology framing (information-destructive 3-bin classification, joint-loss recovery, conformal interval design) lands in a dedicated ADR in a sibling PR after the comparison sweep returns numbers.

**BLOCKED**: needs GPU canonical sweep to produce the 3-config comparison (classification-only / regression-only / dual) for §6.7. Queue this on Runpod once availability returns; the trainer-side knobs (`--head-mode dual`, `--regression-alpha`) are already in repo.