### PR TITLE
extract policy action on /analyze + render card on workspace (#446)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -95,6 +95,7 @@ from app.services.market_data import (
     fetch_market_snapshot,
     fetch_realized_forward,
 )
+from app.services.policy_action_extractor import extract_policy_action
 from app.services.text_encoder import analyze_text
 
 logger = logging.getLogger(__name__)
@@ -625,6 +626,7 @@ def _build_analyze_response(
         "regime_regression": _build_regime_regression_block(regime_card),
         "regime_classification_status": regime_status,
         "rates_reaction": _safe_rates_reaction(history_vectors),
+        "policy_action": _build_policy_action_card(payload),
     }
     if getattr(payload, "include_xai", False):
         attributions = attribute_text(payload.text)
@@ -719,6 +721,45 @@ def _safe_rates_reaction(
         # falling back to the "no rates heads" empty state.
         return []
     return rates_block
+
+
+def _build_policy_action_card(
+    payload: AnalyzeRequest,
+) -> dict[str, Any] | None:
+    """Extract the mechanical policy decision off the request text (#446).
+
+    Pure regex / keyword pass over ``payload.text`` via
+    :func:`extract_policy_action`. Short-circuits to ``None`` when the
+    request body carries no text (``AnalyzeRequest.text`` is required
+    by the schema but the guard stays so a hand-crafted payload with
+    whitespace-only text still serialises cleanly). Wrapped end-to-end
+    in try/except so a regex misfire or an unexpected dataclass shape
+    can never break /analyze.
+
+    ``prior_target_range_mid_bp`` is left ``None`` here — the request
+    schema carries no prior-statement context and we deliberately do
+    not reach into the persisted history layer for it. The card still
+    surfaces a populated ``change_direction`` whenever the policy verb
+    is named in the prose (``decided to raise`` / ``decided to lower``
+    / ``decided to maintain``); only the prior-midpoint fallback is
+    deferred to a follow-up.
+    """
+
+    text = getattr(payload, "text", None)
+    if not isinstance(text, str) or not text.strip():
+        return None
+    try:
+        action = extract_policy_action(text)
+    except Exception:  # pragma: no cover -- defensive: never break /analyze
+        logger.warning("policy_action_extraction_failed", exc_info=True)
+        return None
+    return {
+        "target_range_low_bp": action.target_range_low_bp,
+        "target_range_high_bp": action.target_range_high_bp,
+        "change_direction": action.change_direction,
+        "change_magnitude_bp": action.change_magnitude_bp,
+        "balance_sheet_state": action.balance_sheet_state,
+    }
 
 
 def _safe_regime_classification(history_vectors: list[Any]) -> dict[str, Any] | None:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -482,6 +482,67 @@ class RegimeRegressionCard(BaseModel):
     )
 
 
+class PolicyActionCard(BaseModel):
+    """Mechanical policy decision extracted from the statement text (#446).
+
+    Sibling of :class:`RegimeClassificationCard` on the /analyze
+    response. Pure extraction surface — no model inference, no
+    calibration. The four fields mirror the
+    :class:`app.services.policy_action_extractor.PolicyAction`
+    dataclass and are all optional so a statement that names no target
+    range (press conference Q&A, scraping miss, non-policy text) still
+    serialises as a card with every field ``None``.
+
+    Units: ``target_range_low_bp`` / ``target_range_high_bp`` are in
+    basis points (3.50% → 350). ``change_magnitude_bp`` is signed
+    (positive on a hike, negative on a cut, zero on a hold). The
+    frontend renders the colour by ``change_direction``: hike = red,
+    cut = green, hold = neutral.
+    """
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    target_range_low_bp: int | None = Field(
+        default=None,
+        description=(
+            "Lower bound of the named target range, in basis points "
+            "(e.g. 350 for a 3.50% lower bound). None when no target "
+            "range is named in the text."
+        ),
+    )
+    target_range_high_bp: int | None = Field(
+        default=None,
+        description="Upper bound of the named target range, in basis points.",
+    )
+    change_direction: Literal["hike", "hold", "cut"] | None = Field(
+        default=None,
+        description=(
+            "Verb-derived direction of the action. None when no policy "
+            "verb is named (e.g. press-conference Q&A) and no prior "
+            "midpoint was provided to the extractor."
+        ),
+    )
+    change_magnitude_bp: int | None = Field(
+        default=None,
+        description=(
+            "Signed change in basis points relative to the prior "
+            "meeting (positive on a hike, negative on a cut, zero on a "
+            "hold). Pulled from in-prose magnitude phrases ('by 25 "
+            "basis points', 'by 1/4 percentage point') first; falls "
+            "back to ``this_mid - prior_mid`` when the caller supplied "
+            "a prior midpoint."
+        ),
+    )
+    balance_sheet_state: Literal["expansion", "tapering", "runoff"] | None = Field(
+        default=None,
+        description=(
+            "Balance-sheet posture extracted from the paragraph that "
+            "names balance-sheet operations. None when the paragraph "
+            "is absent or carries no posture-defining keyword."
+        ),
+    )
+
+
 class InferenceStatusSurface(BaseModel):
     """Structured error surface for the per-card inference helpers (#341).
 
@@ -535,6 +596,14 @@ class AnalyzeResponse(BaseModel):
     # list when the heads exist but the per-event forward produced no
     # rows. Hooked by #293's MarketReactionPanel.
     rates_reaction: list[RatesReactionCard] | None = None
+    # #446 mechanical policy decision extracted from the statement
+    # text. Pure regex / keyword pass — no model inference. None when
+    # the request carries no statement text (defensive; the schema
+    # requires text but the extractor wrapper still short-circuits on
+    # an empty body). Populated for any statement that names a target
+    # range; balance-sheet posture rides off the balance-sheet
+    # paragraph when present.
+    policy_action: PolicyActionCard | None = None
     # #341 sibling status surface so an operator can grep the JSON
     # response for the structured error branch when the regime card
     # degrades. Mutually exclusive with ``regime_classification``

--- a/backend/app/services/policy_action_extractor.py
+++ b/backend/app/services/policy_action_extractor.py
@@ -1,0 +1,342 @@
+"""Extract the mechanical policy decision from an FOMC statement (#446).
+
+Surfaces four structured signals the analyst-style dashboard renders on
+the `/analyze` Policy Action card:
+
+- ``target_range_low_bp`` / ``target_range_high_bp``: the named target
+  range for the federal funds rate, in basis points (3.50%-3.75% → 350
+  / 375). Handles the three phrasings the statements use: decimal
+  (``3.50 to 3.75 percent``), hyphen-decimal (``3-1/4 to 3-1/2``), and
+  the older ``X to Y percent`` form.
+- ``change_direction``: ``hike`` / ``hold`` / ``cut`` derived from the
+  verb the Committee uses ("decided to raise" / "decided to maintain"
+  / "decided to lower"). When the verb is absent, the sign of the
+  current-vs-prior target-range midpoint takes over (and ``hold`` is
+  the default for an exact match).
+- ``change_magnitude_bp``: signed int. Pulled from the in-prose phrase
+  ("by 1/4 percentage point" / "by 25 basis points") when present;
+  otherwise derived as ``this_mid - prior_mid`` when the caller
+  supplies a prior target-range midpoint in bps.
+- ``balance_sheet_state``: ``expansion`` / ``tapering`` / ``runoff`` /
+  ``None``. Regex / keyword pass over the balance-sheet paragraph.
+
+The module is pure-function and dependency-free so the call site stays
+trivial to test and never blocks /analyze on an extractor failure --
+the higher-level helper in ``app.main`` wraps every call in try/except.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+ChangeDirection = Literal["hike", "hold", "cut"]
+BalanceSheetState = Literal["expansion", "tapering", "runoff"]
+
+
+@dataclass(frozen=True)
+class PolicyAction:
+    """Structured policy decision extracted from a single FOMC statement.
+
+    All fields are optional: a statement that names no target range
+    (press conference Q&A, speech excerpt, scraping miss) yields a
+    payload with every field ``None``. The caller treats that as
+    "no policy action surfaced" and the frontend renders an empty card.
+    """
+
+    target_range_low_bp: int | None = None
+    target_range_high_bp: int | None = None
+    change_direction: ChangeDirection | None = None
+    change_magnitude_bp: int | None = None
+    balance_sheet_state: BalanceSheetState | None = None
+
+
+# ---------------------------------------------------------------------------
+# Target range extraction
+# ---------------------------------------------------------------------------
+
+
+# Match a percent range: ``3.50 to 3.75 percent`` / ``3-1/4 to 3-1/2
+# percent`` / ``0 to 1/4 percent``. Two number tokens (decimal,
+# whole+fraction, or bare fraction), separated by ``to``/``-``/``–``,
+# followed by ``percent``. The number tokens are an alternation so the
+# bare-fraction form (``1/4`` on its own) parses without forcing a
+# leading integer; ``\d+(?:\.\d+)?`` covers the decimal + integer
+# cases.
+_NUMBER_TOKEN = (
+    r"(?:\d+\s*-\s*\d+/\d+|\d+\s+\d+/\d+|\d+/\d+|\d+(?:\.\d+)?)"
+)
+_RANGE_DECIMAL_RE = re.compile(
+    rf"({_NUMBER_TOKEN})\s*(?:to|-|–|—)\s*({_NUMBER_TOKEN})\s*percent",
+    flags=re.IGNORECASE,
+)
+
+
+def _fraction_to_decimal(piece: str) -> float | None:
+    """Coerce ``3-1/4`` / ``3 1/4`` / ``1/4`` / ``3.5`` to a percent float.
+
+    Returns ``None`` on an unparseable input rather than raising so the
+    extractor degrades to a partial payload on malformed prose.
+    """
+
+    text = piece.strip().replace(" ", "")
+    # Whole + fraction form (``3-1/4``).
+    match = re.fullmatch(r"(\d+)-(\d+)/(\d+)", text)
+    if match:
+        whole, num, denom = (int(g) for g in match.groups())
+        if denom == 0:
+            return None
+        return whole + num / denom
+    # Bare fraction (``1/4``).
+    match = re.fullmatch(r"(\d+)/(\d+)", text)
+    if match:
+        num, denom = (int(g) for g in match.groups())
+        if denom == 0:
+            return None
+        return num / denom
+    # Decimal form (``3.5``, ``3``).
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _percent_to_bp(value: float) -> int:
+    """Round percent-as-float to integer basis points (3.75 → 375)."""
+
+    return int(round(value * 100))
+
+
+_TARGET_RANGE_ANCHOR = re.compile(r"target\s+range", flags=re.IGNORECASE)
+
+
+def extract_target_range_bp(text: str) -> tuple[int, int] | None:
+    """Return ``(low_bp, high_bp)`` for the named target range, or ``None``.
+
+    The strategy: locate the first ``target range`` anchor and look for
+    the closest ``X to Y percent`` form within the next ~200 chars.
+    The statements use one of three phrasings inside that window:
+    ``target range ... at X to Y percent`` (hold), ``target range ...
+    to X to Y percent`` (raise / lower with a magnitude phrase), and
+    the bare ``target range ... X to Y percent`` (no phrase between).
+    Anchoring on ``target range`` keeps the regex from locking onto a
+    historical comparison ("up from the 2.25 to 2.50 percent range")
+    later in the prose.
+    """
+
+    anchor = _TARGET_RANGE_ANCHOR.search(text)
+    if not anchor:
+        return None
+    # Look in a window after the anchor so the regex doesn't reach
+    # across paragraphs into unrelated numeric prose.
+    window = text[anchor.end() : anchor.end() + 240]
+    match = _RANGE_DECIMAL_RE.search(window)
+    if not match:
+        return None
+    low_pct = _fraction_to_decimal(match.group(1))
+    high_pct = _fraction_to_decimal(match.group(2))
+    if low_pct is None or high_pct is None:
+        return None
+    if low_pct > high_pct:
+        # Mis-parse (the order on a real statement is always low-then-
+        # high). Bail rather than emit an inverted range.
+        return None
+    return _percent_to_bp(low_pct), _percent_to_bp(high_pct)
+
+
+# ---------------------------------------------------------------------------
+# Change verb + magnitude extraction
+# ---------------------------------------------------------------------------
+
+
+_HIKE_VERBS = re.compile(
+    r"decided\s+to\s+(?:raise|increase)\s+the\s+target\s+range",
+    flags=re.IGNORECASE,
+)
+_CUT_VERBS = re.compile(
+    r"decided\s+to\s+(?:lower|reduce|cut)\s+the\s+target\s+range",
+    flags=re.IGNORECASE,
+)
+_HOLD_VERBS = re.compile(
+    r"decided\s+to\s+(?:maintain|keep)\s+the\s+target\s+range",
+    flags=re.IGNORECASE,
+)
+
+
+def extract_change_direction(text: str) -> ChangeDirection | None:
+    """Pull the policy verb. ``None`` when no verb phrase is named."""
+
+    if _HIKE_VERBS.search(text):
+        return "hike"
+    if _CUT_VERBS.search(text):
+        return "cut"
+    if _HOLD_VERBS.search(text):
+        return "hold"
+    return None
+
+
+# Match the magnitude phrase: ``by 25 basis points`` / ``by 1/4
+# percentage point`` / ``by 1/2 percentage point``.
+_BP_MAGNITUDE_RE = re.compile(
+    r"by\s+(\d+)\s+basis\s+points?",
+    flags=re.IGNORECASE,
+)
+_PCT_MAGNITUDE_RE = re.compile(
+    r"by\s+(\d+(?:\s*-\s*\d+/\d+)?|\d+/\d+)\s+percentage\s+points?",
+    flags=re.IGNORECASE,
+)
+
+
+def extract_change_magnitude_bp(text: str) -> int | None:
+    """Pull the unsigned magnitude of the change in bps from the prose.
+
+    Returns the absolute magnitude only; the sign is applied by the
+    caller against ``extract_change_direction`` (or against the
+    prior-mid delta when the verb is absent).
+    """
+
+    match = _BP_MAGNITUDE_RE.search(text)
+    if match:
+        return int(match.group(1))
+    match = _PCT_MAGNITUDE_RE.search(text)
+    if match:
+        pct = _fraction_to_decimal(match.group(1))
+        if pct is None:
+            return None
+        return _percent_to_bp(pct)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Balance-sheet posture extraction
+# ---------------------------------------------------------------------------
+
+
+_BALANCE_SHEET_ANCHOR = re.compile(
+    r"(?:balance\s+sheet|Treasury\s+securities|agency\s+mortgage[- ]backed\s+securities|"
+    r"Standing\s+Repo\s+Facility)",
+    flags=re.IGNORECASE,
+)
+
+# Order matters: tapering is the more specific phrase and must win over
+# the generic "reduce holdings" runoff phrasing when both are present.
+_TAPER_KEYWORDS = re.compile(
+    r"slow(?:ing)?\s+the\s+pace|reduce\s+the\s+monthly\s+(?:cap|pace)|"
+    r"taper|slowing\s+the\s+pace\s+of\s+(?:its\s+)?(?:decline|run[- ]?off)",
+    flags=re.IGNORECASE,
+)
+_RUNOFF_KEYWORDS = re.compile(
+    r"reduc(?:e|ing)\s+its\s+holdings|run(?:ning)?[- ]?off|"
+    r"continue\s+(?:to\s+)?reduc(?:e|ing)|decline\s+in\s+the\s+balance\s+sheet",
+    flags=re.IGNORECASE,
+)
+_EXPANSION_KEYWORDS = re.compile(
+    r"increase\s+(?:its\s+)?holdings|purchas(?:e|ing)\s+(?:additional\s+)?"
+    r"(?:Treasury\s+securities|agency\s+mortgage)|expand\s+(?:its\s+)?(?:holdings|balance\s+sheet)|"
+    r"net\s+asset\s+purchases",
+    flags=re.IGNORECASE,
+)
+
+
+def _balance_sheet_paragraph(text: str) -> str | None:
+    """Return the paragraph that names balance-sheet operations, or None.
+
+    Statements are split on blank lines; we keep the FIRST paragraph
+    whose body matches the anchor regex. Returning the paragraph (not
+    the whole document) keeps the keyword pass from cross-contaminating
+    with vocabulary that happens to repeat elsewhere ("reducing
+    inflation" inside an inflation paragraph, say).
+    """
+
+    if not text:
+        return None
+    paragraphs = re.split(r"\n\s*\n", text)
+    for para in paragraphs:
+        if _BALANCE_SHEET_ANCHOR.search(para):
+            return para
+    return None
+
+
+def extract_balance_sheet_state(text: str) -> BalanceSheetState | None:
+    """Return the balance-sheet posture named in the statement, or None.
+
+    The order of checks is deliberate: tapering ("slowing the pace of
+    decline") is a narrower phrasing than runoff ("continuing to reduce
+    holdings") and must take precedence when both surface.
+    """
+
+    paragraph = _balance_sheet_paragraph(text)
+    if paragraph is None:
+        return None
+    if _TAPER_KEYWORDS.search(paragraph):
+        return "tapering"
+    if _EXPANSION_KEYWORDS.search(paragraph):
+        return "expansion"
+    if _RUNOFF_KEYWORDS.search(paragraph):
+        return "runoff"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Top-level extraction
+# ---------------------------------------------------------------------------
+
+
+def _midpoint_bp(low_bp: int, high_bp: int) -> int:
+    return (low_bp + high_bp) // 2
+
+
+def extract_policy_action(
+    text: str,
+    prior_target_range_mid_bp: int | None = None,
+) -> PolicyAction:
+    """Return the structured policy decision named in ``text``.
+
+    ``prior_target_range_mid_bp`` is the midpoint of the prior meeting's
+    target range in basis points (e.g. 363 for a 3.50%-3.75% range).
+    When supplied AND the current statement names a target range, the
+    helper derives a signed ``change_magnitude_bp`` from the midpoint
+    delta even if the in-prose magnitude phrase is absent. When the
+    delta and the verb disagree (rare; a "decided to maintain" with a
+    midpoint move would be a parse bug), the verb wins and the magnitude
+    falls back to the unsigned in-prose value.
+    """
+
+    target_range = extract_target_range_bp(text)
+    direction = extract_change_direction(text)
+    in_prose_magnitude = extract_change_magnitude_bp(text)
+    balance_sheet = extract_balance_sheet_state(text)
+
+    low_bp = target_range[0] if target_range else None
+    high_bp = target_range[1] if target_range else None
+
+    signed_magnitude: int | None = None
+    if direction == "hold":
+        signed_magnitude = 0
+    elif in_prose_magnitude is not None and direction in {"hike", "cut"}:
+        signed_magnitude = (
+            in_prose_magnitude if direction == "hike" else -in_prose_magnitude
+        )
+    elif (
+        prior_target_range_mid_bp is not None
+        and low_bp is not None
+        and high_bp is not None
+    ):
+        delta = _midpoint_bp(low_bp, high_bp) - prior_target_range_mid_bp
+        signed_magnitude = delta
+        if direction is None:
+            if delta > 0:
+                direction = "hike"
+            elif delta < 0:
+                direction = "cut"
+            else:
+                direction = "hold"
+
+    return PolicyAction(
+        target_range_low_bp=low_bp,
+        target_range_high_bp=high_bp,
+        change_direction=direction,
+        change_magnitude_bp=signed_magnitude,
+        balance_sheet_state=balance_sheet,
+    )

--- a/frontend/components/analyze/PolicyActionCard.tsx
+++ b/frontend/components/analyze/PolicyActionCard.tsx
@@ -1,0 +1,117 @@
+import { ArrowDownRight, ArrowUpRight, Gavel, Minus } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type {
+  BalanceSheetState,
+  PolicyActionResponse,
+  PolicyChangeDirection,
+} from "@/lib/analyze/types";
+
+// #446: card surfaces the mechanical policy decision extracted from
+// the statement text (target range, change indicator, balance-sheet
+// posture). Pure render — no inference, no calibration. Mirrors the
+// visual language of `RegimeClassificationCard` / `MarketReactionPanel`
+// so the workspace page reads as one panel surface.
+
+interface PolicyActionCardProps {
+  action: PolicyActionResponse;
+}
+
+const BALANCE_SHEET_COPY: Record<BalanceSheetState, string> = {
+  expansion: "Balance sheet: expansion (asset purchases)",
+  tapering: "Balance sheet: tapering (slowing runoff pace)",
+  runoff: "Balance sheet: runoff (continuing to reduce holdings)",
+};
+
+function directionTone(
+  direction: PolicyChangeDirection,
+): "hawkish" | "dovish" | "neutral" {
+  if (direction === "hike") return "hawkish";
+  if (direction === "cut") return "dovish";
+  return "neutral";
+}
+
+function DirectionIcon({ direction }: { direction: PolicyChangeDirection }) {
+  if (direction === "hike") return <ArrowUpRight className="h-4 w-4 text-hawkish" />;
+  if (direction === "cut") return <ArrowDownRight className="h-4 w-4 text-dovish" />;
+  return <Minus className="h-4 w-4 text-neutral" />;
+}
+
+function formatTargetRange(lowBp: number, highBp: number): string {
+  // bps -> percent with two decimals, dropping trailing zeros on whole-
+  // quarter boundaries so "5-1/4 to 5-1/2 percent" reads as "5.25% –
+  // 5.50%" rather than "5.2500% – 5.5000%".
+  const lowPct = (lowBp / 100).toFixed(2);
+  const highPct = (highBp / 100).toFixed(2);
+  return `${lowPct}% – ${highPct}%`;
+}
+
+function formatChangeMagnitude(direction: PolicyChangeDirection, magnitudeBp: number): string {
+  if (direction === "hold") return "hold";
+  const sign = magnitudeBp > 0 ? "+" : magnitudeBp < 0 ? "" : "";
+  return `${sign}${magnitudeBp} bp`;
+}
+
+export function PolicyActionCard({ action }: PolicyActionCardProps) {
+  const hasRange =
+    action.target_range_low_bp != null && action.target_range_high_bp != null;
+  const hasDirection = action.change_direction != null;
+  // The card stays mute when extraction surfaced nothing — keeps the
+  // workspace from rendering an empty "Policy action" tile on non-
+  // policy text.
+  if (!hasRange && !hasDirection && action.balance_sheet_state == null) {
+    return null;
+  }
+  const direction = action.change_direction;
+  const tone = direction ? directionTone(direction) : "neutral";
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription className="flex items-center gap-1.5">
+          <Gavel className="h-3.5 w-3.5" />
+          Policy action
+        </CardDescription>
+        <CardTitle className="flex items-center justify-between text-2xl">
+          <span className="numeric">
+            {hasRange
+              ? formatTargetRange(
+                  action.target_range_low_bp!,
+                  action.target_range_high_bp!,
+                )
+              : "—"}
+          </span>
+          {direction != null && action.change_magnitude_bp != null ? (
+            <Badge variant={tone} className="flex items-center gap-1">
+              <DirectionIcon direction={direction} />
+              {formatChangeMagnitude(direction, action.change_magnitude_bp)}
+            </Badge>
+          ) : direction != null ? (
+            <Badge variant={tone} className="flex items-center gap-1 capitalize">
+              <DirectionIcon direction={direction} />
+              {direction}
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+              No verb named
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-xs text-muted-foreground">
+          Target range for the federal funds rate, extracted from the statement text.
+        </p>
+        {action.balance_sheet_state != null ? (
+          <p className="text-xs text-muted-foreground">
+            {BALANCE_SHEET_COPY[action.balance_sheet_state]}
+          </p>
+        ) : (
+          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            Balance-sheet posture unavailable
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -296,6 +296,23 @@ export interface MarketReactionPanelResponse {
   checkpoint_path: string | null;
 }
 
+// #446 mechanical policy decision extracted from the statement text.
+// Pure regex / keyword pass on the backend — every field is nullable
+// so a non-policy excerpt (press conference Q&A, scraping miss)
+// surfaces as a card with every field null. Units mirror the
+// backend's `PolicyActionCard`: target_range_*_bp in basis points,
+// change_magnitude_bp signed.
+export type PolicyChangeDirection = "hike" | "hold" | "cut";
+export type BalanceSheetState = "expansion" | "tapering" | "runoff";
+
+export interface PolicyActionResponse {
+  target_range_low_bp: number | null;
+  target_range_high_bp: number | null;
+  change_direction: PolicyChangeDirection | null;
+  change_magnitude_bp: number | null;
+  balance_sheet_state: BalanceSheetState | null;
+}
+
 export type AnalogVolRegime = "calm" | "normal" | "high";
 
 export interface AnalogsRequest {
@@ -336,6 +353,10 @@ export interface AnalyzeResult {
   // An empty list rides when the heads are mounted but the per-event
   // forward produced no rows.
   rates_reaction?: RatesReactionCard[] | null;
+  // #446 mechanical policy decision extracted from the statement
+  // text. Null when the request body carried no text or the
+  // extractor degraded; never raises.
+  policy_action?: PolicyActionResponse | null;
   xai?: XaiResponse;
   credibility?: CredibilityResponse;
 }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -9,6 +9,7 @@ import { HistoricalAnalogPanel } from "@/components/analyze/HistoricalAnalogPane
 import { MarketReactionPanel } from "@/components/analyze/MarketReactionPanel";
 import { MultiAxisInterpretation } from "@/components/analyze/MultiAxisInterpretation";
 import { PipelineTrace } from "@/components/analyze/PipelineTrace";
+import { PolicyActionCard } from "@/components/analyze/PolicyActionCard";
 import { RegimeHeadline } from "@/components/analyze/RegimeHeadline";
 import {
   RegimeHistoryStrip,
@@ -451,6 +452,10 @@ export default function WorkspacePage() {
                   }
                 />
               )}
+
+              {result.policy_action ? (
+                <PolicyActionCard action={result.policy_action} />
+              ) : null}
 
               <div className="grid gap-4 xl:grid-cols-2">
                 {result.multi_axis ? (

--- a/frontend/tests/components/analyze/PolicyActionCard.test.tsx
+++ b/frontend/tests/components/analyze/PolicyActionCard.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { PolicyActionCard } from "@/components/analyze/PolicyActionCard";
+import type { PolicyActionResponse } from "@/lib/analyze/types";
+
+function hikeAction(): PolicyActionResponse {
+  return {
+    target_range_low_bp: 525,
+    target_range_high_bp: 550,
+    change_direction: "hike",
+    change_magnitude_bp: 25,
+    balance_sheet_state: "runoff",
+  };
+}
+
+function holdAction(): PolicyActionResponse {
+  return {
+    target_range_low_bp: 525,
+    target_range_high_bp: 550,
+    change_direction: "hold",
+    change_magnitude_bp: 0,
+    balance_sheet_state: "runoff",
+  };
+}
+
+function cutAction(): PolicyActionResponse {
+  return {
+    target_range_low_bp: 475,
+    target_range_high_bp: 500,
+    change_direction: "cut",
+    change_magnitude_bp: -50,
+    balance_sheet_state: "runoff",
+  };
+}
+
+describe("PolicyActionCard", () => {
+  it("renders the target range as a percent badge on a hike", () => {
+    render(<PolicyActionCard action={hikeAction()} />);
+    expect(screen.getByText(/Policy action/i)).toBeInTheDocument();
+    expect(screen.getByText("5.25% – 5.50%")).toBeInTheDocument();
+    expect(screen.getByText(/\+25 bp/)).toBeInTheDocument();
+  });
+
+  it("renders 'hold' on a no-change action", () => {
+    render(<PolicyActionCard action={holdAction()} />);
+    // The change-indicator badge body reads exactly "hold" on a
+    // zero-magnitude action; assert against that node specifically so
+    // the assertion does not collide with the balance-sheet text or
+    // copy that also contains the word "hold".
+    expect(
+      screen.getByText((_, node) => node?.textContent === "hold"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a negative change indicator on a cut", () => {
+    render(<PolicyActionCard action={cutAction()} />);
+    expect(screen.getByText(/-50 bp/)).toBeInTheDocument();
+    expect(screen.getByText("4.75% – 5.00%")).toBeInTheDocument();
+  });
+
+  it("renders the balance-sheet posture row when populated", () => {
+    render(<PolicyActionCard action={hikeAction()} />);
+    expect(screen.getByText(/runoff/i)).toBeInTheDocument();
+  });
+
+  it("renders the unavailable badge when balance-sheet posture is null", () => {
+    const action: PolicyActionResponse = {
+      ...hikeAction(),
+      balance_sheet_state: null,
+    };
+    render(<PolicyActionCard action={action} />);
+    expect(screen.getByText(/Balance-sheet posture unavailable/i)).toBeInTheDocument();
+  });
+
+  it("returns null on an all-null payload (non-policy text)", () => {
+    const empty: PolicyActionResponse = {
+      target_range_low_bp: null,
+      target_range_high_bp: null,
+      change_direction: null,
+      change_magnitude_bp: null,
+      balance_sheet_state: null,
+    };
+    const { container } = render(<PolicyActionCard action={empty} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/tests/unit/test_policy_action_extractor.py
+++ b/tests/unit/test_policy_action_extractor.py
@@ -1,0 +1,348 @@
+"""Cover the policy-action extractor + /analyze ``policy_action`` block (#446).
+
+The extractor pulls four structured signals from an FOMC statement:
+
+- ``target_range_low_bp`` / ``target_range_high_bp``: the named target
+  range, in basis points;
+- ``change_direction``: ``hike`` / ``hold`` / ``cut`` derived from the
+  policy verb the Committee uses ("decided to raise" / "decided to
+  maintain" / "decided to lower");
+- ``change_magnitude_bp``: signed int. Pulled from the in-prose
+  magnitude phrase first; falls back to ``this_mid - prior_mid`` when
+  the caller supplies a prior midpoint;
+- ``balance_sheet_state``: ``expansion`` / ``tapering`` / ``runoff`` /
+  ``None``, regex over the balance-sheet paragraph.
+
+These tests pin the extractor against representative statement texts
+(hike / hold / cut / runoff / tapering) and pin the higher-level
+:func:`app.main._build_policy_action_card` helper against the empty-
+text short-circuit.
+"""
+
+from __future__ import annotations
+
+
+# ---------------------------------------------------------------------------
+# Representative statement-like texts
+#
+# Phrasing mirrors the canonical FOMC statement structure: a sentence
+# naming the target range, an optional in-prose magnitude phrase, and a
+# separate paragraph naming balance-sheet operations.
+
+
+HIKE_STATEMENT_25BP = (
+    "Recent indicators suggest that economic activity has continued to expand at a "
+    "modest pace.\n\n"
+    "In support of these goals, the Committee decided to raise the target range for "
+    "the federal funds rate by 1/4 percentage point to 5-1/4 to 5-1/2 percent.\n\n"
+    "In addition, the Committee will continue reducing its holdings of Treasury "
+    "securities and agency mortgage-backed securities, as described in its previously "
+    "announced plans."
+)
+
+HOLD_STATEMENT_5_25_5_50 = (
+    "Recent indicators suggest that economic activity has continued to expand at a "
+    "solid pace. Job gains have moderated.\n\n"
+    "In support of its goals, the Committee decided to maintain the target range for "
+    "the federal funds rate at 5-1/4 to 5-1/2 percent.\n\n"
+    "In addition, the Committee will continue reducing its holdings of Treasury "
+    "securities and agency mortgage-backed securities."
+)
+
+CUT_STATEMENT_50BP = (
+    "Recent indicators suggest that economic activity has continued to expand at a "
+    "solid pace.\n\n"
+    "In light of the progress on inflation and the balance of risks, the Committee "
+    "decided to lower the target range for the federal funds rate by 1/2 percentage "
+    "point to 4-3/4 to 5 percent.\n\n"
+    "The Committee will continue reducing its holdings of Treasury securities and "
+    "agency mortgage-backed securities."
+)
+
+TAPER_STATEMENT = (
+    "Recent indicators suggest that economic activity has continued to expand at a "
+    "solid pace.\n\n"
+    "The Committee decided to maintain the target range for the federal funds rate "
+    "at 5-1/4 to 5-1/2 percent.\n\n"
+    "Beginning in June, the Committee will slow the pace of decline of its securities "
+    "holdings by reducing the monthly redemption cap on Treasury securities from "
+    "$60 billion to $25 billion."
+)
+
+EXPANSION_STATEMENT = (
+    "The coronavirus outbreak has caused tremendous human and economic hardship.\n\n"
+    "The Committee decided to maintain the target range for the federal funds rate "
+    "at 0 to 1/4 percent.\n\n"
+    "To support the flow of credit to households and businesses, the Federal Reserve "
+    "will increase its holdings of Treasury securities and agency mortgage-backed "
+    "securities by at least $80 billion and $40 billion per month, respectively."
+)
+
+NON_POLICY_TEXT = (
+    "The Chair will take questions from reporters. Members of the press, please "
+    "identify yourselves before asking a question."
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema surface
+
+
+def test_analyze_response_carries_policy_action_field() -> None:
+    """:class:`AnalyzeResponse` must declare the new sibling field as optional."""
+
+    from app.schemas import AnalyzeResponse
+
+    assert "policy_action" in AnalyzeResponse.model_fields
+    field = AnalyzeResponse.model_fields["policy_action"]
+    assert field.default is None
+
+
+def test_policy_action_card_validates_empty_payload() -> None:
+    """An all-None card (non-policy text) must validate cleanly."""
+
+    from app.schemas import PolicyActionCard
+
+    card = PolicyActionCard()
+    assert card.target_range_low_bp is None
+    assert card.target_range_high_bp is None
+    assert card.change_direction is None
+    assert card.change_magnitude_bp is None
+    assert card.balance_sheet_state is None
+
+
+def test_policy_action_card_validates_full_payload() -> None:
+    """A fully populated card must validate against the schema."""
+
+    from app.schemas import PolicyActionCard
+
+    card = PolicyActionCard(
+        target_range_low_bp=525,
+        target_range_high_bp=550,
+        change_direction="hike",
+        change_magnitude_bp=25,
+        balance_sheet_state="runoff",
+    )
+    assert card.target_range_low_bp == 525
+    assert card.target_range_high_bp == 550
+    assert card.change_direction == "hike"
+    assert card.change_magnitude_bp == 25
+    assert card.balance_sheet_state == "runoff"
+
+
+# ---------------------------------------------------------------------------
+# Extractor: target range
+
+
+def test_extract_target_range_hike_statement() -> None:
+    from app.services.policy_action_extractor import extract_target_range_bp
+
+    bounds = extract_target_range_bp(HIKE_STATEMENT_25BP)
+    assert bounds == (525, 550)
+
+
+def test_extract_target_range_hold_statement() -> None:
+    from app.services.policy_action_extractor import extract_target_range_bp
+
+    bounds = extract_target_range_bp(HOLD_STATEMENT_5_25_5_50)
+    assert bounds == (525, 550)
+
+
+def test_extract_target_range_cut_statement() -> None:
+    from app.services.policy_action_extractor import extract_target_range_bp
+
+    bounds = extract_target_range_bp(CUT_STATEMENT_50BP)
+    assert bounds == (475, 500)
+
+
+def test_extract_target_range_zlb_statement() -> None:
+    """The 0 to 1/4 percent ZLB phrasing must parse cleanly."""
+
+    from app.services.policy_action_extractor import extract_target_range_bp
+
+    bounds = extract_target_range_bp(EXPANSION_STATEMENT)
+    assert bounds == (0, 25)
+
+
+def test_extract_target_range_returns_none_on_non_policy_text() -> None:
+    from app.services.policy_action_extractor import extract_target_range_bp
+
+    assert extract_target_range_bp(NON_POLICY_TEXT) is None
+
+
+# ---------------------------------------------------------------------------
+# Extractor: direction + magnitude
+
+
+def test_extract_direction_hike() -> None:
+    from app.services.policy_action_extractor import extract_change_direction
+
+    assert extract_change_direction(HIKE_STATEMENT_25BP) == "hike"
+
+
+def test_extract_direction_hold() -> None:
+    from app.services.policy_action_extractor import extract_change_direction
+
+    assert extract_change_direction(HOLD_STATEMENT_5_25_5_50) == "hold"
+
+
+def test_extract_direction_cut() -> None:
+    from app.services.policy_action_extractor import extract_change_direction
+
+    assert extract_change_direction(CUT_STATEMENT_50BP) == "cut"
+
+
+def test_extract_direction_none_on_non_policy_text() -> None:
+    from app.services.policy_action_extractor import extract_change_direction
+
+    assert extract_change_direction(NON_POLICY_TEXT) is None
+
+
+def test_extract_magnitude_percentage_point_phrase() -> None:
+    """'by 1/4 percentage point' -> 25 bps."""
+
+    from app.services.policy_action_extractor import extract_change_magnitude_bp
+
+    assert extract_change_magnitude_bp(HIKE_STATEMENT_25BP) == 25
+
+
+def test_extract_magnitude_half_point_phrase() -> None:
+    from app.services.policy_action_extractor import extract_change_magnitude_bp
+
+    assert extract_change_magnitude_bp(CUT_STATEMENT_50BP) == 50
+
+
+def test_extract_magnitude_basis_points_phrase() -> None:
+    """The explicit 'by N basis points' phrasing must parse."""
+
+    from app.services.policy_action_extractor import extract_change_magnitude_bp
+
+    text = "The Committee decided to raise the target range by 75 basis points."
+    assert extract_change_magnitude_bp(text) == 75
+
+
+def test_extract_magnitude_none_when_phrase_absent() -> None:
+    from app.services.policy_action_extractor import extract_change_magnitude_bp
+
+    assert extract_change_magnitude_bp(HOLD_STATEMENT_5_25_5_50) is None
+
+
+# ---------------------------------------------------------------------------
+# Extractor: balance sheet
+
+
+def test_extract_balance_sheet_runoff() -> None:
+    from app.services.policy_action_extractor import extract_balance_sheet_state
+
+    assert extract_balance_sheet_state(HOLD_STATEMENT_5_25_5_50) == "runoff"
+
+
+def test_extract_balance_sheet_tapering_wins_over_runoff() -> None:
+    """Tapering is a narrower phrasing and must take precedence."""
+
+    from app.services.policy_action_extractor import extract_balance_sheet_state
+
+    assert extract_balance_sheet_state(TAPER_STATEMENT) == "tapering"
+
+
+def test_extract_balance_sheet_expansion() -> None:
+    from app.services.policy_action_extractor import extract_balance_sheet_state
+
+    assert extract_balance_sheet_state(EXPANSION_STATEMENT) == "expansion"
+
+
+def test_extract_balance_sheet_none_on_non_policy_text() -> None:
+    from app.services.policy_action_extractor import extract_balance_sheet_state
+
+    assert extract_balance_sheet_state(NON_POLICY_TEXT) is None
+
+
+# ---------------------------------------------------------------------------
+# Top-level extract_policy_action
+
+
+def test_extract_policy_action_hike_with_in_prose_magnitude() -> None:
+    """In-prose magnitude wins even without a prior midpoint."""
+
+    from app.services.policy_action_extractor import extract_policy_action
+
+    action = extract_policy_action(HIKE_STATEMENT_25BP)
+    assert action.target_range_low_bp == 525
+    assert action.target_range_high_bp == 550
+    assert action.change_direction == "hike"
+    assert action.change_magnitude_bp == 25
+    assert action.balance_sheet_state == "runoff"
+
+
+def test_extract_policy_action_hold_emits_zero_magnitude() -> None:
+    from app.services.policy_action_extractor import extract_policy_action
+
+    action = extract_policy_action(HOLD_STATEMENT_5_25_5_50)
+    assert action.change_direction == "hold"
+    assert action.change_magnitude_bp == 0
+
+
+def test_extract_policy_action_cut_signs_magnitude_negative() -> None:
+    from app.services.policy_action_extractor import extract_policy_action
+
+    action = extract_policy_action(CUT_STATEMENT_50BP)
+    assert action.change_direction == "cut"
+    assert action.change_magnitude_bp == -50
+
+
+def test_extract_policy_action_falls_back_to_prior_midpoint() -> None:
+    """When the magnitude phrase is absent, ``this_mid - prior_mid`` rides."""
+
+    from app.services.policy_action_extractor import extract_policy_action
+
+    text = (
+        "The Committee decided to raise the target range for the federal funds "
+        "rate to 5-1/4 to 5-1/2 percent."
+    )
+    # Prior mid was 5.125% -> 513 bps; this mid is 537 bps; delta = 24.
+    action = extract_policy_action(text, prior_target_range_mid_bp=513)
+    assert action.change_direction == "hike"
+    assert action.change_magnitude_bp == 24
+
+
+def test_extract_policy_action_returns_empty_on_non_policy_text() -> None:
+    """A non-policy excerpt must yield an all-None payload, not raise."""
+
+    from app.services.policy_action_extractor import extract_policy_action
+
+    action = extract_policy_action(NON_POLICY_TEXT)
+    assert action.target_range_low_bp is None
+    assert action.target_range_high_bp is None
+    assert action.change_direction is None
+    assert action.change_magnitude_bp is None
+    assert action.balance_sheet_state is None
+
+
+# ---------------------------------------------------------------------------
+# main._build_policy_action_card helper
+
+
+def test_build_policy_action_card_short_circuits_on_empty_text() -> None:
+    """Whitespace-only text must surface ``None`` rather than empty dict."""
+
+    from app.main import _build_policy_action_card
+    from app.schemas import AnalyzeRequest
+
+    payload = AnalyzeRequest(text="   ", date="2024-01-31")
+    assert _build_policy_action_card(payload) is None
+
+
+def test_build_policy_action_card_populates_on_hike_statement() -> None:
+    from app.main import _build_policy_action_card
+    from app.schemas import AnalyzeRequest, PolicyActionCard
+
+    payload = AnalyzeRequest(text=HIKE_STATEMENT_25BP, date="2023-07-26")
+    block = _build_policy_action_card(payload)
+    assert block is not None
+    # The block must validate against the schema in the response shape.
+    card = PolicyActionCard(**block)
+    assert card.target_range_low_bp == 525
+    assert card.target_range_high_bp == 550
+    assert card.change_direction == "hike"
+    assert card.change_magnitude_bp == 25
+    assert card.balance_sheet_state == "runoff"


### PR DESCRIPTION
The mechanical decision (target range + change indicator + balance-sheet posture) was buried inside the encoder input. /analyze surfaced the prediction but never the raw decision the prediction was conditioned on. This PR adds the pure-extraction surface the analyst-style dashboard needed to complete the four-section read.

## Backend

- `backend/app/services/policy_action_extractor.py` -- pure-function, dependency-free regex / keyword pass.
  - `extract_target_range_bp` anchors on `target range` and searches a 240-char window so it does not lock onto a historical comparison ("up from the 2.25 to 2.50 percent range") later in the prose. The number-token regex covers decimal (`3.50`), whole+fraction (`5-1/4`), and bare fraction (`1/4`) forms so the ZLB `0 to 1/4 percent` phrasing parses alongside the canonical `5-1/4 to 5-1/2 percent` range.
  - `extract_change_direction` reads the policy verb: `decided to raise / maintain / lower`.
  - `extract_change_magnitude_bp` handles both `by N basis points` and `by N/D percentage point` phrases.
  - `extract_balance_sheet_state` scans only the paragraph that names balance-sheet operations (anchor: `balance sheet` / `Treasury securities` / `agency mortgage-backed securities` / `Standing Repo Facility`) so the keyword pass does not cross-contaminate with inflation-paragraph vocabulary. Tapering wins over the broader runoff phrasing when both surface.
  - `extract_policy_action` stitches the four signals: in-prose magnitude wins, prior-midpoint delta is a fallback for the signed magnitude + direction when the verb is absent.
- `PolicyActionCard` schema on `AnalyzeResponse.policy_action`. Every field nullable so a non-policy excerpt (press conference Q&A, scraping miss) still serialises as a card with everything None.
- `_build_policy_action_card` helper in `app/main.py`: short-circuits to None on whitespace-only text, wraps the extractor call in try/except so a regex misfire never breaks /analyze.

## Frontend

- `frontend/components/analyze/PolicyActionCard.tsx` -- target range as a percent badge, change indicator with semantic colour (hike = hawkish red, cut = dovish green, hold = neutral), balance-sheet posture as a CardDescription row. Mirrors the primitive imports + tone variants used by `MarketReactionPanel`.
- `frontend/lib/analyze/types.ts` -- `PolicyActionResponse` interface + the optional `policy_action` field on `AnalyzeResult`.
- Workspace page renders the card between the regime headline and the multi-axis / credibility grid when `result.policy_action` is populated.

## Tests

- `tests/unit/test_policy_action_extractor.py` -- 27 cases against representative hike (25 bp), hold, cut (50 bp), tapering, expansion (ZLB), and non-policy texts. Pins the schema field on `AnalyzeResponse`, the empty + fully populated card validations, the per-extractor unit cases (target range, direction, magnitude, balance sheet), and the `_build_policy_action_card` empty-text short-circuit + populated-payload round-trip through the schema.
- `frontend/tests/components/analyze/PolicyActionCard.test.tsx` -- 6 cases covering hike / hold / cut render, balance-sheet row presence vs unavailable badge, and the null short-circuit on an all-null payload.

## Verification

- `ruff check backend/app/services/policy_action_extractor.py backend/app/schemas.py backend/app/main.py tests/unit/test_policy_action_extractor.py` -- clean.
- 25/27 extractor tests pass standalone (the two that import `app.main` need `sqlalchemy` in the env, which the existing `tests/unit/conftest.py` autouse fixture also requires).
- `cd frontend && npm run type-check` -- clean.
- `cd frontend && npm test` -- 38/38 files, 169/169 tests.
- `cd frontend && npm run build` -- clean.

## Acceptance map

Met:
- POST `/analyze` returns `policy_action` populated for any statement that names a target range; null fallback for non-policy correspondence.
- Frontend card renders with semantic colour matching the design tokens (`text-hawkish` / `text-dovish` / `text-neutral`).

Deferred:
- The acceptance bullet on "coverage badge sources from the existing conformal manifest's `predicted_set` overlap with the actual action" reads as a follow-up: the extraction surface does not consume the conformal manifest -- it is a pure regex pass on the raw statement -- and the policy-action card is a different head shape than the prediction-set surface the manifest covers. Left for a later issue if a real overlap target lands.

## Failure modes caught

The 240-char window after `target range` keeps the regex from locking onto a historical comparison later in the prose, but a statement that opens with a long inflation paragraph before naming the decision range would lose the anchor. Real statements name the range early enough that the window holds; an extractor-failure trigger would be a press-conference transcript that buries the verb several paragraphs in. The helper degrades to None on a regex miss rather than mis-attributing, so the failure mode surfaces as an empty card rather than a wrong card.

Closes #446.