### PR TITLE
Loughran-McDonald lexicon as encoder ablation arm (#445)

### DIFF
--- a/backend/app/data/loughran_mcdonald.py
+++ b/backend/app/data/loughran_mcdonald.py
@@ -123,7 +123,7 @@ def _is_flagged(cell: str | int | float | None) -> bool:
         return False
     if isinstance(cell, bool):
         return bool(cell)
-    if isinstance(cell, (int, float)):
+    if isinstance(cell, int | float):
         return cell != 0
     text = str(cell).strip()
     if not text:

--- a/backend/app/data/loughran_mcdonald.py
+++ b/backend/app/data/loughran_mcdonald.py
@@ -1,0 +1,289 @@
+"""Loughran-McDonald financial sentiment lexicon loader (#445).
+
+The L-M Master Dictionary is the most-cited classical financial sentiment
+resource (Loughran & McDonald, 2011; updated annually by McDonald at
+https://sraf.nd.edu/loughranmcdonald-master-dictionary/). Each entry tags
+a word with one or more sentiment categories (Negative, Positive,
+Uncertainty, Litigious, Strong_Modal, Weak_Modal, Constraining) by the
+year the word was first added; a non-zero cell means the word belongs
+to that category in the published lexicon.
+
+#445 wires the lexicon as an ablation baseline against the canonical
+FinBERT-Fed-Adjacent encoder (ADR 0019). The loader reads the cached
+CSV under ``data/external/loughran_mcdonald/<sha>__master_dictionary.csv``
+and returns per-category word sets keyed on lowercase tokens; the
+``compute_lm_features`` helper turns a document into six category-count
+percentages that slot into the same FeatureVector position the pooled
+encoder vector occupies on the canonical path.
+
+The lexicon is public but is not re-downloaded in CI -- the SHA pin
+locks the on-disk artefact, tests work off a small fixture passed via
+``local_csv=``, and the HF / network paths are out of scope here. If the
+cached file is missing, the loader raises ``FileNotFoundError`` rather
+than reaching for the McDonald site at runtime.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from app.config import DATA_DIR
+
+_logger = logging.getLogger(__name__)
+
+
+# Canonical category names. ``modal`` is the union of ``Strong_Modal`` and
+# ``Weak_Modal`` per the issue body -- the published lexicon splits modal
+# strength into two columns; the ablation collapses them into a single
+# modality count so the feature vector stays at six dims.
+LM_CATEGORIES: tuple[str, ...] = (
+    "positive",
+    "negative",
+    "uncertainty",
+    "litigious",
+    "constraining",
+    "modal",
+)
+
+# CSV column names in the published Master Dictionary. The dictionary's
+# schema has been stable since the 2014 release; the columns below are
+# the ones the lexicon-as-feature path reads.
+_LM_CSV_COLUMNS: dict[str, tuple[str, ...]] = {
+    "positive": ("Positive",),
+    "negative": ("Negative",),
+    "uncertainty": ("Uncertainty",),
+    "litigious": ("Litigious",),
+    "constraining": ("Constraining",),
+    # Modal: union of Strong_Modal + Weak_Modal so the count is "any
+    # modal word" rather than a strength-weighted blend.
+    "modal": ("Strong_Modal", "Weak_Modal"),
+}
+
+# Pinned SHA of the cached Master Dictionary CSV. The on-disk file is
+# named ``<sha>__master_dictionary.csv`` so multiple vintages can sit
+# side by side; the loader resolves the active vintage off the pinned
+# constant rather than walking the directory. Updating the pin is a
+# deliberate methodology decision -- a new vintage may shift the
+# per-category counts and the ablation row's framing should be re-run
+# against the new SHA before the wiki cell is updated.
+LM_LEXICON_SHA: str = "lm_master_2024_q4"
+
+DEFAULT_CACHE_ROOT = DATA_DIR / "external" / "loughran_mcdonald"
+
+
+def _default_cache_path() -> Path:
+    return DEFAULT_CACHE_ROOT / f"{LM_LEXICON_SHA}__master_dictionary.csv"
+
+
+@dataclass(frozen=True)
+class LoughranMcDonaldLexicon:
+    """Per-category word sets keyed on lowercase tokens.
+
+    Each set holds the tokens flagged in the named category on the
+    cached Master Dictionary CSV. The ``source_sha`` field records the
+    vintage tag the loader resolved against so a downstream artefact
+    can be traced back to a specific lexicon pin.
+    """
+
+    source_sha: str
+    categories: dict[str, frozenset[str]] = field(default_factory=dict)
+
+    def words(self, category: str) -> frozenset[str]:
+        if category not in LM_CATEGORIES:
+            raise KeyError(
+                f"Unknown L-M category: {category!r}. "
+                f"Known: {LM_CATEGORIES}"
+            )
+        return self.categories.get(category, frozenset())
+
+    @property
+    def total_words(self) -> int:
+        """Distinct tokens across every category (no double counting)."""
+
+        merged: set[str] = set()
+        for words in self.categories.values():
+            merged.update(words)
+        return len(merged)
+
+
+def _is_flagged(cell: str | int | float | None) -> bool:
+    """Return True when the lexicon cell marks a word as in-category.
+
+    The published cells encode the year the word was first added to that
+    category (e.g. ``2009``); an unmapped word has ``0`` (or empty).
+    Treat any non-zero numeric (or non-empty truthy string) as flagged.
+    """
+
+    if cell is None:
+        return False
+    if isinstance(cell, bool):
+        return bool(cell)
+    if isinstance(cell, (int, float)):
+        return cell != 0
+    text = str(cell).strip()
+    if not text:
+        return False
+    try:
+        return float(text) != 0.0
+    except ValueError:
+        # Non-numeric truthy strings (e.g. "yes") are not part of the
+        # published schema but we accept them defensively.
+        return text.lower() not in {"0", "false", "no"}
+
+
+def _normalise_token(word: str) -> str:
+    return word.strip().lower()
+
+
+def load_loughran_mcdonald(
+    *,
+    cache_root: Path | None = None,
+    local_csv: Path | None = None,
+    source_sha: str | None = None,
+) -> LoughranMcDonaldLexicon:
+    """Load the Loughran-McDonald Master Dictionary from cache.
+
+    Parameters
+    ----------
+    cache_root
+        Optional override for the cache root. Defaults to
+        :data:`DEFAULT_CACHE_ROOT`.
+    local_csv
+        Optional path to a CSV fixture. When supplied the loader reads
+        from this path directly and ignores ``cache_root`` -- this is
+        the air-gapped path tests use so CI never reaches the network.
+    source_sha
+        Tag stored on the returned lexicon. Defaults to
+        :data:`LM_LEXICON_SHA` (or the stem of ``local_csv`` when that
+        path is supplied without an explicit tag).
+
+    Raises
+    ------
+    FileNotFoundError
+        When the resolved CSV does not exist on disk. The loader does
+        not fetch the lexicon at runtime -- the SHA-pinned cache is the
+        contract.
+    """
+
+    if local_csv is not None:
+        csv_path = Path(local_csv)
+        sha = source_sha or csv_path.stem
+    else:
+        root = cache_root if cache_root is not None else DEFAULT_CACHE_ROOT
+        sha = source_sha or LM_LEXICON_SHA
+        csv_path = root / f"{sha}__master_dictionary.csv"
+
+    if not csv_path.exists():
+        raise FileNotFoundError(
+            f"Loughran-McDonald cache miss at {csv_path}. The lexicon "
+            "is public but not auto-downloaded; place the Master "
+            "Dictionary CSV at the expected path or pass local_csv= "
+            "(see docs/adr/0036-loughran-mcdonald-baseline.md)."
+        )
+
+    buckets: dict[str, set[str]] = {cat: set() for cat in LM_CATEGORIES}
+    with csv_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise ValueError(
+                f"Loughran-McDonald CSV at {csv_path} is empty or has no header."
+            )
+        word_column = _resolve_word_column(reader.fieldnames)
+        for row in reader:
+            token = _normalise_token(str(row.get(word_column, "")))
+            if not token:
+                continue
+            for category, columns in _LM_CSV_COLUMNS.items():
+                if any(_is_flagged(row.get(col)) for col in columns):
+                    buckets[category].add(token)
+
+    return LoughranMcDonaldLexicon(
+        source_sha=sha,
+        categories={cat: frozenset(words) for cat, words in buckets.items()},
+    )
+
+
+def _resolve_word_column(fieldnames: Iterable[str]) -> str:
+    """Pick the word column off the CSV header.
+
+    The published schema uses ``Word``; older mirrors capitalise as
+    ``WORD`` or ship a leading ``word`` lowercase variant. Accept any
+    of them but raise when none are present so an upstream rename does
+    not silently emit empty word sets.
+    """
+
+    field_list = list(fieldnames)
+    for candidate in ("Word", "WORD", "word"):
+        if candidate in field_list:
+            return candidate
+    raise ValueError(
+        f"Loughran-McDonald CSV header missing the Word column; "
+        f"saw {field_list[:8]}..."
+    )
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z']+")
+
+
+def _tokenise(text: str) -> list[str]:
+    """Lowercase + alphabetic-only tokeniser.
+
+    The L-M lexicon is alphabetic; the tokeniser strips punctuation and
+    digits so the per-category counts measure word-level matches rather
+    than the noise from numeric mentions or quoted symbols. Apostrophes
+    are kept (the lexicon includes contractions / possessives in a few
+    rows) but stripped at the token boundaries.
+    """
+
+    return [match.group(0).lower().strip("'") for match in _TOKEN_RE.finditer(text)]
+
+
+def compute_lm_features(
+    text: str,
+    lexicon: LoughranMcDonaldLexicon,
+) -> dict[str, float]:
+    """Return the six per-category L-M percentages for ``text``.
+
+    The keys follow the issue body's naming: ``lm_positive_pct``,
+    ``lm_negative_pct``, ``lm_uncertainty_pct``, ``lm_litigious_pct``,
+    ``lm_constraining_pct``, ``lm_modal_pct``. Each value is the share
+    of document tokens (after lowercase + alphabetic-only tokenisation)
+    that match the L-M category, expressed as a percentage in
+    ``[0.0, 100.0]``. An empty document returns all zeros so the
+    feature vector is well-defined on the missing-text branch.
+    """
+
+    tokens = _tokenise(text)
+    if not tokens:
+        return {f"lm_{cat}_pct": 0.0 for cat in LM_CATEGORIES}
+
+    counts = dict.fromkeys(LM_CATEGORIES, 0)
+    for token in tokens:
+        for category in LM_CATEGORIES:
+            if token in lexicon.categories.get(category, frozenset()):
+                counts[category] += 1
+
+    denom = float(len(tokens))
+    return {
+        f"lm_{cat}_pct": 100.0 * counts[cat] / denom for cat in LM_CATEGORIES
+    }
+
+
+def compute_lm_feature_vector(
+    text: str,
+    lexicon: LoughranMcDonaldLexicon,
+) -> list[float]:
+    """Return the six L-M percentages as an ordered list.
+
+    Order follows :data:`LM_CATEGORIES`. The list is what the ablation
+    runner writes into ``FeatureVector.text_embedding_pooled`` when the
+    L-M arm replaces the canonical pooled-encoder block.
+    """
+
+    features = compute_lm_features(text, lexicon)
+    return [features[f"lm_{cat}_pct"] for cat in LM_CATEGORIES]

--- a/docs/adr/0036-loughran-mcdonald-baseline.md
+++ b/docs/adr/0036-loughran-mcdonald-baseline.md
@@ -1,0 +1,56 @@
+# ADR 0036 — Loughran-McDonald financial sentiment lexicon as the §6 encoder baseline
+
+Issue #445 lands the Loughran-McDonald (L-M) Master Dictionary as an ablation arm against the canonical FinBERT-Fed-Adjacent encoder (ADR 0019) on the per-family rich-feature ablation runner. Before this PR the §6 table picks a financial-domain encoder as the text-channel substrate without measuring it against a classical lexicon-counts baseline; the standard reviewer punch on that gap is "why didn't you compare to L-M?" and the answer was "we will". This ADR is the answer.
+
+L-M is the most-cited classical financial sentiment resource in the literature (Loughran & McDonald, 2011, *Journal of Finance*; updated annually by McDonald at the Notre Dame SRAF page). The dictionary tags each word with one or more sentiment categories — Negative, Positive, Uncertainty, Litigious, Strong_Modal, Weak_Modal, Constraining — by the year the word was first added; a non-zero cell means the word belongs to that category in the published lexicon. The standard usage in the accounting / finance literature is per-document category-share features: tokenise the text, count the per-category matches, divide by the document length. The result is a six-scalar vector per document (we collapse Strong_Modal + Weak_Modal into a single ``modal`` count so the vector stays at six dims). Cheap to compute, no model parameters, no encoder weights, no fine-tuning step. The baseline a classical financial-NLP paper from 2014 would ship.
+
+The ablation arm substitutes that six-scalar vector for the canonical FinBERT-Fed-Adjacent pooled-encoder block on the same fold protocol. Same per-family ablation runner (``scripts/run_per_family_ablation.py``), same training package, same seeds, same fold ids, same head topology, same hyperparameters. The only thing that changes is what fills the ``FeatureVector.text_embedding_pooled`` slot before the per-fold scaler fit: encoder arm writes the softmax-pooled FinBERT vector across the four most recent prior statements; L-M arm writes the six L-M category percentages computed off the event's own raw text.
+
+## What the ablation answers
+
+The §6 table cell reads as one of three diagnostics:
+
+*FinBERT-Fed-Adjacent beats L-M by a measurable margin.* The continued-pretraining DAPT pass (#190) plus the in-domain FOMC fine-tune (B2) push a representation that catches contextual signal the pre-2014 lexicon counts can't reach. The headline framing "we use a domain-adapted encoder because the classical baseline is not enough" is supported by data rather than asserted. This is the reading the literature on encoder vs lexicon comparisons on financial tasks reports as typical (FinBERT, Araci 2019; FiLM-NLP, Yang 2020) — encoders beat L-M on document-level sentiment by 5-15 pp macro-F1 depending on the corpus. The numbers we expect on FOMC vol-regime / stance classification sit in the same band.
+
+*Comparable.* L-M counts already saturate the per-document signal the head can read off FOMC text on this corpus size (~895 supervised events). The encoder's extra parameters do not buy a measurable lift because the regime label is dominated by market features and the text channel's marginal contribution is bounded by what any reasonable text representation can pick up. This is a publishable reading too — the ensemble lift framing ("L-M is cheap, the encoder adds X pp, the ensemble lifts by Y pp") is the alternative narrative the report would adopt.
+
+*L-M beats the encoder.* The encoder is over-parameterised for the small downstream pool; the lexicon's bias-variance tradeoff is better matched to the corpus size. This reading would force a re-examination of whether the encoder belongs in the headline at all — the methodology contribution would shift to "classical lexicon counts are the right text substrate for FOMC-scale corpora, not domain-adapted transformers". Lower probability but the experiment has to be willing to land there for the test to be honest.
+
+## What ships
+
+A pure-Python lexicon loader at ``backend/app/data/loughran_mcdonald.py``. The Master Dictionary is read from a SHA-pinned CSV cached at ``data/external/loughran_mcdonald/<sha>__master_dictionary.csv``; the loader returns per-category lowercase word sets keyed on ``LM_CATEGORIES = (positive, negative, uncertainty, litigious, constraining, modal)``. ``compute_lm_features(text, lexicon)`` tokenises (lowercase + alphabetic-only regex; punctuation and digits drop), counts per-category matches, and emits the six percentages keyed as ``lm_<category>_pct`` in ``[0.0, 100.0]``. The list-shaped helper ``compute_lm_feature_vector`` returns the same six numbers in ``LM_CATEGORIES`` order so the ablation runner can write them straight into the existing text-embedding slot.
+
+The lexicon is public but the loader never reaches for the network at runtime. The SHA pin (``LM_LEXICON_SHA``) names the active vintage on disk; tests pass ``local_csv=`` to a fixture so the air-gapped path is the exercised one. A missing cache file raises ``FileNotFoundError`` with the expected path in the message rather than silently fetching — the published cached vintage is the contract.
+
+The ablation arm wires into ``scripts/run_per_family_ablation.py`` behind ``--arm lm_lexicon``. On the L-M arm the loader runs with ``text_encoder=None`` (the pooled-encoder pool stays empty), ``encoder_lora=True`` (so the loader writes the target row's raw text into ``vectors[-1].raw_text`` — LoRA training is not activated; ``ModelConfig.encoder_lora`` stays False, the flag only governs whether the loader harvests text), and a post-load walker computes the six L-M percentages off the target text and broadcasts the vector into ``text_embedding_pooled`` on every bar of every sequence. The ``ModelConfig`` widens its text-embedding adapter to the six-dim L-M width so the recurrent core sees the substituted block at the same position the canonical encoder block occupies on the default arm. Everything else — the rich-feature 35-dim slice, the per-family ablation cells, the cumulative chain, the rates target, the regime conditioning — is unchanged.
+
+## Why the lexicon is pinned, not auto-downloaded
+
+The L-M Master Dictionary is updated roughly annually as McDonald revises the per-category word membership; a 2026 vintage can shift the per-category counts measurably against a 2023 vintage on the same FOMC document. Auto-downloading the lexicon at runtime would make the head-to-head numbers a moving target — a re-run six months later against a different vintage would conflate methodology change with feature drift. The SHA pin (``lm_master_2024_q4`` at PR time) freezes the comparison; bumping the pin is a deliberate methodology decision that ships with a rerun of the head-to-head.
+
+The CI smoke runs off a small fixture CSV (10 words covering every category, including a cross-listed entry for the negative + uncertainty union) so the loader's parse contract, the lowercase normalisation, and the modal-column union are pinned without the production lexicon ever touching the test runner. Tests live at ``tests/unit/test_loughran_mcdonald_loader.py`` (loader contract, fixture round-trip, missing-cache failure, category lookup) and ``tests/unit/test_lm_features.py`` (compute_lm_features against known short documents — empty / all-positive / all-uncertainty / mixed / modal-union / punctuation-stripped / case-insensitive).
+
+## Caveats
+
+The L-M lexicon is alphabetic and English-only; tokens with embedded digits or non-ASCII characters drop out of the count. This is the standard literature convention and matches what the published lexicon was built against, but it does mean a sentence like "rates rose 25 bps" has the same L-M signature as "rates rose" — the magnitude of the move is invisible to the lexicon. The encoder arm catches the magnitude via the contextual embedding; the L-M arm cannot. That asymmetry sits inside the comparison and the report frames the result with the caveat called out.
+
+The modal collapse (Strong_Modal + Weak_Modal → ``modal``) is a six-vs-seven dim choice. The seven-dim variant (keep strong and weak separate) is the alternative the literature sometimes ships; we pick the six-dim union because the issue body specifies six features and because the strong / weak distinction does not change the headline diagnostic. A follow-up could sweep both and report whether the strong / weak split changes the head-to-head materially; the runner's arm-resolution is per-cell so the split would be a separate ``--arm`` value rather than a new family.
+
+The runner does not currently exercise the L-M lexicon as a *supplementary* feature alongside the encoder — the head-to-head is "L-M instead of encoder", not "L-M plus encoder". The supplementary variant is out of scope per the issue body; the v1 question is whether the encoder beats the lexicon, not whether stacking the two on the same model lifts further. That follow-up is straightforward (concat the L-M six-vector to the encoder block, widen ``text_embedding_dim`` to encoder_dim + 6) but the gradient sharing argument and the bias-variance read on the small downstream pool make it a separate ablation question.
+
+## Acceptance
+
+A new ablation row sits alongside the §6.19 per-family table once the GPU sweep populates ``backend/artifacts/experiments/per_family_ablation_lm.json``. The cell compares pooled macro-F1 and the regression-band RMSE on ``log(RV)`` between the encoder arm and the ``lm_lexicon`` arm on the canonical 5 seeds × walk-forward folds × 11 cells × 40 epochs surface. The §6 caption frames the result as a methodology diagnostic: encoder beats L-M → the domain-adapted transformer earns its place in the headline; comparable → the ensemble framing is publishable; L-M beats encoder → the methodology contribution rewrites itself around the classical baseline. All three readings are publishable.
+
+The full sweep is GPU-blocked and rides the queued Runpod batch. The runner-side wiring (``--arm lm_lexicon``, the loader plumbing, the lexicon cache contract, the audit-doc row) lands here so the sweep is one command once the queue clears.
+
+## References
+
+- ``backend/app/data/loughran_mcdonald.py`` — lexicon loader + ``compute_lm_features`` / ``compute_lm_feature_vector``.
+- ``scripts/run_per_family_ablation.py`` — ``--arm {encoder, lm_lexicon}`` resolution + the L-M post-load injection helper.
+- ``tests/unit/test_loughran_mcdonald_loader.py`` — loader contract on a fixture CSV.
+- ``tests/unit/test_lm_features.py`` — compute_lm_features against known short documents.
+- ADR 0019 — canonical encoder split (the baseline this ablation compares against).
+- ADR 0033 — PhraseBank auxiliary fine-tune (the loader-pattern reference for the SHA-pinned external lexicon cache).
+- Loughran, T., & McDonald, B. (2011). *When Is a Liability Not a Liability? Textual Analysis, Dictionaries, and 10-Ks*. Journal of Finance.
+- https://sraf.nd.edu/loughranmcdonald-master-dictionary/ — McDonald's distribution page for the Master Dictionary.

--- a/scripts/run_per_family_ablation.py
+++ b/scripts/run_per_family_ablation.py
@@ -300,6 +300,43 @@ def _parse_args() -> argparse.Namespace:
         use_retrieval_analogs=False,
         use_regime_conditioning=False,
     )
+    # #445 Loughran-McDonald ablation arm. ``encoder`` (default) runs the
+    # canonical text-encoder path -- ``--text-encoder`` selects the
+    # alias. ``lm_lexicon`` replaces the pooled-encoder text-embedding
+    # block with the six L-M category percentages (positive / negative /
+    # uncertainty / litigious / constraining / modal), training on the
+    # same fold protocol so the head-to-head reads off the same surface.
+    # See ADR 0036.
+    parser.add_argument(
+        "--arm",
+        type=str,
+        choices=("encoder", "lm_lexicon"),
+        default="encoder",
+        help=(
+            "Text-embedding arm. ``encoder`` (default) keeps the canonical "
+            "FinBERT-Fed-Adjacent pooled vector on the text-embedding "
+            "block; ``lm_lexicon`` substitutes the 6-dim Loughran-McDonald "
+            "category-percentage vector and runs the same fold protocol."
+        ),
+    )
+    parser.add_argument(
+        "--lm-cache-root",
+        type=Path,
+        default=None,
+        help=(
+            "Optional override for the Loughran-McDonald cache root. "
+            "Defaults to ``data/external/loughran_mcdonald/``."
+        ),
+    )
+    parser.add_argument(
+        "--lm-local-csv",
+        type=Path,
+        default=None,
+        help=(
+            "Optional path to a local L-M CSV fixture (air-gapped path; "
+            "ignores --lm-cache-root)."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -309,6 +346,24 @@ def _resolve_output_path(arg: Path | None) -> Path:
     base = BACKEND_ROOT.parent / "artifacts" / "experiments"
     base.mkdir(parents=True, exist_ok=True)
     return base / "per_family_ablation.json"
+
+
+def _resolve_lm_lexicon_sha_for_payload(args: argparse.Namespace) -> str | None:
+    """Surface the active L-M lexicon SHA in the output JSON.
+
+    ``None`` on the encoder arm (no lexicon involved); the pinned cache
+    SHA (or the local fixture stem) on the ``lm_lexicon`` arm so the
+    audit row can pin which vintage produced the head-to-head numbers.
+    """
+
+    if str(getattr(args, "arm", "encoder")) != "lm_lexicon":
+        return None
+    from app.data.loughran_mcdonald import LM_LEXICON_SHA
+
+    local_csv = getattr(args, "lm_local_csv", None)
+    if local_csv is not None:
+        return Path(local_csv).stem
+    return LM_LEXICON_SHA
 
 
 def _resolved_rates_heads_for_payload(rates_target_mode: str) -> list[str]:
@@ -342,6 +397,43 @@ def _resolve_fold_ids(training_package_id: str, override: list[str] | None) -> l
             "--folds explicitly."
         )
     return sorted(manifest.keys())
+
+
+def _attach_lm_text_block(
+    sequences: list[list[Any]],
+    *,
+    lexicon: Any,
+) -> None:
+    """Replace the pooled text-embedding block with the L-M 6-vector.
+
+    The canonical encoder arm populates ``FeatureVector.text_embedding_pooled``
+    with the softmax-pooled FinBERT vector at the loader level. For the
+    L-M ablation the loader runs with ``text_encoder=None`` (so the
+    pooled slot stays empty + ``text_embedding_missing=1.0``); this
+    helper reads ``vectors[-1].raw_text`` per sequence -- harvested by
+    the loader under ``encoder_lora=True`` -- and writes the six L-M
+    category percentages into ``text_embedding_pooled`` on every bar
+    of the sequence. The bar broadcast mirrors the canonical pooled
+    path so the model's text-embedding adapter sees the same shape.
+
+    Sequences whose target row has no raw text (empty string) keep the
+    default zero list + ``text_embedding_missing=1.0`` so the head
+    treats them as "no L-M signal", consistent with the encoder arm's
+    treatment of missing prior statements.
+    """
+
+    from app.data.loughran_mcdonald import compute_lm_feature_vector
+
+    for sequence in sequences:
+        if not sequence:
+            continue
+        target_text = str(getattr(sequence[-1], "raw_text", "") or "").strip()
+        if not target_text:
+            continue
+        vector = compute_lm_feature_vector(target_text, lexicon)
+        for fv in sequence:
+            fv.text_embedding_pooled = list(vector)
+            fv.text_embedding_missing = 0.0
 
 
 def _zero_per_bar_market_aux(
@@ -504,6 +596,41 @@ def _run_one_cell(
         tuple(RATES_HEAD_NAMES) if rates_target_mode != "raw" else ()
     )
 
+    # #445 ablation arm wiring. The L-M arm turns off the loader's
+    # pooled-encoder path (so ``text_embedding_pooled`` stays empty after
+    # ``load_walk_forward_split``) and pins the model's text-embedding
+    # adapter at the 6-dim L-M vector width. Raw event text is harvested
+    # off ``vectors[-1].raw_text`` via the loader's ``encoder_lora`` flag
+    # (LoRA training is not activated -- ``ModelConfig.encoder_lora``
+    # stays False -- the flag only governs whether the loader writes
+    # ``raw_text`` onto the target-row bar). The L-M vector is then
+    # broadcast into ``text_embedding_pooled`` for every bar of every
+    # sequence before ``train_model`` sees the partition. The encoder
+    # arm keeps the canonical text-encoder path.
+    arm = str(getattr(args, "arm", "encoder"))
+    if arm == "lm_lexicon":
+        from app.data.loughran_mcdonald import (
+            LM_CATEGORIES,
+            load_loughran_mcdonald,
+        )
+
+        loader_text_encoder: str | None = None
+        loader_use_text_embeddings = False
+        loader_encoder_lora = True
+        text_embedding_dim = len(LM_CATEGORIES)
+        text_adapter_dim = len(LM_CATEGORIES)
+        lm_lexicon = load_loughran_mcdonald(
+            cache_root=getattr(args, "lm_cache_root", None),
+            local_csv=getattr(args, "lm_local_csv", None),
+        )
+    else:
+        loader_text_encoder = str(args.text_encoder)
+        loader_use_text_embeddings = True
+        loader_encoder_lora = False
+        text_embedding_dim = 0
+        text_adapter_dim = 0
+        lm_lexicon = None
+
     config = ModelConfig(
         input_size=RICH_FEATURE_SIZE,
         output_mode="classification",
@@ -516,6 +643,8 @@ def _run_one_cell(
         use_regime_conditioning=bool(
             getattr(args, "use_regime_conditioning", False)
         ),
+        text_embedding_dim=text_embedding_dim,
+        text_adapter_dim=text_adapter_dim,
     )
 
     per_fold: list[dict[str, Any]] = []
@@ -524,7 +653,9 @@ def _run_one_cell(
             training_package_id=args.training_package_id,
             fold_id=fold_id,
             rich_features=True,
-            text_encoder=str(args.text_encoder),
+            text_encoder=loader_text_encoder,
+            use_text_embeddings=loader_use_text_embeddings,
+            encoder_lora=loader_encoder_lora,
             use_retrieval_analogs=bool(
                 getattr(args, "use_retrieval_analogs", False)
             ),
@@ -533,6 +664,10 @@ def _run_one_cell(
             ),
             **flags["loader"],
         )
+        if arm == "lm_lexicon" and lm_lexicon is not None:
+            _attach_lm_text_block(split.train, lexicon=lm_lexicon)
+            _attach_lm_text_block(split.val, lexicon=lm_lexicon)
+            _attach_lm_text_block(split.test, lexicon=lm_lexicon)
         # Pre-scaler-fit zeroing for the per-bar families that the
         # loader has no flag for. Same contract as #309's
         # ``_zero_derived_text_features`` rewrite -- the scaler in
@@ -670,6 +805,8 @@ def main() -> int:
         ),
         "use_retrieval_analogs": bool(args.use_retrieval_analogs),
         "use_regime_conditioning": bool(args.use_regime_conditioning),
+        "arm": str(getattr(args, "arm", "encoder")),
+        "lm_lexicon_sha": _resolve_lm_lexicon_sha_for_payload(args),
         "post_350_status": str(args.post_350_status),
         "cumulative_chain": [
             {"label": label, "families": list(families)}

--- a/tests/unit/test_lm_features.py
+++ b/tests/unit/test_lm_features.py
@@ -1,0 +1,95 @@
+"""compute_lm_features contract tests (#445)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.data.loughran_mcdonald import (
+    LM_CATEGORIES,
+    compute_lm_feature_vector,
+    compute_lm_features,
+    load_loughran_mcdonald,
+)
+
+
+# Reuse the fixture row writer from the loader test module.
+from tests.unit.test_loughran_mcdonald_loader import _write_fixture
+
+
+@pytest.fixture
+def lexicon(tmp_path: Path):
+    csv_path = _write_fixture(tmp_path / "fixture__master_dictionary.csv")
+    return load_loughran_mcdonald(local_csv=csv_path)
+
+
+def test_empty_document_returns_zeros(lexicon) -> None:
+    features = compute_lm_features("", lexicon)
+    assert features == {f"lm_{cat}_pct": 0.0 for cat in LM_CATEGORIES}
+
+
+def test_all_positive_document(lexicon) -> None:
+    # Three tokens, all in the positive set ('able', 'gain').
+    features = compute_lm_features("Able gain able", lexicon)
+    assert features["lm_positive_pct"] == pytest.approx(100.0)
+    assert features["lm_negative_pct"] == pytest.approx(0.0)
+    assert features["lm_uncertainty_pct"] == pytest.approx(0.0)
+
+
+def test_all_uncertainty_document(lexicon) -> None:
+    # 'uncertain' is uncertainty-only; 'doubtful' is cross-listed in
+    # negative + uncertainty -- the counts increment both buckets.
+    features = compute_lm_features("Uncertain doubtful", lexicon)
+    assert features["lm_uncertainty_pct"] == pytest.approx(100.0)
+    # doubtful is also negative, so 1/2 == 50%.
+    assert features["lm_negative_pct"] == pytest.approx(50.0)
+    assert features["lm_positive_pct"] == pytest.approx(0.0)
+
+
+def test_mixed_document_percentages(lexicon) -> None:
+    # 5 tokens: 'gain' (positive), 'loss' (negative), 'must' (modal),
+    # 'restricted' (constraining), 'the' (not flagged).
+    text = "Gain loss must restricted the"
+    features = compute_lm_features(text, lexicon)
+    assert features["lm_positive_pct"] == pytest.approx(20.0)
+    assert features["lm_negative_pct"] == pytest.approx(20.0)
+    assert features["lm_modal_pct"] == pytest.approx(20.0)
+    assert features["lm_constraining_pct"] == pytest.approx(20.0)
+    assert features["lm_uncertainty_pct"] == pytest.approx(0.0)
+    assert features["lm_litigious_pct"] == pytest.approx(0.0)
+
+
+def test_modal_union_strong_and_weak(lexicon) -> None:
+    # 'must' is Strong_Modal, 'may' is Weak_Modal -- both count toward
+    # lm_modal_pct because the loader unions the two columns.
+    features = compute_lm_features("must may", lexicon)
+    assert features["lm_modal_pct"] == pytest.approx(100.0)
+
+
+def test_compute_lm_feature_vector_order(lexicon) -> None:
+    """The list-shaped helper emits values in LM_CATEGORIES order."""
+
+    text = "Gain loss uncertain lawsuit restricted must"
+    vector = compute_lm_feature_vector(text, lexicon)
+    assert len(vector) == len(LM_CATEGORIES)
+    # Six tokens, one per category; each percentage should be ~16.67.
+    for value in vector:
+        assert value == pytest.approx(100.0 / 6.0)
+
+
+def test_punctuation_and_digits_are_stripped(lexicon) -> None:
+    # Digits, numerals, and punctuation must not inflate the denominator.
+    text = "Gain, gain! 2025 25% the-loss."
+    features = compute_lm_features(text, lexicon)
+    # Tokens after tokenisation: gain, gain, the, loss => 4 tokens.
+    # positive = 2 (gain x2) => 50%; negative = 1 (loss) => 25%.
+    assert features["lm_positive_pct"] == pytest.approx(50.0)
+    assert features["lm_negative_pct"] == pytest.approx(25.0)
+
+
+def test_lowercase_input_matches_uppercase_lexicon(lexicon) -> None:
+    # The lexicon stores words lowercase; compute_lm_features lowercases
+    # the document, so mixed-case input still matches.
+    features = compute_lm_features("LOSS Loss loss", lexicon)
+    assert features["lm_negative_pct"] == pytest.approx(100.0)

--- a/tests/unit/test_loughran_mcdonald_loader.py
+++ b/tests/unit/test_loughran_mcdonald_loader.py
@@ -1,0 +1,163 @@
+"""Loader contract tests for the Loughran-McDonald lexicon (#445)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.data.loughran_mcdonald import (
+    DEFAULT_CACHE_ROOT,
+    LM_CATEGORIES,
+    LM_LEXICON_SHA,
+    LoughranMcDonaldLexicon,
+    _is_flagged,
+    _normalise_token,
+    _tokenise,
+    load_loughran_mcdonald,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture CSV: 10 rows that cover every category at least once. ``year`` cells
+# encode the year first added; ``0`` means the word is not flagged.
+# Strong_Modal + Weak_Modal both fold into the ``modal`` bucket; the fixture
+# carries one of each so the union is exercised.
+# ---------------------------------------------------------------------------
+
+
+_FIXTURE_HEADER = (
+    "Word,Negative,Positive,Uncertainty,Litigious,Strong_Modal,Weak_Modal,Constraining\n"
+)
+
+_FIXTURE_ROWS = [
+    # Word           Neg   Pos   Unc   Lit   Str   Wek   Con
+    ("ABLE",         "0",  "2009","0",  "0",  "0",  "0",  "0"),
+    ("LOSS",         "2009","0", "0",  "0",  "0",  "0",  "0"),
+    ("UNCERTAIN",    "0",  "0",  "2009","0", "0",  "0",  "0"),
+    ("LAWSUIT",      "0",  "0",  "0",  "2009","0", "0",  "0"),
+    ("RESTRICTED",   "0",  "0",  "0",  "0",  "0",  "0",  "2009"),
+    ("MUST",         "0",  "0",  "0",  "0",  "2009","0", "0"),
+    ("MAY",          "0",  "0",  "0",  "0",  "0",  "2009","0"),
+    # A word flagged on two categories (negative AND uncertainty) -- the
+    # canonical lexicon has a handful of these cross-listed entries.
+    ("DOUBTFUL",     "2009","0", "2009","0", "0",  "0",  "0"),
+    # Unflagged filler. Should not appear in any category set.
+    ("THE",          "0",  "0",  "0",  "0",  "0",  "0",  "0"),
+    # Already-lowercase word + leading whitespace -- the loader must
+    # normalise both.
+    ("  gain ",      "0",  "2009","0",  "0",  "0",  "0",  "0"),
+]
+
+
+def _write_fixture(path: Path) -> Path:
+    body = _FIXTURE_HEADER + "".join(
+        ",".join(row) + "\n" for row in _FIXTURE_ROWS
+    )
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Pure-Python contract: helpers + category list.
+# ---------------------------------------------------------------------------
+
+
+def test_lm_categories_pinned() -> None:
+    assert LM_CATEGORIES == (
+        "positive",
+        "negative",
+        "uncertainty",
+        "litigious",
+        "constraining",
+        "modal",
+    )
+
+
+def test_normalise_token_lowercases_and_strips() -> None:
+    assert _normalise_token("  HAWKISH  ") == "hawkish"
+    assert _normalise_token("Loss") == "loss"
+
+
+def test_tokenise_strips_punctuation_and_lowercases() -> None:
+    tokens = _tokenise("Net sales rose 12%; profit fell sharply.")
+    # No digits, no punctuation, every token lowercase.
+    assert tokens == ["net", "sales", "rose", "profit", "fell", "sharply"]
+
+
+def test_is_flagged_treats_nonzero_year_cells_as_true() -> None:
+    assert _is_flagged("2009") is True
+    assert _is_flagged(2009) is True
+    assert _is_flagged("0") is False
+    assert _is_flagged(0) is False
+    assert _is_flagged("") is False
+    assert _is_flagged(None) is False
+
+
+# ---------------------------------------------------------------------------
+# Loader: from local CSV fixture.
+# ---------------------------------------------------------------------------
+
+
+def test_load_loughran_mcdonald_from_fixture(tmp_path: Path) -> None:
+    csv_path = _write_fixture(tmp_path / "fixture__master_dictionary.csv")
+    lexicon = load_loughran_mcdonald(local_csv=csv_path)
+
+    assert isinstance(lexicon, LoughranMcDonaldLexicon)
+    assert lexicon.source_sha  # set off the filename stem when no override
+
+    # Each category populated as expected.
+    assert lexicon.words("positive") == frozenset({"able", "gain"})
+    assert lexicon.words("negative") == frozenset({"loss", "doubtful"})
+    assert lexicon.words("uncertainty") == frozenset({"uncertain", "doubtful"})
+    assert lexicon.words("litigious") == frozenset({"lawsuit"})
+    assert lexicon.words("constraining") == frozenset({"restricted"})
+    # Modal is the union of Strong_Modal + Weak_Modal.
+    assert lexicon.words("modal") == frozenset({"must", "may"})
+
+
+def test_load_loughran_mcdonald_lowercases_word_column(tmp_path: Path) -> None:
+    """Tokens flagged in CAPS on disk are normalised to lowercase keys."""
+
+    csv_path = _write_fixture(tmp_path / "fixture__master_dictionary.csv")
+    lexicon = load_loughran_mcdonald(local_csv=csv_path)
+    # The fixture writes LAWSUIT in caps; the lookup is lowercase.
+    assert "lawsuit" in lexicon.words("litigious")
+    assert "LAWSUIT" not in lexicon.words("litigious")
+
+
+def test_load_loughran_mcdonald_unknown_category_raises(tmp_path: Path) -> None:
+    csv_path = _write_fixture(tmp_path / "fixture__master_dictionary.csv")
+    lexicon = load_loughran_mcdonald(local_csv=csv_path)
+    with pytest.raises(KeyError, match="Unknown L-M category"):
+        lexicon.words("hawkish")
+
+
+def test_load_loughran_mcdonald_missing_cache_raises(tmp_path: Path) -> None:
+    """Loader does not reach for the network -- missing CSV => FileNotFoundError."""
+
+    with pytest.raises(FileNotFoundError, match="cache miss"):
+        load_loughran_mcdonald(cache_root=tmp_path)
+
+
+def test_load_loughran_mcdonald_total_words_counts_distinct(tmp_path: Path) -> None:
+    csv_path = _write_fixture(tmp_path / "fixture__master_dictionary.csv")
+    lexicon = load_loughran_mcdonald(local_csv=csv_path)
+    # 'doubtful' is in both negative + uncertainty; total_words counts
+    # it once. Fixture distinct words: able, loss, uncertain, lawsuit,
+    # restricted, must, may, doubtful, gain = 9.
+    assert lexicon.total_words == 9
+
+
+def test_default_cache_root_under_data_external(tmp_path: Path) -> None:
+    """The default cache root lives where the wiki says it does."""
+
+    assert DEFAULT_CACHE_ROOT.name == "loughran_mcdonald"
+    assert DEFAULT_CACHE_ROOT.parent.name == "external"
+    assert LM_LEXICON_SHA  # non-empty pin
+
+
+def test_load_loughran_mcdonald_source_sha_override(tmp_path: Path) -> None:
+    csv_path = _write_fixture(tmp_path / "fixture__master_dictionary.csv")
+    lexicon = load_loughran_mcdonald(local_csv=csv_path, source_sha="custom_pin")
+    assert lexicon.source_sha == "custom_pin"


### PR DESCRIPTION
Closes #445.

L-M Master Dictionary lands as a classical-baseline arm against the canonical FinBERT-Fed-Adjacent text-encoder block on the per-family ablation runner. The head-to-head sweep on the 5-seed x walk-forward x 11-cell x 40-epoch surface is GPU-bound and rides the queued Runpod batch; the runner-side wiring + lexicon loader + ADR ship here so the sweep is one command once the queue clears.

## What lands

- `backend/app/data/loughran_mcdonald.py` -- lexicon loader. Reads a SHA-pinned CSV under `data/external/loughran_mcdonald/<sha>__master_dictionary.csv` (pin `lm_master_2024_q4`). The lexicon is public but never auto-downloaded at runtime; missing cache raises `FileNotFoundError`. Tests pass a 10-word fixture via `local_csv=` so CI is air-gapped. Per-category word sets keyed on lowercase tokens. `Strong_Modal` + `Weak_Modal` union into the single `modal` bucket so the feature vector stays at six dims.
- `compute_lm_features(text, lexicon)` -- the six per-document percentages keyed as `lm_<category>_pct` in `[0.0, 100.0]`. `compute_lm_feature_vector(text, lexicon)` returns the six numbers in `LM_CATEGORIES` order for the ablation runner.
- `scripts/run_per_family_ablation.py` gains `--arm {encoder, lm_lexicon}`. The `lm_lexicon` arm runs the loader with `text_encoder=None` + `use_text_embeddings=False` + `encoder_lora=True` (raw-text harvest only; LoRA training is NOT activated -- `ModelConfig.encoder_lora` stays False), computes the six L-M percentages off the target text, and broadcasts the vector into `FeatureVector.text_embedding_pooled` on every bar of every sequence. `ModelConfig.text_embedding_dim` / `text_adapter_dim` pin to 6 so the text-adapter sees the substituted block at the same slot the canonical pooled vector occupies on the default arm. Rich-feature 35-dim slice, per-family cells, cumulative chain, rates target, regime conditioning -- all unchanged.
- `--lm-cache-root` / `--lm-local-csv` -- cache-root override + air-gapped CSV path for the runner.
- Output JSON now carries `arm` + `lm_lexicon_sha` so the audit row can pin which vintage produced the head-to-head numbers.
- `docs/adr/0036-loughran-mcdonald-baseline.md` -- methodology framing. Why L-M as the baseline (most-cited classical financial-sentiment resource), what the three readings settle (FinBERT beats / comparable / L-M beats), the modal-collapse + alphabetic-only caveats, why the lexicon is SHA-pinned rather than auto-downloaded.

## Tests

- `tests/unit/test_loughran_mcdonald_loader.py` -- 10 tests. Loader contract on the 10-word fixture, source_sha override, lowercase normalisation, modal-column union, missing-cache failure, distinct-token total, unknown-category rejection.
- `tests/unit/test_lm_features.py` -- 8 tests. compute_lm_features against known short documents: empty, all-positive, all-uncertainty (with cross-listed token), mixed, modal Strong+Weak union, list-shaped vector ordering, punctuation / digit stripping, mixed-case input.

Both files air-gapped via `local_csv=`. No network access on CI.

## Audit

- Wiki §13 burn-down row #445 updated on the wiki side (`16_Finalization_Roadmap.md`) with the loader / runner / test surface + the ADR pointer + the BLOCKED-on-GPU-sweep note. Lands as a separate wiki commit.

## Verification

- `ruff check backend tests scripts` -- 48 pre-existing errors elsewhere; the new files (`loughran_mcdonald.py`, `run_per_family_ablation.py`, the two test modules, the ADR) are ruff-clean on the changed surface.
- Local backend env not available on this box; pytest is queued for the next backend-env run. The loader + features modules parse cleanly under `python -m ast`.
- No HF Hub writes. No `torch.compile`. No automated download path -- the L-M lexicon is the SHA-pinned cache contract.

## BLOCKED

- §6 head-to-head row -- needs the GPU canonical sweep on the 5-seed x walk-forward x 11-cell x 40-epoch surface. Queue once Runpod availability returns; the runner-side knob (`--arm lm_lexicon`) + the loader cache contract + the audit doc row are all in repo.

## Test plan

- [ ] CI green on `tests/unit/test_loughran_mcdonald_loader.py` + `tests/unit/test_lm_features.py`
- [ ] `ruff check backend tests scripts` -- no new errors on the changed surface
- [ ] Existing `tests/unit/test_per_family_ablation*.py` (if any) stays green -- default `--arm encoder` path is byte-identical to pre-#445 because `text_embedding_dim` / `text_adapter_dim` default to 0 on the encoder arm wiring
- [ ] Determinism regression at `tests/regression/test_forecaster_determinism.py` stays green (no default-path change)