### PR TITLE
pre-sweep prep: PRIOR_WINDOW Makefile, dump CM per fold, paired-Wilcoxon, sealed-holdout protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,8 @@ build-events-parquet:
 			--output events.parquet \
 			--full-output events_full.parquet \
 			$(if $(RATES_PANEL_PATH),--rates-panel-path "$(RATES_PANEL_PATH)",) \
-			$(if $(PER_ASSET_CACHE_DIR),--per-asset-target-cache-dir "$(PER_ASSET_CACHE_DIR)",)
+			$(if $(PER_ASSET_CACHE_DIR),--per-asset-target-cache-dir "$(PER_ASSET_CACHE_DIR)",) \
+			$(if $(PRIOR_WINDOW),--prior-window $(PRIOR_WINDOW),)
 
 pull-op-fed:
 	docker compose run --rm backend \

--- a/docs/sealed_holdout_protocol.md
+++ b/docs/sealed_holdout_protocol.md
@@ -1,0 +1,130 @@
+# Sealed-holdout pre-registration protocol (#501)
+
+This document is the pre-registered contract for the post-cutoff sealed
+holdout at `data/external/sealed_holdout/fomc_2025.jsonl`. Once committed
+with witness sign-off it must not be edited; subsequent breaks of the
+seal (the one allowed final-submission read) link back to the commit
+SHA that introduced this file as the integrity anchor.
+
+The companion technical documentation lives in
+`data/external/sealed_holdout/README.md`. This file is the procedural
+contract, not the technical one.
+
+## Holdout definition
+
+- **File**: `data/external/sealed_holdout/fomc_2025.jsonl`.
+- **Row schema**: one JSON object per line. Fields: `event_date`
+  (ISO yyyy-mm-dd, all values strictly after 2024-12-31), `event_type`
+  (`statement` | `minutes`), `text` (scraped from federalreserve.gov,
+  no derivation), `url` (source URL), `scraped_at_utc` (scrape
+  timestamp).
+- **Cutoff contract**: every row's `event_date` is strictly after the
+  canonical training package's cutoff (2024-12-31). No row appears in
+  any walk-forward train / val / test partition, no row appears in any
+  sweep / HP grid, no row appears in any embedding / DAPT / encoder
+  used during the training programme.
+
+### Stub state at pre-registration time
+
+The file currently ships stub rows carrying a leading
+`# pragma: stub` marker in the `text` field. The integrity sha pinned
+below is captured at the moment the stubs are replaced with real
+scraped text. Until that swap the audit script (see "Integrity
+verification" below) intentionally reports a sha mismatch — that is
+the desired state, not a bug, because reporting a sealed-eval headline
+against stubbed text would be a methodology defect.
+
+## Pre-declared evaluation metrics
+
+These are the metrics that will be reported against the sealed
+holdout, declared before any model has seen the file:
+
+- **Classification head**:
+  - `regime_f1_macro` (macro-averaged F1 over the 3 vol-regime bins).
+  - Per-class precision / recall / F1 (3 rows).
+  - 3x3 confusion matrix.
+  - Macro ROC-AUC and macro PR-AUC.
+- **Regression head**:
+  - RMSE on `log(forward_realized_vol_10d)`.
+  - MAE on `log(forward_realized_vol_10d)`.
+  - R^2 on `log(forward_realized_vol_10d)`.
+- **Conformal coverage** at the pre-declared significance level
+  α = 0.20 (i.e. nominal 80% coverage band).
+
+No other metric will be added post-hoc. Adding one would invalidate
+the pre-registration.
+
+## Number of model runs against the holdout
+
+**Exactly one (1).** The single allowed read is the final-submission
+inference pass, executed against the checkpoint frozen by the final
+sweep batch on the dev / val partitions. The full sweep grid is
+selected and frozen on the dev splits; the holdout is read only after
+no methodology decision remains open.
+
+Any second read invalidates the pre-registration and the sealed-eval
+headline must be removed from the final report.
+
+## Seal-break protocol
+
+1. The operator verifies the integrity sha against
+   `data/external/sealed_holdout/fomc_2025.jsonl` (see "Integrity
+   verification" below).
+2. The operator records the code revision (git SHA of `HEAD`) the
+   inference run will execute under.
+3. The operator runs the single inference pass and writes the metrics
+   from the pre-declared list above to
+   `backend/artifacts/experiments/sealed_eval_holdout_<timestamp>.json`.
+4. The operator increments `usage_count` and sets
+   `last_accessed_utc` in `data/external/sealed_holdout/AUDIT_TOKEN`.
+   The post-run `usage_count` must equal exactly `1`.
+5. The witness named in the sign-off section below countersigns the
+   result by committing the metrics file with their authenticated
+   identity.
+
+## Integrity verification
+
+The script that computes and verifies the holdout file's sha256:
+
+```
+shasum -a 256 data/external/sealed_holdout/fomc_2025.jsonl
+```
+
+The pre-registered sha will be committed to this file in a follow-up
+commit at the moment the stub replacement lands. Until then the
+sha-pin block below is empty.
+
+### Pinned sha256 (post stub replacement)
+
+```
+<INTENTIONALLY BLANK — see "Stub state at pre-registration time">
+```
+
+To pin: replace the placeholder above with the output of `shasum -a 256
+data/external/sealed_holdout/fomc_2025.jsonl` as run on the commit
+SHA that lands the real scraped rows. The pinning commit must
+reference issue #501.
+
+## Code revision that defines this holdout
+
+- Pre-registration commit (this document) — see commit SHA in PR #N
+  (replace `#N` with the merging PR's number once the squash SHA is
+  known).
+- Sealed-holdout loader: `backend/app/data/sealed_holdout_loader.py`.
+- Audit-token state machine: `data/external/sealed_holdout/AUDIT_TOKEN`.
+
+## Witness sign-off
+
+To be filled in by the supervisor on commit:
+
+- **Witness identity**: ________________________________________
+- **Witness sign-off date** (UTC): ____________________________
+- **Confirmation**: I have read the pre-registered metrics list,
+  the one-run cap, and the seal-break protocol above. I countersign
+  the pre-registration as valid for the final submission of the
+  fed-pulse thesis project.
+
+(The witness commits this completed block as a follow-up to the
+PR that introduces the file. The follow-up commit must reference
+issue #501 and must be authored by the witness's authenticated
+identity for the audit trail.)

--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -186,12 +186,30 @@ def _resolve_output_path(arg: Path | None) -> Path:
     return base / "dual_head_comparison.json"
 
 
-def _trial_metrics(summary: Any) -> dict[str, float | None]:
-    """Pull the headline numbers out of a TrainingRunSummary."""
+def _trial_metrics(summary: Any) -> dict[str, Any]:
+    """Pull headline numbers + the per-fold classification breakdown
+    out of a ``TrainingRunSummary``. The classification breakdown
+    carries the 3x3 confusion matrix and the per-class P/R/F1 + support
+    counts that the downstream defense analyses (#496 ordinal confusion,
+    #500 per-fold baselines) read.
+
+    ``classification_breakdown`` is included whenever the test partition
+    ran a classification head; on regression-only arms it lands as
+    ``None`` and consumers degrade cleanly.
+    """
 
     test = getattr(summary, "test_metrics", None) or getattr(summary, "metrics", None)
     if test is None:
         return {}
+    breakdown = getattr(test, "classification_breakdown", None)
+    breakdown_payload: dict[str, Any] | None = None
+    if breakdown is not None:
+        # ``classification_breakdown`` on EvaluationMetrics is already a
+        # dict at this stage (loop.py assigns ``breakdown.to_dict()``).
+        if isinstance(breakdown, dict):
+            breakdown_payload = breakdown
+        elif hasattr(breakdown, "to_dict"):
+            breakdown_payload = breakdown.to_dict()
     return {
         "regime_f1_macro": getattr(test, "regime_f1_macro", None),
         "regime_accuracy": getattr(test, "regime_accuracy", None),
@@ -199,6 +217,7 @@ def _trial_metrics(summary: Any) -> dict[str, float | None]:
         "regression_rmse_log_rv": getattr(test, "regression_rmse_log_rv", None),
         "regression_mae_log_rv": getattr(test, "regression_mae_log_rv", None),
         "regression_loss": getattr(test, "regression_loss", None),
+        "classification_breakdown": breakdown_payload,
     }
 
 

--- a/scripts/run_paired_comparison_tests.py
+++ b/scripts/run_paired_comparison_tests.py
@@ -1,0 +1,238 @@
+"""Paired Wilcoxon signed-rank tests on a head-mode comparison sweep (#497).
+
+Reads a sweep JSON of the shape produced by
+``scripts/run_dual_head_comparison.py``, matches per-(seed, fold) cells
+across arms, and emits a paired test per arm-arm comparison. Sharpens
+the §6.7 / §6.10 headline from "looks better" into "is better, p<X".
+
+The 25 cells per arm (5 seeds × 5 folds) are NOT independent — the
+same fold appears with 5 different seeds and vice versa — so a paired
+test on the per-(seed, fold) delta is the right framing.
+
+Holm-Bonferroni correction is applied across the comparison family
+when multiple arm-arm pairs are tested in the same run.
+
+Usage:
+
+    python -m scripts.run_paired_comparison_tests \
+        --input backend/artifacts/experiments/dual_head_comparison_canonical.json \
+        --metric regime_f1_macro
+
+Outputs a single JSON to stdout (or to ``--output`` if set) with one
+row per pair carrying ``mean_delta``, ``std_delta``, ``wilcoxon_W``,
+``wilcoxon_p``, ``holm_p`` (corrected), and ``n_pairs``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from itertools import combinations
+from pathlib import Path
+from typing import Any
+
+
+def _collect_per_cell(
+    arm_trials: list[dict[str, Any]],
+    metric: str,
+) -> dict[tuple[int, str], float]:
+    """Return a {(seed, fold_id): metric} mapping for one arm."""
+
+    out: dict[tuple[int, str], float] = {}
+    for trial in arm_trials:
+        seed = int(trial.get("seed", -1))
+        for fold in trial.get("folds", []) or []:
+            fold_id = str(fold.get("fold_id", ""))
+            metrics = fold.get("metrics") or {}
+            value = metrics.get(metric)
+            if value is None:
+                continue
+            try:
+                out[(seed, fold_id)] = float(value)
+            except (TypeError, ValueError):
+                continue
+    return out
+
+
+def _wilcoxon_signed_rank(deltas: list[float]) -> tuple[float, float, int]:
+    """Compute the Wilcoxon signed-rank W statistic and a two-sided
+    p-value for ``H0: deltas symmetric around zero``.
+
+    Implemented by hand (not via scipy) so the script has zero non-
+    stdlib runtime deps. Uses the normal approximation when n >= 10
+    (the canonical 25-cell sweep gives n = 25 so the approximation is
+    well-justified); for smaller n falls back to an exact enumeration
+    over signed permutations.
+
+    Returns ``(W, p_two_sided, n_nonzero)``.
+    """
+
+    nonzero = [d for d in deltas if d != 0]
+    n = len(nonzero)
+    if n == 0:
+        return 0.0, 1.0, 0
+
+    abs_ranked = sorted(enumerate(nonzero), key=lambda kv: abs(kv[1]))
+    ranks = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and abs(abs_ranked[j + 1][1]) == abs(abs_ranked[i][1]):
+            j += 1
+        avg_rank = (i + j) / 2.0 + 1.0
+        for k in range(i, j + 1):
+            ranks[abs_ranked[k][0]] = avg_rank
+        i = j + 1
+
+    w_plus = sum(r for r, d in zip(ranks, nonzero) if d > 0)
+    w_minus = sum(r for r, d in zip(ranks, nonzero) if d < 0)
+    w_stat = min(w_plus, w_minus)
+
+    if n >= 10:
+        mean_w = n * (n + 1) / 4.0
+        var_w = n * (n + 1) * (2 * n + 1) / 24.0
+        z = (w_stat - mean_w) / math.sqrt(var_w) if var_w > 0 else 0.0
+        # Two-sided p via normal CDF
+        p = 2.0 * (1.0 - 0.5 * (1.0 + math.erf(abs(z) / math.sqrt(2.0))))
+        return float(w_stat), max(min(p, 1.0), 0.0), n
+
+    # Exact enumeration for n < 10
+    from itertools import product
+
+    target = w_stat
+    count = 0
+    total = 0
+    for signs in product((-1, 1), repeat=n):
+        signed = [s * r for s, r in zip(signs, ranks)]
+        w_pos = sum(r for r in signed if r > 0)
+        w_neg = -sum(r for r in signed if r < 0)
+        w_min = min(w_pos, w_neg)
+        if w_min <= target:
+            count += 1
+        total += 1
+    p = count / total
+    return float(w_stat), max(min(p, 1.0), 0.0), n
+
+
+def _holm_correct(p_values: list[float]) -> list[float]:
+    """Holm-Bonferroni step-down correction on a vector of p-values."""
+
+    order = sorted(range(len(p_values)), key=lambda i: p_values[i])
+    n = len(p_values)
+    corrected = [0.0] * n
+    running_max = 0.0
+    for rank, idx in enumerate(order):
+        adj = (n - rank) * p_values[idx]
+        running_max = max(running_max, adj)
+        corrected[idx] = min(running_max, 1.0)
+    return corrected
+
+
+def run_paired_tests(
+    sweep_payload: dict[str, Any],
+    metric: str,
+) -> list[dict[str, Any]]:
+    """Run paired tests for every arm-arm pair in ``sweep_payload``."""
+
+    trials_block = sweep_payload.get("trials") or {}
+    if not trials_block:
+        raise ValueError("input JSON has no 'trials' block")
+    arms = list(trials_block.keys())
+    per_arm_cells: dict[str, dict[tuple[int, str], float]] = {
+        arm: _collect_per_cell(trials_block[arm], metric=metric)
+        for arm in arms
+    }
+
+    pair_payloads: list[dict[str, Any]] = []
+    raw_p_values: list[float] = []
+    for arm_a, arm_b in combinations(arms, 2):
+        a_cells = per_arm_cells[arm_a]
+        b_cells = per_arm_cells[arm_b]
+        shared = sorted(set(a_cells) & set(b_cells))
+        if not shared:
+            continue
+        deltas = [b_cells[k] - a_cells[k] for k in shared]
+        mean_delta = statistics.fmean(deltas)
+        std_delta = (
+            statistics.pstdev(deltas) if len(deltas) > 1 else 0.0
+        )
+        w_stat, p_two, n_nonzero = _wilcoxon_signed_rank(deltas)
+        pair_payloads.append(
+            {
+                "metric": metric,
+                "arm_a": arm_a,
+                "arm_b": arm_b,
+                "n_pairs": len(shared),
+                "n_nonzero_pairs": n_nonzero,
+                "mean_delta_b_minus_a": mean_delta,
+                "std_delta": std_delta,
+                "effect_size_d": (
+                    mean_delta / std_delta if std_delta > 0 else None
+                ),
+                "wilcoxon_W": w_stat,
+                "wilcoxon_p_two_sided": p_two,
+            }
+        )
+        raw_p_values.append(p_two)
+
+    holm = _holm_correct(raw_p_values) if raw_p_values else []
+    for payload, p_corr in zip(pair_payloads, holm):
+        payload["holm_corrected_p"] = p_corr
+    return pair_payloads
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Paired Wilcoxon signed-rank tests on a head-mode "
+            "comparison sweep. See #497."
+        )
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help=(
+            "Path to a sweep JSON (e.g. "
+            "backend/artifacts/experiments/dual_head_comparison_canonical.json)."
+        ),
+    )
+    parser.add_argument(
+        "--metric",
+        type=str,
+        default="regime_f1_macro",
+        help="Per-fold metric to compare (default: regime_f1_macro).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write JSON to this path; default stdout.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    payload = json.loads(args.input.read_text(encoding="utf-8"))
+    rows = run_paired_tests(payload, metric=args.metric)
+    report = {
+        "source": str(args.input),
+        "metric": args.metric,
+        "pairs": rows,
+    }
+    text = json.dumps(report, indent=2)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+        print(f"[paired-tests] wrote {args.output}")
+    else:
+        sys.stdout.write(text + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_run_paired_comparison_tests.py
+++ b/tests/unit/test_run_paired_comparison_tests.py
@@ -1,0 +1,144 @@
+"""Tests for the paired Wilcoxon analysis script (#497)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from scripts.run_paired_comparison_tests import (
+    _holm_correct,
+    _wilcoxon_signed_rank,
+    run_paired_tests,
+)
+
+
+def _make_sweep_payload(
+    arm_a_values: list[float],
+    arm_b_values: list[float],
+    fold_ids: list[str] | None = None,
+    seeds: list[int] | None = None,
+) -> dict[str, object]:
+    """Build a sweep JSON shape with one arm per name. Both arms get the
+    same (seed, fold) grid so pairing succeeds.
+    """
+
+    seeds = seeds or [11, 29, 47, 71, 97]
+    fold_ids = fold_ids or [
+        "wf_fold_1",
+        "wf_fold_2",
+        "wf_fold_3",
+        "wf_fold_4",
+        "wf_fold_5",
+    ]
+    expected = len(seeds) * len(fold_ids)
+    assert len(arm_a_values) == expected
+    assert len(arm_b_values) == expected
+
+    def _trials(values: list[float]) -> list[dict[str, object]]:
+        out: list[dict[str, object]] = []
+        cursor = 0
+        for seed in seeds:
+            fold_block = []
+            for fold_id in fold_ids:
+                fold_block.append(
+                    {
+                        "fold_id": fold_id,
+                        "metrics": {
+                            "regime_f1_macro": values[cursor],
+                        },
+                    }
+                )
+                cursor += 1
+            out.append({"seed": seed, "folds": fold_block})
+        return out
+
+    return {
+        "trials": {
+            "arm_a": _trials(arm_a_values),
+            "arm_b": _trials(arm_b_values),
+        }
+    }
+
+
+def test_wilcoxon_zero_deltas_returns_p_one() -> None:
+    w, p, n = _wilcoxon_signed_rank([0.0] * 5)
+    assert p == 1.0
+    assert n == 0
+
+
+def test_wilcoxon_all_positive_deltas_normal_approx() -> None:
+    # n = 25, all positive => W = 0 (min(W+, W-) = 0), p should be tiny.
+    deltas = [0.01 * (i + 1) for i in range(25)]
+    w, p, n = _wilcoxon_signed_rank(deltas)
+    assert n == 25
+    assert w == 0.0
+    assert p < 0.001
+
+
+def test_wilcoxon_symmetric_small_n_exact() -> None:
+    # n=4, balanced signs => p should be ~1.0 (no preference for either side)
+    deltas = [0.5, -0.5, 0.3, -0.3]
+    w, p, n = _wilcoxon_signed_rank(deltas)
+    assert n == 4
+    assert p == pytest.approx(1.0, abs=0.1)
+
+
+def test_holm_correction_orders_correctly() -> None:
+    raw = [0.001, 0.01, 0.04, 0.06]
+    corrected = _holm_correct(raw)
+    # Holm: multiply smallest by 4, next by 3, etc.
+    # 0.001 * 4 = 0.004
+    # 0.01 * 3 = 0.03
+    # 0.04 * 2 = 0.08
+    # 0.06 * 1 = 0.06 (but must be >= 0.08 from running max)
+    assert corrected[0] == pytest.approx(0.004)
+    assert corrected[1] == pytest.approx(0.03)
+    assert corrected[2] == pytest.approx(0.08)
+    assert corrected[3] == pytest.approx(0.08)  # bumped by running max
+
+
+def test_run_paired_tests_recovers_known_delta_direction() -> None:
+    """Arm B uniformly beats Arm A by +0.01 → mean_delta == +0.01,
+    Wilcoxon p should be very small.
+    """
+
+    arm_a = [0.40] * 25
+    arm_b = [0.41] * 25
+    payload = _make_sweep_payload(arm_a, arm_b)
+    rows = run_paired_tests(payload, metric="regime_f1_macro")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["arm_a"] == "arm_a"
+    assert row["arm_b"] == "arm_b"
+    assert row["n_pairs"] == 25
+    assert row["mean_delta_b_minus_a"] == pytest.approx(0.01, abs=1e-9)
+    # All deltas identical → Wilcoxon W = 0 (every nonzero rank is on
+    # the positive side); p < 0.001 under normal approx.
+    assert row["wilcoxon_p_two_sided"] < 0.001
+    # Holm with one pair is identity (multiplier = 1)
+    assert row["holm_corrected_p"] == pytest.approx(
+        row["wilcoxon_p_two_sided"]
+    )
+
+
+def test_run_paired_tests_no_delta_returns_p_one() -> None:
+    arm_a = [0.40] * 25
+    arm_b = [0.40] * 25
+    payload = _make_sweep_payload(arm_a, arm_b)
+    rows = run_paired_tests(payload, metric="regime_f1_macro")
+    assert rows[0]["wilcoxon_p_two_sided"] == 1.0
+    assert rows[0]["n_nonzero_pairs"] == 0
+
+
+def test_run_paired_tests_handles_missing_cells() -> None:
+    payload = _make_sweep_payload([0.40] * 25, [0.45] * 25)
+    # Drop one fold from arm_b to simulate a missing cell
+    payload["trials"]["arm_b"][0]["folds"][0]["metrics"]["regime_f1_macro"] = None
+    rows = run_paired_tests(payload, metric="regime_f1_macro")
+    assert rows[0]["n_pairs"] == 24
+
+
+def test_run_paired_tests_raises_on_empty_input() -> None:
+    with pytest.raises(ValueError, match="trials"):
+        run_paired_tests({}, metric="regime_f1_macro")


### PR DESCRIPTION
Bundles four pieces of work that must land before the Phase 3 sweep batch to make the resulting artifacts maximally useful for the defense analyses.

## 1. \`PRIOR_WINDOW\` Makefile gap

\`build-events-parquet\` now passes \`PRIOR_WINDOW=N\` to \`event_dataset_builder\` when set. Without this the #494 \`--prior-window\` flag was reachable only via direct \`python -m\` invocations. With this the rebuild recipe in \`docs/training-package-rebuild.md\` stays a single-command path even when the 60-day sequence variant is selected.

## 2. Confusion matrix dumped per fold (#496 / #500 enabler)

The canonical sweep JSON shipped only the summary metrics. The classification breakdown carrying the 3x3 confusion matrix and per-class P/R/F1 + support counts is computed in the trainer (\`backend/app/training/loop.py:2284\`) but discarded at the aggregator boundary (\`_trial_metrics\` in \`scripts/run_dual_head_comparison.py\`). One-line fix: include it in \`_trial_metrics\` so the next sweep run carries the data the ordinal-confusion (#496) and per-fold-baselines (#500) analyses need, with no GPU rerun required.

Regression-only arms emit \`None\` here and consumers degrade cleanly.

## 3. Paired Wilcoxon analysis script (#497)

New \`scripts/run_paired_comparison_tests.py\` reads the existing sweep JSON shape, matches per-(seed, fold) cells across arms, computes Wilcoxon signed-rank tests + Holm-corrected p-values. 8 unit tests cover the stat machinery.

### Live finding on the existing canonical artifact
\`\`\`
classification vs regression: p = 1.39e-05, mean Δ = -0.198  (regression head loses badly on F1)
classification vs dual:       p = 0.74,     mean Δ = +0.002  (NOT statistically distinguishable)
regression vs dual:           p = 1.39e-05, mean Δ = +0.199  (dual recovers from regression's F1 loss)
\`\`\`

The middle row is the substantive finding: the dual head is statistically indistinguishable from classification-only on F1 in the canonical 25-cell pairing. The §6.7 footnote will need that p value.

## 4. Sealed-holdout pre-registration (#501)

New \`docs/sealed_holdout_protocol.md\` documents the pre-declared metrics list (regime_f1_macro / per-class P/R/F1 / 3x3 CM / macro ROC-AUC / macro PR-AUC / regression RMSE/MAE/R^2 on log RV / conformal coverage at α=0.20), the exactly-one-run cap, the seal-break protocol, and an empty witness sign-off block.

The sha pin is intentionally **left blank** because the holdout file currently ships stub rows. Pinning before the stub replacement would lock in placeholder text. The real pin lands in a follow-up commit at stub-swap time. Witness signature is also left blank for the supervisor to fill on the merge follow-up.

## Test plan
- [ ] CI green.
- [ ] \`make build-events-parquet PRIOR_WINDOW=60 TRAINING_PACKAGE_ID=<id>\` renders the expected CLI invocation.
- [ ] \`python -m scripts.run_paired_comparison_tests --input backend/artifacts/experiments/dual_head_comparison_canonical.json\` matches the numbers above.
- [ ] After the next sweep run, the resulting JSON carries \`classification_breakdown\` on every classification/dual fold and \`None\` on regression folds.

Refs #476, #496, #497, #500, #501.