### PR TITLE
fix quality dedup: key on text_hash only

### DIFF
--- a/backend/app/data/quality_checks.py
+++ b/backend/app/data/quality_checks.py
@@ -88,11 +88,15 @@ def _is_valid_date(value: str) -> bool:
 
 
 def _exact_dedup(rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    # QualityPassedRowSchema asserts ``unique=["text_hash"]``, so dedup keys
+    # on text_hash alone. Keying on (event_date, text_hash) kept the second
+    # row when the same text was linked to two events and the schema
+    # validation downstream then rejected the frame.
     kept: list[dict[str, Any]] = []
     dropped: list[dict[str, str]] = []
     seen: dict[str, str] = {}
     for row in rows:
-        key = f"{row.get('event_date','')}::{row.get('text_hash','')}"
+        key = str(row.get("text_hash", ""))
         rid = str(row.get("record_id", ""))
         if key in seen:
             dropped.append({"record_id": rid, "kept_record_id": seen[key], "reason": "exact_text_hash_duplicate"})

--- a/tests/unit/test_quality_checks.py
+++ b/tests/unit/test_quality_checks.py
@@ -7,6 +7,42 @@ from app.data.source_type import (
 )
 
 
+def test_exact_dedup_collapses_same_text_hash_across_different_event_dates() -> None:
+    # The same speech text can be linked to two FOMC events (e.g. when a
+    # cross-source row mirrors a release date and the prior-day window).
+    # QualityPassedRowSchema asserts text_hash uniqueness, so dedup must
+    # keep one row per text_hash regardless of event_date.
+    rows = [
+        {"record_id": "r1", "text_hash": "h1", "event_date": "2024-01-30"},
+        {"record_id": "r2", "text_hash": "h1", "event_date": "2024-03-20"},
+        {"record_id": "r3", "text_hash": "h2", "event_date": "2024-01-30"},
+    ]
+
+    kept, report = quality_checks._exact_dedup(rows)
+
+    kept_hashes = [row["text_hash"] for row in kept]
+    assert kept_hashes == ["h1", "h2"]
+    assert report["input_rows"] == 3
+    assert report["kept_rows"] == 2
+    assert report["dropped_rows"] == 1
+    assert report["dropped"][0]["record_id"] == "r2"
+    assert report["dropped"][0]["kept_record_id"] == "r1"
+    assert report["dropped"][0]["reason"] == "exact_text_hash_duplicate"
+
+
+def test_exact_dedup_still_collapses_same_text_hash_same_event_date() -> None:
+    rows = [
+        {"record_id": "r1", "text_hash": "h1", "event_date": "2024-01-30"},
+        {"record_id": "r2", "text_hash": "h1", "event_date": "2024-01-30"},
+    ]
+
+    kept, report = quality_checks._exact_dedup(rows)
+
+    assert [row["record_id"] for row in kept] == ["r1"]
+    assert report["kept_rows"] == 1
+    assert report["dropped_rows"] == 1
+
+
 def test_distribution_report_carries_source_type_aggregations() -> None:
     rows = [
         {


### PR DESCRIPTION
## The bug

`backend/app/data/quality_checks.py:_exact_dedup` keys on `(event_date, text_hash)` but `QualityPassedRowSchema` in `backend/app/data/schemas.py` asserts `unique=["text_hash"]`. When the same text gets linked to two `event_date` values, dedup keeps both rows; `_validate_quality_passed_rows` then throws on the duplicate `text_hash` and `make data-prep` crashes at quality-validation.

The schema description (`"asserts text_hash uniqueness"`) and the dropped-reason string the function already emits (`"exact_text_hash_duplicate"`) both confirm the intent has always been text_hash-only. The composite key was the defect.

## The fix

Key `_exact_dedup` on `text_hash` alone.

## Tests

Two unit tests in `tests/unit/test_quality_checks.py`:

- `test_exact_dedup_collapses_same_text_hash_across_different_event_dates`: pre-fix kept both rows, post-fix collapses to one and surfaces the second as `exact_text_hash_duplicate` in the report.
- `test_exact_dedup_still_collapses_same_text_hash_same_event_date`: no regression on the same-event-date case the old code already handled.

## Why this matters now

Blocks the v3 TP rebuild on the runpod. Without it a clean `make data-prep` against the current source mix hits the SchemaError at the quality-validation step.
