### PR TITLE
Wave 3 follow-ups: calendar mobile, history empty copy, tap targets, errors tests

### DIFF
--- a/frontend/components/analyze/AnalyzeForm.tsx
+++ b/frontend/components/analyze/AnalyzeForm.tsx
@@ -91,7 +91,11 @@ export function AnalyzeForm({ value, onChange, onSubmit, loading }: AnalyzeFormP
           </div>
 
           <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
-            <Button type="submit" disabled={loading} className="w-full sm:w-auto">
+            <Button
+              type="submit"
+              disabled={loading}
+              className="min-h-[44px] w-full sm:min-h-9 sm:w-auto"
+            >
               {submitLabel}
             </Button>
             <Select
@@ -103,7 +107,7 @@ export function AnalyzeForm({ value, onChange, onSubmit, loading }: AnalyzeFormP
               }}
             >
               <SelectTrigger
-                className="h-9 w-full sm:w-[16rem]"
+                className="h-9 min-h-[44px] w-full sm:min-h-9 sm:w-[16rem]"
                 aria-label="Load a sample FOMC statement"
               >
                 <SelectValue placeholder="Load sample statement…" />

--- a/frontend/components/shell/header.tsx
+++ b/frontend/components/shell/header.tsx
@@ -127,7 +127,7 @@ export function Header() {
               type="button"
               variant="ghost"
               size="icon"
-              className="h-9 w-9 sm:hidden"
+              className="min-h-[44px] min-w-[44px] sm:hidden"
               aria-label={mobileOpen ? "Close navigation menu" : "Open navigation menu"}
               aria-expanded={mobileOpen}
               aria-controls="mobile-nav-panel"

--- a/frontend/pages/calendar.tsx
+++ b/frontend/pages/calendar.tsx
@@ -71,9 +71,9 @@ function CountdownCard({ targetDate }: { targetDate: string }) {
   }, []);
   return (
     <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="flex items-center gap-2 text-base">
-          <Clock className="h-4 w-4 text-primary" />
+      <CardHeader className="px-4 pb-3 pt-4 sm:px-6 sm:pt-6">
+        <CardTitle className="flex items-center gap-2 text-2xl sm:text-3xl">
+          <Clock className="h-5 w-5 text-primary sm:h-6 sm:w-6" />
           FOMC meeting in {formatCountdown(targetDate, now)}
         </CardTitle>
         <CardDescription>
@@ -98,7 +98,7 @@ function MeetingRow({ meeting, onAnalyze, predictedAction, contextLabel }: Meeti
       <button
         type="button"
         onClick={() => onAnalyze(targetDate)}
-        className="flex w-full flex-wrap items-center justify-between gap-3 py-3 text-left hover:bg-accent/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm px-2"
+        className="flex w-full min-h-[44px] flex-col gap-2 rounded-sm px-2 py-3 text-left hover:bg-accent/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:min-h-0 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-3"
       >
         <div className="space-y-0.5">
           <p className="font-mono text-sm">{meeting.meeting_date}</p>
@@ -112,7 +112,7 @@ function MeetingRow({ meeting, onAnalyze, predictedAction, contextLabel }: Meeti
             {contextLabel ? <span>· {contextLabel}</span> : null}
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {predictedAction ? (
             <Badge variant="outline" className="text-[10px]">
               forecast · {predictedAction}

--- a/frontend/pages/history/index.tsx
+++ b/frontend/pages/history/index.tsx
@@ -626,8 +626,12 @@ export default function HistoryPage() {
                   ) : visibleRows.length === 0 ? (
                     <div className="p-4">
                       <EmptyState
-                        title="No runs match these filters"
-                        description="Submit an analysis from the Workspace to populate the history, or relax the filters."
+                        title={total === 0 ? "No history yet." : "No runs match these filters."}
+                        description={
+                          total === 0
+                            ? "Use the Workspace to analyze a statement."
+                            : "Relax the filters or use the Workspace to analyze a new statement."
+                        }
                         action={
                           <Button asChild size="sm" variant="outline">
                             <Link href="/">Open Workspace</Link>

--- a/frontend/tests/lib/analyze/errors.test.ts
+++ b/frontend/tests/lib/analyze/errors.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { categorizeError, errorMessage } from "@/lib/analyze/errors";
+
+describe("categorizeError", () => {
+  it("maps 400 to bad_input and surfaces the detail copy", () => {
+    const result = categorizeError({
+      response: { status: 400, data: { detail: "Symbol missing" } },
+    });
+    expect(result.category).toBe("bad_input");
+    expect(result.message).toBe("Symbol missing");
+  });
+
+  it("maps 422 to bad_input with a default message when detail is empty", () => {
+    const result = categorizeError({ response: { status: 422 } });
+    expect(result.category).toBe("bad_input");
+    expect(result.message).toMatch(/check the inputs/i);
+  });
+
+  it("maps 404 to not_found and surfaces the detail copy", () => {
+    const result = categorizeError({
+      response: { status: 404, data: { detail: "Run not in store" } },
+    });
+    expect(result.category).toBe("not_found");
+    expect(result.message).toBe("Run not in store");
+  });
+
+  it("falls back to 'Not found.' when 404 has no detail", () => {
+    const result = categorizeError({ response: { status: 404 } });
+    expect(result.category).toBe("not_found");
+    expect(result.message).toBe("Not found.");
+  });
+
+  it.each([500, 502, 503, 504])("maps %s to model_unavailable", (status) => {
+    const result = categorizeError({ response: { status } });
+    expect(result.category).toBe("model_unavailable");
+    expect(result.message).toMatch(/model unavailable/i);
+  });
+
+  it("maps 409 to model_unavailable", () => {
+    const result = categorizeError({ response: { status: 409 } });
+    expect(result.category).toBe("model_unavailable");
+  });
+
+  it("maps code=ERR_NETWORK to network", () => {
+    const result = categorizeError({ code: "ERR_NETWORK" });
+    expect(result.category).toBe("network");
+    expect(result.message).toMatch(/network error/i);
+  });
+
+  it("maps code=ETIMEDOUT to network", () => {
+    const result = categorizeError({ code: "ETIMEDOUT" });
+    expect(result.category).toBe("network");
+  });
+
+  it("treats a request without a response as network", () => {
+    const result = categorizeError({ request: {} });
+    expect(result.category).toBe("network");
+  });
+
+  it("treats 'Failed to fetch' message without response as network", () => {
+    const result = categorizeError(new Error("Failed to fetch"));
+    expect(result.category).toBe("network");
+  });
+
+  it("falls through to model_unavailable for a plain Error with no shape", () => {
+    const result = categorizeError(new Error("boom"));
+    expect(result.category).toBe("model_unavailable");
+  });
+
+  it("returns network + fallback copy for null", () => {
+    const result = categorizeError(null);
+    expect(result.category).toBe("network");
+    expect(result.message).toMatch(/something went wrong/i);
+  });
+
+  it("returns network + fallback copy for undefined", () => {
+    const result = categorizeError(undefined);
+    expect(result.category).toBe("network");
+    expect(result.message).toMatch(/something went wrong/i);
+  });
+});
+
+describe("errorMessage", () => {
+  it("returns the categorized message when err is present", () => {
+    const message = errorMessage({
+      response: { status: 400, data: { detail: "Bad date" } },
+    });
+    expect(message).toBe("Bad date");
+  });
+
+  it("returns the fallback when err is null and fallback is passed", () => {
+    expect(errorMessage(null, "Could not load.")).toBe("Could not load.");
+  });
+
+  it("returns the default fallback copy when err is null and no fallback", () => {
+    expect(errorMessage(null)).toMatch(/something went wrong/i);
+  });
+});

--- a/frontend/tests/pages/history.test.tsx
+++ b/frontend/tests/pages/history.test.tsx
@@ -87,7 +87,9 @@ describe("HistoryPage", () => {
     const { default: HistoryPage } = await import("@/pages/history");
     render(<HistoryPage />);
     await waitFor(() =>
-      expect(screen.getByText(/no history yet/i)).toBeInTheDocument(),
+      expect(
+        screen.getByText(/use the workspace to analyze a statement\./i),
+      ).toBeInTheDocument(),
     );
   });
 


### PR DESCRIPTION
Frontend-only Wave 3 polish.

- Re-applies the calendar mobile treatment that dropped in the rebase: meeting rows stack badges below the date label under sm, the row button hits 44px on mobile, and CountdownCard tightens padding while the headline stays at 24px+.
- Rewrites the /history list empty state into two branches — "No history yet." when total is zero and "No runs match these filters." when filters hide everything. Test now asserts on the list copy.
- Bumps the header hamburger, AnalyzeForm submit, and sample picker to 44px on sub-sm viewports.
- Adds unit tests for categorizeError + errorMessage covering all four buckets and the fallback paths.

Closes #462.