### PR TITLE
swanson: ISO-normalise xlsx text dates

### DIFF
--- a/backend/app/data/ingest_sources.py
+++ b/backend/app/data/ingest_sources.py
@@ -709,7 +709,13 @@ def _iter_swanson_three_factor_records(
         try:
             event_date = raw_date.strftime("%Y-%m-%d")  # type: ignore[union-attr]
         except AttributeError:
-            event_date = str(raw_date)[:10]
+            # Some xlsx cells are stored as text (e.g. "12/16/2015")
+            # rather than Excel date serials, so .strftime raises.
+            # Coerce through pd.to_datetime so the schema gate sees ISO.
+            parsed_dt = pd.to_datetime(str(raw_date), errors="coerce")
+            if pd.isna(parsed_dt):
+                continue
+            event_date = parsed_dt.strftime("%Y-%m-%d")
         if not event_date or len(event_date) < 10:
             continue
 

--- a/backend/app/data/sources/swanson_three_factor.py
+++ b/backend/app/data/sources/swanson_three_factor.py
@@ -202,7 +202,14 @@ def _parse_swanson_row(row: dict[str, Any]) -> dict[str, Any] | None:
         # pandas Timestamp / datetime
         iso_date = raw_date.strftime("%Y-%m-%d")
     except AttributeError:
-        iso_date = str(raw_date)[:10]
+        # xlsx text cells (e.g. "12/16/2015") don't have strftime. Coerce
+        # to a Timestamp via pandas so the registry sees ISO format.
+        import pandas as pd
+
+        parsed_dt = pd.to_datetime(str(raw_date), errors="coerce")
+        if pd.isna(parsed_dt):
+            return None
+        iso_date = parsed_dt.strftime("%Y-%m-%d")
     if not iso_date or len(iso_date) < 10:
         return None
 


### PR DESCRIPTION
4 cells in the Swanson xlsx (Dec 2015 through Dec 2018) are stored as text MM/DD/YYYY instead of Excel serials. .strftime raises on a str, the fallback sliced the first 10 chars, the registry schema rejected the result and aborted all of data-prep on the runpod.

route the fallback through pd.to_datetime so the contract on both code paths is ISO. fix in both _iter_swanson_three_factor_records and _parse_swanson_row.

blocking Phase C on the runpod, so merging fast.