### PR TITLE
pin datasets<4 in backend extras (#465)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -33,7 +33,9 @@ dependencies = [
   "pandas",
   "pandera>=0.20",
   "pyarrow",
-  "datasets",
+  # datasets 4.x removed APIs the loaders use (#465 / #409); pin <4 until
+  # the loaders migrate to the new API surface.
+  "datasets>=3.0,<4",
   "kagglehub",
   "anthropic>=0.40.0",
   "google-genai>=1.0.0",

--- a/tests/unit/test_datasets_version_pin.py
+++ b/tests/unit/test_datasets_version_pin.py
@@ -1,0 +1,31 @@
+"""Guard rail for the `datasets` major-version pin (#465).
+
+`datasets` 4.x removed loading-script APIs the PhraseBank loader (and
+the other ingest paths at `app/data/ingest_sources.py`,
+`app/data/continued_pretraining.py`) call through `load_dataset`. On
+the Phase 1 Runpod sweep batch the resolver picked up a 4.x version on
+a fresh pod and the loader broke; the only fix was a downgrade to the
+3.x line. `backend/pyproject.toml` now caps the constraint at `<4`;
+this test asserts the constraint is honoured at runtime so a future
+bump cannot silently slip through the lock.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+datasets = pytest.importorskip(
+    "datasets",
+    reason="datasets not installed in this environment",
+)
+
+
+def test_datasets_major_version_is_three() -> None:
+    version = str(getattr(datasets, "__version__", "")).strip()
+    assert version, "datasets must expose a `__version__` attribute"
+    major = version.split(".", 1)[0]
+    assert major == "3", (
+        f"datasets must remain on the 3.x line (got {version!r}); 4.x "
+        "removed loading-script APIs the PhraseBank + ingest loaders rely "
+        "on through `load_dataset` (see #465)."
+    )


### PR DESCRIPTION
Closes #465.

The PhraseBank loader (`backend/app/data/phrasebank.py`), `ingest_sources.py`, and `continued_pretraining.py` all call through `datasets.load_dataset`. The 4.x line removed loading-script APIs the loaders rely on. The Phase 1 Runpod sweep batch broke on a fresh pod because `pip` resolved a 4.x version through the unpinned constraint and `load_dataset` lost behaviour the loaders need.

Pinned `>=3.0,<4` in `backend/pyproject.toml`. New `tests/unit/test_datasets_version_pin.py` asserts the major-version stays on 3.x so a future bump cannot slip through silently. Mirrors the pattern from #409 / #452 (transformers pin).

**Lockfile note**: the lockfile still references `datasets==4.8.5` and needs a fresh resolve via the docker compose backend image. The hash pinning means I cannot regenerate locally without the container. Operator action before the next pod build: \`make lock\`.