### PR TITLE
fix #505 audit: gate on non-nullable required + expand fold ranges

### DIFF
--- a/scripts/run_pre_sweep_column_audit.py
+++ b/scripts/run_pre_sweep_column_audit.py
@@ -59,11 +59,23 @@ def _load_event_schema_columns() -> dict[str, dict[str, bool]]:
     }
 
 
-def _load_fold_manifest(path: Path) -> dict[str, list[str]] | None:
-    """Return {fold_id: [event_date strings in that fold's TEST split]}.
+def _load_fold_manifest(
+    path: Path,
+    event_dates: pd.Series | None = None,
+) -> dict[str, list[str]] | None:
+    """Return ``{fold_id: [event_date strings in that fold's TEST split]}``.
 
-    Returns ``None`` when the manifest can't be parsed; the audit falls
-    back to overall-only populations in that case.
+    The production manifest (``fold_manifest_expanding_walk_forward.json``)
+    declares each fold as a ``[test_start, test_end]`` ISO-date range, not
+    as an enumerated event list — so the reader expands the range against
+    ``event_dates`` (the ``event_date`` column from the parquet under
+    audit) and emits the intersection per fold. We also accept the legacy
+    enumerated forms (``test`` / ``test_event_dates``) so older fixtures
+    keep working.
+
+    Returns ``None`` when the manifest can't be parsed or no fold could be
+    resolved; the audit falls back to overall-only populations in that
+    case.
     """
 
     try:
@@ -75,15 +87,27 @@ def _load_fold_manifest(path: Path) -> dict[str, list[str]] | None:
     if not isinstance(folds, list):
         return None
 
+    date_strings: list[str] | None = None
+    if event_dates is not None:
+        date_strings = [str(d) for d in event_dates.tolist() if d is not None]
+
     out: dict[str, list[str]] = {}
     for entry in folds:
         if not isinstance(entry, dict):
             continue
         fold_id = entry.get("fold_id") or entry.get("id")
-        test_dates = entry.get("test") or entry.get("test_event_dates")
-        if not fold_id or not isinstance(test_dates, list):
+        if not fold_id:
             continue
-        out[str(fold_id)] = [str(d) for d in test_dates if d]
+        legacy_dates = entry.get("test") or entry.get("test_event_dates")
+        if isinstance(legacy_dates, list):
+            out[str(fold_id)] = [str(d) for d in legacy_dates if d]
+            continue
+        test_start = entry.get("test_start")
+        test_end = entry.get("test_end")
+        if not test_start or not test_end or date_strings is None:
+            continue
+        lo, hi = str(test_start), str(test_end)
+        out[str(fold_id)] = [d for d in date_strings if lo <= d <= hi]
     return out or None
 
 
@@ -160,7 +184,12 @@ def audit_column_populations(
 
     fold_test_dates: dict[str, list[str]] | None = None
     if fold_manifest is not None and fold_manifest.exists():
-        fold_test_dates = _load_fold_manifest(fold_manifest)
+        event_dates = (
+            df_events["event_date"].astype(str)
+            if "event_date" in df_events.columns
+            else None
+        )
+        fold_test_dates = _load_fold_manifest(fold_manifest, event_dates)
 
     rows: list[dict[str, Any]] = []
     flagged_required: list[dict[str, Any]] = []
@@ -193,6 +222,8 @@ def audit_column_populations(
                 (f"fold:{fold_id}", evdates.isin(dates))
             )
 
+    advisory_nullable: list[dict[str, Any]] = []
+
     for column in sorted(df_events.columns):
         for slice_label, slice_filter in slice_filters:
             _populate_per_slice(
@@ -203,18 +234,29 @@ def audit_column_populations(
             continue
         if not schema_cols[column]["required"]:
             continue
-        # Required-column gate runs against the overall non-null rate.
-        non_null_rate = float(df_events[column].notna().sum() / max(len(df_events), 1))
-        if non_null_rate + 1e-12 < threshold_rate:
-            flagged_required.append(
-                {
-                    "column": column,
-                    "non_null_rate": non_null_rate,
-                    "n_rows": int(len(df_events)),
-                    "n_non_null": int(df_events[column].notna().sum()),
-                    "threshold_rate": threshold_rate,
-                }
-            )
+        # The strict gate fires only when the schema marks the column
+        # as both required AND non-nullable. Columns declared
+        # ``nullable=True`` are populated only on the source/window
+        # subset that emits them (e.g. ``axis_stance`` ships on HF-style
+        # corpora; ``realized_return`` is null when the prior price
+        # window won't resolve), so flagging them against an overall
+        # non-null floor double-counts a population gap the schema
+        # already accepts. We still report them as advisory.
+        non_null = int(df_events[column].notna().sum())
+        non_null_rate = float(non_null / max(len(df_events), 1))
+        if non_null_rate + 1e-12 >= threshold_rate:
+            continue
+        entry = {
+            "column": column,
+            "non_null_rate": non_null_rate,
+            "n_rows": int(len(df_events)),
+            "n_non_null": non_null,
+            "threshold_rate": threshold_rate,
+        }
+        if schema_cols[column]["nullable"]:
+            advisory_nullable.append(entry)
+        else:
+            flagged_required.append(entry)
 
     schema_only_columns = [
         c for c in schema_cols if c not in df_events.columns
@@ -235,6 +277,7 @@ def audit_column_populations(
             schema_only_required_missing
         ),
         "required_columns_under_threshold": flagged_required,
+        "nullable_required_columns_under_threshold": advisory_nullable,
         "threshold_pct": float(threshold_pct),
         "fold_manifest_used": bool(fold_test_dates),
         "pass": (
@@ -278,8 +321,27 @@ def _render_summary_md(summary: dict[str, Any]) -> str:
                 f"({entry['n_non_null']}/{entry['n_rows']})"
             )
         lines.append("")
+    advisory = summary.get("nullable_required_columns_under_threshold") or []
+    if advisory:
+        lines.append(
+            f"## Advisory: nullable required columns below {summary['threshold_pct']}% non-null"
+        )
+        lines.append(
+            "These columns are declared ``nullable=True`` in the schema, so "
+            "the population gap is allowed by design and does not fail the "
+            "gate. Listed for source/window-mix visibility."
+        )
+        for entry in advisory:
+            pct = 100.0 * entry["non_null_rate"]
+            lines.append(
+                f"- `{entry['column']}` — {pct:.2f}% "
+                f"({entry['n_non_null']}/{entry['n_rows']})"
+            )
+        lines.append("")
     if summary["pass"]:
-        lines.append("All required schema columns present and at full population.")
+        lines.append(
+            "All schema columns required as non-nullable are present and at full population."
+        )
     return "\n".join(lines) + "\n"
 
 

--- a/tests/unit/test_run_pre_sweep_column_audit.py
+++ b/tests/unit/test_run_pre_sweep_column_audit.py
@@ -108,6 +108,34 @@ def test_audit_fails_when_required_column_partially_null(tmp_path: Path) -> None
     assert summary["pass"] is False
 
 
+def test_audit_treats_partial_nullable_required_column_as_advisory(
+    tmp_path: Path,
+) -> None:
+    """``axis_stance`` is declared ``required=True, nullable=True``: the
+    column must exist on the parquet, but individual rows may legitimately
+    carry ``None`` (only HF-style multi-axis sources ship it). The audit
+    must surface the population gap as advisory rather than failing the
+    strict gate.
+    """
+
+    df = _make_minimal_events(n=10)
+    df["axis_stance"] = [None] * 10  # 0% non-null, allowed by schema
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+
+    _, summary = audit_column_populations(parquet)
+    flagged = {
+        entry["column"] for entry in summary["required_columns_under_threshold"]
+    }
+    advisory = {
+        entry["column"]
+        for entry in summary["nullable_required_columns_under_threshold"]
+    }
+    assert "axis_stance" not in flagged
+    assert "axis_stance" in advisory
+    assert summary["pass"] is True
+
+
 def test_audit_threshold_override_relaxes_required_gate(
     tmp_path: Path,
 ) -> None:
@@ -177,6 +205,54 @@ def test_audit_uses_fold_manifest_when_provided(tmp_path: Path) -> None:
     assert {"wf_fold_1", "wf_fold_2"} <= fold_slices
 
 
+def test_audit_expands_fold_manifest_with_test_start_end_ranges(
+    tmp_path: Path,
+) -> None:
+    """The production manifest writer emits per-fold ``test_start`` /
+    ``test_end`` ISO-date ranges, not enumerated date lists. The reader
+    must expand the range against ``event_date`` so the per-fold breakdown
+    actually fires.
+    """
+
+    df = _make_minimal_events(n=6)
+    df["event_date"] = [
+        "2024-01-01",
+        "2024-02-01",
+        "2024-03-01",
+        "2024-04-01",
+        "2024-05-01",
+        "2024-06-01",
+    ]
+    parquet = tmp_path / "events.parquet"
+    df.to_parquet(parquet)
+    manifest = {
+        "folds": [
+            {
+                "fold_id": "wf_fold_1",
+                "test_start": "2024-01-01",
+                "test_end": "2024-03-01",
+            },
+            {
+                "fold_id": "wf_fold_2",
+                "test_start": "2024-04-01",
+                "test_end": "2024-06-01",
+            },
+        ]
+    }
+    manifest_path = tmp_path / "fold_manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    population, summary = audit_column_populations(
+        parquet, fold_manifest=manifest_path
+    )
+    assert summary["fold_manifest_used"] is True
+    fold_slices = population[population["slice_kind"] == "fold"]
+    by_fold = dict(zip(fold_slices["slice_value"], fold_slices["rows"]))
+    # Each fold's test window covers exactly three of the six synthetic events.
+    assert by_fold.get("wf_fold_1") == 3
+    assert by_fold.get("wf_fold_2") == 3
+
+
 def test_audit_skips_fold_breakdown_on_corrupt_manifest(tmp_path: Path) -> None:
     df = _make_minimal_events(n=2)
     parquet = tmp_path / "events.parquet"
@@ -212,6 +288,7 @@ def test_summary_md_lists_flagged_columns() -> None:
                 "threshold_rate": 1.0,
             }
         ],
+        "nullable_required_columns_under_threshold": [],
         "threshold_pct": 100.0,
         "fold_manifest_used": False,
         "pass": False,
@@ -232,10 +309,39 @@ def test_summary_md_pass_message() -> None:
         "schema_columns_absent": [],
         "required_columns_missing_from_parquet": [],
         "required_columns_under_threshold": [],
+        "nullable_required_columns_under_threshold": [],
         "threshold_pct": 100.0,
         "fold_manifest_used": True,
         "pass": True,
     }
     md = _render_summary_md(summary)
     assert "PASS" in md
-    assert "All required schema columns present" in md
+    assert "non-nullable" in md
+
+
+def test_summary_md_renders_advisory_section() -> None:
+    summary = {
+        "events_parquet": "x.parquet",
+        "n_rows": 100,
+        "n_columns": 10,
+        "schema_columns_present": [],
+        "schema_columns_absent": [],
+        "required_columns_missing_from_parquet": [],
+        "required_columns_under_threshold": [],
+        "nullable_required_columns_under_threshold": [
+            {
+                "column": "axis_stance",
+                "non_null_rate": 0.0,
+                "n_non_null": 0,
+                "n_rows": 100,
+                "threshold_rate": 1.0,
+            }
+        ],
+        "threshold_pct": 100.0,
+        "fold_manifest_used": True,
+        "pass": True,
+    }
+    md = _render_summary_md(summary)
+    assert "PASS" in md
+    assert "Advisory" in md
+    assert "`axis_stance`" in md


### PR DESCRIPTION
Two defects in `scripts/run_pre_sweep_column_audit.py` that surfaced when the runpod tried to gate the v3 TP build.

## (1) strict gate over-fired on nullable-required columns

The schema marks 14 columns as `required=True, nullable=True`: the `axis_*` multi-axis labels, `realized_return` / `abnormal_return` / `alpha` / `beta`, `direction_t1d` / `volatility_shift`, the intra-meeting shifts. In pandera those mean "column must exist on the parquet; values may be null." The gate was checking overall non-null only, so it double-counted population gaps the schema already accepts (`axis_*` ships only on HF-style sources; `realized_return` is null when the prior price window won't resolve).

Strict gate now covers `required=True AND nullable=False` (17 columns). Nullable-required columns under threshold land in a new `nullable_required_columns_under_threshold` advisory section so the source/window mix stays visible without failing the sweep.

## (2) fold-manifest reader missed the production schema

`training_package_builder` writes per-fold `test_start` / `test_end` ISO ranges; the reader expected per-fold `test` / `test_event_dates` lists. `_load_fold_manifest` returned None on every production manifest and the per-fold gate silently no-oped (`per-fold breakdown: no (fold manifest not loaded)`). Reader now expands each fold to `event_date` rows in `[test_start, test_end]`, keeps the legacy enumerated form working for the existing fixture.

## verification

Probe on the current pinned TP (`data/processed/tp_pinned/`):

```
- rows: 9072, columns on parquet: 36
- threshold for required-column gate: 100.0%
- per-fold breakdown: yes

## Advisory: nullable required columns below 100.0% non-null
- `axis_certainty`: 0.00% (0/9072)
- `axis_factor`: 0.00% (0/9072)
- `axis_stance`: 60.20% (5461/9072)
- `axis_time`: 0.00% (0/9072)
- `axis_topic`: 54.77% (4969/9072)
- `intra_meeting_certainty_shift`: 0.00% (0/9072)
- `intra_meeting_factor_shift`: 0.00% (0/9072)
- `intra_meeting_stance_shift`: 0.00% (0/9072)
- `volatility_shift`: 99.98% (9070/9072)
```

CSV now carries 36 cols x 5 folds = 180 fold-slice rows (was 0).

## test plan

- [x] `pytest tests/unit/test_run_pre_sweep_column_audit.py`: 13 pass (3 new: nullable-required-as-advisory, fold range expansion, advisory rendering)
- [x] CLI smoke against pinned TP: PASS verdict, 5/5 folds resolved, advisory section populated
- [ ] runpod reruns the gate against the probe TP and unblocks the sweep
