### PR TITLE
audit events.parquet coverage before sweeps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -128,6 +128,11 @@ data-prep:
 		--feature-version "$(FEATURE_VERSION)" \
 		--owner "$(OWNER)" \
 		$(if $(TRAINING_PACKAGE_ID),--training-package-id "$(TRAINING_PACKAGE_ID)",)
+
+audit-training-package:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	python -m scripts.audit_training_package_coverage \
+		--training-package-id "$(TRAINING_PACKAGE_ID)"
 
 train-smoke:
 	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)

--- a/scripts/audit_training_package_coverage.py
+++ b/scripts/audit_training_package_coverage.py
@@ -132,9 +132,11 @@ SIDECAR_FILES: dict[str, dict[str, object]] = {
     },
 }
 
-# Canonical source / event_kind values emitted by
-# ``backend/app/data/source_type.py`` and recorded in events.parquet
-# under the ``event_kind`` column. The pinned TP carries 6 event_kinds.
+# Canonical event_kind values per ``backend/app/data/schemas.py::
+# _ALLOWED_EVENT_KIND``. event_kind is the document-type axis (what kind
+# of FOMC artefact is this row) and is distinct from source_type (which
+# data provider). The narrower event_kind set above is what
+# events.parquet rows carry.
 EXPECTED_EVENT_KINDS = {
     "statement",
     "minutes",
@@ -142,10 +144,6 @@ EXPECTED_EVENT_KINDS = {
     "speech",
     "testimony",
     "macro_release",
-    "beige_book",
-    "regional_research",
-    "chair_speech",
-    "governor_speech",
 }
 
 

--- a/scripts/audit_training_package_coverage.py
+++ b/scripts/audit_training_package_coverage.py
@@ -1,23 +1,37 @@
-"""Audit a training package's events.parquet for column coverage.
+"""Audit a training package's events.parquet + sidecars for column coverage.
 
 Run before any sweep to confirm every feature family the trainer flag
-surface targets is materialised on the dataset. The sweep loop is
-expensive — a sparse or missing column burns GPU hours producing
-fallback baselines instead of the methodology cell the operator wanted.
+surface targets is materialised. The sweep loop is expensive — a sparse
+or missing column burns GPU hours producing fallback baselines instead
+of the methodology cell the operator wanted.
+
+The audit splits checks into two layers:
+
+- **events.parquet columns**: the canonical row schema emitted by
+  ``backend/app/data/event_dataset_builder.py`` and validated by
+  ``backend/app/data/schemas.py::EventRowSchema``.
+- **Sidecar parquets**: lookup files that the training loaders consume
+  alongside events.parquet (press-conference Q&A, SEP projections,
+  per-asset close caches). These do not live on events.parquet but
+  drive feature flags the trainer reads.
+
+Both layers are inventoried; only events.parquet failures gate the
+sweep, sidecar gaps are reported as warnings (the trainer's flags
+default off and degrade gracefully).
 
 Usage:
 
     python -m scripts.audit_training_package_coverage \
         --training-package-id tp_v3_phase3_<version>
 
-Exits non-zero when a required column is missing or under-populated.
-Optional columns are reported but do not fail the audit (they reflect
-ongoing data work).
+Exits non-zero when a required events.parquet column is missing or
+under-populated. Sidecar gaps are reported but do not fail the audit.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -25,18 +39,34 @@ import pandas as pd
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_PROCESSED = REPO_ROOT / "data" / "processed"
+DEFAULT_EXTERNAL = REPO_ROOT / "data" / "external"
 
 # Sparse threshold: a required column with less than this share of rows
-# populated counts as a failure. Set conservatively — most columns
-# should be populated on most rows.
+# populated counts as a failure. Set conservatively.
 DEFAULT_SPARSE_THRESHOLD_PCT = 50.0
 
-# Required column families. Each entry: family label → list of column
-# names that must exist AND be at least `SPARSE_THRESHOLD_PCT` populated.
-REQUIRED_FAMILIES: dict[str, list[str]] = {
-    "rates_panel": [
-        "forward_yield_2y_change_5d",
-        "forward_yield_terminal_change_5d",
+# Required events.parquet column families. Each entry: family label →
+# (column names that must exist AND be at least sparse_threshold
+# populated, optional issue/PR reference). Column names verified against
+# ``backend/app/data/schemas.py`` and the loader sidecars.
+#
+# Note: press_conference QA, SEP projections, and per-asset close caches
+# do NOT live on events.parquet — they live in sidecar parquets and are
+# reported under SIDECAR_FILES below.
+REQUIRED_EVENT_FAMILIES: dict[str, list[str]] = {
+    "canonical_target": [
+        "forward_realized_vol_10d",
+    ],
+    "rates_panel_pre_meeting": [
+        "pre_meeting_yield_1y",
+        "pre_meeting_yield_2y",
+        "pre_meeting_yield_5y",
+        "pre_meeting_yield_10y",
+    ],
+    "rates_panel_change_5d": [
+        "yield_2y_change_5d",
+        "yield_5y_change_5d",
+        "terminal_rate_change_5d",
     ],
     "garch_residual": [
         "forward_realized_vol_10d_garch_baseline",
@@ -54,31 +84,20 @@ REQUIRED_FAMILIES: dict[str, list[str]] = {
         "dissent_count",
         "dissent_direction",
     ],
-    "press_conference": [
-        "qa_text",
-        "qa_embedding",
-        "has_press_conf",
-    ],
-    "sep_next_year": [
-        "ffr_median_next_year",
-    ],
-    "canonical_target": [
-        "forward_realized_vol_10d",
-    ],
 }
 
-# Optional column families: presence reported but absence does NOT fail.
-# These reflect feature additions that may or may not be on the current
-# dataset version depending on which builders ran.
-OPTIONAL_FAMILIES: dict[str, list[str]] = {
-    "multi_horizon": [
+# Optional events.parquet column families: presence reported, absence
+# does NOT fail the audit. Reflects feature additions that may or may
+# not have a builder firing on the current rebuild.
+OPTIONAL_EVENT_FAMILIES: dict[str, list[str]] = {
+    "multi_horizon_vol": [
         "forward_realized_vol_1d",
         "forward_realized_vol_3d",
         "forward_realized_vol_5d",
         "forward_realized_vol_20d",
         "forward_realized_vol_30d",
     ],
-    "per_asset_targets": [
+    "per_asset_vol": [
         "forward_realized_vol_10d_gspc",
         "forward_realized_vol_10d_ndx",
         "forward_realized_vol_10d_dji",
@@ -90,17 +109,43 @@ OPTIONAL_FAMILIES: dict[str, list[str]] = {
     ],
 }
 
-EXPECTED_SOURCE_TYPES = {
-    "fomc_statement",
-    "fomc_minutes",
-    "fomc_meeting_transcript",
+# Sidecar parquet files the training loader reads alongside events.parquet.
+# Each entry: family label → (relative path under the training-package dir
+# OR a list of fallback paths under data/external/, required columns on
+# the sidecar). Missing sidecars do not fail the audit — they degrade
+# trainer flags that default off — but the report surfaces them so the
+# operator knows which feature flags will silently no-op.
+SIDECAR_FILES: dict[str, dict[str, object]] = {
+    "press_conference_qa": {
+        "package_path": "qa_lookup.parquet",
+        "external_paths": ["fomc_press_conferences/qa_lookup.parquet"],
+        "expected_columns": ["qa_text", "has_press_conf"],
+    },
+    "sep_projections": {
+        "package_path": "sep_projections.parquet",
+        "external_paths": ["fred/sep_projections.parquet"],
+        "expected_columns": [
+            "ffr_median_current_year",
+            "ffr_median_next_year",
+            "ffr_median_longer_run",
+        ],
+    },
+}
+
+# Canonical source / event_kind values emitted by
+# ``backend/app/data/source_type.py`` and recorded in events.parquet
+# under the ``event_kind`` column. The pinned TP carries 6 event_kinds.
+EXPECTED_EVENT_KINDS = {
+    "statement",
+    "minutes",
     "press_conference",
     "speech",
     "testimony",
+    "macro_release",
     "beige_book",
-    "ny_fed",
-    "op_fed",
-    "gss_factor_decomposition",
+    "regional_research",
+    "chair_speech",
+    "governor_speech",
 }
 
 
@@ -130,6 +175,127 @@ def _check_column(
     return "ok", True, populated_int, n
 
 
+def _audit_event_families(
+    df: pd.DataFrame, sparse_threshold: float
+) -> list[str]:
+    """Walk required event-schema families. Return list of failure
+    descriptions; empty list means everything passed.
+    """
+    failures: list[str] = []
+
+    print("=== REQUIRED EVENTS.PARQUET FAMILIES ===")
+    for family, columns in REQUIRED_EVENT_FAMILIES.items():
+        print(f"\n[{family}]")
+        for column in columns:
+            status, ok, n_pop, n = _check_column(df, column, sparse_threshold)
+            marker = "OK " if ok else "FAIL"
+            line = (
+                f"  {marker} {column:55s} {_format_pct(n_pop, n)} "
+                f"({n_pop}/{n}) [{status}]"
+            )
+            print(line)
+            if not ok:
+                failures.append(f"{family}: {column} ({status})")
+
+    print("\n=== OPTIONAL EVENTS.PARQUET FAMILIES (presence reported) ===")
+    n_total = len(df)
+    for family, columns in OPTIONAL_EVENT_FAMILIES.items():
+        print(f"\n[{family}]")
+        for column in columns:
+            if column in df.columns:
+                n_pop = int(df[column].notna().sum())
+                print(
+                    f"  PRESENT {column:53s} {_format_pct(n_pop, n_total)} "
+                    f"({n_pop}/{n_total})"
+                )
+            else:
+                print(f"  ABSENT  {column}")
+
+    return failures
+
+
+def _audit_event_kind_distribution(df: pd.DataFrame) -> None:
+    """Print the event_kind value_counts. The current schema uses the
+    ``event_kind`` column for the corpus-diversity axis; the canonical
+    catalog lives in ``backend/app/data/source_type.py``. Missing event
+    kinds are reported but do not fail the audit — they reflect
+    upstream-data gaps tracked separately.
+    """
+    print("\n=== EVENT_KIND DISTRIBUTION ===")
+    if "event_kind" not in df.columns:
+        print("  event_kind column not present on this training package")
+        return
+    counts = df["event_kind"].value_counts(dropna=False)
+    for kind, count in counts.items():
+        in_expected = (
+            "canonical" if str(kind) in EXPECTED_EVENT_KINDS else "unknown"
+        )
+        print(f"  {str(kind):40s} {count:6d}  [{in_expected}]")
+    missing = EXPECTED_EVENT_KINDS - set(map(str, counts.index))
+    if missing:
+        print("\n  Canonical event kinds with zero rows on this package:")
+        for kind in sorted(missing):
+            print(f"    - {kind}")
+        print(
+            "\n  (Adapter ingestion gaps are tracked in #485; missing "
+            "event_kinds do NOT fail the audit.)"
+        )
+
+
+def _resolve_sidecar(
+    package_dir: Path, package_path: str, external_paths: list[str]
+) -> tuple[Path | None, str]:
+    """Return (resolved path or None, source label).
+
+    Walks the package directory first (sidecar shipped with the TP),
+    then falls back to the repo's data/external/ tree.
+    """
+    candidate = package_dir / package_path
+    if candidate.exists():
+        return candidate, "package"
+    for relative in external_paths:
+        candidate = DEFAULT_EXTERNAL / relative
+        if candidate.exists():
+            return candidate, "external"
+    return None, "missing"
+
+
+def _audit_sidecars(package_dir: Path, sparse_threshold: float) -> None:
+    """Walk sidecar parquets. Report-only; sidecar gaps do not fail
+    the audit (the corresponding trainer flags default off).
+    """
+    print("\n=== SIDECAR PARQUETS (report only — flags default off) ===")
+    for family, spec in SIDECAR_FILES.items():
+        print(f"\n[{family}]")
+        pkg_path = str(spec["package_path"])
+        ext_paths = list(spec["external_paths"])  # type: ignore[arg-type]
+        expected = list(spec["expected_columns"])  # type: ignore[arg-type]
+        resolved, source_label = _resolve_sidecar(
+            package_dir, pkg_path, ext_paths
+        )
+        if resolved is None:
+            print(f"  ABSENT  expected at {pkg_path} (package) or one of:")
+            for relative in ext_paths:
+                print(f"            data/external/{relative}")
+            continue
+        print(f"  PRESENT {resolved.relative_to(REPO_ROOT)} [{source_label}]")
+        try:
+            sidecar_df = pd.read_parquet(resolved)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  ERROR   could not read sidecar: {exc}")
+            continue
+        n_rows = len(sidecar_df)
+        for column in expected:
+            if column not in sidecar_df.columns:
+                print(f"  MISS    {column}  (sidecar column missing)")
+                continue
+            n_pop = int(sidecar_df[column].notna().sum())
+            print(
+                f"  COL     {column:50s} {_format_pct(n_pop, n_rows)} "
+                f"({n_pop}/{n_rows})"
+            )
+
+
 def audit(
     events_parquet: Path, sparse_threshold: float = DEFAULT_SPARSE_THRESHOLD_PCT
 ) -> int:
@@ -143,49 +309,9 @@ def audit(
     print(f"rows: {n_total}, columns: {len(df.columns)}")
     print()
 
-    failures: list[str] = []
-
-    print("=== REQUIRED FAMILIES ===")
-    for family, columns in REQUIRED_FAMILIES.items():
-        print(f"\n[{family}]")
-        for column in columns:
-            status, ok, n_pop, n = _check_column(df, column, sparse_threshold)
-            marker = "OK " if ok else "FAIL"
-            line = (
-                f"  {marker} {column:50s} {_format_pct(n_pop, n)} ({n_pop}/{n}) [{status}]"
-            )
-            print(line)
-            if not ok:
-                failures.append(f"{family}: {column} ({status})")
-
-    print("\n=== OPTIONAL FAMILIES (presence reported) ===")
-    for family, columns in OPTIONAL_FAMILIES.items():
-        print(f"\n[{family}]")
-        for column in columns:
-            if column in df.columns:
-                n_pop = int(df[column].notna().sum())
-                print(
-                    f"  PRESENT {column:48s} {_format_pct(n_pop, n_total)} ({n_pop}/{n_total})"
-                )
-            else:
-                print(f"  ABSENT  {column}")
-
-    print("\n=== SOURCE TYPE COVERAGE ===")
-    if "source_type" in df.columns:
-        counts = df["source_type"].value_counts(dropna=False)
-        for kind, count in counts.items():
-            in_expected = (
-                "expected" if str(kind) in EXPECTED_SOURCE_TYPES else "unexpected"
-            )
-            print(f"  {str(kind):40s} {count:6d}  [{in_expected}]")
-        missing_kinds = EXPECTED_SOURCE_TYPES - set(map(str, counts.index))
-        if missing_kinds:
-            print("\n  Expected source_types with zero rows:")
-            for kind in sorted(missing_kinds):
-                print(f"    - {kind}")
-    else:
-        print("  source_type column not present")
-        failures.append("source_type: column missing")
+    failures = _audit_event_families(df, sparse_threshold)
+    _audit_event_kind_distribution(df)
+    _audit_sidecars(events_parquet.parent, sparse_threshold)
 
     print()
     if failures:
@@ -193,22 +319,26 @@ def audit(
         for line in failures:
             print(f"  - {line}")
         print(
-            "\nDo not run sweeps against this training package until the failures "
-            "are resolved. Either re-run the source ingestion + data-prep "
+            "\nDo not run sweeps against this training package until the "
+            "failures are resolved. Either re-run the ingestion + data-prep "
             "rebuild, or drop the affected sweep from the batch."
         )
         return 1
 
     print("=== AUDIT PASSED ===")
-    print("Every required column is present and populated above the sparse threshold.")
-    print("Optional columns are reported above; absent ones reflect ongoing data work.")
+    print(
+        "Every required events.parquet column is present and populated "
+        "above the sparse threshold. Sidecar gaps and event-kind coverage "
+        "are reported above; address them per #485 if the cross-source "
+        "matrix is on the sweep batch."
+    )
     return 0
 
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Audit a training package's events.parquet for column coverage "
+            "Audit a training package's events.parquet + sidecar coverage "
             "before running a sweep."
         )
     )
@@ -234,8 +364,15 @@ def _parse_args() -> argparse.Namespace:
         default=DEFAULT_SPARSE_THRESHOLD_PCT,
         help=(
             "Required columns populated below this share of rows fail the "
-            "audit (default 50.0)."
+            "audit (default 50.0). At 0.0 any non-empty column passes; at "
+            "100.0 only fully-populated columns pass."
         ),
+    )
+    parser.add_argument(
+        "--json-summary",
+        type=Path,
+        required=False,
+        help="Optional path to write a one-line JSON summary of the audit.",
     )
     return parser.parse_args()
 
@@ -252,7 +389,19 @@ def main() -> int:
         target = args.events_parquet
     else:
         target = DEFAULT_PROCESSED / args.training_package_id / "events.parquet"
-    return audit(target, sparse_threshold=args.sparse_threshold_pct)
+    exit_code = audit(target, sparse_threshold=args.sparse_threshold_pct)
+    if args.json_summary:
+        args.json_summary.parent.mkdir(parents=True, exist_ok=True)
+        args.json_summary.write_text(
+            json.dumps(
+                {
+                    "events_parquet": str(target),
+                    "exit_code": exit_code,
+                    "sparse_threshold_pct": args.sparse_threshold_pct,
+                }
+            )
+        )
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/scripts/audit_training_package_coverage.py
+++ b/scripts/audit_training_package_coverage.py
@@ -1,0 +1,259 @@
+"""Audit a training package's events.parquet for column coverage.
+
+Run before any sweep to confirm every feature family the trainer flag
+surface targets is materialised on the dataset. The sweep loop is
+expensive — a sparse or missing column burns GPU hours producing
+fallback baselines instead of the methodology cell the operator wanted.
+
+Usage:
+
+    python -m scripts.audit_training_package_coverage \
+        --training-package-id tp_v3_phase3_<version>
+
+Exits non-zero when a required column is missing or under-populated.
+Optional columns are reported but do not fail the audit (they reflect
+ongoing data work).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PROCESSED = REPO_ROOT / "data" / "processed"
+
+# Sparse threshold: a required column with less than this share of rows
+# populated counts as a failure. Set conservatively — most columns
+# should be populated on most rows.
+DEFAULT_SPARSE_THRESHOLD_PCT = 50.0
+
+# Required column families. Each entry: family label → list of column
+# names that must exist AND be at least `SPARSE_THRESHOLD_PCT` populated.
+REQUIRED_FAMILIES: dict[str, list[str]] = {
+    "rates_panel": [
+        "forward_yield_2y_change_5d",
+        "forward_yield_terminal_change_5d",
+    ],
+    "garch_residual": [
+        "forward_realized_vol_10d_garch_baseline",
+        "forward_realized_vol_10d_garch_residual",
+    ],
+    "statement_delta": [
+        "statement_delta_inserted",
+        "statement_delta_deleted",
+        "statement_delta_substituted_pairs",
+        "statement_delta_embedding",
+    ],
+    "vote_tally": [
+        "votes_for",
+        "votes_against",
+        "dissent_count",
+        "dissent_direction",
+    ],
+    "press_conference": [
+        "qa_text",
+        "qa_embedding",
+        "has_press_conf",
+    ],
+    "sep_next_year": [
+        "ffr_median_next_year",
+    ],
+    "canonical_target": [
+        "forward_realized_vol_10d",
+    ],
+}
+
+# Optional column families: presence reported but absence does NOT fail.
+# These reflect feature additions that may or may not be on the current
+# dataset version depending on which builders ran.
+OPTIONAL_FAMILIES: dict[str, list[str]] = {
+    "multi_horizon": [
+        "forward_realized_vol_1d",
+        "forward_realized_vol_3d",
+        "forward_realized_vol_5d",
+        "forward_realized_vol_20d",
+        "forward_realized_vol_30d",
+    ],
+    "per_asset_targets": [
+        "forward_realized_vol_10d_gspc",
+        "forward_realized_vol_10d_ndx",
+        "forward_realized_vol_10d_dji",
+        "forward_realized_vol_10d_dxy",
+        "forward_realized_vol_10d_vix",
+        "forward_realized_vol_10d_eurusd",
+        "forward_realized_vol_10d_usdjpy",
+        "forward_realized_vol_10d_gbpusd",
+    ],
+}
+
+EXPECTED_SOURCE_TYPES = {
+    "fomc_statement",
+    "fomc_minutes",
+    "fomc_meeting_transcript",
+    "press_conference",
+    "speech",
+    "testimony",
+    "beige_book",
+    "ny_fed",
+    "op_fed",
+    "gss_factor_decomposition",
+}
+
+
+def _format_pct(n_pop: int, n_total: int) -> str:
+    pct = 100.0 * n_pop / n_total if n_total else 0.0
+    return f"{pct:5.1f}%"
+
+
+def _check_column(
+    df: pd.DataFrame, column: str, sparse_threshold: float
+) -> tuple[str, bool, int, int]:
+    """Return (status, ok, n_populated, n_total).
+
+    status is one of: 'missing', 'empty', 'sparse', 'ok'. ok is False
+    when the column should fail the audit.
+    """
+    n = len(df)
+    if column not in df.columns:
+        return "missing", False, 0, n
+    populated = df[column].notna().sum()
+    populated_int = int(populated)
+    if populated_int == 0:
+        return "empty", False, 0, n
+    pct = 100.0 * populated_int / n if n else 0.0
+    if pct < sparse_threshold:
+        return "sparse", False, populated_int, n
+    return "ok", True, populated_int, n
+
+
+def audit(
+    events_parquet: Path, sparse_threshold: float = DEFAULT_SPARSE_THRESHOLD_PCT
+) -> int:
+    if not events_parquet.exists():
+        print(f"events.parquet not found at {events_parquet}", file=sys.stderr)
+        return 2
+
+    df = pd.read_parquet(events_parquet)
+    n_total = len(df)
+    print(f"events.parquet: {events_parquet}")
+    print(f"rows: {n_total}, columns: {len(df.columns)}")
+    print()
+
+    failures: list[str] = []
+
+    print("=== REQUIRED FAMILIES ===")
+    for family, columns in REQUIRED_FAMILIES.items():
+        print(f"\n[{family}]")
+        for column in columns:
+            status, ok, n_pop, n = _check_column(df, column, sparse_threshold)
+            marker = "OK " if ok else "FAIL"
+            line = (
+                f"  {marker} {column:50s} {_format_pct(n_pop, n)} ({n_pop}/{n}) [{status}]"
+            )
+            print(line)
+            if not ok:
+                failures.append(f"{family}: {column} ({status})")
+
+    print("\n=== OPTIONAL FAMILIES (presence reported) ===")
+    for family, columns in OPTIONAL_FAMILIES.items():
+        print(f"\n[{family}]")
+        for column in columns:
+            if column in df.columns:
+                n_pop = int(df[column].notna().sum())
+                print(
+                    f"  PRESENT {column:48s} {_format_pct(n_pop, n_total)} ({n_pop}/{n_total})"
+                )
+            else:
+                print(f"  ABSENT  {column}")
+
+    print("\n=== SOURCE TYPE COVERAGE ===")
+    if "source_type" in df.columns:
+        counts = df["source_type"].value_counts(dropna=False)
+        for kind, count in counts.items():
+            in_expected = (
+                "expected" if str(kind) in EXPECTED_SOURCE_TYPES else "unexpected"
+            )
+            print(f"  {str(kind):40s} {count:6d}  [{in_expected}]")
+        missing_kinds = EXPECTED_SOURCE_TYPES - set(map(str, counts.index))
+        if missing_kinds:
+            print("\n  Expected source_types with zero rows:")
+            for kind in sorted(missing_kinds):
+                print(f"    - {kind}")
+    else:
+        print("  source_type column not present")
+        failures.append("source_type: column missing")
+
+    print()
+    if failures:
+        print("=== AUDIT FAILED ===")
+        for line in failures:
+            print(f"  - {line}")
+        print(
+            "\nDo not run sweeps against this training package until the failures "
+            "are resolved. Either re-run the source ingestion + data-prep "
+            "rebuild, or drop the affected sweep from the batch."
+        )
+        return 1
+
+    print("=== AUDIT PASSED ===")
+    print("Every required column is present and populated above the sparse threshold.")
+    print("Optional columns are reported above; absent ones reflect ongoing data work.")
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Audit a training package's events.parquet for column coverage "
+            "before running a sweep."
+        )
+    )
+    parser.add_argument(
+        "--training-package-id",
+        type=str,
+        required=False,
+        help=(
+            "Training package id; resolves to "
+            "data/processed/<id>/events.parquet. Mutually exclusive with "
+            "--events-parquet."
+        ),
+    )
+    parser.add_argument(
+        "--events-parquet",
+        type=Path,
+        required=False,
+        help="Direct path to an events.parquet file.",
+    )
+    parser.add_argument(
+        "--sparse-threshold-pct",
+        type=float,
+        default=DEFAULT_SPARSE_THRESHOLD_PCT,
+        help=(
+            "Required columns populated below this share of rows fail the "
+            "audit (default 50.0)."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.training_package_id and not args.events_parquet:
+        print(
+            "one of --training-package-id or --events-parquet is required",
+            file=sys.stderr,
+        )
+        return 2
+    if args.events_parquet:
+        target = args.events_parquet
+    else:
+        target = DEFAULT_PROCESSED / args.training_package_id / "events.parquet"
+    return audit(target, sparse_threshold=args.sparse_threshold_pct)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_audit_training_package_coverage.py
+++ b/tests/unit/test_audit_training_package_coverage.py
@@ -1,48 +1,52 @@
-"""Smoke tests for the coverage audit script."""
+"""Tests for the coverage audit script.
+
+The required column families exercised here are the actual events.parquet
+column names from ``backend/app/data/schemas.py``. The audit also walks
+sidecar parquets (press-conf Q&A, SEP projections); those are reported
+but do NOT fail the audit.
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 import pandas as pd
-import pytest
 
 from scripts.audit_training_package_coverage import (
-    REQUIRED_FAMILIES,
+    REQUIRED_EVENT_FAMILIES,
     _check_column,
     audit,
 )
 
 
-def _all_required_columns() -> list[str]:
+def _all_required_event_columns() -> list[str]:
     columns: list[str] = []
-    for cols in REQUIRED_FAMILIES.values():
+    for cols in REQUIRED_EVENT_FAMILIES.values():
         columns.extend(cols)
     return columns
 
 
-def _make_full_dataframe(n: int = 10) -> pd.DataFrame:
-    data: dict[str, list[float | str | int]] = {}
-    for column in _all_required_columns():
-        if column in {
-            "statement_delta_inserted",
-            "statement_delta_deleted",
-            "statement_delta_substituted_pairs",
-            "qa_text",
-            "dissent_direction",
-        }:
+def _make_full_event_dataframe(n: int = 10) -> pd.DataFrame:
+    """Build a synthetic events.parquet frame with every required column
+    populated. The string-typed columns get text; numeric columns get
+    floats.
+    """
+    string_cols = {
+        "statement_delta_inserted",
+        "statement_delta_deleted",
+        "statement_delta_substituted_pairs",
+        "dissent_direction",
+    }
+    list_cols = {"statement_delta_embedding"}
+    data: dict[str, list[object]] = {}
+    for column in _all_required_event_columns():
+        if column in string_cols:
             data[column] = ["text"] * n
-        elif column == "statement_delta_embedding" or column == "qa_embedding":
-            data[column] = [[0.0]] * n  # type: ignore[list-item]
-        elif column == "has_press_conf":
-            data[column] = [1.0] * n
-        elif column == "dissent_count":
-            data[column] = [0.0] * n
-        elif column == "votes_for" or column == "votes_against":
-            data[column] = [10.0] * n
+        elif column in list_cols:
+            data[column] = [[0.0]] * n
         else:
             data[column] = [0.05] * n
-    data["source_type"] = ["fomc_statement"] * n
+    data["event_kind"] = ["statement"] * n
     return pd.DataFrame(data)
 
 
@@ -80,8 +84,8 @@ def test_check_column_ok() -> None:
     assert populated == 4
 
 
-def test_audit_passes_on_full_dataframe(tmp_path: Path) -> None:
-    df = _make_full_dataframe(n=10)
+def test_audit_passes_on_full_event_dataframe(tmp_path: Path) -> None:
+    df = _make_full_event_dataframe(n=10)
     parquet = tmp_path / "events.parquet"
     df.to_parquet(parquet)
 
@@ -89,9 +93,8 @@ def test_audit_passes_on_full_dataframe(tmp_path: Path) -> None:
     assert result == 0
 
 
-def test_audit_fails_when_required_column_missing(tmp_path: Path) -> None:
-    df = _make_full_dataframe(n=10)
-    df = df.drop(columns=["forward_yield_2y_change_5d"])
+def test_audit_fails_when_required_rates_column_missing(tmp_path: Path) -> None:
+    df = _make_full_event_dataframe(n=10).drop(columns=["yield_2y_change_5d"])
     parquet = tmp_path / "events.parquet"
     df.to_parquet(parquet)
 
@@ -100,8 +103,19 @@ def test_audit_fails_when_required_column_missing(tmp_path: Path) -> None:
 
 
 def test_audit_fails_when_required_column_sparse(tmp_path: Path) -> None:
-    df = _make_full_dataframe(n=10)
-    df["statement_delta_inserted"] = ["text"] + [None] * 9  # type: ignore[list-item]
+    df = _make_full_event_dataframe(n=10)
+    df["statement_delta_inserted"] = ["text"] + [None] * 9
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    result = audit(parquet)
+    assert result == 1
+
+
+def test_audit_fails_when_canonical_target_missing(tmp_path: Path) -> None:
+    df = _make_full_event_dataframe(n=10).drop(
+        columns=["forward_realized_vol_10d"]
+    )
     parquet = tmp_path / "events.parquet"
     df.to_parquet(parquet)
 
@@ -115,33 +129,46 @@ def test_audit_returns_two_when_file_missing(tmp_path: Path) -> None:
     assert result == 2
 
 
-def test_audit_passes_when_source_type_includes_unexpected_kinds(
-    tmp_path: Path,
-) -> None:
-    df = _make_full_dataframe(n=10)
-    df.loc[0, "source_type"] = "novel_kind"
+def test_audit_passes_when_event_kind_includes_unknown(tmp_path: Path) -> None:
+    df = _make_full_event_dataframe(n=10)
+    df.loc[0, "event_kind"] = "unrecognised_kind"
     parquet = tmp_path / "events.parquet"
     df.to_parquet(parquet)
 
+    # Unknown event_kind values are reported but do not fail the audit.
     result = audit(parquet)
     assert result == 0
 
 
-def test_audit_fails_when_source_type_column_missing(tmp_path: Path) -> None:
-    df = _make_full_dataframe(n=10).drop(columns=["source_type"])
+def test_audit_passes_when_event_kind_column_missing(tmp_path: Path) -> None:
+    df = _make_full_event_dataframe(n=10).drop(columns=["event_kind"])
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    # Missing event_kind column is reported but does NOT fail the audit
+    # (corpus-diversity gaps are tracked separately under #485).
+    result = audit(parquet)
+    assert result == 0
+
+
+def test_sparse_threshold_override_relaxes_audit(tmp_path: Path) -> None:
+    df = _make_full_event_dataframe(n=10)
+    df["statement_delta_inserted"] = ["text"] + [None] * 9
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    result = audit(parquet, sparse_threshold=5.0)
+    assert result == 0
+
+
+def test_audit_reports_sidecar_absence_without_failing(tmp_path: Path) -> None:
+    """No sidecar parquets present alongside events.parquet — audit
+    still passes since sidecar gaps degrade trainer flags that default
+    off. The report visibly notes the absence; the exit code is 0.
+    """
+    df = _make_full_event_dataframe(n=10)
     parquet = tmp_path / "events.parquet"
     df.to_parquet(parquet)
 
     result = audit(parquet)
-    assert result == 1
-
-
-def test_sparse_threshold_override_relaxes_audit(tmp_path: Path) -> None:
-    df = _make_full_dataframe(n=10)
-    df["statement_delta_inserted"] = ["text"] + [None] * 9  # type: ignore[list-item]
-    parquet = tmp_path / "events.parquet"
-    df.to_parquet(parquet)
-
-    pytest.importorskip("pandas")
-    result = audit(parquet, sparse_threshold=5.0)
     assert result == 0

--- a/tests/unit/test_audit_training_package_coverage.py
+++ b/tests/unit/test_audit_training_package_coverage.py
@@ -1,0 +1,147 @@
+"""Smoke tests for the coverage audit script."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from scripts.audit_training_package_coverage import (
+    REQUIRED_FAMILIES,
+    _check_column,
+    audit,
+)
+
+
+def _all_required_columns() -> list[str]:
+    columns: list[str] = []
+    for cols in REQUIRED_FAMILIES.values():
+        columns.extend(cols)
+    return columns
+
+
+def _make_full_dataframe(n: int = 10) -> pd.DataFrame:
+    data: dict[str, list[float | str | int]] = {}
+    for column in _all_required_columns():
+        if column in {
+            "statement_delta_inserted",
+            "statement_delta_deleted",
+            "statement_delta_substituted_pairs",
+            "qa_text",
+            "dissent_direction",
+        }:
+            data[column] = ["text"] * n
+        elif column == "statement_delta_embedding" or column == "qa_embedding":
+            data[column] = [[0.0]] * n  # type: ignore[list-item]
+        elif column == "has_press_conf":
+            data[column] = [1.0] * n
+        elif column == "dissent_count":
+            data[column] = [0.0] * n
+        elif column == "votes_for" or column == "votes_against":
+            data[column] = [10.0] * n
+        else:
+            data[column] = [0.05] * n
+    data["source_type"] = ["fomc_statement"] * n
+    return pd.DataFrame(data)
+
+
+def test_check_column_missing() -> None:
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    status, ok, populated, total = _check_column(df, "y", 50.0)
+    assert status == "missing"
+    assert ok is False
+    assert populated == 0
+    assert total == 3
+
+
+def test_check_column_empty() -> None:
+    df = pd.DataFrame({"x": [None, None, None]})
+    status, ok, populated, total = _check_column(df, "x", 50.0)
+    assert status == "empty"
+    assert ok is False
+    assert populated == 0
+
+
+def test_check_column_sparse() -> None:
+    df = pd.DataFrame({"x": [1.0, None, None, None]})
+    status, ok, populated, total = _check_column(df, "x", 50.0)
+    assert status == "sparse"
+    assert ok is False
+    assert populated == 1
+    assert total == 4
+
+
+def test_check_column_ok() -> None:
+    df = pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]})
+    status, ok, populated, total = _check_column(df, "x", 50.0)
+    assert status == "ok"
+    assert ok is True
+    assert populated == 4
+
+
+def test_audit_passes_on_full_dataframe(tmp_path: Path) -> None:
+    df = _make_full_dataframe(n=10)
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    result = audit(parquet)
+    assert result == 0
+
+
+def test_audit_fails_when_required_column_missing(tmp_path: Path) -> None:
+    df = _make_full_dataframe(n=10)
+    df = df.drop(columns=["forward_yield_2y_change_5d"])
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    result = audit(parquet)
+    assert result == 1
+
+
+def test_audit_fails_when_required_column_sparse(tmp_path: Path) -> None:
+    df = _make_full_dataframe(n=10)
+    df["statement_delta_inserted"] = ["text"] + [None] * 9  # type: ignore[list-item]
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    result = audit(parquet)
+    assert result == 1
+
+
+def test_audit_returns_two_when_file_missing(tmp_path: Path) -> None:
+    target = tmp_path / "does-not-exist.parquet"
+    result = audit(target)
+    assert result == 2
+
+
+def test_audit_passes_when_source_type_includes_unexpected_kinds(
+    tmp_path: Path,
+) -> None:
+    df = _make_full_dataframe(n=10)
+    df.loc[0, "source_type"] = "novel_kind"
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    result = audit(parquet)
+    assert result == 0
+
+
+def test_audit_fails_when_source_type_column_missing(tmp_path: Path) -> None:
+    df = _make_full_dataframe(n=10).drop(columns=["source_type"])
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    result = audit(parquet)
+    assert result == 1
+
+
+def test_sparse_threshold_override_relaxes_audit(tmp_path: Path) -> None:
+    df = _make_full_dataframe(n=10)
+    df["statement_delta_inserted"] = ["text"] + [None] * 9  # type: ignore[list-item]
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    pytest.importorskip("pandas")
+    result = audit(parquet, sparse_threshold=5.0)
+    assert result == 0


### PR DESCRIPTION
Adds `scripts/audit_training_package_coverage.py` and a `make audit-training-package` wrapper.

The audit walks every required column family on a built events.parquet:
- rates panel (#291), GARCH residual (#434), statement delta (#443), vote tally (#444), press conference (#214), SEP next-year (#415), and the canonical `forward_realized_vol_10d` target
- exits non-zero on a missing column, an empty column, or a column populated below the sparse threshold (default 50%)

Optional families (multi-horizon #483, per-asset targets #482) are reported but not gated.

`source_type` distribution is summarised so a sparse cross-source matrix is visible before the sweep starts.

Operator runs `make audit-training-package TRAINING_PACKAGE_ID=<id>` before every sweep batch. A 60% fallback-engaged column (Phase 2 GARCH residual) or an 8-out-of-10 `no_rows` matrix (Phase 2 cross-source) should fail the gate, not the sweep.

10 unit tests pin the pass / fail / sparse / file-missing / source-type-missing branches.