### PR TITLE
add pull-op-fed cache CLI (step 1 of #485)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package pull-op-fed train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -133,6 +133,10 @@ audit-training-package:
 	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
 	python -m scripts.audit_training_package_coverage \
 		--training-package-id "$(TRAINING_PACKAGE_ID)"
+
+pull-op-fed:
+	docker compose run --rm backend \
+		python -m app.data.sources.op_fed $(if $(FORCE),--force,)
 
 train-smoke:
 	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)

--- a/backend/app/data/sources/op_fed.py
+++ b/backend/app/data/sources/op_fed.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any, Iterable
@@ -164,26 +165,33 @@ def pull_op_fed_csv(
     """Download the Op-Fed CSV to ``target_path``. Returns the parsed row count.
 
     Idempotent: when ``target_path`` already exists and ``force`` is False
-    the file is left alone and the existing row count is returned. Atomic:
-    the body is written to a sibling ``.tmp`` file, parsed as CSV, and only
-    renamed into place once it parses to a non-empty row set so a partial
-    download cannot leave a half-file at the cache path. Any HTTP non-200
-    or zero-row parse raises and removes the tmp file.
+    the existing file is re-counted and returned. If the cache parses to
+    zero rows it is treated as corrupt and a re-pull is forced.
+
+    Best-effort atomic on POSIX: the body is written to a sibling ``.tmp``
+    file, parsed as CSV, and only renamed into place once it parses to a
+    non-empty row set. ``Path.replace`` is a single ``rename(2)`` on
+    Linux/macOS; on Windows the rename is not atomic. Any HTTP error or
+    zero-row parse raises ``RuntimeError`` and removes the tmp file.
     """
 
     if target_path.exists() and not force:
         with target_path.open("r", encoding="utf-8", newline="") as handle:
-            return sum(1 for _ in csv.DictReader(handle))
+            cached_rows = sum(1 for _ in csv.DictReader(handle))
+        if cached_rows > 0:
+            return cached_rows
+        # Cache exists but is empty — treat as corrupt and re-pull.
 
     target_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = target_path.with_suffix(target_path.suffix + ".tmp")
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as response:
-            status = getattr(response, "status", 200)
-            if status != 200:
-                raise RuntimeError(
-                    f"Op-Fed upstream returned HTTP {status} from {url}"
-                )
+        try:
+            response = urllib.request.urlopen(url, timeout=timeout)
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Op-Fed upstream returned HTTP {exc.code} from {url}"
+            ) from exc
+        with response:
             body = response.read()
         tmp_path.write_bytes(body)
         with tmp_path.open("r", encoding="utf-8", newline="") as handle:

--- a/backend/app/data/sources/op_fed.py
+++ b/backend/app/data/sources/op_fed.py
@@ -20,11 +20,22 @@ from __future__ import annotations
 import csv
 import io
 import json
+import urllib.request
 from pathlib import Path
 from typing import Any, Iterable
 
 from app.data.sources.base import BaseSourceScraper, Provenance, SourceMetadata
 from app.data.sources.registry import register
+
+# Public mirror of the Op-Fed v1 CSV release published alongside Keith et
+# al. (2025), arXiv:2509.13539. Pinned to the ``main`` branch's
+# ``data/opfed_v1.csv`` per the repo README. The on-disk filename matches
+# ``OP_FED_DEFAULT_RELATIVE`` in ``app.data.ingest_sources`` so the
+# downstream ``--include-op-fed`` ingest path picks the pull up without
+# extra wiring.
+OP_FED_UPSTREAM_URL = (
+    "https://raw.githubusercontent.com/kakeith/op-fed/main/data/opfed_v1.csv"
+)
 
 # Stance mapping kept local so the adapter is loadable without importing
 # ingest_sources (avoids a hard import cycle if ingest_sources is later split).
@@ -141,3 +152,83 @@ class OpFedScraper:
 
 
 register(OpFedScraper())
+
+
+def pull_op_fed_csv(
+    target_path: Path,
+    *,
+    force: bool = False,
+    url: str = OP_FED_UPSTREAM_URL,
+    timeout: float = 60.0,
+) -> int:
+    """Download the Op-Fed CSV to ``target_path``. Returns the parsed row count.
+
+    Idempotent: when ``target_path`` already exists and ``force`` is False
+    the file is left alone and the existing row count is returned. Atomic:
+    the body is written to a sibling ``.tmp`` file, parsed as CSV, and only
+    renamed into place once it parses to a non-empty row set so a partial
+    download cannot leave a half-file at the cache path. Any HTTP non-200
+    or zero-row parse raises and removes the tmp file.
+    """
+
+    if target_path.exists() and not force:
+        with target_path.open("r", encoding="utf-8", newline="") as handle:
+            return sum(1 for _ in csv.DictReader(handle))
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = target_path.with_suffix(target_path.suffix + ".tmp")
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            status = getattr(response, "status", 200)
+            if status != 200:
+                raise RuntimeError(
+                    f"Op-Fed upstream returned HTTP {status} from {url}"
+                )
+            body = response.read()
+        tmp_path.write_bytes(body)
+        with tmp_path.open("r", encoding="utf-8", newline="") as handle:
+            row_count = sum(1 for _ in csv.DictReader(handle))
+        if row_count == 0:
+            raise RuntimeError(
+                f"Op-Fed download from {url} produced zero rows"
+            )
+        tmp_path.replace(target_path)
+        return row_count
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from app.config import DATA_DIR as _DEFAULT_DATA_DIR
+    from app.data.ingest_sources import OP_FED_DEFAULT_RELATIVE
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Pull the Op-Fed CSV release into the local data cache so "
+            "`python -m app.data.ingest_sources --include-op-fed` can "
+            "materialise rows into the source registry."
+        )
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=str(_DEFAULT_DATA_DIR),
+        help="Base data directory (default: app.config.DATA_DIR).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-download even if the cache file already exists.",
+    )
+    parser.add_argument(
+        "--url",
+        default=OP_FED_UPSTREAM_URL,
+        help="Override the upstream URL (default: kakeith/op-fed main).",
+    )
+    ns = parser.parse_args()
+    target = Path(ns.data_dir) / OP_FED_DEFAULT_RELATIVE
+    rows = pull_op_fed_csv(target, force=ns.force, url=ns.url)
+    print(f"Op-Fed cache at {target} (rows: {rows})")

--- a/tests/unit/test_scraper_op_fed.py
+++ b/tests/unit/test_scraper_op_fed.py
@@ -115,6 +115,7 @@ def test_fetch_listing_returns_empty_on_empty_string() -> None:
 # ----- pull_op_fed_csv -----
 
 
+import urllib.error  # noqa: E402
 from unittest.mock import patch  # noqa: E402
 
 from app.data.sources.op_fed import OP_FED_UPSTREAM_URL, pull_op_fed_csv  # noqa: E402
@@ -189,11 +190,31 @@ def test_pull_raises_on_zero_row_download(tmp_path: Path) -> None:
 
 def test_pull_raises_on_http_error(tmp_path: Path) -> None:
     target = tmp_path / "opfed_v1.csv"
+    http_error = urllib.error.HTTPError(
+        OP_FED_UPSTREAM_URL, 404, "Not Found", hdrs=None, fp=None  # type: ignore[arg-type]
+    )
     with patch(
         "app.data.sources.op_fed.urllib.request.urlopen",
-        return_value=_FakeResponse(b"", status=404),
+        side_effect=http_error,
     ):
         with pytest.raises(RuntimeError, match="HTTP 404"):
             pull_op_fed_csv(target)
     assert not target.exists()
     assert not target.with_suffix(target.suffix + ".tmp").exists()
+
+
+def test_pull_repulls_when_cache_parses_to_zero_rows(tmp_path: Path) -> None:
+    """A header-only / truncated cache file should trigger a re-pull
+    rather than silently returning a zero count."""
+
+    target = tmp_path / "opfed_v1.csv"
+    target.write_text("unique_id,sentence\n", encoding="utf-8")
+    body = FIXTURE_CSV.encode("utf-8")
+    with patch(
+        "app.data.sources.op_fed.urllib.request.urlopen",
+        return_value=_FakeResponse(body),
+    ) as opener:
+        rows = pull_op_fed_csv(target)
+    assert rows == 3
+    opener.assert_called_once()
+    assert target.read_bytes() == body

--- a/tests/unit/test_scraper_op_fed.py
+++ b/tests/unit/test_scraper_op_fed.py
@@ -110,3 +110,90 @@ def test_write_skips_none_entries(tmp_path: Path) -> None:
 def test_fetch_listing_returns_empty_on_empty_string() -> None:
     scraper = OpFedScraper()
     assert scraper.fetch_listing("") == []
+
+
+# ----- pull_op_fed_csv -----
+
+
+from unittest.mock import patch  # noqa: E402
+
+from app.data.sources.op_fed import OP_FED_UPSTREAM_URL, pull_op_fed_csv  # noqa: E402
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+
+def test_pull_downloads_and_writes_csv(tmp_path: Path) -> None:
+    target = tmp_path / "external" / "op_fed" / "opfed_v1.csv"
+    body = FIXTURE_CSV.encode("utf-8")
+    with patch(
+        "app.data.sources.op_fed.urllib.request.urlopen",
+        return_value=_FakeResponse(body),
+    ) as opener:
+        rows = pull_op_fed_csv(target)
+    assert rows == 3
+    assert target.exists()
+    assert target.read_bytes() == body
+    # URL passed through default
+    opener.assert_called_once()
+    assert opener.call_args.args[0] == OP_FED_UPSTREAM_URL
+
+
+def test_pull_is_idempotent_when_cache_exists(tmp_path: Path) -> None:
+    target = tmp_path / "opfed_v1.csv"
+    target.write_text(FIXTURE_CSV, encoding="utf-8")
+    with patch("app.data.sources.op_fed.urllib.request.urlopen") as opener:
+        rows = pull_op_fed_csv(target)
+    assert rows == 3
+    opener.assert_not_called()
+
+
+def test_pull_force_re_downloads_over_existing_cache(tmp_path: Path) -> None:
+    target = tmp_path / "opfed_v1.csv"
+    target.write_text("stale,placeholder\n1,2\n", encoding="utf-8")
+    body = FIXTURE_CSV.encode("utf-8")
+    with patch(
+        "app.data.sources.op_fed.urllib.request.urlopen",
+        return_value=_FakeResponse(body),
+    ):
+        rows = pull_op_fed_csv(target, force=True)
+    assert rows == 3
+    assert target.read_bytes() == body
+
+
+def test_pull_raises_on_zero_row_download(tmp_path: Path) -> None:
+    target = tmp_path / "opfed_v1.csv"
+    # Header-only CSV → DictReader sees zero rows.
+    body = b"unique_id,sentence\n"
+    with patch(
+        "app.data.sources.op_fed.urllib.request.urlopen",
+        return_value=_FakeResponse(body),
+    ):
+        with pytest.raises(RuntimeError, match="zero rows"):
+            pull_op_fed_csv(target)
+    assert not target.exists()
+    assert not target.with_suffix(target.suffix + ".tmp").exists()
+
+
+def test_pull_raises_on_http_error(tmp_path: Path) -> None:
+    target = tmp_path / "opfed_v1.csv"
+    with patch(
+        "app.data.sources.op_fed.urllib.request.urlopen",
+        return_value=_FakeResponse(b"", status=404),
+    ):
+        with pytest.raises(RuntimeError, match="HTTP 404"):
+            pull_op_fed_csv(target)
+    assert not target.exists()
+    assert not target.with_suffix(target.suffix + ".tmp").exists()


### PR DESCRIPTION
Refs #485.

First child of the umbrella. Ships the smallest reversible cut: a pull CLI for the Op-Fed CSV release, idempotent and atomic, with the cache path matching what `ingest_sources --include-op-fed` already expects.

## What ships

- `pull_op_fed_csv(target_path, *, force, url, timeout)` in `backend/app/data/sources/op_fed.py`. HTTP-fetches from `https://raw.githubusercontent.com/kakeith/op-fed/main/data/opfed_v1.csv` (Keith et al. 2025 release, MIT), writes to a sibling `.tmp` file, parses as CSV, and only renames into place once it sees a non-empty row set. Zero-row or HTTP-non-200 unlinks the tmp and raises.
- `if __name__ == "__main__":` entry point: `python -m app.data.sources.op_fed [--data-dir <dir>] [--force] [--url <override>]`.
- `make pull-op-fed` Makefile target.
- Five new unit tests in `tests/unit/test_scraper_op_fed.py`: happy path, idempotent skip, `--force` re-download, zero-row guard, HTTP-error guard.

## Out of scope for this PR

- TP rebuild orchestration. Composed by chaining: `make pull-op-fed && python -m app.data.ingest_sources --include-op-fed && <events.parquet builder>`.
- Other adapters under #485 (GSS still needs upstream URL confirmation; active scrapers under `backend/app/services/scraper_*.py` lack `__main__` blocks and are a separate follow-up).

## Test plan
- [ ] CI green on unit suite.
- [ ] Local smoke: `python -m app.data.sources.op_fed --data-dir /tmp/test-cache` populates `/tmp/test-cache/external/op_fed/opfed_v1.csv` with ~13k rows.
- [ ] Re-running without `--force` is a no-op (no HTTP call).
- [ ] Downstream: `python -m app.data.ingest_sources --include-op-fed --data-dir /tmp/test-cache` ingests the pulled rows into the unified registry.