### PR TITLE
add pull-beige-book scraper CLI (step 2 of #485)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package pull-op-fed train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package pull-op-fed pull-beige-book train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -137,6 +137,12 @@ audit-training-package:
 pull-op-fed:
 	docker compose run --rm backend \
 		python -m app.data.sources.op_fed $(if $(FORCE),--force,)
+
+pull-beige-book:
+	docker compose run --rm backend \
+		python -m app.services.scraper_beige_book \
+			$(if $(FORCE),--force,) \
+			$(if $(LIMIT),--limit $(LIMIT),)
 
 train-smoke:
 	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)

--- a/backend/app/services/scraper_beige_book.py
+++ b/backend/app/services/scraper_beige_book.py
@@ -279,7 +279,7 @@ def _http_get_text(url: str, *, timeout: float) -> str:
     return body.decode("utf-8", errors="replace")
 
 
-def pull_beige_book_archive(
+def pull_beige_book_archive(  # noqa: PLR0913
     target_path: Path,
     *,
     force: bool = False,

--- a/backend/app/services/scraper_beige_book.py
+++ b/backend/app/services/scraper_beige_book.py
@@ -22,6 +22,9 @@ from __future__ import annotations
 
 import json
 import re
+import urllib.error
+import urllib.request
+import warnings
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -32,6 +35,10 @@ from bs4 import BeautifulSoup
 
 
 ARCHIVE_BASE_URL = "https://www.federalreserve.gov"
+ARCHIVE_LISTING_URL = (
+    ARCHIVE_BASE_URL + "/monetarypolicy/publications/beige-book-default.htm"
+)
+OUTPUT_FILENAME = "beige_book.json"
 
 # Matches any beigebook URL that looks like an issue page:
 #   beigebook202401.htm           (6-digit YYYYMM)
@@ -240,3 +247,140 @@ def write_beige_book_json(parsed: Iterable[ParsedBeigeBook], output_path: Path) 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(rows, indent=2), encoding="utf-8")
     return len(rows)
+
+
+# federalreserve.gov 403s the stdlib default ``Python-urllib/x.y`` UA, so
+# every request needs a real-browser-ish header. Identifying the project
+# in the UA keeps the traffic auditable on the upstream's side.
+_USER_AGENT = (
+    "fed-pulse-data-ingester/1.0 "
+    "(+https://github.com/yusufizzetmurat/fed-pulse)"
+)
+
+
+def _http_get_text(url: str, *, timeout: float) -> str:
+    """Fetch ``url`` and return the response body as decoded text.
+
+    Wraps stdlib ``urllib.request.urlopen`` so HTTP non-2xx surfaces as
+    ``RuntimeError`` (the upstream ``HTTPError`` is re-raised with the URL
+    in the message so the caller logs see which issue page failed). A
+    User-Agent header is set explicitly because the federalreserve.gov
+    edge rejects requests without one.
+    """
+
+    request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    try:
+        response = urllib.request.urlopen(request, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"HTTP {exc.code} from {url}") from exc
+    with response:
+        body = response.read()
+    return body.decode("utf-8", errors="replace")
+
+
+def pull_beige_book_archive(
+    target_path: Path,
+    *,
+    force: bool = False,
+    archive_url: str = ARCHIVE_LISTING_URL,
+    limit: int | None = None,
+    timeout: float = 30.0,
+) -> int:
+    """Walk the federalreserve.gov Beige Book archive and write parsed rows.
+
+    Fetches the archive listing, discovers every issue summary URL, then
+    fetches and parses each summary page. The parsed rows are written to
+    ``target_path`` via :func:`write_beige_book_json` — the same JSON
+    shape ``ingest_sources._iter_scraped_records`` consumes.
+
+    Idempotent: when ``target_path`` already exists with a non-empty JSON
+    list and ``force`` is False, the existing row count is returned
+    without any HTTP traffic. A corrupt or empty file forces a re-pull.
+
+    Per-issue failures (HTTP error on a single summary page, parse miss)
+    are logged via :mod:`warnings` and the walk continues — one bad
+    issue page must not drop the whole pull. ``limit`` caps the walk at
+    the first ``N`` discovered issues, useful for smoke-testing.
+    """
+
+    if target_path.exists() and not force:
+        try:
+            cached = json.loads(target_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            cached = None
+        if isinstance(cached, list) and len(cached) > 0:
+            return len(cached)
+
+    listing_html = _http_get_text(archive_url, timeout=timeout)
+    entries = extract_beige_book_listing(listing_html)
+    if limit is not None:
+        entries = entries[:limit]
+
+    parsed: list[ParsedBeigeBook] = []
+    for entry in entries:
+        try:
+            page_html = _http_get_text(entry.url, timeout=timeout)
+            parsed.append(parse_beige_book_page(page_html, source_url=entry.url))
+        except Exception as exc:
+            warnings.warn(
+                f"Beige Book fetch failed for {entry.url}: {exc}",
+                stacklevel=2,
+            )
+            continue
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = target_path.with_suffix(target_path.suffix + ".tmp")
+    try:
+        written = write_beige_book_json(parsed, tmp_path)
+        if written == 0:
+            raise RuntimeError(
+                f"Beige Book pull from {archive_url} produced zero rows"
+            )
+        tmp_path.replace(target_path)
+        return written
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from app.config import DATA_DIR as _DEFAULT_DATA_DIR
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Walk the federalreserve.gov Beige Book archive and write "
+            f"{OUTPUT_FILENAME} into the data directory. The resulting "
+            "JSON is picked up unchanged by "
+            "`python -m app.data.ingest_sources --include-scraped`."
+        )
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=str(_DEFAULT_DATA_DIR),
+        help="Base data directory (default: app.config.DATA_DIR).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-pull even if the cache file already exists.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Stop after fetching N issues (smoke testing).",
+    )
+    parser.add_argument(
+        "--archive-url",
+        default=ARCHIVE_LISTING_URL,
+        help="Override the archive listing URL.",
+    )
+    ns = parser.parse_args()
+    target = Path(ns.data_dir) / OUTPUT_FILENAME
+    rows = pull_beige_book_archive(
+        target, force=ns.force, archive_url=ns.archive_url, limit=ns.limit
+    )
+    print(f"Beige Book cache at {target} (rows: {rows})")

--- a/backend/app/services/scraper_beige_book.py
+++ b/backend/app/services/scraper_beige_book.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import re
+import time
 import urllib.error
 import urllib.request
 import warnings
@@ -285,6 +286,7 @@ def pull_beige_book_archive(
     archive_url: str = ARCHIVE_LISTING_URL,
     limit: int | None = None,
     timeout: float = 30.0,
+    delay_seconds: float = 0.5,
 ) -> int:
     """Walk the federalreserve.gov Beige Book archive and write parsed rows.
 
@@ -317,7 +319,7 @@ def pull_beige_book_archive(
         entries = entries[:limit]
 
     parsed: list[ParsedBeigeBook] = []
-    for entry in entries:
+    for i, entry in enumerate(entries):
         try:
             page_html = _http_get_text(entry.url, timeout=timeout)
             parsed.append(parse_beige_book_page(page_html, source_url=entry.url))
@@ -327,8 +329,13 @@ def pull_beige_book_archive(
                 stacklevel=2,
             )
             continue
+        # Polite delay between page fetches so a 400-issue walk doesn't
+        # trigger an upstream throttle (which would silently truncate the
+        # cache to N rows with no surface-level error). Skipped after the
+        # last entry.
+        if delay_seconds > 0 and i + 1 < len(entries):
+            time.sleep(delay_seconds)
 
-    target_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = target_path.with_suffix(target_path.suffix + ".tmp")
     try:
         written = write_beige_book_json(parsed, tmp_path)
@@ -378,9 +385,19 @@ if __name__ == "__main__":
         default=ARCHIVE_LISTING_URL,
         help="Override the archive listing URL.",
     )
+    parser.add_argument(
+        "--delay-seconds",
+        type=float,
+        default=0.5,
+        help="Polite delay between page fetches (default: 0.5s).",
+    )
     ns = parser.parse_args()
     target = Path(ns.data_dir) / OUTPUT_FILENAME
     rows = pull_beige_book_archive(
-        target, force=ns.force, archive_url=ns.archive_url, limit=ns.limit
+        target,
+        force=ns.force,
+        archive_url=ns.archive_url,
+        limit=ns.limit,
+        delay_seconds=ns.delay_seconds,
     )
     print(f"Beige Book cache at {target} (rows: {rows})")

--- a/backend/app/services/scraper_beige_book.py
+++ b/backend/app/services/scraper_beige_book.py
@@ -275,7 +275,7 @@ def _http_get_text(url: str, *, timeout: float) -> str:
     except urllib.error.HTTPError as exc:
         raise RuntimeError(f"HTTP {exc.code} from {url}") from exc
     with response:
-        body = response.read()
+        body: bytes = response.read()
     return body.decode("utf-8", errors="replace")
 
 

--- a/tests/unit/test_scraper_beige_book.py
+++ b/tests/unit/test_scraper_beige_book.py
@@ -115,13 +115,19 @@ _PAGE_HTML_TEMPLATE = """
 <html><head><meta property="og:title" content="Beige Book {month}"></head>
 <body><div id="article">
 <p>{filler}</p>
+<p>{filler2}</p>
+<p>{filler3}</p>
 </div></body></html>
 """
 
 
 def _fake_page(month: str) -> str:
-    filler = ("Substantive regional summary " * 20)
-    return _PAGE_HTML_TEMPLATE.format(month=month, filler=filler)
+    filler = "Substantive regional summary " * 20
+    filler2 = "Manufacturing activity expanded modestly across most districts " * 6
+    filler3 = "Labor markets remained tight with wage pressures elevated " * 6
+    return _PAGE_HTML_TEMPLATE.format(
+        month=month, filler=filler, filler2=filler2, filler3=filler3
+    )
 
 
 def _route_urlopen(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
@@ -141,7 +147,7 @@ def test_pull_walks_listing_and_writes_json(tmp_path: Path) -> None:
         "app.services.scraper_beige_book.urllib.request.urlopen",
         side_effect=_route_urlopen,
     ) as opener:
-        rows = pull_beige_book_archive(target)
+        rows = pull_beige_book_archive(target, delay_seconds=0.0)
     assert rows == 2
     payload = json.loads(target.read_text(encoding="utf-8"))
     assert [r["date"] for r in payload] == ["2024-01-01", "2024-03-01"]
@@ -156,7 +162,7 @@ def test_pull_is_idempotent_when_cache_has_rows(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     with patch("app.services.scraper_beige_book.urllib.request.urlopen") as opener:
-        rows = pull_beige_book_archive(target)
+        rows = pull_beige_book_archive(target, delay_seconds=0.0)
     assert rows == 1
     opener.assert_not_called()
 
@@ -168,7 +174,7 @@ def test_pull_force_re_walks_over_existing_cache(tmp_path: Path) -> None:
         "app.services.scraper_beige_book.urllib.request.urlopen",
         side_effect=_route_urlopen,
     ):
-        rows = pull_beige_book_archive(target, force=True)
+        rows = pull_beige_book_archive(target, force=True, delay_seconds=0.0)
     assert rows == 2
 
 
@@ -179,7 +185,7 @@ def test_pull_repulls_when_cache_is_empty_list(tmp_path: Path) -> None:
         "app.services.scraper_beige_book.urllib.request.urlopen",
         side_effect=_route_urlopen,
     ) as opener:
-        rows = pull_beige_book_archive(target)
+        rows = pull_beige_book_archive(target, delay_seconds=0.0)
     assert rows == 2
     assert opener.call_count == 3
 
@@ -190,7 +196,7 @@ def test_pull_limit_caps_walk(tmp_path: Path) -> None:
         "app.services.scraper_beige_book.urllib.request.urlopen",
         side_effect=_route_urlopen,
     ) as opener:
-        rows = pull_beige_book_archive(target, limit=1)
+        rows = pull_beige_book_archive(target, limit=1, delay_seconds=0.0)
     assert rows == 1
     # 1 listing + 1 page = 2 fetches
     assert opener.call_count == 2
@@ -210,7 +216,7 @@ def test_pull_continues_when_one_page_404s(tmp_path: Path) -> None:
         side_effect=_route_with_one_404,
     ):
         with pytest.warns(UserWarning, match="Beige Book fetch failed"):
-            rows = pull_beige_book_archive(target)
+            rows = pull_beige_book_archive(target, delay_seconds=0.0)
     assert rows == 1  # only March survived
 
 
@@ -222,7 +228,7 @@ def test_pull_raises_on_listing_http_error(tmp_path: Path) -> None:
         side_effect=err,
     ):
         with pytest.raises(RuntimeError, match="HTTP 503"):
-            pull_beige_book_archive(target)
+            pull_beige_book_archive(target, delay_seconds=0.0)
     assert not target.exists()
     assert not target.with_suffix(target.suffix + ".tmp").exists()
 
@@ -242,6 +248,6 @@ def test_pull_raises_when_every_page_fails(tmp_path: Path) -> None:
     ):
         with pytest.warns(UserWarning):
             with pytest.raises(RuntimeError, match="zero rows"):
-                pull_beige_book_archive(target)
+                pull_beige_book_archive(target, delay_seconds=0.0)
     assert not target.exists()
     assert not target.with_suffix(target.suffix + ".tmp").exists()

--- a/tests/unit/test_scraper_beige_book.py
+++ b/tests/unit/test_scraper_beige_book.py
@@ -6,11 +6,16 @@ from pathlib import Path
 
 import pytest
 
+import urllib.error
+from unittest.mock import patch
+
 from app.services.scraper_beige_book import (
+    ARCHIVE_LISTING_URL,
     BeigeBookListingEntry,
     ParsedBeigeBook,
     extract_beige_book_listing,
     parse_beige_book_page,
+    pull_beige_book_archive,
     write_beige_book_json,
 )
 
@@ -79,3 +84,164 @@ def test_write_beige_book_json_emits_one_row_per_parsed(tmp_path: Path) -> None:
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert len(payload) == 1
     assert payload[0]["document_type"] == "beige_book"
+
+
+# ----- pull_beige_book_archive -----
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+
+_LISTING_HTML = """
+<html><body>
+<a href="/monetarypolicy/beigebook202401-summary.htm">January 2024</a>
+<a href="/monetarypolicy/beigebook202403-summary.htm">March 2024</a>
+</body></html>
+"""
+
+_PAGE_HTML_TEMPLATE = """
+<html><head><meta property="og:title" content="Beige Book {month}"></head>
+<body><div id="article">
+<p>{filler}</p>
+</div></body></html>
+"""
+
+
+def _fake_page(month: str) -> str:
+    filler = ("Substantive regional summary " * 20)
+    return _PAGE_HTML_TEMPLATE.format(month=month, filler=filler)
+
+
+def _route_urlopen(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+    url_str = url if isinstance(url, str) else url.full_url
+    if url_str == ARCHIVE_LISTING_URL:
+        return _FakeResponse(_LISTING_HTML.encode("utf-8"))
+    if "202401" in url_str:
+        return _FakeResponse(_fake_page("January 2024").encode("utf-8"))
+    if "202403" in url_str:
+        return _FakeResponse(_fake_page("March 2024").encode("utf-8"))
+    raise AssertionError(f"unexpected URL fetched: {url_str}")
+
+
+def test_pull_walks_listing_and_writes_json(tmp_path: Path) -> None:
+    target = tmp_path / "beige_book.json"
+    with patch(
+        "app.services.scraper_beige_book.urllib.request.urlopen",
+        side_effect=_route_urlopen,
+    ) as opener:
+        rows = pull_beige_book_archive(target)
+    assert rows == 2
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert [r["date"] for r in payload] == ["2024-01-01", "2024-03-01"]
+    # 1 listing fetch + 2 page fetches
+    assert opener.call_count == 3
+
+
+def test_pull_is_idempotent_when_cache_has_rows(tmp_path: Path) -> None:
+    target = tmp_path / "beige_book.json"
+    target.write_text(
+        json.dumps([{"date": "2024-01-01", "text": "x", "document_type": "beige_book"}]),
+        encoding="utf-8",
+    )
+    with patch("app.services.scraper_beige_book.urllib.request.urlopen") as opener:
+        rows = pull_beige_book_archive(target)
+    assert rows == 1
+    opener.assert_not_called()
+
+
+def test_pull_force_re_walks_over_existing_cache(tmp_path: Path) -> None:
+    target = tmp_path / "beige_book.json"
+    target.write_text(json.dumps([{"date": "stale", "text": "x"}]), encoding="utf-8")
+    with patch(
+        "app.services.scraper_beige_book.urllib.request.urlopen",
+        side_effect=_route_urlopen,
+    ):
+        rows = pull_beige_book_archive(target, force=True)
+    assert rows == 2
+
+
+def test_pull_repulls_when_cache_is_empty_list(tmp_path: Path) -> None:
+    target = tmp_path / "beige_book.json"
+    target.write_text("[]", encoding="utf-8")
+    with patch(
+        "app.services.scraper_beige_book.urllib.request.urlopen",
+        side_effect=_route_urlopen,
+    ) as opener:
+        rows = pull_beige_book_archive(target)
+    assert rows == 2
+    assert opener.call_count == 3
+
+
+def test_pull_limit_caps_walk(tmp_path: Path) -> None:
+    target = tmp_path / "beige_book.json"
+    with patch(
+        "app.services.scraper_beige_book.urllib.request.urlopen",
+        side_effect=_route_urlopen,
+    ) as opener:
+        rows = pull_beige_book_archive(target, limit=1)
+    assert rows == 1
+    # 1 listing + 1 page = 2 fetches
+    assert opener.call_count == 2
+
+
+def test_pull_continues_when_one_page_404s(tmp_path: Path) -> None:
+    target = tmp_path / "beige_book.json"
+
+    def _route_with_one_404(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        url_str = url if isinstance(url, str) else url.full_url
+        if "202401" in url_str:
+            raise urllib.error.HTTPError(url_str, 404, "Not Found", None, None)  # type: ignore[arg-type]
+        return _route_urlopen(url, *args, **kwargs)
+
+    with patch(
+        "app.services.scraper_beige_book.urllib.request.urlopen",
+        side_effect=_route_with_one_404,
+    ):
+        with pytest.warns(UserWarning, match="Beige Book fetch failed"):
+            rows = pull_beige_book_archive(target)
+    assert rows == 1  # only March survived
+
+
+def test_pull_raises_on_listing_http_error(tmp_path: Path) -> None:
+    target = tmp_path / "beige_book.json"
+    err = urllib.error.HTTPError(ARCHIVE_LISTING_URL, 503, "boom", None, None)  # type: ignore[arg-type]
+    with patch(
+        "app.services.scraper_beige_book.urllib.request.urlopen",
+        side_effect=err,
+    ):
+        with pytest.raises(RuntimeError, match="HTTP 503"):
+            pull_beige_book_archive(target)
+    assert not target.exists()
+    assert not target.with_suffix(target.suffix + ".tmp").exists()
+
+
+def test_pull_raises_when_every_page_fails(tmp_path: Path) -> None:
+    target = tmp_path / "beige_book.json"
+
+    def _route_all_fail(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        url_str = url if isinstance(url, str) else url.full_url
+        if url_str == ARCHIVE_LISTING_URL:
+            return _FakeResponse(_LISTING_HTML.encode("utf-8"))
+        raise urllib.error.HTTPError(url_str, 500, "x", None, None)  # type: ignore[arg-type]
+
+    with patch(
+        "app.services.scraper_beige_book.urllib.request.urlopen",
+        side_effect=_route_all_fail,
+    ):
+        with pytest.warns(UserWarning):
+            with pytest.raises(RuntimeError, match="zero rows"):
+                pull_beige_book_archive(target)
+    assert not target.exists()
+    assert not target.with_suffix(target.suffix + ".tmp").exists()


### PR DESCRIPTION
Refs #485.

Second child of the umbrella, after #487. The Beige Book scraper has always shipped as a parser library — `extract_beige_book_listing`, `parse_beige_book_page`, `write_beige_book_json` accept HTML and return data structures, but nothing fetches the archive. Cross-source transfer matrix → `beige_book` source_type stays at zero rows on a fresh checkout.

## What ships

- `pull_beige_book_archive(target_path, *, force, archive_url, limit, timeout)` in `backend/app/services/scraper_beige_book.py`. Walks `/monetarypolicy/publications/beige-book-default.htm`, fetches every discovered issue summary page, parses, writes to `<data-dir>/beige_book.json` (the exact path `_iter_scraped_records` reads under `--include-scraped`).
- `if __name__ == "__main__":` entry: `python -m app.services.scraper_beige_book [--data-dir <dir>] [--force] [--limit N] [--archive-url <override>]`.
- `make pull-beige-book [FORCE=1] [LIMIT=N]` Makefile target.
- Eight new unit tests in `tests/unit/test_scraper_beige_book.py`: listing walk happy path / idempotent cache / `--force` re-walk / empty-list cache re-pull / `--limit` / per-page-404 tolerance / listing-HTTP-error abort / all-pages-fail-→-zero-rows guard.

## Failure model
- Listing HTTP error → `RuntimeError`, no partial write.
- Per-issue HTTP error → `warnings.warn` + skip, walk continues.
- Zero rows after walk → `RuntimeError`, tmp cleaned up.

## Live smoke test
Local `--limit 3` against federalreserve.gov returned 3 issues from 2026-01/2026-02/2026-04, each with ~8 KB of substantive text. Idempotent re-call did zero HTTP requests.

## User-Agent finding
federalreserve.gov 403s the stdlib default `Python-urllib/x.y` UA. Added a project-identifying UA (`fed-pulse-data-ingester/1.0 (+https://github.com/yusufizzetmurat/fed-pulse)`) — same pattern will be needed for the other scrapers in this umbrella.

## Out of scope
- The other four `backend/app/services/scraper_*.py` modules (press_conferences, speeches, testimonies, regional_research) — separate PRs per the same pattern.

## Test plan
- [ ] CI green on unit suite.
- [ ] Local smoke: `make pull-beige-book LIMIT=3` returns 3 rows in `data/beige_book.json`.
- [ ] Downstream: `python -m app.data.ingest_sources --include-scraped` ingests the rows into the unified registry tagged with `source_type=beige_book`.