### PR TITLE
fix three adapter defects (runpod)

### DIFF
--- a/backend/app/data/pipeline_data_prep.py
+++ b/backend/app/data/pipeline_data_prep.py
@@ -26,6 +26,36 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--include-kaggle", action="store_true", help="Include Kaggle ingestion.")
     parser.add_argument("--include-scraped", action="store_true", help="Include scraped ingestion.")
     parser.add_argument(
+        "--include-op-fed",
+        action="store_true",
+        help="Include Op-Fed sentence-level annotations (Keith et al. 2025).",
+    )
+    parser.add_argument(
+        "--include-swanson-three-factor",
+        action="store_true",
+        help="Include Swanson 2021 three-factor decomposition.",
+    )
+    parser.add_argument(
+        "--include-gss-factors",
+        action="store_true",
+        help="Include GSS factor decomposition (offline-PDF-derived; needs prior CSV extraction).",
+    )
+    parser.add_argument(
+        "--include-gtfintechlab-fed",
+        action="store_true",
+        help="Include gtfintechlab/federal_reserve_system multi-axis labels.",
+    )
+    parser.add_argument(
+        "--include-gtfintechlab-cross-bank",
+        action="store_true",
+        help="Include gtfintechlab cross-bank datasets (ECB / BoJ / BoE / BoC / RBA).",
+    )
+    parser.add_argument(
+        "--include-fomc-archive",
+        action="store_true",
+        help="Include vtasca FOMC archive (HF dataset).",
+    )
+    parser.add_argument(
         "--all-sources",
         action="store_true",
         help="Include all sources (overrides source-specific flags).",
@@ -71,7 +101,26 @@ def main() -> int:
     include_hf = args.all_sources or args.include_hf
     include_kaggle = args.all_sources or args.include_kaggle
     include_scraped = args.all_sources or args.include_scraped
-    if not (include_hf or include_kaggle or include_scraped):
+    include_op_fed = args.all_sources or args.include_op_fed
+    include_swanson = args.all_sources or args.include_swanson_three_factor
+    include_gss = args.all_sources or args.include_gss_factors
+    include_gtf_fed = args.all_sources or args.include_gtfintechlab_fed
+    include_gtf_xbank = args.all_sources or args.include_gtfintechlab_cross_bank
+    include_fomc_archive = args.all_sources or args.include_fomc_archive
+    selected_any = any(
+        (
+            include_hf,
+            include_kaggle,
+            include_scraped,
+            include_op_fed,
+            include_swanson,
+            include_gss,
+            include_gtf_fed,
+            include_gtf_xbank,
+            include_fomc_archive,
+        )
+    )
+    if not selected_any:
         include_hf = include_kaggle = include_scraped = True
 
     training_package_id = args.training_package_id or _auto_training_package_id(
@@ -92,6 +141,18 @@ def main() -> int:
         ingest_cmd.append("--include-kaggle")
     if include_scraped:
         ingest_cmd.append("--include-scraped")
+    if include_op_fed:
+        ingest_cmd.append("--include-op-fed")
+    if include_swanson:
+        ingest_cmd.append("--include-swanson-three-factor")
+    if include_gss:
+        ingest_cmd.append("--include-gss-factors")
+    if include_gtf_fed:
+        ingest_cmd.append("--include-gtfintechlab-fed")
+    if include_gtf_xbank:
+        ingest_cmd.append("--include-gtfintechlab-cross-bank")
+    if include_fomc_archive:
+        ingest_cmd.append("--include-fomc-archive")
 
     normalize_cmd = [
         python_exec,

--- a/backend/app/data/sources/base.py
+++ b/backend/app/data/sources/base.py
@@ -24,6 +24,7 @@ _VALID_SOURCE_TYPES = frozenset({
     "regional_research",
     "ny_fed_liberty_street",
     "gss_factor_decomposition",
+    "swanson_three_factor",
 })
 
 

--- a/backend/app/data/sources/op_fed.py
+++ b/backend/app/data/sources/op_fed.py
@@ -152,7 +152,14 @@ class OpFedScraper:
         return count
 
 
-register(OpFedScraper())
+# Only register when imported as a module. When the file runs under
+# `python -m app.data.sources.op_fed`, Python first imports the
+# package (which imports this file as a module and registers the
+# scraper), then re-executes this file as __main__. Without the guard
+# the second pass tries to register again and the registry raises a
+# duplicate-source_type error.
+if __name__ != "__main__":
+    register(OpFedScraper())
 
 
 def pull_op_fed_csv(

--- a/backend/app/data/sources/swanson_three_factor.py
+++ b/backend/app/data/sources/swanson_three_factor.py
@@ -250,7 +250,11 @@ def _parse_swanson_row(row: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
-register(SwansonThreeFactorScraper())
+# Only register when imported as a module; see op_fed.py for the same
+# guard's rationale (python -m re-executes this file as __main__ after
+# the package init already imported and registered it).
+if __name__ != "__main__":
+    register(SwansonThreeFactorScraper())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. swanson_three_factor missing from the ADR-0004 source_type vocab. import raised. one-line add to base.py.

2. op_fed and swanson_three_factor double-register under `python -m`. package __init__ imports the module (register fires), then __main__ re-executes the file (register fires again). guard with `__name__ != "__main__"`.

3. pipeline_data_prep didn't plumb the new ingest flags. --include-op-fed, --include-swanson-three-factor, --include-gss-factors, --include-gtfintechlab-{fed,cross-bank}, --include-fomc-archive now wired through. --all-sources picks them all up.

found by the runpod claude during the rebuild dry-run. all three are real and would fail under docker too.