### PR TITLE
Frontend Wave 2: per-page UX depth (#201)

### DIFF
--- a/frontend/components/analyze/ConfusionMatrix.tsx
+++ b/frontend/components/analyze/ConfusionMatrix.tsx
@@ -7,6 +7,11 @@ interface ConfusionMatrixProps {
   rows: ConfusionRow[];
   classes: readonly string[];
   className?: string;
+  // Drill-down: fires when a user clicks a class label (axis = "predicted"
+  // for column headers, "actual" for row headers) or a body cell
+  // (axis = "cell").
+  onClassClick?: (klass: string, axis: "predicted" | "actual") => void;
+  activeClass?: string | null;
 }
 
 function intensityClass(share: number): string {
@@ -17,7 +22,7 @@ function intensityClass(share: number): string {
   return "bg-muted/30 text-muted-foreground";
 }
 
-export function ConfusionMatrix({ rows, classes, className }: ConfusionMatrixProps) {
+export function ConfusionMatrix({ rows, classes, className, onClassClick, activeClass }: ConfusionMatrixProps) {
   const totalResolved = rows.reduce((sum, row) => sum + row.total, 0);
   if (totalResolved === 0) {
     return (
@@ -42,7 +47,12 @@ export function ConfusionMatrix({ rows, classes, className }: ConfusionMatrixPro
               <th
                 key={klass}
                 scope="col"
-                className="px-2 py-1 text-center text-[10px] uppercase tracking-wide capitalize text-muted-foreground"
+                className={cn(
+                  "px-2 py-1 text-center text-[10px] uppercase tracking-wide capitalize text-muted-foreground",
+                  onClassClick && "cursor-pointer hover:text-foreground",
+                  activeClass === klass && "text-foreground",
+                )}
+                onClick={onClassClick ? () => onClassClick(klass, "predicted") : undefined}
               >
                 {klass}
               </th>
@@ -60,7 +70,12 @@ export function ConfusionMatrix({ rows, classes, className }: ConfusionMatrixPro
             <tr key={row.truth}>
               <th
                 scope="row"
-                className="px-2 py-1 text-left text-xs font-medium capitalize text-muted-foreground"
+                className={cn(
+                  "px-2 py-1 text-left text-xs font-medium capitalize text-muted-foreground",
+                  onClassClick && "cursor-pointer hover:text-foreground",
+                  activeClass === row.truth && "text-foreground",
+                )}
+                onClick={onClassClick ? () => onClassClick(row.truth, "actual") : undefined}
               >
                 {row.truth}
               </th>
@@ -74,7 +89,7 @@ export function ConfusionMatrix({ rows, classes, className }: ConfusionMatrixPro
                       "numeric h-row-sm rounded-sm px-2 text-center text-xs",
                       intensityClass(share),
                     )}
-                    title={`actual ${row.truth} → predicted ${klass}: ${count} / ${row.total}`}
+                    title={`Predicted ${klass}, actually ${row.truth}: ${count} times (${(share * 100).toFixed(1)}% of ${row.truth} class)`}
                   >
                     {count}
                   </td>

--- a/frontend/components/analyze/HistoryTimelineChart.tsx
+++ b/frontend/components/analyze/HistoryTimelineChart.tsx
@@ -1,0 +1,242 @@
+import * as React from "react";
+import {
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ResponsiveContainer,
+  Scatter,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { toStance } from "@/lib/analyze/format";
+import type { HistoryEntry } from "@/lib/analyze/types";
+
+export interface HistoryTimelineRow extends HistoryEntry {
+  realized_regime?: string | null;
+  forward_realized_vol_10d?: number | null;
+}
+
+interface HistoryTimelineChartProps {
+  rows: HistoryTimelineRow[];
+}
+
+interface ChartDatum {
+  date: string;
+  ts: number;
+  stance: number;
+  regime: string | null;
+  vol: number | null;
+  symbol: string;
+  id: string;
+}
+
+const REGIME_COLOR: Record<string, string> = {
+  calm: "hsl(var(--up))",
+  normal: "hsl(var(--neutral))",
+  high: "hsl(var(--down))",
+};
+
+const TOOLTIP_STYLE: React.CSSProperties = {
+  background: "hsl(var(--popover))",
+  color: "hsl(var(--popover-foreground))",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: 6,
+  padding: "6px 8px",
+  fontSize: 12,
+};
+
+function stanceToScore(label: string): number {
+  const stance = toStance(label);
+  if (stance === "hawkish") return 1;
+  if (stance === "dovish") return -1;
+  return 0;
+}
+
+function readForwardVol(row: HistoryTimelineRow): number | null {
+  const direct = row.forward_realized_vol_10d;
+  if (typeof direct === "number" && Number.isFinite(direct)) return direct;
+  return null;
+}
+
+export function HistoryTimelineChart({ rows }: HistoryTimelineChartProps) {
+  const data = React.useMemo<ChartDatum[]>(() => {
+    return rows
+      .map((row) => {
+        const ts = new Date(row.document_date).getTime();
+        if (!Number.isFinite(ts)) return null;
+        const stance = typeof row.sentiment_score === "number"
+          ? Math.max(-1, Math.min(1, row.sentiment_score))
+          : stanceToScore(row.stance);
+        return {
+          date: row.document_date,
+          ts,
+          stance,
+          regime: row.argmax_regime ?? null,
+          vol: readForwardVol(row),
+          symbol: row.symbol,
+          id: row.id,
+        } satisfies ChartDatum;
+      })
+      .filter((value): value is ChartDatum => value != null)
+      .sort((a, b) => a.ts - b.ts);
+  }, [rows]);
+
+  const hasVol = data.some((d) => d.vol != null);
+
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Stance over time</CardTitle>
+          <CardDescription>
+            Stance score per run, coloured by regime. Forward realised vol overlay on the
+            right axis when available.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <EmptyState
+            variant="inline"
+            title="No history yet"
+            description="Use the Workspace to analyze a statement."
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Stance over time</CardTitle>
+        <CardDescription>
+          Stance score per run, coloured by regime. {hasVol ? "Forward 10-day realised vol on the right axis." : "No forward vol data on these rows."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="h-72 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart
+              data={data}
+              margin={{ top: 8, right: 16, bottom: 8, left: 0 }}
+            >
+              <CartesianGrid stroke="hsl(var(--border))" strokeDasharray="2 3" />
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+                stroke="hsl(var(--border))"
+              />
+              <YAxis
+                yAxisId="stance"
+                domain={[-1, 1]}
+                tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+                stroke="hsl(var(--border))"
+                label={{
+                  value: "stance",
+                  angle: -90,
+                  position: "insideLeft",
+                  style: { fontSize: 10, fill: "hsl(var(--muted-foreground))" },
+                }}
+              />
+              {hasVol ? (
+                <YAxis
+                  yAxisId="vol"
+                  orientation="right"
+                  tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+                  stroke="hsl(var(--border))"
+                  label={{
+                    value: "forward vol",
+                    angle: 90,
+                    position: "insideRight",
+                    style: { fontSize: 10, fill: "hsl(var(--muted-foreground))" },
+                  }}
+                />
+              ) : null}
+              <Tooltip
+                contentStyle={TOOLTIP_STYLE}
+                cursor={{ strokeDasharray: "2 3" }}
+                formatter={(value, name, ctx) => {
+                  const d = ctx?.payload as ChartDatum | undefined;
+                  if (!d) return [String(value), String(name)];
+                  if (name === "vol") {
+                    return [
+                      d.vol != null ? d.vol.toFixed(4) : "—",
+                      "forward vol",
+                    ];
+                  }
+                  return [
+                    `${d.stance.toFixed(2)} · ${d.regime ?? "—"} · ${d.symbol}`,
+                    "stance",
+                  ];
+                }}
+                labelFormatter={(label) => String(label)}
+              />
+              <Line
+                yAxisId="stance"
+                type="monotone"
+                dataKey="stance"
+                stroke="hsl(var(--muted-foreground))"
+                strokeWidth={1}
+                dot={false}
+                isAnimationActive={false}
+              />
+              <Scatter
+                yAxisId="stance"
+                dataKey="stance"
+                isAnimationActive={false}
+                shape={(props: unknown) => {
+                  const p = props as { cx?: number; cy?: number; payload?: ChartDatum };
+                  if (p.cx == null || p.cy == null || !p.payload) return <></>;
+                  const fill = REGIME_COLOR[p.payload.regime ?? ""] ?? "hsl(var(--muted-foreground))";
+                  return <circle cx={p.cx} cy={p.cy} r={4} fill={fill} />;
+                }}
+              />
+              {hasVol ? (
+                <Line
+                  yAxisId="vol"
+                  type="monotone"
+                  dataKey="vol"
+                  stroke="hsl(var(--primary))"
+                  strokeWidth={1}
+                  strokeDasharray="3 3"
+                  dot={false}
+                  connectNulls
+                  isAnimationActive={false}
+                />
+              ) : null}
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+        <div className="mt-2 flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 rounded-full" style={{ background: REGIME_COLOR.calm }} />
+            calm
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 rounded-full" style={{ background: REGIME_COLOR.normal }} />
+            normal
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 rounded-full" style={{ background: REGIME_COLOR.high }} />
+            high
+          </span>
+          {hasVol ? (
+            <span className="flex items-center gap-1">
+              <span className="inline-block h-0.5 w-4" style={{ background: "hsl(var(--primary))" }} />
+              forward vol (right)
+            </span>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9331,6 +9331,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9331,7 +9331,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [

--- a/frontend/pages/calendar.tsx
+++ b/frontend/pages/calendar.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { Calendar as CalendarIcon } from "lucide-react";
+import { Calendar as CalendarIcon, Clock } from "lucide-react";
 import { toast } from "sonner";
 
 import { Header } from "@/components/shell/header";
@@ -16,37 +16,179 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { fetchFomcCalendar, resolveApiBaseUrl } from "@/lib/analyze/api";
-import type { FomcCalendarResponse, FomcMeeting } from "@/lib/analyze/types";
+import {
+  fetchFomcCalendar,
+  fetchNextFomcForecast,
+  resolveApiBaseUrl,
+} from "@/lib/analyze/api";
+import type {
+  FomcCalendarResponse,
+  FomcMeeting,
+  NextFomcForecastResponse,
+} from "@/lib/analyze/types";
 
-function MeetingRow({ meeting, onAnalyze }: { meeting: FomcMeeting; onAnalyze: (date: string) => void }) {
+const ORDINAL_LABELS: Record<string, string> = {
+  cut_50: "Cut 50",
+  cut_25: "Cut 25",
+  hold: "Hold",
+  hike_25: "Hike 25",
+  hike_50: "Hike 50",
+  hike_75: "Hike 75",
+};
+
+function ordinalSuffix(n: number): string {
+  const v = n % 100;
+  if (v >= 11 && v <= 13) return `${n}th`;
+  const last = n % 10;
+  if (last === 1) return `${n}st`;
+  if (last === 2) return `${n}nd`;
+  if (last === 3) return `${n}rd`;
+  return `${n}th`;
+}
+
+function formatCountdown(targetIso: string, nowMs: number): string {
+  const target = new Date(`${targetIso}T00:00:00`).getTime();
+  if (!Number.isFinite(target)) return "—";
+  const diffMs = target - nowMs;
+  if (diffMs <= 0) return "today";
+  const totalMinutes = Math.floor(diffMs / 60000);
+  const days = Math.floor(totalMinutes / (60 * 24));
+  const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+  if (days >= 1) {
+    return `${days} day${days === 1 ? "" : "s"}, ${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  if (hours >= 1) {
+    return `${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  return "less than 1 hour";
+}
+
+function CountdownCard({ targetDate }: { targetDate: string }) {
+  const [now, setNow] = React.useState(() => Date.now());
+  React.useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
   return (
-    <li className="flex flex-wrap items-center justify-between gap-3 border-b border-border py-3 last:border-0">
-      <div className="space-y-0.5">
-        <p className="font-mono text-sm">{meeting.meeting_date}</p>
-        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-          {meeting.statement_release_date ? (
-            <span>Statement {meeting.statement_release_date}</span>
-          ) : null}
-          {meeting.minutes_release_date ? (
-            <span>Minutes {meeting.minutes_release_date}</span>
-          ) : null}
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Clock className="h-4 w-4 text-primary" />
+          FOMC meeting in {formatCountdown(targetDate, now)}
+        </CardTitle>
+        <CardDescription>
+          Next scheduled meeting: <span className="font-mono">{targetDate}</span>
+        </CardDescription>
+      </CardHeader>
+    </Card>
+  );
+}
+
+interface MeetingRowProps {
+  meeting: FomcMeeting;
+  onAnalyze: (date: string) => void;
+  predictedAction?: string | null;
+  contextLabel?: string | null;
+}
+
+function MeetingRow({ meeting, onAnalyze, predictedAction, contextLabel }: MeetingRowProps) {
+  const targetDate = meeting.statement_release_date ?? meeting.meeting_date;
+  return (
+    <li className="border-b border-border last:border-0">
+      <button
+        type="button"
+        onClick={() => onAnalyze(targetDate)}
+        className="flex w-full flex-wrap items-center justify-between gap-3 py-3 text-left hover:bg-accent/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm px-2"
+      >
+        <div className="space-y-0.5">
+          <p className="font-mono text-sm">{meeting.meeting_date}</p>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            {meeting.statement_release_date ? (
+              <span>Statement {meeting.statement_release_date}</span>
+            ) : null}
+            {meeting.minutes_release_date ? (
+              <span>Minutes {meeting.minutes_release_date}</span>
+            ) : null}
+            {contextLabel ? <span>· {contextLabel}</span> : null}
+          </div>
         </div>
-      </div>
-      <div className="flex items-center gap-2">
-        <Badge variant="outline" className="capitalize">{meeting.meeting_type}</Badge>
-        <Button size="sm" variant="outline" onClick={() => onAnalyze(meeting.statement_release_date ?? meeting.meeting_date)}>
-          Analyze
-        </Button>
-      </div>
+        <div className="flex items-center gap-2">
+          {predictedAction ? (
+            <Badge variant="outline" className="text-[10px]">
+              forecast · {predictedAction}
+            </Badge>
+          ) : null}
+          <Badge variant="outline" className="capitalize">
+            {meeting.meeting_type}
+          </Badge>
+          <span className="text-xs text-muted-foreground">Analyze →</span>
+        </div>
+      </button>
     </li>
   );
+}
+
+// Compute historical context labels for the past meetings list (newest-first).
+// Iterates oldest → newest accumulating streaks, then maps back so each
+// row gets the label that describes "as of that meeting".
+interface CalendarHistoricalContext {
+  labels: Record<string, string>;
+}
+
+function computeHistoricalContext(past: FomcMeeting[], forecastHistory: NextFomcForecastResponse["history"]): CalendarHistoricalContext {
+  const labels: Record<string, string> = {};
+  if (!forecastHistory || forecastHistory.length === 0) return { labels };
+  // Build date → realised action lookup from forecast history.
+  const byDate = new Map<string, string | null>();
+  for (const entry of forecastHistory) {
+    if (entry.target_event_date) {
+      byDate.set(entry.target_event_date, entry.target_class ?? null);
+    }
+  }
+  // Walk past meetings oldest-first.
+  const ordered = [...past].sort((a, b) =>
+    a.meeting_date.localeCompare(b.meeting_date),
+  );
+  let prevAction: string | null = null;
+  let streak = 0;
+  let sinceLastCut = 0;
+  for (const meeting of ordered) {
+    const action = byDate.get(meeting.meeting_date) ?? null;
+    if (!action) {
+      streak = 0;
+      sinceLastCut += 1;
+      continue;
+    }
+    if (action === prevAction) {
+      streak += 1;
+    } else {
+      streak = 1;
+    }
+    if (action.startsWith("cut")) {
+      sinceLastCut = 0;
+    } else {
+      sinceLastCut += 1;
+    }
+    if (streak >= 2) {
+      const word = action.startsWith("hike")
+        ? "hike"
+        : action.startsWith("cut")
+        ? "cut"
+        : "hold";
+      labels[meeting.meeting_date] = `${ordinalSuffix(streak)} consecutive ${word}`;
+    } else if (action.startsWith("hike") && sinceLastCut > 0) {
+      labels[meeting.meeting_date] = `${sinceLastCut} meeting${sinceLastCut === 1 ? "" : "s"} since last cut`;
+    }
+    prevAction = action;
+  }
+  return { labels };
 }
 
 export default function CalendarPage() {
   const router = useRouter();
   const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
   const [data, setData] = React.useState<FomcCalendarResponse | null>(null);
+  const [decisions, setDecisions] = React.useState<NextFomcForecastResponse | null>(null);
   const [loading, setLoading] = React.useState(true);
 
   React.useEffect(() => {
@@ -61,21 +203,50 @@ export default function CalendarPage() {
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
+    // Best-effort decisions read — surfaces predicted action badges on
+    // upcoming meetings. Silent failure when the artifact is absent.
+    fetchNextFomcForecast(apiBaseUrl)
+      .then((result) => {
+        if (!cancelled) setDecisions(result);
+      })
+      .catch(() => {
+        // Silent.
+      });
     return () => {
       cancelled = true;
     };
   }, [apiBaseUrl]);
 
   const goAnalyze = (meetingDate: string) => {
-    // ?kind=statement asks the analyze page to fetch the matching FOMC
-    // statement text from /documents/by-date and prefill the textarea.
-    // Without it, only the date prefills and the user has to paste the
-    // text themselves.
     router.push({
       pathname: "/",
       query: { date: meetingDate, kind: "statement" },
     });
   };
+
+  const nextMeeting = data?.upcoming?.[0] ?? null;
+  const nextDate = nextMeeting?.statement_release_date ?? nextMeeting?.meeting_date ?? null;
+
+  // Build a forecast lookup for upcoming meetings. The decisions endpoint
+  // exposes one "headline" prediction for the next meeting; older
+  // history entries cover past meetings.
+  const upcomingForecastByDate = React.useMemo(() => {
+    const map: Record<string, string> = {};
+    if (!decisions?.headline) return map;
+    const primaryModel = decisions.model_names?.[0];
+    const predicted = primaryModel
+      ? decisions.headline.predicted_class[primaryModel] ?? null
+      : null;
+    if (predicted && decisions.headline.target_event_date) {
+      map[decisions.headline.target_event_date] = ORDINAL_LABELS[predicted] ?? predicted;
+    }
+    return map;
+  }, [decisions]);
+
+  const historicalContext = React.useMemo(
+    () => computeHistoricalContext(data?.past ?? [], decisions?.history ?? []),
+    [data, decisions],
+  );
 
   return (
     <>
@@ -93,8 +264,11 @@ export default function CalendarPage() {
             </h1>
             <p className="max-w-2xl text-muted-foreground">
               Scheduled FOMC meetings sourced from the Federal Reserve's published calendar.
+              Click a past meeting to load its statement on the Workspace.
             </p>
           </div>
+
+          {nextDate ? <CountdownCard targetDate={nextDate} /> : null}
 
           {loading ? (
             <div className="space-y-2">
@@ -119,6 +293,7 @@ export default function CalendarPage() {
                           key={`up-${meeting.meeting_date}`}
                           meeting={meeting}
                           onAnalyze={goAnalyze}
+                          predictedAction={upcomingForecastByDate[meeting.meeting_date] ?? null}
                         />
                       ))}
                     </ul>
@@ -140,6 +315,7 @@ export default function CalendarPage() {
                           key={`past-${meeting.meeting_date}`}
                           meeting={meeting}
                           onAnalyze={goAnalyze}
+                          contextLabel={historicalContext.labels[meeting.meeting_date] ?? null}
                         />
                       ))}
                     </ul>

--- a/frontend/pages/compare.tsx
+++ b/frontend/pages/compare.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { ArrowDownRight, ArrowRight, ArrowUpRight, GitCompare } from "lucide-react";
+import { ArrowDownRight, ArrowRight, ArrowUpRight, GitCompare, Share2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { MultiAxisCards } from "@/components/analyze/MultiAxisCards";
@@ -43,6 +43,67 @@ function formatDelta(value: number | null, fractionDigits = 2): string {
 function deltaColorClass(value: number | null): string {
   if (value == null || value === 0) return "text-muted-foreground";
   return value > 0 ? "text-hawkish" : "text-dovish";
+}
+
+// Annotated delta for a sentiment axis. Positive = more hawkish (red),
+// negative = more dovish (green). The bracketed label is the
+// directional readout the user picked.
+function annotatedAxisDelta(value: number | null, axis: string): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  const sign = value > 0 ? "+" : "";
+  const direction =
+    value > 0 ? `${axis} hawkish` : value < 0 ? `${axis} dovish` : axis;
+  return `${sign}${value.toFixed(2)} (${direction})`;
+}
+
+// One-sentence narrative covering the largest absolute Δ on each
+// available axis. Hides quietly when no axis carries a signal.
+function buildNarrativeSummary(delta: MultiAxisDelta): string | null {
+  type Bullet = { axis: string; magnitude: number; phrase: string };
+  const candidates: Bullet[] = [];
+  if (delta.stanceRankDelta != null) {
+    candidates.push({
+      axis: "stance",
+      magnitude: Math.abs(delta.stanceRankDelta),
+      phrase:
+        delta.stanceRankDelta > 0
+          ? `Run A is more hawkish on rate guidance (+${delta.stanceRankDelta.toFixed(2)})`
+          : delta.stanceRankDelta < 0
+          ? `Run A is more dovish on rate guidance (${delta.stanceRankDelta.toFixed(2)})`
+          : "Stance unchanged",
+    });
+  }
+  if (delta.factorDelta != null) {
+    candidates.push({
+      axis: "factor",
+      magnitude: Math.abs(delta.factorDelta),
+      phrase:
+        delta.factorDelta > 0
+          ? `more hawkish on inflation tone (+${delta.factorDelta.toFixed(2)})`
+          : delta.factorDelta < 0
+          ? `more dovish on inflation tone (${delta.factorDelta.toFixed(2)})`
+          : "inflation tone unchanged",
+    });
+  }
+  if (candidates.length === 0) return null;
+  // Sort by absolute magnitude, take up to two for the narrative.
+  candidates.sort((a, b) => b.magnitude - a.magnitude);
+  const primary = candidates[0];
+  if (candidates.length === 1) return `${primary.phrase}.`;
+  const secondary = candidates[1];
+  return `${primary.phrase} but ${secondary.phrase}.`;
+}
+
+function NarrativeSummaryCard({ delta }: { delta: MultiAxisDelta }) {
+  const sentence = buildNarrativeSummary(delta);
+  if (!sentence) return null;
+  return (
+    <Card>
+      <CardContent className="py-3">
+        <p className="text-sm">{sentence}</p>
+      </CardContent>
+    </Card>
+  );
 }
 
 function DeltaIcon({ value }: { value: number | null }) {
@@ -174,7 +235,9 @@ function MultiAxisDeltaCard({ delta }: { delta: MultiAxisDelta }) {
           <tbody>
             <tr className="border-b border-border">
               <td className="px-4 py-2 font-mono">stance</td>
-              <td className="px-4 py-2 text-right font-mono">{stanceDir}</td>
+              <td className={`px-4 py-2 text-right font-mono ${deltaColorClass(delta.stanceRankDelta)}`}>
+                {delta.stanceRankDelta != null ? annotatedAxisDelta(delta.stanceRankDelta, "stance") : stanceDir}
+              </td>
               <td className="px-4 py-2 text-right font-mono">
                 {delta.stanceConfidenceDelta != null
                   ? `${delta.stanceConfidenceDelta >= 0 ? "+" : ""}${delta.stanceConfidenceDelta.toFixed(2)}`
@@ -183,10 +246,8 @@ function MultiAxisDeltaCard({ delta }: { delta: MultiAxisDelta }) {
             </tr>
             <tr className="border-b border-border">
               <td className="px-4 py-2 font-mono">factor</td>
-              <td className="px-4 py-2 text-right font-mono">
-                {delta.factorDelta != null
-                  ? `${delta.factorDelta >= 0 ? "+" : ""}${delta.factorDelta.toFixed(2)}`
-                  : "—"}
+              <td className={`px-4 py-2 text-right font-mono ${deltaColorClass(delta.factorDelta)}`}>
+                {annotatedAxisDelta(delta.factorDelta, "factor")}
               </td>
               <td className="px-4 py-2 text-right font-mono">
                 {delta.factorConfidenceDelta != null
@@ -485,12 +546,33 @@ export default function ComparePage() {
         <Header />
         <StatusBar />
         <main id="main-content" tabIndex={-1} className="container space-y-6 py-8 focus:outline-none">
-          <div className="space-y-2">
-            <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Compare runs</h1>
-            <p className="max-w-2xl text-muted-foreground">
-              Pick two past analyses and see the stance, prediction, and confidence deltas side by
-              side. Selections are sticky in the URL — share the link to send a paired view.
-            </p>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-2">
+              <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Compare runs</h1>
+              <p className="max-w-2xl text-muted-foreground">
+                Pick two past analyses and see the stance, prediction, and confidence deltas side by
+                side. Selections are sticky in the URL — share the link to send a paired view.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                if (typeof window === "undefined") return;
+                const url = window.location.href;
+                const writer = navigator?.clipboard?.writeText;
+                if (writer) {
+                  writer.call(navigator.clipboard, url)
+                    .then(() => toast.success("Share link copied"))
+                    .catch(() => toast.error("Could not copy link"));
+                } else {
+                  toast.info(url);
+                }
+              }}
+            >
+              <Share2 className="h-3.5 w-3.5" aria-hidden="true" />
+              Copy share link
+            </Button>
           </div>
 
           {entriesLoading ? (
@@ -525,6 +607,7 @@ export default function ComparePage() {
             </div>
           )}
 
+          {multiAxisDelta ? <NarrativeSummaryCard delta={multiAxisDelta} /> : null}
           {delta ? <DeltaSummary delta={delta} /> : null}
           {multiAxisDelta ? <MultiAxisDeltaCard delta={multiAxisDelta} /> : null}
           {detailA && detailB ? (

--- a/frontend/pages/history/index.tsx
+++ b/frontend/pages/history/index.tsx
@@ -1,9 +1,11 @@
 import * as React from "react";
 import Head from "next/head";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { ChevronRight, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
+import { HistoryTimelineChart, type HistoryTimelineRow } from "@/components/analyze/HistoryTimelineChart";
 import { Header } from "@/components/shell/header";
 import { StatusBar } from "@/components/shell/status-bar";
 import { Badge } from "@/components/ui/badge";
@@ -19,13 +21,6 @@ import { DataTable, type DataTableColumn } from "@/components/ui/data-table";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   deleteHistoryRun,
@@ -34,23 +29,13 @@ import {
   resolveApiBaseUrl,
 } from "@/lib/analyze/api";
 import { stanceLabel, toStance } from "@/lib/analyze/format";
-import type { HistoryEntry, HistoryQuery } from "@/lib/analyze/types";
+import { useSymbols } from "@/lib/analyze/useSymbols";
+import type { HistoryEntry, Stance } from "@/lib/analyze/types";
 
-const STANCE_OPTIONS = [
-  { value: "any", label: "Any stance" },
-  { value: "hawkish", label: "Hawkish" },
-  { value: "neutral", label: "Neutral" },
-  { value: "dovish", label: "Dovish" },
-];
+const STANCE_VALUES: Stance[] = ["hawkish", "neutral", "dovish"];
+const REGIME_VALUES = ["calm", "normal", "high"] as const;
 
-const REGIME_OPTIONS = [
-  { value: "any", label: "Any regime" },
-  { value: "calm", label: "Calm" },
-  { value: "normal", label: "Normal" },
-  { value: "high", label: "High" },
-];
-
-const HORIZON_OPTIONS = ["any", "1d", "3d", "5d", "10d"];
+type RegimeValue = (typeof REGIME_VALUES)[number];
 
 function regimeVariant(label: string | null | undefined): "hawkish" | "dovish" | "neutral" | "outline" {
   if (label === "calm") return "dovish";
@@ -63,23 +48,148 @@ interface RowWithRealized extends HistoryEntry {
   realized_regime?: string | null;
 }
 
+interface Filters {
+  stances: Set<Stance>;
+  regimes: Set<RegimeValue>;
+  symbols: Set<string>;
+  variants: Set<string>;
+  dateStart: string;
+  dateEnd: string;
+}
+
+function parseSet<T extends string>(value: string | string[] | undefined, allowed: readonly T[]): Set<T> {
+  if (!value) return new Set<T>();
+  const list = Array.isArray(value) ? value : value.split(",");
+  const set = new Set<T>();
+  for (const item of list) {
+    const trimmed = String(item).trim();
+    if (allowed.includes(trimmed as T)) set.add(trimmed as T);
+  }
+  return set;
+}
+
+function parseFreeSet(value: string | string[] | undefined): Set<string> {
+  if (!value) return new Set<string>();
+  const list = Array.isArray(value) ? value : value.split(",");
+  return new Set(list.map((v) => String(v).trim()).filter((v) => v.length > 0));
+}
+
+function parseDate(value: string | string[] | undefined): string {
+  if (!value) return "";
+  if (Array.isArray(value)) return value[0] ?? "";
+  return value;
+}
+
+function readFilters(query: Record<string, string | string[] | undefined>): Filters {
+  return {
+    stances: parseSet(query.stance, STANCE_VALUES),
+    regimes: parseSet(query.regime, REGIME_VALUES),
+    symbols: parseFreeSet(query.symbol),
+    variants: parseFreeSet(query.variant),
+    dateStart: parseDate(query.start),
+    dateEnd: parseDate(query.end),
+  };
+}
+
+function serialiseFilters(filters: Filters, search: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (filters.stances.size > 0) out.stance = [...filters.stances].join(",");
+  if (filters.regimes.size > 0) out.regime = [...filters.regimes].join(",");
+  if (filters.symbols.size > 0) out.symbol = [...filters.symbols].join(",");
+  if (filters.variants.size > 0) out.variant = [...filters.variants].join(",");
+  if (filters.dateStart) out.start = filters.dateStart;
+  if (filters.dateEnd) out.end = filters.dateEnd;
+  if (search) out.q = search;
+  return out;
+}
+
+function emptyFilters(): Filters {
+  return {
+    stances: new Set(),
+    regimes: new Set(),
+    symbols: new Set(),
+    variants: new Set(),
+    dateStart: "",
+    dateEnd: "",
+  };
+}
+
+function MultiToggle<T extends string>({
+  label,
+  options,
+  selected,
+  onToggle,
+  variant,
+}: {
+  label: string;
+  options: readonly { value: T; label: string }[];
+  selected: Set<T>;
+  onToggle: (value: T) => void;
+  variant?: (value: T) => "hawkish" | "dovish" | "neutral" | "outline";
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs uppercase tracking-wide text-muted-foreground">{label}</Label>
+      <div className="flex flex-wrap gap-1.5">
+        {options.map((opt) => {
+          const active = selected.has(opt.value);
+          const tone = variant ? variant(opt.value) : "outline";
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => onToggle(opt.value)}
+              className="focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-full"
+            >
+              <Badge
+                variant={active ? tone : "outline"}
+                className={`cursor-pointer text-[10px] ${active ? "" : "opacity-60"}`}
+              >
+                {opt.label}
+              </Badge>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export default function HistoryPage() {
   const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+  const router = useRouter();
+  const { symbols: symbolUniverse } = useSymbols();
   const [items, setItems] = React.useState<RowWithRealized[]>([]);
   const [total, setTotal] = React.useState(0);
   const [loading, setLoading] = React.useState(false);
-  const [filters, setFilters] = React.useState<HistoryQuery>({ limit: 50, offset: 0 });
-  const [regimeFilter, setRegimeFilter] = React.useState<string>("any");
 
-  // Bump this version to force a refetch (e.g. after a delete) without
-  // rebuilding the filters object. The effect owns the AbortController
-  // so cleanup actually runs when React tears it down — an async
-  // useCallback cannot hand the cleanup back to React.
-  const [reloadVersion, setReloadVersion] = React.useState(0);
+  const [filters, setFilters] = React.useState<Filters>(emptyFilters);
   const [search, setSearch] = React.useState("");
+  const [reloadVersion, setReloadVersion] = React.useState(0);
   const reload = React.useCallback(() => {
     setReloadVersion((value) => value + 1);
   }, []);
+
+  // Hydrate filters from URL once router is ready. Only runs on mount /
+  // first ready; subsequent edits flow through pushUrl() and don't
+  // re-hydrate (avoiding the round-trip loop).
+  const hydratedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!router.isReady || hydratedRef.current) return;
+    hydratedRef.current = true;
+    setFilters(readFilters(router.query as Record<string, string | string[] | undefined>));
+    const q = router.query.q;
+    setSearch(typeof q === "string" ? q : "");
+  }, [router.isReady, router.query]);
+
+  // Mirror filter state to URL.
+  const pushUrl = React.useCallback(
+    (nextFilters: Filters, nextSearch: string) => {
+      const params = serialiseFilters(nextFilters, nextSearch);
+      router.replace({ pathname: "/history", query: params }, undefined, { shallow: true });
+    },
+    [router],
+  );
 
   React.useEffect(() => {
     const controller = new AbortController();
@@ -87,15 +197,10 @@ export default function HistoryPage() {
     setLoading(true);
     (async () => {
       try {
-        const result = await fetchHistory(apiBaseUrl, filters, signal);
+        const result = await fetchHistory(apiBaseUrl, { limit: 200, offset: 0 }, signal);
         if (signal.aborted) return;
         setItems(result.items.map((row) => ({ ...row, realized_regime: null })));
         setTotal(result.total);
-        // One batched round trip replaces the N per-row fetches the page
-        // used to fan out. Backend caps the batch at 50 ids; the page
-        // limit defaults to 50 so the call fits in one request. Failures
-        // are best-effort — aborted requests and yfinance hiccups leave
-        // the realized column on "pending" rather than nuking the table.
         const ids = result.items.map((row) => row.id);
         try {
           const batch = await fetchHistoryRealizedBatch(apiBaseUrl, ids, signal);
@@ -108,7 +213,7 @@ export default function HistoryPage() {
             }),
           );
         } catch {
-          // Best-effort: realized column stays "pending" on batch failure.
+          // Best-effort.
         }
       } catch (err) {
         if (!signal.aborted) {
@@ -121,7 +226,7 @@ export default function HistoryPage() {
     return () => {
       controller.abort();
     };
-  }, [apiBaseUrl, filters, reloadVersion]);
+  }, [apiBaseUrl, reloadVersion]);
 
   const handleDelete = React.useCallback(
     async (id: string) => {
@@ -136,28 +241,83 @@ export default function HistoryPage() {
     [apiBaseUrl, reload],
   );
 
-  const patchFilter = (delta: Partial<HistoryQuery>) =>
-    setFilters((value) => ({ ...value, offset: 0, ...delta }));
+  // Collect the available variant / symbol options from the loaded rows.
+  // Symbols also include the static universe so filters work pre-load.
+  const symbolOptions = React.useMemo(() => {
+    const set = new Set<string>(symbolUniverse.map((s) => s.symbol));
+    for (const row of items) set.add(row.symbol);
+    return [...set].sort();
+  }, [items, symbolUniverse]);
+
+  const variantOptions = React.useMemo(() => {
+    const set = new Set<string>();
+    for (const row of items) {
+      if (row.forecast_mode) set.add(row.forecast_mode);
+    }
+    return [...set].sort();
+  }, [items]);
 
   const visibleRows = React.useMemo(() => {
-    const regimeFiltered =
-      regimeFilter === "any" ? items : items.filter((row) => row.argmax_regime === regimeFilter);
     const needle = search.trim().toLowerCase();
-    if (!needle) return regimeFiltered;
-    return regimeFiltered.filter((row) => {
-      const haystack = [
-        row.id,
-        row.document_date,
-        row.stance,
-        row.symbol,
-        row.horizon,
-        row.argmax_regime ?? "",
-      ]
-        .join(" ")
-        .toLowerCase();
-      return haystack.includes(needle);
+    return items.filter((row) => {
+      if (filters.stances.size > 0 && !filters.stances.has(toStance(row.stance))) return false;
+      if (filters.regimes.size > 0) {
+        if (!row.argmax_regime || !filters.regimes.has(row.argmax_regime as RegimeValue)) return false;
+      }
+      if (filters.symbols.size > 0 && !filters.symbols.has(row.symbol)) return false;
+      if (filters.variants.size > 0 && !filters.variants.has(row.forecast_mode)) return false;
+      if (filters.dateStart && row.document_date < filters.dateStart) return false;
+      if (filters.dateEnd && row.document_date > filters.dateEnd) return false;
+      if (needle) {
+        const haystack = [
+          row.id,
+          row.document_date,
+          row.stance,
+          row.symbol,
+          row.horizon,
+          row.argmax_regime ?? "",
+        ]
+          .join(" ")
+          .toLowerCase();
+        if (!haystack.includes(needle)) return false;
+      }
+      return true;
     });
-  }, [items, regimeFilter, search]);
+  }, [items, filters, search]);
+
+  const patchFilters = React.useCallback(
+    (delta: Partial<Filters>) => {
+      setFilters((prev) => {
+        const next = { ...prev, ...delta } as Filters;
+        pushUrl(next, search);
+        return next;
+      });
+    },
+    [pushUrl, search],
+  );
+
+  const toggleInSet = <T extends string>(set: Set<T>, value: T): Set<T> => {
+    const next = new Set(set);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    return next;
+  };
+
+  const handleResetFilters = () => {
+    const next = emptyFilters();
+    setFilters(next);
+    setSearch("");
+    pushUrl(next, "");
+  };
+
+  const filtersActive =
+    filters.stances.size > 0 ||
+    filters.regimes.size > 0 ||
+    filters.symbols.size > 0 ||
+    filters.variants.size > 0 ||
+    !!filters.dateStart ||
+    !!filters.dateEnd ||
+    !!search;
 
   const columns = React.useMemo<DataTableColumn<RowWithRealized>[]>(
     () => [
@@ -311,133 +471,182 @@ export default function HistoryPage() {
             </p>
           </div>
 
-          <div className="space-y-1">
-            <Label htmlFor="history-search">Search</Label>
-            <Input
-              id="history-search"
-              type="search"
-              placeholder="Filter by run id, date, stance, or symbol…"
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-            />
-          </div>
+          <HistoryTimelineChart rows={visibleRows as HistoryTimelineRow[]} />
 
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base">Filters</CardTitle>
-              <CardDescription>
-                {total} total run{total === 1 ? "" : "s"}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="grid gap-3 md:grid-cols-5">
-                <div className="space-y-1">
-                  <Label htmlFor="filter-symbol">Symbol</Label>
+          <div className="grid gap-4 lg:grid-cols-[260px_minmax(0,1fr)]">
+            <aside className="space-y-4 rounded-md border border-border p-4">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-medium">Filters</p>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleResetFilters}
+                  disabled={!filtersActive}
+                  className="h-7 text-[11px]"
+                >
+                  Reset
+                </Button>
+              </div>
+
+              <MultiToggle
+                label="Stance"
+                options={[
+                  { value: "hawkish" as Stance, label: "Hawkish" },
+                  { value: "neutral" as Stance, label: "Neutral" },
+                  { value: "dovish" as Stance, label: "Dovish" },
+                ]}
+                selected={filters.stances}
+                onToggle={(value) => patchFilters({ stances: toggleInSet(filters.stances, value) })}
+                variant={(value) =>
+                  value === "hawkish" ? "hawkish" : value === "dovish" ? "dovish" : "neutral"
+                }
+              />
+
+              <MultiToggle
+                label="Regime"
+                options={[
+                  { value: "calm" as RegimeValue, label: "Calm" },
+                  { value: "normal" as RegimeValue, label: "Normal" },
+                  { value: "high" as RegimeValue, label: "High" },
+                ]}
+                selected={filters.regimes}
+                onToggle={(value) => patchFilters({ regimes: toggleInSet(filters.regimes, value) })}
+                variant={(value) =>
+                  value === "high" ? "hawkish" : value === "calm" ? "dovish" : "neutral"
+                }
+              />
+
+              <div className="space-y-1.5">
+                <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+                  Date range
+                </Label>
+                <div className="grid grid-cols-2 gap-1.5">
                   <Input
-                    id="filter-symbol"
-                    placeholder="e.g. ^GSPC"
-                    value={filters.symbol ?? ""}
-                    onChange={(event) => patchFilter({ symbol: event.target.value || undefined })}
-                  />
-                </div>
-                <div className="space-y-1">
-                  <Label htmlFor="filter-horizon">Horizon</Label>
-                  <Select
-                    value={filters.horizon ?? "any"}
-                    onValueChange={(value) =>
-                      patchFilter({ horizon: value === "any" ? undefined : value })
-                    }
-                  >
-                    <SelectTrigger id="filter-horizon">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {HORIZON_OPTIONS.map((option) => (
-                        <SelectItem key={option} value={option}>
-                          {option === "any" ? "Any horizon" : option}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-1">
-                  <Label htmlFor="filter-stance">Stance</Label>
-                  <Select
-                    value={filters.stance ?? "any"}
-                    onValueChange={(value) =>
-                      patchFilter({ stance: value === "any" ? undefined : value })
-                    }
-                  >
-                    <SelectTrigger id="filter-stance">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {STANCE_OPTIONS.map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-1">
-                  <Label htmlFor="filter-regime">Regime</Label>
-                  <Select value={regimeFilter} onValueChange={setRegimeFilter}>
-                    <SelectTrigger id="filter-regime">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {REGIME_OPTIONS.map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-1">
-                  <Label htmlFor="filter-date">Document date</Label>
-                  <Input
-                    id="filter-date"
                     type="date"
-                    value={filters.document_date ?? ""}
-                    onChange={(event) =>
-                      patchFilter({ document_date: event.target.value || undefined })
-                    }
+                    value={filters.dateStart}
+                    onChange={(e) => patchFilters({ dateStart: e.target.value })}
+                    aria-label="Start date"
+                  />
+                  <Input
+                    type="date"
+                    value={filters.dateEnd}
+                    onChange={(e) => patchFilters({ dateEnd: e.target.value })}
+                    aria-label="End date"
                   />
                 </div>
               </div>
-            </CardContent>
-          </Card>
 
-          {loading ? (
-            <div className="space-y-2">
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-            </div>
-          ) : visibleRows.length === 0 ? (
-            <EmptyState
-              title="No runs match these filters"
-              description="Submit an analysis from the Workspace to populate the history, or relax the filters."
-              action={
-                <Button asChild size="sm" variant="outline">
-                  <Link href="/">Open Workspace</Link>
-                </Button>
-              }
-            />
-          ) : (
-            <Card>
-              <CardContent className="p-0">
-                <DataTable
-                  rows={visibleRows}
-                  columns={columns}
-                  rowKey={(row) => row.id}
-                  rowHref={(row) => `/history/${row.id}`}
+              {symbolOptions.length > 0 ? (
+                <div className="space-y-1.5">
+                  <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+                    Symbol
+                  </Label>
+                  <div className="flex max-h-32 flex-wrap gap-1.5 overflow-y-auto">
+                    {symbolOptions.map((sym) => {
+                      const active = filters.symbols.has(sym);
+                      return (
+                        <button
+                          key={sym}
+                          type="button"
+                          onClick={() => patchFilters({ symbols: toggleInSet(filters.symbols, sym) })}
+                          className="focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-full"
+                        >
+                          <Badge
+                            variant={active ? "outline" : "outline"}
+                            className={`cursor-pointer text-[10px] font-mono ${active ? "border-primary text-foreground" : "opacity-60"}`}
+                          >
+                            {sym}
+                          </Badge>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+
+              {variantOptions.length > 0 ? (
+                <div className="space-y-1.5">
+                  <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+                    Model variant
+                  </Label>
+                  <div className="flex flex-wrap gap-1.5">
+                    {variantOptions.map((v) => {
+                      const active = filters.variants.has(v);
+                      return (
+                        <button
+                          key={v}
+                          type="button"
+                          onClick={() => patchFilters({ variants: toggleInSet(filters.variants, v) })}
+                          className="focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-full"
+                        >
+                          <Badge
+                            variant="outline"
+                            className={`cursor-pointer text-[10px] font-mono ${active ? "border-primary text-foreground" : "opacity-60"}`}
+                          >
+                            {v}
+                          </Badge>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+            </aside>
+
+            <div className="space-y-3">
+              <div className="space-y-1">
+                <Label htmlFor="history-search">Search</Label>
+                <Input
+                  id="history-search"
+                  type="search"
+                  placeholder="Filter by run id, date, stance, or symbol…"
+                  value={search}
+                  onChange={(event) => {
+                    const next = event.target.value;
+                    setSearch(next);
+                    pushUrl(filters, next);
+                  }}
                 />
-              </CardContent>
-            </Card>
-          )}
+              </div>
+
+              <Card>
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-base">Runs</CardTitle>
+                  <CardDescription>
+                    {visibleRows.length} shown · {total} total run{total === 1 ? "" : "s"}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="p-0">
+                  {loading ? (
+                    <div className="space-y-2 p-4">
+                      <Skeleton className="h-10 w-full" />
+                      <Skeleton className="h-10 w-full" />
+                      <Skeleton className="h-10 w-full" />
+                    </div>
+                  ) : visibleRows.length === 0 ? (
+                    <div className="p-4">
+                      <EmptyState
+                        title="No runs match these filters"
+                        description="Submit an analysis from the Workspace to populate the history, or relax the filters."
+                        action={
+                          <Button asChild size="sm" variant="outline">
+                            <Link href="/">Open Workspace</Link>
+                          </Button>
+                        }
+                      />
+                    </div>
+                  ) : (
+                    <DataTable
+                      rows={visibleRows}
+                      columns={columns}
+                      rowKey={(row) => row.id}
+                      rowHref={(row) => `/history/${row.id}`}
+                    />
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          </div>
         </main>
       </div>
     </>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -126,6 +126,13 @@ export default function WorkspacePage() {
     });
   }, []);
 
+  // Pending request to auto-submit after a deep-link prefill so the user
+  // lands on a populated workspace without an extra click. ``handleSubmit``
+  // is declared further down — we keep this in a ref so the effect that
+  // schedules the submit doesn't need to retrigger when handleSubmit
+  // changes identity each render.
+  const autoSubmitPendingRef = React.useRef<AnalyzeRequest | null>(null);
+
   // Calendar / cross-page deep links land here with ?date=&symbol=&horizon=&kind=.
   React.useEffect(() => {
     if (!router.isReady) return;
@@ -159,7 +166,14 @@ export default function WorkspacePage() {
         }
         const payload = await response.json();
         if (cancelled || typeof payload?.text !== "string" || !payload.text) return;
-        setRequest((prev) => ({ ...prev, text: payload.text }));
+        setRequest((prev) => {
+          const next = { ...prev, text: payload.text };
+          // Mark the next state as the one that should auto-submit. The
+          // submit fires from a follow-up effect that watches request.text
+          // so handleSubmit sees the populated request.
+          autoSubmitPendingRef.current = next;
+          return next;
+        });
         toast.success(`Prefilled FOMC ${payload.kind} from ${queryDate}.`);
       } catch (err) {
         toast.error((err as Error).message || "Could not load document for this date.");
@@ -347,6 +361,19 @@ export default function WorkspacePage() {
     },
     [apiBaseUrl, baselineResult, request],
   );
+
+  // Auto-fire handleSubmit once the deep-link prefill flushes into the
+  // request state. We compare against the ref the prefill effect parked
+  // there so a manual edit between prefill and run doesn't accidentally
+  // trigger this branch.
+  React.useEffect(() => {
+    const pending = autoSubmitPendingRef.current;
+    if (pending && request.text === pending.text && request.date === pending.date) {
+      autoSubmitPendingRef.current = null;
+      handleSubmit();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [request.text, request.date]);
 
   const handleStruckChange = React.useCallback(
     (next: Set<number>) => {

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -70,6 +70,14 @@ function defaultRequest(): AnalyzeRequest {
   };
 }
 
+function SectionDivider({ label }: { label: string }) {
+  return (
+    <div className="border-t border-border mt-6 mb-1 pt-3">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
 function takeArgmaxRegime(entry: HistoryEntry, detailPayload: AnalyzeResult | null): string | null {
   const regime = detailPayload?.regime_classification;
   if (regime?.argmax_class) return regime.argmax_class;
@@ -423,9 +431,12 @@ export default function WorkspacePage() {
 
           {result ? (
             <>
+              <SectionDivider label="Statement analysis" />
               <TldrCard result={result} />
-              <WorkspaceMetaStrip result={result} />
               <StatementDeltaCard result={result} />
+              <WorkspaceMetaStrip result={result} />
+
+              <SectionDivider label="Model prediction" />
               {result.regime_classification ? (
                 <RegimeHeadline
                   regime={result.regime_classification}
@@ -467,6 +478,11 @@ export default function WorkspacePage() {
                 <PolicyActionCard action={result.policy_action} />
               ) : null}
 
+              {marketPanel && (marketPanel.rates.length > 0 || marketPanel.vol_regime) ? (
+                <MarketReactionPanel panel={marketPanel} />
+              ) : null}
+
+              <SectionDivider label="Sentiment and context" />
               <div className="grid gap-4 xl:grid-cols-2">
                 {result.multi_axis ? (
                   <MultiAxisInterpretation multiAxis={result.multi_axis} />
@@ -488,12 +504,16 @@ export default function WorkspacePage() {
                 )}
               </div>
 
-              {marketPanel && (marketPanel.rates.length > 0 || marketPanel.vol_regime) ? (
-                <MarketReactionPanel panel={marketPanel} />
-              ) : null}
-
               <HistoricalAnalogPanel analogs={analogsPanel} loading={analogsLoading} />
 
+              <TrajectoryPanel
+                apiBaseUrl={apiBaseUrl}
+                asOfDate={request.date}
+                historyLength={12}
+              />
+
+              <SectionDivider label="Model internals" />
+              <PipelineTrace result={result} inputText={request.text} />
 
               {result.xai ? (
                 <SentenceStrikeXaiPanel
@@ -505,14 +525,6 @@ export default function WorkspacePage() {
                   loading={counterfactualLoading}
                 />
               ) : null}
-
-              <TrajectoryPanel
-                apiBaseUrl={apiBaseUrl}
-                asOfDate={request.date}
-                historyLength={12}
-              />
-
-              <PipelineTrace result={result} inputText={request.text} />
 
               <RegimeHistoryStrip entries={historyEntries} symbol={request.symbol} />
             </>

--- a/frontend/pages/performance.tsx
+++ b/frontend/pages/performance.tsx
@@ -1,7 +1,17 @@
 import * as React from "react";
 import Head from "next/head";
 import Link from "next/link";
-import { Target } from "lucide-react";
+import { Target, X } from "lucide-react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import { toast } from "sonner";
 
 import { ConfusionMatrix } from "@/components/analyze/ConfusionMatrix";
@@ -61,12 +71,40 @@ function regimeVariant(label: string | null | undefined): "hawkish" | "dovish" |
   return "outline";
 }
 
+// Wald-style 95% half-width for a proportion p over a support of n.
+// Returns null when n is too small for the approximation to be meaningful.
+function proportionHalfWidth(p: number | null, n: number): number | null {
+  if (p == null || !Number.isFinite(p) || n < 5) return null;
+  const variance = p * (1 - p);
+  if (variance <= 0) return null;
+  return 1.96 * Math.sqrt(variance / n);
+}
+
+function formatScoreWithCi(value: number | null, halfWidth: number | null): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  if (halfWidth == null) return value.toFixed(3);
+  return `${value.toFixed(3)} ±${halfWidth.toFixed(3)}`;
+}
+
+const PERF_TOOLTIP_STYLE: React.CSSProperties = {
+  background: "hsl(var(--popover))",
+  color: "hsl(var(--popover-foreground))",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: 6,
+  padding: "6px 8px",
+  fontSize: 12,
+};
+
 export default function PerformancePage() {
   const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
   const [rows, setRows] = React.useState<RunRegimeRecord[]>([]);
   const [loading, setLoading] = React.useState(true);
   const [totalRuns, setTotalRuns] = React.useState(0);
   const [breakdown, setBreakdown] = React.useState<ClassificationBreakdownResponse | null>(null);
+  // Drill-down: when set, the per-asset chart, per-asset table, and
+  // run-level table only show runs where this class was either
+  // predicted as argmax or appeared as realised.
+  const [classFilter, setClassFilter] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     const controller = new AbortController();
@@ -117,6 +155,19 @@ export default function PerformancePage() {
   }, [apiBaseUrl]);
 
   const aggregate = React.useMemo(() => aggregateRegimePerformance(rows), [rows]);
+  // Subset of rows that match the active class drill-down (or all rows
+  // when no filter is set). The per-asset chart, per-asset table, and
+  // run-level table all read from the filtered rows / aggregate.
+  const filteredRows = React.useMemo(() => {
+    if (!classFilter) return rows;
+    return rows.filter(
+      (row) => row.argmax === classFilter || row.realized === classFilter,
+    );
+  }, [rows, classFilter]);
+  const filteredAggregate = React.useMemo(
+    () => aggregateRegimePerformance(filteredRows),
+    [filteredRows],
+  );
   const breakdownAvailable = breakdown?.available === true;
   const headlineMacroF1 = breakdownAvailable
     ? breakdown?.macro_f1 ?? null
@@ -380,27 +431,54 @@ export default function PerformancePage() {
                       {breakdownAvailable && breakdown?.per_class
                         ? breakdown.per_class.map((row, idx) => {
                             const label = breakdown.class_labels?.[row.class_id] ?? REGIME_CLASSES[row.class_id] ?? `class ${row.class_id}`;
+                            const precisionHw = proportionHalfWidth(row.precision, row.support);
+                            const recallHw = proportionHalfWidth(row.recall, row.support);
+                            // F1 has no closed-form Wald SE; use the
+                            // larger of precision / recall half-widths
+                            // as a conservative band-width approximation.
+                            const f1Hw =
+                              precisionHw != null && recallHw != null
+                                ? Math.max(precisionHw, recallHw)
+                                : null;
+                            const isActive = classFilter === label;
                             return (
-                              <tr key={`${row.class_id}-${idx}`} className="border-b border-border last:border-0">
+                              <tr
+                                key={`${row.class_id}-${idx}`}
+                                className={`border-b border-border last:border-0 cursor-pointer hover:bg-accent/40 ${isActive ? "bg-accent/30" : ""}`}
+                                onClick={() => setClassFilter(isActive ? null : label)}
+                              >
                                 <td className="px-4 py-2 capitalize">{label}</td>
                                 <td className="numeric px-4 py-2 text-right">{row.support}</td>
-                                <td className="numeric px-4 py-2 text-right">{formatScore(row.precision)}</td>
-                                <td className="numeric px-4 py-2 text-right">{formatScore(row.recall)}</td>
-                                <td className="numeric px-4 py-2 text-right">{formatScore(row.f1)}</td>
+                                <td className="numeric px-4 py-2 text-right">{formatScoreWithCi(row.precision, precisionHw)}</td>
+                                <td className="numeric px-4 py-2 text-right">{formatScoreWithCi(row.recall, recallHw)}</td>
+                                <td className="numeric px-4 py-2 text-right">{formatScoreWithCi(row.f1, f1Hw)}</td>
                                 <td className="numeric px-4 py-2 text-right">{formatScore(row.roc_auc ?? null)}</td>
                                 <td className="numeric px-4 py-2 text-right">{formatScore(row.pr_auc ?? null)}</td>
                               </tr>
                             );
                           })
-                        : aggregate.perClass.map((entry) => (
-                            <tr key={entry.klass} className="border-b border-border last:border-0">
-                              <td className="px-4 py-2 capitalize">{entry.klass}</td>
-                              <td className="numeric px-4 py-2 text-right">{entry.support}</td>
-                              <td className="numeric px-4 py-2 text-right">{formatScore(entry.precision)}</td>
-                              <td className="numeric px-4 py-2 text-right">{formatScore(entry.recall)}</td>
-                              <td className="numeric px-4 py-2 text-right">{formatScore(entry.f1)}</td>
-                            </tr>
-                          ))}
+                        : aggregate.perClass.map((entry) => {
+                            const precisionHw = proportionHalfWidth(entry.precision, entry.support);
+                            const recallHw = proportionHalfWidth(entry.recall, entry.support);
+                            const f1Hw =
+                              precisionHw != null && recallHw != null
+                                ? Math.max(precisionHw, recallHw)
+                                : null;
+                            const isActive = classFilter === entry.klass;
+                            return (
+                              <tr
+                                key={entry.klass}
+                                className={`border-b border-border last:border-0 cursor-pointer hover:bg-accent/40 ${isActive ? "bg-accent/30" : ""}`}
+                                onClick={() => setClassFilter(isActive ? null : entry.klass)}
+                              >
+                                <td className="px-4 py-2 capitalize">{entry.klass}</td>
+                                <td className="numeric px-4 py-2 text-right">{entry.support}</td>
+                                <td className="numeric px-4 py-2 text-right">{formatScoreWithCi(entry.precision, precisionHw)}</td>
+                                <td className="numeric px-4 py-2 text-right">{formatScoreWithCi(entry.recall, recallHw)}</td>
+                                <td className="numeric px-4 py-2 text-right">{formatScoreWithCi(entry.f1, f1Hw)}</td>
+                              </tr>
+                            );
+                          })}
                     </tbody>
                   </table>
                 </CardContent>
@@ -441,9 +519,42 @@ export default function PerformancePage() {
                           ),
                           total: counts.reduce((acc, n) => acc + n, 0),
                         }));
-                        return <ConfusionMatrix rows={matrixRows} classes={labels} />;
+                        return (
+                          <ConfusionMatrix
+                            rows={matrixRows}
+                            classes={labels}
+                            onClassClick={(klass) =>
+                              setClassFilter((prev) => (prev === klass ? null : klass))
+                            }
+                            activeClass={classFilter}
+                          />
+                        );
                       })()
-                    : <ConfusionMatrix rows={aggregate.confusion} classes={REGIME_CLASSES} />}
+                    : (
+                      <ConfusionMatrix
+                        rows={aggregate.confusion}
+                        classes={REGIME_CLASSES}
+                        onClassClick={(klass) =>
+                          setClassFilter((prev) => (prev === klass ? null : klass))
+                        }
+                        activeClass={classFilter}
+                      />
+                    )}
+                  {classFilter ? (
+                    <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+                      <span>
+                        Filtered to runs where <span className="font-mono capitalize">{classFilter}</span> was predicted or actual.
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setClassFilter(null)}
+                        className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 hover:bg-accent/40"
+                      >
+                        <X className="h-3 w-3" aria-hidden="true" />
+                        Clear
+                      </button>
+                    </div>
+                  ) : null}
                 </CardContent>
               </Card>
 
@@ -452,12 +563,69 @@ export default function PerformancePage() {
                   <CardTitle className="text-base">Per-asset breakdown</CardTitle>
                   <CardDescription>
                     Top-pick accuracy and actual coverage for every symbol with at least one
-                    resolved run.
+                    resolved run.{classFilter ? ` Filtered to ${classFilter}.` : ""}
                   </CardDescription>
                 </CardHeader>
-                <CardContent className="p-0">
+                <CardContent className="space-y-4 p-0">
+                  {(() => {
+                    const chartRows = filteredAggregate.bySymbol
+                      .filter((row) => row.argmaxAccuracy != null)
+                      .map((row) => ({
+                        symbol: row.symbol,
+                        accuracy: row.argmaxAccuracy ?? 0,
+                        resolved: row.resolved,
+                      }))
+                      .sort((a, b) => b.accuracy - a.accuracy);
+                    if (chartRows.length === 0) return null;
+                    return (
+                      <div className="px-4 pt-4">
+                        <div className="h-56 w-full">
+                          <ResponsiveContainer width="100%" height="100%">
+                            <BarChart
+                              data={chartRows}
+                              margin={{ top: 8, right: 16, bottom: 24, left: 0 }}
+                            >
+                              <CartesianGrid stroke="hsl(var(--border))" strokeDasharray="2 3" />
+                              <XAxis
+                                dataKey="symbol"
+                                tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+                                interval={0}
+                                angle={-30}
+                                textAnchor="end"
+                              />
+                              <YAxis
+                                tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+                                domain={[0, 1]}
+                                tickFormatter={(v) => `${Math.round(Number(v) * 100)}%`}
+                              />
+                              <Tooltip
+                                cursor={{ fill: "hsl(var(--muted) / 0.4)" }}
+                                contentStyle={PERF_TOOLTIP_STYLE}
+                                formatter={(value, _name, ctx) => {
+                                  const d = ctx?.payload as { symbol: string; accuracy: number; resolved: number } | undefined;
+                                  if (!d) return [String(value), "accuracy"];
+                                  return [
+                                    `${(d.accuracy * 100).toFixed(1)}% on ${d.resolved} run${d.resolved === 1 ? "" : "s"}`,
+                                    "top-pick accuracy",
+                                  ];
+                                }}
+                              />
+                              <Bar dataKey="accuracy" isAnimationActive={false}>
+                                {chartRows.map((d) => (
+                                  <Cell
+                                    key={d.symbol}
+                                    fill={d.accuracy >= 1 / REGIME_CLASSES.length ? "hsl(var(--up))" : "hsl(var(--down))"}
+                                  />
+                                ))}
+                              </Bar>
+                            </BarChart>
+                          </ResponsiveContainer>
+                        </div>
+                      </div>
+                    );
+                  })()}
                   <DataTable
-                    rows={aggregate.bySymbol}
+                    rows={filteredAggregate.bySymbol}
                     columns={symbolColumns}
                     rowKey={(row) => row.symbol}
                   />
@@ -469,12 +637,12 @@ export default function PerformancePage() {
                   <CardTitle className="text-base">Run-level detail</CardTitle>
                   <CardDescription>
                     Each scanned run with predicted argmax, calibrated probability, realised regime,
-                    and set-membership coverage.
+                    and set-membership coverage.{classFilter ? ` Filtered to ${classFilter}.` : ""}
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="p-0">
                   <DataTable
-                    rows={rows}
+                    rows={filteredRows}
                     columns={runColumns}
                     rowKey={(row) => row.id}
                     rowHref={(row) => `/history/${row.id}`}

--- a/frontend/pages/research.tsx
+++ b/frontend/pages/research.tsx
@@ -1,6 +1,17 @@
 import * as React from "react";
 import Head from "next/head";
 import { FlaskConical } from "lucide-react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ErrorBar,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import { toast } from "sonner";
 
 import { DecisionsLink } from "@/components/research/DecisionsLink";
@@ -50,6 +61,90 @@ function heatmapColor(value: number, min: number, max: number): string {
   return `rgba(16, 185, 129, ${alpha.toFixed(3)})`;
 }
 
+const BAKEOFF_TOOLTIP_STYLE: React.CSSProperties = {
+  background: "hsl(var(--popover))",
+  color: "hsl(var(--popover-foreground))",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: 6,
+  padding: "6px 8px",
+  fontSize: 12,
+};
+
+function bakeoffBarColor(value: number, min: number, max: number): string {
+  if (max <= min) return "hsl(var(--primary))";
+  const t = Math.max(0, Math.min(1, (value - min) / (max - min)));
+  // Sequential primary-tinted ramp; lighter at low scores.
+  const alpha = 0.35 + 0.6 * t;
+  return `hsla(var(--primary) / ${alpha.toFixed(3)})`;
+}
+
+interface BakeoffBarDatum {
+  name: string;
+  macroF1: number;
+  ciLow: number | null;
+  ciHigh: number | null;
+  // recharts error bars accept a [low, high] tuple-difference.
+  errorOffsets: [number, number];
+}
+
+function buildBakeoffBarData(section: EncoderBakeoffSection): BakeoffBarDatum[] {
+  return [...section.rows]
+    .sort((a, b) => b.macro_f1_mean - a.macro_f1_mean)
+    .map((row) => {
+      const low = row.macro_f1_ci_low;
+      const high = row.macro_f1_ci_high;
+      const offsetLow = low != null ? Math.max(0, row.macro_f1_mean - low) : 0;
+      const offsetHigh = high != null ? Math.max(0, high - row.macro_f1_mean) : 0;
+      return {
+        name: row.encoder_key,
+        macroF1: row.macro_f1_mean,
+        ciLow: low,
+        ciHigh: high,
+        errorOffsets: [offsetLow, offsetHigh] as [number, number],
+      };
+    });
+}
+
+function bakeoffCallout(section: EncoderBakeoffSection): string | null {
+  if (section.rows.length < 2) return null;
+  const sorted = [...section.rows].sort((a, b) => b.macro_f1_mean - a.macro_f1_mean);
+  const leader = sorted[0];
+  const runner = sorted[1];
+  const gapPp = (leader.macro_f1_mean - runner.macro_f1_mean) * 100;
+  if (!Number.isFinite(gapPp) || gapPp <= 0) return null;
+  return `${leader.encoder_key} leads by ${gapPp.toFixed(1)}pp macro-F1 over ${runner.encoder_key}.`;
+}
+
+function crossBankCallout(
+  section: CrossBankTransferSection,
+  cellMap: Map<string, TransferMatrixCell>,
+  sources: string[],
+  targets: string[],
+): string | null {
+  if (sources.length === 0 || targets.length === 0) return null;
+  // Largest in-domain to off-diagonal drop across all rows.
+  let worstDrop = 0;
+  let worstSource = "";
+  let worstTarget = "";
+  for (const src of sources) {
+    const inDomain = cellMap.get(`${src}|${src}`);
+    if (!inDomain) continue;
+    for (const tgt of targets) {
+      if (tgt === src) continue;
+      const cell = cellMap.get(`${src}|${tgt}`);
+      if (!cell) continue;
+      const drop = inDomain.metric - cell.metric;
+      if (drop > worstDrop) {
+        worstDrop = drop;
+        worstSource = src;
+        worstTarget = tgt;
+      }
+    }
+  }
+  if (worstDrop <= 0 || !worstSource || !worstTarget) return null;
+  return `Transfer from ${worstSource} to ${worstTarget} drops ${(worstDrop * 100).toFixed(1)}pp ${section.metric_name.replace("_", "-")} vs in-domain.`;
+}
+
 function EncoderBakeoffPane({ section }: { section: EncoderBakeoffSection }) {
   if (!section.available || section.rows.length === 0) {
     return (
@@ -68,6 +163,11 @@ function EncoderBakeoffPane({ section }: { section: EncoderBakeoffSection }) {
       </Card>
     );
   }
+  const barData = buildBakeoffBarData(section);
+  const macroValues = barData.map((d) => d.macroF1);
+  const minF1 = macroValues.length ? Math.min(...macroValues) : 0;
+  const maxF1 = macroValues.length ? Math.max(...macroValues) : 1;
+  const callout = bakeoffCallout(section);
   return (
     <Card>
       <CardHeader>
@@ -76,7 +176,52 @@ function EncoderBakeoffPane({ section }: { section: EncoderBakeoffSection }) {
           {section.rows.length} encoders, coverage {section.coverage ? `${(section.coverage * 100).toFixed(0)}%` : "—"} block-bootstrap CI.
         </CardDescription>
       </CardHeader>
-      <CardContent className="p-0">
+      <CardContent className="space-y-4 p-0">
+        {barData.length > 0 ? (
+          <div className="px-4 pt-4">
+            <div className="h-64 w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={barData} margin={{ top: 12, right: 16, bottom: 24, left: 0 }}>
+                  <CartesianGrid stroke="hsl(var(--border))" strokeDasharray="2 3" />
+                  <XAxis
+                    dataKey="name"
+                    tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+                    interval={0}
+                    angle={-30}
+                    textAnchor="end"
+                  />
+                  <YAxis
+                    tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+                    domain={[0, 1]}
+                    tickFormatter={(v) => Number(v).toFixed(2)}
+                  />
+                  <Tooltip
+                    cursor={{ fill: "hsl(var(--muted) / 0.4)" }}
+                    contentStyle={BAKEOFF_TOOLTIP_STYLE}
+                    formatter={(value, _name, ctx) => {
+                      const d = ctx?.payload as BakeoffBarDatum | undefined;
+                      if (!d) return [String(value), "macro-F1"];
+                      const ci =
+                        d.ciLow != null && d.ciHigh != null
+                          ? ` (95% CI ${d.ciLow.toFixed(3)}–${d.ciHigh.toFixed(3)})`
+                          : "";
+                      return [`${d.macroF1.toFixed(3)}${ci}`, "macro-F1"];
+                    }}
+                  />
+                  <Bar dataKey="macroF1" isAnimationActive={false}>
+                    {barData.map((d) => (
+                      <Cell key={d.name} fill={bakeoffBarColor(d.macroF1, minF1, maxF1)} />
+                    ))}
+                    <ErrorBar dataKey="errorOffsets" stroke="hsl(var(--muted-foreground))" width={4} />
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+            {callout ? (
+              <p className="mt-2 text-xs text-muted-foreground">{callout}</p>
+            ) : null}
+          </div>
+        ) : null}
         <table className="w-full text-sm">
           <thead className="border-b border-border bg-muted/30 text-xs uppercase tracking-wide text-muted-foreground">
             <tr>
@@ -143,53 +288,126 @@ function CrossBankTransferPane({ section }: { section: CrossBankTransferSection 
   const metrics = section.cells.map((c) => c.metric);
   const min = Math.min(...metrics);
   const max = Math.max(...metrics);
+  const callout = crossBankCallout(section, cellMap, sources, targets);
+  const renderCellTooltip = (src: string, tgt: string, cell: TransferMatrixCell | undefined) => {
+    if (!cell) return undefined;
+    const inDomain = cellMap.get(`${src}|${src}`);
+    if (!inDomain || src === tgt) {
+      return `Trained on ${src}, evaluated on ${tgt}: ${cell.metric.toFixed(3)} ${section.metric_name.replace("_", "-")}.`;
+    }
+    const delta = cell.metric - inDomain.metric;
+    const deltaLabel =
+      delta >= 0
+        ? `+${(delta * 100).toFixed(1)}pp vs in-domain`
+        : `${(delta * 100).toFixed(1)}pp vs in-domain`;
+    return `Trained on ${src}, evaluated on ${tgt}: ${cell.metric.toFixed(3)} ${section.metric_name.replace("_", "-")}. ${deltaLabel}.`;
+  };
   return (
     <Card>
       <CardHeader>
         <CardTitle>Cross-CB transfer matrix</CardTitle>
         <CardDescription>
-          {section.metric_name.replace("_", "-")}. Rows are training banks, columns are evaluation banks.
+          {section.metric_name.replace("_", "-")}. Rows are training banks, columns are evaluation banks. Heatmap on top, numeric values below.
         </CardDescription>
       </CardHeader>
-      <CardContent className="overflow-auto">
-        <table className="w-full border-collapse text-sm">
-          <thead>
-            <tr>
-              <th className="border border-border bg-muted/30 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                source ↓ / target →
-              </th>
-              {targets.map((tgt) => (
-                <th key={tgt} className="border border-border bg-muted/30 px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  {tgt}
+      <CardContent className="space-y-4 overflow-auto">
+        <div>
+          <p className="mb-1 text-xs uppercase tracking-wide text-muted-foreground">Heatmap</p>
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr>
+                <th className="border border-border bg-muted/30 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  source ↓ / target →
                 </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {sources.map((src) => (
-              <tr key={src}>
-                <th className="border border-border bg-muted/20 px-3 py-2 text-left text-xs font-medium text-muted-foreground">
-                  {src}
-                </th>
-                {targets.map((tgt) => {
-                  const cell = cellMap.get(`${src}|${tgt}`);
-                  return (
-                    <td
-                      key={`${src}-${tgt}`}
-                      className="border border-border px-3 py-2 text-right font-mono text-xs"
-                      style={cell ? { backgroundColor: heatmapColor(cell.metric, min, max) } : undefined}
-                    >
-                      {cell ? cell.metric.toFixed(3) : "—"}
-                    </td>
-                  );
-                })}
+                {targets.map((tgt) => (
+                  <th key={tgt} className="border border-border bg-muted/30 px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {tgt}
+                  </th>
+                ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {sources.map((src) => (
+                <tr key={`heat-${src}`}>
+                  <th className="border border-border bg-muted/20 px-3 py-2 text-left text-xs font-medium text-muted-foreground">
+                    {src}
+                  </th>
+                  {targets.map((tgt) => {
+                    const cell = cellMap.get(`${src}|${tgt}`);
+                    return (
+                      <td
+                        key={`heat-${src}-${tgt}`}
+                        className="border border-border px-3 py-3 text-center font-mono text-[10px]"
+                        style={cell ? { backgroundColor: heatmapColor(cell.metric, min, max) } : undefined}
+                        title={renderCellTooltip(src, tgt, cell)}
+                      >
+                        {cell ? "" : "—"}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {callout ? (
+            <p className="mt-2 text-xs text-muted-foreground">{callout}</p>
+          ) : null}
+        </div>
+        <div>
+          <p className="mb-1 text-xs uppercase tracking-wide text-muted-foreground">Values</p>
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr>
+                <th className="border border-border bg-muted/30 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  source ↓ / target →
+                </th>
+                {targets.map((tgt) => (
+                  <th key={tgt} className="border border-border bg-muted/30 px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {tgt}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sources.map((src) => (
+                <tr key={`val-${src}`}>
+                  <th className="border border-border bg-muted/20 px-3 py-2 text-left text-xs font-medium text-muted-foreground">
+                    {src}
+                  </th>
+                  {targets.map((tgt) => {
+                    const cell = cellMap.get(`${src}|${tgt}`);
+                    return (
+                      <td
+                        key={`val-${src}-${tgt}`}
+                        className="border border-border px-3 py-2 text-right font-mono text-xs"
+                        title={renderCellTooltip(src, tgt, cell)}
+                      >
+                        {cell ? cell.metric.toFixed(3) : "—"}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </CardContent>
     </Card>
   );
+}
+
+function describeArtifactFile(relativePath: string): string {
+  const last = relativePath.split("/").pop() ?? "";
+  if (last.endsWith(".parquet")) return "Tabular cache for downstream loaders.";
+  if (last.endsWith(".pt") || last.endsWith(".bin")) return "Model checkpoint weights.";
+  if (last.includes("aggregate")) return "Aggregated metrics across seeds.";
+  if (last.includes("conformal")) return "Conformal calibration sidecar.";
+  if (last.includes("breakdown")) return "Per-class breakdown for the evaluation harness.";
+  if (last.includes("transfer")) return "Cross-bank transfer evaluation row.";
+  if (last.endsWith(".json")) return "Structured evaluation artefact.";
+  if (last.endsWith(".csv")) return "CSV table of evaluation rows.";
+  if (last.endsWith(".md")) return "Markdown notes for this run.";
+  return "Research artefact.";
 }
 
 function ArtifactsExplorer({
@@ -202,9 +420,9 @@ function ArtifactsExplorer({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Artefact files</CardTitle>
+        <CardTitle>Downloads</CardTitle>
         <CardDescription>
-          {totalFiles} files indexed across {sectionEntries.length} sections.
+          {totalFiles} files across {sectionEntries.length} sections. Each file lists its size, last update, and a short note on what it is.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -217,16 +435,21 @@ function ArtifactsExplorer({
             {files.length === 0 ? (
               <p className="text-xs text-muted-foreground">No files emitted yet.</p>
             ) : (
-              <ul className="space-y-0.5">
+              <ul className="space-y-1.5">
                 {files.slice(0, 20).map((file) => (
                   <li
                     key={file.relative_path}
-                    className="flex flex-wrap items-center justify-between gap-2 font-mono text-xs text-muted-foreground"
+                    className="space-y-0.5 border-b border-border/40 pb-1.5 last:border-0"
                   >
-                    <span>{file.relative_path}</span>
-                    <span>
-                      {formatBytes(file.size_bytes)} · {file.modified_at.slice(0, 19)}
-                    </span>
+                    <div className="flex flex-wrap items-center justify-between gap-2 font-mono text-xs text-muted-foreground">
+                      <span>{file.relative_path}</span>
+                      <span>
+                        {formatBytes(file.size_bytes)} · updated {file.modified_at.slice(0, 19)}
+                      </span>
+                    </div>
+                    <p className="text-[11px] text-muted-foreground">
+                      {describeArtifactFile(file.relative_path)}
+                    </p>
                   </li>
                 ))}
                 {files.length > 20 ? (
@@ -300,7 +523,7 @@ export default function ResearchPage() {
                 <TabsTrigger value="transfer">Transfer</TabsTrigger>
                 <TabsTrigger value="decisions">Decisions</TabsTrigger>
                 <TabsTrigger value="jobs">Jobs</TabsTrigger>
-                <TabsTrigger value="files">Files</TabsTrigger>
+                <TabsTrigger value="files">Downloads</TabsTrigger>
               </TabsList>
               <TabsContent value="bakeoff" className="space-y-3">
                 <EncoderBakeoffPane section={data.encoder_bakeoff} />

--- a/frontend/tests/pages/calendar.test.tsx
+++ b/frontend/tests/pages/calendar.test.tsx
@@ -16,14 +16,18 @@ vi.mock("next/head", () => ({
 }));
 
 const fetchFomcCalendarMock = vi.fn();
+const fetchNextFomcForecastMock = vi.fn();
 vi.mock("@/lib/analyze/api", () => ({
   resolveApiBaseUrl: () => "http://localhost:8000",
   fetchFomcCalendar: (...args: unknown[]) => fetchFomcCalendarMock(...args),
+  fetchNextFomcForecast: (...args: unknown[]) => fetchNextFomcForecastMock(...args),
 }));
 
 describe("CalendarPage", () => {
   beforeEach(() => {
     fetchFomcCalendarMock.mockReset();
+    fetchNextFomcForecastMock.mockReset();
+    fetchNextFomcForecastMock.mockRejectedValue(new Error("not available"));
     pushMock.mockReset();
   });
 

--- a/frontend/tests/pages/history.test.tsx
+++ b/frontend/tests/pages/history.test.tsx
@@ -6,11 +6,13 @@ vi.mock("sonner", () => ({
   Toaster: () => null,
 }));
 
+const replaceMock = vi.fn();
 vi.mock("next/router", () => ({
   useRouter: () => ({
     isReady: true,
     query: {},
     push: vi.fn(),
+    replace: replaceMock,
   }),
 }));
 
@@ -22,11 +24,14 @@ const fetchHistoryMock = vi.fn();
 const fetchHistoryRealizedBatchMock = vi.fn();
 const deleteHistoryRunMock = vi.fn();
 
+const fetchSymbolsMock = vi.fn();
+
 vi.mock("@/lib/analyze/api", () => ({
   resolveApiBaseUrl: () => "http://localhost:8000",
   fetchHistory: (...args: unknown[]) => fetchHistoryMock(...args),
   fetchHistoryRealizedBatch: (...args: unknown[]) => fetchHistoryRealizedBatchMock(...args),
   deleteHistoryRun: (...args: unknown[]) => deleteHistoryRunMock(...args),
+  fetchSymbols: (...args: unknown[]) => fetchSymbolsMock(...args),
 }));
 
 describe("HistoryPage", () => {
@@ -35,6 +40,9 @@ describe("HistoryPage", () => {
     fetchHistoryRealizedBatchMock.mockReset();
     fetchHistoryRealizedBatchMock.mockResolvedValue({ items: {}, missing: [] });
     deleteHistoryRunMock.mockReset();
+    fetchSymbolsMock.mockReset();
+    fetchSymbolsMock.mockResolvedValue({ symbols: [] });
+    replaceMock.mockReset();
   });
 
   it("renders the rows returned by the backend", async () => {
@@ -67,8 +75,8 @@ describe("HistoryPage", () => {
     });
     const { default: HistoryPage } = await import("@/pages/history");
     render(<HistoryPage />);
-    await waitFor(() => expect(screen.getByText("^GSPC")).toBeInTheDocument());
-    expect(screen.getByText("^NDX")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByText("^GSPC").length).toBeGreaterThan(0));
+    expect(screen.getAllByText("^NDX").length).toBeGreaterThan(0);
     expect(screen.getByText("2024-09-18")).toBeInTheDocument();
     expect(screen.getByText("2024-11-06")).toBeInTheDocument();
     expect(screen.getAllByText(/hawkish/i).length).toBeGreaterThan(0);


### PR DESCRIPTION
Closes #201.

- Workspace: reordered panels into Statement analysis, Model prediction, Sentiment + context, Model internals; added subtle section dividers.
- History: stance-over-time chart (regime-coloured dots, optional forward-vol overlay) above the list; collapsible filter sidebar with stance, regime, date range, symbol, model variant; URL-persisted filter state.
- Calendar: rows are click-targets that deep-link to the Workspace with auto-submit; live countdown card to the next meeting; forecast badge on upcoming rows; historical-context label on past rows.
- Compare: numeric Δ values gained directional colour + axis annotation; narrative summary card at top; "Copy share link" button on the header.
- Research: ranked macro-F1 bar chart with CI error bars above the bake-off table, heatmap + numeric matrix for cross-bank transfer with in-domain Δ tooltip, "what we learned" callouts on both sections, Files tab renamed to Downloads with per-file descriptions.
- Performance: per-class precision/recall/F1 with ± half-width CIs; confusion matrix class labels are click-to-filter (mirrored from clickable per-class rows); per-asset bar chart sorted by accuracy above the table; drill-down propagates to per-asset chart, per-asset table, and run-level table.