### PR TITLE
frontend: plain-language labels for the analyze workspace

### DIFF
--- a/frontend/components/analyze/AnalyzeForm.tsx
+++ b/frontend/components/analyze/AnalyzeForm.tsx
@@ -94,8 +94,8 @@ export function AnalyzeForm({ value, onChange, onSubmit, loading }: AnalyzeFormP
               {submitLabel}
             </Button>
             <p className="text-xs text-muted-foreground">
-              Runs the calibrated vol-regime classifier and the supporting multi-axis, XAI, and
-              credibility heads against the FOMC excerpt.
+              Runs the Volatility Regime prediction along with the sentiment breakdown,
+              explanation, and credibility checks against the FOMC excerpt.
             </p>
           </div>
         </form>

--- a/frontend/components/analyze/ConfusionMatrix.tsx
+++ b/frontend/components/analyze/ConfusionMatrix.tsx
@@ -22,7 +22,8 @@ export function ConfusionMatrix({ rows, classes, className }: ConfusionMatrixPro
   if (totalResolved === 0) {
     return (
       <p className="text-xs text-muted-foreground">
-        No resolved runs yet — submit analyses past their 10d window to populate the matrix.
+        No resolved runs yet — submit analyses whose 10-day window has passed to populate
+        the matrix.
       </p>
     );
   }
@@ -30,12 +31,12 @@ export function ConfusionMatrix({ rows, classes, className }: ConfusionMatrixPro
     <div className={cn("overflow-x-auto", className)}>
       <table className="w-full border-separate" style={{ borderSpacing: 2 }}>
         <caption className="sr-only">
-          Confusion matrix: rows are the realised regime, columns are the predicted argmax.
+          Confusion matrix: rows are the realised regime, columns are the model's top pick.
         </caption>
         <thead>
           <tr>
             <th scope="col" className="px-2 py-1 text-left text-[10px] uppercase tracking-wide text-muted-foreground">
-              truth / pred
+              actual / predicted
             </th>
             {classes.map((klass) => (
               <th
@@ -50,7 +51,7 @@ export function ConfusionMatrix({ rows, classes, className }: ConfusionMatrixPro
               scope="col"
               className="px-2 py-1 text-right text-[10px] uppercase tracking-wide text-muted-foreground"
             >
-              support
+              total
             </th>
           </tr>
         </thead>
@@ -73,7 +74,7 @@ export function ConfusionMatrix({ rows, classes, className }: ConfusionMatrixPro
                       "numeric h-row-sm rounded-sm px-2 text-center text-xs",
                       intensityClass(share),
                     )}
-                    title={`truth ${row.truth} → predicted ${klass}: ${count} / ${row.total}`}
+                    title={`actual ${row.truth} → predicted ${klass}: ${count} / ${row.total}`}
                   >
                     {count}
                   </td>

--- a/frontend/components/analyze/CredibilityKpis.tsx
+++ b/frontend/components/analyze/CredibilityKpis.tsx
@@ -34,13 +34,14 @@ export function CredibilityKpis({ credibility }: CredibilityKpisProps) {
     return (
       <div className="rounded-md border border-dashed border-border bg-muted/20 p-4 text-xs text-muted-foreground">
         <p className="mb-1 text-[10px] uppercase tracking-wide text-foreground">
-          Credibility features unpopulated
+          Credibility signals not yet available
         </p>
         <p>
-          The credibility module ran but every signal is at its placeholder value. Needs the
-          prior four FOMC statements + the DFF history under <code className="rounded bg-muted px-1">data/external/fred/</code>
-          {" "}to compute drift, realized-vs-stated gap, and months-since-reversal. The
-          market-implied gap stays N/A until the SEP / OIS curve scrapers ship.
+          The credibility module ran but every signal is at its default value. Computing
+          the shift score, the gap between what was done vs. said, and time since the last
+          reversal requires the previous four FOMC statements plus federal funds rate
+          history. The gap to market expectations stays unavailable until the SEP and OIS
+          data feeds are connected.
         </p>
       </div>
     );
@@ -49,21 +50,21 @@ export function CredibilityKpis({ credibility }: CredibilityKpisProps) {
   return (
     <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
       <KpiTile
-        label="Drift score"
+        label="Shift score"
         icon={<GitBranch className="h-3.5 w-3.5" />}
         value={<span className="numeric">{drift.toFixed(2)}</span>}
         sparkline={credibility.drift_trend}
         tone={drift > 0.6 ? "warn" : drift < 0.3 ? "neutral" : "neutral"}
         caption={
           drift > 0.6
-            ? "Diverging from prior 4 statements"
+            ? "Diverging from the last 4 statements"
             : drift < 0.3
-            ? "Stable vs prior 4 statements"
-            : "Mild drift vs prior 4"
+            ? "Stable vs the last 4 statements"
+            : "Mild shift vs the last 4"
         }
       />
       <KpiTile
-        label="Realized vs stated"
+        label="What was done vs. said"
         icon={<Scale className="h-3.5 w-3.5" />}
         value={
           realizedGap == null ? (
@@ -84,13 +85,13 @@ export function CredibilityKpis({ credibility }: CredibilityKpisProps) {
             ? "down"
             : "neutral"
         }
-        caption="90-day Pearson · stance vs DFF moves"
+        caption="90-day correlation between stance and actual rate moves"
       />
       <Tooltip>
         <TooltipTrigger asChild>
           <div>
             <KpiTile
-              label="Market-implied gap"
+              label="Gap to market expectations"
               icon={<Activity className="h-3.5 w-3.5" />}
               value={
                 marketGapReady ? (
@@ -104,19 +105,19 @@ export function CredibilityKpis({ credibility }: CredibilityKpisProps) {
               }
               caption={
                 marketGapReady
-                  ? "stance vs OIS-implied path"
-                  : "Pending SEP / OIS curve ingest"
+                  ? "Stance vs the rate path priced into OIS swaps"
+                  : "Waiting on SEP and OIS data feeds"
               }
             />
           </div>
         </TooltipTrigger>
         <TooltipContent side="top" className="max-w-xs text-[11px]">
-          Populated once the SEP dot-plot and Eurodollar / OIS curve scrapers ship. Today the backend
-          returns 0.0 as a placeholder; the UI shows N/A rather than implying confidence.
+          Fills in once the SEP dot-plot and OIS curve data feeds are connected. For now the
+          backend returns a placeholder value, so the UI shows N/A rather than implying a reading.
         </TooltipContent>
       </Tooltip>
       <KpiTile
-        label="Since reversal"
+        label="Time since last reversal"
         icon={<Timer className="h-3.5 w-3.5" />}
         value={
           monthsSince == null ? (
@@ -125,7 +126,7 @@ export function CredibilityKpis({ credibility }: CredibilityKpisProps) {
             <span className="numeric">{monthsSince} mo</span>
           )
         }
-        caption="Months since last stance sign flip"
+        caption="Months since the stance last flipped direction"
       />
     </div>
   );

--- a/frontend/components/analyze/CredibilityPanel.tsx
+++ b/frontend/components/analyze/CredibilityPanel.tsx
@@ -65,19 +65,19 @@ export function CredibilityPanel({ credibility, previewMode }: CredibilityPanelP
           Central-bank credibility
           {previewMode ? (
             <Badge variant="outline" className="ml-2 text-[10px] uppercase tracking-wide">
-              Preview · fixture
+              Preview · sample data
             </Badge>
           ) : null}
         </CardTitle>
         <CardDescription>
-          Four-axis credibility check on the issuing institution at this statement date.
+          A four-part credibility check on the issuing central bank at this statement date.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-5">
         <div className="space-y-2">
           <div className="flex items-center justify-between text-sm">
             <span className="flex items-center gap-1.5 text-muted-foreground">
-              <GitBranch className="h-3.5 w-3.5" /> Drift vs. prior 4 statements
+              <GitBranch className="h-3.5 w-3.5" /> Shift vs. last 4 statements
             </span>
             <Badge variant={tone}>{driftLabel(driftScore)} · {driftScore.toFixed(2)}</Badge>
           </div>
@@ -93,31 +93,31 @@ export function CredibilityPanel({ credibility, previewMode }: CredibilityPanelP
         <div className="grid gap-3 sm:grid-cols-3">
           <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
             <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-muted-foreground">
-              <span>Realized vs. stated</span>
+              <span>What was done vs. said</span>
               <Scale className="h-3.5 w-3.5" />
             </div>
             <div className="mt-1 flex items-center justify-between">
               <strong>{formatGap(credibility.realized_vs_stated_gap)}</strong>
               <Badge variant={gapTone(credibility.realized_vs_stated_gap)} className="text-[10px]">
-                {credibility.realized_vs_stated_gap == null ? "—" : "90d corr"}
+                {credibility.realized_vs_stated_gap == null ? "—" : "90-day correlation"}
               </Badge>
             </div>
           </div>
           <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
             <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-muted-foreground">
-              <span>Market-implied gap</span>
+              <span>Gap to market expectations</span>
               <Scale className="h-3.5 w-3.5" />
             </div>
             <div className="mt-1 flex items-center justify-between">
               <strong>{formatGap(credibility.market_implied_gap)}</strong>
               <Badge variant={gapTone(credibility.market_implied_gap)} className="text-[10px]">
-                {credibility.market_implied_gap == null ? "—" : "vs OIS"}
+                {credibility.market_implied_gap == null ? "—" : "vs OIS swaps"}
               </Badge>
             </div>
           </div>
           <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
             <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-muted-foreground">
-              <span>Since reversal</span>
+              <span>Time since last reversal</span>
               <Timer className="h-3.5 w-3.5" />
             </div>
             <div className="mt-1 flex items-center justify-between">

--- a/frontend/components/analyze/HistoricalAnalogPanel.tsx
+++ b/frontend/components/analyze/HistoricalAnalogPanel.tsx
@@ -61,7 +61,7 @@ function WhatHappenedNext({ bucket }: WhatHappenedNextProps) {
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between text-[10px] uppercase tracking-wide text-muted-foreground">
-        <span>What happened next · 10d vol</span>
+        <span>What happened next · 10-day volatility</span>
         <span className="numeric capitalize text-foreground">
           {bucket ? VOL_REGIME_LABEL[bucket] : "—"}
         </span>
@@ -71,8 +71,8 @@ function WhatHappenedNext({ bucket }: WhatHappenedNextProps) {
         role="img"
         aria-label={
           bucket
-            ? `Post-event 10-day realised volatility bucket: ${VOL_REGIME_LABEL[bucket]}`
-            : "Post-event volatility bucket unavailable"
+            ? `10-day realised volatility after the event: ${VOL_REGIME_LABEL[bucket]}`
+            : "Post-event volatility unavailable"
         }
       >
         {VOL_REGIME_ORDER.map((segment) => {
@@ -185,9 +185,9 @@ export function HistoricalAnalogPanel({
   const headerBadge = (
     <div className="flex flex-wrap items-center gap-2">
       <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-        Historical analog panel
+        Historical analogs
       </Badge>
-      <EvidenceLink section="6.16" label="Retrieval supervision rebuild · recall@k" />
+      <EvidenceLink section="6.16" label="Method notes · retrieval quality" />
     </div>
   );
 
@@ -224,12 +224,11 @@ export function HistoricalAnalogPanel({
         <EmptyState
           variant="card"
           icon={<History className="h-5 w-5" />}
-          title="Retrieval index not loaded"
+          title="Analog index not loaded"
           description={
             <span>
-              Train the retrieval encoder via{" "}
-              <code className="rounded bg-muted px-1">python -m app.retrieval.train</code>{" "}
-              against the canonical training package to produce the analog index, then refresh.
+              The historical analog index is not available. Train and load the retrieval
+              model against the training corpus, then refresh.
             </span>
           }
         />
@@ -248,13 +247,13 @@ export function HistoricalAnalogPanel({
         <EmptyState
           variant="card"
           icon={<Sparkles className="h-5 w-5" />}
-          title="No analogs above threshold"
+          title="No close analogs found"
           description={
             <span>
-              The retrieval encoder scored {analogs.analogs.length} candidate
+              The retrieval model scored {analogs.analogs.length} candidate
               {analogs.analogs.length === 1 ? "" : "s"} but none crossed the{" "}
               <span className="numeric">{formatSimilarity(similarityThreshold)}</span>{" "}
-              similarity floor for this statement.
+              similarity threshold for this statement.
             </span>
           }
         />
@@ -279,13 +278,12 @@ export function HistoricalAnalogPanel({
         ))}
       </div>
       <p className="text-[11px] leading-relaxed text-muted-foreground">
-        Past FOMC statements most similar to the current text, ranked by
-        cosine similarity in the retrieval encoder embedding space.
-        Post-event regime bucket is a UI-only marker — the raw 10-day
-        realised vol is withheld from this surface to avoid leaking the
-        supervised target. Index size:{" "}
+        Past FOMC statements most similar to the current text, ranked by a
+        retrieval model. The post-event volatility marker shows a coarse
+        calm / normal / high band only — raw values are hidden so the
+        analog does not give away the answer. Index size:{" "}
         <span className="numeric">{analogs.index_size.toLocaleString()}</span>
-        {" "}past statements · encoder{" "}
+        {" "}past statements · model variant{" "}
         <code className="rounded bg-muted px-1">{analogs.encoder_alias}</code>.
       </p>
     </div>

--- a/frontend/components/analyze/LegacyForecastCard.tsx
+++ b/frontend/components/analyze/LegacyForecastCard.tsx
@@ -69,16 +69,16 @@ export function LegacyForecastCard({
             Legacy point forecast
           </CardTitle>
           <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-            regression head
+            numeric prediction
           </Badge>
         </div>
         <CardDescription className="flex items-start gap-1.5 text-xs">
           <Info className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
           <span>
-            The deployed forecaster is in regression mode — it emits scalar close + volatility
-            predictions instead of the calibrated <span className="numeric">calm / normal / high</span>{" "}
-            regime set. This card surfaces those numbers as a fallback while the classification head
-            ships; the demo headline target is still the regime card above.
+            The active forecaster is in numeric mode — it produces single close and volatility
+            numbers rather than the calibrated <span className="numeric">calm / normal / high</span>{" "}
+            Volatility Regime prediction. This card shows those numbers as a fallback; the
+            Volatility Regime card above remains the headline.
           </span>
         </CardDescription>
       </CardHeader>
@@ -97,8 +97,8 @@ export function LegacyForecastCard({
             value={<span className="numeric">{formatVol(vol)}</span>}
             caption={
               market?.volatility_5d != null
-                ? `5d realised ${formatVol(market.volatility_5d)}`
-                : "annualised stdev of log returns"
+                ? `5-day realised ${formatVol(market.volatility_5d)}`
+                : "annualised standard deviation of log returns"
             }
           />
         </div>

--- a/frontend/components/analyze/MarketReactionPanel.tsx
+++ b/frontend/components/analyze/MarketReactionPanel.tsx
@@ -69,7 +69,7 @@ export function RatesReactionCard({ card }: RatesReactionCardProps) {
             </Badge>
           ) : (
             <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-              Aux classifier unavailable
+              Direction model unavailable
             </Badge>
           )}
         </CardTitle>
@@ -77,19 +77,19 @@ export function RatesReactionCard({ card }: RatesReactionCardProps) {
       <CardContent className="space-y-3">
         <div className="space-y-1 text-xs text-muted-foreground">
           <p>
-            5-day post-event change predicted by the rates head.
+            Predicted change over the 5 days after the event.
           </p>
           <p>
             <span className="font-mono">{bandText}</span>
             {card.coverage != null ? (
               <span className="ml-2 text-[10px] uppercase tracking-wide text-muted-foreground">
-                {(card.coverage * 100).toFixed(0)}% conformal
+                {(card.coverage * 100).toFixed(0)}% confidence range
               </span>
             ) : null}
           </p>
           {card.predicted_set != null && card.predicted_set.length > 0 ? (
             <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-              calibrated set: {`{${card.predicted_set.join(", ")}}`}
+              Prediction set: {`{${card.predicted_set.join(", ")}}`}
             </p>
           ) : null}
         </div>
@@ -135,7 +135,7 @@ function VolRegimeCard({ card }: VolRegimeReactionCardProps) {
       <CardHeader className="pb-2">
         <CardDescription className="flex items-center gap-1.5">
           <TrendingUp className="h-3.5 w-3.5" />
-          Vol regime
+          Volatility Regime
         </CardDescription>
         <CardTitle className="flex items-center justify-between text-2xl capitalize">
           <span>{card.regime_label}</span>
@@ -156,12 +156,12 @@ function VolRegimeCard({ card }: VolRegimeReactionCardProps) {
         ))}
         {card.log_rv_point != null ? (
           <p className="text-xs text-muted-foreground pt-1">
-            Dual-head log(RV) prediction: <span className="font-mono">{card.log_rv_point.toFixed(3)}</span>
+            Point estimate (log volatility): <span className="font-mono">{card.log_rv_point.toFixed(3)}</span>
           </p>
         ) : null}
         {card.coverage != null ? (
           <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-            {(card.coverage * 100).toFixed(0)}% conformal
+            {(card.coverage * 100).toFixed(0)}% confidence level
           </p>
         ) : null}
       </CardContent>
@@ -182,9 +182,9 @@ export function MarketReactionPanel({ panel }: MarketReactionPanelProps) {
     <div className="space-y-2">
       <div className="flex flex-wrap items-center gap-2">
         <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-          Market reaction panel
+          Market reaction
         </Badge>
-        <EvidenceLink section="6.15" label="Dual-head methodology · rates + vol cards" />
+        <EvidenceLink section="6.15" label="Method notes · rates and volatility cards" />
       </div>
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {panel.rates.map((card) => (

--- a/frontend/components/analyze/MultiAxisCards.tsx
+++ b/frontend/components/analyze/MultiAxisCards.tsx
@@ -86,10 +86,10 @@ function FactorCard({ factor }: { factor: NonNullable<MultiAxisResponse["factor"
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-1.5 text-xs text-muted-foreground">
-        <p>Signed magnitude on the hawkish (+) ↔ dovish (−) axis.</p>
+        <p>Score along the hawkish (+) to dovish (−) scale.</p>
         {range ? (
           <p>
-            80% range: <span className="font-mono">{range[0].toFixed(2)} … {range[1].toFixed(2)}</span>
+            80% confidence range: <span className="font-mono">{range[0].toFixed(2)} … {range[1].toFixed(2)}</span>
           </p>
         ) : null}
       </CardContent>
@@ -113,7 +113,7 @@ function CertaintyCard({ certainty }: { certainty: NonNullable<MultiAxisResponse
       <CardContent className="space-y-2">
         <Progress value={certainty.confidence} />
         <p className="text-xs text-muted-foreground">
-          How firmly the language commits to the stance.
+          How firmly the wording commits to a stance.
         </p>
       </CardContent>
     </Card>
@@ -132,7 +132,7 @@ function TopicCard({ topic }: { topic: NonNullable<MultiAxisResponse["topic"]> }
       </CardHeader>
       <CardContent className="space-y-2">
         <div className="flex items-center justify-between text-xs text-muted-foreground">
-          <span>Primary confidence</span>
+          <span>Confidence in main topic</span>
           <span className="font-medium text-foreground">{topic.confidence.toFixed(2)}</span>
         </div>
         <Progress value={topic.confidence} />
@@ -158,7 +158,7 @@ export function MultiAxisCards({ multiAxis, previewMode }: MultiAxisCardsProps) 
     <div className="space-y-2">
       {previewMode ? (
         <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-          Multi-axis preview · fixture data
+          Sentiment breakdown preview · sample data
         </Badge>
       ) : null}
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">

--- a/frontend/components/analyze/MultiAxisInterpretation.tsx
+++ b/frontend/components/analyze/MultiAxisInterpretation.tsx
@@ -37,7 +37,7 @@ function StanceTile({ stance, history }: { stance: MultiAxisStance; history?: Ar
         </span>
       }
       sparkline={history}
-      caption="Hawkish (+) / Dovish (−)"
+      caption="Hawkish (+) favours tighter policy; Dovish (−) favours easier policy"
     />
   );
 }
@@ -71,7 +71,7 @@ function FactorTile({
       tone={tone}
       sparkline={history}
       sparklineTone={tone}
-      caption="GSS forward-guidance vs target-shock · low-coverage axis (§6.13)"
+      caption="Forward-guidance vs near-term rate shock · limited training data"
     />
   );
 }
@@ -91,7 +91,7 @@ function CertaintyTile({
       delta={certainty.confidence}
       deltaFormatter={(v) => v.toFixed(2)}
       sparkline={history}
-      caption="How firmly the language commits"
+      caption="How firmly the wording commits to a stance"
     />
   );
 }
@@ -110,7 +110,7 @@ function TopicTile({ topic }: { topic: NonNullable<MultiAxisResponse["topic"]> }
       caption={
         topic.secondary?.length
           ? `also: ${topic.secondary.map((t) => t.replace(/_/g, " ")).join(", ")}`
-          : "primary topic"
+          : "main topic"
       }
     />
   );
@@ -130,14 +130,13 @@ export function MultiAxisInterpretation({
     return (
       <div className="rounded-md border border-dashed border-border bg-muted/20 p-4 text-xs text-muted-foreground sm:col-span-2">
         <p className="mb-1 text-[10px] uppercase tracking-wide text-foreground">
-          Multi-axis classifier returned no axis labels
+          Sentiment breakdown returned no labels
         </p>
         <p>
-          The classifier ran but every head returned null. The most common cause is a missing
-          checkpoint at <code className="rounded bg-muted px-1">backend/models/multi_axis_classifier.pt</code>
-          {" "}or a passage shorter than the encoder context window. Train and deploy the
-          checkpoint, or paste a longer FOMC statement to populate stance, factor, certainty,
-          and topic.
+          The sentiment model ran but produced no labels for any axis. This usually means
+          the active model file is missing, or the passage is too short for the model to
+          read. Load a sentiment model, or paste a longer FOMC statement to populate stance,
+          factor, certainty, and topic.
         </p>
       </div>
     );
@@ -147,12 +146,12 @@ export function MultiAxisInterpretation({
     <div className="space-y-2">
       <div className="flex flex-wrap items-center gap-2">
         <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-          Multi-axis interpretation
+          Sentiment breakdown
         </Badge>
-        <EvidenceLink section="6.13" label="Multi-task null + factor-axis gate (#328)" />
+        <EvidenceLink section="6.13" label="Method notes · sentiment axes" />
         {!multiAxis.factor ? (
-          <Badge variant="outline" className="text-[10px]" title="Per §6.13 / #328 the factor card is gated off when training-pool coverage falls below 0.01.">
-            factor · gated off (null result)
+          <Badge variant="outline" className="text-[10px]" title="The factor card is hidden when the training data does not contain enough labelled examples to support a confident prediction.">
+            factor · hidden (low confidence)
           </Badge>
         ) : null}
       </div>

--- a/frontend/components/analyze/PipelineTrace.tsx
+++ b/frontend/components/analyze/PipelineTrace.tsx
@@ -91,7 +91,7 @@ function CoverageGauge({ coverage }: { coverage: number }) {
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between text-xs">
-        <span className="text-muted-foreground">Nominal coverage</span>
+        <span className="text-muted-foreground">Confidence level</span>
         <span className="numeric text-foreground">{pct}%</span>
       </div>
       <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
@@ -110,7 +110,7 @@ function multiAxisSummary(multiAxis: MultiAxisResponse): string {
     parts.push(
       `topic ${(multiAxis.topic.label ?? multiAxis.topic.primary ?? "—").toString()}`,
     );
-  return parts.join(" · ") || "axes absent";
+  return parts.join(" · ") || "no sentiment labels";
 }
 
 function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
@@ -153,24 +153,24 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
     key: "encode",
     title: "Encode",
     blurb:
-      "Runs the text through the encoder backbone. Surfaces an energy-based OOD signal so the workspace can flag inputs outside the training distribution.",
+      "Runs the text through the language model. Flags inputs that look unlike anything the model was trained on, so the workspace can warn before trusting the result.",
     icon: <Layers className="h-3.5 w-3.5" />,
     state: ood === false ? "warn" : "ok",
     summary: encoderKey
-      ? `Encoder: ${encoderKey}${ood === false ? " · OOD flag set" : ""}`
-      : "Encoder: classifier-side embedding (default)",
+      ? `Model variant: ${encoderKey}${ood === false ? " · unfamiliar text flag set" : ""}`
+      : "Model variant: default",
     body: (
       <div className="space-y-3">
         <dl className="grid gap-x-4 gap-y-1.5 text-sm sm:grid-cols-2">
-          <dt className="text-muted-foreground">Encoder alias</dt>
+          <dt className="text-muted-foreground">Model variant</dt>
           <dd className="numeric text-right">{encoderKey ?? "default"}</dd>
-          <dt className="text-muted-foreground">OOD energy</dt>
+          <dt className="text-muted-foreground">Unfamiliarity score</dt>
           <dd className="numeric text-right">{oodEnergy != null ? oodEnergy.toFixed(3) : "—"}</dd>
-          <dt className="text-muted-foreground">OOD threshold</dt>
+          <dt className="text-muted-foreground">Unfamiliarity threshold</dt>
           <dd className="numeric text-right">
             {oodThreshold != null ? oodThreshold.toFixed(3) : "—"}
           </dd>
-          <dt className="text-muted-foreground">In-distribution</dt>
+          <dt className="text-muted-foreground">Familiar to model</dt>
           <dd className="text-right">
             {ood == null ? (
               "—"
@@ -188,7 +188,7 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
         {oodEnergy != null && oodThreshold != null && oodThreshold !== 0 ? (
           <div className="space-y-1">
             <div className="flex items-center justify-between text-xs">
-              <span className="text-muted-foreground">Energy vs threshold</span>
+              <span className="text-muted-foreground">Score vs threshold</span>
               <span className="numeric text-foreground">
                 {oodEnergy.toFixed(3)} / {oodThreshold.toFixed(3)}
               </span>
@@ -206,7 +206,8 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
               />
             </div>
             <p className="text-[11px] text-muted-foreground">
-              Energy below the threshold reads as in-distribution; above flags OOD.
+              A score below the threshold means the text looks familiar to the model; above
+              means it does not.
             </p>
           </div>
         ) : null}
@@ -216,12 +217,12 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
 
   const multiAxisStep: Step = {
     key: "multi-axis",
-    title: "Multi-axis head",
+    title: "Sentiment breakdown",
     blurb:
-      "Four heads off the shared trunk — stance, hawkish-dovish factor, certainty, topic — each calibrated against the labeled FOMC corpus.",
+      "Four predictions from the same shared model — stance, hawkish / dovish score, certainty, and topic — calibrated against the labelled FOMC corpus.",
     icon: <Workflow className="h-3.5 w-3.5" />,
     state: multiAxis ? "ok" : "absent",
-    summary: multiAxis ? multiAxisSummary(multiAxis) : "Multi-axis checkpoint absent",
+    summary: multiAxis ? multiAxisSummary(multiAxis) : "Sentiment model not loaded",
     body: multiAxis ? (
       <div className="space-y-3">
         <ul className="grid gap-1.5 text-sm sm:grid-cols-2">
@@ -288,31 +289,28 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
       </div>
     ) : (
       <p className="text-sm text-muted-foreground">
-        No multi-axis classifier checkpoint at{" "}
-        <code className="rounded bg-muted px-1 font-mono text-xs">
-          backend/models/text_multi_axis_best.pt
-        </code>
-        . The stance card is populated from the legacy sentiment classifier fallback.
+        No sentiment breakdown model is loaded. The stance card falls back to the
+        legacy sentiment classifier.
       </p>
     ),
   };
 
   const regimeStep: Step = {
     key: "regime",
-    title: "Regime head",
+    title: "Volatility Regime prediction",
     blurb:
-      "Predicts the 10-day forward vol regime — calm / normal / high — plus the calibrated conformal set so the UI can hedge across more than one class when the model is unsure.",
+      "Predicts the 10-day forward volatility regime — calm / normal / high — together with a calibrated prediction set so the UI can hedge across more than one class when the model is unsure.",
     icon: <Cpu className="h-3.5 w-3.5" />,
     state: regime ? "ok" : "absent",
     summary: regime
-      ? `argmax: ${regime.argmax_class} · set size ${regime.set_size}`
-      : "Regression-mode checkpoint or conformal sidecar absent",
+      ? `Top pick: ${regime.argmax_class} · ${regime.set_size} label${regime.set_size === 1 ? "" : "s"} in set`
+      : "Numeric-mode model or calibration data not loaded",
     body: regime ? (
       <div className="space-y-3 text-sm">
         <dl className="grid gap-x-4 gap-y-1.5 sm:grid-cols-2">
-          <dt className="text-muted-foreground">Argmax class</dt>
+          <dt className="text-muted-foreground">Top pick</dt>
           <dd className="text-right capitalize">{regime.argmax_class}</dd>
-          <dt className="text-muted-foreground">Set composition</dt>
+          <dt className="text-muted-foreground">Labels in prediction set</dt>
           <dd className="text-right capitalize">{regime.predicted_set.join(", ") || "—"}</dd>
           <dt className="text-muted-foreground">Set size</dt>
           <dd className="numeric text-right">{regime.set_size}</dd>
@@ -353,25 +351,25 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
           })}
         </div>
         <p className="text-xs text-muted-foreground">
-          Calibrated APS: classes whose softmax mass meets the calibration quantile are included in
-          the set. Coverage + quantile come from the conformal sidecar.
+          The prediction set includes every regime whose probability clears the calibration
+          threshold. The threshold and confidence level come from a calibration step run on
+          held-out data.
         </p>
       </div>
     ) : (
       <p className="text-sm text-muted-foreground">
-        The active checkpoint is regression-mode or no <code>.conformal.json</code> sidecar with{" "}
-        <code>softmax_quantile</code> was found. The regression head still emits close + vol point
-        forecasts in the response; the workspace hides them because the headline target is the
-        calibrated regime set.
+        The active model is in numeric mode, or no calibration data was found. The numeric
+        forecaster still produces close and volatility point predictions in the response; the
+        workspace hides them because the Volatility Regime prediction is the headline.
       </p>
     ),
   };
 
   const xaiStep: Step = {
     key: "xai",
-    title: "Sentence attribution",
+    title: "Per-sentence explanation",
     blurb:
-      "Per-sentence attribution against the stance logit. Surfaces which sentences pushed the model toward its decision and feeds the strike-out counterfactual loop.",
+      "Scores each sentence by how much it pushed the model toward its stance decision. Powers the strike-out tool that lets you remove a sentence and re-score.",
     icon: <Highlighter className="h-3.5 w-3.5" />,
     state: xaiSentences > 0 ? "ok" : "absent",
     summary:
@@ -382,7 +380,7 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
       xaiSentences > 0 ? (
         <div className="space-y-2">
           <p className="text-sm text-muted-foreground">
-            Three highest-magnitude sentences. The full panel above lets you strike any of them.
+            Three highest-impact sentences. The full panel above lets you strike any of them.
           </p>
           <ul className="space-y-1.5">
             {[...(result.xai?.sentences ?? [])]
@@ -411,8 +409,8 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
         </div>
       ) : (
         <p className="text-sm text-muted-foreground">
-          No salient sentences detected — common for very short inputs or text outside the FOMC
-          vocabulary the attribution dictionary covers.
+          No high-impact sentences found. This is common for very short inputs, or for text
+          outside the FOMC vocabulary the explanation dictionary covers.
         </p>
       ),
   };
@@ -421,12 +419,12 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
     key: "calibration",
     title: "Calibration",
     blurb:
-      "How tight the conformal set is and what coverage was calibrated for. Empirical coverage on resolved runs lives on the Performance page.",
+      "How tight the prediction set is, and the confidence level it was calibrated for. Actual coverage on resolved runs is tracked on the Performance page.",
     icon: <ShieldCheck className="h-3.5 w-3.5" />,
     state: regime ? "ok" : "absent",
     summary: regime
-      ? `Calibrated split-conformal · ${Math.round(regime.coverage * 100)}% nominal`
-      : "Calibration sidecar absent",
+      ? `Calibrated prediction set · ${Math.round(regime.coverage * 100)}% confidence level`
+      : "Calibration data not loaded",
     body: regime ? (
       <div className="space-y-3">
         <CoverageGauge coverage={regime.coverage} />
@@ -437,15 +435,15 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
           <dd className="text-right">{regime.set_label}</dd>
         </dl>
         <p className="text-xs text-muted-foreground">
-          A tighter set (size 1) means the model is confident enough to single out one regime; a
-          looser set hedges across more classes. Empirical coverage over resolved runs is tracked
-          on the Performance page.
+          A tight set (size 1) means the model is confident enough to single out one regime; a
+          looser set hedges across more classes. Actual coverage on resolved runs is tracked on
+          the Performance page.
         </p>
       </div>
     ) : (
       <p className="text-sm text-muted-foreground">
-        Calibration is only available when the regime head is active. Empirical coverage is still
-        computed on the Performance page when realised regimes resolve.
+        Calibration is only available when the Volatility Regime prediction is active. Actual
+        coverage is still computed on the Performance page when realised regimes resolve.
       </p>
     ),
   };
@@ -518,7 +516,7 @@ export function PipelineTrace({ result, inputText }: PipelineTraceProps) {
           </CardTitle>
           <CardDescription>
             End-to-end view of what the backend actually ran on this input. Click any step in the
-            rail or row below for the diagnostics.
+            rail or row below for details.
           </CardDescription>
         </div>
         <StepRail steps={steps} activeKey={openKey} onSelect={setOpenKey} />

--- a/frontend/components/analyze/PolicyActionCard.tsx
+++ b/frontend/components/analyze/PolicyActionCard.tsx
@@ -93,7 +93,7 @@ export function PolicyActionCard({ action }: PolicyActionCardProps) {
             </Badge>
           ) : (
             <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-              No verb named
+              No action verb detected
             </Badge>
           )}
         </CardTitle>
@@ -108,7 +108,7 @@ export function PolicyActionCard({ action }: PolicyActionCardProps) {
           </p>
         ) : (
           <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-            Balance-sheet posture unavailable
+            Balance sheet stance unavailable
           </p>
         )}
       </CardContent>

--- a/frontend/components/analyze/RegimeClassificationCard.tsx
+++ b/frontend/components/analyze/RegimeClassificationCard.tsx
@@ -58,11 +58,11 @@ export function RegimeClassificationCard({ regime, regression }: RegimeClassific
       <CardHeader className="pb-2">
         <CardDescription className="flex items-center gap-1.5">
           <ShieldCheck className="h-3.5 w-3.5" />
-          Regime prediction set
+          Volatility Regime prediction
         </CardDescription>
         <CardTitle className="flex items-center justify-between text-2xl">
           <span className="font-mono">{regime.set_label}</span>
-          <Badge variant="outline">{coveragePct}% coverage</Badge>
+          <Badge variant="outline">{coveragePct}% confidence level</Badge>
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
@@ -94,8 +94,8 @@ export function RegimeClassificationCard({ regime, regression }: RegimeClassific
           })}
         </div>
         <p className="text-xs text-muted-foreground">
-          Split-conformal prediction set at nominal {coveragePct}% coverage.
-          Argmax: <span className="font-medium text-foreground capitalize">{regime.argmax_class}</span> · set size {regime.set_size}.
+          Calibrated prediction set at {coveragePct}% confidence level.
+          Top pick: <span className="font-medium text-foreground capitalize">{regime.argmax_class}</span> · {regime.set_size} label{regime.set_size === 1 ? "" : "s"} in set.
         </p>
         {hasRegression && (
           <div className="border-t pt-2">
@@ -113,7 +113,7 @@ export function RegimeClassificationCard({ regime, regression }: RegimeClassific
               ) : (
                 <ChevronDown className="mr-1 h-3 w-3" />
               )}
-              {showRegression ? "Hide regression details" : "Show regression details"}
+              {showRegression ? "Hide numeric forecast" : "Show numeric forecast"}
             </Button>
             {showRegression && regression && (
               <div
@@ -121,19 +121,19 @@ export function RegimeClassificationCard({ regime, regression }: RegimeClassific
                 className="mt-2 space-y-1 rounded-md border bg-muted/40 px-3 py-2 text-xs text-muted-foreground"
               >
                 <div className="flex items-center justify-between">
-                  <span>log(RV) point</span>
+                  <span>Point estimate (log volatility)</span>
                   <span className="font-mono text-foreground">{formatLogRv(regression.log_rv_point)}</span>
                 </div>
                 <div className="flex items-center justify-between">
-                  <span>{regressionCoveragePct}% interval</span>
+                  <span>{regressionCoveragePct}% confidence range</span>
                   <span className="font-mono text-foreground">
                     [{formatLogRv(regression.log_rv_lower)}, {formatLogRv(regression.log_rv_upper)}]
                   </span>
                 </div>
                 <p className="pt-1 text-[10px] leading-snug">
-                  Dual-head regression on standardised log(forward realized vol);
-                  conformal interval at nominal {regressionCoveragePct}% coverage.
-                  Classification surface above stays the headline.
+                  A numeric forecast of forward volatility (in log units), shown alongside
+                  a {regressionCoveragePct}% calibrated confidence range. The regime
+                  prediction above remains the headline.
                 </p>
               </div>
             )}

--- a/frontend/components/analyze/RegimeHeadline.tsx
+++ b/frontend/components/analyze/RegimeHeadline.tsx
@@ -115,8 +115,8 @@ export function RegimeHeadline({
           <CardDescription className="flex items-center gap-1.5">
             <ShieldCheck className="h-3.5 w-3.5" />
             {hasRegressionBand
-              ? "log(RV) regression band · 10d forward"
-              : "Vol-regime prediction set · 10d forward"}
+              ? "Volatility forecast · 10 days ahead (log scale)"
+              : "Volatility Regime prediction · 10 days ahead"}
           </CardDescription>
           <div className="flex flex-wrap items-center gap-2">
             {symbol ? (
@@ -131,28 +131,28 @@ export function RegimeHeadline({
             ) : null}
             <Badge variant="outline" className="numeric text-[10px]">
               {hasEmpirical
-                ? `Nominal ${coveragePct}% · Empirical ${empiricalPct}%`
-                : `${coveragePct}% coverage`}
-              {` · set size ${regime.set_size}`}
+                ? `Target ${coveragePct}% · Actual ${empiricalPct}%`
+                : `${coveragePct}% confidence level`}
+              {` · ${regime.set_size} label${regime.set_size === 1 ? "" : "s"} in set`}
             </Badge>
             {hasEmpirical && coverageDriftLarge ? (
               <Badge
                 variant={coverageDeltaPct < 0 ? "hawkish" : "neutral"}
                 className="text-[10px]"
-                title={`Empirical coverage drifted ${
+                title={`Actual coverage drifted ${
                   coverageDeltaPct < 0 ? "below" : "above"
-                } nominal across ${empiricalCoverageSampleSize ?? 0} runs.`}
+                } target across ${empiricalCoverageSampleSize ?? 0} runs.`}
               >
                 {coverageDeltaPct > 0 ? "+" : ""}
                 {coverageDeltaPct}pp drift
               </Badge>
             ) : null}
             {oodFlag ? (
-              <Badge variant="hawkish" className="text-[10px]">
-                <AlertTriangle className="h-3 w-3" /> OOD
+              <Badge variant="hawkish" className="text-[10px]" title="Text looks unlike anything the model was trained on">
+                <AlertTriangle className="h-3 w-3" /> Unfamiliar text
               </Badge>
             ) : null}
-            <EvidenceLink section="6.15" label="Three-way comparison · row 10b" />
+            <EvidenceLink section="6.15" label="Method notes · benchmark comparison" />
           </div>
         </div>
         {hasRegressionBand ? (
@@ -161,7 +161,7 @@ export function RegimeHeadline({
               {(regime.log_rv_point as number).toFixed(3)}
             </span>
             <span className="numeric text-sm text-muted-foreground sm:text-base">
-              log(RV) point · band [{(regime.log_rv_lower as number).toFixed(3)},{" "}
+              Point estimate · confidence range [{(regime.log_rv_lower as number).toFixed(3)},{" "}
               {(regime.log_rv_upper as number).toFixed(3)}]
               {bandWidth != null ? (
                 <span className="ml-1 text-muted-foreground/80">
@@ -172,13 +172,13 @@ export function RegimeHeadline({
             <Badge
               variant={regimeChipVariant(regime.argmax_class)}
               className="capitalize"
-              title="UI-side bucket derived from the regression point against the per-fold tertile cutoffs."
+              title="Regime bucket derived from the numeric forecast using the per-fold cutoffs."
             >
-              {regime.argmax_class} bucket
+              {regime.argmax_class} regime
             </Badge>
             {regime.bucket_source ? (
               <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-                bucket source · {regime.bucket_source}
+                regime source · {regime.bucket_source}
               </Badge>
             ) : null}
           </CardTitle>
@@ -188,7 +188,7 @@ export function RegimeHeadline({
               {regime.argmax_class}
             </span>
             <span className="numeric text-sm text-muted-foreground sm:text-base">
-              argmax · {(argmaxProb * 100).toFixed(1)}%
+              top pick · {(argmaxProb * 100).toFixed(1)}%
             </span>
             <div className="flex flex-wrap items-center gap-1.5">
               {regime.predicted_set.map((label) => (
@@ -207,39 +207,38 @@ export function RegimeHeadline({
       <CardContent className="grid gap-6 md:grid-cols-2">
         <div className="space-y-3 rounded-md border border-border bg-muted/10 p-3">
           <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-            Fold-4 with / without · dual head, 5 seeds × 5 folds
+            Cross-validated accuracy · 5 seeds × 5 folds
           </p>
           <div className="grid grid-cols-2 gap-3 text-xs">
             <div className="space-y-1">
-              <p className="text-muted-foreground">With fold-4 (canonical)</p>
+              <p className="text-muted-foreground">Including fold 4 (headline)</p>
               <p className="numeric font-medium text-foreground">
-                F1 {FOLD4_DUAL_F1_WITH.toFixed(3)} ± {FOLD4_DUAL_F1_STD_WITH.toFixed(3)}
+                F1 score {FOLD4_DUAL_F1_WITH.toFixed(3)} ± {FOLD4_DUAL_F1_STD_WITH.toFixed(3)}
               </p>
               <p className="numeric text-muted-foreground">
-                RMSE log(RV) {FOLD4_DUAL_RMSE_WITH.toFixed(3)}
+                Root-mean-square error (log volatility) {FOLD4_DUAL_RMSE_WITH.toFixed(3)}
               </p>
             </div>
             <div className="space-y-1">
-              <p className="text-muted-foreground">Without fold-4</p>
+              <p className="text-muted-foreground">Excluding fold 4</p>
               <p className="numeric font-medium text-foreground">
-                F1 {FOLD4_DUAL_F1_WITHOUT.toFixed(3)} ± {FOLD4_DUAL_F1_STD_WITHOUT.toFixed(3)}
+                F1 score {FOLD4_DUAL_F1_WITHOUT.toFixed(3)} ± {FOLD4_DUAL_F1_STD_WITHOUT.toFixed(3)}
               </p>
               <p className="numeric text-muted-foreground">
-                RMSE log(RV) {FOLD4_DUAL_RMSE_WITHOUT.toFixed(3)}
+                Root-mean-square error (log volatility) {FOLD4_DUAL_RMSE_WITHOUT.toFixed(3)}
               </p>
             </div>
           </div>
           <p className="text-[11px] leading-relaxed text-muted-foreground">
-            Fold-4 sits at the R-17 zero-<span className="numeric">calm</span> slice. The delta is small (F1
-            +0.005, RMSE −0.039) which means the canonical headline is not load-bearing on the
-            degenerate fold. Cells from <code>dual_head_comparison_canonical.json</code>; full
-            four-variant context in §6.7.
+            Fold 4 covers a stretch with very few <span className="numeric">calm</span>{" "}
+            examples. The difference between including and excluding it is small (F1 +0.005,
+            error −0.039), so the headline score is not driven by that one slice.
           </p>
-          <EvidenceLink section="6.7" label="Honest headline reporting · four-variant table" />
+          <EvidenceLink section="6.7" label="Method notes · full four-variant table" />
         </div>
         <div className="space-y-3 rounded-md border border-border bg-muted/20 p-3">
           <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-            Past {trendValues.length || 0} runs · argmax regime
+            Past {trendValues.length || 0} runs · top-pick regime
           </p>
           {trendValues.length ? (
             <Sparkline
@@ -265,7 +264,7 @@ export function RegimeHeadline({
         </div>
         <details className="md:col-span-2 group rounded-md border border-border bg-muted/10 p-3 text-xs">
           <summary className="cursor-pointer select-none text-[11px] uppercase tracking-wide text-muted-foreground group-open:text-foreground">
-            Per-class softmax + calibrated set (secondary detail)
+            Per-class probabilities and prediction set (details)
           </summary>
           <div className="mt-3 grid gap-3 md:grid-cols-2">
             <div className="space-y-2">
@@ -308,19 +307,18 @@ export function RegimeHeadline({
             </div>
             <div className="space-y-2 text-muted-foreground">
               <p>
-                Calibrated APS prediction set at nominal {coveragePct}% coverage:{" "}
+                Calibrated prediction set at {coveragePct}% confidence level:{" "}
                 <span className="text-foreground numeric">
                   {`{${regime.predicted_set.join(", ")}}`}
                 </span>{" "}
-                · size {regime.set_size}.
+                · {regime.set_size} label{regime.set_size === 1 ? "" : "s"} in set.
               </p>
               <p>
-                Argmax: <span className="text-foreground capitalize">{regime.argmax_class}</span>{" "}
-                ({(argmaxProb * 100).toFixed(1)}%). Per-class precision / recall / F1 publish on
-                the §6.10 baselines table; the classifier-branch macro-F1 on this checkpoint
-                lands at 0.418 ± 0.052 (row 10b sibling). Demoted from the headline because
-                §6.15 / row 10b makes the regression band the canonical surface and the
-                classification head sits inside its CI.
+                Top pick: <span className="text-foreground capitalize">{regime.argmax_class}</span>{" "}
+                ({(argmaxProb * 100).toFixed(1)}%). Per-class precision, recall, and F1 score
+                live in the baselines table; the classifier scores 0.418 ± 0.052 F1 on this
+                model. Numeric forecast above is the headline, with the classifier shown as
+                supporting detail.
               </p>
               <EvidenceLink section="6.10" label="Baselines table · per-class detail" />
             </div>

--- a/frontend/components/analyze/SentenceStrikeXaiPanel.tsx
+++ b/frontend/components/analyze/SentenceStrikeXaiPanel.tsx
@@ -279,7 +279,7 @@ export function SentenceStrikeXaiPanel({
         <div className="flex flex-wrap items-center justify-between gap-2">
           <CardTitle className="flex items-center gap-2">
             <Highlighter className="h-4 w-4 text-primary" />
-            Sentence attribution
+            Per-sentence explanation
             {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" /> : null}
           </CardTitle>
           <div className="flex flex-wrap items-center gap-2">
@@ -318,15 +318,15 @@ export function SentenceStrikeXaiPanel({
         </div>
         <CardDescription>
           {interactive
-            ? "Click a sentence to strike it out — the dashboard re-runs the classifier without it and shows the Δ above. "
-            : "Hover any sentence to see the five tokens with the largest attribution. "}
+            ? "Click a sentence to strike it out — the dashboard re-runs the model without it and shows the change above. "
+            : "Hover any sentence to see the five words that mattered most. "}
           {xai.method ? `Method: ${xai.method}.` : null}
         </CardDescription>
         {driftPoints ? (
           <div className="mt-3 rounded-md border border-border bg-muted/20 px-3 py-2">
             <div className="flex items-center justify-between text-[10px] uppercase tracking-wide text-muted-foreground">
               <span>
-                P({baselineArgmax ?? "argmax"}) across {driftPoints.length - 1} strike
+                Probability of {baselineArgmax ?? "top pick"} across {driftPoints.length - 1} strike
                 {driftPoints.length - 1 === 1 ? "" : "s"}
               </span>
               <span className="numeric text-foreground">

--- a/frontend/components/analyze/TrajectoryPanel.tsx
+++ b/frontend/components/analyze/TrajectoryPanel.tsx
@@ -182,7 +182,7 @@ export function TrajectoryPanel({
             description={
               error
                 ? `Backend reported: ${error}`
-                : "No bundle loaded on this host."
+                : "No trajectory model loaded on this host."
             }
           />
         </CardContent>
@@ -203,11 +203,11 @@ export function TrajectoryPanel({
         <CardContent>
           <EmptyState
             variant="inline"
-            title="Trajectory bundle absent"
+            title="Trajectory model not loaded"
             description={
               <span>
-                Run <code className="rounded bg-muted px-1">python -m app.trajectory.train --architecture transformer</code>{" "}
-                against the canonical training package to produce the bundle, then refresh.
+                Train and load the trajectory model against the training corpus to populate
+                this panel.
               </span>
             }
           />
@@ -282,7 +282,7 @@ export function TrajectoryPanel({
           <div className="flex flex-wrap items-center gap-2">
             {data.train_end ? (
               <Badge variant="outline" className="numeric text-[10px]">
-                train_end · {data.train_end}
+                training ended · {data.train_end}
               </Badge>
             ) : null}
             {hasLiftSignal && !liftEstablished ? (
@@ -291,19 +291,19 @@ export function TrajectoryPanel({
                 className="text-[10px] uppercase tracking-wide"
                 title={
                   data.delta_dir_acc != null && data.baseline_used
-                    ? `Δ dir-acc vs ${data.baseline_used} = ${(data.delta_dir_acc * 100).toFixed(1)}pp; needs ≥ 5pp.`
-                    : "Lift over naive baselines not yet established (#332)."
+                    ? `Improvement vs ${data.baseline_used}: ${(data.delta_dir_acc * 100).toFixed(1)}pp; needs at least 5pp.`
+                    : "No measurable improvement over simple baselines yet."
                 }
               >
-                no lift over baseline · §6.17
+                no improvement over baseline
               </Badge>
             ) : null}
             {liftEstablished ? (
               <Badge variant="dovish" className="text-[10px] uppercase tracking-wide">
-                lift +{((data.delta_dir_acc ?? 0) * 100).toFixed(1)}pp
+                +{((data.delta_dir_acc ?? 0) * 100).toFixed(1)}pp vs baseline
               </Badge>
             ) : null}
-            <EvidenceLink section="6.17" label="Trajectory baselines + parameter cap" />
+            <EvidenceLink section="6.17" label="Method notes · trajectory baselines" />
           </div>
         </CardTitle>
       </CardHeader>
@@ -378,7 +378,7 @@ export function TrajectoryPanel({
               </div>
               {projection.confidence_band && projection.confidence_band.length > 0 ? (
                 <Badge variant="outline" className="text-[10px]">
-                  band · {projection.confidence_band.join(", ")}
+                  prediction set · {projection.confidence_band.join(", ")}
                 </Badge>
               ) : null}
             </div>
@@ -399,9 +399,9 @@ export function TrajectoryPanel({
         ) : null}
 
         <p className="text-[11px] leading-relaxed text-muted-foreground">
-          PCA projection of meeting-level embeddings from the cross-bank DAPT encoder.
-          Marker brightness encodes recency (older meetings fade); the star is the next-meeting
-          projection. Confidence band is the APS-calibrated stance set.
+          Each dot is a past FOMC meeting, placed by a 2-D summary of the meeting text.
+          Brighter dots are more recent; the star is the projected next meeting. The
+          prediction set is the calibrated range of likely stances.
         </p>
       </CardContent>
     </Card>

--- a/frontend/components/analyze/XaiPanel.tsx
+++ b/frontend/components/analyze/XaiPanel.tsx
@@ -91,9 +91,9 @@ function familyLabel(family: string): string {
     market: "Market",
     credibility: "Credibility",
     linguistic: "Linguistic",
-    mp_surprise: "MP surprise",
-    multi_axis: "Multi-axis",
-    realized_vol: "Realised vol",
+    mp_surprise: "Policy surprise",
+    multi_axis: "Sentiment breakdown",
+    realized_vol: "Realised volatility",
     cross_asset: "Cross-asset",
     llm: "LLM features",
     trajectory_input: "Trajectory input",
@@ -102,7 +102,7 @@ function familyLabel(family: string): string {
 }
 
 function panelLabel(panel: string): string {
-  if (panel === "regime") return "Vol regime";
+  if (panel === "regime") return "Volatility Regime";
   if (panel.startsWith("rates_")) {
     const head = panel.slice("rates_".length);
     return `Rates · ${head}`;
@@ -114,21 +114,21 @@ function panelLabel(panel: string): string {
 function unavailableCopy(reason: string | null): string {
   switch (reason) {
     case "not_classification_mode":
-      return "Panel inactive on the current checkpoint.";
+      return "Panel inactive on the active model.";
     case "head_not_mounted":
-      return "Head not mounted on the current checkpoint.";
+      return "This prediction is not enabled on the active model.";
     case "no_multi_task_forward":
-      return "Model exposes no multi-task forward.";
+      return "Model does not expose the joint prediction needed for this view.";
     case "inference_kwarg_missing":
-      return "Inference contract mismatch — operator follow-up.";
+      return "Model inputs do not match what the explainer expects.";
     case "ig_runtime_error":
     case "unexpected_exception":
-      return "Attribution runtime error.";
+      return "Explanation engine error.";
     case "missing_stance_logits":
     case "missing_logits":
-      return "Target logits missing from the forward dict.";
+      return "Target prediction missing from the model output.";
     case "bundle_not_loaded":
-      return "Model bundle not loaded.";
+      return "Model not loaded.";
     default:
       return "Explanation unavailable for this panel.";
   }
@@ -143,7 +143,7 @@ export function PanelAttributionRow({ panel }: { panel: XaiPanelAttribution }) {
       >
         <span className="text-xs font-medium">{panelLabel(panel.panel)}</span>
         <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-          Explanation unavailable
+          Explanation not available
         </Badge>
         <span className="ml-2 text-[11px] text-muted-foreground">
           {unavailableCopy(panel.reason)}
@@ -163,7 +163,7 @@ export function PanelAttributionRow({ panel }: { panel: XaiPanelAttribution }) {
       <div className="flex items-center justify-between">
         <span className="text-xs font-semibold">{panelLabel(panel.panel)}</span>
         <span className="text-[10px] text-muted-foreground">
-          target: {panel.target} · IG n={panel.n_steps}
+          target: {panel.target} · {panel.n_steps} attribution steps
         </span>
       </div>
       <div className="space-y-1">
@@ -201,23 +201,24 @@ export function XaiPanel({ xai, previewMode }: XaiPanelProps) {
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Highlighter className="h-4 w-4 text-primary" />
-          Sentence attribution
+          Per-sentence explanation
           {previewMode ? (
             <Badge variant="outline" className="ml-2 text-[10px] uppercase tracking-wide">
-              Preview · fixture
+              Preview · sample data
             </Badge>
           ) : null}
         </CardTitle>
         <CardDescription>
-          Hover any sentence to see the five tokens with the largest attribution.
+          Hover any sentence to see the five words that mattered most.
           {xai.method ? ` Method: ${xai.method}.` : null}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         {isEmpty ? (
           <p className="rounded-md border border-dashed border-border bg-muted/30 px-3 py-4 text-sm text-muted-foreground">
-            No salient sentences detected. The attribution method found no tokens above the salience floor — common for very short
-            inputs or text that lies outside the FOMC vocabulary the model was trained on.
+            No high-impact sentences found. The explanation method found no words above the
+            sensitivity threshold. This is common for very short inputs, or text that lies
+            outside the FOMC vocabulary the model was trained on.
           </p>
         ) : (
           <p className="space-x-1.5 text-sm leading-7">
@@ -229,7 +230,7 @@ export function XaiPanel({ xai, previewMode }: XaiPanelProps) {
         {panels.length > 0 ? (
           <div className="space-y-3 border-t border-border pt-3" data-testid="panel-attributions">
             <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
-              Per-panel feature-family attribution · integrated gradients
+              What drove each panel · grouped by feature type
             </p>
             {panels.map((panel) => (
               <PanelAttributionRow key={panel.panel} panel={panel} />

--- a/frontend/components/shell/header.tsx
+++ b/frontend/components/shell/header.tsx
@@ -48,7 +48,7 @@ export function Header() {
             <Activity className="h-4 w-4 text-primary" aria-hidden="true" />
             <span>Fed Pulse</span>
             <Badge variant="outline" className="ml-1 text-[10px] uppercase tracking-wide">
-              vol-regime
+              Volatility Regime
             </Badge>
           </Link>
           <nav aria-label="Primary" className="hidden items-center gap-0.5 sm:flex">

--- a/frontend/lib/analyze/format.ts
+++ b/frontend/lib/analyze/format.ts
@@ -121,7 +121,7 @@ export function bandLabel(
   confidenceLevel: number,
   source: "conformal" | "gaussian_z" | null | undefined,
 ): string {
-  if (source === "conformal") return `${confidenceLevel}% conformal band`;
-  if (source === "gaussian_z") return `${confidenceLevel}% Gaussian-z band`;
-  return `${confidenceLevel}% confidence band`;
+  if (source === "conformal") return `${confidenceLevel}% calibrated range`;
+  if (source === "gaussian_z") return `${confidenceLevel}% Gaussian range`;
+  return `${confidenceLevel}% confidence range`;
 }

--- a/frontend/pages/compare.tsx
+++ b/frontend/pages/compare.tsx
@@ -156,10 +156,10 @@ function MultiAxisDeltaCard({ delta }: { delta: MultiAxisDelta }) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Multi-axis Δ A − B</CardTitle>
+        <CardTitle>Sentiment breakdown change · A − B</CardTitle>
         <CardDescription>
-          Per-axis deltas from the multi-axis schema. Missing axes appear as
-          "—" when at least one side does not carry that axis.
+          Change on each sentiment axis. Axes show "—" when at least one side
+          did not include that axis.
         </CardDescription>
       </CardHeader>
       <CardContent className="p-0">
@@ -167,8 +167,8 @@ function MultiAxisDeltaCard({ delta }: { delta: MultiAxisDelta }) {
           <thead className="border-b border-border bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
             <tr>
               <th className="px-4 py-2 text-left">Axis</th>
-              <th className="px-4 py-2 text-right">Δ A − B</th>
-              <th className="px-4 py-2 text-right">Confidence Δ</th>
+              <th className="px-4 py-2 text-right">Change A − B</th>
+              <th className="px-4 py-2 text-right">Confidence change</th>
             </tr>
           </thead>
           <tbody>
@@ -211,8 +211,8 @@ function MultiAxisDeltaCard({ delta }: { delta: MultiAxisDelta }) {
                 {delta.topicChanged == null
                   ? "—"
                   : delta.topicChanged
-                  ? "primary topic changed"
-                  : "primary topic unchanged"}
+                  ? "main topic changed"
+                  : "main topic unchanged"}
               </td>
             </tr>
           </tbody>
@@ -235,21 +235,21 @@ function MultiAxisSideBySide({
   return (
     <div className="grid gap-4 xl:grid-cols-2">
       <div className="space-y-2">
-        <p className="text-xs uppercase tracking-wide text-muted-foreground">Run A · multi-axis</p>
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">Run A · sentiment breakdown</p>
         {ma ? <MultiAxisCards multiAxis={ma} /> : (
           <Card>
             <CardContent className="py-6 text-center text-sm text-muted-foreground">
-              Run A has no multi-axis payload.
+              Run A has no sentiment breakdown.
             </CardContent>
           </Card>
         )}
       </div>
       <div className="space-y-2">
-        <p className="text-xs uppercase tracking-wide text-muted-foreground">Run B · multi-axis</p>
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">Run B · sentiment breakdown</p>
         {mb ? <MultiAxisCards multiAxis={mb} /> : (
           <Card>
             <CardContent className="py-6 text-center text-sm text-muted-foreground">
-              Run B has no multi-axis payload.
+              Run B has no sentiment breakdown.
             </CardContent>
           </Card>
         )}
@@ -292,7 +292,7 @@ function DeltaSummary({ delta }: { delta: CompareDelta }) {
         </span>
       )
     ) : (
-      <span className="text-muted-foreground">regime absent on at least one side</span>
+      <span className="text-muted-foreground">Volatility Regime missing on at least one side</span>
     );
 
   return (
@@ -331,7 +331,7 @@ function DeltaSummary({ delta }: { delta: CompareDelta }) {
             ) : null}
           </div>
           <div>
-            <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">Drift score</dt>
+            <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">Shift score</dt>
             <dd
               className={`numeric mt-1 flex items-center gap-1 ${deltaColorClass(delta.driftDelta)}`}
             >
@@ -340,7 +340,7 @@ function DeltaSummary({ delta }: { delta: CompareDelta }) {
             </dd>
           </div>
           <div>
-            <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">Realized-vs-stated</dt>
+            <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">What was done vs. said</dt>
             <dd
               className={`numeric mt-1 flex items-center gap-1 ${deltaColorClass(delta.realizedGapDelta)}`}
             >

--- a/frontend/pages/history/index.tsx
+++ b/frontend/pages/history/index.tsx
@@ -202,7 +202,7 @@ export default function HistoryPage() {
       },
       {
         key: "argmax_probability",
-        header: "P(argmax)",
+        header: "Probability",
         align: "right",
         numeric: true,
         sortable: true,
@@ -214,7 +214,7 @@ export default function HistoryPage() {
       },
       {
         key: "regime_set_size",
-        header: "Set",
+        header: "Set size",
         align: "right",
         numeric: true,
         sortable: true,
@@ -223,7 +223,7 @@ export default function HistoryPage() {
       },
       {
         key: "realized_regime",
-        header: "Realized",
+        header: "Actual",
         render: (row) =>
           row.realized_regime ? (
             <Badge variant={regimeVariant(row.realized_regime)} className="text-[10px] capitalize">

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -362,7 +362,7 @@ export default function WorkspacePage() {
   return (
     <>
       <Head>
-        <title>Fed Pulse — vol-regime workspace</title>
+        <title>Fed Pulse — Volatility Regime workspace</title>
       </Head>
       <div className="min-h-screen bg-background text-foreground">
         <Header />
@@ -377,17 +377,18 @@ export default function WorkspacePage() {
             <div className="space-y-1">
               <h1 className="text-2xl font-semibold tracking-tight">Workspace</h1>
               <p className="max-w-2xl text-sm text-muted-foreground">
-                Paste an FOMC excerpt and the classifier returns a calibrated 10-day vol-regime set,
-                the multi-axis breakdown, sentence attribution, credibility KPIs, and the full pipeline
-                trace. Everything is read off the live backend.
+                Paste an FOMC excerpt and the model returns a calibrated 10-day Volatility
+                Regime prediction, a sentiment breakdown, a per-sentence explanation,
+                credibility checks, and a full pipeline trace. Everything comes from the live
+                backend.
               </p>
             </div>
             <div className="flex flex-wrap items-center gap-2">
               <Badge variant="outline" className="numeric text-[10px]">
-                horizon · 10d
+                horizon · 10 days
               </Badge>
               <Badge variant="outline" className="numeric text-[10px]">
-                target · vol regime
+                target · Volatility Regime
               </Badge>
             </div>
           </div>
@@ -435,18 +436,19 @@ export default function WorkspacePage() {
                 />
               ) : (
                 <EmptyState
-                  title="Calibrated regime card not in this build"
+                  title="Volatility Regime card not available in this build"
                   description={
                     <div className="space-y-2">
                       <p>
-                        The deployed forecaster is regression-mode — it predicts close and volatility numerically
-                        but does not bucket them into a calibrated{" "}
-                        <span className="numeric">calm / normal / high</span> set. The classification head and its
-                        conformal sidecar (<code>softmax_quantile</code>) ship as part of #216 / Round 1.
+                        The active forecaster is in numeric mode — it predicts close and
+                        volatility as single numbers rather than a calibrated{" "}
+                        <span className="numeric">calm / normal / high</span> prediction set.
+                        The Volatility Regime classifier and its calibration data are not loaded.
                       </p>
                       <p className="text-muted-foreground">
-                        Every other workspace surface below — multi-axis breakdown, sentence attribution,
-                        credibility KPIs, pipeline trace, history strip — is live against the current checkpoint.
+                        Every other workspace panel below — sentiment breakdown, per-sentence
+                        explanation, credibility checks, pipeline trace, and history strip — is
+                        live against the current model.
                       </p>
                     </div>
                   }
@@ -463,8 +465,8 @@ export default function WorkspacePage() {
                 ) : (
                   <EmptyState
                     variant="inline"
-                    title="Multi-axis checkpoint absent"
-                    description="Train and deploy the multi-axis classifier to populate stance, factor, certainty, topic."
+                    title="Sentiment breakdown not loaded"
+                    description="Load the sentiment model to populate stance, factor, certainty, and topic."
                   />
                 )}
                 {result.credibility ? (
@@ -472,8 +474,8 @@ export default function WorkspacePage() {
                 ) : (
                   <EmptyState
                     variant="inline"
-                    title="Credibility features unavailable"
-                    description="No embedding or FRED cache attached on this host yet."
+                    title="Credibility signals unavailable"
+                    description="The required embedding model and historical rate cache are not loaded on this host yet."
                   />
                 )}
               </div>

--- a/frontend/pages/performance.tsx
+++ b/frontend/pages/performance.tsx
@@ -143,7 +143,7 @@ export default function PerformancePage() {
       },
       {
         key: "argmaxAccuracy",
-        header: "Argmax acc",
+        header: "Top-pick accuracy",
         align: "right",
         numeric: true,
         sortable: true,
@@ -152,7 +152,7 @@ export default function PerformancePage() {
       },
       {
         key: "empiricalCoverage",
-        header: "Empirical coverage",
+        header: "Actual coverage",
         align: "right",
         numeric: true,
         sortable: true,
@@ -187,7 +187,7 @@ export default function PerformancePage() {
       },
       {
         key: "argmax",
-        header: "Argmax",
+        header: "Top pick",
         render: (row) =>
           row.argmax ? (
             <Badge variant={regimeVariant(row.argmax)} className="text-[10px] capitalize">
@@ -199,7 +199,7 @@ export default function PerformancePage() {
       },
       {
         key: "argmaxProbability",
-        header: "P(argmax)",
+        header: "Probability",
         align: "right",
         numeric: true,
         sortable: true,
@@ -208,7 +208,7 @@ export default function PerformancePage() {
       },
       {
         key: "realized",
-        header: "Realized",
+        header: "Actual",
         render: (row) =>
           row.realized ? (
             <Badge variant={regimeVariant(row.realized)} className="text-[10px] capitalize">
@@ -220,7 +220,7 @@ export default function PerformancePage() {
       },
       {
         key: "argmaxHit",
-        header: "Argmax",
+        header: "Top-pick result",
         align: "center",
         render: (row) => {
           if (!row.argmax || !row.realized) {
@@ -236,7 +236,7 @@ export default function PerformancePage() {
       },
       {
         key: "setHit",
-        header: "Set",
+        header: "Prediction set",
         align: "center",
         render: (row) => {
           if (row.setHit == null) return <span className="text-muted-foreground">—</span>;
@@ -263,9 +263,9 @@ export default function PerformancePage() {
           <div className="space-y-1">
             <h1 className="text-2xl font-semibold tracking-tight">Performance</h1>
             <p className="max-w-2xl text-sm text-muted-foreground">
-              Macro-F1, per-class precision / recall / F1, confusion matrix, and empirical conformal
-              coverage on the resolved regime predictions. Realized regime is bucketed from the 10d
-              forward vol path using the classifier&apos;s trained quantile cutoffs.
+              Accuracy, per-class precision / recall / F1, confusion matrix, and actual coverage
+              of the prediction set on resolved regime predictions. The realised regime is
+              bucketed from the 10-day forward volatility path using the model&apos;s trained cutoffs.
             </p>
           </div>
 
@@ -287,12 +287,12 @@ export default function PerformancePage() {
               icon={<Target className="h-3.5 w-3.5" />}
             />
             <KpiTile
-              label="Argmax accuracy"
+              label="Top-pick accuracy"
               value={<span className="numeric">{formatPercent(aggregate.argmaxAccuracy)}</span>}
               caption={
                 aggregate.argmaxAccuracy != null && aggregate.argmaxAccuracy >= 1 / REGIME_CLASSES.length
-                  ? "above uniform baseline"
-                  : "below uniform baseline"
+                  ? "above random-guess baseline"
+                  : "below random-guess baseline"
               }
               tone={
                 aggregate.argmaxAccuracy != null && aggregate.argmaxAccuracy >= 1 / REGIME_CLASSES.length
@@ -303,29 +303,29 @@ export default function PerformancePage() {
               }
             />
             <KpiTile
-              label="Macro-F1"
+              label="Overall F1 score"
               value={<span className="numeric">{formatScore(headlineMacroF1)}</span>}
               caption={
                 breakdownAvailable
-                  ? "from training eval artifact"
+                  ? "from training evaluation"
                   : aggregate.macroF1 != null
-                  ? "client aggregation across history"
+                  ? "computed from your history"
                   : aggregate.resolved > 0
-                  ? "needs resolved runs in every regime class"
+                  ? "needs resolved runs in every regime"
                   : "needs resolved runs"
               }
               tone={headlineMacroF1 != null && headlineMacroF1 >= 0.4 ? "up" : "neutral"}
             />
             <KpiTile
-              label="Empirical coverage"
+              label="Actual coverage"
               value={<span className="numeric">{formatPercent(aggregate.empiricalCoverage)}</span>}
-              caption="realised regime inside the predicted set"
+              caption="how often the realised regime fell inside the prediction set"
             />
             {headlineMacroRocAuc != null ? (
               <KpiTile
-                label="Macro ROC-AUC"
+                label="Overall ROC-AUC"
                 value={<span className="numeric">{formatScore(headlineMacroRocAuc)}</span>}
-                caption="one-vs-rest, training eval"
+                caption="one-vs-rest, from training evaluation"
                 tone={headlineMacroRocAuc >= 0.6 ? "up" : "neutral"}
               />
             ) : null}
@@ -354,8 +354,8 @@ export default function PerformancePage() {
                   <CardTitle className="text-base">Per-class metrics</CardTitle>
                   <CardDescription>
                     {breakdownAvailable
-                      ? "From the training-time classification breakdown — precision, recall, F1, ROC-AUC, PR-AUC."
-                      : "Computed client-side from resolved history runs. Will switch to the training eval artifact when one is published."}
+                      ? "From training-time evaluation — precision, recall, F1, ROC-AUC, PR-AUC."
+                      : "Computed from your resolved history runs. Will switch to the training evaluation when one is published."}
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="p-0">
@@ -423,8 +423,8 @@ export default function PerformancePage() {
                   <CardTitle className="text-base">Confusion matrix</CardTitle>
                   <CardDescription>
                     {breakdownAvailable
-                      ? "From the training-time classification breakdown — rows are the true class, columns the predicted argmax."
-                      : "Computed client-side from resolved runs — rows are realised regime, columns are predicted argmax."}
+                      ? "From training-time evaluation — rows are the actual class, columns are the predicted top pick."
+                      : "Computed from your resolved runs — rows are the realised regime, columns are the predicted top pick."}
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
@@ -450,7 +450,7 @@ export default function PerformancePage() {
                 <CardHeader className="pb-3">
                   <CardTitle className="text-base">Per-asset breakdown</CardTitle>
                   <CardDescription>
-                    Argmax accuracy and empirical coverage for every symbol with at least one
+                    Top-pick accuracy and actual coverage for every symbol with at least one
                     resolved run.
                   </CardDescription>
                 </CardHeader>

--- a/frontend/pages/settings.tsx
+++ b/frontend/pages/settings.tsx
@@ -60,9 +60,9 @@ function roleLabel(role: string): string {
     case "forecaster":
       return "Forecaster";
     case "multi_axis":
-      return "Multi-axis classifier";
+      return "Sentiment breakdown model";
     case "lora_adapter":
-      return "LoRA adapter";
+      return "LoRA (low-rank adapter)";
     case "calibration":
       return "Calibration";
     default:
@@ -120,16 +120,18 @@ function CheckpointRow({ checkpoint }: { checkpoint: SettingsCheckpoint }) {
             {checkpoint.encoder_alias ? (
               <>
                 <span>·</span>
-                <span className="numeric">{checkpoint.encoder_alias}</span>
+                <span>
+                  Model variant: <span className="numeric">{checkpoint.encoder_alias}</span>
+                </span>
               </>
             ) : null}
             {checkpoint.role === "forecaster" ? (
               <>
                 <span>·</span>
                 <span>
-                  conformal sidecar:{" "}
+                  Calibration data:{" "}
                   {checkpoint.conformal_sidecar_present ? (
-                    <span className="text-up">present</span>
+                    <span className="text-up">loaded</span>
                   ) : (
                     <span className="text-down">missing</span>
                   )}
@@ -140,10 +142,10 @@ function CheckpointRow({ checkpoint }: { checkpoint: SettingsCheckpoint }) {
           {checkpoint.role === "forecaster" && contractStatus ? (
             <div
               className="flex flex-wrap items-center gap-1.5 pt-1"
-              aria-label="inference contract kwargs"
+              aria-label="model input check"
             >
               <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                inference contract:
+                Model input check:
               </span>
               {contractStatus === "sidecar_absent" ? (
                 <Badge
@@ -155,7 +157,7 @@ function CheckpointRow({ checkpoint }: { checkpoint: SettingsCheckpoint }) {
                 </Badge>
               ) : requiredKwargs.length === 0 ? (
                 <Badge variant="outline" className="text-[10px] text-muted-foreground">
-                  no required kwargs
+                  no required inputs
                 </Badge>
               ) : (
                 requiredKwargs.map((name) => {
@@ -172,8 +174,8 @@ function CheckpointRow({ checkpoint }: { checkpoint: SettingsCheckpoint }) {
                       }
                       title={
                         isSupplied
-                          ? `${name} is supplied by the serving wiring`
-                          : `${name} declared by the checkpoint sidecar but NOT supplied by the serving wiring`
+                          ? `${name} is supplied by the backend`
+                          : `${name} is required by this model file but not supplied by the backend`
                       }
                     >
                       {name}
@@ -235,8 +237,8 @@ function ModelsSection() {
           {modelsDir ? (
             <>
               Read-only inventory of <code className="rounded bg-muted px-1 font-mono text-xs">{modelsDir}</code>.
-              Active flag points at the file each service is currently loaded from. Live swap is intentionally
-              not wired — drop a new checkpoint into the directory and restart the backend container to switch.
+              The active flag points at the file each service is currently loaded from. To switch models,
+              drop a new file into the directory and restart the backend; live swap is intentionally disabled.
             </>
           ) : (
             "Read-only inventory of the backend models directory."
@@ -253,14 +255,14 @@ function ModelsSection() {
         ) : error ? (
           <EmptyState
             variant="inline"
-            title="Could not load checkpoints"
+            title="Could not load model files"
             description={<p>{error}</p>}
           />
         ) : data.length === 0 ? (
           <EmptyState
             variant="inline"
-            title="No checkpoints on disk"
-            description="The backend models directory is empty. Train a checkpoint and drop it into the path above."
+            title="No model files on disk"
+            description="The backend models directory is empty. Train a model and drop the file into the path above."
           />
         ) : (
           <div className="space-y-4">
@@ -394,7 +396,7 @@ export default function SettingsPage() {
               Settings
             </h1>
             <p className="max-w-2xl text-sm text-muted-foreground">
-              Read-only inventory of the model files the backend has loaded, plus the per-browser
+              Read-only view of the model files the backend has loaded, plus the per-browser
               defaults the workspace uses when you open it.
             </p>
           </div>

--- a/frontend/tests/components/analyze/CredibilityPanel.test.tsx
+++ b/frontend/tests/components/analyze/CredibilityPanel.test.tsx
@@ -7,10 +7,10 @@ import { SAMPLE_CREDIBILITY } from "@/lib/analyze/fixtures";
 describe("CredibilityPanel", () => {
   it("renders the four credibility surface items from the fixture", () => {
     render(<CredibilityPanel credibility={SAMPLE_CREDIBILITY} />);
-    expect(screen.getByText(/drift vs. prior 4 statements/i)).toBeInTheDocument();
-    expect(screen.getByText(/realized vs\. stated/i)).toBeInTheDocument();
-    expect(screen.getByText(/market-implied gap/i)).toBeInTheDocument();
-    expect(screen.getByText(/since reversal/i)).toBeInTheDocument();
+    expect(screen.getByText(/shift vs\. last 4 statements/i)).toBeInTheDocument();
+    expect(screen.getByText(/what was done vs\. said/i)).toBeInTheDocument();
+    expect(screen.getByText(/gap to market expectations/i)).toBeInTheDocument();
+    expect(screen.getByText(/time since last reversal/i)).toBeInTheDocument();
     expect(screen.getByText(/14 mo/)).toBeInTheDocument();
   });
 

--- a/frontend/tests/components/analyze/EmptyStateReasons.test.tsx
+++ b/frontend/tests/components/analyze/EmptyStateReasons.test.tsx
@@ -17,9 +17,9 @@ describe("Inline 'awaiting checkpoint' reasons", () => {
       />,
     );
     expect(
-      screen.getByText(/multi-axis classifier returned no axis labels/i),
+      screen.getByText(/sentiment breakdown returned no labels/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/multi_axis_classifier\.pt/)).toBeInTheDocument();
+    expect(screen.getByText(/active model file is missing/i)).toBeInTheDocument();
   });
 
   it("MultiAxisInterpretation renders the tile grid when at least one axis is present", () => {
@@ -34,7 +34,7 @@ describe("Inline 'awaiting checkpoint' reasons", () => {
       />,
     );
     expect(
-      screen.queryByText(/multi-axis classifier returned no axis labels/i),
+      screen.queryByText(/sentiment breakdown returned no labels/i),
     ).not.toBeInTheDocument();
     expect(screen.getByText(/stance/i)).toBeInTheDocument();
   });
@@ -51,8 +51,8 @@ describe("Inline 'awaiting checkpoint' reasons", () => {
         }}
       />,
     );
-    expect(screen.getByText(/credibility features unpopulated/i)).toBeInTheDocument();
-    expect(screen.getByText(/data\/external\/fred/)).toBeInTheDocument();
+    expect(screen.getByText(/credibility signals not yet available/i)).toBeInTheDocument();
+    expect(screen.getByText(/federal funds rate/i)).toBeInTheDocument();
   });
 
   it("CredibilityKpis renders the KPI tiles when drift trend has real history", () => {
@@ -67,7 +67,7 @@ describe("Inline 'awaiting checkpoint' reasons", () => {
         }}
       />,
     );
-    expect(screen.queryByText(/credibility features unpopulated/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/drift score/i)).toBeInTheDocument();
+    expect(screen.queryByText(/credibility signals not yet available/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/shift score/i)).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/analyze/HistoricalAnalogPanel.test.tsx
+++ b/frontend/tests/components/analyze/HistoricalAnalogPanel.test.tsx
@@ -83,10 +83,10 @@ describe("HistoricalAnalogPanel", () => {
   it("surfaces the post-event volatility bucket via the mini-chart aria-label", () => {
     render(<HistoricalAnalogPanel analogs={fixture()} />);
     expect(
-      screen.getByLabelText(/post-event 10-day realised volatility bucket: high/i),
+      screen.getByLabelText(/10-day realised volatility after the event: high/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByLabelText(/post-event 10-day realised volatility bucket: normal/i),
+      screen.getByLabelText(/10-day realised volatility after the event: normal/i),
     ).toBeInTheDocument();
   });
 
@@ -96,7 +96,7 @@ describe("HistoricalAnalogPanel", () => {
     );
     // Each skeleton card has 4 Skeleton bars (header + body).
     expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
-    expect(screen.getByText(/Historical analog panel/i)).toBeInTheDocument();
+    expect(screen.getByText(/Historical analogs/i)).toBeInTheDocument();
   });
 
   it("renders nothing when analogs is null and not loading", () => {
@@ -112,7 +112,7 @@ describe("HistoricalAnalogPanel", () => {
         analogs={{ analogs: [], index_size: 0, encoder_alias: "" }}
       />,
     );
-    expect(screen.getByText(/Retrieval index not loaded/i)).toBeInTheDocument();
+    expect(screen.getByText(/Analog index not loaded/i)).toBeInTheDocument();
   });
 
   it("renders the threshold-empty state when no analog crosses the floor", () => {
@@ -120,7 +120,7 @@ describe("HistoricalAnalogPanel", () => {
       analogs: fixture().analogs.map((card) => ({ ...card, similarity: 0.12 })),
     });
     render(<HistoricalAnalogPanel analogs={lowSim} similarityThreshold={0.4} />);
-    expect(screen.getByText(/No analogs above threshold/i)).toBeInTheDocument();
+    expect(screen.getByText(/No close analogs found/i)).toBeInTheDocument();
     // The threshold floor is rendered in the description so the
     // user knows what bar was used.
     expect(screen.getByText(/40.0%/)).toBeInTheDocument();
@@ -211,7 +211,7 @@ describe("HistoricalAnalogPanel", () => {
     render(<HistoricalAnalogPanel analogs={fixture()} />);
     // index size is formatted with toLocaleString — accept either
     // comma-grouped or plain formatting depending on test locale.
-    const footer = screen.getByText(/encoder/i);
+    const footer = screen.getByText(/model variant/i);
     expect(within(footer).getByText(/finbert_fed_adjacent_xbank_dapt_retrieval/)).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/analyze/MarketReactionPanel.test.tsx
+++ b/frontend/tests/components/analyze/MarketReactionPanel.test.tsx
@@ -53,12 +53,12 @@ function fixture(): MarketReactionPanelResponse {
 }
 
 describe("MarketReactionPanel", () => {
-  it("renders one card per rates head plus the vol regime card", () => {
+  it("renders one card per rates head plus the Volatility Regime card", () => {
     render(<MarketReactionPanel panel={fixture()} />);
     expect(screen.getByText(/2y yield/i)).toBeInTheDocument();
     expect(screen.getByText(/5y yield/i)).toBeInTheDocument();
     expect(screen.getByText(/Terminal rate/i)).toBeInTheDocument();
-    expect(screen.getByText(/Vol regime/i)).toBeInTheDocument();
+    expect(screen.getByText(/Volatility Regime/i)).toBeInTheDocument();
   });
 
   it("shows the directional bucket badge", () => {
@@ -132,6 +132,6 @@ describe("MarketReactionPanel", () => {
         }}
       />,
     );
-    expect(screen.getByText(/Aux classifier unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/Direction model unavailable/i)).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/analyze/PolicyActionCard.test.tsx
+++ b/frontend/tests/components/analyze/PolicyActionCard.test.tsx
@@ -70,7 +70,7 @@ describe("PolicyActionCard", () => {
       balance_sheet_state: null,
     };
     render(<PolicyActionCard action={action} />);
-    expect(screen.getByText(/Balance-sheet posture unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/Balance sheet stance unavailable/i)).toBeInTheDocument();
   });
 
   it("returns null on an all-null payload (non-policy text)", () => {

--- a/frontend/tests/components/analyze/RegimeHeadline.test.tsx
+++ b/frontend/tests/components/analyze/RegimeHeadline.test.tsx
@@ -24,8 +24,8 @@ const REGIME_WITH_BAND: RegimeClassificationResponse = {
 describe("RegimeHeadline coverage chip", () => {
   it("shows the run-level coverage badge when no empirical figure is provided", () => {
     render(<RegimeHeadline regime={REGIME} symbol="^GSPC" documentDate="2024-09-18" />);
-    expect(screen.getByText(/80% coverage · set size 2/i)).toBeInTheDocument();
-    expect(screen.queryByText(/empirical/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/80% confidence level · 2 labels in set/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Actual/i)).not.toBeInTheDocument();
   });
 
   it("merges nominal + empirical into one chip when empirical coverage is available", () => {
@@ -38,7 +38,7 @@ describe("RegimeHeadline coverage chip", () => {
         empiricalCoverageSampleSize={42}
       />,
     );
-    expect(screen.getByText(/Nominal 80% · Empirical 76%/i)).toBeInTheDocument();
+    expect(screen.getByText(/Target 80% · Actual 76%/i)).toBeInTheDocument();
   });
 
   it("renders the drift badge when empirical drops more than 10pp under nominal", () => {
@@ -64,40 +64,40 @@ describe("RegimeHeadline coverage chip", () => {
         empiricalCoverageSampleSize={0}
       />,
     );
-    expect(screen.queryByText(/empirical/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/80% coverage · set size 2/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Actual/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/80% confidence level · 2 labels in set/i)).toBeInTheDocument();
   });
 });
 
 describe("RegimeHeadline regression-canonical surface (#338)", () => {
-  it("leads with the log(RV) regression band when the dual-head fields are populated", () => {
+  it("leads with the numeric volatility forecast when the dual-head fields are populated", () => {
     render(<RegimeHeadline regime={REGIME_WITH_BAND} symbol="^GSPC" documentDate="2024-09-18" />);
-    expect(screen.getByText(/log\(RV\) regression band/i)).toBeInTheDocument();
+    expect(screen.getByText(/Volatility forecast · 10 days ahead/i)).toBeInTheDocument();
     expect(screen.getByText(/-0\.250/)).toBeInTheDocument();
-    expect(screen.getByText(/band \[-0\.850, 0\.350\]/)).toBeInTheDocument();
-    expect(screen.getByText(/normal bucket/i)).toBeInTheDocument();
-    expect(screen.getByText(/bucket source · regression/i)).toBeInTheDocument();
+    expect(screen.getByText(/confidence range \[-0\.850, 0\.350\]/)).toBeInTheDocument();
+    expect(screen.getByText(/normal regime/i)).toBeInTheDocument();
+    expect(screen.getByText(/regime source · regression/i)).toBeInTheDocument();
   });
 
   it("falls back to the classifier-led surface when no log_rv_point is present", () => {
     render(<RegimeHeadline regime={REGIME} symbol="^GSPC" documentDate="2024-09-18" />);
-    expect(screen.queryByText(/log\(RV\) regression band/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/Vol-regime prediction set/i)).toBeInTheDocument();
-    expect(screen.getByText(/argmax · 45\.0%/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Volatility forecast · 10 days ahead/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Volatility Regime prediction · 10 days ahead/i)).toBeInTheDocument();
+    expect(screen.getByText(/top pick · 45\.0%/i)).toBeInTheDocument();
   });
 
   it("ships the fold-4 with/without callout on every render", () => {
     render(<RegimeHeadline regime={REGIME_WITH_BAND} symbol="^GSPC" documentDate="2024-09-18" />);
-    expect(screen.getByText(/With fold-4/i)).toBeInTheDocument();
-    expect(screen.getByText(/Without fold-4/i)).toBeInTheDocument();
+    expect(screen.getByText(/Including fold 4/i)).toBeInTheDocument();
+    expect(screen.getByText(/Excluding fold 4/i)).toBeInTheDocument();
     // Numbers from dual_head_comparison_canonical.json.
-    expect(screen.getByText(/F1 0\.419 ± 0\.070/)).toBeInTheDocument();
-    expect(screen.getByText(/F1 0\.414 ± 0\.079/)).toBeInTheDocument();
+    expect(screen.getByText(/F1 score 0\.419 ± 0\.070/)).toBeInTheDocument();
+    expect(screen.getByText(/F1 score 0\.414 ± 0\.079/)).toBeInTheDocument();
   });
 
-  it("demotes per-class softmax + predicted set to a foldable section", () => {
+  it("demotes per-class probabilities + predicted set to a foldable section", () => {
     render(<RegimeHeadline regime={REGIME_WITH_BAND} symbol="^GSPC" documentDate="2024-09-18" />);
-    const summary = screen.getByText(/Per-class softmax \+ calibrated set/i);
+    const summary = screen.getByText(/Per-class probabilities and prediction set/i);
     expect(summary.tagName.toLowerCase()).toBe("summary");
   });
 

--- a/frontend/tests/components/analyze/XaiPanel.test.tsx
+++ b/frontend/tests/components/analyze/XaiPanel.test.tsx
@@ -13,7 +13,7 @@ function renderWithTooltip(node: React.ReactNode) {
 describe("XaiPanel", () => {
   it("renders the title and one chip per sentence", () => {
     renderWithTooltip(<XaiPanel xai={SAMPLE_XAI} />);
-    expect(screen.getByText(/sentence attribution/i)).toBeInTheDocument();
+    expect(screen.getByText(/per-sentence explanation/i)).toBeInTheDocument();
     for (const sentence of SAMPLE_XAI.sentences) {
       expect(screen.getByText(sentence.text)).toBeInTheDocument();
     }
@@ -21,8 +21,8 @@ describe("XaiPanel", () => {
 
   it("renders the empty-state placeholder when there are no sentences", () => {
     renderWithTooltip(<XaiPanel xai={{ sentences: [] }} />);
-    expect(screen.getByText(/sentence attribution/i)).toBeInTheDocument();
-    expect(screen.getByText(/no salient sentences detected/i)).toBeInTheDocument();
+    expect(screen.getByText(/per-sentence explanation/i)).toBeInTheDocument();
+    expect(screen.getByText(/no high-impact sentences found/i)).toBeInTheDocument();
   });
 
   it("shows the integrated-gradients method label", () => {
@@ -51,7 +51,7 @@ describe("XaiPanel", () => {
     expect(screen.getByTestId("panel-attribution-regime")).toBeInTheDocument();
     expect(screen.getByText("Linguistic")).toBeInTheDocument();
     expect(screen.getByText("Credibility")).toBeInTheDocument();
-    expect(screen.getByText(/IG n=20/)).toBeInTheDocument();
+    expect(screen.getByText(/20 attribution steps/)).toBeInTheDocument();
   });
 
   it("renders the explanation-unavailable badge when a panel is unavailable", () => {
@@ -65,9 +65,9 @@ describe("XaiPanel", () => {
     };
     renderWithTooltip(<PanelAttributionRow panel={panel} />);
     expect(screen.getByTestId("panel-attribution-rates_2y")).toBeInTheDocument();
-    expect(screen.getByText(/explanation unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/explanation not available/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/Head not mounted on the current checkpoint\./i),
+      screen.getByText(/This prediction is not enabled on the active model\./i),
     ).toBeInTheDocument();
   });
 

--- a/frontend/tests/lib/analyze/format.test.ts
+++ b/frontend/tests/lib/analyze/format.test.ts
@@ -81,12 +81,12 @@ describe("format helpers", () => {
   });
 
   it("bandLabel marks conformal vs Gaussian-z vs unknown", () => {
-    expect(bandLabel(80, "conformal")).toBe("80% conformal band");
-    expect(bandLabel(80, "gaussian_z")).toBe("80% Gaussian-z band");
+    expect(bandLabel(80, "conformal")).toBe("80% calibrated range");
+    expect(bandLabel(80, "gaussian_z")).toBe("80% Gaussian range");
     // Null / missing source falls back to the legacy generic label so older
     // history rows (saved before the band-source field existed) still render.
-    expect(bandLabel(80, null)).toBe("80% confidence band");
-    expect(bandLabel(80, undefined)).toBe("80% confidence band");
-    expect(bandLabel(95, "conformal")).toBe("95% conformal band");
+    expect(bandLabel(80, null)).toBe("80% confidence range");
+    expect(bandLabel(80, undefined)).toBe("80% confidence range");
+    expect(bandLabel(95, "conformal")).toBe("95% calibrated range");
   });
 });

--- a/frontend/tests/pages/performance.test.tsx
+++ b/frontend/tests/pages/performance.test.tsx
@@ -146,9 +146,9 @@ describe("PerformancePage", () => {
     // repeat them). getAllByText with a count guard avoids the
     // ambiguous-match error while still asserting presence.
     await waitFor(() =>
-      expect(screen.getAllByText(/Argmax accuracy/i).length).toBeGreaterThan(0),
+      expect(screen.getAllByText(/Top-pick accuracy/i).length).toBeGreaterThan(0),
     );
-    expect(screen.getAllByText(/Empirical coverage/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Actual coverage/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Confusion matrix/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Per-class metrics/i)).toBeInTheDocument();
     expect(screen.getByText(/Per-asset breakdown/i)).toBeInTheDocument();
@@ -203,12 +203,11 @@ describe("PerformancePage", () => {
     const { default: PerformancePage } = await import("@/pages/performance");
     render(<PerformancePage />);
 
-    await waitFor(() => expect(screen.getByText(/macro roc-auc/i)).toBeInTheDocument());
-    expect(screen.getByText(/from training eval artifact/i)).toBeInTheDocument();
-    // The "training-time classification breakdown" phrase appears in
-    // both the per-class table and the confusion matrix descriptions
-    // when the artifact is loaded — assert presence, not uniqueness.
-    expect(screen.getAllByText(/training-time classification breakdown/i).length).toBeGreaterThan(0);
+    await waitFor(() => expect(screen.getByText(/overall roc-auc/i)).toBeInTheDocument());
+    expect(screen.getAllByText(/from training evaluation/i).length).toBeGreaterThan(0);
+    // The phrase appears in both the per-class table and the confusion matrix
+    // descriptions when the artifact is loaded — assert presence, not uniqueness.
+    expect(screen.getAllByText(/training-time evaluation/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/tp_fixture/)).toBeInTheDocument();
   });
 });

--- a/frontend/tests/pages/settings.test.tsx
+++ b/frontend/tests/pages/settings.test.tsx
@@ -165,6 +165,6 @@ describe("SettingsPage — inference contract badges", () => {
 
     expect(screen.queryByTestId(/contract-kwarg-/)).not.toBeInTheDocument();
     expect(screen.queryByTestId("contract-legacy-badge")).not.toBeInTheDocument();
-    expect(screen.getByText(/no required kwargs/i)).toBeInTheDocument();
+    expect(screen.getByText(/no required inputs/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Renames jargon-y labels across the analyze workspace to plain English while keeping every panel, every model internal, and every value visible. UI display only — no backend type, JSON key, or API contract changes.

## Summary
- `vol-regime` and variants become `Volatility Regime`.
- `multi-axis classifier` becomes `Sentiment breakdown`.
- `conformal sidecar`, `conformal interval`, `conformal set` become `Calibration data` / `Confidence range` / `Prediction set`.
- `softmax_quantile` / `nominal coverage` become `Calibration threshold` / `Confidence level`.
- `inference contract`, `kwargs` become `Model input check`, `required inputs`.
- `encoder_alias` becomes `Model variant` (kept as a labelled `<code>` value).
- `macro F1` becomes `Overall F1 score`; `argmax` becomes `Top pick`.
- `MAE/RMSE on log_rv` become `Average error (log volatility)` / `Root-mean-square error (log volatility)`.
- `aux classifier` becomes `Direction model`.
- LoRA expanded as `LoRA (low-rank adapter)` on the Settings card.
- Hawkish / Dovish kept verbatim; tooltip added where it first appears.
- LLM/internal voice removed from copy (no issue/ADR/PR numbers, no "by construction", "load-bearing", "honest framing", no code-blocked Python paths in panel descriptions, no raw JSON keys in prose).

Closes #201.

## Test plan
- [x] `npm run type-check` clean
- [x] `npm test` — 169 passed (38 files)
- [x] `npm run build` clean