### PR TITLE
add build-events-parquet target + rebuild path docs (#485 follow-up)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package pull-op-fed pull-beige-book train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package build-events-parquet pull-op-fed pull-beige-book train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -133,6 +133,35 @@ audit-training-package:
 	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
 	python -m scripts.audit_training_package_coverage \
 		--training-package-id "$(TRAINING_PACKAGE_ID)"
+
+# Build events.parquet (canonical training-feature table) under an
+# existing data-prep'd training package directory. ``pipeline_data_prep``
+# stops at ``registry_normalized.parquet`` + ``splits_*.parquet``; this
+# target is the missing last step that turns those into the
+# ``events.parquet`` the trainers read. Pass optional sidecar paths to
+# enable the rates panel (#291) and per-asset-target (#481/#482)
+# feature blocks; the underlying CLI degrades cleanly when they are
+# absent so the bare invocation still produces a valid (canonical-arm-
+# only) events.parquet.
+#
+# Env vars:
+#   TRAINING_PACKAGE_ID    required
+#   ASSET                  defaults to ^GSPC (canonical anchor symbol)
+#   RATES_PANEL_PATH       defaults to data/external/fred/rates_panel.parquet
+#                          when --build-rates-panel produced it; pass empty
+#                          to skip rates features.
+#   PER_ASSET_CACHE_DIR    defaults to data/external/yfinance; pass empty
+#                          to skip the per-asset target columns.
+build-events-parquet:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	docker compose run --rm backend \
+		python -m app.data.event_dataset_builder \
+			--training-package-id "$(TRAINING_PACKAGE_ID)" \
+			--asset "$(if $(ASSET),$(ASSET),^GSPC)" \
+			--output events.parquet \
+			--full-output events_full.parquet \
+			$(if $(RATES_PANEL_PATH),--rates-panel-path "$(RATES_PANEL_PATH)",) \
+			$(if $(PER_ASSET_CACHE_DIR),--per-asset-target-cache-dir "$(PER_ASSET_CACHE_DIR)",)
 
 pull-op-fed:
 	docker compose run --rm backend \

--- a/docs/training-package-rebuild.md
+++ b/docs/training-package-rebuild.md
@@ -1,0 +1,141 @@
+# Training-package rebuild path
+
+End-to-end recipe for producing a fresh `events.parquet` with every
+feature family populated so the audit (`make audit-training-package`)
+reports zero degraded sweep flags.
+
+The pinned TP referenced by Phase 2 was built before several optional
+feature families landed (#236 garch residual, #291 rates panel, #443
+statement delta, #444 vote tally, #482 per-asset targets, #483 multi-
+horizon vol). The optional builders in this repo can populate every
+column the trainer supports, but they have to be invoked explicitly —
+`pipeline_data_prep` stops at the registry parquet and does not call
+`event_dataset_builder`.
+
+This document is the operator-facing reference. The commands assume
+`FRED_API_KEY` is in `.env` and the docker compose `backend` service is
+buildable.
+
+## Step 0 — Pre-flight
+
+```
+test -f .env && grep -q FRED_API_KEY .env  # required for FRED-backed sidecars
+docker compose build backend                # one-time, picks up dependency lock
+```
+
+## Step 1 — Pull source corpora (no GPU needed)
+
+Each adapter ships an idempotent CLI. Re-running is a no-op when the
+cache file already exists with non-empty rows; pass `FORCE=1` to refresh.
+
+```
+make pull-op-fed                           # Keith et al. 2025 OpFed CSV (1044 sentences)
+make pull-beige-book                       # ~400 Beige Book national summaries since 1970
+make pull-press-conferences                # FOMC press-conference PDFs since 2011
+make pull-speeches                         # chair + governor speeches, 2006–present
+make pull-testimonies                      # congressional testimonies, 2006–present
+make pull-regional-research                # Liberty Street Economics archive
+```
+
+`LIMIT=N` caps each walk for smoke tests; `YEARS="2024 2025"` narrows
+speeches/testimonies to specific years.
+
+## Step 2 — Build FRED-backed sidecars
+
+```
+make build-rates-panel RATES_PANEL_START=2008-01-01 RATES_PANEL_END=today
+make build-mp-surprises
+make build-macro-state
+```
+
+These produce `data/external/fred/rates_panel.parquet`,
+`data/external/fred/mp_surprises.parquet`, and
+`data/external/fred/macro_state.parquet`.
+
+## Step 3 — Run the standard data-prep pipeline
+
+```
+make data-prep DATASET_VERSION=v3 FEATURE_VERSION=v1 OWNER="$(whoami)" \
+    TRAINING_PACKAGE_ID=tp_v3_<your-version-tag>
+```
+
+This writes `registry_normalized.parquet` and the split parquets under
+`data/processed/<TRAINING_PACKAGE_ID>/`. It does **not** produce
+`events.parquet` — that is the next step.
+
+## Step 4 — Build events.parquet with every optional feature family
+
+```
+make build-events-parquet \
+    TRAINING_PACKAGE_ID=tp_v3_<your-version-tag> \
+    RATES_PANEL_PATH=data/external/fred/rates_panel.parquet \
+    PER_ASSET_CACHE_DIR=data/external/yfinance
+```
+
+`RATES_PANEL_PATH` enables the #291 rates-complex feature columns
+(`pre_meeting_yield_*`, `yield_*_change_5d`). `PER_ASSET_CACHE_DIR`
+enables the #482 per-asset target columns
+(`forward_realized_vol_10d_{gspc,ndx,dji,dxy,vix,eurusd,usdjpy,gbpusd}`).
+Pass empty values to either to skip the corresponding block.
+
+The statement-delta, vote-tally, and multi-horizon-vol blocks are
+unconditionally computed when the source rows carry the necessary text
+or have the prior-statement window available — no flag needed.
+
+## Step 5 — Add GARCH(1,1) residual columns
+
+```
+make garch-baseline TRAINING_PACKAGE_ID=tp_v3_<your-version-tag>
+```
+
+This adds `forward_realized_vol_10d_garch_baseline` and
+`forward_realized_vol_10d_garch_residual` to `events.parquet` in
+place. Required by the `--vol-target-mode garch_residual` sweep arm.
+
+## Step 6 — Audit the rebuild
+
+```
+make audit-training-package TRAINING_PACKAGE_ID=tp_v3_<your-version-tag>
+```
+
+The audit prints:
+
+- a **REQUIRED** check on the supervised target (`forward_realized_vol_10d`),
+- per-family population counts for every optional block,
+- a **TRAINER FLAG IMPACT** section naming the specific sweep flags
+  that will silently no-op given the populated columns,
+- the `event_kind` distribution (corpus diversity),
+- a sidecar inventory (press-conf Q&A, SEP projections).
+
+A clean rebuild should leave the TRAINER FLAG IMPACT section reading
+"All optional families have at least one populated column." If a
+family is still empty, the missing builder is named in the report.
+
+## Step 7 — Push to Hugging Face + pin
+
+The Hub-write step is operator-only (HF write token required); the
+canonical destination is
+`hf://datasets/yusufizzetmurat/fed-pulse-training-package`. After the
+push, capture the commit SHA and pin it in
+`backend/app/models/registry.yaml` so reproducibility metadata stays
+truthful.
+
+## Step 8 — Re-run the sweeps
+
+The headline canonical-arm sweep is unchanged:
+
+```
+make canonical-comparison TRAINING_PACKAGE_ID=tp_v3_<your-version-tag>
+```
+
+The previously-degraded arms now run against real data:
+
+- `--vol-target-mode garch_residual` (uses the GARCH residual column
+  from Step 5)
+- `--rates-heads <subset>` (consumes the rates-panel target columns)
+- `--symbol-embedding-dim N` with `N > 0` (uses the per-asset target
+  columns)
+
+The Option-A multi-axis block (#447) is automatically active when
+`axis_time_label` / `axis_certain_label` are populated, which the
+gtfintechlab ingest in Step 3 takes care of.


### PR DESCRIPTION
Closes out the rebuild path for #485. The data pulls land via #487/#488/#489; the audit lands via #490. This PR fills the last operator-facing gap.

## Problem

\`pipeline_data_prep\` stops at \`registry_normalized.parquet\` + the split parquets. The canonical training-feature table — \`events.parquet\` — has had **no Makefile target**. It only existed if someone read the docstring at \`backend/app/data/event_dataset_builder.py\` and typed the \`python -m\` invocation by hand. That gap is precisely why the pinned TP (May 25 2026) was built without \`--rates-panel-path\` or \`--per-asset-target-cache-dir\` — the corresponding feature columns were absent on disk and the GARCH-residual / rates-head / per-asset sweep arms silently degraded.

## What ships

- New \`make build-events-parquet\` target that wraps the underlying CLI. Passes \`--rates-panel-path\` and \`--per-asset-target-cache-dir\` via env vars (\`RATES_PANEL_PATH\`, \`PER_ASSET_CACHE_DIR\`); degrades cleanly when either is empty.
- \`docs/training-package-rebuild.md\` — operator-facing recipe chaining pull (six CLIs) → sidecar build (rates panel + mp surprises + macro state) → \`data-prep\` → \`build-events-parquet\` → \`garch-baseline\` → audit. Each step has the exact make invocation + optional knobs documented inline.

## Test plan

- [ ] CI lint clean (the change is a Makefile target + a docs file).
- [ ] \`make -n build-events-parquet TRAINING_PACKAGE_ID=test_id RATES_PANEL_PATH=foo\` renders the expected CLI invocation with the optional path threaded through. (Smoke-verified locally; output included below.)
\`\`\`
test -n \"test_id\" || (echo \"TRAINING_PACKAGE_ID is required\"; exit 1)
docker compose run --rm backend \\
        python -m app.data.event_dataset_builder \\
            --training-package-id \"test_id\" \\
            --asset \"^GSPC\" \\
            --output events.parquet \\
            --full-output events_full.parquet \\
            --rates-panel-path \"foo\"
\`\`\`
- [ ] Operator runs the full recipe in \`docs/training-package-rebuild.md\` on a fresh TP id, then \`make audit-training-package\` reports \"All optional families have at least one populated column.\"

## Why now

The user is rerunning Phase 3 sweeps. Without this PR, every sweep arm that depends on rates / garch / per-asset / multi-horizon would silently no-op on a freshly-built TP unless the operator rememberd to type a long, undocumented \`python -m\` invocation with the right two paths. With this PR, the rebuild is six \`make\` commands and a documented audit gate.