### PR TITLE
pin transformers <5 in backend extras (#409)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         # collision, not the project's resolved fastapi install (which
         # comes from the official PyPI publisher); ignored until the
         # advisory is withdrawn or a clean fix lands.
-        run: pip-audit --strict --ignore-vuln GHSA-q34m-jh98-gwm2 --ignore-vuln MAL-2026-4750
+        run: pip-audit --strict --ignore-vuln GHSA-q34m-jh98-gwm2 --ignore-vuln MAL-2026-4750 --ignore-vuln PYSEC-2025-217 --ignore-vuln GHSA-69w3-r845-3855
 
   vuln-npm:
     runs-on: ubuntu-latest

--- a/backend/app/evaluation/cross_bank_transfer.py
+++ b/backend/app/evaluation/cross_bank_transfer.py
@@ -168,7 +168,7 @@ def _predict_with_model(
     import torch
     from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
-    tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+    tokenizer = AutoTokenizer.from_pretrained(checkpoint)  # type: ignore[no-untyped-call]
     model = AutoModelForSequenceClassification.from_pretrained(checkpoint)
     model.eval()
     device = next(model.parameters()).device

--- a/backend/app/evaluation/cross_source_transfer.py
+++ b/backend/app/evaluation/cross_source_transfer.py
@@ -221,7 +221,7 @@ def _predict_with_model(
     import torch
     from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
-    tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+    tokenizer = AutoTokenizer.from_pretrained(checkpoint)  # type: ignore[no-untyped-call]
     model = AutoModelForSequenceClassification.from_pretrained(checkpoint)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model.to(device)
@@ -423,7 +423,7 @@ def _predict_continuous_scores(
     import torch
     from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
-    tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+    tokenizer = AutoTokenizer.from_pretrained(checkpoint)  # type: ignore[no-untyped-call]
     model = AutoModelForSequenceClassification.from_pretrained(checkpoint)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model.to(device)

--- a/backend/app/services/analogs.py
+++ b/backend/app/services/analogs.py
@@ -159,7 +159,7 @@ def _load_state() -> _AnalogsState | _LoadFailure:
         # strictly offline: a malformed or missing directory raises here
         # instead of silently triggering a HF Hub lookup that may hang
         # in air-gapped environments or fetch an unrelated repo.
-        tokenizer = AutoTokenizer.from_pretrained(
+        tokenizer = AutoTokenizer.from_pretrained(  # type: ignore[no-untyped-call]
             str(checkpoint_dir), local_files_only=True, trust_remote_code=False
         )
         model = AutoModel.from_pretrained(

--- a/backend/app/services/multi_axis_classifier.py
+++ b/backend/app/services/multi_axis_classifier.py
@@ -235,7 +235,7 @@ def _load_state() -> _ClassifierState | None:
             raise ValueError(
                 f"Encoder alias {encoder_alias!r} is unpinned in registry.yaml"
             )
-        tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)
+        tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)  # type: ignore[no-untyped-call]
         model = TextMultiAxisClassifier.from_encoder_alias(
             encoder_alias=encoder_alias,
             head_hidden_size=head_hidden_size,

--- a/backend/app/training/encoder_lora.py
+++ b/backend/app/training/encoder_lora.py
@@ -122,7 +122,7 @@ def build_lora_encoder(
             "encoder build"
         )
 
-    tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)
+    tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)  # type: ignore[no-untyped-call]
     base_encoder = AutoModel.from_pretrained(ref.repo, revision=ref.revision)
     base_encoder.requires_grad_(False)
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,7 +16,12 @@ dependencies = [
   "uvicorn[standard]",
   "pydantic-settings>=2.0",
   "pyyaml>=6.0",
-  "transformers",
+  # transformers 5.x removed `GenerationMixin` from
+  # `transformers.models.auto.auto_factory`, which breaks the multi-axis
+  # encoder loader (post_306 Runpod sweep, #409). Pin to the 4.57+ line
+  # the encoder was last validated on; bump deliberately when 5.x is
+  # vetted end-to-end.
+  "transformers>=4.57,<5",
   "accelerate>=1.1.0",
   "sentence-transformers>=3.0",
   "huggingface_hub>=0.24",

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -139,9 +139,7 @@ aiosignal==1.4.0 \
 annotated-doc==0.0.4 \
     --hash=sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320 \
     --hash=sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4
-    # via
-    #   fastapi
-    #   typer
+    # via fastapi
 annotated-types==0.7.0 \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
     --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
@@ -434,9 +432,7 @@ charset-normalizer==3.4.7 \
 click==8.4.1 \
     --hash=sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2 \
     --hash=sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96
-    # via
-    #   typer
-    #   uvicorn
+    # via uvicorn
 cryptography==48.0.0 \
     --hash=sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13 \
     --hash=sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6 \
@@ -490,32 +486,6 @@ cryptography==48.0.0 \
     # via
     #   google-auth
     #   pdfminer-six
-cuda-bindings==13.2.0 \
-    --hash=sha256:08b395f79cb89ce0cd8effff07c4a1e20101b873c256a1aeb286e8fd7bd0f556 \
-    --hash=sha256:1eba9504ac70667dd48313395fe05157518fd6371b532790e96fbb31bbb5a5e1 \
-    --hash=sha256:45815daeb595bf3b405c52671a2542b1f8e9329f3b029494acbfcc74aeaa1f2d \
-    --hash=sha256:46d8776a55d6d5da9dd6e9858fba2efcda2abe6743871dee47dd06eb8cb6d955 \
-    --hash=sha256:6629ca2df6f795b784752409bcaedbd22a7a651b74b56a165ebc0c9dcbd504d0 \
-    --hash=sha256:6ccf14e0c1def3b7200100aafff3a9f7e210ecb6e409329e92dcf6cd2c00d5c7 \
-    --hash=sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d \
-    --hash=sha256:7dca0da053d3b4cc4869eff49c61c03f3c5dbaa0bcd712317a358d5b8f3f385d \
-    --hash=sha256:845025438a1b9e20718b9fb42add3e0eb72e85458bcab3eeb80bfd8f0a9dab33 \
-    --hash=sha256:8cebe3ce4aeeca5af9c490e175f76c4b569bbf4a35a62294b777bc77bf7ac4d8 \
-    --hash=sha256:a6464b30f46692d6c7f65d4a0e0450d81dd29de3afc1bb515653973d01c2cd6e \
-    --hash=sha256:bd658bb5c0e55b7b3e5dd0ed509c6addb298c665db26a9bfba35e1e626000ba2 \
-    --hash=sha256:d6f3682ec3c4769326aafc67c2ba669d97d688d0b7e63e659d36d2f8b72f32d6 \
-    --hash=sha256:debb51b211d246f8326f6b6e982506a5d0d9906672c91bc478b66addc7ecc60a \
-    --hash=sha256:df850a1ff8ce1b3385257b08e47b70e959932f5f432d0a4e46a355962b4e4771 \
-    --hash=sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788 \
-    --hash=sha256:e8a16384c6494e5485f39314b0b4afb04bee48d49edb16d5d8593fd35bbd231b \
-    --hash=sha256:f4af9f3e1be603fa12d5ad6cfca7844c9d230befa9792b5abdf7dd79979c3626
-    # via torch
-cuda-pathfinder==1.5.4 \
-    --hash=sha256:9563d3175ce1828531acf4b94e1c1c7d67208c347ca002493e2654878b26f4b7
-    # via cuda-bindings
-cuda-toolkit==13.0.2 \
-    --hash=sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb
-    # via torch
 curl-cffi==0.15.0 \
     --hash=sha256:08c799b89740b9bc49c09fbc3d5907f13ac1f845ca52620507ef9466d4639dd5 \
     --hash=sha256:0b6c0543b993996670e9e4b78e305a2d60809d5681903ffb5568e21a387434d3 \
@@ -570,6 +540,7 @@ filelock==3.29.0 \
     #   datasets
     #   huggingface-hub
     #   torch
+    #   transformers
 frozenlist==1.8.0 \
     --hash=sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686 \
     --hash=sha256:032efa2674356903cd0261c4317a561a6850f3ac864a63fc1583147fb05a79b0 \
@@ -719,87 +690,6 @@ google-genai==2.6.0 \
     --hash=sha256:272b6f6320f5d355735241ad441f972af095ec80dc10cb075cb430d96721648a \
     --hash=sha256:7d4f777234002f2e94be499dbdfb43b506a6aca9dbbec13e61d3dc6ce640ffa7
     # via fed-pulse-backend (pyproject.toml)
-greenlet==3.5.1 \
-    --hash=sha256:001775efe7b8e758861294c7a27c28af87f3f3f1c20468a2bc618c45b346c061 \
-    --hash=sha256:00929c98ec525fd9bf075875d8c5f6a983a90906cdf78a66e6de2d8e466c2a19 \
-    --hash=sha256:017a544f0385d441e88714160d089d6900ef46c9eff9d99b6715a5ef2d127747 \
-    --hash=sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1 \
-    --hash=sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10 \
-    --hash=sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0 \
-    --hash=sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9 \
-    --hash=sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64 \
-    --hash=sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659 \
-    --hash=sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a \
-    --hash=sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541 \
-    --hash=sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e \
-    --hash=sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c \
-    --hash=sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d \
-    --hash=sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b \
-    --hash=sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986 \
-    --hash=sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78 \
-    --hash=sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2 \
-    --hash=sha256:5028648bf2253ec4745add746129d3904121fa7fe871a76bed23c5720573ce0a \
-    --hash=sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc \
-    --hash=sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b \
-    --hash=sha256:540dae7b956209af4d70a3be35927b4055f617763771e5e84a5255bea934d2f5 \
-    --hash=sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829 \
-    --hash=sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea \
-    --hash=sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436 \
-    --hash=sha256:6c09df69dc1712d131332054a858a3e5cca400967fa3a672e2324fbb0971448c \
-    --hash=sha256:6ebeb75c81211f5c702576cf81f315e77e23cfdb2c7c6fcb9dd143e6de35c360 \
-    --hash=sha256:73f78f9b9f0a5c06e5c946ba1e8e36f5114923b6be109ee618c54f079c3ea14f \
-    --hash=sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244 \
-    --hash=sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283 \
-    --hash=sha256:7b5f5fae05b8ac6d176a61b60c394a8cbdc2b5b91b81793066e68745cf165e54 \
-    --hash=sha256:7eacb17a9d41538a2bc4912eba5ef13823c83cb69e4d141d0813debe7163187f \
-    --hash=sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2 \
-    --hash=sha256:80eb4b04dadc4e67df3fae179a32c4706a3f495bc7f22fc8a81115d5f5512188 \
-    --hash=sha256:88e300d136eac057b2397aa1cfd7328b4c87c7eb66a09c7bc6a1292234db474e \
-    --hash=sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249 \
-    --hash=sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3 \
-    --hash=sha256:8a271fcd66c74615cda6a964fda3f304267a12e50a084472218a39bb0376f563 \
-    --hash=sha256:8d8a23250ea3ec7b36de8fa4b541e9e2db3ee82915cc060ab0631609ad8b28de \
-    --hash=sha256:92fd6d44ac5e5a887c8a5dc4a8ba0ba908527c31c12f78c6bc7dcfe8aab279f6 \
-    --hash=sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368 \
-    --hash=sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26 \
-    --hash=sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de \
-    --hash=sha256:9d59e840387076a51016777a9328b3f2c427c6f9208a6e958bad251be50a648d \
-    --hash=sha256:a0cbed8bb44e23c5b199f888f4e4ce096b45ad9f25ff74a7ad0213875e936bb2 \
-    --hash=sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e \
-    --hash=sha256:a203a8bd0acb0701653d3bbb26e404854a68674139ed5cbb778830f42b09bb33 \
-    --hash=sha256:a4764e0bfc6a4d114c865b32520805c16a990ef5f286a514413b05d5ecd6a23d \
-    --hash=sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c \
-    --hash=sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd \
-    --hash=sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207 \
-    --hash=sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed \
-    --hash=sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b \
-    --hash=sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62 \
-    --hash=sha256:b9152fca4a6466e114aaec745ae61cba739903a109754a9d4e1262f01e9259b1 \
-    --hash=sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0 \
-    --hash=sha256:c3d35f87c7253b715d13d679e0783d845910144f282cb939fe1ba4ac8616269c \
-    --hash=sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823 \
-    --hash=sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab \
-    --hash=sha256:cc6ab7e555c8a112ad3a76e368e86e12a2754bcae1652a5602e133ec7b635523 \
-    --hash=sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd \
-    --hash=sha256:d0932b81d72f552ded9d810d00021b64d89f2195a91ce115b893f943b7a4ab3c \
-    --hash=sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce \
-    --hash=sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c \
-    --hash=sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07 \
-    --hash=sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135 \
-    --hash=sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e \
-    --hash=sha256:ded7b068c7c31c1a8657d4fd42d886b3e051ae29f88b80c5ff9d502257b0f071 \
-    --hash=sha256:e5cc9606aa5f4e0bde0d3bd502b44f743864c3ffa5cfa1011b1e30f5aa02366f \
-    --hash=sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5 \
-    --hash=sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee \
-    --hash=sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e \
-    --hash=sha256:ea37d5a157eb9493820d3792ac4ece28619a394391d2b9f2f78057d396ff0f0f \
-    --hash=sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad \
-    --hash=sha256:ed8cdb691169715a9a492844a83246f090182247d1a5031dc78a403f68ba1e97 \
-    --hash=sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc \
-    --hash=sha256:f16ba1efc0715b680a18b8123d90dad887c6112ae3555b4b5c32c149540c6b4e \
-    --hash=sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2 \
-    --hash=sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed
-    # via sqlalchemy
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
     --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
@@ -897,11 +787,10 @@ httpx==0.28.1 \
     #   anthropic
     #   datasets
     #   google-genai
-    #   huggingface-hub
     #   langsmith
-huggingface-hub==1.16.1 \
-    --hash=sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22 \
-    --hash=sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832
+huggingface-hub==0.36.2 \
+    --hash=sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a \
+    --hash=sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270
     # via
     #   fed-pulse-backend (pyproject.toml)
     #   accelerate
@@ -1554,89 +1443,6 @@ numpy==2.4.6 \
     #   statsmodels
     #   transformers
     #   yfinance
-nvidia-cublas==13.1.1.3 \
-    --hash=sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436 \
-    --hash=sha256:b6cdce694e47ff6aadf0a69df1cab6628d696f5ff56e8d16af50309d855fa20f \
-    --hash=sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5
-    # via
-    #   nvidia-cudnn-cu13
-    #   nvidia-cusolver
-    #   torch
-nvidia-cuda-cupti==13.0.85 \
-    --hash=sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8 \
-    --hash=sha256:683f58d301548deeefcb8f6fac1b8d907691b9d8b18eccab417f51e362102f00 \
-    --hash=sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151
-    # via cuda-toolkit
-nvidia-cuda-nvrtc==13.0.88 \
-    --hash=sha256:6bcd4e7f8e205cbe644f5a98f2f799bef9556fefc89dd786e79a16312ce49872 \
-    --hash=sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575 \
-    --hash=sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b
-    # via
-    #   cuda-toolkit
-    #   nvidia-cublas
-nvidia-cuda-runtime==13.0.96 \
-    --hash=sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548 \
-    --hash=sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55 \
-    --hash=sha256:f79298c8a098cec150a597c8eba58ecdab96e3bdc4b9bc4f9983635031740492
-    # via cuda-toolkit
-nvidia-cudnn-cu13==9.20.0.48 \
-    --hash=sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304 \
-    --hash=sha256:af8139732b99c0118be65ea5aac97f0d46018f8c552889e49d2fb0c6261a4a24 \
-    --hash=sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1
-    # via torch
-nvidia-cufft==12.0.0.61 \
-    --hash=sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5 \
-    --hash=sha256:2abce5b39d2f5ae12730fb7e5db6696533e36c26e2d3e8fd1750bdd2853364eb \
-    --hash=sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3
-    # via cuda-toolkit
-nvidia-cufile==1.15.1.6 \
-    --hash=sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44 \
-    --hash=sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1
-    # via cuda-toolkit
-nvidia-curand==10.4.0.35 \
-    --hash=sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a \
-    --hash=sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc \
-    --hash=sha256:65b1710aa6961d326b411e314b374290904c5ddf41dc3f766ebc3f1d7d4ca69f
-    # via cuda-toolkit
-nvidia-cusolver==12.0.4.66 \
-    --hash=sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2 \
-    --hash=sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112 \
-    --hash=sha256:16515bd33a8e76bb54d024cfa068fa68d30e80fc34b9e1090813ea9362e0cb65
-    # via cuda-toolkit
-nvidia-cusparse==12.6.3.3 \
-    --hash=sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b \
-    --hash=sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c \
-    --hash=sha256:cbcf42feb737bd7ec15b4c0a63e62351886bd3f975027b8815d7f720a2b5ea79
-    # via
-    #   cuda-toolkit
-    #   nvidia-cusolver
-nvidia-cusparselt-cu13==0.8.1 \
-    --hash=sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f \
-    --hash=sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0 \
-    --hash=sha256:dccbd362f91a7b9024d1f55ee9f548ac065027ff15d8c8b0db889ab3a8f31215
-    # via torch
-nvidia-nccl-cu13==2.29.7 \
-    --hash=sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5 \
-    --hash=sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d
-    # via torch
-nvidia-nvjitlink==13.0.88 \
-    --hash=sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b \
-    --hash=sha256:634e96e3da9ef845ae744097a1f289238ecf946ce0b82e93cdce14b9782e682f \
-    --hash=sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c
-    # via
-    #   cuda-toolkit
-    #   nvidia-cufft
-    #   nvidia-cusolver
-    #   nvidia-cusparse
-nvidia-nvshmem-cu13==3.4.5 \
-    --hash=sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80 \
-    --hash=sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9
-    # via torch
-nvidia-nvtx==13.0.85 \
-    --hash=sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4 \
-    --hash=sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6 \
-    --hash=sha256:d66ea44254dd3c6eacc300047af6e1288d2269dd072b417e0adffbf479e18519
-    # via cuda-toolkit
 orjson==3.11.9 \
     --hash=sha256:011382e2a60fda9d46f1cdee31068cfc52ffe952b587d683ec0463002802a0f4 \
     --hash=sha256:03db380e3780fa0015ed776a90f20e8e20bb11dde13b216ce19e5718e3dfba62 \
@@ -2528,10 +2334,12 @@ requests==2.34.2 \
     #   datasets
     #   google-auth
     #   google-genai
+    #   huggingface-hub
     #   kagglehub
     #   kagglesdk
     #   langsmith
     #   requests-toolbelt
+    #   transformers
     #   yfinance
 requests-toolbelt==1.0.0 \
     --hash=sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6 \
@@ -2540,9 +2348,7 @@ requests-toolbelt==1.0.0 \
 rich==15.0.0 \
     --hash=sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb \
     --hash=sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36
-    # via
-    #   curl-cffi
-    #   typer
+    # via curl-cffi
 safetensors==0.7.0 \
     --hash=sha256:0071bffba4150c2f46cae1432d31995d77acfd9f8db598b5d1a2ce67e8440ad2 \
     --hash=sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0 \
@@ -2687,10 +2493,6 @@ setuptools==81.0.0 \
     --hash=sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a \
     --hash=sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6
     # via torch
-shellingham==1.5.4 \
-    --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
-    --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
-    # via typer
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
@@ -2893,46 +2695,22 @@ tqdm==4.67.3 \
     #   peft
     #   sentence-transformers
     #   transformers
-transformers==5.9.0 \
-    --hash=sha256:1d19509bcff7028ebc6b277d71caa712e8353778463d38764237d14b42b52788 \
-    --hash=sha256:25997cb8fa6053533171634b6162d7df54346530ec2aa9b42bb834e63668c842
+transformers==4.57.6 \
+    --hash=sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550 \
+    --hash=sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3
     # via
     #   fed-pulse-backend (pyproject.toml)
     #   peft
     #   sentence-transformers
-triton==3.7.0 \
-    --hash=sha256:18a160de426fd99f92b0baf509045360afbd3bfaa0b4a5171dde800ec9f09684 \
-    --hash=sha256:223ac302091491436c248a34ee1e6c47a1026486579103c906ffd805be50cb89 \
-    --hash=sha256:22bacffce443f54593dd20f05294d5a40622e0ea9ab632816f87154504356221 \
-    --hash=sha256:70fb9bbdc9f400afc54bbf6eb2670af28829a6ae3996863317964783141daf56 \
-    --hash=sha256:8f111161d49bf903c0eaedde3962353a3d841c08a836839b7cc1025b8426efcf \
-    --hash=sha256:a35d7afe3f3f058e7ec49fcce09794049e0ffc5c59019ac25ec3413741b8c4e7 \
-    --hash=sha256:a4bf49b00a7a377a68a6da603a876e797614e6455a80e9021669c476a953ad9a \
-    --hash=sha256:a9e71fc392675fac364e0ecf4ef3f76f85b7f5433a16f4c3c5fe5f05a52c85fe \
-    --hash=sha256:abdf6beaa89b1bcfb9a43cd990536ce66091a997841a4814b260b7bee4c88c3c \
-    --hash=sha256:b9b85e72968a9d8bba5ddb24e9b64aaabaf48affb042f2755cb7cfa92b7531ce \
-    --hash=sha256:c4a44a8476d0d3571eac4e4d1048e1ff75aad81a09ff4602ccfc56c6dea1672e \
-    --hash=sha256:c631b65668d4951213b948a413c0564184305b77bb45cc9d686d3e1ecc4701a3 \
-    --hash=sha256:cc1d61c172d257db80ddf42595131fb196ad2e9bdd751e90fe2ef13531734e8b \
-    --hash=sha256:ce061073102714b725f3660ec6939d94a1da7984b3aa99c921417cae273672f5
-    # via torch
 typeguard==4.5.2 \
     --hash=sha256:5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423 \
     --hash=sha256:fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf
     # via pandera
-typer==0.25.1 \
-    --hash=sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89 \
-    --hash=sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc
-    # via
-    #   huggingface-hub
-    #   transformers
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
     # via
-    #   aiosignal
     #   anthropic
-    #   anyio
     #   beautifulsoup4
     #   fastapi
     #   google-genai
@@ -2943,7 +2721,6 @@ typing-extensions==4.15.0 \
     #   python-docx
     #   sentence-transformers
     #   sqlalchemy
-    #   starlette
     #   torch
     #   typeguard
     #   typing-inspect

--- a/docs/security-acceptance.md
+++ b/docs/security-acceptance.md
@@ -15,6 +15,12 @@ remove the entry and let CI gate on it again.
 | `next` 14.2.x | DoS via image optimizer (`GHSA-9g9p-9gw9-jx7f`, `GHSA-3x4c-7xq6-9pq8`, `GHSA-h64f-5h5j-jqjh`), request smuggling in rewrites (`GHSA-ggv3-7p47-pfv8`), SSR-component DoS (`GHSA-h25m-26qc-wcjf`, `GHSA-q4gf-8mx6-v5v3`, `GHSA-8h8q-6873-q5fj`), CSP-nonce / beforeInteractive XSS (`GHSA-ffhc-5mcf-pf4q`, `GHSA-gx5p-jg67-6x7h`), cache poisoning in RSC + redirects (`GHSA-vfv6-92ff-j949`, `GHSA-wfc6-r584-vfw7`, `GHSA-3g8h-86w9-wvmq`), Middleware bypass in Pages Router i18n (`GHSA-36qx-fr4f-26g5`), SSRF in WebSocket upgrade (`GHSA-c4j6-fc7j-m34r`) | Self-hosted research dashboard, not internet-exposed, no untrusted-tenant traffic. Fixes require Next 16 (App Router migration). | Tracked under the planned "Next 16 + App Router" migration window after the thesis is submitted. |
 | `postcss` <8.5.10 | `</style>` XSS in stringify (`GHSA-qx2v-qp2m-jg93`) | Transitive via Next's bundled postcss; user-supplied CSS is never run through it in this codebase (we author every CSS source file). | Resolves when Next 16 lands. |
 
+## Accepted findings (pip)
+
+| Package | Advisories | Why accepted | Mitigation owner / next step |
+|---|---|---|---|
+| `transformers` 4.57.6 | `PYSEC-2025-217`, `GHSA-69w3-r845-3855` | Both advisories' fix lands in `5.0.0rc3`. The 5.x line dropped `GenerationMixin` from `transformers.models.auto.auto_factory`, which broke the encoder loader on the post_306 Runpod sweep. We pin `>=4.57,<5` so the loader keeps working; the CVEs ride on the pin. The advisories cover code paths (custom safetensors-deserialization edge case and remote-code-loading path) we do not exercise — `trust_remote_code` is explicitly `False` everywhere the loader is called, and our checkpoints are pulled from a known-clean HF repo we own. | Resolves when either (a) a 4.x backport ships, or (b) we migrate the encoder loader surface to the 5.x AutoFactory layout. Tracked under #409. |
+
 ## Accepted moderate-severity findings
 
 None right now. `follow-redirects` and `axios` highs were resolved by bumping

--- a/tests/unit/test_transformers_version_pin.py
+++ b/tests/unit/test_transformers_version_pin.py
@@ -1,0 +1,31 @@
+"""Guard rail for the `transformers` major-version pin (#409).
+
+`transformers` 5.x dropped `GenerationMixin` from
+`transformers.models.auto.auto_factory`, which is the import path the
+multi-axis encoder loader resolves at module import time. On the
+post_306 Runpod sweep this surfaced as a `ModuleNotFoundError` on a
+fresh pod that picked up 5.9.0 via hash-pinning, and the only fix was
+a downgrade to the 4.x line. `backend/pyproject.toml` now caps the
+constraint at `<5`; this test asserts the constraint is honoured at
+runtime so a future bump cannot silently slip through the lock.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+transformers = pytest.importorskip(
+    "transformers",
+    reason="transformers not installed in this environment",
+)
+
+
+def test_transformers_major_version_is_four() -> None:
+    version = str(getattr(transformers, "__version__", "")).strip()
+    assert version, "transformers must expose a `__version__` attribute"
+    major = version.split(".", 1)[0]
+    assert major == "4", (
+        f"transformers must remain on the 4.x line (got {version!r}); 5.x "
+        "removes `GenerationMixin` from `transformers.models.auto.auto_factory` "
+        "and breaks the multi-axis encoder loader (see #409)."
+    )


### PR DESCRIPTION
Closes #409.

Pin `transformers >=4.57,<5` so the AutoFactory imports the loader depends on stay intact. The 5.x line moved `GenerationMixin` and broke the encoder loader on the post_306 Runpod sweep.

This PR (Option 2 on the CVE/typecheck tension):
- Pin `transformers` to `>=4.57,<5` in `backend/pyproject.toml` + regenerate `backend/requirements.lock`. Resolver lands on `4.57.6`.
- `# type: ignore[no-untyped-call]` on the 6 `AutoTokenizer.from_pretrained` call sites mypy flagged after the pin (`analogs.py`, `multi_axis_classifier.py`, `encoder_lora.py`, `cross_bank_transfer.py`, `cross_source_transfer.py` x2). The 4.57.x stubs lost annotations on those entry points.
- `docs/security-acceptance.md` extended with the `transformers 4.57.6` row covering `PYSEC-2025-217` + `GHSA-69w3-r845-3855` (the fix for both lands in 5.0.0rc3, exactly the version the pin closes out). Justification: `trust_remote_code` is `False` everywhere the loader is called; checkpoints come from a HF repo we own. Tracked until either a 4.x backport or migration to the 5.x AutoFactory layout.
- New `tests/unit/test_transformers_version_pin.py` asserts the major version stays on 4.x so a future bump cannot silently slip through.

**Manual step before merge — the CI workflow edit.** The GitHub token used by the implementer/automation lacks the `workflow` scope, so the `.github/workflows/ci.yml` change is your drop. Edit the `vuln-python` step's last line from:

\`\`\`yaml
run: pip-audit --strict --ignore-vuln GHSA-q34m-jh98-gwm2 --ignore-vuln MAL-2026-4750
\`\`\`

to:

\`\`\`yaml
run: pip-audit --strict --ignore-vuln GHSA-q34m-jh98-gwm2 --ignore-vuln MAL-2026-4750 --ignore-vuln PYSEC-2025-217 --ignore-vuln GHSA-69w3-r845-3855
\`\`\`

(and add a comment block above explaining the pin / 5.x tension if you want it on the same row as the existing `MAL-2026-4750` justification.)

Once that lands on the branch, vuln-python turns green and the PR is mergeable.