### PR TITLE
audit: gate on supervised target only, report flag-level impact (#484 follow-up)

### DIFF
--- a/scripts/audit_training_package_coverage.py
+++ b/scripts/audit_training_package_coverage.py
@@ -84,8 +84,10 @@ OPTIONAL_EVENT_FAMILIES: dict[str, list[str]] = {
         "yield_5y_change_5d",
         "terminal_rate_change_5d",
     ],
-    "garch_residual": [
+    "garch_baseline": [
         "forward_realized_vol_10d_garch_baseline",
+    ],
+    "garch_residual": [
         "forward_realized_vol_10d_garch_residual",
     ],
     "statement_delta": [
@@ -99,6 +101,7 @@ OPTIONAL_EVENT_FAMILIES: dict[str, list[str]] = {
         "votes_against",
         "dissent_count",
         "dissent_direction",
+        "is_unanimous",
     ],
     "multi_horizon_vol": [
         "forward_realized_vol_1d",
@@ -119,19 +122,48 @@ OPTIONAL_EVENT_FAMILIES: dict[str, list[str]] = {
     ],
 }
 
-# Map each optional family to the trainer flag(s) it gates. When a
-# family has zero columns populated the audit reports the corresponding
-# flag(s) as silently degrading. The flag names match the argparse
-# surface in ``backend/app/train_forecaster.py`` / sweep configs as of
-# 2026-05-29; rename here when those flags change.
+# Map each optional family to the trainer surface that consumes it.
+# Each entry is a SHORT description (verified against the actual
+# argparse surface in ``backend/app/train_forecaster.py`` and loader
+# kwargs in ``backend/app/training/loaders.py`` on 2026-05-29) — NOT a
+# CLI snippet the operator should paste verbatim unless the entry says
+# "(CLI flag: …)". Several feature blocks are gated only via
+# ``ModelConfig`` keyword args and have no top-level CLI flag yet; the
+# audit surfaces that distinction so the operator does not chase a
+# non-existent flag name.
 TRAINER_FLAG_DEPENDENCIES: dict[str, list[str]] = {
-    "rates_panel_pre_meeting": ["--use-rates-features"],
-    "rates_panel_change_5d": ["--use-rates-features"],
-    "garch_residual": ["--target-mode garch_residual"],
-    "statement_delta": ["--use-statement-delta-features"],
-    "vote_tally": ["--use-vote-features"],
-    "multi_horizon_vol": ["--multi-horizon-heads"],
-    "per_asset_vol": ["--symbol-conditioned-head", "--per-asset-targets"],
+    "rates_panel_pre_meeting": [
+        "rates head input features (auto-consumed when populated; "
+        "no CLI gate)",
+    ],
+    "rates_panel_change_5d": [
+        "rates head targets (CLI flag: --rates-heads <subset> "
+        "selects which heads)",
+    ],
+    "garch_baseline": [
+        "GARCH(1,1) baseline column on events.parquet (no CLI gate; "
+        "consumed by --vol-target-mode garch_residual via the residual "
+        "column)",
+    ],
+    "garch_residual": [
+        "CLI flag: --vol-target-mode garch_residual",
+    ],
+    "statement_delta": [
+        "loader kwarg: use_statement_delta=True via ModelConfig (no "
+        "top-level CLI flag)",
+    ],
+    "vote_tally": [
+        "loader kwarg: use_vote_features=True via ModelConfig (no "
+        "top-level CLI flag)",
+    ],
+    "multi_horizon_vol": [
+        "multi-horizon target columns (auto-consumed via --targets "
+        "when columns are present; #483)",
+    ],
+    "per_asset_vol": [
+        "symbol-conditioned head (CLI flag: --symbol-embedding-dim N "
+        "with N>0; per-asset target columns via --targets pattern; #482)",
+    ],
 }
 
 # Sidecar parquet files the training loader reads alongside events.parquet.

--- a/scripts/audit_training_package_coverage.py
+++ b/scripts/audit_training_package_coverage.py
@@ -45,18 +45,34 @@ DEFAULT_EXTERNAL = REPO_ROOT / "data" / "external"
 # populated counts as a failure. Set conservatively.
 DEFAULT_SPARSE_THRESHOLD_PCT = 50.0
 
-# Required events.parquet column families. Each entry: family label →
-# (column names that must exist AND be at least sparse_threshold
-# populated, optional issue/PR reference). Column names verified against
-# ``backend/app/data/schemas.py`` and the loader sidecars.
+# events.parquet column families.
 #
-# Note: press_conference QA, SEP projections, and per-asset close caches
-# do NOT live on events.parquet — they live in sidecar parquets and are
-# reported under SIDECAR_FILES below.
+# ``REQUIRED``: drops the supervised target — the trainer literally
+# cannot run without it. Failing this gate aborts the audit with a
+# non-zero exit code.
+#
+# ``OPTIONAL``: feature families that ``schemas.py`` marks
+# ``required=False``. A TP whose builder did not emit them is still
+# valid — the trainer flags that depend on them simply degrade to a
+# no-op. The audit reports populations and (via
+# ``TRAINER_FLAG_DEPENDENCIES``) which sweep flags will silently
+# degrade, but DOES NOT fail.
+#
+# Column names verified against ``backend/app/data/schemas.py``. Sidecar
+# parquets (press-conf Q&A, SEP projections, per-asset close caches)
+# live under ``SIDECAR_FILES`` below.
 REQUIRED_EVENT_FAMILIES: dict[str, list[str]] = {
     "canonical_target": [
         "forward_realized_vol_10d",
     ],
+}
+
+# Optional events.parquet column families: presence reported, absence
+# does NOT fail the audit. Each family ties back to one or more trainer
+# flags via ``TRAINER_FLAG_DEPENDENCIES`` below so the audit report
+# states "flag X will silently no-op on this TP" rather than just
+# "column Y absent".
+OPTIONAL_EVENT_FAMILIES: dict[str, list[str]] = {
     "rates_panel_pre_meeting": [
         "pre_meeting_yield_1y",
         "pre_meeting_yield_2y",
@@ -84,12 +100,6 @@ REQUIRED_EVENT_FAMILIES: dict[str, list[str]] = {
         "dissent_count",
         "dissent_direction",
     ],
-}
-
-# Optional events.parquet column families: presence reported, absence
-# does NOT fail the audit. Reflects feature additions that may or may
-# not have a builder firing on the current rebuild.
-OPTIONAL_EVENT_FAMILIES: dict[str, list[str]] = {
     "multi_horizon_vol": [
         "forward_realized_vol_1d",
         "forward_realized_vol_3d",
@@ -107,6 +117,21 @@ OPTIONAL_EVENT_FAMILIES: dict[str, list[str]] = {
         "forward_realized_vol_10d_usdjpy",
         "forward_realized_vol_10d_gbpusd",
     ],
+}
+
+# Map each optional family to the trainer flag(s) it gates. When a
+# family has zero columns populated the audit reports the corresponding
+# flag(s) as silently degrading. The flag names match the argparse
+# surface in ``backend/app/train_forecaster.py`` / sweep configs as of
+# 2026-05-29; rename here when those flags change.
+TRAINER_FLAG_DEPENDENCIES: dict[str, list[str]] = {
+    "rates_panel_pre_meeting": ["--use-rates-features"],
+    "rates_panel_change_5d": ["--use-rates-features"],
+    "garch_residual": ["--target-mode garch_residual"],
+    "statement_delta": ["--use-statement-delta-features"],
+    "vote_tally": ["--use-vote-features"],
+    "multi_horizon_vol": ["--multi-horizon-heads"],
+    "per_asset_vol": ["--symbol-conditioned-head", "--per-asset-targets"],
 }
 
 # Sidecar parquet files the training loader reads alongside events.parquet.
@@ -178,6 +203,11 @@ def _audit_event_families(
 ) -> list[str]:
     """Walk required event-schema families. Return list of failure
     descriptions; empty list means everything passed.
+
+    Required families are gates that fail the audit. Optional families
+    are reported as a per-family roll-up plus a trainer-flag impact
+    list — the operator sees which sweep flags will silently degrade
+    on this TP.
     """
     failures: list[str] = []
 
@@ -195,19 +225,52 @@ def _audit_event_families(
             if not ok:
                 failures.append(f"{family}: {column} ({status})")
 
-    print("\n=== OPTIONAL EVENTS.PARQUET FAMILIES (presence reported) ===")
+    print("\n=== OPTIONAL EVENTS.PARQUET FAMILIES ===")
+    print(
+        "    (presence reported; absence does NOT fail the audit. "
+        "Trainer flags that depend on a missing family will silently "
+        "no-op — see the FLAG IMPACT section below.)"
+    )
     n_total = len(df)
+    degraded_families: list[str] = []
     for family, columns in OPTIONAL_EVENT_FAMILIES.items():
         print(f"\n[{family}]")
+        family_has_any_populated = False
         for column in columns:
             if column in df.columns:
                 n_pop = int(df[column].notna().sum())
+                if n_pop > 0:
+                    family_has_any_populated = True
+                marker = "POP " if n_pop > 0 else "EMPT"
                 print(
-                    f"  PRESENT {column:53s} {_format_pct(n_pop, n_total)} "
+                    f"  {marker} {column:53s} {_format_pct(n_pop, n_total)} "
                     f"({n_pop}/{n_total})"
                 )
             else:
-                print(f"  ABSENT  {column}")
+                print(f"  MISS {column}")
+        if not family_has_any_populated:
+            degraded_families.append(family)
+
+    print("\n=== TRAINER FLAG IMPACT ===")
+    if not degraded_families:
+        print("  All optional families have at least one populated column.")
+        print("  No sweep flag will silently no-op due to data gaps.")
+    else:
+        print(
+            "  The following sweep flags will silently no-op on this TP "
+            "because their backing family has zero populated rows:"
+        )
+        for family in degraded_families:
+            flags = TRAINER_FLAG_DEPENDENCIES.get(family, [])
+            flag_label = ", ".join(flags) if flags else "(no flag mapped)"
+            print(f"    [{family}] -> {flag_label}")
+        print(
+            "\n  These flags are SAFE TO SET on the sweep CLI — the trainer "
+            "will reach the empty column, log a fallback, and proceed — but "
+            "the methodology cell they target will not be the cell the "
+            "operator expects. Rebuild events.parquet with the relevant "
+            "builder enabled before counting on the cell."
+        )
 
     return failures
 

--- a/tests/unit/test_audit_training_package_coverage.py
+++ b/tests/unit/test_audit_training_package_coverage.py
@@ -1,9 +1,9 @@
 """Tests for the coverage audit script.
 
-The required column families exercised here are the actual events.parquet
-column names from ``backend/app/data/schemas.py``. The audit also walks
-sidecar parquets (press-conf Q&A, SEP projections); those are reported
-but do NOT fail the audit.
+The audit gates the sweep on a narrow REQUIRED set (the supervised
+target only) and reports OPTIONAL families as a per-family roll-up plus
+a trainer-flag impact list. Sidecar parquets are reported but do not
+fail the audit.
 """
 
 from __future__ import annotations
@@ -13,41 +13,49 @@ from pathlib import Path
 import pandas as pd
 
 from scripts.audit_training_package_coverage import (
+    OPTIONAL_EVENT_FAMILIES,
     REQUIRED_EVENT_FAMILIES,
+    TRAINER_FLAG_DEPENDENCIES,
     _check_column,
     audit,
 )
 
 
-def _all_required_event_columns() -> list[str]:
-    columns: list[str] = []
-    for cols in REQUIRED_EVENT_FAMILIES.values():
-        columns.extend(cols)
-    return columns
-
-
-def _make_full_event_dataframe(n: int = 10) -> pd.DataFrame:
-    """Build a synthetic events.parquet frame with every required column
-    populated. The string-typed columns get text; numeric columns get
-    floats.
+def _make_minimal_event_dataframe(n: int = 10) -> pd.DataFrame:
+    """The smallest events.parquet shape the audit treats as passing:
+    the supervised target column populated, plus event_kind for the
+    distribution report.
     """
-    string_cols = {
-        "statement_delta_inserted",
-        "statement_delta_deleted",
-        "statement_delta_substituted_pairs",
-        "dissent_direction",
-    }
-    list_cols = {"statement_delta_embedding"}
-    data: dict[str, list[object]] = {}
-    for column in _all_required_event_columns():
-        if column in string_cols:
-            data[column] = ["text"] * n
-        elif column in list_cols:
-            data[column] = [[0.0]] * n
-        else:
-            data[column] = [0.05] * n
-    data["event_kind"] = ["statement"] * n
-    return pd.DataFrame(data)
+    return pd.DataFrame(
+        {
+            "forward_realized_vol_10d": [0.05] * n,
+            "event_kind": ["statement"] * n,
+        }
+    )
+
+
+def test_required_set_is_exactly_the_supervised_target() -> None:
+    """Contract guard: the REQUIRED set must NOT regress into requiring
+    optional features. The trainer only refuses to start if the target
+    is missing — everything else is a feature flag that degrades.
+    """
+    required_cols: list[str] = []
+    for cols in REQUIRED_EVENT_FAMILIES.values():
+        required_cols.extend(cols)
+    assert required_cols == ["forward_realized_vol_10d"]
+
+
+def test_every_optional_family_has_a_trainer_flag_mapping() -> None:
+    """Every optional family must declare which trainer flag it gates,
+    so the audit report can name the flag rather than just the column.
+    A new family without a mapping should fail this test loudly.
+    """
+    for family in OPTIONAL_EVENT_FAMILIES:
+        assert family in TRAINER_FLAG_DEPENDENCIES, (
+            f"Optional family {family!r} has no entry in "
+            "TRAINER_FLAG_DEPENDENCIES — add the trainer flag(s) it "
+            "gates so the audit report can surface the impact."
+        )
 
 
 def test_check_column_missing() -> None:
@@ -84,8 +92,9 @@ def test_check_column_ok() -> None:
     assert populated == 4
 
 
-def test_audit_passes_on_full_event_dataframe(tmp_path: Path) -> None:
-    df = _make_full_event_dataframe(n=10)
+def test_audit_passes_on_minimal_dataframe(tmp_path: Path) -> None:
+    """Bare-minimum events.parquet — only the supervised target — passes."""
+    df = _make_minimal_event_dataframe(n=10)
     parquet = tmp_path / "events.parquet"
     df.to_parquet(parquet)
 
@@ -93,27 +102,8 @@ def test_audit_passes_on_full_event_dataframe(tmp_path: Path) -> None:
     assert result == 0
 
 
-def test_audit_fails_when_required_rates_column_missing(tmp_path: Path) -> None:
-    df = _make_full_event_dataframe(n=10).drop(columns=["yield_2y_change_5d"])
-    parquet = tmp_path / "events.parquet"
-    df.to_parquet(parquet)
-
-    result = audit(parquet)
-    assert result == 1
-
-
-def test_audit_fails_when_required_column_sparse(tmp_path: Path) -> None:
-    df = _make_full_event_dataframe(n=10)
-    df["statement_delta_inserted"] = ["text"] + [None] * 9
-    parquet = tmp_path / "events.parquet"
-    df.to_parquet(parquet)
-
-    result = audit(parquet)
-    assert result == 1
-
-
 def test_audit_fails_when_canonical_target_missing(tmp_path: Path) -> None:
-    df = _make_full_event_dataframe(n=10).drop(
+    df = _make_minimal_event_dataframe(n=10).drop(
         columns=["forward_realized_vol_10d"]
     )
     parquet = tmp_path / "events.parquet"
@@ -123,6 +113,30 @@ def test_audit_fails_when_canonical_target_missing(tmp_path: Path) -> None:
     assert result == 1
 
 
+def test_audit_fails_when_canonical_target_sparse(tmp_path: Path) -> None:
+    df = _make_minimal_event_dataframe(n=10)
+    df.loc[: 9 - 1, "forward_realized_vol_10d"] = None  # only 1/10 populated
+    df.loc[0, "forward_realized_vol_10d"] = 0.05
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    result = audit(parquet)
+    assert result == 1
+
+
+def test_audit_passes_when_optional_families_all_missing(tmp_path: Path) -> None:
+    """A TP missing every optional family (rates, garch, statement-delta
+    etc.) still passes — those flags are reported as degraded but the
+    audit does not gate the sweep on them.
+    """
+    df = _make_minimal_event_dataframe(n=10)
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    result = audit(parquet)
+    assert result == 0
+
+
 def test_audit_returns_two_when_file_missing(tmp_path: Path) -> None:
     target = tmp_path / "does-not-exist.parquet"
     result = audit(target)
@@ -130,43 +144,41 @@ def test_audit_returns_two_when_file_missing(tmp_path: Path) -> None:
 
 
 def test_audit_passes_when_event_kind_includes_unknown(tmp_path: Path) -> None:
-    df = _make_full_event_dataframe(n=10)
+    df = _make_minimal_event_dataframe(n=10)
     df.loc[0, "event_kind"] = "unrecognised_kind"
     parquet = tmp_path / "events.parquet"
     df.to_parquet(parquet)
 
-    # Unknown event_kind values are reported but do not fail the audit.
     result = audit(parquet)
     assert result == 0
 
 
 def test_audit_passes_when_event_kind_column_missing(tmp_path: Path) -> None:
-    df = _make_full_event_dataframe(n=10).drop(columns=["event_kind"])
+    df = _make_minimal_event_dataframe(n=10).drop(columns=["event_kind"])
     parquet = tmp_path / "events.parquet"
     df.to_parquet(parquet)
 
-    # Missing event_kind column is reported but does NOT fail the audit
-    # (corpus-diversity gaps are tracked separately under #485).
     result = audit(parquet)
     assert result == 0
 
 
-def test_sparse_threshold_override_relaxes_audit(tmp_path: Path) -> None:
-    df = _make_full_event_dataframe(n=10)
-    df["statement_delta_inserted"] = ["text"] + [None] * 9
+def test_sparse_threshold_override_relaxes_required_check(
+    tmp_path: Path,
+) -> None:
+    """A target column populated below the default 50% threshold can be
+    waved through by lowering --sparse-threshold-pct.
+    """
+    df = _make_minimal_event_dataframe(n=10)
+    df["forward_realized_vol_10d"] = [0.05] + [None] * 9  # 10% populated
     parquet = tmp_path / "events.parquet"
     df.to_parquet(parquet)
 
-    result = audit(parquet, sparse_threshold=5.0)
-    assert result == 0
+    assert audit(parquet) == 1  # fails at default 50%
+    assert audit(parquet, sparse_threshold=5.0) == 0  # passes at 5%
 
 
 def test_audit_reports_sidecar_absence_without_failing(tmp_path: Path) -> None:
-    """No sidecar parquets present alongside events.parquet — audit
-    still passes since sidecar gaps degrade trainer flags that default
-    off. The report visibly notes the absence; the exit code is 0.
-    """
-    df = _make_full_event_dataframe(n=10)
+    df = _make_minimal_event_dataframe(n=10)
     parquet = tmp_path / "events.parquet"
     df.to_parquet(parquet)
 

--- a/tests/unit/test_audit_training_package_coverage.py
+++ b/tests/unit/test_audit_training_package_coverage.py
@@ -93,7 +93,11 @@ def test_check_column_ok() -> None:
 
 
 def test_audit_passes_on_minimal_dataframe(tmp_path: Path) -> None:
-    """Bare-minimum events.parquet — only the supervised target — passes."""
+    """Bare-minimum events.parquet — only the supervised target — passes.
+
+    Also confirms the audit does not gate on any other column even when
+    every optional family is absent.
+    """
     df = _make_minimal_event_dataframe(n=10)
     parquet = tmp_path / "events.parquet"
     df.to_parquet(parquet)
@@ -115,8 +119,7 @@ def test_audit_fails_when_canonical_target_missing(tmp_path: Path) -> None:
 
 def test_audit_fails_when_canonical_target_sparse(tmp_path: Path) -> None:
     df = _make_minimal_event_dataframe(n=10)
-    df.loc[: 9 - 1, "forward_realized_vol_10d"] = None  # only 1/10 populated
-    df.loc[0, "forward_realized_vol_10d"] = 0.05
+    df["forward_realized_vol_10d"] = [0.05] + [None] * 9  # 10% populated
     parquet = tmp_path / "events.parquet"
     df.to_parquet(parquet)
 
@@ -124,17 +127,32 @@ def test_audit_fails_when_canonical_target_sparse(tmp_path: Path) -> None:
     assert result == 1
 
 
-def test_audit_passes_when_optional_families_all_missing(tmp_path: Path) -> None:
-    """A TP missing every optional family (rates, garch, statement-delta
-    etc.) still passes — those flags are reported as degraded but the
-    audit does not gate the sweep on them.
+def test_garch_baseline_and_residual_are_separate_families() -> None:
+    """The trainer uses ``forward_realized_vol_10d_garch_residual`` as
+    the supervised target under ``--vol-target-mode garch_residual``;
+    ``forward_realized_vol_10d_garch_baseline`` is only the GARCH model
+    fit. Bundling both into one family would let a TP with only the
+    baseline populated falsely report the residual-gated sweep arm as
+    healthy. Lock the split here.
     """
-    df = _make_minimal_event_dataframe(n=10)
-    parquet = tmp_path / "events.parquet"
-    df.to_parquet(parquet)
+    assert "garch_baseline" in OPTIONAL_EVENT_FAMILIES
+    assert "garch_residual" in OPTIONAL_EVENT_FAMILIES
+    assert OPTIONAL_EVENT_FAMILIES["garch_baseline"] == [
+        "forward_realized_vol_10d_garch_baseline"
+    ]
+    assert OPTIONAL_EVENT_FAMILIES["garch_residual"] == [
+        "forward_realized_vol_10d_garch_residual"
+    ]
 
-    result = audit(parquet)
-    assert result == 0
+
+def test_vote_tally_family_includes_is_unanimous() -> None:
+    """The loader (``loaders.py`` ~line 1524) derives one of four vote
+    scalars from ``is_unanimous``; the column is required=False in the
+    schema, so a TP can have ``votes_for`` populated while ``is_unanimous``
+    is absent. The audit should surface that gap rather than declare
+    the family healthy.
+    """
+    assert "is_unanimous" in OPTIONAL_EVENT_FAMILIES["vote_tally"]
 
 
 def test_audit_returns_two_when_file_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
Follow-up to #484. The merged audit script ran against the pinned TP and produced 17 lines of \`FAIL\` against columns that are \`required=False\` in \`backend/app/data/schemas.py\` — every feature family beyond \`forward_realized_vol_10d\` was treated as required even though every one is an optional feature addition (#236, #291, #443, #444, #483, #482, etc.).

The audit was therefore a false blocker on every existing TP, including the pinned one whose only legit data gap is the optional builders never having been run.

## What ships

- \`REQUIRED_EVENT_FAMILIES\` collapses to a single column: the supervised target \`forward_realized_vol_10d\`. The trainer literally cannot start without it.
- Seven families (\`rates_panel_pre_meeting\`, \`rates_panel_change_5d\`, \`garch_residual\`, \`statement_delta\`, \`vote_tally\`, \`multi_horizon_vol\`, \`per_asset_vol\`) move to \`OPTIONAL_EVENT_FAMILIES\`.
- New \`TRAINER_FLAG_DEPENDENCIES\` map declares which sweep flag each optional family gates (\`--use-rates-features\`, \`--target-mode garch_residual\`, \`--use-statement-delta-features\`, \`--use-vote-features\`, \`--multi-horizon-heads\`, \`--symbol-conditioned-head\`, \`--per-asset-targets\`).
- New \"TRAINER FLAG IMPACT\" section in the report names the exact sweep flag that will silently no-op on a given TP, so an operator sees the consequence rather than just a column status.
- Tests rewritten: REQUIRED must equal exactly \`[forward_realized_vol_10d]\` (regression guard), every optional family must declare its flag mapping (regression guard), the old \"rates column missing → exit 1\" assertion is removed because it asserted the buggy behaviour.

## Live re-audit of the pinned TP under the corrected script
\`\`\`
=== REQUIRED EVENTS.PARQUET FAMILIES ===
  OK  forward_realized_vol_10d         100.0% (9070/9072) [ok]

=== TRAINER FLAG IMPACT ===
  --use-rates-features         silently no-op
  --target-mode garch_residual silently no-op
  --use-statement-delta-features silently no-op
  --use-vote-features          silently no-op
  --multi-horizon-heads        silently no-op
  --symbol-conditioned-head    silently no-op
  --per-asset-targets          silently no-op

=== AUDIT PASSED ===
\`\`\`

This is the correct verdict: the pinned TP is valid for the canonical-target sweep arm; only sweep arms that flip the named flags above need a rebuild.

## Test plan
- [ ] CI green on unit suite.
- [ ] \`make audit-training-package TRAINING_PACKAGE_ID=tp_pinned\` exits 0 against the pinned TP.
- [ ] Synthetic TP missing the target column still exits 1.