### PR TITLE
E2E event trace (#505 A.1.c)

### DIFF
--- a/scripts/run_e2e_event_trace.py
+++ b/scripts/run_e2e_event_trace.py
@@ -1,0 +1,257 @@
+"""End-to-end event trace smoke (#505 A.1.c).
+
+Loads one walk-forward fold with every rich-feature flag ON, finds the
+target event's prior-window sequence, calls ``as_rich_list`` on the
+event-day bar, and walks every documented core slice from
+``backend/app/models/config.py``. Reports slice-by-slice population
+and asserts:
+
+- vector length matches the loader output
+- every non-missing-flag slice carries at least one finite non-zero
+  value (the missing-flag scalars can legitimately be 0 or 1)
+
+Usage:
+
+    python -m scripts.run_e2e_event_trace \\
+        --training-package-id <tp_id> \\
+        --event-date 2024-09-18 \\
+        --output backend/artifacts/audits/pre_sweep_<tp_id>/e2e_trace.json
+
+Exit 0 on success, 1 if any slice fails the non-zero check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_FOLD = "wf_fold_3"
+DEFAULT_EVENT = "2024-09-18"
+
+# Slice constants we walk. These are the CORE rich slices inside
+# [0, RICH_FEATURE_SIZE]. Missing-flag slots are flagged so the
+# non-zero check skips them (a 0 there means "value is present").
+CORE_SLICES: tuple[tuple[str, str, bool], ...] = (
+    # (logical_name, RICH_*_SLICE constant name, is_missing_flag)
+    ("market", "RICH_MARKET_SLICE", False),
+    ("credibility", "RICH_CREDIBILITY_SLICE", False),
+    ("linguistic", "RICH_LINGUISTIC_SLICE", False),
+    ("mp_surprise", "RICH_MP_SURPRISE_SLICE", False),
+    ("multi_axis", "RICH_MULTI_AXIS_SLICE", False),
+    ("realized_vol", "RICH_REALIZED_VOL_SLICE", False),
+    ("cross_asset", "RICH_CROSS_ASSET_SLICE", False),
+    ("llm_feature", "RICH_LLM_FEATURE_SLICE", False),
+    ("llm_feature_missing", "RICH_LLM_FEATURE_MISSING_SLICE", True),
+    ("retrieval_analog", "RICH_RETRIEVAL_ANALOG_SLICE", False),
+    ("retrieval_analog_missing", "RICH_RETRIEVAL_ANALOG_MISSING_SLICE", True),
+)
+
+
+@dataclass(frozen=True)
+class SliceReport:
+    name: str
+    start: int
+    stop: int
+    dim: int
+    is_missing_flag: bool
+    finite: int
+    non_zero: int
+    sample_values: list[float]
+    ok: bool
+    note: str
+
+
+def _summarise_slice(
+    name: str,
+    sl: slice,
+    is_missing_flag: bool,
+    vector: list[float],
+) -> SliceReport:
+    block = vector[sl]
+    finite = sum(1 for v in block if math.isfinite(v))
+    non_zero = sum(1 for v in block if math.isfinite(v) and v != 0.0)
+    sample = block[: min(8, len(block))]
+    if is_missing_flag:
+        ok = finite == len(block)
+        note = (
+            "missing flag, zero is a valid value (means feature present)"
+            if ok
+            else "missing flag has non-finite value"
+        )
+    else:
+        ok = non_zero > 0
+        note = (
+            "ok"
+            if ok
+            else "every position is zero or non-finite (possible silent zeros)"
+        )
+    return SliceReport(
+        name=name,
+        start=sl.start,
+        stop=sl.stop,
+        dim=len(block),
+        is_missing_flag=is_missing_flag,
+        finite=finite,
+        non_zero=non_zero,
+        sample_values=sample,
+        ok=ok,
+        note=note,
+    )
+
+
+def _trace_event(
+    training_package_id: str,
+    event_date: str,
+    fold_id: str,
+) -> dict[str, Any]:
+    """Run the loader, find the target event, build the slice report."""
+
+    from app.models import config as model_config
+    from app.training.loaders import load_walk_forward_split
+
+    split = load_walk_forward_split(
+        training_package_id=training_package_id,
+        fold_id=fold_id,
+        rich_features=True,
+        use_credibility=True,
+        use_linguistic=True,
+        use_mp_surprise=True,
+        use_multi_axis=True,
+        use_llm_features=True,
+        use_retrieval_analogs=True,
+        use_regime_conditioning=False,
+        use_sep=False,
+        use_press_conf=False,
+        use_statement_delta=False,
+        use_vote_features=False,
+    )
+
+    # Search every partition for the event_date.
+    target_seq: list | None = None
+    found_partition: str = ""
+    for partition_name, sequences, event_dates in (
+        ("train", split.train, split.train_event_dates),
+        ("val", split.val, split.val_event_dates),
+        ("test", split.test, split.test_event_dates),
+    ):
+        for idx, evdate in enumerate(event_dates):
+            if str(evdate)[:10] == event_date:
+                target_seq = sequences[idx]
+                found_partition = partition_name
+                break
+        if target_seq is not None:
+            break
+
+    if target_seq is None:
+        raise SystemExit(
+            f"event_date {event_date} not found in any partition of "
+            f"fold {fold_id}. Pick a different event or a different fold."
+        )
+    if not target_seq:
+        raise SystemExit(
+            f"event_date {event_date} resolved to an empty sequence; "
+            "the loader dropped this event's prior window."
+        )
+
+    event_bar = target_seq[-1]  # event-day bar (last of the prior window)
+    rich = event_bar.as_rich_list()
+
+    slice_reports: list[SliceReport] = []
+    for name, const_name, is_missing_flag in CORE_SLICES:
+        sl = getattr(model_config, const_name)
+        slice_reports.append(
+            _summarise_slice(name, sl, is_missing_flag, rich)
+        )
+
+    rich_feature_size = int(model_config.RICH_FEATURE_SIZE)
+
+    failures = [r for r in slice_reports if not r.ok]
+    return {
+        "training_package_id": training_package_id,
+        "event_date": event_date,
+        "fold_id": fold_id,
+        "partition_found_in": found_partition,
+        "rich_feature_size_const": rich_feature_size,
+        "rich_list_length": len(rich),
+        "length_matches_const": len(rich) == rich_feature_size,
+        "slices": [r.__dict__ for r in slice_reports],
+        "failures": [r.name for r in failures],
+        "pass": len(failures) == 0 and len(rich) == rich_feature_size,
+    }
+
+
+def _render_summary_md(report: dict[str, Any]) -> str:
+    verdict = "PASS" if report["pass"] else "FAIL"
+    lines: list[str] = []
+    lines.append(f"# E2E event trace ({verdict})")
+    lines.append("")
+    lines.append(f"- tp: `{report['training_package_id']}`")
+    lines.append(f"- event_date: `{report['event_date']}`")
+    lines.append(f"- fold: `{report['fold_id']}`")
+    lines.append(f"- partition: `{report['partition_found_in']}`")
+    lines.append(
+        f"- rich_list length: {report['rich_list_length']} "
+        f"(const RICH_FEATURE_SIZE = {report['rich_feature_size_const']})"
+    )
+    lines.append("")
+    lines.append("| slice | range | dim | finite | non_zero | ok |")
+    lines.append("|---|---|---|---|---|---|")
+    for sl in report["slices"]:
+        mark = "ok" if sl["ok"] else "FAIL"
+        lines.append(
+            f"| {sl['name']} | "
+            f"{sl['start']}:{sl['stop']} | "
+            f"{sl['dim']} | {sl['finite']} | {sl['non_zero']} | {mark} |"
+        )
+    lines.append("")
+    if report["failures"]:
+        lines.append("## Failed slices")
+        for sl in report["slices"]:
+            if sl["ok"]:
+                continue
+            lines.append(
+                f"- `{sl['name']}` ({sl['start']}:{sl['stop']}): "
+                f"{sl['note']}; sample: {sl['sample_values']}"
+            )
+    else:
+        lines.append("All slices populated with at least one finite non-zero value.")
+    return "\n".join(lines) + "\n"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="E2E event trace (#505 A.1.c)")
+    parser.add_argument("--training-package-id", required=True)
+    parser.add_argument("--event-date", default=DEFAULT_EVENT)
+    parser.add_argument("--fold-id", default=DEFAULT_FOLD)
+    parser.add_argument("--output", type=Path, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    report = _trace_event(
+        training_package_id=args.training_package_id,
+        event_date=args.event_date,
+        fold_id=args.fold_id,
+    )
+    summary_md = _render_summary_md(report)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(report, indent=2), encoding="utf-8"
+        )
+        md_path = args.output.with_suffix(".md")
+        md_path.write_text(summary_md, encoding="utf-8")
+        print(f"[e2e-trace] wrote {args.output} + {md_path}")
+    else:
+        sys.stdout.write(summary_md)
+    return 0 if report["pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_run_e2e_event_trace.py
+++ b/tests/unit/test_run_e2e_event_trace.py
@@ -1,0 +1,139 @@
+"""Unit tests for the E2E event trace smoke (#505 A.1.c)."""
+
+from __future__ import annotations
+
+import math
+
+from scripts.run_e2e_event_trace import (
+    CORE_SLICES,
+    SliceReport,
+    _render_summary_md,
+    _summarise_slice,
+)
+
+
+def test_summarise_slice_flags_all_zero_non_missing_block() -> None:
+    vec = [0.0] * 50
+    sl = slice(10, 14)
+    report = _summarise_slice("credibility", sl, False, vec)
+    assert report.dim == 4
+    assert report.finite == 4
+    assert report.non_zero == 0
+    assert report.ok is False
+    assert "silent zeros" in report.note
+
+
+def test_summarise_slice_passes_on_one_non_zero() -> None:
+    vec = [0.0] * 50
+    vec[12] = 0.7
+    sl = slice(10, 14)
+    report = _summarise_slice("credibility", sl, False, vec)
+    assert report.non_zero == 1
+    assert report.ok is True
+
+
+def test_summarise_slice_passes_zero_on_missing_flag() -> None:
+    """A missing-flag scalar at 0 means 'value present' and is the
+    expected good state for a rich-feature event.
+    """
+
+    vec = [0.0] * 50
+    sl = slice(40, 41)
+    report = _summarise_slice("llm_missing", sl, True, vec)
+    assert report.ok is True
+    assert report.non_zero == 0
+
+
+def test_summarise_slice_flags_non_finite_on_missing() -> None:
+    vec = [0.0] * 50
+    vec[40] = math.nan
+    sl = slice(40, 41)
+    report = _summarise_slice("llm_missing", sl, True, vec)
+    assert report.finite == 0
+    assert report.ok is False
+
+
+def test_summarise_slice_truncates_sample_to_eight() -> None:
+    vec = [float(i) for i in range(50)]
+    sl = slice(10, 30)
+    report = _summarise_slice("big", sl, False, vec)
+    assert len(report.sample_values) == 8
+    assert report.sample_values == [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0]
+
+
+def test_core_slices_table_has_market_and_missing_flag_pair() -> None:
+    """Sanity check on the slices table the script walks. Lock the
+    market entry first; lock that llm_feature_missing carries the
+    is_missing_flag bit.
+    """
+
+    names = [name for name, _, _ in CORE_SLICES]
+    assert names[0] == "market"
+    flag_entries = {name: flag for name, _, flag in CORE_SLICES}
+    assert flag_entries["llm_feature_missing"] is True
+    assert flag_entries["retrieval_analog_missing"] is True
+    assert flag_entries["llm_feature"] is False
+
+
+def test_render_summary_md_emits_pass_verdict() -> None:
+    report = {
+        "training_package_id": "tp_x",
+        "event_date": "2024-09-18",
+        "fold_id": "wf_fold_3",
+        "partition_found_in": "test",
+        "rich_feature_size_const": 100,
+        "rich_list_length": 100,
+        "length_matches_const": True,
+        "slices": [
+            {
+                "name": "market",
+                "start": 0,
+                "stop": 6,
+                "dim": 6,
+                "finite": 6,
+                "non_zero": 6,
+                "is_missing_flag": False,
+                "sample_values": [1.0, 2.0],
+                "ok": True,
+                "note": "ok",
+            }
+        ],
+        "failures": [],
+        "pass": True,
+    }
+    md = _render_summary_md(report)
+    assert "PASS" in md
+    assert "All slices populated" in md
+    assert "`tp_x`" in md
+
+
+def test_render_summary_md_emits_fail_verdict_and_lists_failures() -> None:
+    report = {
+        "training_package_id": "tp_y",
+        "event_date": "2024-09-18",
+        "fold_id": "wf_fold_3",
+        "partition_found_in": "test",
+        "rich_feature_size_const": 100,
+        "rich_list_length": 100,
+        "length_matches_const": True,
+        "slices": [
+            {
+                "name": "linguistic",
+                "start": 10,
+                "stop": 25,
+                "dim": 15,
+                "finite": 15,
+                "non_zero": 0,
+                "is_missing_flag": False,
+                "sample_values": [0.0, 0.0, 0.0],
+                "ok": False,
+                "note": "every position is zero or non-finite (possible silent zeros)",
+            }
+        ],
+        "failures": ["linguistic"],
+        "pass": False,
+    }
+    md = _render_summary_md(report)
+    assert "FAIL" in md
+    assert "`linguistic`" in md
+    assert "silent zeros" in md


### PR DESCRIPTION
loads one walk-forward fold with every rich flag on, finds the target event's prior-window sequence, calls as_rich_list on the event-day bar, walks every core slice from backend/app/models/config.py.

asserts:
- rich_list length equals RICH_FEATURE_SIZE
- every non-missing-flag slice has at least one finite non-zero value
- missing-flag scalars are finite (0 or 1 both valid)

defaults: --event-date 2024-09-18, --fold-id wf_fold_3.

usage:

```
python -m scripts.run_e2e_event_trace \
    --training-package-id $TP_ID \
    --output backend/artifacts/audits/pre_sweep_$TP_ID/e2e_trace.json
```

exit 0 on pass, 1 if any slice fails. writes both .json and .md beside --output.

refs #505.