### PR TITLE
thread input_size into derived-features ablation cells (#309)

### DIFF
--- a/scripts/run_derived_features_ablation.py
+++ b/scripts/run_derived_features_ablation.py
@@ -365,11 +365,20 @@ def _run_one_cell(
     hidden_size: int,
     use_derived: bool,
 ) -> dict[str, Any]:
-    from app.models.config import ModelConfig
+    from app.models.config import ModelConfig, RICH_FEATURE_SIZE
     from app.training.loaders import load_walk_forward_split
     from app.training.loop import train_model
 
+    # The runner always loads rich features (split is built with
+    # ``rich_features=True`` below); pin the input projection to
+    # ``RICH_FEATURE_SIZE`` so the recurrent core sees the same per-bar
+    # width the loader emits. Mirrors ``train_forecaster._resolved_input_size``.
+    # Without this the ``ModelConfig`` default (``FEATURE_SIZE`` = 6) was
+    # used and ``train_model``'s first forward died on the LSTM
+    # dim mismatch against the 87-dim vectors that land on canonical
+    # training packages.
     config = ModelConfig(
+        input_size=RICH_FEATURE_SIZE,
         output_mode="classification",
         n_classes=3,
         hidden_size=hidden_size,

--- a/tests/unit/test_derived_features_ablation.py
+++ b/tests/unit/test_derived_features_ablation.py
@@ -352,3 +352,35 @@ def test_baseline_arm_preserves_per_bar_slot_values() -> None:
         assert fv.sentiment_score == s0
         assert fv.stance_hawk == h0
         assert fv.certain_label_certain == c0
+
+
+def test_run_one_cell_pins_input_size_to_rich_feature_size() -> None:
+    """`_run_one_cell` must construct ModelConfig with input_size set to
+    RICH_FEATURE_SIZE so the recurrent core sees the same per-bar width
+    the loader emits when ``rich_features=True``.
+
+    Pre-fix, the cell built ModelConfig without an explicit ``input_size``;
+    the dataclass default (FEATURE_SIZE = 6) collided with the 87-dim
+    rich vectors that land on canonical training packages and the LSTM
+    blew up on the first forward. The Phase 2 Runpod batch caught it.
+    """
+
+    import inspect
+    from app.models.config import RICH_FEATURE_SIZE
+    from scripts.run_derived_features_ablation import _run_one_cell
+
+    source = inspect.getsource(_run_one_cell)
+    assert "RICH_FEATURE_SIZE" in source, (
+        "_run_one_cell must reference RICH_FEATURE_SIZE so the ModelConfig "
+        "input_size matches the loader's rich-feature width. Without this "
+        "the trainer dies on a dim mismatch on every canonical training "
+        "package (see Phase 2 Runpod report)."
+    )
+    assert "input_size=RICH_FEATURE_SIZE" in source.replace(" ", ""), (
+        "_run_one_cell's ModelConfig must set input_size to RICH_FEATURE_SIZE "
+        "directly (matches train_forecaster._resolved_input_size)."
+    )
+    assert RICH_FEATURE_SIZE > 6, (
+        "RICH_FEATURE_SIZE must exceed the legacy FEATURE_SIZE default of 6 "
+        "for this test to be meaningful."
+    )


### PR DESCRIPTION
Surfaced during the Phase 2 Runpod batch.

`scripts/run_derived_features_ablation._run_one_cell` built `ModelConfig` without an explicit `input_size`. The dataclass default (`FEATURE_SIZE = 6`) collided with the 87-dim rich vectors that land on canonical training packages — the LSTM died on the first forward.

Fix mirrors `train_forecaster._resolved_input_size`: when rich features are on (the ablation always passes `rich_features=True` to `load_walk_forward_split`), pin `input_size` to `RICH_FEATURE_SIZE` so the recurrent core's input projection matches the loader output.

Regression test asserts the runner references `RICH_FEATURE_SIZE` so a future refactor cannot silently regress.

Refs #309, #456 (the original ship that missed the dim resolution because the implementer's test fixture happened to use 6-dim vectors).

Closes #309 unblocking. The ablation can now answer the #310 + #315 chain on real data.