### PR TITLE
pin greenlet

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -48,6 +48,11 @@ dependencies = [
   "python-docx>=1.1.0",
   "httpx>=0.27.0",
   "SQLAlchemy>=2.0",
+  # SQLAlchemy 2.0 pulls greenlet on Linux CPython but the dep isn't
+  # declared on macOS, so a lock generated on Mac omits it. Without an
+  # explicit pin, pip on the pod resolves greenlet unpinned and the
+  # --require-hashes install fails. Pin so the next lock regen catches it.
+  "greenlet>=3.0",
   "structlog>=24.1",
 ]
 


### PR DESCRIPTION
SQLAlchemy 2.0 pulls greenlet on Linux CPython, not on macOS. Lock generated on Mac omits it; pod install with `--require-hashes` fails on the unpinned transitive.

Explicit pin so the next lock regen includes it. Existing macOS-generated lock still missing greenlet until someone regenerates it on Linux or with the right markers.