### PR TITLE
ship Swanson 2021 three-factor adapter (closes #420)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package pull-op-fed pull-beige-book train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package pull-op-fed pull-swanson-three-factor pull-beige-book train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -137,6 +137,15 @@ audit-training-package:
 pull-op-fed:
 	docker compose run --rm backend \
 		python -m app.data.sources.op_fed $(if $(FORCE),--force,)
+
+# Swanson 2021 three-factor xlsx pulled from UCI mirror (#420).
+# Lands at data/external/swanson/pre-and-post-ZLB-factors-extended.xlsx
+# so the subsequent `python -m app.data.ingest_sources
+# --include-swanson-three-factor` picks it up unchanged.
+pull-swanson-three-factor:
+	docker compose run --rm backend \
+		python -m app.data.sources.swanson_three_factor \
+			$(if $(FORCE),--force,)
 
 pull-beige-book:
 	docker compose run --rm backend \

--- a/backend/app/data/ingest_sources.py
+++ b/backend/app/data/ingest_sources.py
@@ -41,6 +41,9 @@ def _dataset_revision(dataset_id: str) -> str | None:
 OP_FED_DEFAULT_RELATIVE = Path("external") / "op_fed" / "opfed_v1.csv"
 GSS_FACTORS_DEFAULT_RELATIVE = Path("external") / "gss" / "gss_factors.csv"
 GSS_SURPRISES_DEFAULT_RELATIVE = Path("external") / "gss" / "gss_surprises.csv"
+SWANSON_THREE_FACTOR_DEFAULT_RELATIVE = (
+    Path("external") / "swanson" / "pre-and-post-ZLB-factors-extended.xlsx"
+)
 SCRAPED_FILES = (
     "fomc_statements.json",
     "fomc_minutes.json",
@@ -96,6 +99,15 @@ def _parse_args() -> argparse.Namespace:
         "--include-gss-factors",
         action="store_true",
         help="Ingest GSS (Gürkaynak-Sack-Swanson 2005 IJCB) per-FOMC target/path factor decomposition and 30min/1hr/1day surprise windows.",
+    )
+    parser.add_argument(
+        "--include-swanson-three-factor",
+        action="store_true",
+        help=(
+            "Ingest Swanson (2021 JME) per-FOMC three-factor decomposition "
+            "(target rate / forward guidance / LSAP). Extends GSS through "
+            "the ZLB era to 2019-06-19."
+        ),
     )
     parser.add_argument(
         "--include-gtfintechlab-fed",
@@ -639,6 +651,122 @@ def _iter_gss_factors_records(
     return records
 
 
+def _iter_swanson_three_factor_records(
+    xlsx_path: Path,
+) -> list[dict[str, Any]]:
+    """Load the Swanson 2021 JME three-factor decomposition into registry rows.
+
+    Each FOMC meeting becomes one row with target / forward-guidance /
+    LSAP factors on ``multi_axis_extras``. Stance-unlabelled (the
+    decomposition is continuous, not categorical) so rows populate the
+    factor axis of the multi-axis schema without polluting the
+    hawkish/dovish/neutral training pool. Coverage 1991-07-05 through
+    2019-06-19 (241 meetings at last verification).
+
+    Missing xlsx file → warn + return [] (mirrors the GSS path so
+    operators see a single "you forgot a setup step" guard rather than
+    a hard failure on a fresh checkout).
+    """
+
+    if not xlsx_path.exists():
+        warnings.warn(
+            f"Swanson three-factor xlsx not found at {xlsx_path}; skipping.",
+            stacklevel=2,
+        )
+        return []
+
+    try:
+        import pandas as pd  # noqa: F401
+    except ImportError as exc:
+        raise RuntimeError(
+            "pandas is required for the Swanson three-factor loader; "
+            "install backend dependencies first."
+        ) from exc
+    import pandas as pd
+
+    try:
+        df = pd.read_excel(
+            xlsx_path,
+            engine="openpyxl",
+            sheet_name="Data",
+            header=1,
+        )
+    except Exception as exc:
+        warnings.warn(
+            f"Swanson three-factor xlsx at {xlsx_path} failed to parse: "
+            f"{exc}; skipping.",
+            stacklevel=2,
+        )
+        return []
+
+    records: list[dict[str, Any]] = []
+    for _, row in df.iterrows():
+        raw_date = row.iloc[1]  # date is the second column (first is unnamed)
+        if raw_date is None or (
+            isinstance(raw_date, float) and raw_date != raw_date  # NaN check
+        ):
+            continue
+        try:
+            event_date = raw_date.strftime("%Y-%m-%d")  # type: ignore[union-attr]
+        except AttributeError:
+            event_date = str(raw_date)[:10]
+        if not event_date or len(event_date) < 10:
+            continue
+
+        def _float_or_none(value: Any) -> float | None:
+            if value is None:
+                return None
+            try:
+                f = float(value)
+            except (TypeError, ValueError):
+                return None
+            if f != f:  # noqa: PLR0124 (NaN)
+                return None
+            return f
+
+        target = _float_or_none(row.get("Federal Funds Rate factor"))
+        fg = _float_or_none(row.get("Forward Guidance factor"))
+        lsap = _float_or_none(row.get("LSAP factor"))
+        if target is None and fg is None and lsap is None:
+            continue
+
+        extras = {
+            "swanson_target_factor": target,
+            "swanson_forward_guidance_factor": fg,
+            "swanson_lsap_factor": lsap,
+        }
+
+        target_repr = (
+            f"{target:+.4f}" if target is not None else "n/a"
+        )
+        fg_repr = f"{fg:+.4f}" if fg is not None else "n/a"
+        lsap_repr = f"{lsap:+.4f}" if lsap is not None else "n/a"
+        text = (
+            f"Swanson three-factor decomposition for {event_date}: "
+            f"target={target_repr}, forward_guidance={fg_repr}, "
+            f"lsap={lsap_repr}"
+        )
+
+        built = _build_registry_record(
+            source="swanson_three_factor",
+            source_record_id=f"swanson_{event_date}",
+            event_date=event_date,
+            document_type="statement",
+            title=f"Swanson three-factor decomposition {event_date}",
+            text=text,
+            label="",  # factor axis is continuous; no categorical stance
+            license_scope="research_only",
+            citation_ref="swanson_2021_jme",
+            source_type="swanson_three_factor",
+        )
+        if built is None:
+            continue
+        built["provenance"] = "peer_reviewed"
+        built["multi_axis_extras"] = extras
+        records.append(built)
+    return records
+
+
 def _read_json_or_jsonl(path: Path) -> list[dict[str, Any]]:
     text = path.read_text(encoding="utf-8").strip()
     if not text:
@@ -827,6 +955,9 @@ def main() -> int:
     include_scraped = args.all_sources or args.include_scraped
     include_op_fed = args.all_sources or args.include_op_fed
     include_gss_factors = args.all_sources or args.include_gss_factors
+    include_swanson_three_factor = (
+        args.all_sources or args.include_swanson_three_factor
+    )
     include_gtfintechlab_fed = args.all_sources or args.include_gtfintechlab_fed
     include_gtfintechlab_cross_bank = args.all_sources or args.include_gtfintechlab_cross_bank
     include_fomc_archive = args.all_sources or args.include_fomc_archive
@@ -836,6 +967,7 @@ def main() -> int:
         or include_scraped
         or include_op_fed
         or include_gss_factors
+        or include_swanson_three_factor
         or include_gtfintechlab_fed
         or include_gtfintechlab_cross_bank
         or include_fomc_archive
@@ -843,7 +975,8 @@ def main() -> int:
         print(
             "No source selected. Use --all-sources or one of "
             "--include-hf/--include-kaggle/--include-scraped/--include-op-fed/"
-            "--include-gss-factors/--include-gtfintechlab-fed/"
+            "--include-gss-factors/--include-swanson-three-factor/"
+            "--include-gtfintechlab-fed/"
             "--include-gtfintechlab-cross-bank/--include-fomc-archive."
         )
         return 1
@@ -873,6 +1006,15 @@ def main() -> int:
         )
         print(f"Ingested GSS factor records: {len(gss_records)} (per-FOMC target/path factors; factor axis only)")
         unified.extend(gss_records)
+    if include_swanson_three_factor:
+        swanson_records = _iter_swanson_three_factor_records(
+            data_dir / SWANSON_THREE_FACTOR_DEFAULT_RELATIVE,
+        )
+        print(
+            f"Ingested Swanson three-factor records: {len(swanson_records)} "
+            "(per-FOMC target / forward-guidance / LSAP factors; factor axis only)"
+        )
+        unified.extend(swanson_records)
     if include_gtfintechlab_fed:
         gtfintechlab_records = _iter_gtfintechlab_federal_reserve_records()
         labelled = sum(1 for r in gtfintechlab_records if r.get("label"))

--- a/backend/app/data/sources/swanson_three_factor.py
+++ b/backend/app/data/sources/swanson_three_factor.py
@@ -200,7 +200,7 @@ def _parse_swanson_row(row: dict[str, Any]) -> dict[str, Any] | None:
     iso_date: str = ""
     try:
         # pandas Timestamp / datetime
-        iso_date = raw_date.strftime("%Y-%m-%d")  # type: ignore[union-attr]
+        iso_date = raw_date.strftime("%Y-%m-%d")
     except AttributeError:
         iso_date = str(raw_date)[:10]
     if not iso_date or len(iso_date) < 10:

--- a/backend/app/data/sources/swanson_three_factor.py
+++ b/backend/app/data/sources/swanson_three_factor.py
@@ -1,0 +1,290 @@
+"""Swanson 2021 three-factor monetary-policy adapter.
+
+Extends the GSS 2005 (Gürkaynak-Sack-Swanson) factor decomposition into the
+ZLB era. Swanson (2021, JME) re-estimates the principal-component
+decomposition over the pre- and post-ZLB samples and exposes a third axis
+(LSAP / asset-purchase factor) on top of GSS's target-rate / forward-
+guidance pair.
+
+The canonical xlsx mirror is on Swanson's UC Irvine homepage:
+
+    https://sites.socsci.uci.edu/~swanson2/papers/pre-and-post-ZLB-factors-extended.xlsx
+
+One sheet ("Data") with one row per FOMC meeting, columns ``Federal Funds
+Rate factor``, ``Forward Guidance factor``, ``LSAP factor``, and the
+sign-flipped ``- LSAP factor``. Coverage 1991-07-05 through 2019-06-19 at
+last verification (241 meetings). The xlsx is updated in place by the
+author, so the adapter records the upstream URL on every row's
+``multi_axis_extras`` so downstream consumers can audit which release
+they are training against.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterable
+
+from app.data.sources.base import BaseSourceScraper, Provenance, SourceMetadata
+from app.data.sources.registry import register
+
+# Public xlsx mirror — verified live 2026-05-29. Pinned to the UCI
+# homepage because Swanson's prior author domain (ericswanson.org) is
+# dead per #420. The on-disk filename matches
+# ``SWANSON_THREE_FACTOR_DEFAULT_RELATIVE`` in
+# ``app.data.ingest_sources`` so the downstream
+# ``--include-swanson-three-factor`` ingest path picks the pull up
+# without extra wiring.
+SWANSON_THREE_FACTOR_UPSTREAM_URL = (
+    "https://sites.socsci.uci.edu/~swanson2/papers/"
+    "pre-and-post-ZLB-factors-extended.xlsx"
+)
+
+_USER_AGENT = (
+    "fed-pulse-data-ingester/1.0 "
+    "(+https://github.com/yusufizzetmurat/fed-pulse)"
+)
+
+
+def pull_swanson_three_factor_xlsx(
+    target_path: Path,
+    *,
+    force: bool = False,
+    url: str = SWANSON_THREE_FACTOR_UPSTREAM_URL,
+    timeout: float = 60.0,
+) -> int:
+    """Download the Swanson three-factor xlsx to ``target_path``.
+
+    Returns the row count after parsing. Idempotent: when the cache
+    exists and parses to a non-empty row set, the existing row count
+    is returned without HTTP traffic. Atomic-on-POSIX via
+    ``Path.replace`` after a sibling ``.tmp`` write.
+    """
+
+    # pandas import is deferred so module import does not pull the
+    # heavy dependency for callers that only want the metadata.
+    import pandas as pd
+
+    if target_path.exists() and not force:
+        try:
+            cached = pd.read_excel(
+                target_path, engine="openpyxl", sheet_name="Data", header=1
+            )
+            if len(cached) > 0:
+                return int(len(cached))
+        except Exception:
+            pass  # fall through to re-pull on corrupt cache
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = target_path.with_suffix(target_path.suffix + ".tmp")
+    try:
+        request = urllib.request.Request(
+            url, headers={"User-Agent": _USER_AGENT}
+        )
+        try:
+            response = urllib.request.urlopen(request, timeout=timeout)
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Swanson three-factor upstream returned HTTP {exc.code} "
+                f"from {url}"
+            ) from exc
+        with response:
+            body: bytes = response.read()
+        tmp_path.write_bytes(body)
+        parsed = pd.read_excel(
+            tmp_path, engine="openpyxl", sheet_name="Data", header=1
+        )
+        row_count = int(len(parsed))
+        if row_count == 0:
+            raise RuntimeError(
+                f"Swanson three-factor download from {url} produced zero rows"
+            )
+        tmp_path.replace(target_path)
+        return row_count
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+
+
+class SwansonThreeFactorScraper:
+    """``BaseSourceScraper``-shaped wrapper around the xlsx release.
+
+    The adapter does NOT walk an HTML index — the xlsx is the entire
+    corpus in a single file — so ``fetch_listing`` returns a list of
+    one dict per spreadsheet row and ``parse_entry`` accepts each one
+    as a JSON-encoded string for protocol parity with the HTML-on-the-
+    wire scrapers.
+    """
+
+    metadata = SourceMetadata(
+        name="Swanson three-factor (2021 JME, UCI mirror)",
+        source_type="swanson_three_factor",
+        provenance=Provenance.PEER_REVIEWED,
+        citation=(
+            "Swanson, E. T. (2021). Measuring the Effects of Federal "
+            "Reserve Forward Guidance and Asset Purchases on Financial "
+            "Markets. J. Monetary Economics 118."
+        ),
+    )
+
+    def fetch_listing(self, html: str) -> list[dict[str, Any]]:
+        """Parse the xlsx-on-disk path passed via ``html`` and return the
+        row dicts. ``html`` here carries the path string to keep the
+        Protocol signature uniform across CSV/HTML/xlsx sources.
+        """
+
+        if not html:
+            return []
+        import pandas as pd
+
+        df = pd.read_excel(
+            html, engine="openpyxl", sheet_name="Data", header=1
+        )
+        rows: list[dict[str, Any]] = []
+        for _, row in df.iterrows():
+            rows.append(
+                {
+                    "meeting_date": row.iloc[1],
+                    "target_factor": row.get("Federal Funds Rate factor"),
+                    "forward_guidance_factor": row.get(
+                        "Forward Guidance factor"
+                    ),
+                    "lsap_factor": row.get("LSAP factor"),
+                }
+            )
+        return rows
+
+    def parse_entry(
+        self, raw_html: str, *, source_url: str
+    ) -> dict[str, Any] | None:
+        try:
+            row = json.loads(raw_html)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(row, dict):
+            return None
+        parsed = _parse_swanson_row(row)
+        if parsed is None:
+            return None
+        parsed["source_url"] = source_url
+        return parsed
+
+    def write(
+        self, parsed: Iterable[dict[str, Any]], output_path: Path
+    ) -> int:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        count = 0
+        with output_path.open("w", encoding="utf-8") as handle:
+            for entry in parsed:
+                if entry is None:
+                    continue
+                handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                count += 1
+        return count
+
+
+def _parse_swanson_row(row: dict[str, Any]) -> dict[str, Any] | None:
+    """Build one registry record from a Swanson row dict.
+
+    Returns None when the meeting date or all three factor values are
+    missing. Factor values are kept as floats; downstream consumers read
+    them off ``multi_axis_extras``.
+    """
+
+    raw_date = row.get("meeting_date")
+    if raw_date is None:
+        return None
+    iso_date: str = ""
+    try:
+        # pandas Timestamp / datetime
+        iso_date = raw_date.strftime("%Y-%m-%d")  # type: ignore[union-attr]
+    except AttributeError:
+        iso_date = str(raw_date)[:10]
+    if not iso_date or len(iso_date) < 10:
+        return None
+
+    def _float_or_none(v: Any) -> float | None:
+        if v is None:
+            return None
+        try:
+            f = float(v)
+        except (TypeError, ValueError):
+            return None
+        # pandas reads blanks as NaN; treat NaN as missing
+        if f != f:  # noqa: PLR0124
+            return None
+        return f
+
+    target = _float_or_none(row.get("target_factor"))
+    fg = _float_or_none(row.get("forward_guidance_factor"))
+    lsap = _float_or_none(row.get("lsap_factor"))
+    if target is None and fg is None and lsap is None:
+        return None
+
+    extras = {
+        "swanson_target_factor": target,
+        "swanson_forward_guidance_factor": fg,
+        "swanson_lsap_factor": lsap,
+        "swanson_upstream_url": SWANSON_THREE_FACTOR_UPSTREAM_URL,
+    }
+    title = f"Swanson three-factor decomposition {iso_date}"
+    text = (
+        f"Swanson three-factor decomposition for {iso_date}: "
+        f"target={target if target is not None else 'n/a':+.4f}, "
+        f"forward_guidance={fg if fg is not None else 'n/a':+.4f}, "
+        f"lsap={lsap if lsap is not None else 'n/a':+.4f}"
+    )
+    return {
+        "source_record_id": f"swanson_{iso_date}",
+        "event_date_hint": iso_date,
+        "document_type": "statement",
+        "title": title,
+        "text": text,
+        "label": "",
+        "license_scope": "research_only",
+        "citation_ref": "swanson_2021_jme",
+        "multi_axis_extras": extras,
+    }
+
+
+register(SwansonThreeFactorScraper())
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from app.config import DATA_DIR as _DEFAULT_DATA_DIR
+    from app.data.ingest_sources import SWANSON_THREE_FACTOR_DEFAULT_RELATIVE
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Pull the Swanson 2021 three-factor xlsx into the local data "
+            "cache so `python -m app.data.ingest_sources "
+            "--include-swanson-three-factor` can materialise rows into "
+            "the source registry."
+        )
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=str(_DEFAULT_DATA_DIR),
+        help="Base data directory (default: app.config.DATA_DIR).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-download even if the cache file already exists.",
+    )
+    parser.add_argument(
+        "--url",
+        default=SWANSON_THREE_FACTOR_UPSTREAM_URL,
+        help="Override the upstream URL (default: UCI mirror).",
+    )
+    ns = parser.parse_args()
+    target = Path(ns.data_dir) / SWANSON_THREE_FACTOR_DEFAULT_RELATIVE
+    rows = pull_swanson_three_factor_xlsx(
+        target, force=ns.force, url=ns.url
+    )
+    print(f"Swanson three-factor cache at {target} (rows: {rows})")

--- a/tests/unit/test_scraper_swanson_three_factor.py
+++ b/tests/unit/test_scraper_swanson_three_factor.py
@@ -1,0 +1,208 @@
+"""Tests for the Swanson 2021 three-factor adapter (#420)."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+pytest.importorskip("bs4")  # source registry init imports HTML scrapers
+pytest.importorskip("openpyxl")  # xlsx engine
+
+from app.data.sources import SOURCES  # noqa: E402
+from app.data.sources.swanson_three_factor import (  # noqa: E402
+    SWANSON_THREE_FACTOR_UPSTREAM_URL,
+    SwansonThreeFactorScraper,
+    _parse_swanson_row,
+    pull_swanson_three_factor_xlsx,
+)
+
+
+def _write_fixture_xlsx(path: Path, n: int = 3) -> None:
+    """Write a Swanson-shape xlsx fixture mirroring the upstream layout
+    (header row 1, date column second, three factor columns + a
+    sign-flipped LSAP column).
+    """
+
+    dates = pd.date_range("2010-01-27", periods=n, freq="60D")
+    df = pd.DataFrame(
+        {
+            "Unnamed: 0": [None] * n,
+            "Unnamed: 1": dates,
+            "Federal Funds Rate factor": [-0.10 + i * 0.05 for i in range(n)],
+            "Forward Guidance factor": [0.20 + i * 0.01 for i in range(n)],
+            "LSAP factor": [-0.05 + i * 0.02 for i in range(n)],
+            " – LSAP factor": [0.05 - i * 0.02 for i in range(n)],
+        }
+    )
+    # Upstream has a single label row before the column headers; mimic
+    # that so pd.read_excel(header=1) picks up the right header row.
+    label_row = pd.DataFrame(
+        [
+            {
+                "Unnamed: 0": None,
+                "Unnamed: 1": None,
+                "Federal Funds Rate factor": "Estimated Factors",
+                "Forward Guidance factor": None,
+                "LSAP factor": None,
+                " – LSAP factor": None,
+            }
+        ]
+    )
+    full = pd.concat([label_row, df], ignore_index=True)
+    with pd.ExcelWriter(path, engine="openpyxl") as writer:
+        full.to_excel(writer, sheet_name="Data", index=False, header=True)
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+
+def test_swanson_scraper_is_registered() -> None:
+    assert "swanson_three_factor" in SOURCES
+    scraper = SOURCES["swanson_three_factor"]
+    assert isinstance(scraper, SwansonThreeFactorScraper)
+    assert scraper.metadata.provenance.value == "peer_reviewed"
+    assert "Swanson" in scraper.metadata.name
+
+
+def test_parse_row_returns_registry_shape() -> None:
+    row = {
+        "meeting_date": pd.Timestamp("2014-09-17"),
+        "target_factor": 0.123,
+        "forward_guidance_factor": -0.456,
+        "lsap_factor": 0.789,
+    }
+    parsed = _parse_swanson_row(row)
+    assert parsed is not None
+    assert parsed["source_record_id"] == "swanson_2014-09-17"
+    assert parsed["event_date_hint"] == "2014-09-17"
+    assert parsed["document_type"] == "statement"
+    assert parsed["license_scope"] == "research_only"
+    assert parsed["citation_ref"] == "swanson_2021_jme"
+    extras = parsed["multi_axis_extras"]
+    assert extras["swanson_target_factor"] == pytest.approx(0.123)
+    assert extras["swanson_forward_guidance_factor"] == pytest.approx(-0.456)
+    assert extras["swanson_lsap_factor"] == pytest.approx(0.789)
+
+
+def test_parse_row_drops_row_with_no_factors() -> None:
+    row = {
+        "meeting_date": pd.Timestamp("2014-09-17"),
+        "target_factor": None,
+        "forward_guidance_factor": None,
+        "lsap_factor": None,
+    }
+    assert _parse_swanson_row(row) is None
+
+
+def test_parse_row_drops_row_with_missing_date() -> None:
+    assert (
+        _parse_swanson_row(
+            {
+                "meeting_date": None,
+                "target_factor": 0.1,
+                "forward_guidance_factor": 0.2,
+                "lsap_factor": 0.3,
+            }
+        )
+        is None
+    )
+
+
+def test_pull_downloads_and_writes_xlsx(tmp_path: Path) -> None:
+    target = tmp_path / "external" / "swanson" / "release.xlsx"
+    src = tmp_path / "src.xlsx"
+    _write_fixture_xlsx(src, n=3)
+    body = src.read_bytes()
+    with patch(
+        "app.data.sources.swanson_three_factor.urllib.request.urlopen",
+        return_value=_FakeResponse(body),
+    ) as opener:
+        rows = pull_swanson_three_factor_xlsx(target)
+    assert rows == 3
+    assert target.exists()
+    opener.assert_called_once()
+
+
+def test_pull_is_idempotent_when_cache_has_rows(tmp_path: Path) -> None:
+    target = tmp_path / "release.xlsx"
+    _write_fixture_xlsx(target, n=2)
+    with patch(
+        "app.data.sources.swanson_three_factor.urllib.request.urlopen"
+    ) as opener:
+        rows = pull_swanson_three_factor_xlsx(target)
+    assert rows == 2
+    opener.assert_not_called()
+
+
+def test_pull_force_re_downloads_over_existing_cache(tmp_path: Path) -> None:
+    target = tmp_path / "release.xlsx"
+    _write_fixture_xlsx(target, n=1)
+    src = tmp_path / "src.xlsx"
+    _write_fixture_xlsx(src, n=4)
+    body = src.read_bytes()
+    with patch(
+        "app.data.sources.swanson_three_factor.urllib.request.urlopen",
+        return_value=_FakeResponse(body),
+    ):
+        rows = pull_swanson_three_factor_xlsx(target, force=True)
+    assert rows == 4
+
+
+def test_pull_raises_on_http_error(tmp_path: Path) -> None:
+    target = tmp_path / "release.xlsx"
+    err = urllib.error.HTTPError(
+        SWANSON_THREE_FACTOR_UPSTREAM_URL, 404, "Not Found", None, None  # type: ignore[arg-type]
+    )
+    with patch(
+        "app.data.sources.swanson_three_factor.urllib.request.urlopen",
+        side_effect=err,
+    ):
+        with pytest.raises(RuntimeError, match="HTTP 404"):
+            pull_swanson_three_factor_xlsx(target)
+    assert not target.exists()
+    assert not target.with_suffix(target.suffix + ".tmp").exists()
+
+
+def test_scraper_fetch_listing_returns_row_dicts(tmp_path: Path) -> None:
+    src = tmp_path / "src.xlsx"
+    _write_fixture_xlsx(src, n=3)
+    listing = SwansonThreeFactorScraper().fetch_listing(str(src))
+    assert len(listing) == 3
+    assert "meeting_date" in listing[0]
+    assert "target_factor" in listing[0]
+
+
+def test_scraper_parse_entry_round_trips(tmp_path: Path) -> None:
+    src = tmp_path / "src.xlsx"
+    _write_fixture_xlsx(src, n=1)
+    scraper = SwansonThreeFactorScraper()
+    listing = scraper.fetch_listing(str(src))
+    row = listing[0]
+    # Coerce non-JSON-serialisable Timestamp to isoformat string
+    row["meeting_date"] = (
+        row["meeting_date"].strftime("%Y-%m-%d")  # type: ignore[union-attr]
+        if hasattr(row["meeting_date"], "strftime")
+        else row["meeting_date"]
+    )
+    parsed = scraper.parse_entry(
+        json.dumps(row), source_url="https://swanson.test"
+    )
+    assert parsed is not None
+    assert parsed["source_url"] == "https://swanson.test"


### PR DESCRIPTION
Closes #420.

The original #420 body marked the issue blocked on a dead author homepage (ericswanson.org). Updated body 2026-05-29 confirmed the UCI mirror is live; this PR ships the adapter.

## Live verification
\`\`\`
HTTP 200  size=69952  241 rows  range 1991-07-05 -> 2019-06-19
\`\`\`

Direct end-to-end run of \`pull_swanson_three_factor_xlsx\` against \`https://sites.socsci.uci.edu/~swanson2/papers/pre-and-post-ZLB-factors-extended.xlsx\` writes a 70 KB xlsx, pandas parses 241 meeting rows with the three factor columns (Federal Funds Rate / Forward Guidance / LSAP) populated for every row. Idempotent re-call does zero HTTP traffic.

## What ships

- \`backend/app/data/sources/swanson_three_factor.py\` — \`pull_swanson_three_factor_xlsx\` helper + \`SwansonThreeFactorScraper\` + \`__main__\` argparse entry. Same atomic-on-POSIX tmp-then-replace pattern as #487 OpFed.
- \`_iter_swanson_three_factor_records\` in \`ingest_sources.py\` + \`--include-swanson-three-factor\` CLI flag. \`--all-sources\` picks it up automatically.
- \`SWANSON_THREE_FACTOR_DEFAULT_RELATIVE\` = \`data/external/swanson/pre-and-post-ZLB-factors-extended.xlsx\`.
- \`make pull-swanson-three-factor\` Makefile target.
- 9 unit tests: registry registration, parse_row happy/null/missing-date paths, pull (download/idempotent/force/HTTP-404), scraper round-trip.

## Multi-axis surface

Rows are stance-unlabelled (the decomposition is continuous, not categorical). The three factors land on \`multi_axis_extras\` as \`swanson_target_factor\`, \`swanson_forward_guidance_factor\`, \`swanson_lsap_factor\`. \`source_type=\"swanson_three_factor\"\`, \`citation_ref=\"swanson_2021_jme\"\`, \`provenance=\"peer_reviewed\"\`.

## Why now

The pinned TP audit shows the factor axis was only covered by GSS rows (138 meetings through 2004-12-14). Adding Swanson extends factor-axis coverage through the ZLB era to 2019-06-19. The cross-source transfer matrix (#421) gains a new column.

## Test plan
- [ ] CI green on the new unit suite.
- [ ] Live smoke: \`make pull-swanson-three-factor\` writes the 70 KB xlsx at the expected path.
- [ ] Downstream: \`python -m app.data.ingest_sources --include-swanson-three-factor\` produces ~241 registry records tagged \`source_type=swanson_three_factor\`.