### PR TITLE
fix(frontend): close #460 wave-2 polish nits

### DIFF
--- a/frontend/lib/analyze/compare.ts
+++ b/frontend/lib/analyze/compare.ts
@@ -214,3 +214,46 @@ export function computeMultiAxisDelta(
     topicChanged,
   };
 }
+
+// One-sentence narrative covering the largest absolute Δ on each
+// available axis. Hides quietly when no axis carries a signal.
+export function buildNarrativeSummary(delta: MultiAxisDelta): string | null {
+  type Bullet = { axis: string; magnitude: number; phrase: string };
+  const candidates: Bullet[] = [];
+  if (delta.stanceRankDelta != null && Number.isFinite(delta.stanceRankDelta)) {
+    candidates.push({
+      axis: "stance",
+      magnitude: Math.abs(delta.stanceRankDelta),
+      phrase:
+        delta.stanceRankDelta > 0
+          ? `Run A is more hawkish on rate guidance (+${delta.stanceRankDelta.toFixed(2)})`
+          : delta.stanceRankDelta < 0
+          ? `Run A is more dovish on rate guidance (${delta.stanceRankDelta.toFixed(2)})`
+          : "Stance unchanged",
+    });
+  }
+  if (delta.factorDelta != null && Number.isFinite(delta.factorDelta)) {
+    candidates.push({
+      axis: "factor",
+      magnitude: Math.abs(delta.factorDelta),
+      phrase:
+        delta.factorDelta > 0
+          ? `more hawkish on inflation tone (+${delta.factorDelta.toFixed(2)})`
+          : delta.factorDelta < 0
+          ? `more dovish on inflation tone (${delta.factorDelta.toFixed(2)})`
+          : "inflation tone unchanged",
+    });
+  }
+  // No usable signal — caller suppresses the callout.
+  if (candidates.length === 0) return null;
+  // When every candidate has zero magnitude there is nothing newsworthy
+  // to surface; treat as "no signal" rather than emitting a confusing
+  // "unchanged but unchanged" sentence.
+  if (candidates.every((c) => c.magnitude === 0)) return null;
+  // Sort by absolute magnitude; primary leads, secondary follows.
+  candidates.sort((a, b) => b.magnitude - a.magnitude);
+  const primary = candidates[0];
+  if (candidates.length === 1) return `${primary.phrase}.`;
+  const secondary = candidates[1];
+  return `${primary.phrase} but ${secondary.phrase}.`;
+}

--- a/frontend/lib/analyze/performance.ts
+++ b/frontend/lib/analyze/performance.ts
@@ -197,3 +197,14 @@ function mean(values: number[]): number {
   if (values.length === 0) return 0;
   return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
+
+// Wald-style 95% half-width for a proportion p over a support of n.
+// Returns null when n is too small for the normal approximation to be
+// meaningful or when p is degenerate (variance ≤ 0). Non-finite inputs
+// also return null so the caller's "—" branch fires.
+export function proportionHalfWidth(p: number | null, n: number): number | null {
+  if (p == null || !Number.isFinite(p) || !Number.isFinite(n) || n < 5) return null;
+  const variance = p * (1 - p);
+  if (variance <= 0) return null;
+  return 1.96 * Math.sqrt(variance / n);
+}

--- a/frontend/pages/calendar.tsx
+++ b/frontend/pages/calendar.tsx
@@ -47,7 +47,10 @@ function ordinalSuffix(n: number): string {
 }
 
 function formatCountdown(targetIso: string, nowMs: number): string {
-  const target = new Date(`${targetIso}T00:00:00`).getTime();
+  // Parse the target as UTC midnight so viewers in every timezone see the
+  // same countdown to the same meeting. The displayed value is still a
+  // relative duration ("in 3d 4h"), which is timezone-agnostic.
+  const target = new Date(`${targetIso}T00:00:00Z`).getTime();
   if (!Number.isFinite(target)) return "—";
   const diffMs = target - nowMs;
   if (diffMs <= 0) return "today";

--- a/frontend/pages/compare.tsx
+++ b/frontend/pages/compare.tsx
@@ -21,6 +21,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { fetchHistory, fetchHistoryRun, resolveApiBaseUrl } from "@/lib/analyze/api";
 import { errorMessage } from "@/lib/analyze/errors";
 import {
+  buildNarrativeSummary,
   computeCompareDelta,
   computeMultiAxisDelta,
   describeStanceShift,
@@ -55,44 +56,6 @@ function annotatedAxisDelta(value: number | null, axis: string): string {
   const direction =
     value > 0 ? `${axis} hawkish` : value < 0 ? `${axis} dovish` : axis;
   return `${sign}${value.toFixed(2)} (${direction})`;
-}
-
-// One-sentence narrative covering the largest absolute Δ on each
-// available axis. Hides quietly when no axis carries a signal.
-function buildNarrativeSummary(delta: MultiAxisDelta): string | null {
-  type Bullet = { axis: string; magnitude: number; phrase: string };
-  const candidates: Bullet[] = [];
-  if (delta.stanceRankDelta != null) {
-    candidates.push({
-      axis: "stance",
-      magnitude: Math.abs(delta.stanceRankDelta),
-      phrase:
-        delta.stanceRankDelta > 0
-          ? `Run A is more hawkish on rate guidance (+${delta.stanceRankDelta.toFixed(2)})`
-          : delta.stanceRankDelta < 0
-          ? `Run A is more dovish on rate guidance (${delta.stanceRankDelta.toFixed(2)})`
-          : "Stance unchanged",
-    });
-  }
-  if (delta.factorDelta != null) {
-    candidates.push({
-      axis: "factor",
-      magnitude: Math.abs(delta.factorDelta),
-      phrase:
-        delta.factorDelta > 0
-          ? `more hawkish on inflation tone (+${delta.factorDelta.toFixed(2)})`
-          : delta.factorDelta < 0
-          ? `more dovish on inflation tone (${delta.factorDelta.toFixed(2)})`
-          : "inflation tone unchanged",
-    });
-  }
-  if (candidates.length === 0) return null;
-  // Sort by absolute magnitude, take up to two for the narrative.
-  candidates.sort((a, b) => b.magnitude - a.magnitude);
-  const primary = candidates[0];
-  if (candidates.length === 1) return `${primary.phrase}.`;
-  const secondary = candidates[1];
-  return `${primary.phrase} but ${secondary.phrase}.`;
 }
 
 function NarrativeSummaryCard({ delta }: { delta: MultiAxisDelta }) {

--- a/frontend/pages/performance.tsx
+++ b/frontend/pages/performance.tsx
@@ -45,6 +45,7 @@ import {
   REGIME_CLASSES,
   aggregateRegimePerformance,
   buildRunRegimeRecord,
+  proportionHalfWidth,
   type RunRegimeRecord,
 } from "@/lib/analyze/performance";
 import type {
@@ -70,15 +71,6 @@ function regimeVariant(label: string | null | undefined): "hawkish" | "dovish" |
   if (label === "high") return "hawkish";
   if (label === "normal") return "neutral";
   return "outline";
-}
-
-// Wald-style 95% half-width for a proportion p over a support of n.
-// Returns null when n is too small for the approximation to be meaningful.
-function proportionHalfWidth(p: number | null, n: number): number | null {
-  if (p == null || !Number.isFinite(p) || n < 5) return null;
-  const variance = p * (1 - p);
-  if (variance <= 0) return null;
-  return 1.96 * Math.sqrt(variance / n);
 }
 
 function formatScoreWithCi(value: number | null, halfWidth: number | null): string {

--- a/frontend/pages/research.tsx
+++ b/frontend/pages/research.tsx
@@ -111,9 +111,9 @@ function bakeoffCallout(section: EncoderBakeoffSection): string | null {
   const sorted = [...section.rows].sort((a, b) => b.macro_f1_mean - a.macro_f1_mean);
   const leader = sorted[0];
   const runner = sorted[1];
-  const gapPp = (leader.macro_f1_mean - runner.macro_f1_mean) * 100;
-  if (!Number.isFinite(gapPp) || gapPp <= 0) return null;
-  return `${leader.encoder_key} leads by ${gapPp.toFixed(1)}pp macro-F1 over ${runner.encoder_key}.`;
+  const gapPoints = (leader.macro_f1_mean - runner.macro_f1_mean) * 100;
+  if (!Number.isFinite(gapPoints) || gapPoints <= 0) return null;
+  return `${leader.encoder_key} leads the overall F1 score by ${gapPoints.toFixed(1)} percentage points over ${runner.encoder_key}.`;
 }
 
 function crossBankCallout(
@@ -143,7 +143,8 @@ function crossBankCallout(
     }
   }
   if (worstDrop <= 0 || !worstSource || !worstTarget) return null;
-  return `Transfer from ${worstSource} to ${worstTarget} drops ${(worstDrop * 100).toFixed(1)}pp ${section.metric_name.replace("_", "-")} vs in-domain.`;
+  const metricLabel = section.metric_name.replace("_", "-");
+  return `Transferring from ${worstSource} to ${worstTarget} drops ${metricLabel} by ${(worstDrop * 100).toFixed(1)} percentage points compared with training and evaluating on the same bank.`;
 }
 
 function EncoderBakeoffPane({ section }: { section: EncoderBakeoffSection }) {

--- a/frontend/tests/components/analyze/HistoryTimelineChart.test.tsx
+++ b/frontend/tests/components/analyze/HistoryTimelineChart.test.tsx
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Recharts renders inside a <ResponsiveContainer> sized via the parent's
+// box, which jsdom collapses to 0×0 — the SVG never paints. The mock
+// below substitutes each primitive with a deterministic <div> that
+// preserves children and the props we want to assert on, so the smoke
+// test can observe presence/absence without driving the real chart.
+vi.mock("recharts", () => {
+  const passthrough =
+    (name: string) =>
+    ({ children, ...rest }: { children?: React.ReactNode } & Record<string, unknown>) => (
+      <div data-testid={`rc-${name}`} data-props={JSON.stringify(rest)}>
+        {children}
+      </div>
+    );
+  return {
+    CartesianGrid: passthrough("cartesian-grid"),
+    ComposedChart: ({ children, data }: { children?: React.ReactNode; data?: unknown[] }) => (
+      <div data-testid="rc-composed-chart" data-row-count={(data ?? []).length}>
+        {children}
+        {/* Expose the per-row scatter dots as discrete nodes so the
+            smoke test can count them and reason about the right-axis
+            vol line covering only the rows that carry the metric. */}
+        {(data ?? []).map((row, idx) => {
+          const r = row as { vol?: number | null; date?: string };
+          return (
+            <div
+              key={idx}
+              data-testid="rc-row"
+              data-has-vol={r.vol != null ? "true" : "false"}
+              data-date={r.date}
+            />
+          );
+        })}
+      </div>
+    ),
+    Line: ({ dataKey, yAxisId }: { dataKey?: string; yAxisId?: string }) => (
+      <div data-testid={`rc-line-${String(dataKey)}`} data-y-axis={yAxisId} />
+    ),
+    ResponsiveContainer: ({ children }: { children?: React.ReactNode }) => (
+      <div data-testid="rc-responsive-container">{children}</div>
+    ),
+    Scatter: ({ dataKey, yAxisId }: { dataKey?: string; yAxisId?: string }) => (
+      <div data-testid={`rc-scatter-${String(dataKey)}`} data-y-axis={yAxisId} />
+    ),
+    Tooltip: () => <div data-testid="rc-tooltip" />,
+    XAxis: () => <div data-testid="rc-x-axis" />,
+    YAxis: ({ yAxisId, orientation }: { yAxisId?: string; orientation?: string }) => (
+      <div
+        data-testid={`rc-y-axis-${String(yAxisId ?? "default")}`}
+        data-orientation={orientation ?? "left"}
+      />
+    ),
+  };
+});
+
+import { HistoryTimelineChart, type HistoryTimelineRow } from "@/components/analyze/HistoryTimelineChart";
+
+function makeRow(overrides: Partial<HistoryTimelineRow> = {}): HistoryTimelineRow {
+  return {
+    id: overrides.id ?? "run-1",
+    created_at: overrides.created_at ?? "2026-04-01T12:00:00Z",
+    symbol: overrides.symbol ?? "^GSPC",
+    document_date: overrides.document_date ?? "2026-04-01",
+    horizon: overrides.horizon ?? "10d",
+    forecast_mode: "fast",
+    stance: overrides.stance ?? "neutral",
+    sentiment_score: overrides.sentiment_score ?? 0,
+    predicted_close: null,
+    current_close: null,
+    predicted_volatility: null,
+    text_excerpt: null,
+    argmax_regime: overrides.argmax_regime ?? "normal",
+    argmax_probability: 0.5,
+    regime_set_size: 2,
+    forward_realized_vol_10d: overrides.forward_realized_vol_10d ?? null,
+  };
+}
+
+describe("HistoryTimelineChart", () => {
+  it("renders the empty-state card when rows is empty", () => {
+    render(<HistoryTimelineChart rows={[]} />);
+    expect(screen.getByText(/No history yet/i)).toBeInTheDocument();
+    // No chart canvas should mount in the empty branch.
+    expect(screen.queryByTestId("rc-composed-chart")).toBeNull();
+  });
+
+  it("renders one dot per row with mixed regimes and no collisions", () => {
+    const rows = [
+      makeRow({ id: "a", document_date: "2026-03-01", argmax_regime: "calm", sentiment_score: -0.7 }),
+      makeRow({ id: "b", document_date: "2026-03-08", argmax_regime: "normal", sentiment_score: 0.1 }),
+      makeRow({ id: "c", document_date: "2026-03-15", argmax_regime: "high", sentiment_score: 0.8 }),
+    ];
+    render(<HistoryTimelineChart rows={rows} />);
+    const chart = screen.getByTestId("rc-composed-chart");
+    expect(chart).toHaveAttribute("data-row-count", "3");
+    // Scatter dots are emitted as one node per row; uniqueness on the
+    // x-axis (document_date) means there are no overlapping label
+    // collisions for this fixture.
+    const dots = screen.getAllByTestId("rc-row");
+    expect(dots).toHaveLength(3);
+    const dates = dots.map((node) => node.getAttribute("data-date"));
+    expect(new Set(dates).size).toBe(3);
+    // The stance scatter primitive is mounted exactly once.
+    expect(screen.getByTestId("rc-scatter-stance")).toBeInTheDocument();
+  });
+
+  it("hides the right-hand vol axis when no row carries forward_realized_vol_10d", () => {
+    const rows = [
+      makeRow({ id: "a", document_date: "2026-03-01" }),
+      makeRow({ id: "b", document_date: "2026-03-08" }),
+    ];
+    render(<HistoryTimelineChart rows={rows} />);
+    expect(screen.queryByTestId("rc-y-axis-vol")).toBeNull();
+    expect(screen.queryByTestId("rc-line-vol")).toBeNull();
+    // Card copy mirrors the axis state so the user sees a matching note.
+    expect(screen.getByText(/No forward vol data on these rows\./i)).toBeInTheDocument();
+  });
+
+  it("shows the right axis and the vol line, with vol present only on the rows that carry it", () => {
+    const rows = [
+      makeRow({ id: "a", document_date: "2026-03-01", forward_realized_vol_10d: 0.12 }),
+      makeRow({ id: "b", document_date: "2026-03-08", forward_realized_vol_10d: null }),
+      makeRow({ id: "c", document_date: "2026-03-15", forward_realized_vol_10d: 0.18 }),
+    ];
+    render(<HistoryTimelineChart rows={rows} />);
+    // Right axis primitive is mounted and orientation is right.
+    const volAxis = screen.getByTestId("rc-y-axis-vol");
+    expect(volAxis).toHaveAttribute("data-orientation", "right");
+    // The vol line is bound to the vol axis.
+    const volLine = screen.getByTestId("rc-line-vol");
+    expect(volLine).toHaveAttribute("data-y-axis", "vol");
+    // Only the two rows carrying a numeric vol contribute to the line;
+    // the middle row is rendered but its vol slot stays null so the
+    // primitive's connectNulls bridge is the only thing joining the
+    // two real points.
+    const dots = screen.getAllByTestId("rc-row");
+    const volBearing = dots.filter((node) => node.getAttribute("data-has-vol") === "true");
+    expect(volBearing).toHaveLength(2);
+    expect(volBearing.map((d) => d.getAttribute("data-date"))).toEqual([
+      "2026-03-01",
+      "2026-03-15",
+    ]);
+  });
+});

--- a/frontend/tests/lib/analyze/compare.test.ts
+++ b/frontend/tests/lib/analyze/compare.test.ts
@@ -1,12 +1,27 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildNarrativeSummary,
   computeCompareDelta,
   computeMultiAxisDelta,
   computeRegimeDelta,
   describeStanceShift,
+  type MultiAxisDelta,
 } from "@/lib/analyze/compare";
 import type { HistoryDetail } from "@/lib/analyze/types";
+
+function makeMultiAxisDelta(overrides: Partial<MultiAxisDelta> = {}): MultiAxisDelta {
+  return {
+    stanceRankDelta: null,
+    stanceConfidenceDelta: null,
+    factorDelta: null,
+    factorConfidenceDelta: null,
+    certaintyConfidenceDelta: null,
+    certaintyShift: "unknown",
+    topicChanged: null,
+    ...overrides,
+  };
+}
 
 function makeDetail(overrides: Partial<HistoryDetail> & { payload?: Record<string, unknown> }): HistoryDetail {
   return {
@@ -175,5 +190,54 @@ describe("computeMultiAxisDelta", () => {
     expect(d.factorDelta).toBe(null);
     expect(d.certaintyShift).toBe("unknown");
     expect(d.topicChanged).toBe(null);
+  });
+});
+
+describe("buildNarrativeSummary", () => {
+  it("leads with the largest absolute stance delta when stance dominates", () => {
+    const sentence = buildNarrativeSummary(
+      makeMultiAxisDelta({ stanceRankDelta: 1.5, factorDelta: 0.2 }),
+    );
+    expect(sentence).not.toBeNull();
+    // Stance wins the primary clause.
+    expect(sentence!.startsWith("Run A is more hawkish on rate guidance")).toBe(true);
+    // Factor is demoted to the secondary clause.
+    expect(sentence).toContain("but more hawkish on inflation tone");
+  });
+
+  it("leads with the largest absolute factor delta when factor dominates", () => {
+    const sentence = buildNarrativeSummary(
+      makeMultiAxisDelta({ stanceRankDelta: 0.1, factorDelta: -0.9 }),
+    );
+    expect(sentence).not.toBeNull();
+    // Factor leads with a dovish framing.
+    expect(sentence!.startsWith("more dovish on inflation tone")).toBe(true);
+  });
+
+  it("returns null when both axes carry a zero delta", () => {
+    const sentence = buildNarrativeSummary(
+      makeMultiAxisDelta({ stanceRankDelta: 0, factorDelta: 0 }),
+    );
+    expect(sentence).toBeNull();
+  });
+
+  it("returns null when neither axis is present", () => {
+    expect(buildNarrativeSummary(makeMultiAxisDelta())).toBeNull();
+  });
+
+  it("handles mixed signs across the two axes", () => {
+    const sentence = buildNarrativeSummary(
+      makeMultiAxisDelta({ stanceRankDelta: 0.8, factorDelta: -0.4 }),
+    );
+    expect(sentence).not.toBeNull();
+    expect(sentence).toContain("more hawkish on rate guidance");
+    expect(sentence).toContain("more dovish on inflation tone");
+  });
+
+  it("returns null when both inputs are NaN", () => {
+    const sentence = buildNarrativeSummary(
+      makeMultiAxisDelta({ stanceRankDelta: Number.NaN, factorDelta: Number.NaN }),
+    );
+    expect(sentence).toBeNull();
   });
 });

--- a/frontend/tests/lib/analyze/performance.test.ts
+++ b/frontend/tests/lib/analyze/performance.test.ts
@@ -4,6 +4,7 @@ import {
   REGIME_CLASSES,
   aggregateRegimePerformance,
   buildRunRegimeRecord,
+  proportionHalfWidth,
 } from "@/lib/analyze/performance";
 import type { HistoryEntry, HistoryRealizedResponse } from "@/lib/analyze/types";
 
@@ -120,5 +121,32 @@ describe("aggregateRegimePerformance", () => {
     expect(agg.empiricalCoverage).toBe(null);
     expect(agg.macroF1).toBe(null);
     expect(agg.perClass.map((entry) => entry.klass)).toEqual([...REGIME_CLASSES]);
+  });
+});
+
+describe("proportionHalfWidth", () => {
+  it("returns the canonical Wald half-width for p=0.5, n=100", () => {
+    // 1.96 * sqrt(0.25 / 100) = 1.96 * 0.05 = 0.098.
+    const value = proportionHalfWidth(0.5, 100);
+    expect(value).not.toBeNull();
+    expect(value!).toBeCloseTo(0.098, 5);
+  });
+
+  it("returns null at the degenerate endpoints (p=0 and p=1)", () => {
+    expect(proportionHalfWidth(0, 100)).toBeNull();
+    expect(proportionHalfWidth(1, 100)).toBeNull();
+  });
+
+  it("returns null when the support is too small for the normal approximation", () => {
+    expect(proportionHalfWidth(0.5, 4)).toBeNull();
+    expect(proportionHalfWidth(0.5, 0)).toBeNull();
+  });
+
+  it("returns null on non-finite inputs", () => {
+    expect(proportionHalfWidth(Number.NaN, 100)).toBeNull();
+    expect(proportionHalfWidth(Number.POSITIVE_INFINITY, 100)).toBeNull();
+    expect(proportionHalfWidth(0.5, Number.NaN)).toBeNull();
+    expect(proportionHalfWidth(0.5, Number.POSITIVE_INFINITY)).toBeNull();
+    expect(proportionHalfWidth(null, 100)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Calendar countdown now anchors on UTC midnight so every timezone sees the same value.
- Research bake-off + cross-bank callouts re-jargonized macro-F1 / pp; rewritten in plain English.
- Extracted buildNarrativeSummary into lib/analyze/compare.ts and proportionHalfWidth into lib/analyze/performance.ts, with unit coverage for the requested edge cases.
- Smoke-tested HistoryTimelineChart against empty rows, mixed regimes, and the forward-vol axis toggling.

Closes #460.

## Test plan
- [x] npm run type-check
- [x] npm run build
- [x] npm test (183 / 183)