### PR TITLE
add pull-CLIs for press-conferences, speeches, testimonies, regional-research (step 3 of #485)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package pull-op-fed train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package pull-op-fed pull-press-conferences pull-speeches pull-testimonies pull-regional-research train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -137,6 +137,44 @@ audit-training-package:
 pull-op-fed:
 	docker compose run --rm backend \
 		python -m app.data.sources.op_fed $(if $(FORCE),--force,)
+
+# Walk the federalreserve.gov FOMC calendar + historical pages and write
+# press_conferences.json under the data dir. FORCE=1 re-pulls even when
+# the cache is present; LIMIT=N caps the walk for smoke testing.
+pull-press-conferences:
+	docker compose run --rm backend \
+		python -m app.services.scraper_press_conferences \
+			$(if $(FORCE),--force,) \
+			$(if $(LIMIT),--limit $(LIMIT),)
+
+# Walk the federalreserve.gov annual speech archives and write both
+# chair_speeches.json and governor_speeches.json under the data dir.
+# YEARS overrides the default 2006-current walk window.
+pull-speeches:
+	docker compose run --rm backend \
+		python -m app.services.scraper_speeches \
+			$(if $(FORCE),--force,) \
+			$(if $(LIMIT),--limit $(LIMIT),) \
+			$(if $(YEARS),--years $(YEARS),)
+
+# Walk the federalreserve.gov annual testimony archives and write
+# congressional_testimonies.json under the data dir. YEARS overrides
+# the default 2006-current walk window.
+pull-testimonies:
+	docker compose run --rm backend \
+		python -m app.services.scraper_testimonies \
+			$(if $(FORCE),--force,) \
+			$(if $(LIMIT),--limit $(LIMIT),) \
+			$(if $(YEARS),--years $(YEARS),)
+
+# Walk the Liberty Street Economics archive (NY Fed regional research)
+# and write regional_research.json under the data dir. The default
+# archive URL is the site homepage, which surfaces the most recent posts.
+pull-regional-research:
+	docker compose run --rm backend \
+		python -m app.services.scraper_regional_research \
+			$(if $(FORCE),--force,) \
+			$(if $(LIMIT),--limit $(LIMIT),)
 
 train-smoke:
 	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)

--- a/backend/app/services/scraper_press_conferences.py
+++ b/backend/app/services/scraper_press_conferences.py
@@ -59,6 +59,16 @@ HISTORICAL_YEAR_URL_TEMPLATE = (
 _DEFAULT_HISTORICAL_YEARS_LOWER = 2011
 _DEFAULT_HISTORICAL_YEARS_UPPER = 2020
 
+# federalreserve.gov 403s the stdlib default ``Python-urllib/x.y`` UA
+# and the bare ``python-requests`` UA on some edge nodes. Identifying
+# the project in the UA keeps the traffic auditable on the upstream's
+# side and matches the convention the other federalreserve.gov
+# scrapers in this package use.
+_USER_AGENT = (
+    "fed-pulse-data-ingester/1.0 "
+    "(+https://github.com/yusufizzetmurat/fed-pulse)"
+)
+
 # Page-header noise stamped on every page of the Federal Reserve press
 # conference PDFs ("January 29, 2025   Chair Powell's Press Conference
 # FINAL\nPage 4 of 27"). Stripped before Q&A splitting so the speaker-turn
@@ -409,17 +419,6 @@ def build_qa_lookup(parsed: Iterable[ParsedPressConference]) -> dict[str, dict[s
             "has_press_conf": "1",
         }
     return lookup
-
-
-# federalreserve.gov 403s the stdlib default ``Python-urllib/x.y`` UA
-# and the bare ``python-requests`` UA on some edge nodes. Identifying
-# the project in the UA keeps the traffic auditable on the upstream's
-# side and matches the convention the other federalreserve.gov
-# scrapers in this package use.
-_USER_AGENT = (
-    "fed-pulse-data-ingester/1.0 "
-    "(+https://github.com/yusufizzetmurat/fed-pulse)"
-)
 
 
 def _http_get_text(url: str, *, timeout: float) -> str:

--- a/backend/app/services/scraper_press_conferences.py
+++ b/backend/app/services/scraper_press_conferences.py
@@ -457,7 +457,7 @@ def _default_historical_years() -> list[int]:
     )
 
 
-def pull_press_conferences_archive(
+def pull_press_conferences_archive(  # noqa: PLR0913
     target_path: Path,
     *,
     force: bool = False,

--- a/backend/app/services/scraper_press_conferences.py
+++ b/backend/app/services/scraper_press_conferences.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 
 import json
 import re
+import time
+import warnings
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from io import BytesIO
@@ -41,6 +43,21 @@ from bs4 import BeautifulSoup
 ARCHIVE_BASE_URL = "https://www.federalreserve.gov"
 PRESS_CONF_URL_PATTERN = re.compile(r"^/monetarypolicy/fomcpresconf(\d{8})\.htm$")
 DATE_FROM_URL_PATTERN = re.compile(r"/fomcpresconf(\d{8})\.htm$")
+
+OUTPUT_FILENAME = "press_conferences.json"
+# Recent press-conference URLs live on the FOMC calendars page. The
+# orchestrator can additionally walk per-year historical pages
+# (/monetarypolicy/fomchistorical{year}.htm) to back-fill pre-2021
+# events; the calendar by itself covers 2021 forward only.
+ARCHIVE_LISTING_URL = ARCHIVE_BASE_URL + "/monetarypolicy/fomccalendars.htm"
+HISTORICAL_YEAR_URL_TEMPLATE = (
+    ARCHIVE_BASE_URL + "/monetarypolicy/fomchistorical{year}.htm"
+)
+# Press conferences started in April 2011. The default historical
+# window walks calendar + 2011-2020 historical pages so the cache
+# covers the full press-conf era.
+_DEFAULT_HISTORICAL_YEARS_LOWER = 2011
+_DEFAULT_HISTORICAL_YEARS_UPPER = 2020
 
 # Page-header noise stamped on every page of the Federal Reserve press
 # conference PDFs ("January 29, 2025   Chair Powell's Press Conference
@@ -256,7 +273,11 @@ def _load_or_fetch_pdf_bytes(
     if not pdf_url:
         return b""
     try:
-        response = requests.get(pdf_url, timeout=30)
+        response = requests.get(
+            pdf_url,
+            timeout=30,
+            headers={"User-Agent": _USER_AGENT},
+        )
         response.raise_for_status()
     except Exception:
         return b""
@@ -388,3 +409,237 @@ def build_qa_lookup(parsed: Iterable[ParsedPressConference]) -> dict[str, dict[s
             "has_press_conf": "1",
         }
     return lookup
+
+
+# federalreserve.gov 403s the stdlib default ``Python-urllib/x.y`` UA
+# and the bare ``python-requests`` UA on some edge nodes. Identifying
+# the project in the UA keeps the traffic auditable on the upstream's
+# side and matches the convention the other federalreserve.gov
+# scrapers in this package use.
+_USER_AGENT = (
+    "fed-pulse-data-ingester/1.0 "
+    "(+https://github.com/yusufizzetmurat/fed-pulse)"
+)
+
+
+def _http_get_text(url: str, *, timeout: float) -> str:
+    """Fetch ``url`` and return the response body as decoded text.
+
+    Wraps ``requests.get`` so HTTP non-2xx surfaces as ``RuntimeError``
+    (the upstream error is re-raised with the URL in the message so
+    the caller logs see which page failed). The press-conference
+    scraper uses ``requests`` rather than stdlib ``urllib`` for
+    consistency with :func:`_load_or_fetch_pdf_bytes`, which already
+    fetches PDFs via the same library.
+    """
+
+    try:
+        response = requests.get(
+            url, timeout=timeout, headers={"User-Agent": _USER_AGENT}
+        )
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        code = exc.response.status_code if exc.response is not None else "?"
+        raise RuntimeError(f"HTTP {code} from {url}") from exc
+    return response.text
+
+
+def _default_historical_years() -> list[int]:
+    """Years walked for the historical back-fill by default.
+
+    Press conferences started in April 2011. The default window walks
+    2011 through 2020 inclusive; 2021 onward is covered by the
+    ``fomccalendars.htm`` listing already.
+    """
+
+    return list(
+        range(_DEFAULT_HISTORICAL_YEARS_LOWER, _DEFAULT_HISTORICAL_YEARS_UPPER + 1)
+    )
+
+
+def pull_press_conferences_archive(
+    target_path: Path,
+    *,
+    force: bool = False,
+    archive_url: str = ARCHIVE_LISTING_URL,
+    historical_years: list[int] | None = None,
+    limit: int | None = None,
+    timeout: float = 30.0,
+    delay_seconds: float = 0.5,
+    cache_pdf_dir: Path | None = None,
+) -> int:
+    """Walk the federalreserve.gov FOMC calendars + historical pages and write parsed rows.
+
+    Press-conference URLs live on two sources:
+
+    1. ``/monetarypolicy/fomccalendars.htm`` -- the current calendar
+       page, which surfaces 2021-onward press-conference links inline.
+    2. ``/monetarypolicy/fomchistorical{year}.htm`` -- per-year
+       historical pages, used to back-fill 2011-2020 press confs.
+
+    The orchestrator fetches the calendar page (or whatever
+    ``archive_url`` points at), then each historical year page,
+    de-duplicates the discovered URLs, and parses every press
+    conference. Each parse downloads the sibling PDF and runs the
+    pypdf text extractor + Q&A splitter.
+
+    Parsed rows are written to ``target_path`` via
+    :func:`write_press_conferences_json` -- the same JSON shape
+    ``ingest_sources._iter_scraped_records`` consumes. The Q&A
+    lookup sidecar (#214) is intentionally NOT produced here; that
+    follow-up writes it from the same parsed rows separately.
+
+    Idempotent: when ``target_path`` already exists with a non-empty
+    JSON list and ``force`` is False, the existing row count is
+    returned without any HTTP traffic. Per-page failures are logged
+    via :mod:`warnings` and the walk continues. A walk producing zero
+    rows raises ``RuntimeError`` so a broken default surfaces loudly.
+    """
+
+    if target_path.exists() and not force:
+        try:
+            cached = json.loads(target_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            cached = None
+        if isinstance(cached, list) and len(cached) > 0:
+            return len(cached)
+
+    year_list = (
+        historical_years
+        if historical_years is not None
+        else _default_historical_years()
+    )
+    listing_urls = [archive_url] + [
+        HISTORICAL_YEAR_URL_TEMPLATE.format(year=y) for y in year_list
+    ]
+
+    entries: list[PressConferenceListingEntry] = []
+    seen_urls: set[str] = set()
+    for listing_url in listing_urls:
+        try:
+            listing_html = _http_get_text(listing_url, timeout=timeout)
+        except Exception as exc:
+            warnings.warn(
+                f"Press conference listing fetch failed for {listing_url}: {exc}",
+                stacklevel=2,
+            )
+            continue
+        for entry in extract_press_conference_listing(listing_html):
+            if entry.url in seen_urls:
+                continue
+            seen_urls.add(entry.url)
+            entries.append(entry)
+
+    # Sort by date so smoke-test ``--limit N`` returns the most recent
+    # N press confs (most useful for end-to-end smoke tests).
+    entries.sort(key=lambda e: e.date, reverse=True)
+    if limit is not None:
+        entries = entries[:limit]
+
+    parsed: list[ParsedPressConference] = []
+    for i, entry in enumerate(entries):
+        try:
+            page_html = _http_get_text(entry.url, timeout=timeout)
+            parsed.append(
+                parse_press_conference_page(
+                    page_html,
+                    source_url=entry.url,
+                    cache_pdf_dir=cache_pdf_dir,
+                )
+            )
+        except Exception as exc:
+            warnings.warn(
+                f"Press conference fetch failed for {entry.url}: {exc}",
+                stacklevel=2,
+            )
+            continue
+        if delay_seconds > 0 and i + 1 < len(entries):
+            time.sleep(delay_seconds)
+
+    tmp_path = target_path.with_suffix(target_path.suffix + ".tmp")
+    try:
+        written = write_press_conferences_json(parsed, tmp_path)
+        if written == 0:
+            raise RuntimeError(
+                f"Press conferences pull produced zero rows (listings tried: "
+                f"{len(listing_urls)})"
+            )
+        tmp_path.replace(target_path)
+        return written
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from app.config import DATA_DIR as _DEFAULT_DATA_DIR
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Walk the federalreserve.gov FOMC calendar + historical pages "
+            f"and write {OUTPUT_FILENAME} into the data directory. The "
+            "resulting JSON is picked up unchanged by "
+            "`python -m app.data.ingest_sources --include-scraped`."
+        )
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=str(_DEFAULT_DATA_DIR),
+        help="Base data directory (default: app.config.DATA_DIR).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-pull even if the cache file already exists.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Stop after fetching N press confs (smoke testing).",
+    )
+    parser.add_argument(
+        "--archive-url",
+        default=ARCHIVE_LISTING_URL,
+        help="Override the FOMC calendar URL.",
+    )
+    parser.add_argument(
+        "--historical-years",
+        type=int,
+        nargs="+",
+        default=None,
+        help=(
+            "Historical years to back-fill via "
+            "/monetarypolicy/fomchistorical{year}.htm (default: 2011-2020)."
+        ),
+    )
+    parser.add_argument(
+        "--delay-seconds",
+        type=float,
+        default=0.5,
+        help="Polite delay between page fetches (default: 0.5s).",
+    )
+    parser.add_argument(
+        "--cache-pdf-dir",
+        default=None,
+        help=(
+            "Local directory under which press-conference PDFs are "
+            "cached so a re-pull does not re-download every PDF "
+            "(default: no PDF cache)."
+        ),
+    )
+    ns = parser.parse_args()
+    target = Path(ns.data_dir) / OUTPUT_FILENAME
+    rows = pull_press_conferences_archive(
+        target,
+        force=ns.force,
+        archive_url=ns.archive_url,
+        historical_years=ns.historical_years,
+        limit=ns.limit,
+        delay_seconds=ns.delay_seconds,
+        cache_pdf_dir=Path(ns.cache_pdf_dir) if ns.cache_pdf_dir else None,
+    )
+    print(f"Press conferences cache at {target} (rows: {rows})")

--- a/backend/app/services/scraper_regional_research.py
+++ b/backend/app/services/scraper_regional_research.py
@@ -224,7 +224,7 @@ def _http_get_text(url: str, *, timeout: float) -> str:
     except urllib.error.HTTPError as exc:
         raise RuntimeError(f"HTTP {exc.code} from {url}") from exc
     with response:
-        body = response.read()
+        body: bytes = response.read()
     return body.decode("utf-8", errors="replace")
 
 

--- a/backend/app/services/scraper_regional_research.py
+++ b/backend/app/services/scraper_regional_research.py
@@ -17,6 +17,10 @@ from __future__ import annotations
 
 import json
 import re
+import time
+import urllib.error
+import urllib.request
+import warnings
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -26,6 +30,9 @@ from bs4 import BeautifulSoup
 
 
 LSE_BASE_URL = "https://libertystreeteconomics.newyorkfed.org"
+ARCHIVE_LISTING_URL = LSE_BASE_URL + "/"
+OUTPUT_FILENAME = "regional_research.json"
+
 LSE_POST_URL_PATTERN = re.compile(
     r"^https://libertystreeteconomics\.newyorkfed\.org/(\d{4})/(\d{2})/[a-z0-9-]+/?$"
 )
@@ -191,3 +198,156 @@ def write_regional_research_json(
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(rows, indent=2), encoding="utf-8")
     return len(rows)
+
+
+# Liberty Street Economics is fronted by a CDN that 403s the stdlib
+# default ``Python-urllib/x.y`` UA on some edge nodes. Identifying the
+# project in the UA keeps the traffic auditable on the upstream's side
+# and matches the convention the federalreserve.gov scrapers use.
+_USER_AGENT = (
+    "fed-pulse-data-ingester/1.0 "
+    "(+https://github.com/yusufizzetmurat/fed-pulse)"
+)
+
+
+def _http_get_text(url: str, *, timeout: float) -> str:
+    """Fetch ``url`` and return the response body as decoded text.
+
+    Wraps stdlib ``urllib.request.urlopen`` so HTTP non-2xx surfaces as
+    ``RuntimeError`` (the upstream ``HTTPError`` is re-raised with the URL
+    in the message so the caller logs see which post page failed).
+    """
+
+    request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    try:
+        response = urllib.request.urlopen(request, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"HTTP {exc.code} from {url}") from exc
+    with response:
+        body = response.read()
+    return body.decode("utf-8", errors="replace")
+
+
+def pull_regional_research_archive(
+    target_path: Path,
+    *,
+    force: bool = False,
+    archive_url: str = ARCHIVE_LISTING_URL,
+    limit: int | None = None,
+    timeout: float = 30.0,
+    delay_seconds: float = 0.5,
+) -> int:
+    """Walk the Liberty Street Economics archive and write parsed rows.
+
+    Fetches the archive listing (defaults to the site homepage, which
+    surfaces the most recent posts), discovers every post URL matching
+    the canonical ``/{YYYY}/{MM}/{slug}/`` pattern, then fetches and
+    parses each post page. Parsed rows are written to ``target_path``
+    via :func:`write_regional_research_json` -- the same JSON shape
+    ``ingest_sources._iter_scraped_records`` consumes.
+
+    Idempotent: when ``target_path`` already exists with a non-empty
+    JSON list and ``force`` is False, the existing row count is
+    returned without any HTTP traffic. A corrupt or empty file forces
+    a re-pull.
+
+    Per-post failures (HTTP error on a single post page, parse miss)
+    are logged via :mod:`warnings` and the walk continues -- one bad
+    post page must not drop the whole pull. ``limit`` caps the walk at
+    the first ``N`` discovered posts, useful for smoke-testing.
+    """
+
+    if target_path.exists() and not force:
+        try:
+            cached = json.loads(target_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            cached = None
+        if isinstance(cached, list) and len(cached) > 0:
+            return len(cached)
+
+    listing_html = _http_get_text(archive_url, timeout=timeout)
+    entries = extract_lse_listing(listing_html)
+    if limit is not None:
+        entries = entries[:limit]
+
+    parsed: list[ParsedRegionalResearch] = []
+    for i, entry in enumerate(entries):
+        try:
+            page_html = _http_get_text(entry.url, timeout=timeout)
+            parsed.append(parse_lse_post(page_html, source_url=entry.url))
+        except Exception as exc:
+            warnings.warn(
+                f"Regional research fetch failed for {entry.url}: {exc}",
+                stacklevel=2,
+            )
+            continue
+        # Polite delay between page fetches so a long walk does not
+        # trigger an upstream throttle. Skipped after the last entry.
+        if delay_seconds > 0 and i + 1 < len(entries):
+            time.sleep(delay_seconds)
+
+    tmp_path = target_path.with_suffix(target_path.suffix + ".tmp")
+    try:
+        written = write_regional_research_json(parsed, tmp_path)
+        if written == 0:
+            raise RuntimeError(
+                f"Regional research pull from {archive_url} produced zero rows"
+            )
+        tmp_path.replace(target_path)
+        return written
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from app.config import DATA_DIR as _DEFAULT_DATA_DIR
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Walk the Liberty Street Economics archive and write "
+            f"{OUTPUT_FILENAME} into the data directory. The resulting "
+            "JSON is picked up unchanged by "
+            "`python -m app.data.ingest_sources --include-scraped`."
+        )
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=str(_DEFAULT_DATA_DIR),
+        help="Base data directory (default: app.config.DATA_DIR).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-pull even if the cache file already exists.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Stop after fetching N posts (smoke testing).",
+    )
+    parser.add_argument(
+        "--archive-url",
+        default=ARCHIVE_LISTING_URL,
+        help="Override the archive listing URL.",
+    )
+    parser.add_argument(
+        "--delay-seconds",
+        type=float,
+        default=0.5,
+        help="Polite delay between page fetches (default: 0.5s).",
+    )
+    ns = parser.parse_args()
+    target = Path(ns.data_dir) / OUTPUT_FILENAME
+    rows = pull_regional_research_archive(
+        target,
+        force=ns.force,
+        archive_url=ns.archive_url,
+        limit=ns.limit,
+        delay_seconds=ns.delay_seconds,
+    )
+    print(f"Regional research cache at {target} (rows: {rows})")

--- a/backend/app/services/scraper_regional_research.py
+++ b/backend/app/services/scraper_regional_research.py
@@ -228,7 +228,7 @@ def _http_get_text(url: str, *, timeout: float) -> str:
     return body.decode("utf-8", errors="replace")
 
 
-def pull_regional_research_archive(
+def pull_regional_research_archive(  # noqa: PLR0913
     target_path: Path,
     *,
     force: bool = False,

--- a/backend/app/services/scraper_speeches.py
+++ b/backend/app/services/scraper_speeches.py
@@ -13,6 +13,10 @@ from __future__ import annotations
 
 import json
 import re
+import time
+import urllib.error
+import urllib.request
+import warnings
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,6 +28,26 @@ from bs4 import BeautifulSoup
 ARCHIVE_BASE_URL = "https://www.federalreserve.gov"
 SPEECH_URL_PATTERN = re.compile(r"^/newsevents/speech/[a-z]+(\d{8})[a-z]\.htm$")
 DATE_FROM_URL_PATTERN = re.compile(r"/speech/[a-z]+(\d{8})[a-z]\.htm$")
+
+# Two distinct output files: one for chair speeches, one for governor
+# speeches. The same parsed-entry list is filtered through both writers,
+# which key on the speaker's title to assign each entry to the right
+# sub-corpus. ``ingest_sources.SCRAPED_FILES`` lists both filenames so
+# the downstream record iterator picks them up unchanged.
+CHAIR_OUTPUT_FILENAME = "chair_speeches.json"
+GOVERNOR_OUTPUT_FILENAME = "governor_speeches.json"
+ARCHIVE_LISTING_URL_TEMPLATE = (
+    ARCHIVE_BASE_URL + "/newsevents/speech/{year}-speeches.htm"
+)
+ARCHIVE_LISTING_URL = ARCHIVE_LISTING_URL_TEMPLATE.format(
+    year=datetime.now(timezone.utc).year
+)
+# Default historical window when ``--years`` is not specified on the
+# CLI. The Fed's annual speech archives go back to 1996; the canonical
+# FOMC corpus this project trains on starts in 2006 so we use that as
+# the default lower bound. The window collapses to a single year via
+# ``--years 2025``.
+_DEFAULT_YEAR_LOWER = 2006
 
 _MONTH_PATTERN = re.compile(
     r"(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),\s+(\d{4})",
@@ -313,3 +337,249 @@ def write_governor_speeches_json(parsed: Iterable[ParsedSpeech], output_path: Pa
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(rows, indent=2), encoding="utf-8")
     return len(rows)
+
+
+# federalreserve.gov 403s the stdlib default ``Python-urllib/x.y`` UA,
+# so every request needs a real-browser-ish header. Identifying the
+# project in the UA keeps the traffic auditable on the upstream's side.
+_USER_AGENT = (
+    "fed-pulse-data-ingester/1.0 "
+    "(+https://github.com/yusufizzetmurat/fed-pulse)"
+)
+
+
+def _http_get_text(url: str, *, timeout: float) -> str:
+    """Fetch ``url`` and return the response body as decoded text.
+
+    Wraps stdlib ``urllib.request.urlopen`` so HTTP non-2xx surfaces as
+    ``RuntimeError`` (the upstream ``HTTPError`` is re-raised with the
+    URL in the message so the caller logs see which page failed). A
+    User-Agent header is set explicitly because the federalreserve.gov
+    edge rejects requests without one.
+    """
+
+    request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    try:
+        response = urllib.request.urlopen(request, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"HTTP {exc.code} from {url}") from exc
+    with response:
+        body = response.read()
+    return body.decode("utf-8", errors="replace")
+
+
+def _default_years() -> list[int]:
+    """Return the default per-year archive coverage window.
+
+    Walks from ``_DEFAULT_YEAR_LOWER`` to the current calendar year
+    inclusive. Operators can override with ``--years`` on the CLI.
+    """
+
+    current = datetime.now(timezone.utc).year
+    return list(range(_DEFAULT_YEAR_LOWER, current + 1))
+
+
+def pull_speeches_archive(
+    chair_target_path: Path,
+    governor_target_path: Path,
+    *,
+    force: bool = False,
+    archive_url: str | None = None,
+    years: list[int] | None = None,
+    limit: int | None = None,
+    timeout: float = 30.0,
+    delay_seconds: float = 0.5,
+) -> int:
+    """Walk the federalreserve.gov speech archives and write the chair + governor JSONs.
+
+    The Fed publishes one annual archive page per year at
+    ``/newsevents/speech/{year}-speeches.htm`` (the master
+    ``/newsevents/speeches.htm`` is a 301 redirect to the latest year,
+    so we generate year URLs over a range rather than scraping it).
+    This orchestrator walks every year in ``years`` (defaults to 2006
+    through the current calendar year), discovers individual speech
+    URLs from each annual page, then fetches and parses each speech.
+
+    Because the speech corpus is split into two output files keyed by
+    the speaker's title (chair vs governor), the same parsed-entry
+    list is funnelled through BOTH
+    :func:`write_chair_speeches_json` and
+    :func:`write_governor_speeches_json` -- two JSON files land in the
+    operator's data directory. The function returns the total row
+    count across both files so the CLI can print one summary line.
+
+    Idempotency check looks at BOTH cache files: when both exist with
+    non-empty JSON lists and ``force`` is False, the combined row
+    count is returned without any HTTP traffic. A corrupt or empty
+    file on either side forces a re-pull of both.
+
+    ``archive_url`` short-circuits the year walk: when set, the
+    orchestrator treats it as the single listing URL to walk (useful
+    for testing). Per-page failures (listing or detail) are logged via
+    :mod:`warnings` and the walk continues; a walk producing zero
+    total rows raises ``RuntimeError``.
+    """
+
+    if (
+        chair_target_path.exists()
+        and governor_target_path.exists()
+        and not force
+    ):
+        try:
+            chair_cached = json.loads(chair_target_path.read_text(encoding="utf-8"))
+            gov_cached = json.loads(governor_target_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            chair_cached = None
+            gov_cached = None
+        if (
+            isinstance(chair_cached, list)
+            and isinstance(gov_cached, list)
+            and (len(chair_cached) + len(gov_cached)) > 0
+        ):
+            return len(chair_cached) + len(gov_cached)
+
+    if archive_url is not None:
+        listing_urls = [archive_url]
+    else:
+        year_list = years if years is not None else _default_years()
+        listing_urls = [
+            ARCHIVE_LISTING_URL_TEMPLATE.format(year=y) for y in year_list
+        ]
+
+    entries: list[SpeechListingEntry] = []
+    seen_urls: set[str] = set()
+    for listing_url in listing_urls:
+        try:
+            listing_html = _http_get_text(listing_url, timeout=timeout)
+        except Exception as exc:
+            warnings.warn(
+                f"Speech listing fetch failed for {listing_url}: {exc}",
+                stacklevel=2,
+            )
+            continue
+        for entry in extract_speech_listing(listing_html):
+            if entry.url in seen_urls:
+                continue
+            seen_urls.add(entry.url)
+            entries.append(entry)
+
+    if limit is not None:
+        entries = entries[:limit]
+
+    parsed: list[ParsedSpeech] = []
+    for i, entry in enumerate(entries):
+        try:
+            page_html = _http_get_text(entry.url, timeout=timeout)
+            single = parse_speech_page(page_html, source_url=entry.url)
+            # The detail page may not always carry the speaker; fall
+            # back to the listing-entry speaker when the parsed row is
+            # empty, so the chair/governor classifier has something to
+            # match on.
+            if not single.speaker and entry.speaker:
+                single = ParsedSpeech(
+                    date=single.date or entry.date,
+                    speaker=entry.speaker,
+                    title=single.title or entry.title,
+                    text=single.text,
+                    url=single.url,
+                )
+            parsed.append(single)
+        except Exception as exc:
+            warnings.warn(
+                f"Speech fetch failed for {entry.url}: {exc}",
+                stacklevel=2,
+            )
+            continue
+        if delay_seconds > 0 and i + 1 < len(entries):
+            time.sleep(delay_seconds)
+
+    chair_tmp = chair_target_path.with_suffix(chair_target_path.suffix + ".tmp")
+    gov_tmp = governor_target_path.with_suffix(governor_target_path.suffix + ".tmp")
+    try:
+        chair_written = write_chair_speeches_json(parsed, chair_tmp)
+        gov_written = write_governor_speeches_json(parsed, gov_tmp)
+        if (chair_written + gov_written) == 0:
+            raise RuntimeError(
+                f"Speeches pull produced zero rows (listings tried: "
+                f"{len(listing_urls)})"
+            )
+        chair_tmp.replace(chair_target_path)
+        gov_tmp.replace(governor_target_path)
+        return chair_written + gov_written
+    except Exception:
+        for tmp in (chair_tmp, gov_tmp):
+            if tmp.exists():
+                tmp.unlink()
+        raise
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from app.config import DATA_DIR as _DEFAULT_DATA_DIR
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Walk the federalreserve.gov speech archives and write both "
+            f"{CHAIR_OUTPUT_FILENAME} and {GOVERNOR_OUTPUT_FILENAME} into "
+            "the data directory. The resulting JSONs are picked up "
+            "unchanged by `python -m app.data.ingest_sources --include-scraped`."
+        )
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=str(_DEFAULT_DATA_DIR),
+        help="Base data directory (default: app.config.DATA_DIR).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-pull even if both cache files already exist.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Stop after fetching N speeches (smoke testing).",
+    )
+    parser.add_argument(
+        "--archive-url",
+        default=None,
+        help=(
+            "Override the listing URL. When set, the orchestrator walks "
+            "this single URL instead of the per-year template."
+        ),
+    )
+    parser.add_argument(
+        "--years",
+        type=int,
+        nargs="+",
+        default=None,
+        help=(
+            "Years to walk via the per-year template (default: 2006 "
+            "through the current calendar year)."
+        ),
+    )
+    parser.add_argument(
+        "--delay-seconds",
+        type=float,
+        default=0.5,
+        help="Polite delay between page fetches (default: 0.5s).",
+    )
+    ns = parser.parse_args()
+    data_dir = Path(ns.data_dir)
+    chair_target = data_dir / CHAIR_OUTPUT_FILENAME
+    governor_target = data_dir / GOVERNOR_OUTPUT_FILENAME
+    rows = pull_speeches_archive(
+        chair_target,
+        governor_target,
+        force=ns.force,
+        archive_url=ns.archive_url,
+        years=ns.years,
+        limit=ns.limit,
+        delay_seconds=ns.delay_seconds,
+    )
+    print(
+        f"Speeches cache at {chair_target} + {governor_target} "
+        f"(rows: {rows})"
+    )

--- a/backend/app/services/scraper_speeches.py
+++ b/backend/app/services/scraper_speeches.py
@@ -379,7 +379,7 @@ def _default_years() -> list[int]:
     return list(range(_DEFAULT_YEAR_LOWER, current + 1))
 
 
-def pull_speeches_archive(
+def pull_speeches_archive(  # noqa: PLR0913
     chair_target_path: Path,
     governor_target_path: Path,
     *,

--- a/backend/app/services/scraper_speeches.py
+++ b/backend/app/services/scraper_speeches.py
@@ -420,6 +420,12 @@ def pull_speeches_archive(  # noqa: PLR0913
     total rows raises ``RuntimeError``.
     """
 
+    # Idempotency: ONLY honour a cache hit when BOTH files exist. A run
+    # that exited between the chair and governor ``replace()`` swaps
+    # below would leave a half-written pair on disk; treating that state
+    # as a cache hit would freeze the divergence across all future
+    # invocations. Forcing a re-pull whenever the pair is incomplete is
+    # the safe recovery path.
     if (
         chair_target_path.exists()
         and governor_target_path.exists()
@@ -437,6 +443,18 @@ def pull_speeches_archive(  # noqa: PLR0913
             and (len(chair_cached) + len(gov_cached)) > 0
         ):
             return len(chair_cached) + len(gov_cached)
+    elif (
+        chair_target_path.exists() != governor_target_path.exists()
+        and not force
+    ):
+        # Partial-write recovery: warn so the operator can see the
+        # divergence in the run log, then fall through to the re-pull.
+        present = "chair" if chair_target_path.exists() else "governor"
+        warnings.warn(
+            f"Speeches cache is partial — only {present}_speeches.json "
+            "present; re-pulling both files",
+            stacklevel=2,
+        )
 
     if archive_url is not None:
         listing_urls = [archive_url]

--- a/backend/app/services/scraper_speeches.py
+++ b/backend/app/services/scraper_speeches.py
@@ -364,7 +364,7 @@ def _http_get_text(url: str, *, timeout: float) -> str:
     except urllib.error.HTTPError as exc:
         raise RuntimeError(f"HTTP {exc.code} from {url}") from exc
     with response:
-        body = response.read()
+        body: bytes = response.read()
     return body.decode("utf-8", errors="replace")
 
 

--- a/backend/app/services/scraper_testimonies.py
+++ b/backend/app/services/scraper_testimonies.py
@@ -13,6 +13,10 @@ from __future__ import annotations
 
 import json
 import re
+import time
+import urllib.error
+import urllib.request
+import warnings
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,6 +28,19 @@ from bs4 import BeautifulSoup
 ARCHIVE_BASE_URL = "https://www.federalreserve.gov"
 TESTIMONY_URL_PATTERN = re.compile(r"^/newsevents/testimony/[a-z]+(\d{8})[a-z]\.htm$")
 DATE_FROM_URL_PATTERN = re.compile(r"/testimony/[a-z]+(\d{8})[a-z]\.htm$")
+
+OUTPUT_FILENAME = "congressional_testimonies.json"
+ARCHIVE_LISTING_URL_TEMPLATE = (
+    ARCHIVE_BASE_URL + "/newsevents/testimony/{year}-testimony.htm"
+)
+ARCHIVE_LISTING_URL = ARCHIVE_LISTING_URL_TEMPLATE.format(
+    year=datetime.now(timezone.utc).year
+)
+# Default historical window when ``--years`` is not specified on the CLI.
+# The Fed's annual testimony archives go back to ~1996 but the pre-2006
+# pages have looser HTML; the canonical FOMC corpus this project trains
+# on starts in 2006 so we use that as the default lower bound.
+_DEFAULT_YEAR_LOWER = 2006
 
 _MONTH_PATTERN = re.compile(
     r"(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),\s+(\d{4})",
@@ -246,3 +263,217 @@ def write_testimonies_json(parsed: Iterable[ParsedTestimony], output_path: Path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(rows, indent=2), encoding="utf-8")
     return len(rows)
+
+
+# federalreserve.gov 403s the stdlib default ``Python-urllib/x.y`` UA,
+# so every request needs a real-browser-ish header. Identifying the
+# project in the UA keeps the traffic auditable on the upstream's side.
+_USER_AGENT = (
+    "fed-pulse-data-ingester/1.0 "
+    "(+https://github.com/yusufizzetmurat/fed-pulse)"
+)
+
+
+def _http_get_text(url: str, *, timeout: float) -> str:
+    """Fetch ``url`` and return the response body as decoded text.
+
+    Wraps stdlib ``urllib.request.urlopen`` so HTTP non-2xx surfaces as
+    ``RuntimeError`` (the upstream ``HTTPError`` is re-raised with the
+    URL in the message so the caller logs see which page failed). A
+    User-Agent header is set explicitly because the federalreserve.gov
+    edge rejects requests without one.
+    """
+
+    request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    try:
+        response = urllib.request.urlopen(request, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"HTTP {exc.code} from {url}") from exc
+    with response:
+        body = response.read()
+    return body.decode("utf-8", errors="replace")
+
+
+def _default_years() -> list[int]:
+    """Return the default per-year archive coverage window.
+
+    Walks from ``_DEFAULT_YEAR_LOWER`` to the current calendar year
+    inclusive. Operators can override with ``--years`` on the CLI.
+    """
+
+    current = datetime.now(timezone.utc).year
+    return list(range(_DEFAULT_YEAR_LOWER, current + 1))
+
+
+def pull_testimonies_archive(
+    target_path: Path,
+    *,
+    force: bool = False,
+    archive_url: str | None = None,
+    years: list[int] | None = None,
+    limit: int | None = None,
+    timeout: float = 30.0,
+    delay_seconds: float = 0.5,
+) -> int:
+    """Walk the federalreserve.gov testimony archives and write parsed rows.
+
+    The Fed publishes one annual archive page per year at
+    ``/newsevents/testimony/{year}-testimony.htm``. This orchestrator
+    walks every year in ``years`` (defaults to 2006 through the current
+    calendar year), discovers individual testimony URLs from each
+    annual page, then fetches and parses each testimony. Parsed rows
+    are written to ``target_path`` via :func:`write_testimonies_json`
+    -- the same JSON shape ``ingest_sources._iter_scraped_records``
+    consumes.
+
+    ``archive_url`` short-circuits the year walk: when set, the
+    orchestrator treats it as the single listing URL to walk (useful
+    for testing). When unset, the per-year template is used.
+
+    Idempotent: when ``target_path`` already exists with a non-empty
+    JSON list and ``force`` is False, the existing row count is
+    returned without any HTTP traffic. A corrupt or empty file forces
+    a re-pull.
+
+    Per-page failures (HTTP error on a single annual archive or
+    testimony page, parse miss) are logged via :mod:`warnings` and the
+    walk continues -- one bad page must not drop the whole pull.
+    ``limit`` caps the walk at the first ``N`` discovered testimonies,
+    useful for smoke-testing. A walk that produces zero rows raises
+    ``RuntimeError`` so a broken default surfaces loudly.
+    """
+
+    if target_path.exists() and not force:
+        try:
+            cached = json.loads(target_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            cached = None
+        if isinstance(cached, list) and len(cached) > 0:
+            return len(cached)
+
+    if archive_url is not None:
+        listing_urls = [archive_url]
+    else:
+        year_list = years if years is not None else _default_years()
+        listing_urls = [
+            ARCHIVE_LISTING_URL_TEMPLATE.format(year=y) for y in year_list
+        ]
+
+    entries: list[TestimonyListingEntry] = []
+    seen_urls: set[str] = set()
+    for listing_url in listing_urls:
+        try:
+            listing_html = _http_get_text(listing_url, timeout=timeout)
+        except Exception as exc:
+            # Listing-page failures degrade gracefully -- one missing
+            # year (e.g. a future year before the page is generated)
+            # must not abort the walk. The aggregate zero-rows check
+            # below still catches a fully broken default.
+            warnings.warn(
+                f"Testimony listing fetch failed for {listing_url}: {exc}",
+                stacklevel=2,
+            )
+            continue
+        for entry in extract_testimony_listing(listing_html):
+            if entry.url in seen_urls:
+                continue
+            seen_urls.add(entry.url)
+            entries.append(entry)
+
+    if limit is not None:
+        entries = entries[:limit]
+
+    parsed: list[ParsedTestimony] = []
+    for i, entry in enumerate(entries):
+        try:
+            page_html = _http_get_text(entry.url, timeout=timeout)
+            parsed.append(parse_testimony_page(page_html, source_url=entry.url))
+        except Exception as exc:
+            warnings.warn(
+                f"Testimony fetch failed for {entry.url}: {exc}",
+                stacklevel=2,
+            )
+            continue
+        if delay_seconds > 0 and i + 1 < len(entries):
+            time.sleep(delay_seconds)
+
+    tmp_path = target_path.with_suffix(target_path.suffix + ".tmp")
+    try:
+        written = write_testimonies_json(parsed, tmp_path)
+        if written == 0:
+            raise RuntimeError(
+                f"Testimonies pull produced zero rows (listings tried: "
+                f"{len(listing_urls)})"
+            )
+        tmp_path.replace(target_path)
+        return written
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from app.config import DATA_DIR as _DEFAULT_DATA_DIR
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Walk the federalreserve.gov testimony archives and write "
+            f"{OUTPUT_FILENAME} into the data directory. The resulting "
+            "JSON is picked up unchanged by "
+            "`python -m app.data.ingest_sources --include-scraped`."
+        )
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=str(_DEFAULT_DATA_DIR),
+        help="Base data directory (default: app.config.DATA_DIR).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-pull even if the cache file already exists.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Stop after fetching N testimonies (smoke testing).",
+    )
+    parser.add_argument(
+        "--archive-url",
+        default=None,
+        help=(
+            "Override the listing URL. When set, the orchestrator walks "
+            "this single URL instead of the per-year template."
+        ),
+    )
+    parser.add_argument(
+        "--years",
+        type=int,
+        nargs="+",
+        default=None,
+        help=(
+            "Years to walk via the per-year template (default: 2006 "
+            "through the current calendar year)."
+        ),
+    )
+    parser.add_argument(
+        "--delay-seconds",
+        type=float,
+        default=0.5,
+        help="Polite delay between page fetches (default: 0.5s).",
+    )
+    ns = parser.parse_args()
+    target = Path(ns.data_dir) / OUTPUT_FILENAME
+    rows = pull_testimonies_archive(
+        target,
+        force=ns.force,
+        archive_url=ns.archive_url,
+        years=ns.years,
+        limit=ns.limit,
+        delay_seconds=ns.delay_seconds,
+    )
+    print(f"Congressional testimonies cache at {target} (rows: {rows})")

--- a/backend/app/services/scraper_testimonies.py
+++ b/backend/app/services/scraper_testimonies.py
@@ -305,7 +305,7 @@ def _default_years() -> list[int]:
     return list(range(_DEFAULT_YEAR_LOWER, current + 1))
 
 
-def pull_testimonies_archive(
+def pull_testimonies_archive(  # noqa: PLR0913
     target_path: Path,
     *,
     force: bool = False,

--- a/backend/app/services/scraper_testimonies.py
+++ b/backend/app/services/scraper_testimonies.py
@@ -290,7 +290,7 @@ def _http_get_text(url: str, *, timeout: float) -> str:
     except urllib.error.HTTPError as exc:
         raise RuntimeError(f"HTTP {exc.code} from {url}") from exc
     with response:
-        body = response.read()
+        body: bytes = response.read()
     return body.decode("utf-8", errors="replace")
 
 

--- a/tests/unit/test_scraper_press_conferences.py
+++ b/tests/unit/test_scraper_press_conferences.py
@@ -3,15 +3,19 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+import requests
 
 from app.services.scraper_press_conferences import (
+    ARCHIVE_LISTING_URL,
     PressConferenceListingEntry,
     ParsedPressConference,
     build_qa_lookup,
     extract_press_conference_listing,
     parse_press_conference_page,
+    pull_press_conferences_archive,
     split_prepared_remarks_and_qa,
     write_press_conferences_json,
 )
@@ -239,3 +243,195 @@ def test_parse_press_conference_page_caches_pdf_to_disk(tmp_path: Path, monkeypa
     assert parsed_first.qa_text == parsed_second.qa_text
     assert parsed_first.qa_text
     assert parsed_first.prepared_remarks_text
+
+
+# ----- pull_press_conferences_archive -----
+
+
+class _FakeRequestsResponse:
+    def __init__(
+        self,
+        *,
+        text: str = "",
+        content: bytes = b"",
+        status_code: int = 200,
+    ) -> None:
+        self.text = text
+        self.content = content
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            err = requests.HTTPError(f"HTTP {self.status_code}")
+            err.response = self  # type: ignore[assignment]
+            raise err
+
+
+_LISTING_HTML = """
+<html><body>
+<a href="/monetarypolicy/fomcpresconf20240131.htm">January</a>
+<a href="/monetarypolicy/fomcpresconf20240320.htm">March</a>
+</body></html>
+"""
+
+_PRESS_HTML_TEMPLATE = """
+<html><head><meta property="og:title" content="FOMC Press Conference - {label}"></head>
+<body><p>See the PDF.</p></body></html>
+"""
+
+
+def _route_requests_get(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+    if url == ARCHIVE_LISTING_URL:
+        return _FakeRequestsResponse(text=_LISTING_HTML)
+    # Suppress historical-year listing fetches (they 404 in the
+    # default historical window and are caught by the per-listing
+    # try/except in the orchestrator).
+    if "fomchistorical" in url:
+        return _FakeRequestsResponse(status_code=404)
+    if "fomcpresconf20240131.htm" in url:
+        return _FakeRequestsResponse(text=_PRESS_HTML_TEMPLATE.format(label="January"))
+    if "fomcpresconf20240320.htm" in url:
+        return _FakeRequestsResponse(text=_PRESS_HTML_TEMPLATE.format(label="March"))
+    raise AssertionError(f"unexpected URL fetched: {url}")
+
+
+def _stub_pdf_text(_bytes: bytes) -> str:
+    return "Prepared remarks. " + "Filler. " * 20
+
+
+def test_pull_press_walks_listing_and_writes_json(tmp_path: Path) -> None:
+    target = tmp_path / "press_conferences.json"
+    with patch(
+        "app.services.scraper_press_conferences.requests.get",
+        side_effect=_route_requests_get,
+    ), patch(
+        "app.services.scraper_press_conferences._load_or_fetch_pdf_bytes",
+        return_value=b"%PDF-1.4 stub",
+    ), patch(
+        "app.services.scraper_press_conferences._extract_pdf_text",
+        side_effect=_stub_pdf_text,
+    ):
+        rows = pull_press_conferences_archive(
+            target,
+            historical_years=[],
+            delay_seconds=0.0,
+        )
+    assert rows == 2
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    # Sorted by date desc: March first, then January
+    assert [r["date"] for r in payload] == ["2024-03-20", "2024-01-31"]
+    for row in payload:
+        assert row["document_type"] == "press_conference"
+        assert row["text"]
+
+
+def test_pull_press_is_idempotent_when_cache_has_rows(tmp_path: Path) -> None:
+    target = tmp_path / "press_conferences.json"
+    target.write_text(
+        json.dumps(
+            [{"date": "2024-01-31", "text": "x", "document_type": "press_conference"}]
+        ),
+        encoding="utf-8",
+    )
+    with patch(
+        "app.services.scraper_press_conferences.requests.get"
+    ) as get_mock:
+        rows = pull_press_conferences_archive(
+            target, historical_years=[], delay_seconds=0.0
+        )
+    assert rows == 1
+    get_mock.assert_not_called()
+
+
+def test_pull_press_force_re_walks_over_existing_cache(tmp_path: Path) -> None:
+    target = tmp_path / "press_conferences.json"
+    target.write_text(json.dumps([{"date": "stale", "text": "x"}]), encoding="utf-8")
+    with patch(
+        "app.services.scraper_press_conferences.requests.get",
+        side_effect=_route_requests_get,
+    ), patch(
+        "app.services.scraper_press_conferences._load_or_fetch_pdf_bytes",
+        return_value=b"%PDF-1.4 stub",
+    ), patch(
+        "app.services.scraper_press_conferences._extract_pdf_text",
+        side_effect=_stub_pdf_text,
+    ):
+        rows = pull_press_conferences_archive(
+            target,
+            force=True,
+            historical_years=[],
+            delay_seconds=0.0,
+        )
+    assert rows == 2
+
+
+def test_pull_press_continues_when_one_page_404s(tmp_path: Path) -> None:
+    target = tmp_path / "press_conferences.json"
+
+    def _route_one_404(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        if "fomcpresconf20240131.htm" in url:
+            return _FakeRequestsResponse(status_code=404)
+        return _route_requests_get(url, *args, **kwargs)
+
+    with patch(
+        "app.services.scraper_press_conferences.requests.get",
+        side_effect=_route_one_404,
+    ), patch(
+        "app.services.scraper_press_conferences._load_or_fetch_pdf_bytes",
+        return_value=b"%PDF-1.4 stub",
+    ), patch(
+        "app.services.scraper_press_conferences._extract_pdf_text",
+        side_effect=_stub_pdf_text,
+    ):
+        with pytest.warns(UserWarning, match="Press conference fetch failed"):
+            rows = pull_press_conferences_archive(
+                target,
+                historical_years=[],
+                delay_seconds=0.0,
+            )
+    assert rows == 1  # only March survived
+
+
+def test_pull_press_raises_on_calendar_listing_http_error(tmp_path: Path) -> None:
+    target = tmp_path / "press_conferences.json"
+
+    def _route_calendar_503(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        return _FakeRequestsResponse(status_code=503)
+
+    with patch(
+        "app.services.scraper_press_conferences.requests.get",
+        side_effect=_route_calendar_503,
+    ):
+        with pytest.warns(UserWarning, match="Press conference listing fetch failed"):
+            with pytest.raises(RuntimeError, match="zero rows"):
+                pull_press_conferences_archive(
+                    target,
+                    historical_years=[],
+                    delay_seconds=0.0,
+                )
+    assert not target.exists()
+    assert not target.with_suffix(target.suffix + ".tmp").exists()
+
+
+def test_pull_press_limit_caps_walk(tmp_path: Path) -> None:
+    target = tmp_path / "press_conferences.json"
+    with patch(
+        "app.services.scraper_press_conferences.requests.get",
+        side_effect=_route_requests_get,
+    ), patch(
+        "app.services.scraper_press_conferences._load_or_fetch_pdf_bytes",
+        return_value=b"%PDF-1.4 stub",
+    ), patch(
+        "app.services.scraper_press_conferences._extract_pdf_text",
+        side_effect=_stub_pdf_text,
+    ):
+        rows = pull_press_conferences_archive(
+            target,
+            historical_years=[],
+            limit=1,
+            delay_seconds=0.0,
+        )
+    assert rows == 1
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    # Most recent first
+    assert payload[0]["date"] == "2024-03-20"

--- a/tests/unit/test_scraper_regional_research.py
+++ b/tests/unit/test_scraper_regional_research.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import json
 import re
+import urllib.error
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from app.services.scraper_regional_research import (
+    ARCHIVE_LISTING_URL,
     RegionalResearchListingEntry,
     ParsedRegionalResearch,
     extract_lse_listing,
     parse_lse_post,
+    pull_regional_research_archive,
     write_regional_research_json,
 )
 
@@ -83,3 +87,140 @@ def test_write_regional_research_json_emits_one_row_per_parsed(tmp_path: Path) -
     assert len(payload) == 1
     assert payload[0]["document_type"] == "regional_research"
     assert payload[0]["source_bank"] == "ny_fed"
+
+
+# ----- pull_regional_research_archive -----
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+
+_LISTING_HTML = """
+<html><body>
+<a href="https://libertystreeteconomics.newyorkfed.org/2024/03/post-one/">Post One</a>
+<a href="https://libertystreeteconomics.newyorkfed.org/2024/04/post-two/">Post Two</a>
+</body></html>
+"""
+
+_POST_HTML_TEMPLATE = """
+<html><head><meta property="og:title" content="LSE Post {month}"></head>
+<body><div class="ts-article-text">
+<p>{filler}</p>
+<p>{filler2}</p>
+<p>{filler3}</p>
+</div></body></html>
+"""
+
+
+def _fake_post(month: str) -> str:
+    filler = "Substantive analytical paragraph from the Liberty Street post body " * 8
+    filler2 = "The data show that bond market liquidity has thinned materially since the prior quarter " * 6
+    filler3 = "Cross sectional analysis across maturities suggests a persistent term premium adjustment " * 6
+    return _POST_HTML_TEMPLATE.format(
+        month=month, filler=filler, filler2=filler2, filler3=filler3
+    )
+
+
+def _route_urlopen(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+    url_str = url if isinstance(url, str) else url.full_url
+    if url_str == ARCHIVE_LISTING_URL:
+        return _FakeResponse(_LISTING_HTML.encode("utf-8"))
+    if "post-one" in url_str:
+        return _FakeResponse(_fake_post("March 2024").encode("utf-8"))
+    if "post-two" in url_str:
+        return _FakeResponse(_fake_post("April 2024").encode("utf-8"))
+    raise AssertionError(f"unexpected URL fetched: {url_str}")
+
+
+def test_pull_walks_listing_and_writes_json(tmp_path: Path) -> None:
+    target = tmp_path / "regional_research.json"
+    with patch(
+        "app.services.scraper_regional_research.urllib.request.urlopen",
+        side_effect=_route_urlopen,
+    ) as opener:
+        rows = pull_regional_research_archive(target, delay_seconds=0.0)
+    assert rows == 2
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert [r["date"] for r in payload] == ["2024-03-01", "2024-04-01"]
+    assert opener.call_count == 3
+
+
+def test_pull_is_idempotent_when_cache_has_rows(tmp_path: Path) -> None:
+    target = tmp_path / "regional_research.json"
+    target.write_text(
+        json.dumps(
+            [{"date": "2024-03-01", "text": "x", "document_type": "regional_research"}]
+        ),
+        encoding="utf-8",
+    )
+    with patch(
+        "app.services.scraper_regional_research.urllib.request.urlopen"
+    ) as opener:
+        rows = pull_regional_research_archive(target, delay_seconds=0.0)
+    assert rows == 1
+    opener.assert_not_called()
+
+
+def test_pull_force_re_walks_over_existing_cache(tmp_path: Path) -> None:
+    target = tmp_path / "regional_research.json"
+    target.write_text(json.dumps([{"date": "stale", "text": "x"}]), encoding="utf-8")
+    with patch(
+        "app.services.scraper_regional_research.urllib.request.urlopen",
+        side_effect=_route_urlopen,
+    ):
+        rows = pull_regional_research_archive(target, force=True, delay_seconds=0.0)
+    assert rows == 2
+
+
+def test_pull_continues_when_one_page_404s(tmp_path: Path) -> None:
+    target = tmp_path / "regional_research.json"
+
+    def _route_with_one_404(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        url_str = url if isinstance(url, str) else url.full_url
+        if "post-one" in url_str:
+            raise urllib.error.HTTPError(url_str, 404, "Not Found", None, None)  # type: ignore[arg-type]
+        return _route_urlopen(url, *args, **kwargs)
+
+    with patch(
+        "app.services.scraper_regional_research.urllib.request.urlopen",
+        side_effect=_route_with_one_404,
+    ):
+        with pytest.warns(UserWarning, match="Regional research fetch failed"):
+            rows = pull_regional_research_archive(target, delay_seconds=0.0)
+    assert rows == 1  # only post-two survived
+
+
+def test_pull_raises_on_listing_http_error(tmp_path: Path) -> None:
+    target = tmp_path / "regional_research.json"
+    err = urllib.error.HTTPError(ARCHIVE_LISTING_URL, 503, "boom", None, None)  # type: ignore[arg-type]
+    with patch(
+        "app.services.scraper_regional_research.urllib.request.urlopen",
+        side_effect=err,
+    ):
+        with pytest.raises(RuntimeError, match="HTTP 503"):
+            pull_regional_research_archive(target, delay_seconds=0.0)
+    assert not target.exists()
+    assert not target.with_suffix(target.suffix + ".tmp").exists()
+
+
+def test_pull_limit_caps_walk(tmp_path: Path) -> None:
+    target = tmp_path / "regional_research.json"
+    with patch(
+        "app.services.scraper_regional_research.urllib.request.urlopen",
+        side_effect=_route_urlopen,
+    ) as opener:
+        rows = pull_regional_research_archive(target, limit=1, delay_seconds=0.0)
+    assert rows == 1
+    assert opener.call_count == 2

--- a/tests/unit/test_scraper_speeches.py
+++ b/tests/unit/test_scraper_speeches.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import json
+import urllib.error
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from app.services.scraper_speeches import (
+    ParsedSpeech,
     SpeechListingEntry,
     extract_speech_listing,
+    pull_speeches_archive,
 )
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
@@ -217,3 +222,202 @@ def test_write_governor_speeches_json_skips_rows_with_empty_body(tmp_path: Path)
     written = write_governor_speeches_json(parsed, output)
     assert written == 0
     assert output.read_text(encoding="utf-8") == "[]"
+
+
+# ----- pull_speeches_archive -----
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+
+_LISTING_HTML = """
+<html><body>
+<div class="row">
+  <div class="speaker">Chair Powell</div>
+  <p><a href="/newsevents/speech/powell20240306a.htm">A Chair Speech</a></p>
+</div>
+<div class="row">
+  <div class="speaker">Governor Waller</div>
+  <p><a href="/newsevents/speech/waller20240501a.htm">A Governor Speech</a></p>
+</div>
+</body></html>
+"""
+
+_PAGE_HTML_TEMPLATE = """
+<html><head><meta property="og:title" content="Speech - {speaker} - {label}"></head>
+<body><div id="article">
+<p class="speaker">{speaker}</p>
+<p>{filler}</p>
+<p>{filler2}</p>
+<p>{filler3}</p>
+</div></body></html>
+"""
+
+
+def _fake_page(speaker: str, label: str) -> str:
+    filler = "Substantive speech paragraph on monetary policy and the economy " * 8
+    filler2 = "Labor market conditions remain resilient and consistent with the dual mandate " * 6
+    filler3 = "Inflation has eased materially over the past year toward the two percent objective " * 6
+    return _PAGE_HTML_TEMPLATE.format(
+        speaker=speaker, label=label, filler=filler, filler2=filler2, filler3=filler3
+    )
+
+
+_SINGLE_ARCHIVE_URL = "https://www.federalreserve.gov/newsevents/speech/2024-speeches.htm"
+
+
+def _route_urlopen(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+    url_str = url if isinstance(url, str) else url.full_url
+    if url_str == _SINGLE_ARCHIVE_URL:
+        return _FakeResponse(_LISTING_HTML.encode("utf-8"))
+    if "powell20240306" in url_str:
+        return _FakeResponse(_fake_page("Chair Powell", "March 2024").encode("utf-8"))
+    if "waller20240501" in url_str:
+        return _FakeResponse(_fake_page("Governor Waller", "May 2024").encode("utf-8"))
+    raise AssertionError(f"unexpected URL fetched: {url_str}")
+
+
+def test_pull_walks_listing_and_writes_both_outputs(tmp_path: Path) -> None:
+    chair_target = tmp_path / "chair_speeches.json"
+    gov_target = tmp_path / "governor_speeches.json"
+    with patch(
+        "app.services.scraper_speeches.urllib.request.urlopen",
+        side_effect=_route_urlopen,
+    ) as opener:
+        rows = pull_speeches_archive(
+            chair_target,
+            gov_target,
+            archive_url=_SINGLE_ARCHIVE_URL,
+            delay_seconds=0.0,
+        )
+    assert rows == 2  # one chair row + one governor row
+    chair_payload = json.loads(chair_target.read_text(encoding="utf-8"))
+    gov_payload = json.loads(gov_target.read_text(encoding="utf-8"))
+    assert len(chair_payload) == 1
+    assert chair_payload[0]["document_type"] == "chair_speech"
+    assert len(gov_payload) == 1
+    assert gov_payload[0]["document_type"] == "governor_speech"
+    # 1 listing fetch + 2 page fetches
+    assert opener.call_count == 3
+
+
+def test_pull_is_idempotent_when_both_caches_have_rows(tmp_path: Path) -> None:
+    chair_target = tmp_path / "chair_speeches.json"
+    gov_target = tmp_path / "governor_speeches.json"
+    chair_target.write_text(
+        json.dumps([{"date": "2024-03-06", "text": "x", "document_type": "chair_speech"}]),
+        encoding="utf-8",
+    )
+    gov_target.write_text(
+        json.dumps([{"date": "2024-05-01", "text": "x", "document_type": "governor_speech"}]),
+        encoding="utf-8",
+    )
+    with patch("app.services.scraper_speeches.urllib.request.urlopen") as opener:
+        rows = pull_speeches_archive(
+            chair_target,
+            gov_target,
+            archive_url=_SINGLE_ARCHIVE_URL,
+            delay_seconds=0.0,
+        )
+    assert rows == 2
+    opener.assert_not_called()
+
+
+def test_pull_force_re_walks_over_existing_caches(tmp_path: Path) -> None:
+    chair_target = tmp_path / "chair_speeches.json"
+    gov_target = tmp_path / "governor_speeches.json"
+    chair_target.write_text(json.dumps([{"date": "stale", "text": "x"}]), encoding="utf-8")
+    gov_target.write_text(json.dumps([{"date": "stale", "text": "x"}]), encoding="utf-8")
+    with patch(
+        "app.services.scraper_speeches.urllib.request.urlopen",
+        side_effect=_route_urlopen,
+    ):
+        rows = pull_speeches_archive(
+            chair_target,
+            gov_target,
+            archive_url=_SINGLE_ARCHIVE_URL,
+            force=True,
+            delay_seconds=0.0,
+        )
+    assert rows == 2
+
+
+def test_pull_continues_when_one_page_404s(tmp_path: Path) -> None:
+    chair_target = tmp_path / "chair_speeches.json"
+    gov_target = tmp_path / "governor_speeches.json"
+
+    def _route_with_one_404(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        url_str = url if isinstance(url, str) else url.full_url
+        if "powell20240306" in url_str:
+            raise urllib.error.HTTPError(url_str, 404, "Not Found", None, None)  # type: ignore[arg-type]
+        return _route_urlopen(url, *args, **kwargs)
+
+    with patch(
+        "app.services.scraper_speeches.urllib.request.urlopen",
+        side_effect=_route_with_one_404,
+    ):
+        with pytest.warns(UserWarning, match="Speech fetch failed"):
+            rows = pull_speeches_archive(
+                chair_target,
+                gov_target,
+                archive_url=_SINGLE_ARCHIVE_URL,
+                delay_seconds=0.0,
+            )
+    assert rows == 1  # only the governor row survived
+
+
+def test_pull_raises_on_listing_http_error(tmp_path: Path) -> None:
+    chair_target = tmp_path / "chair_speeches.json"
+    gov_target = tmp_path / "governor_speeches.json"
+
+    def _route_listing_503(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        url_str = url if isinstance(url, str) else url.full_url
+        raise urllib.error.HTTPError(url_str, 503, "boom", None, None)  # type: ignore[arg-type]
+
+    with patch(
+        "app.services.scraper_speeches.urllib.request.urlopen",
+        side_effect=_route_listing_503,
+    ):
+        with pytest.warns(UserWarning, match="Speech listing fetch failed"):
+            with pytest.raises(RuntimeError, match="zero rows"):
+                pull_speeches_archive(
+                    chair_target,
+                    gov_target,
+                    archive_url=_SINGLE_ARCHIVE_URL,
+                    delay_seconds=0.0,
+                )
+    assert not chair_target.exists()
+    assert not gov_target.exists()
+
+
+def test_pull_limit_caps_walk(tmp_path: Path) -> None:
+    chair_target = tmp_path / "chair_speeches.json"
+    gov_target = tmp_path / "governor_speeches.json"
+    with patch(
+        "app.services.scraper_speeches.urllib.request.urlopen",
+        side_effect=_route_urlopen,
+    ) as opener:
+        rows = pull_speeches_archive(
+            chair_target,
+            gov_target,
+            archive_url=_SINGLE_ARCHIVE_URL,
+            limit=1,
+            delay_seconds=0.0,
+        )
+    # First entry from the fixture listing is the chair; governor file
+    # is written but empty.
+    assert rows == 1
+    # 1 listing + 1 page = 2 fetches
+    assert opener.call_count == 2

--- a/tests/unit/test_scraper_testimonies.py
+++ b/tests/unit/test_scraper_testimonies.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import urllib.error
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -10,6 +12,7 @@ from app.services.scraper_testimonies import (
     ParsedTestimony,
     extract_testimony_listing,
     parse_testimony_page,
+    pull_testimonies_archive,
     write_testimonies_json,
 )
 
@@ -89,3 +92,189 @@ def test_write_testimonies_json_emits_one_row_per_parsed(tmp_path: Path) -> None
     assert len(payload) == 1
     assert payload[0]["document_type"] == "congressional_testimony"
     assert payload[0]["title"] == "Semiannual Monetary Policy Report"
+
+
+# ----- pull_testimonies_archive -----
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+
+_LISTING_HTML = """
+<html><body>
+<a href="/newsevents/testimony/powell20240306a.htm">Semiannual Monetary Policy Report</a>
+<a href="/newsevents/testimony/waller20240501a.htm">Banking Conditions</a>
+</body></html>
+"""
+
+_PAGE_HTML_TEMPLATE = """
+<html><head><meta property="og:title" content="Testimony - {speaker} - {label}"></head>
+<body><div id="article">
+<p class="speaker">{speaker}</p>
+<p>{filler}</p>
+<p>{filler2}</p>
+<p>{filler3}</p>
+</div></body></html>
+"""
+
+
+def _fake_page(speaker: str, label: str) -> str:
+    filler = "Substantive testimony paragraph on monetary policy and the economy " * 8
+    filler2 = "Labor market conditions remain resilient and consistent with the dual mandate " * 6
+    filler3 = "Inflation has eased materially over the past year toward the two percent objective " * 6
+    return _PAGE_HTML_TEMPLATE.format(
+        speaker=speaker, label=label, filler=filler, filler2=filler2, filler3=filler3
+    )
+
+
+_SINGLE_ARCHIVE_URL = "https://www.federalreserve.gov/newsevents/testimony/2024-testimony.htm"
+
+
+def _route_urlopen(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+    url_str = url if isinstance(url, str) else url.full_url
+    if url_str == _SINGLE_ARCHIVE_URL:
+        return _FakeResponse(_LISTING_HTML.encode("utf-8"))
+    if "powell20240306" in url_str:
+        return _FakeResponse(_fake_page("Chair Powell", "March 2024").encode("utf-8"))
+    if "waller20240501" in url_str:
+        return _FakeResponse(_fake_page("Governor Waller", "May 2024").encode("utf-8"))
+    raise AssertionError(f"unexpected URL fetched: {url_str}")
+
+
+def test_pull_walks_listing_and_writes_json(tmp_path: Path) -> None:
+    target = tmp_path / "congressional_testimonies.json"
+    with patch(
+        "app.services.scraper_testimonies.urllib.request.urlopen",
+        side_effect=_route_urlopen,
+    ) as opener:
+        rows = pull_testimonies_archive(
+            target, archive_url=_SINGLE_ARCHIVE_URL, delay_seconds=0.0
+        )
+    assert rows == 2
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert [r["date"] for r in payload] == ["2024-03-06", "2024-05-01"]
+    assert opener.call_count == 3
+
+
+def test_pull_is_idempotent_when_cache_has_rows(tmp_path: Path) -> None:
+    target = tmp_path / "congressional_testimonies.json"
+    target.write_text(
+        json.dumps(
+            [
+                {
+                    "date": "2024-03-06",
+                    "text": "x",
+                    "document_type": "congressional_testimony",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    with patch("app.services.scraper_testimonies.urllib.request.urlopen") as opener:
+        rows = pull_testimonies_archive(
+            target, archive_url=_SINGLE_ARCHIVE_URL, delay_seconds=0.0
+        )
+    assert rows == 1
+    opener.assert_not_called()
+
+
+def test_pull_force_re_walks_over_existing_cache(tmp_path: Path) -> None:
+    target = tmp_path / "congressional_testimonies.json"
+    target.write_text(json.dumps([{"date": "stale", "text": "x"}]), encoding="utf-8")
+    with patch(
+        "app.services.scraper_testimonies.urllib.request.urlopen",
+        side_effect=_route_urlopen,
+    ):
+        rows = pull_testimonies_archive(
+            target,
+            archive_url=_SINGLE_ARCHIVE_URL,
+            force=True,
+            delay_seconds=0.0,
+        )
+    assert rows == 2
+
+
+def test_pull_continues_when_one_page_404s(tmp_path: Path) -> None:
+    target = tmp_path / "congressional_testimonies.json"
+
+    def _route_with_one_404(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        url_str = url if isinstance(url, str) else url.full_url
+        if "powell20240306" in url_str:
+            raise urllib.error.HTTPError(url_str, 404, "Not Found", None, None)  # type: ignore[arg-type]
+        return _route_urlopen(url, *args, **kwargs)
+
+    with patch(
+        "app.services.scraper_testimonies.urllib.request.urlopen",
+        side_effect=_route_with_one_404,
+    ):
+        with pytest.warns(UserWarning, match="Testimony fetch failed"):
+            rows = pull_testimonies_archive(
+                target, archive_url=_SINGLE_ARCHIVE_URL, delay_seconds=0.0
+            )
+    assert rows == 1  # only the May testimony survived
+
+
+def test_pull_raises_when_every_page_fails(tmp_path: Path) -> None:
+    target = tmp_path / "congressional_testimonies.json"
+
+    def _route_all_fail(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        url_str = url if isinstance(url, str) else url.full_url
+        if url_str == _SINGLE_ARCHIVE_URL:
+            return _FakeResponse(_LISTING_HTML.encode("utf-8"))
+        raise urllib.error.HTTPError(url_str, 500, "x", None, None)  # type: ignore[arg-type]
+
+    with patch(
+        "app.services.scraper_testimonies.urllib.request.urlopen",
+        side_effect=_route_all_fail,
+    ):
+        with pytest.warns(UserWarning):
+            with pytest.raises(RuntimeError, match="zero rows"):
+                pull_testimonies_archive(
+                    target, archive_url=_SINGLE_ARCHIVE_URL, delay_seconds=0.0
+                )
+    assert not target.exists()
+    assert not target.with_suffix(target.suffix + ".tmp").exists()
+
+
+def test_pull_warns_and_continues_when_one_year_listing_404s(tmp_path: Path) -> None:
+    target = tmp_path / "congressional_testimonies.json"
+    good_listing = "https://www.federalreserve.gov/newsevents/testimony/2024-testimony.htm"
+    bad_listing = "https://www.federalreserve.gov/newsevents/testimony/2099-testimony.htm"
+
+    def _route_with_bad_year(url, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        url_str = url if isinstance(url, str) else url.full_url
+        if url_str == bad_listing:
+            raise urllib.error.HTTPError(url_str, 404, "Not Found", None, None)  # type: ignore[arg-type]
+        if url_str == good_listing:
+            return _FakeResponse(_LISTING_HTML.encode("utf-8"))
+        if "powell20240306" in url_str:
+            return _FakeResponse(
+                _fake_page("Chair Powell", "March 2024").encode("utf-8")
+            )
+        if "waller20240501" in url_str:
+            return _FakeResponse(
+                _fake_page("Governor Waller", "May 2024").encode("utf-8")
+            )
+        raise AssertionError(f"unexpected URL fetched: {url_str}")
+
+    with patch(
+        "app.services.scraper_testimonies.urllib.request.urlopen",
+        side_effect=_route_with_bad_year,
+    ):
+        with pytest.warns(UserWarning, match="Testimony listing fetch failed"):
+            rows = pull_testimonies_archive(
+                target, years=[2024, 2099], delay_seconds=0.0
+            )
+    assert rows == 2


### PR DESCRIPTION
## What ships

Pull-CLI entry points for the four in-house federalreserve.gov / newyorkfed.org scrapers, closing out the umbrella in #485 alongside #487 (Op-Fed CSV) and #488 (Beige Book).

Each scraper grows:
- a ``pull_*_archive(target_path, *, force, archive_url, limit, timeout, delay_seconds, ...)`` orchestrator that walks the listing, fetches every detail page, sleeps ``delay_seconds`` between requests, and writes the canonical JSON via ``tmp_path.replace(target_path)`` for POSIX-atomic swaps;
- an ``if __name__ == "__main__"`` argparse entry mirroring ``scraper_beige_book.py``'s flag surface (``--data-dir`` / ``--force`` / ``--limit`` / ``--archive-url`` / ``--delay-seconds``);
- a module-level ``_USER_AGENT`` constant (``fed-pulse-data-ingester/1.0 (+https://github.com/yusufizzetmurat/fed-pulse)``) -- federalreserve.gov 403s the stdlib default UA.

Output filenames match ``ingest_sources.SCRAPED_FILES`` so the downstream record iterator picks the JSONs up unchanged. Output paths:

| scraper | output filename(s) | listing URL(s) |
|---|---|---|
| press_conferences | ``press_conferences.json`` | ``/monetarypolicy/fomccalendars.htm`` + ``/monetarypolicy/fomchistorical{year}.htm`` for 2011-2020 back-fill |
| speeches | ``chair_speeches.json`` + ``governor_speeches.json`` | ``/newsevents/speech/{year}-speeches.htm`` (year walk, default 2006-current) |
| testimonies | ``congressional_testimonies.json`` | ``/newsevents/testimony/{year}-testimony.htm`` (year walk, default 2006-current) |
| regional_research | ``regional_research.json`` | ``https://libertystreeteconomics.newyorkfed.org/`` |

Speeches has two outputs because the corpus is split by speaker title; the orchestrator funnels the same parsed-entry list through both ``write_chair_speeches_json`` and ``write_governor_speeches_json``. Idempotency checks both files; ``--force`` re-walks both.

Four matching Makefile targets land alongside (``pull-press-conferences``, ``pull-speeches``, ``pull-testimonies``, ``pull-regional-research``) with ``FORCE=1`` / ``LIMIT=N`` / ``YEARS=...`` overrides.

## Failure model

- Listing 4xx/5xx surfaces as ``RuntimeError("HTTP {code} from {url}")`` from ``_http_get_text``. For multi-year walks (speeches / testimonies / press_conferences historical) a single missing year is warned and skipped so a future year before its page exists does not abort the pull; only a fully empty walk raises.
- Per-detail-page failures emit ``warnings.warn(...)`` and the walk continues -- one bad URL must not drop the whole pull.
- Zero-rows raises ``RuntimeError`` and cleans up the tmp file so a broken default surfaces loudly instead of silently writing an empty JSON.

## Live smoke test

Each scraper smoke-tested against its real archive with ``--limit`` and a polite ``delay-seconds``:

```
regional_research:    3 rows, sample 2026-05-01 (9447 chars)
testimonies (2025):   3 rows, sample 2025-12-02 (14457 chars)
speeches (2025):      4 rows split chair 1 / governor 3, sample chair 2025-12-01 (4878 chars)
press_conferences:    2 rows, sample 2026-04-29 (text 57064 / qa 50080 chars)
```

All rows have non-empty ``date`` + ``text``. Press-conference Q&A split also non-empty on both sampled rows.

## Out of scope

- Q&A lookup sidecar (``qa_lookup.parquet``) -- follow-up to #214.
- GSS factor adapter -- separate issue (upstream URL unknown).
- Events.parquet rebuild -- downstream step.

## Test plan

- [x] 5+ pytest unit tests per scraper (happy path, idempotent cache, force re-walk, single-page 404 tolerance, listing-HTTP-error abort, ``limit`` cap) -- 74 tests pass.
- [x] Live smoke test against real archives (see above).
- [x] Syntax check via ``py_compile`` on each scraper + test file.
- [x] Makefile dry-run for the four new targets.