### PR TITLE
pre-sweep audit: per-column population gate (#505 A.1.a)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package build-events-parquet pull-op-fed pull-swanson-three-factor pull-beige-book pull-press-conferences pull-speeches pull-testimonies pull-regional-research train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package pre-sweep-column-audit build-events-parquet pull-op-fed pull-swanson-three-factor pull-beige-book pull-press-conferences pull-speeches pull-testimonies pull-regional-research train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
 
 help:
 	@echo "Targets:"
@@ -133,6 +133,20 @@ audit-training-package:
 	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
 	python -m scripts.audit_training_package_coverage \
 		--training-package-id "$(TRAINING_PACKAGE_ID)"
+
+# Pre-sweep per-column population audit (#505 A.1.a). Reads
+# events.parquet, computes non-null rates per (overall + event_kind +
+# source + fold), gates the sweep launch on schema-required columns.
+# Writes column_population.csv + summary.md + summary.json under
+# backend/artifacts/audits/pre_sweep_<TRAINING_PACKAGE_ID>/.
+pre-sweep-column-audit:
+	@test -n "$(TRAINING_PACKAGE_ID)" || (echo "TRAINING_PACKAGE_ID is required"; exit 1)
+	docker compose run --rm backend \
+		python -m scripts.run_pre_sweep_column_audit \
+			--events-parquet "data/processed/$(TRAINING_PACKAGE_ID)/events.parquet" \
+			--fold-manifest "data/processed/$(TRAINING_PACKAGE_ID)/fold_manifest_expanding_walk_forward.json" \
+			--output-dir "backend/artifacts/audits/pre_sweep_$(TRAINING_PACKAGE_ID)" \
+			$(if $(THRESHOLD_PCT),--threshold-pct $(THRESHOLD_PCT),)
 
 # Build events.parquet (canonical training-feature table) under an
 # existing data-prep'd training package directory. ``pipeline_data_prep``

--- a/scripts/run_pre_sweep_column_audit.py
+++ b/scripts/run_pre_sweep_column_audit.py
@@ -1,0 +1,355 @@
+"""Per-column population audit on events.parquet (#505 A.1.a).
+
+For every column declared in ``backend/app/data/schemas.py::_EVENT_ROW_COLUMNS``
+that's actually present on the parquet, compute:
+
+- ``non_null_rate`` overall + per fold + per event_kind + per source
+- ``n_distinct``
+- ``std`` (numeric columns only)
+
+Flag any ``required=True`` column whose empirical non-null rate is below
+the configured threshold (default 100%). Exit non-zero if any required
+column fails the gate, so the script can be wired into the sweep-launch
+pre-flight.
+
+Output:
+
+- ``column_population.csv`` — long-format, one row per (column, slice).
+- ``summary.md`` — human-readable summary of the gate result + flagged
+  columns.
+- ``summary.json`` — machine-readable summary for CI / dashboards.
+
+Usage:
+
+    python -m scripts.run_pre_sweep_column_audit \\
+        --events-parquet data/processed/<tp>/events.parquet \\
+        --fold-manifest data/processed/<tp>/fold_manifest_expanding_walk_forward.json \\
+        --output-dir backend/artifacts/audits/pre_sweep_<date>/
+
+Both ``--fold-manifest`` and ``--output-dir`` are optional. Without the
+fold manifest, per-fold breakdowns are skipped (the report header notes
+this) and the gate continues to run on the overall populations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_THRESHOLD_PCT = 100.0
+
+
+def _load_event_schema_columns() -> dict[str, dict[str, bool]]:
+    """Return a mapping of column name -> {required, nullable} from the
+    pandera schema. Imported lazily so the script can be smoke-tested
+    on machines without the full backend dependency set.
+    """
+
+    from app.data.schemas import _EVENT_ROW_COLUMNS  # noqa: PLC0415
+
+    return {
+        name: {"required": bool(col.required), "nullable": bool(col.nullable)}
+        for name, col in _EVENT_ROW_COLUMNS.items()
+    }
+
+
+def _load_fold_manifest(path: Path) -> dict[str, list[str]] | None:
+    """Return {fold_id: [event_date strings in that fold's TEST split]}.
+
+    Returns ``None`` when the manifest can't be parsed; the audit falls
+    back to overall-only populations in that case.
+    """
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    folds = payload.get("folds")
+    if not isinstance(folds, list):
+        return None
+
+    out: dict[str, list[str]] = {}
+    for entry in folds:
+        if not isinstance(entry, dict):
+            continue
+        fold_id = entry.get("fold_id") or entry.get("id")
+        test_dates = entry.get("test") or entry.get("test_event_dates")
+        if not fold_id or not isinstance(test_dates, list):
+            continue
+        out[str(fold_id)] = [str(d) for d in test_dates if d]
+    return out or None
+
+
+def _populate_per_slice(
+    df: pd.DataFrame,
+    column: str,
+    slice_label: str,
+    slice_filter: pd.Series | None,
+    rows: list[dict[str, Any]],
+) -> None:
+    """Append one row to the report for ``(column, slice_label)``."""
+
+    if slice_filter is not None:
+        slice_df = df.loc[slice_filter, column]
+    else:
+        slice_df = df[column]
+    total = int(len(slice_df))
+    if total == 0:
+        rows.append(
+            {
+                "column": column,
+                "slice_kind": slice_label.split(":", 1)[0],
+                "slice_value": slice_label.split(":", 1)[-1]
+                if ":" in slice_label
+                else "",
+                "rows": 0,
+                "non_null": 0,
+                "non_null_rate": None,
+                "n_distinct": 0,
+                "std": None,
+            }
+        )
+        return
+    non_null = int(slice_df.notna().sum())
+    rate = float(non_null / total)
+    n_distinct = int(slice_df.dropna().nunique())
+    std: float | None = None
+    if pd.api.types.is_numeric_dtype(slice_df):
+        std_value = slice_df.std(skipna=True)
+        if pd.notna(std_value):
+            std = float(std_value)
+    rows.append(
+        {
+            "column": column,
+            "slice_kind": slice_label.split(":", 1)[0],
+            "slice_value": slice_label.split(":", 1)[-1]
+            if ":" in slice_label
+            else "",
+            "rows": total,
+            "non_null": non_null,
+            "non_null_rate": rate,
+            "n_distinct": n_distinct,
+            "std": std,
+        }
+    )
+
+
+def audit_column_populations(
+    events_parquet: Path,
+    fold_manifest: Path | None = None,
+    threshold_pct: float = DEFAULT_THRESHOLD_PCT,
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    """Run the column-population audit and return ``(df, summary)``.
+
+    ``df`` is the long-format population CSV. ``summary`` carries the
+    pass/fail verdict + the list of flagged required columns.
+    """
+
+    if not events_parquet.exists():
+        raise SystemExit(f"events.parquet not found at {events_parquet}")
+
+    schema_cols = _load_event_schema_columns()
+    df_events = pd.read_parquet(events_parquet)
+
+    fold_test_dates: dict[str, list[str]] | None = None
+    if fold_manifest is not None and fold_manifest.exists():
+        fold_test_dates = _load_fold_manifest(fold_manifest)
+
+    rows: list[dict[str, Any]] = []
+    flagged_required: list[dict[str, Any]] = []
+
+    threshold_rate = float(threshold_pct) / 100.0
+
+    event_kind_values = (
+        sorted(df_events["event_kind"].dropna().unique().tolist())
+        if "event_kind" in df_events.columns
+        else []
+    )
+    source_values = (
+        sorted(df_events["source"].dropna().unique().tolist())
+        if "source" in df_events.columns
+        else []
+    )
+
+    # Build per-slice filters once so we don't re-evaluate per column.
+    slice_filters: list[tuple[str, pd.Series | None]] = [("overall:", None)]
+    for kind in event_kind_values:
+        slice_filters.append(
+            (f"event_kind:{kind}", df_events["event_kind"] == kind)
+        )
+    for src in source_values:
+        slice_filters.append((f"source:{src}", df_events["source"] == src))
+    if fold_test_dates is not None and "event_date" in df_events.columns:
+        evdates = df_events["event_date"].astype(str)
+        for fold_id, dates in fold_test_dates.items():
+            slice_filters.append(
+                (f"fold:{fold_id}", evdates.isin(dates))
+            )
+
+    for column in sorted(df_events.columns):
+        for slice_label, slice_filter in slice_filters:
+            _populate_per_slice(
+                df_events, column, slice_label, slice_filter, rows
+            )
+
+        if column not in schema_cols:
+            continue
+        if not schema_cols[column]["required"]:
+            continue
+        # Required-column gate runs against the overall non-null rate.
+        non_null_rate = float(df_events[column].notna().sum() / max(len(df_events), 1))
+        if non_null_rate + 1e-12 < threshold_rate:
+            flagged_required.append(
+                {
+                    "column": column,
+                    "non_null_rate": non_null_rate,
+                    "n_rows": int(len(df_events)),
+                    "n_non_null": int(df_events[column].notna().sum()),
+                    "threshold_rate": threshold_rate,
+                }
+            )
+
+    schema_only_columns = [
+        c for c in schema_cols if c not in df_events.columns
+    ]
+    schema_only_required_missing = [
+        c for c in schema_only_columns if schema_cols[c]["required"]
+    ]
+
+    summary: dict[str, Any] = {
+        "events_parquet": str(events_parquet),
+        "n_rows": int(len(df_events)),
+        "n_columns": int(len(df_events.columns)),
+        "schema_columns_present": sorted(
+            set(df_events.columns) & set(schema_cols)
+        ),
+        "schema_columns_absent": sorted(schema_only_columns),
+        "required_columns_missing_from_parquet": sorted(
+            schema_only_required_missing
+        ),
+        "required_columns_under_threshold": flagged_required,
+        "threshold_pct": float(threshold_pct),
+        "fold_manifest_used": bool(fold_test_dates),
+        "pass": (
+            len(schema_only_required_missing) == 0 and len(flagged_required) == 0
+        ),
+    }
+
+    return pd.DataFrame(rows), summary
+
+
+def _render_summary_md(summary: dict[str, Any]) -> str:
+    """Render the human-readable summary."""
+
+    verdict = "PASS" if summary["pass"] else "FAIL"
+    lines: list[str] = []
+    lines.append(f"# Pre-sweep column audit — {verdict}")
+    lines.append("")
+    lines.append(f"- events.parquet: `{summary['events_parquet']}`")
+    lines.append(
+        f"- rows: {summary['n_rows']} · columns on parquet: {summary['n_columns']}"
+    )
+    lines.append(f"- threshold for required-column gate: {summary['threshold_pct']}%")
+    lines.append(
+        "- per-fold breakdown: "
+        + ("yes" if summary["fold_manifest_used"] else "no (fold manifest not loaded)")
+    )
+    lines.append("")
+    if summary["required_columns_missing_from_parquet"]:
+        lines.append("## Required columns absent from events.parquet")
+        for col in summary["required_columns_missing_from_parquet"]:
+            lines.append(f"- `{col}`")
+        lines.append("")
+    if summary["required_columns_under_threshold"]:
+        lines.append(
+            f"## Required columns below {summary['threshold_pct']}% non-null"
+        )
+        for entry in summary["required_columns_under_threshold"]:
+            pct = 100.0 * entry["non_null_rate"]
+            lines.append(
+                f"- `{entry['column']}` — {pct:.2f}% "
+                f"({entry['n_non_null']}/{entry['n_rows']})"
+            )
+        lines.append("")
+    if summary["pass"]:
+        lines.append("All required schema columns present and at full population.")
+    return "\n".join(lines) + "\n"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Per-column population audit on events.parquet (#505 A.1.a). "
+            "Gates the next sweep on required-column populations."
+        )
+    )
+    parser.add_argument(
+        "--events-parquet",
+        type=Path,
+        required=True,
+        help="Path to events.parquet for the training package being audited.",
+    )
+    parser.add_argument(
+        "--fold-manifest",
+        type=Path,
+        default=None,
+        help=(
+            "Optional fold manifest (JSON) to enable per-fold breakdowns. "
+            "Defaults to skip per-fold."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Where to write column_population.csv + summary.md + summary.json. "
+            "Defaults to printing summary.md to stdout only."
+        ),
+    )
+    parser.add_argument(
+        "--threshold-pct",
+        type=float,
+        default=DEFAULT_THRESHOLD_PCT,
+        help=(
+            "Required-column non-null gate (default: 100.0). Set lower to "
+            "wave through sparse columns during incremental rebuilds."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    df_population, summary = audit_column_populations(
+        events_parquet=args.events_parquet,
+        fold_manifest=args.fold_manifest,
+        threshold_pct=args.threshold_pct,
+    )
+    summary_md = _render_summary_md(summary)
+    if args.output_dir is not None:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        df_population.to_csv(
+            args.output_dir / "column_population.csv", index=False
+        )
+        (args.output_dir / "summary.md").write_text(
+            summary_md, encoding="utf-8"
+        )
+        (args.output_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2, default=str), encoding="utf-8"
+        )
+        print(f"[pre-sweep-audit] artefacts under {args.output_dir}")
+    else:
+        sys.stdout.write(summary_md)
+    return 0 if summary["pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_run_pre_sweep_column_audit.py
+++ b/tests/unit/test_run_pre_sweep_column_audit.py
@@ -80,14 +80,12 @@ def test_audit_passes_when_every_required_column_is_present_and_populated(
 
 
 def test_audit_fails_when_required_column_absent(tmp_path: Path) -> None:
-    df = _make_minimal_events(n=10).drop(columns=["forward_realized_vol_10d"])
+    """Drop a column that the schema marks ``required=True`` and confirm
+    the audit reports it as missing.
+    """
+
+    df = _make_minimal_events(n=10).drop(columns=["event_date"])
     parquet = tmp_path / "events.parquet"
-    df.to_parquet(parquet)
-    # forward_realized_vol_10d is required=False in the schema today,
-    # so we instead drop a column that IS required=True. ``event_date``
-    # qualifies.
-    if "event_date" in df.columns:
-        df = df.drop(columns=["event_date"])
     df.to_parquet(parquet)
 
     _, summary = audit_column_populations(parquet)

--- a/tests/unit/test_run_pre_sweep_column_audit.py
+++ b/tests/unit/test_run_pre_sweep_column_audit.py
@@ -1,0 +1,243 @@
+"""Tests for the pre-sweep per-column population audit (#505 A.1.a)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from scripts.run_pre_sweep_column_audit import (
+    _render_summary_md,
+    audit_column_populations,
+)
+
+
+def _make_minimal_events(n: int = 10) -> pd.DataFrame:
+    """Build a synthetic events.parquet frame that satisfies every
+    schema-required column. The pinned schema in
+    ``backend/app/data/schemas.py::_EVENT_ROW_COLUMNS`` is the
+    authoritative list; this helper covers the canonical-arm required
+    set plus the indexing columns the audit slices on.
+    """
+
+    from app.data.schemas import _EVENT_ROW_COLUMNS
+
+    required_cols = {
+        name
+        for name, col in _EVENT_ROW_COLUMNS.items()
+        if col.required
+    }
+
+    string_defaults = {
+        "event_kind": "statement",
+        "document_id": "doc_0",
+        "text_hash": "hash_0",
+        "source": "scraped_fed",
+        "source_record_id": "rec_0",
+        "as_of_ts": "2024-06-12T18:00:00Z",
+        "document_type": "statement",
+        "label_origin": "model",
+        "license_scope": "public",
+        "citation_ref": "test_citation",
+        "text": "test",
+        "asset_symbol": "^GSPC",
+        "prior_window_sha256": "0" * 64,
+        "prior_bars_json": "[]",
+        "event_date": "2024-06-12",
+        "realized_date": "2024-06-26",
+        "concurrent_macro_release": False,
+    }
+
+    data: dict[str, list] = {}
+    for col in required_cols:
+        if col in string_defaults:
+            data[col] = [string_defaults[col]] * n
+        else:
+            # Default numeric required columns to 0.0; schemas with
+            # int/bool types coerce on read.
+            data[col] = [0.0] * n
+    return pd.DataFrame(data)
+
+
+def test_audit_passes_when_every_required_column_is_present_and_populated(
+    tmp_path: Path,
+) -> None:
+    df = _make_minimal_events(n=10)
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    population, summary = audit_column_populations(parquet)
+
+    assert summary["pass"] is True
+    assert summary["required_columns_under_threshold"] == []
+    assert summary["required_columns_missing_from_parquet"] == []
+    assert summary["n_rows"] == 10
+    # Overall slice present for every column on the parquet.
+    overall = population[population["slice_kind"] == "overall"]
+    assert len(overall) == len(df.columns)
+
+
+def test_audit_fails_when_required_column_absent(tmp_path: Path) -> None:
+    df = _make_minimal_events(n=10).drop(columns=["forward_realized_vol_10d"])
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+    # forward_realized_vol_10d is required=False in the schema today,
+    # so we instead drop a column that IS required=True. ``event_date``
+    # qualifies.
+    if "event_date" in df.columns:
+        df = df.drop(columns=["event_date"])
+    df.to_parquet(parquet)
+
+    _, summary = audit_column_populations(parquet)
+    assert summary["pass"] is False
+    assert "event_date" in summary["required_columns_missing_from_parquet"]
+
+
+def test_audit_fails_when_required_column_partially_null(tmp_path: Path) -> None:
+    df = _make_minimal_events(n=10)
+    df.loc[5:, "event_date"] = None  # half-empty required column
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    _, summary = audit_column_populations(parquet)
+    flagged = {
+        entry["column"]
+        for entry in summary["required_columns_under_threshold"]
+    }
+    assert "event_date" in flagged
+    assert summary["pass"] is False
+
+
+def test_audit_threshold_override_relaxes_required_gate(
+    tmp_path: Path,
+) -> None:
+    df = _make_minimal_events(n=10)
+    df.loc[5:, "event_date"] = None  # 50% non-null
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    # At threshold 40% the required-column gate passes.
+    _, summary = audit_column_populations(parquet, threshold_pct=40.0)
+    assert summary["pass"] is True
+
+
+def test_audit_groups_by_event_kind_and_source(tmp_path: Path) -> None:
+    df = _make_minimal_events(n=6)
+    df["event_kind"] = ["statement"] * 3 + ["minutes"] * 3
+    df["source"] = ["scraped_fed"] * 2 + ["kaggle"] * 2 + ["op_fed"] * 2
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    population, _ = audit_column_populations(parquet)
+
+    kinds = set(
+        population[population["slice_kind"] == "event_kind"]["slice_value"]
+    )
+    sources = set(
+        population[population["slice_kind"] == "source"]["slice_value"]
+    )
+    assert {"statement", "minutes"} <= kinds
+    assert {"scraped_fed", "kaggle", "op_fed"} <= sources
+
+
+def test_audit_uses_fold_manifest_when_provided(tmp_path: Path) -> None:
+    df = _make_minimal_events(n=6)
+    df["event_date"] = [
+        "2024-01-01",
+        "2024-02-01",
+        "2024-03-01",
+        "2024-04-01",
+        "2024-05-01",
+        "2024-06-01",
+    ]
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+    manifest = {
+        "folds": [
+            {
+                "fold_id": "wf_fold_1",
+                "test": ["2024-01-01", "2024-02-01", "2024-03-01"],
+            },
+            {
+                "fold_id": "wf_fold_2",
+                "test": ["2024-04-01", "2024-05-01", "2024-06-01"],
+            },
+        ]
+    }
+    manifest_path = tmp_path / "fold_manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    population, summary = audit_column_populations(
+        parquet, fold_manifest=manifest_path
+    )
+    assert summary["fold_manifest_used"] is True
+    fold_slices = set(
+        population[population["slice_kind"] == "fold"]["slice_value"]
+    )
+    assert {"wf_fold_1", "wf_fold_2"} <= fold_slices
+
+
+def test_audit_skips_fold_breakdown_on_corrupt_manifest(tmp_path: Path) -> None:
+    df = _make_minimal_events(n=2)
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text("{not json", encoding="utf-8")
+
+    _, summary = audit_column_populations(
+        parquet, fold_manifest=manifest_path
+    )
+    assert summary["fold_manifest_used"] is False
+
+
+def test_audit_raises_on_missing_parquet(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="not found"):
+        audit_column_populations(tmp_path / "missing.parquet")
+
+
+def test_summary_md_lists_flagged_columns() -> None:
+    summary = {
+        "events_parquet": "x.parquet",
+        "n_rows": 100,
+        "n_columns": 10,
+        "schema_columns_present": [],
+        "schema_columns_absent": [],
+        "required_columns_missing_from_parquet": ["foo"],
+        "required_columns_under_threshold": [
+            {
+                "column": "bar",
+                "non_null_rate": 0.5,
+                "n_non_null": 50,
+                "n_rows": 100,
+                "threshold_rate": 1.0,
+            }
+        ],
+        "threshold_pct": 100.0,
+        "fold_manifest_used": False,
+        "pass": False,
+    }
+    md = _render_summary_md(summary)
+    assert "FAIL" in md
+    assert "`foo`" in md
+    assert "`bar`" in md
+    assert "50.00%" in md
+
+
+def test_summary_md_pass_message() -> None:
+    summary = {
+        "events_parquet": "x.parquet",
+        "n_rows": 100,
+        "n_columns": 10,
+        "schema_columns_present": [],
+        "schema_columns_absent": [],
+        "required_columns_missing_from_parquet": [],
+        "required_columns_under_threshold": [],
+        "threshold_pct": 100.0,
+        "fold_manifest_used": True,
+        "pass": True,
+    }
+    md = _render_summary_md(summary)
+    assert "PASS" in md
+    assert "All required schema columns present" in md


### PR DESCRIPTION
Refs #505 (A.1.a). First piece of the pre-sweep data integrity audit; the family zero-out smoke (A.1.b) and end-to-end event trace (A.1.c) follow as separate PRs.

## What ships

\`scripts/run_pre_sweep_column_audit.py\` — for every column declared on \`backend/app/data/schemas.py::_EVENT_ROW_COLUMNS\`, computes:

- \`non_null_rate\` overall + per fold + per event_kind + per source
- \`n_distinct\`
- \`std\` (numeric columns only)

Flag any \`required=True\` column whose empirical non-null rate is below the configured threshold (default 100%). Exits non-zero on a flagged required column so the script is wirable into the sweep-launch pre-flight.

\`make pre-sweep-column-audit TRAINING_PACKAGE_ID=<id>\` runs the audit under docker compose backend; resolves \`events.parquet\` and \`fold_manifest_expanding_walk_forward.json\` paths automatically; writes artefacts to \`backend/artifacts/audits/pre_sweep_<id>/\`. Optional \`THRESHOLD_PCT\` knob waves through sparse columns during incremental rebuilds.

## Outputs

- \`column_population.csv\` — long-format, one row per (column, slice).
- \`summary.md\` — human-readable verdict + flagged columns.
- \`summary.json\` — machine-readable summary for CI / dashboards.

## Tests

10 unit tests:
- pass on minimal schema-complete frame
- fail when a required column is absent from the parquet
- fail when a required column is partially null
- threshold override relaxes the required-column gate
- per-event_kind and per-source slicing produces the expected partitions
- fold-manifest loading produces per-fold rows
- corrupt fold manifest falls back to overall-only without raising
- missing parquet raises a SystemExit with a useful message
- summary.md renders both FAIL and PASS verdicts

## Operator usage

Before launching the Phase 3 sweep:

\`\`\`
make pre-sweep-column-audit TRAINING_PACKAGE_ID=tp_v3_phase3_v1
\`\`\`

If exit code is 0, every schema-required column is present and at full population. If non-zero, the summary.md names the column(s) that failed the gate.

Refs #505.