### PR TITLE
Drop the topic axis from multi-axis surface (no upstream source)

### DIFF
--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -45,7 +45,7 @@ Schema (one row per event x kind x horizon x asset):
 - ``token_count``               Whitespace-token count of ``text`` (used as
                                  a coarse truncation budget upstream)
 - ``axis_stance``               ``hawkish | dovish | neutral`` or None
-- ``axis_time``, ``axis_certainty``, ``axis_factor``, ``axis_topic``
+- ``axis_time``, ``axis_certainty``, ``axis_factor``
                                 Multi-axis labels (None when unavailable)
 - ``credibility_*``             Four credibility-vector axes
 - ``prior_window_sha256``       sha256 over the concatenated prior bars,
@@ -593,7 +593,6 @@ def _aggregate_events(rows: Iterable[_RegistryRow]) -> list[_EventDoc]:
             "time": None,
             "certainty": None,
             "factor": None,
-            "topic": None,
         }
         # gtfintechlab cross-bank corpora ship two extra categorical labels
         # ("time_label" forward/not-forward, "certain_label" certain/uncertain)
@@ -623,7 +622,7 @@ def _aggregate_events(rows: Iterable[_RegistryRow]) -> list[_EventDoc]:
         for r in bucket_sorted:
             if multi_axis["stance"] is None and r.mapped_label:
                 multi_axis["stance"] = r.mapped_label
-            for axis_name in ("time", "certainty", "factor", "topic"):
+            for axis_name in ("time", "certainty", "factor"):
                 if multi_axis[axis_name] is None:
                     val = r.axes.get(axis_name)
                     if val is not None:
@@ -1693,7 +1692,6 @@ def _build_event_rows(
                     doc.multi_axis.get("certainty")
                 ),
                 "axis_factor": _encode_axis_factor(doc.multi_axis.get("factor")),
-                "axis_topic": doc.multi_axis.get("topic"),
                 "axis_time_label": doc.time_label,
                 "axis_certain_label": doc.certain_label,
                 "multi_axis_extras": doc.multi_axis_extras or None,
@@ -1925,7 +1923,6 @@ COLUMN_ORDER = (
     "axis_time",
     "axis_certainty",
     "axis_factor",
-    "axis_topic",
     "axis_time_label",
     "axis_certain_label",
     # Merged ``multi_axis_extras`` payload from the bucketed source rows.

--- a/backend/app/data/finetune_pilot_b2.py
+++ b/backend/app/data/finetune_pilot_b2.py
@@ -920,8 +920,7 @@ def _parse_args() -> argparse.Namespace:
             "Auxiliary-loss weight applied to the PhraseBank CE term "
             "when --enable-phrasebank-aux is on. Default 0.3 mirrors "
             "the multi-task LSTM-stage default lambdas in "
-            "MultiTaskLoss (lambda_factor / lambda_certainty / "
-            "lambda_topic)."
+            "MultiTaskLoss (lambda_factor / lambda_certainty)."
         ),
     )
     parser.add_argument(

--- a/backend/app/data/normalize_labels.py
+++ b/backend/app/data/normalize_labels.py
@@ -243,17 +243,18 @@ def main() -> int:
         row["provenance"] = provenance
         row["sample_weight"] = sample_weight_for(provenance) if mapped else 0.0
         # Audit Tier 1.8: ``axes`` was constructed by reading flat
-        # ``axis_factor`` / ``axis_certainty`` / ``axis_topic`` columns
-        # that no upstream source actually emits, so the dict was
-        # ``{stance: <mapped>, factor: None, certainty: None, topic: None}``
-        # on every row even when the upstream had the data. The
-        # gtfintechlab and Op-Fed ingesters park their per-axis labels in
+        # ``axis_factor`` / ``axis_certainty`` columns that no upstream
+        # source actually emits, so the dict was
+        # ``{stance: <mapped>, factor: None, certainty: None}`` on every
+        # row even when the upstream had the data. The gtfintechlab and
+        # Op-Fed ingesters park their per-axis labels in
         # ``multi_axis_extras`` (gtfintechlab_time_label,
         # gtfintechlab_certain_label, op_fed_stance_nli, gss_target_factor,
         # gss_path_factor, ...). Lift those into ``axes`` so the
-        # downstream event-row builder, multi-axis slot, and any future
-        # per-topic stance head actually see them. The flat ``axis_*``
-        # path stays as a fallback for sources that one day emit them.
+        # downstream event-row builder + multi-axis slot actually see
+        # them. The flat ``axis_*`` path stays as a fallback for sources
+        # that one day emit them. The topic axis was retired (ADR 0044)
+        # because no upstream corpus ships topic labels.
         extras = row.get("multi_axis_extras") or {}
         if not isinstance(extras, dict):
             extras = {}
@@ -268,13 +269,11 @@ def main() -> int:
             else extras.get("gtfintechlab_certain_label")
         )
         time_value = _coerce_optional_str(extras.get("gtfintechlab_time_label"))
-        topic_value = _coerce_optional_str(row.get("axis_topic"))
         row["axes"] = {
             "stance": mapped,
             "factor": factor_value,
             "certainty": certainty_value,
             "time": time_value,
-            "topic": topic_value,
         }
 
         if not raw_label:

--- a/backend/app/data/schemas.py
+++ b/backend/app/data/schemas.py
@@ -289,10 +289,6 @@ def _axes_time_ok(value: Any) -> bool:
     return value is None or isinstance(value, str)
 
 
-def _axes_topic_ok(value: Any) -> bool:
-    return value is None or isinstance(value, str)
-
-
 def _axes_dict_ok(series: pd.Series) -> pd.Series:
     def _ok(value: Any) -> bool:
         if value is None:
@@ -304,7 +300,6 @@ def _axes_dict_ok(series: pd.Series) -> pd.Series:
             and _axes_factor_ok(value.get("factor"))
             and _axes_certainty_ok(value.get("certainty"))
             and _axes_time_ok(value.get("time"))
-            and _axes_topic_ok(value.get("topic"))
         )
 
     return series.map(_ok)
@@ -330,7 +325,7 @@ _NORMALIZED_DOC_COLUMNS: dict[str, Column] = {
         checks=Check(_axes_dict_ok, element_wise=False),
         nullable=True,
         required=True,
-        description="Multi-axis label payload {stance, factor, certainty, topic}.",
+        description="Multi-axis label payload {stance, factor, certainty}.",
     ),
     # Optional flat axis columns surface on emitters that flatten the axes
     # dict (e.g. event_dataset_builder writes flat columns). Marked
@@ -352,11 +347,6 @@ _NORMALIZED_DOC_COLUMNS: dict[str, Column] = {
     ),
     "axis_factor": Column(
         checks=Check(_nullable_finite_in_range(-1.0, 1.0)),
-        nullable=True,
-        required=False,
-    ),
-    "axis_topic": Column(
-        checks=Check(_nullable_str_or_none, element_wise=False),
         nullable=True,
         required=False,
     ),
@@ -492,11 +482,6 @@ _EVENT_ROW_COLUMNS: dict[str, Column] = {
     ),
     "axis_factor": Column(
         checks=Check(_nullable_finite_in_range(-1.0, 1.0)),
-        nullable=True,
-        required=True,
-    ),
-    "axis_topic": Column(
-        checks=Check(_nullable_str_or_none, element_wise=False),
         nullable=True,
         required=True,
     ),

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -43,8 +43,6 @@ from app.models.config import (
     MULTI_TASK_CERTAINTY_LABELS,
     MULTI_TASK_STANCE_CLASSES,
     MULTI_TASK_STANCE_LABELS,
-    MULTI_TASK_TOPIC_CLASSES,
-    MULTI_TASK_TOPIC_LABELS,
 )
 from app.models.text_multi_axis_classifier import TextMultiAxisClassifier
 from app.training.loss import MultiTaskLoss
@@ -152,52 +150,29 @@ def _certainty_target(row: dict[str, Any]) -> tuple[int, bool]:
     return MULTI_TASK_CERTAINTY_LABELS.index("neutral"), True
 
 
-# Explicit aliases for upstream topic values that do not contain a
-# canonical substring. "economic_indicator" comes off the macro-release
-# augmentation (CPI / NFP rows) and is the macro topic by construction.
-_TOPIC_ALIASES: dict[str, str] = {
-    "economic_indicator": "macro",
-    "rate_decision": "forward_guidance",
-}
-
-
-def _topic_target(row: dict[str, Any]) -> tuple[int, bool]:
-    raw = row.get("axis_topic")
-    if not isinstance(raw, str) or not raw.strip():
-        return 0, False
-    topic_str = raw.strip().lower()
-    if topic_str in _TOPIC_ALIASES:
-        return MULTI_TASK_TOPIC_LABELS.index(_TOPIC_ALIASES[topic_str]), True
-    for canonical in MULTI_TASK_TOPIC_LABELS[:-1]:
-        if canonical in topic_str:
-            return MULTI_TASK_TOPIC_LABELS.index(canonical), True
-    return MULTI_TASK_TOPIC_LABELS.index("other"), True
-
-
 def _row_targets(row: dict[str, Any]) -> tuple[dict[str, float | int], dict[str, bool]]:
     """Map one events.parquet row to per-axis targets + masks.
 
     Mirrors the extraction in
     ``app.training.loaders._attach_rich_features`` so the classifier
     consumes the same canonical label mappings the forecaster does.
+    The topic axis was retired in ADR 0044 — no upstream source ships
+    topic labels.
     """
 
     stance_idx, stance_present = _stance_target(row)
     factor_value, factor_present = _factor_target(row)
     certainty_idx, certainty_present = _certainty_target(row)
-    topic_idx, topic_present = _topic_target(row)
     return (
         {
             "stance": stance_idx,
             "factor": factor_value,
             "certainty": certainty_idx,
-            "topic": topic_idx,
         },
         {
             "stance": stance_present,
             "factor": factor_present,
             "certainty": certainty_present,
-            "topic": topic_present,
         },
     )
 
@@ -288,13 +263,11 @@ def _gtfintechlab_row_to_axis_row(
         "stance": 0,
         "factor": 0.0,
         "certainty": 0,
-        "topic": 0,
     }
     masks: dict[str, bool] = {
         "stance": False,
         "factor": False,
         "certainty": False,
-        "topic": False,
     }
 
     stance_raw = str(item.get("stance_label") or "").strip().lower()
@@ -307,13 +280,12 @@ def _gtfintechlab_row_to_axis_row(
         targets["certainty"] = MULTI_TASK_CERTAINTY_LABELS.index(certain_raw)
         masks["certainty"] = True
 
-    # The gtfintechlab corpus does not carry a topic taxonomy and the
-    # factor axis is exclusive to the gss_factor source. The classifier
-    # learns those branches only from rows that DO carry the label
-    # (mask=True); on this dataset both stay at False so the masked
-    # loss contributes nothing for them. The branches still emit
-    # predictions at inference, which the frontend can choose to
-    # render as low-confidence.
+    # The factor axis is exclusive to the gss_factor source. The
+    # classifier learns that branch only from rows that DO carry the
+    # label (mask=True); on this dataset it stays at False so the
+    # masked loss contributes nothing for it. The branch still emits
+    # predictions at inference, which the frontend renders as
+    # low-confidence. The topic axis was retired (ADR 0044).
     stance_sample_weight = 1.0
     if provenance == "peer_reviewed_cross_bank":
         if cross_bank_mode == "stance_masked":
@@ -567,11 +539,9 @@ def _build_axis_class_weights(rows: list[_AxisRow]) -> dict[str, torch.Tensor]:
 
     stance_indices = [int(r.targets["stance"]) for r in rows if r.masks["stance"]]
     certainty_indices = [int(r.targets["certainty"]) for r in rows if r.masks["certainty"]]
-    topic_indices = [int(r.targets["topic"]) for r in rows if r.masks["topic"]]
     return {
         "stance": _fit_class_weights(stance_indices, MULTI_TASK_STANCE_CLASSES),
         "certainty": _fit_class_weights(certainty_indices, MULTI_TASK_CERTAINTY_CLASSES),
-        "topic": _fit_class_weights(topic_indices, MULTI_TASK_TOPIC_CLASSES),
     }
 
 
@@ -599,11 +569,9 @@ class _MultiAxisDataset(Dataset):
             "target_stance": int(row.targets["stance"]),
             "target_factor": float(row.targets["factor"]),
             "target_certainty": int(row.targets["certainty"]),
-            "target_topic": int(row.targets["topic"]),
             "mask_stance": bool(row.masks["stance"]),
             "mask_factor": bool(row.masks["factor"]),
             "mask_certainty": bool(row.masks["certainty"]),
-            "mask_topic": bool(row.masks["topic"]),
             # Source bank label rides on every batch row so the eval
             # pass can compute per-bank macro-F1 without re-loading
             # the original rows. Collated as a list of strings.
@@ -634,9 +602,6 @@ def _collate(batch: list[dict[str, Any]]) -> dict[str, Any]:
     out["target_certainty"] = torch.tensor(
         [item["target_certainty"] for item in batch], dtype=torch.long
     )
-    out["target_topic"] = torch.tensor(
-        [item["target_topic"] for item in batch], dtype=torch.long
-    )
     out["mask_stance"] = torch.tensor(
         [item["mask_stance"] for item in batch], dtype=torch.bool
     )
@@ -645,9 +610,6 @@ def _collate(batch: list[dict[str, Any]]) -> dict[str, Any]:
     )
     out["mask_certainty"] = torch.tensor(
         [item["mask_certainty"] for item in batch], dtype=torch.bool
-    )
-    out["mask_topic"] = torch.tensor(
-        [item["mask_topic"] for item in batch], dtype=torch.bool
     )
     # ``source`` and ``provenance`` are per-row strings (the per-bank
     # eval and the first-epoch sanity log read them); the rest of the
@@ -684,7 +646,7 @@ def _log_per_axis_provenance_breakdown(rows: list[_AxisRow]) -> None:
     not encode that as a permanent assumption.
     """
 
-    axis_names: tuple[str, ...] = ("stance", "factor", "certainty", "topic")
+    axis_names: tuple[str, ...] = ("stance", "factor", "certainty")
     for axis_name in axis_names:
         from_other = 0
         from_cross_bank = 0
@@ -714,7 +676,7 @@ def _train_one_epoch(
 ) -> dict[str, float]:
     model.train()
     sum_total = 0.0
-    sum_axis = {"stance": 0.0, "factor": 0.0, "certainty": 0.0, "topic": 0.0}
+    sum_axis = {"stance": 0.0, "factor": 0.0, "certainty": 0.0}
     n_batches = 0
     for batch in loader:
         optimizer.zero_grad(set_to_none=True)
@@ -725,13 +687,11 @@ def _train_one_epoch(
             "stance": batch["target_stance"].to(device),
             "factor": batch["target_factor"].to(device),
             "certainty": batch["target_certainty"].to(device),
-            "topic": batch["target_topic"].to(device),
         }
         masks = {
             "stance_mask": batch["mask_stance"].to(device),
             "factor_mask": batch["mask_factor"].to(device),
             "certainty_mask": batch["mask_certainty"].to(device),
-            "topic_mask": batch["mask_topic"].to(device),
         }
         stance_weight = batch.get("stance_sample_weight")
         if stance_weight is not None:
@@ -770,8 +730,8 @@ def _compute_weighted_total_loss(
 
     ``MultiTaskLoss.forward`` takes an optional ``stance_sample_weight``
     kwarg that turns the stance branch into a weighted-mean CE; the
-    factor / certainty / topic branches are unchanged. Passing the
-    vector straight through keeps every gradient path on the loss
+    factor / certainty branches are unchanged. Passing the vector
+    straight through keeps every gradient path on the loss
     side, so the helper here is a thin call-site adapter: when the
     batch carries no weights, or every weight is exactly 1.0 (the
     only state the FOMC-only pool ever produces), we call the loss
@@ -834,19 +794,19 @@ def _evaluate_per_bank(
 
     Returns ``{source: {axis: {macro_f1, n}}}`` where ``source`` is the
     originating corpus tag (e.g. ``"gtfintechlab/federal_reserve_system"``,
-    ``"events_parquet"``) and ``axis`` ∈ ``{stance, certainty, topic}``.
+    ``"events_parquet"``) and ``axis`` ∈ ``{stance, certainty}``.
     Factor is regression-typed and is omitted here; the parent
     ``_evaluate`` already reports its SmoothL1 loss.
 
     Rows whose axis mask is False on a given (source, axis) are
     dropped before computing F1 — keeps the macro-F1 honest on the
-    sparse axes (factor / certainty / topic) where most rows from
-    most banks have nothing to score.
+    sparse axes (factor / certainty) where most rows from most banks
+    have nothing to score.
     """
 
     model.eval()
     per_source_axis: dict[str, dict[str, list[tuple[int, int]]]] = {}
-    classification_axes: tuple[str, ...] = ("stance", "certainty", "topic")
+    classification_axes: tuple[str, ...] = ("stance", "certainty")
     for batch in loader:
         input_ids = batch["input_ids"].to(device)
         attn = batch["attention_mask"].to(device)
@@ -867,7 +827,6 @@ def _evaluate_per_bank(
     axis_n_classes = {
         "stance": MULTI_TASK_STANCE_CLASSES,
         "certainty": MULTI_TASK_CERTAINTY_CLASSES,
-        "topic": MULTI_TASK_TOPIC_CLASSES,
     }
     out: dict[str, dict[str, dict[str, float | int]]] = {}
     for source, axis_bucket in per_source_axis.items():
@@ -907,9 +866,9 @@ def _evaluate(
 
     model.eval()
     sum_total = 0.0
-    sum_axis = {"stance": 0.0, "factor": 0.0, "certainty": 0.0, "topic": 0.0}
-    correct_axis = {"stance": 0, "certainty": 0, "topic": 0}
-    seen_axis = {"stance": 0, "certainty": 0, "topic": 0}
+    sum_axis = {"stance": 0.0, "factor": 0.0, "certainty": 0.0}
+    correct_axis = {"stance": 0, "certainty": 0}
+    seen_axis = {"stance": 0, "certainty": 0}
     n_batches = 0
     for batch in loader:
         input_ids = batch["input_ids"].to(device)
@@ -919,13 +878,11 @@ def _evaluate(
             "stance": batch["target_stance"].to(device),
             "factor": batch["target_factor"].to(device),
             "certainty": batch["target_certainty"].to(device),
-            "topic": batch["target_topic"].to(device),
         }
         masks = {
             "stance_mask": batch["mask_stance"].to(device),
             "factor_mask": batch["mask_factor"].to(device),
             "certainty_mask": batch["mask_certainty"].to(device),
-            "topic_mask": batch["mask_topic"].to(device),
         }
         stance_weight = batch.get("stance_sample_weight")
         if stance_weight is not None:
@@ -941,7 +898,7 @@ def _evaluate(
         for axis_name in sum_axis:
             sum_axis[axis_name] += float(breakdown[axis_name].item())
         n_batches += 1
-        for axis_name in ("stance", "certainty", "topic"):
+        for axis_name in ("stance", "certainty"):
             mask = masks[f"{axis_name}_mask"]
             if mask.any():
                 pred = logits[axis_name][mask].argmax(dim=-1)
@@ -953,7 +910,7 @@ def _evaluate(
     out = {"loss": sum_total / n_batches}
     for axis_name, total in sum_axis.items():
         out[f"loss_{axis_name}"] = total / n_batches
-    for axis_name in ("stance", "certainty", "topic"):
+    for axis_name in ("stance", "certainty"):
         if seen_axis[axis_name] > 0:
             out[f"acc_{axis_name}"] = correct_axis[axis_name] / seen_axis[axis_name]
     return out
@@ -1190,11 +1147,9 @@ def main(argv: list[str] | None = None) -> int:
     loss_fn = MultiTaskLoss(
         stance_weight=class_weights["stance"].to(device),
         certainty_weight=class_weights["certainty"].to(device),
-        topic_weight=class_weights["topic"].to(device),
         lambda_stance=args.lambda_stance,
         lambda_factor=args.lambda_factor,
         lambda_certainty=args.lambda_certainty,
-        lambda_topic=args.lambda_topic,
     ).to(device)
 
     train_ds = _MultiAxisDataset(train_rows, tokenizer, max_length=args.max_length)
@@ -1242,13 +1197,12 @@ def main(argv: list[str] | None = None) -> int:
         train_metrics = _train_one_epoch(model, train_loader, loss_fn, optimizer, device)
         val_metrics = _evaluate(model, val_loader, loss_fn, device)
         _logger.info(
-            "epoch=%d train_loss=%.4f val_loss=%.4f val_acc_stance=%.3f val_acc_certainty=%.3f val_acc_topic=%.3f",
+            "epoch=%d train_loss=%.4f val_loss=%.4f val_acc_stance=%.3f val_acc_certainty=%.3f",
             epoch,
             train_metrics["loss"],
             val_metrics["loss"],
             val_metrics.get("acc_stance", float("nan")),
             val_metrics.get("acc_certainty", float("nan")),
-            val_metrics.get("acc_topic", float("nan")),
         )
         if val_metrics["loss"] < best_val_loss:
             best_val_loss = val_metrics["loss"]
@@ -1380,7 +1334,6 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--lambda-stance", type=float, default=1.0)
     parser.add_argument("--lambda-factor", type=float, default=0.3)
     parser.add_argument("--lambda-certainty", type=float, default=0.3)
-    parser.add_argument("--lambda-topic", type=float, default=0.3)
     # Bundle A.1: cross-bank auxiliary supervision flag on the
     # text-encoder fine-tune. ``off`` (default) keeps the strict
     # FOMC stance pool — cross-bank rows are excluded so the
@@ -1388,8 +1341,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     # ``stance_masked`` admits cross-bank rows but forces their
     # stance mask to False so the head only fits the FOMC stance
     # distribution while the encoder still trains on the
-    # cross-bank text + auxiliary (certainty / topic / factor /
-    # time) supervision. ``weighted`` admits them with the natural
+    # cross-bank text + auxiliary (certainty / factor / time)
+    # supervision. ``weighted`` admits them with the natural
     # stance label and downscales their stance contribution by
     # ``--cross-bank-stance-weight`` so the head can be A/B-tested
     # against the masked arm to re-litigate the Phase C

--- a/backend/app/forecasting/next_fomc_decision.py
+++ b/backend/app/forecasting/next_fomc_decision.py
@@ -18,7 +18,7 @@ Feature families
 
 * ``ois``        -- 5-tenor pre-event OIS-implied curve + level/path/info
                     factors from :file:`mp_surprises.parquet`.
-* ``text``       -- multi-axis stance / time / certainty / factor / topic
+* ``text``       -- multi-axis stance / time / certainty / factor
                     from :file:`events.parquet`. Multi-source duplicates
                     collapse to one row per meeting; the statement is the
                     preferred document kind when available.
@@ -645,10 +645,11 @@ def _ois_feature_names() -> tuple[str, ...]:
 
 
 def _text_feature_names() -> tuple[str, ...]:
-    # 3 one-hot dims per axis * 5 axes = 15 dims.
+    # 3 one-hot dims per axis * 4 axes = 12 dims. The topic axis was
+    # retired in ADR 0044 (no upstream source ships topic labels).
     return tuple(
         f"axis_{axis}_{label}"
-        for axis in ("stance", "time", "certainty", "factor", "topic")
+        for axis in ("stance", "time", "certainty", "factor")
         for label in ("dovish", "neutral", "hawkish")
     )
 
@@ -695,7 +696,7 @@ def _extract_ois_features(row: pd.Series) -> list[float]:
 
 def _extract_text_features(row: pd.Series) -> list[float]:
     out: list[float] = []
-    for axis_col in ("axis_stance", "axis_time", "axis_certainty", "axis_factor", "axis_topic"):
+    for axis_col in ("axis_stance", "axis_time", "axis_certainty", "axis_factor"):
         d, n, h = _axis_to_float(row.get(axis_col))
         out.extend([d, n, h])
     return out

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -857,13 +857,14 @@ def _build_multi_axis_block(
 
     1. **Trained multi-axis classifier present.** Run the
        ``TextMultiAxisClassifier`` checkpoint via
-       ``app.services.multi_axis_classifier.score_text``; populate all
-       four cards (stance / factor / certainty / topic) from the
-       per-axis predictions.
+       ``app.services.multi_axis_classifier.score_text``; populate the
+       three cards (stance / factor / certainty) from the per-axis
+       predictions. (The topic axis was retired in ADR 0044 — no
+       upstream corpus shipped topic labels.)
 
     2. **No checkpoint.** Fall back to populating the stance card from
        the existing sentiment classifier output and leave the other
-       three axes at ``None``. The frontend renders ``None`` cards as
+       two axes at ``None``. The frontend renders ``None`` cards as
        absent so the user sees honest absence rather than a
        placeholder value.
     """
@@ -902,7 +903,6 @@ def _build_multi_axis_block(
         },
         "factor": None,
         "certainty": None,
-        "topic": None,
     }
 
 

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -225,23 +225,17 @@ RICH_PRESS_CONF_SLICE = slice(
 )
 
 # Multi-task head (#78) axis cardinalities and canonical label maps.
-# The multi-task head emits four branches; the cardinalities are pinned
-# here so the loader, the model factory, and the inference path agree on
-# the shape. Adding a topic label would require bumping
-# MULTI_TASK_TOPIC_LABELS in lockstep with the loader's topic-string
-# normaliser; the four buckets below cover the only topic-string
-# families that show up on gtfintechlab + scraped Fed rows.
+# The multi-task head emits three branches (stance / certainty / factor);
+# the cardinalities are pinned here so the loader, the model factory,
+# and the inference path agree on the shape. The topic axis was retired
+# per ADR 0044 — no upstream FOMC corpus or cross-bank gtfintechlab
+# dataset ships topic labels, and the only path that ever populated
+# ``axis_topic`` was the internal macro-release augmentation which the
+# rebuild path no longer fires.
 MULTI_TASK_STANCE_CLASSES = 3
 MULTI_TASK_CERTAINTY_CLASSES = 3
-MULTI_TASK_TOPIC_CLASSES = 4
 MULTI_TASK_STANCE_LABELS: tuple[str, ...] = ("hawkish", "dovish", "neutral")
 MULTI_TASK_CERTAINTY_LABELS: tuple[str, ...] = ("certain", "uncertain", "neutral")
-MULTI_TASK_TOPIC_LABELS: tuple[str, ...] = (
-    "macro",
-    "forward_guidance",
-    "market_reaction",
-    "other",
-)
 
 # Text-embedding adapter dim search axis. The forecaster sweep iterates
 # over these values so the diminishing-returns curve across {32, 64, 128}
@@ -508,15 +502,15 @@ class ModelConfig:
     # #273 follow-up to the multi-task head (#272). When True, the
     # training loop swaps the single-axis CrossEntropy for
     # :class:`app.training.loss.MultiTaskLoss`, which folds per-axis
-    # CE / SmoothL1 terms onto stance / factor / certainty / topic
-    # with per-axis class weights and a per-row availability mask.
-    # Default False keeps the byte-identity regression contract on
-    # every existing classification run (stance-only training).
+    # CE / SmoothL1 terms onto stance / factor / certainty with per-axis
+    # class weights and a per-row availability mask. Default False keeps
+    # the byte-identity regression contract on every existing
+    # classification run (stance-only training). The topic axis was
+    # retired in ADR 0044 (no upstream source ships topic labels).
     multi_task_loss: bool = False
     multi_task_lambda_stance: float = 1.0
     multi_task_lambda_factor: float = 0.3
     multi_task_lambda_certainty: float = 0.3
-    multi_task_lambda_topic: float = 0.3
     # Steepens inverse-frequency class weights via ``raw[c] = 1 / (n_c + 1) ** power``.
     # ``1.0`` (default) is the legacy formula and preserves byte-identity with
     # pre-2026-05-25 sweep numbers; higher values force the gradient onto the
@@ -690,7 +684,6 @@ class ModelConfig:
             multi_task_lambda_stance=float(getattr(model, "multi_task_lambda_stance", 1.0)),
             multi_task_lambda_factor=float(getattr(model, "multi_task_lambda_factor", 0.3)),
             multi_task_lambda_certainty=float(getattr(model, "multi_task_lambda_certainty", 0.3)),
-            multi_task_lambda_topic=float(getattr(model, "multi_task_lambda_topic", 0.3)),
             class_weight_power=float(getattr(model, "class_weight_power", 1.0)),
             head_mode=str(getattr(model, "head_mode", "dual") or "dual"),
             regression_alpha=float(getattr(model, "regression_alpha", 0.5)),
@@ -1075,19 +1068,18 @@ class FeatureVector:
     # is the per-axis mask the loss reads to decide whether the row
     # contributes to that axis's loss. Indices use the canonical
     # mappings: stance {hawkish: 0, dovish: 1, neutral: 2}, certainty
-    # {certain: 0, uncertain: 1, neutral: 2}, topic {macro: 0,
-    # forward_guidance: 1, market_reaction: 2, other: 3}. Factor is a
-    # signed scalar in [-1, 1] (no idx). When a label is absent the
-    # target field stays at its default and the mask is False, so the
-    # masked loss contributes zero for that axis on that row.
+    # {certain: 0, uncertain: 1, neutral: 2}. Factor is a signed scalar
+    # in [-1, 1] (no idx). When a label is absent the target field stays
+    # at its default and the mask is False, so the masked loss
+    # contributes zero for that axis on that row. The topic axis was
+    # retired in ADR 0044 — no upstream FOMC or cross-bank corpus ships
+    # topic labels.
     target_stance_idx: int = -1
     target_stance_present: bool = False
     target_factor: float = 0.0
     target_factor_present: bool = False
     target_certainty_idx: int = -1
     target_certainty_present: bool = False
-    target_topic_idx: int = -1
-    target_topic_present: bool = False
 
     @classmethod
     def from_market_state(

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -152,7 +152,6 @@ def build_forecaster(
             "multi_task_lambda_stance",
             "multi_task_lambda_factor",
             "multi_task_lambda_certainty",
-            "multi_task_lambda_topic",
             "class_weight_power",
             "regression_alpha",
             "use_derived_text_features",
@@ -194,7 +193,6 @@ def build_forecaster(
         flat.multi_task_lambda_stance = float(resolved.multi_task_lambda_stance)  # type: ignore[assignment]
         flat.multi_task_lambda_factor = float(resolved.multi_task_lambda_factor)  # type: ignore[assignment]
         flat.multi_task_lambda_certainty = float(resolved.multi_task_lambda_certainty)  # type: ignore[assignment]
-        flat.multi_task_lambda_topic = float(resolved.multi_task_lambda_topic)  # type: ignore[assignment]
         flat.class_weight_power = float(resolved.class_weight_power)  # type: ignore[assignment]
         flat.regression_alpha = float(resolved.regression_alpha)  # type: ignore[assignment]
         flat.use_derived_text_features = bool(resolved.use_derived_text_features)  # type: ignore[assignment]
@@ -233,7 +231,6 @@ def build_forecaster(
     multi_task_lambda_stance = float(kwargs.pop("multi_task_lambda_stance", 1.0))
     multi_task_lambda_factor = float(kwargs.pop("multi_task_lambda_factor", 0.3))
     multi_task_lambda_certainty = float(kwargs.pop("multi_task_lambda_certainty", 0.3))
-    multi_task_lambda_topic = float(kwargs.pop("multi_task_lambda_topic", 0.3))
     class_weight_power = float(kwargs.pop("class_weight_power", 1.0))
     # #304 dual-head methodology. ``regression_alpha`` is a loss-side
     # knob (the training loop reads it from the model attribute);
@@ -387,7 +384,6 @@ def build_forecaster(
     model.multi_task_lambda_stance = multi_task_lambda_stance  # type: ignore[assignment]
     model.multi_task_lambda_factor = multi_task_lambda_factor  # type: ignore[assignment]
     model.multi_task_lambda_certainty = multi_task_lambda_certainty  # type: ignore[assignment]
-    model.multi_task_lambda_topic = multi_task_lambda_topic  # type: ignore[assignment]
     model.class_weight_power = class_weight_power  # type: ignore[assignment]
     # #304 / #309 -- stash the loss + loader flags so
     # ``ModelConfig.from_model`` round-trips them onto the persisted

--- a/backend/app/models/multi_task_head.py
+++ b/backend/app/models/multi_task_head.py
@@ -1,7 +1,7 @@
 """Multi-task head for the forecaster (#78).
 
 Replaces the legacy single-output classification head on
-``ForecasterModel`` when ``output_mode=="classification"``. Emits four
+``ForecasterModel`` when ``output_mode=="classification"``. Emits three
 branches from a shared pre-classifier stem:
 
 - ``stance`` — 3-class logits over ``{hawkish, dovish, neutral}`` (the
@@ -10,14 +10,15 @@ branches from a shared pre-classifier stem:
   comparable to the single-head baseline).
 - ``factor`` — scalar regression in ``[-1, 1]`` (tanh-bounded).
 - ``certainty`` — 3-class logits over ``{certain, uncertain, neutral}``.
-- ``topic`` — K-class logits over ``MULTI_TASK_TOPIC_LABELS``
-  (``{macro, forward_guidance, market_reaction, other}``).
 
 The shared stem (LayerNorm + Linear + GELU + Dropout) mirrors the
 existing single-head pre-classifier so the representation capacity
 per branch is comparable to the baseline. Each branch is a single
 linear projection from the stem output, which keeps the parameter
 count small on top of the recurrent core.
+
+The topic branch was retired in ADR 0044 because no upstream FOMC
+corpus or cross-bank gtfintechlab dataset ships topic labels.
 
 Loss masking lives in :class:`app.training.loss.MultiTaskLoss`; the
 head itself is mask-unaware (it always emits the same shape).
@@ -31,7 +32,6 @@ from torch import nn
 from app.models.config import (
     MULTI_TASK_CERTAINTY_CLASSES,
     MULTI_TASK_STANCE_CLASSES,
-    MULTI_TASK_TOPIC_CLASSES,
 )
 
 
@@ -40,7 +40,7 @@ class MultiTaskHead(nn.Module):
 
     Construction mirrors the legacy single-head Sequential at
     ``lstm.py:230-247`` (LayerNorm + Linear + GELU + Dropout) so the
-    head capacity is comparable. The four output projections are
+    head capacity is comparable. The three output projections are
     independent linears applied to the stem output.
     """
 
@@ -52,7 +52,6 @@ class MultiTaskHead(nn.Module):
         *,
         stance_classes: int = MULTI_TASK_STANCE_CLASSES,
         certainty_classes: int = MULTI_TASK_CERTAINTY_CLASSES,
-        topic_classes: int = MULTI_TASK_TOPIC_CLASSES,
     ) -> None:
         super().__init__()
         self.hidden_size = int(hidden_size)
@@ -60,7 +59,6 @@ class MultiTaskHead(nn.Module):
         self.dropout = float(dropout)
         self.stance_classes = int(stance_classes)
         self.certainty_classes = int(certainty_classes)
-        self.topic_classes = int(topic_classes)
 
         self.stem = nn.Sequential(
             nn.LayerNorm(self.hidden_size),
@@ -71,17 +69,15 @@ class MultiTaskHead(nn.Module):
         self.stance = nn.Linear(self.head_hidden_size, self.stance_classes)
         self.factor = nn.Linear(self.head_hidden_size, 1)
         self.certainty = nn.Linear(self.head_hidden_size, self.certainty_classes)
-        self.topic = nn.Linear(self.head_hidden_size, self.topic_classes)
 
     def forward(self, pooled: torch.Tensor) -> dict[str, torch.Tensor]:
         """Emit per-axis predictions from the pooled backbone output.
 
-        Returns a dict with four keys:
+        Returns a dict with three keys:
 
         - ``stance`` — ``(B, stance_classes)`` raw logits
         - ``factor`` — ``(B,)`` tanh-bounded scalar in ``[-1, 1]``
         - ``certainty`` — ``(B, certainty_classes)`` raw logits
-        - ``topic`` — ``(B, topic_classes)`` raw logits
 
         Classification branches return raw logits so CrossEntropy can
         apply log-softmax internally. The factor branch applies a tanh
@@ -95,5 +91,4 @@ class MultiTaskHead(nn.Module):
             "stance": self.stance(stem),
             "factor": torch.tanh(self.factor(stem).squeeze(-1)),
             "certainty": self.certainty(stem),
-            "topic": self.topic(stem),
         }

--- a/backend/app/models/text_multi_axis_classifier.py
+++ b/backend/app/models/text_multi_axis_classifier.py
@@ -3,19 +3,23 @@
 Wraps a pre-trained transformer encoder (default: finbert_fed_adjacent,
 the project's continued-pretrained FinBERT on BIS speeches) with the
 multi-task head shipped in #272. Emits per-axis predictions on stance,
-factor, certainty, and topic from a single input text.
+factor, and certainty from a single input text.
 
 The classifier is trained on the supervised rows in events.parquet
 that carry axis labels (primarily the gtfintechlab cross-bank rows
-for stance / certainty / topic plus the gss_factor rows for factor),
-not on the volatility-regime target the time-series forecaster uses.
-This is a parallel model to the forecaster, not a replacement.
+for stance / certainty plus the gss_factor rows for factor), not on
+the volatility-regime target the time-series forecaster uses. This is
+a parallel model to the forecaster, not a replacement.
 
 The encoder pools the [CLS] token from the last hidden state into a
-single vector per text; the MultiTaskHead emits four branches from
+single vector per text; the MultiTaskHead emits three branches from
 that pooled representation. The shared encoder is fine-tuned end-to-
 end during training; at inference the model is frozen behind the
 service singleton at backend/app/services/multi_axis_classifier.py.
+
+The topic axis was retired in ADR 0044 — no upstream corpus shipped
+topic labels, so the topic branch always predicted on zero training
+signal and the inference card always rendered the same fallback.
 """
 
 from __future__ import annotations
@@ -29,7 +33,6 @@ from app.models.multi_task_head import MultiTaskHead
 from app.models.config import (
     MULTI_TASK_CERTAINTY_CLASSES,
     MULTI_TASK_STANCE_CLASSES,
-    MULTI_TASK_TOPIC_CLASSES,
 )
 
 
@@ -50,7 +53,6 @@ class TextMultiAxisClassifier(nn.Module):
         dropout: float = 0.1,
         stance_classes: int = MULTI_TASK_STANCE_CLASSES,
         certainty_classes: int = MULTI_TASK_CERTAINTY_CLASSES,
-        topic_classes: int = MULTI_TASK_TOPIC_CLASSES,
         encoder_alias: str = "",
         encoder_revision: str = "",
     ) -> None:
@@ -63,7 +65,6 @@ class TextMultiAxisClassifier(nn.Module):
             dropout=dropout,
             stance_classes=stance_classes,
             certainty_classes=certainty_classes,
-            topic_classes=topic_classes,
         )
         # Surface the encoder provenance on the module so the
         # checkpoint payload can persist the exact alias + revision
@@ -127,7 +128,7 @@ class TextMultiAxisClassifier(nn.Module):
         """Emit per-axis predictions for a batch of tokenised inputs.
 
         Uses the [CLS] token pooling convention. Returns the same
-        dict shape MultiTaskHead emits: ``{stance, factor, certainty, topic}``.
+        dict shape MultiTaskHead emits: ``{stance, factor, certainty}``.
         """
 
         outputs = self.encoder(input_ids=input_ids, attention_mask=attention_mask)
@@ -147,5 +148,4 @@ class TextMultiAxisClassifier(nn.Module):
             "dropout": self.head.dropout,
             "stance_classes": self.head.stance_classes,
             "certainty_classes": self.head.certainty_classes,
-            "topic_classes": self.head.topic_classes,
         }

--- a/backend/app/retrieval/train.py
+++ b/backend/app/retrieval/train.py
@@ -117,17 +117,17 @@ POSITIVE_KINDS = ("minutes", "press_conference")
 # Pair-policy menu for ``build_training_pairs`` (#329). ``same_meeting``
 # is the pre-#329 default and preserves the original MNRL contract
 # byte-identical. ``shared_axis`` is the rebuild policy that draws
-# positives from statements which share an axis_stance / axis_factor /
-# axis_topic label across different meetings — supervision that
-# targets cross-meeting semantic similarity rather than
-# same-meeting-ness.
+# positives from statements which share an axis_stance / axis_factor
+# label across different meetings — supervision that targets
+# cross-meeting semantic similarity rather than same-meeting-ness.
+# (The topic axis was retired in ADR 0044.)
 PAIR_POLICIES = ("same_meeting", "shared_axis")
 DEFAULT_PAIR_POLICY = "same_meeting"
 
 # Axis columns the shared-axis policy reads from the events parquet.
 # Order matters: when more than one axis matches, the first hit wins
 # so the recorded ``positive_kind`` is deterministic across reruns.
-SHARED_AXIS_COLUMNS = ("axis_stance", "axis_factor", "axis_topic")
+SHARED_AXIS_COLUMNS = ("axis_stance", "axis_factor")
 
 
 @dataclass(frozen=True)
@@ -241,8 +241,8 @@ def build_training_pairs(  # noqa: C901 — flat column-validation guards keep t
 
     * ``shared_axis`` (#329 rebuild). Anchors are statements; positives
       are statements from a DIFFERENT meeting that share at least one
-      multi-axis label (``axis_stance`` / ``axis_factor`` /
-      ``axis_topic``). The first matching axis wins so
+      multi-axis label (``axis_stance`` / ``axis_factor``).
+      The first matching axis wins so
       ``positive_kind`` is deterministic across reruns. Rows missing
       every axis label are skipped (cannot match anyone); rows whose
       axis value is empty / NaN are treated as unlabelled and excluded
@@ -685,8 +685,8 @@ def _parse_args() -> argparse.Namespace:
             "uses minutes / press_conference rows released on the "
             "anchor's event_date — the pre-#329 recipe. 'shared_axis' "
             "draws positives from cross-meeting statements sharing an "
-            "axis_stance / axis_factor / axis_topic label and targets "
-            "cross-meeting semantic similarity directly."
+            "axis_stance / axis_factor label and targets cross-meeting "
+            "semantic similarity directly."
         ),
     )
     return parser.parse_args()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -250,25 +250,20 @@ class MultiAxisCertaintyCard(BaseModel):
     distribution: dict[str, float] = Field(default_factory=dict)
 
 
-class MultiAxisTopicCard(BaseModel):
-    """Topic prediction from the multi-task head."""
-
-    model_config = _FORBID_FROZEN_CONFIG
-
-    label: str = Field(..., description="macro | forward_guidance | market_reaction | other")
-    confidence: float = Field(..., ge=0.0, le=1.0)
-    distribution: dict[str, float] = Field(default_factory=dict)
-
-
 class MultiAxisBlock(BaseModel):
     """Multi-task head per-axis predictions surfaced on /analyze (#78).
 
-    The four axes mirror the multi-task head's four output branches.
+    The three axes mirror the multi-task head's three output branches.
     Stance reuses the canonical 3-class classifier (also exposed on
-    the legacy ``sentiment`` field for back-compat); the other three
-    branches are populated for the first time with this block. Axes
+    the legacy ``sentiment`` field for back-compat); the other two
+    branches were populated for the first time with this block. Axes
     whose checkpoint was trained on very few labels are flagged as
     low-confidence; the frontend renders a muted card in that case.
+
+    The topic axis was retired in ADR 0044 — no upstream FOMC or
+    cross-bank corpus shipped topic labels, and the only path that
+    ever populated ``axis_topic`` was an internal macro-release
+    augmentation that no longer fires on the rebuild path.
     """
 
     model_config = _FORBID_FROZEN_CONFIG
@@ -276,7 +271,6 @@ class MultiAxisBlock(BaseModel):
     stance: MultiAxisStanceCard
     factor: MultiAxisFactorCard | None = None
     certainty: MultiAxisCertaintyCard | None = None
-    topic: MultiAxisTopicCard | None = None
 
 
 class RatesReactionCard(BaseModel):

--- a/backend/app/services/multi_axis_classifier.py
+++ b/backend/app/services/multi_axis_classifier.py
@@ -30,7 +30,6 @@ from app.config import MODEL_CHECKPOINT_DIR
 from app.models.config import (
     MULTI_TASK_CERTAINTY_LABELS,
     MULTI_TASK_STANCE_LABELS,
-    MULTI_TASK_TOPIC_LABELS,
 )
 from app.models.text_multi_axis_classifier import TextMultiAxisClassifier
 
@@ -377,9 +376,10 @@ def score_text(text: str) -> dict[str, Any] | None:
 
     Returns ``None`` when no checkpoint is loaded. The output shape
     matches the ``MultiAxisBlock`` Pydantic schema in
-    ``app.schemas`` — keys for stance / factor / certainty / topic
-    each carrying ``label``, ``confidence``, and (where applicable)
-    a per-class distribution.
+    ``app.schemas`` — keys for stance / factor / certainty each
+    carrying ``label``, ``confidence``, and (where applicable) a
+    per-class distribution. The topic axis was retired in ADR 0044
+    (no upstream source ships topic labels).
 
     The factor card is gated on the persisted factor-axis label
     coverage (#328): when the active checkpoint's training pool
@@ -423,14 +423,6 @@ def score_text(text: str) -> dict[str, Any] | None:
         for i in range(len(MULTI_TASK_CERTAINTY_LABELS))
     }
 
-    topic_probs = torch.softmax(logits["topic"], dim=-1)[0]
-    topic_idx = int(topic_probs.argmax().item())
-    topic_label = MULTI_TASK_TOPIC_LABELS[topic_idx]
-    topic_dist = {
-        MULTI_TASK_TOPIC_LABELS[i]: float(topic_probs[i].item())
-        for i in range(len(MULTI_TASK_TOPIC_LABELS))
-    }
-
     factor_card = _build_factor_card(state, logits)
 
     return {
@@ -444,11 +436,6 @@ def score_text(text: str) -> dict[str, Any] | None:
             "label": certainty_label,
             "confidence": float(certainty_probs[certainty_idx].item()),
             "distribution": certainty_dist,
-        },
-        "topic": {
-            "label": topic_label,
-            "confidence": float(topic_probs[topic_idx].item()),
-            "distribution": topic_dist,
         },
     }
 

--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -724,7 +724,7 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help=(
             "Train classification with MultiTaskLoss over stance / factor / "
-            "certainty / topic instead of single-axis CrossEntropy. "
+            "certainty instead of single-axis CrossEntropy. "
             "Per-axis class weights fit on the train slice; per-row mask "
             "drops axes whose label is absent on a given row."
         ),
@@ -747,12 +747,6 @@ def _parse_args() -> argparse.Namespace:
         type=float,
         default=0.3,
         help="Loss weight on the certainty branch.",
-    )
-    parser.add_argument(
-        "--multi-task-lambda-topic",
-        type=float,
-        default=0.3,
-        help="Loss weight on the topic branch.",
     )
     parser.add_argument(
         "--class-weight-power",
@@ -926,7 +920,7 @@ def _parse_args() -> argparse.Namespace:
             "forecaster head (#309). ``on`` (default) leaves the "
             "FeatureVector slots populated as in the pre-#309 baseline. "
             "``off`` zeros ``sentiment_score`` + the multi-axis stance / "
-            "certainty / topic slots so only the document-level encoder "
+            "certainty slots so only the document-level encoder "
             "path drives the forecaster. Used by "
             "``scripts/run_derived_features_ablation.py`` for the three-way "
             "comparison (baseline / ablation / replacement)."
@@ -1379,7 +1373,6 @@ def _build_model_config(args: argparse.Namespace) -> ModelConfig:
         multi_task_lambda_stance=float(getattr(args, "multi_task_lambda_stance", 1.0)),
         multi_task_lambda_factor=float(getattr(args, "multi_task_lambda_factor", 0.3)),
         multi_task_lambda_certainty=float(getattr(args, "multi_task_lambda_certainty", 0.3)),
-        multi_task_lambda_topic=float(getattr(args, "multi_task_lambda_topic", 0.3)),
         class_weight_power=float(getattr(args, "class_weight_power", 1.0)),
         head_mode=str(getattr(args, "head_mode", "classification") or "classification"),
         regression_alpha=float(getattr(args, "regression_alpha", 0.5)),
@@ -1643,7 +1636,6 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                                 multi_task_lambda_stance=float(getattr(args, "multi_task_lambda_stance", 1.0)),
                                 multi_task_lambda_factor=float(getattr(args, "multi_task_lambda_factor", 0.3)),
                                 multi_task_lambda_certainty=float(getattr(args, "multi_task_lambda_certainty", 0.3)),
-                                multi_task_lambda_topic=float(getattr(args, "multi_task_lambda_topic", 0.3)),
                                 class_weight_power=float(getattr(args, "class_weight_power", 1.0)),
                                 head_mode=str(getattr(args, "head_mode", "classification") or "classification"),
                                 regression_alpha=float(getattr(args, "regression_alpha", 0.5)),
@@ -1766,7 +1758,6 @@ def build_sweep_candidates(args: argparse.Namespace) -> list[dict[str, Any]]:
                         multi_task_lambda_stance=float(getattr(args, "multi_task_lambda_stance", 1.0)),
                         multi_task_lambda_factor=float(getattr(args, "multi_task_lambda_factor", 0.3)),
                         multi_task_lambda_certainty=float(getattr(args, "multi_task_lambda_certainty", 0.3)),
-                        multi_task_lambda_topic=float(getattr(args, "multi_task_lambda_topic", 0.3)),
                         class_weight_power=float(getattr(args, "class_weight_power", 1.0)),
                         head_mode=str(getattr(args, "head_mode", "classification") or "classification"),
                         regression_alpha=float(getattr(args, "regression_alpha", 0.5)),

--- a/backend/app/training/checkpoint.py
+++ b/backend/app/training/checkpoint.py
@@ -192,9 +192,6 @@ def _coerce_payload_config(payload: dict[str, Any] | None) -> ModelConfig:
             multi_task_lambda_certainty=float(
                 raw.get("multi_task_lambda_certainty", 0.3)
             ),
-            multi_task_lambda_topic=float(
-                raw.get("multi_task_lambda_topic", 0.3)
-            ),
             # #214: round-trip press-conf opt-in.
             use_press_conf=bool(raw.get("use_press_conf", False)),
             # #443/#444: forward the two new opt-in flags so a checkpoint

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -22,7 +22,6 @@ from app.models.config import (
     FEATURE_SIZE,
     MULTI_TASK_CERTAINTY_LABELS,
     MULTI_TASK_STANCE_LABELS,
-    MULTI_TASK_TOPIC_LABELS,
     RICH_FEATURE_SIZE,
     RICH_LINGUISTIC_DIM,
     RichFeatureScalerParams,
@@ -1325,24 +1324,6 @@ def _attach_rich_features(
                 target_certainty_idx = MULTI_TASK_CERTAINTY_LABELS.index("neutral")
             target_certainty_present = True
 
-    target_topic_idx = -1
-    target_topic_present = False
-    topic_raw = event_row.get("axis_topic")
-    topic_str = (
-        str(topic_raw).strip().lower()
-        if isinstance(topic_raw, str) and str(topic_raw).strip()
-        else None
-    )
-    if topic_str is not None:
-        for canonical in MULTI_TASK_TOPIC_LABELS[:-1]:
-            if canonical in topic_str:
-                target_topic_idx = MULTI_TASK_TOPIC_LABELS.index(canonical)
-                target_topic_present = True
-                break
-        if not target_topic_present:
-            target_topic_idx = MULTI_TASK_TOPIC_LABELS.index("other")
-            target_topic_present = True
-
     for vector in vectors:
         vector.credibility_drift_score = cred_drift
         vector.credibility_realized_vs_stated_gap = cred_realized
@@ -1365,8 +1346,6 @@ def _attach_rich_features(
         vector.target_factor_present = target_factor_present
         vector.target_certainty_idx = target_certainty_idx
         vector.target_certainty_present = target_certainty_present
-        vector.target_topic_idx = target_topic_idx
-        vector.target_topic_present = target_topic_present
         vector.rich_payload = True
 
 
@@ -3402,8 +3381,6 @@ def _build_multi_task_target_tensors(
     factor_masks: list[bool] = []
     certainty_targets: list[int] = []
     certainty_masks: list[bool] = []
-    topic_targets: list[int] = []
-    topic_masks: list[bool] = []
 
     for sequence_group in sequence_groups:
         if len(sequence_group) < SEQUENCE_LENGTH + 1:
@@ -3433,11 +3410,6 @@ def _build_multi_task_target_tensors(
             certainty_targets.append(max(certainty_idx, 0))
             certainty_masks.append(certainty_present)
 
-            topic_idx = int(getattr(target_row, "target_topic_idx", -1) or 0)
-            topic_present = bool(getattr(target_row, "target_topic_present", False))
-            topic_targets.append(max(topic_idx, 0))
-            topic_masks.append(topic_present)
-
     if not stance_targets:
         return None
     return {
@@ -3447,8 +3419,6 @@ def _build_multi_task_target_tensors(
         "factor_mask": torch.tensor(factor_masks, dtype=torch.bool),
         "certainty": torch.tensor(certainty_targets, dtype=torch.long),
         "certainty_mask": torch.tensor(certainty_masks, dtype=torch.bool),
-        "topic": torch.tensor(topic_targets, dtype=torch.long),
-        "topic_mask": torch.tensor(topic_masks, dtype=torch.bool),
     }
 
 

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -745,16 +745,16 @@ def _make_partition_dataset(
 ) -> TensorDataset:
     """Pack one partition's tensors into a TensorDataset using a fixed contract.
 
-    Supported arities, in order:
+    Supported arities, in order (post-ADR-0044 — topic axis retired):
 
     - 2: ``(x, y)``
     - 3: ``(x, y, log_rv)`` -- #304 dual-head log(RV) target only
     - 4: ``(x, y, text_emb, text_missing)``
     - 5: text + log_rv combined
-    - 8: ``(x, y, factor, factor_mask, certainty, certainty_mask, topic, topic_mask)``
-    - 9: mt_aux + log_rv combined
-    - 10: text + multi-task combined
-    - 11: text + multi-task + log_rv combined
+    - 6: ``(x, y, factor, factor_mask, certainty, certainty_mask)``
+    - 7: mt_aux + log_rv combined
+    - 8: text + multi-task combined
+    - 9: text + multi-task + log_rv combined
 
     The multi-task aux ordering is fixed by :data:`_MULTI_TASK_AUX_KEYS` so
     :func:`_unpack_batch` can recover the tensors positionally. The
@@ -804,11 +804,11 @@ def _unpack_batch(
     """Decode a DataLoader batch into ``(x, y, text, text_missing, mt_aux, log_rv)``.
 
     Eight batch shapes are tolerated; see :func:`_make_partition_dataset`
-    for the arity-to-contents map. ``mt_aux`` is a 6-key dict (factor,
-    factor_mask, certainty, certainty_mask, topic, topic_mask) when the
-    multi-task path is active and ``None`` otherwise. ``log_rv`` is the
-    optional 1-D dual-head regression target tensor (#304); ``None``
-    on classification-only runs.
+    for the arity-to-contents map. ``mt_aux`` is a 4-key dict (factor,
+    factor_mask, certainty, certainty_mask) when the multi-task path is
+    active and ``None`` otherwise; the topic axis pair was retired in
+    ADR 0044. ``log_rv`` is the optional 1-D dual-head regression target
+    tensor (#304); ``None`` on classification-only runs.
     """
 
     arity = len(batch)
@@ -842,7 +842,7 @@ def _unpack_batch(
             and candidate.dim() == 1
             and candidate.dtype == torch.int64
             and int(candidate.size(0)) == batch_size_probe
-            and len(batch_list) - 1 in {2, 3, 4, 5, 8, 9, 10, 11}
+            and len(batch_list) - 1 in {2, 3, 4, 5, 6, 7, 8, 9}
         )
         if is_rates_index_candidate:
             # Value-range guard: rates_index is produced by torch.arange(N)
@@ -1311,8 +1311,8 @@ def _fit_axis_class_weights_from_mask(
     """Inverse-frequency class weights fit on masked rows of one axis (#273).
 
     Mirrors :func:`app.training.loaders.fit_class_weights` for the
-    multi-task path: each axis (stance, certainty, topic) computes its
-    own class weights using only the rows where the axis mask is True.
+    multi-task path: each axis (stance, certainty) computes its own
+    class weights using only the rows where the axis mask is True.
     Smoothing keeps an empty class from blowing the weight up; the
     weights are normalised so they sum to ``n_classes``.
 
@@ -1471,10 +1471,10 @@ def _maybe_add_dual_head_loss(
     """Augment an existing multi-task loss with the dual-head MSE.
 
     The multi-task path already pays the per-axis losses (stance CE +
-    factor SmoothL1 + certainty CE + topic CE) inside
-    :class:`MultiTaskLoss`; this helper preserves the full multi-task
-    objective and adds the dual-head log(RV) MSE on top so the four
-    axis classifiers keep learning under every head_mode.
+    factor SmoothL1 + certainty CE) inside :class:`MultiTaskLoss`; this
+    helper preserves the full multi-task objective and adds the dual-
+    head log(RV) MSE on top so the three axis branches keep learning
+    under every head_mode. (Topic was retired in ADR 0044.)
 
     Per-mode behaviour:
 
@@ -1487,9 +1487,9 @@ def _maybe_add_dual_head_loss(
       stance head's classification view is the secondary surface. The
       regression head is the primary learning signal here; the
       per-axis losses still contribute their (smaller) gradient so the
-      certainty / topic / factor heads continue to learn. The previous
+      certainty / factor branches continue to learn. The previous
       implementation discarded ``loss`` entirely, which silently
-      stopped the four axis classifiers under multi-task + regression.
+      stopped the three axis branches under multi-task + regression.
 
     ``logits_dict`` missing ``log_rv`` or ``batch_log_rv == None``
     short-circuits to ``loss`` to keep degenerate fixtures from
@@ -2834,7 +2834,7 @@ def train_model(
             print(
                 "[train_model] derived-text-features OFF: zeroed slices "
                 "[0], [10:25], [25:29], [29:35], [45:80] on x before "
-                "scaler fit; masked factor/certainty/topic on mt_aux",
+                "scaler fit; masked factor/certainty on mt_aux",
                 flush=True,
             )
         test_x = apply_rich_feature_scaler_tensor(test_x, rich_feature_scaler)

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -381,8 +381,6 @@ _MULTI_TASK_AUX_KEYS: tuple[str, ...] = (
     "factor_mask",
     "certainty",
     "certainty_mask",
-    "topic",
-    "topic_mask",
 )
 
 
@@ -870,33 +868,37 @@ def _unpack_batch(
     if arity == 5:
         batch_x, batch_y, batch_text, batch_text_missing, batch_log_rv = batch_list
         return batch_x, batch_y, batch_text, batch_text_missing, None, batch_log_rv, trailing_rates_index
-    if arity == 8:
+    # Multi-task aux tensors went from 6 (factor / factor_mask / certainty /
+    # certainty_mask / topic / topic_mask) to 4 in ADR 0044 after the
+    # topic axis was retired. The arity table reads against the current
+    # 4-tensor aux block; legacy 6-tensor batches are no longer produced.
+    if arity == 6:
         batch_x = batch_list[0]
         batch_y = batch_list[1]
         mt_aux = {key: batch_list[2 + idx] for idx, key in enumerate(_MULTI_TASK_AUX_KEYS)}
         return batch_x, batch_y, None, None, mt_aux, None, trailing_rates_index
-    if arity == 9:
+    if arity == 7:
         batch_x = batch_list[0]
         batch_y = batch_list[1]
         mt_aux = {key: batch_list[2 + idx] for idx, key in enumerate(_MULTI_TASK_AUX_KEYS)}
-        return batch_x, batch_y, None, None, mt_aux, batch_list[8], trailing_rates_index
-    if arity == 10:
+        return batch_x, batch_y, None, None, mt_aux, batch_list[6], trailing_rates_index
+    if arity == 8:
         batch_x = batch_list[0]
         batch_y = batch_list[1]
         batch_text = batch_list[2]
         batch_text_missing = batch_list[3]
         mt_aux = {key: batch_list[4 + idx] for idx, key in enumerate(_MULTI_TASK_AUX_KEYS)}
         return batch_x, batch_y, batch_text, batch_text_missing, mt_aux, None, trailing_rates_index
-    if arity == 11:
+    if arity == 9:
         batch_x = batch_list[0]
         batch_y = batch_list[1]
         batch_text = batch_list[2]
         batch_text_missing = batch_list[3]
         mt_aux = {key: batch_list[4 + idx] for idx, key in enumerate(_MULTI_TASK_AUX_KEYS)}
-        return batch_x, batch_y, batch_text, batch_text_missing, mt_aux, batch_list[10], trailing_rates_index
+        return batch_x, batch_y, batch_text, batch_text_missing, mt_aux, batch_list[8], trailing_rates_index
     raise ValueError(
         f"unexpected batch arity from DataLoader: {arity} "
-        "(want 2, 3, 4, 5, 8, 9, 10, or 11)"
+        "(want 2, 3, 4, 5, 6, 7, 8, or 9)"
     )
 
 
@@ -1623,7 +1625,7 @@ def _zero_derived_text_features(
             x[..., start:effective_stop] = 0.0
     if mt_aux is not None:
         new_aux = dict(mt_aux)
-        for axis in ("factor", "certainty", "topic"):
+        for axis in ("factor", "certainty"):
             mask_key = f"{axis}_mask"
             if mask_key in new_aux:
                 new_aux[mask_key] = torch.zeros_like(new_aux[mask_key])
@@ -1905,7 +1907,6 @@ def _evaluate_model(
         "stance": torch.zeros((), dtype=torch.float64, device=device),
         "factor": torch.zeros((), dtype=torch.float64, device=device),
         "certainty": torch.zeros((), dtype=torch.float64, device=device),
-        "topic": torch.zeros((), dtype=torch.float64, device=device),
     }
     # Weighted CE bookkeeping. When ``loss_fn`` is
     # ``CrossEntropyLoss(weight=w, reduction='mean')`` the per-batch
@@ -2048,20 +2049,18 @@ def _evaluate_model(
                     "stance": batch_y,
                     "factor": batch_mt_aux["factor"].to(device, non_blocking=non_blocking),
                     "certainty": batch_mt_aux["certainty"].to(device, non_blocking=non_blocking),
-                    "topic": batch_mt_aux["topic"].to(device, non_blocking=non_blocking),
                 }
                 mt_masks = {
                     "stance_mask": stance_mask,
                     "factor_mask": batch_mt_aux["factor_mask"].to(device, non_blocking=non_blocking),
                     "certainty_mask": batch_mt_aux["certainty_mask"].to(device, non_blocking=non_blocking),
-                    "topic_mask": batch_mt_aux["topic_mask"].to(device, non_blocking=non_blocking),
                 }
                 loss, axis_breakdown = multi_task_loss_fn(
                     logits_dict, mt_targets, mt_masks
                 )
                 predictions = logits_dict["stance"]
                 total_loss_sum += loss.detach().to(torch.float64) * batch_size
-                for axis_name in ("stance", "factor", "certainty", "topic"):
+                for axis_name in ("stance", "factor", "certainty"):
                     mt_axis_loss_sums[axis_name] += (
                         axis_breakdown[axis_name].detach().to(torch.float64) * batch_size
                     )
@@ -2183,7 +2182,7 @@ def _evaluate_model(
     if multi_task_active and total_items_int > 0:
         multi_task_axis_losses = {
             axis: float(mt_axis_loss_sums[axis].item()) / float(total_items_int)
-            for axis in ("stance", "factor", "certainty", "topic")
+            for axis in ("stance", "factor", "certainty")
         }
 
     if is_classification:
@@ -3338,17 +3337,13 @@ def train_model(
     # checkpoint contract on every pre-#273 caller stays byte-identical.
     multi_task_class_weights_payload: dict[str, Any] | None = None
     if multi_task_loss_active and _active_output_mode == "classification":
-        from app.models.config import (
-            MULTI_TASK_CERTAINTY_CLASSES,
-            MULTI_TASK_TOPIC_CLASSES,
-        )
+        from app.models.config import MULTI_TASK_CERTAINTY_CLASSES
         from app.training.loss import MultiTaskLoss
 
         # Per-axis class counts pinned in app.models.config; the head
         # uses these exact constants so the fitted class-weight tensors
         # match the logit shape.
         n_certainty_classes = int(MULTI_TASK_CERTAINTY_CLASSES)
-        n_topic_classes = int(MULTI_TASK_TOPIC_CLASSES)
         if train_mt_aux is None:
             raise RuntimeError(
                 "multi_task_loss_active=True but train_mt_aux is None; "
@@ -3359,19 +3354,12 @@ def train_model(
             train_mt_aux["certainty_mask"],
             n_certainty_classes,
         ).to(device_obj)
-        topic_weight = _fit_axis_class_weights_from_mask(
-            train_mt_aux["topic"],
-            train_mt_aux["topic_mask"],
-            n_topic_classes,
-        ).to(device_obj)
         multi_task_loss_fn = MultiTaskLoss(
             stance_weight=class_weight_tensor,  # vol-regime weights
             certainty_weight=certainty_weight,
-            topic_weight=topic_weight,
             lambda_stance=float(getattr(active_model_config, "multi_task_lambda_stance", 1.0)),
             lambda_factor=float(getattr(active_model_config, "multi_task_lambda_factor", 0.3)),
             lambda_certainty=float(getattr(active_model_config, "multi_task_lambda_certainty", 0.3)),
-            lambda_topic=float(getattr(active_model_config, "multi_task_lambda_topic", 0.3)),
         ).to(device_obj)
         # Stash the per-axis weights + lambdas on a plain dict so the
         # TrainingRunSummary -> torch.save round-trip carries them onto
@@ -3385,20 +3373,17 @@ def train_model(
                 else None
             ),
             "certainty": certainty_weight.detach().cpu().tolist(),
-            "topic": topic_weight.detach().cpu().tolist(),
             "lambdas": {
                 "stance": float(multi_task_loss_fn.lambda_stance),
                 "factor": float(multi_task_loss_fn.lambda_factor),
                 "certainty": float(multi_task_loss_fn.lambda_certainty),
-                "topic": float(multi_task_loss_fn.lambda_topic),
             },
         }
         print(
             "[train_model] multi_task_loss active: "
             f"lambda_stance={multi_task_loss_fn.lambda_stance} "
             f"lambda_factor={multi_task_loss_fn.lambda_factor} "
-            f"lambda_certainty={multi_task_loss_fn.lambda_certainty} "
-            f"lambda_topic={multi_task_loss_fn.lambda_topic}",
+            f"lambda_certainty={multi_task_loss_fn.lambda_certainty}",
             flush=True,
         )
 
@@ -3644,13 +3629,11 @@ def train_model(
                         "stance": batch_y,
                         "factor": batch_mt_aux["factor"],
                         "certainty": batch_mt_aux["certainty"],
-                        "topic": batch_mt_aux["topic"],
                     }
                     mt_masks = {
                         "stance_mask": stance_mask,
                         "factor_mask": batch_mt_aux["factor_mask"],
                         "certainty_mask": batch_mt_aux["certainty_mask"],
-                        "topic_mask": batch_mt_aux["topic_mask"],
                     }
                     loss, _ = multi_task_loss_fn(logits_dict, mt_targets, mt_masks)
                     loss = _maybe_add_dual_head_loss(

--- a/backend/app/training/loss.py
+++ b/backend/app/training/loss.py
@@ -1,31 +1,31 @@
-"""Multi-task loss for the four-branch classification head (#78).
+"""Multi-task loss for the three-branch classification head (#78).
 
-The four axes (stance, factor, certainty, topic) have very different
+The three axes (stance, factor, certainty) have very different
 label-coverage rates on the supervised corpus: stance ~100%, factor
 and certainty <5% (gtfintechlab cross-bank rows + the gss_factor
-source only), topic 0% upstream. The loss handles this with per-axis
-masks — a row only contributes loss on axes where its label was
-populated, so the optimiser never learns from a synthetic placeholder
-that would otherwise lock the head in on a meaningless mean.
+source only). The loss handles this with per-axis masks — a row only
+contributes loss on axes where its label was populated, so the
+optimiser never learns from a synthetic placeholder that would
+otherwise lock the head in on a meaningless mean. The topic axis was
+retired in ADR 0044 (no upstream source ships topic labels).
 
 The total loss is a lambda-weighted sum:
 
     L = lambda_stance * stance_loss
       + lambda_factor * factor_loss
       + lambda_certainty * certainty_loss
-      + lambda_topic * topic_loss
 
 Each per-axis term is the mean of the row-wise loss over rows where
 that axis's mask is True (0 when the mask is empty for that batch,
-which avoids div-by-zero). Lambdas default to (1.0, 0.3, 0.3, 0.3) so
+which avoids div-by-zero). Lambdas default to (1.0, 0.3, 0.3) so
 the headline stance F1 stays the dominant gradient signal; the
 sparser axes contribute auxiliary gradients without overpowering
 stance.
 
 Class weights are passed per axis. Stance reuses the per-fold
-``fit_class_weights`` output; certainty / topic class weights are
-fitted on the train slice independently using the same helper. The
-factor branch is a regression (SmoothL1, ``beta=0.02`` to mirror the
+``fit_class_weights`` output; certainty class weights are fitted on
+the train slice independently using the same helper. The factor
+branch is a regression (SmoothL1, ``beta=0.02`` to mirror the
 existing vol-regression loss) so it does not consume a class-weight
 tensor.
 """
@@ -41,9 +41,9 @@ class MultiTaskLoss(nn.Module):
     """Per-axis weighted + masked loss for the multi-task head.
 
     Reads logits and targets from dicts keyed by axis name and applies
-    the corresponding per-axis loss (CE for stance / certainty /
-    topic; SmoothL1 for factor). Class weights are optional per axis
-    — None gives uniform weighting on that axis.
+    the corresponding per-axis loss (CE for stance / certainty;
+    SmoothL1 for factor). Class weights are optional per axis — None
+    gives uniform weighting on that axis.
     """
 
     def __init__(  # noqa: PLR0913 — per-axis class weights + lambdas surface as named kwargs by design
@@ -51,11 +51,9 @@ class MultiTaskLoss(nn.Module):
         *,
         stance_weight: torch.Tensor | None = None,
         certainty_weight: torch.Tensor | None = None,
-        topic_weight: torch.Tensor | None = None,
         lambda_stance: float = 1.0,
         lambda_factor: float = 0.3,
         lambda_certainty: float = 0.3,
-        lambda_topic: float = 0.3,
         factor_smooth_l1_beta: float = 0.02,
     ) -> None:
         super().__init__()
@@ -67,14 +65,9 @@ class MultiTaskLoss(nn.Module):
             "_certainty_weight",
             certainty_weight if certainty_weight is not None else torch.empty(0),
         )
-        self.register_buffer(
-            "_topic_weight",
-            topic_weight if topic_weight is not None else torch.empty(0),
-        )
         self.lambda_stance = float(lambda_stance)
         self.lambda_factor = float(lambda_factor)
         self.lambda_certainty = float(lambda_certainty)
-        self.lambda_topic = float(lambda_topic)
         self.factor_smooth_l1_beta = float(factor_smooth_l1_beta)
 
     def _stance_weight_or_none(self) -> torch.Tensor | None:
@@ -83,10 +76,6 @@ class MultiTaskLoss(nn.Module):
 
     def _certainty_weight_or_none(self) -> torch.Tensor | None:
         buf = self.get_buffer("_certainty_weight")
-        return buf if buf.numel() > 0 else None
-
-    def _topic_weight_or_none(self) -> torch.Tensor | None:
-        buf = self.get_buffer("_topic_weight")
         return buf if buf.numel() > 0 else None
 
     def forward(
@@ -137,18 +126,11 @@ class MultiTaskLoss(nn.Module):
             masks["certainty_mask"],
             weight=self._certainty_weight_or_none(),
         )
-        topic_loss = self._masked_classification_loss(
-            logits["topic"],
-            targets["topic"],
-            masks["topic_mask"],
-            weight=self._topic_weight_or_none(),
-        )
 
         total = (
             self.lambda_stance * stance_loss
             + self.lambda_factor * factor_loss
             + self.lambda_certainty * certainty_loss
-            + self.lambda_topic * topic_loss
         )
         if not total.requires_grad and stance_loss.requires_grad:
             total = total + zero
@@ -156,7 +138,6 @@ class MultiTaskLoss(nn.Module):
             "stance": stance_loss.detach(),
             "factor": factor_loss.detach(),
             "certainty": certainty_loss.detach(),
-            "topic": topic_loss.detach(),
         }
 
     @staticmethod

--- a/docs/adr/0044-drop-axis-topic-no-upstream-source.md
+++ b/docs/adr/0044-drop-axis-topic-no-upstream-source.md
@@ -1,0 +1,57 @@
+# ADR 0044 — Drop the topic axis from the multi-axis surface (no upstream source ships topic labels)
+
+Status: accepted, in production (as of merge).
+Date: 2026-05-30.
+Supersedes parts of: ADR 0009 (multi-axis label schema), ADR 0010 (multi-task head replaces single classification head), ADR 0018 (multi-task null + factor-axis disposition).
+References:
+- Audit on the rebuilt training package `tp_v3_full_rebuild_2026_05_30` (2026-05-30): `axis_topic` populated on 0 / 7172 rows.
+- `MULTI_TASK_TOPIC_LABELS` consumer scan (2026-05-30): every populated `axis_topic` value historically traced back to the internal macro-release augmentation (`scripts/build_macro_augmented_registry.py`), which emitted `axis_topic = "economic_indicator"` → `macro` via `_TOPIC_ALIASES`.
+- `gtfintechlab/federal_reserve_system` schema audit (2026-05-30): per-row columns are `sentences, stance_label, time_label, certain_label, year` — no topic field. Every other gtfintechlab cross-bank corpus mirrors the same schema.
+
+## Context
+
+The multi-task head shipped under #78 (ADR 0010) carries four output branches: stance, factor, certainty, topic. The topic branch was sized for four classes (`macro`, `forward_guidance`, `market_reaction`, `other`) on the assumption that an upstream Fed-text corpus would ship topic-style labels we could mask-train against.
+
+That upstream never arrived. Every corpus we ingest — gtfintechlab/federal_reserve_system, the cross-bank ECB/BoJ/BoE/BoC/RBA siblings, Op-Fed, Swanson, GSS, vtasca, the Kaggle Fed statements/minutes mirror, the scraped federalreserve.gov archive — emits stance / certainty / factor labels but no topic taxonomy. The only path that ever populated `axis_topic` was an in-tree augmentation that synthesised macro-release event rows from CPI / NFP releases and emitted `axis_topic = "economic_indicator"` → `macro`. That augmentation only ever populated **one** of the four topic classes (the other three never saw a single labelled example), and the rebuild path in `docs/training-package-rebuild.md` no longer fires it (the macro_release event_kind is absent from the rebuilt TP).
+
+The audit on `tp_v3_full_rebuild_2026_05_30` reported 0 / 7172 rows populated on `axis_topic`. The trainer's masked loss therefore contributed exactly zero gradient on the topic branch on every batch of every fold; the inference card always rendered the same low-confidence fallback because the head was trained on zero positives.
+
+The earlier framing under ADR 0018 ("multi-task null + factor-axis disposition") already concluded the topic axis carried no information gain over stance — the present ADR follows that conclusion to its logical end: a head that trains on zero labels and predicts no signal is dead code in every meaningful sense.
+
+## Decision
+
+Remove the topic axis from the project's data + training + inference + presentation surface. Concretely:
+
+**Schema.** `axis_topic` Column dropped from `EventRowSchema` and `NormalizedDocSchema` in `backend/app/data/schemas.py`. The `axes` dict no longer carries a `topic` key (`_axes_dict_ok` validator updated). The `_axes_topic_ok` validator is removed entirely.
+
+**Data pipeline.** `event_dataset_builder.COLUMN_ORDER` no longer lists `axis_topic`. The row-emission dict no longer writes a `topic` column. `_EventDoc.multi_axis` no longer carries a `topic` key; the axis-name iteration loop drops `topic`. `normalize_labels._normalize_one_row` no longer extracts `topic_value` from `axis_topic` / `multi_axis_extras`.
+
+**Training surface.** `MULTI_TASK_TOPIC_CLASSES` and `MULTI_TASK_TOPIC_LABELS` removed from `app.models.config`. `multi_task_lambda_topic` field removed from `ModelConfig` (resume path drops the matching `getattr` lookup). `MultiTaskHead` no longer constructs the topic linear layer; `forward` returns a 3-key dict. `TextMultiAxisClassifier` no longer takes a `topic_classes` kwarg and no longer surfaces a `topic_classes` field on its `metadata()` payload. `MultiTaskLoss` no longer accepts `topic_weight` / `lambda_topic` and no longer computes `topic_loss`. `_topic_target` / `_TOPIC_ALIASES` removed from `train_text_multi_axis_classifier`. Per-axis loops over `("stance", "factor", "certainty", "topic")` collapse to `("stance", "factor", "certainty")`; per-axis class-weight + loss-breakdown dicts drop the `topic` key.
+
+**Aux block on the loader.** `_MULTI_TASK_AUX_KEYS` collapses from six tensors (factor / factor_mask / certainty / certainty_mask / topic / topic_mask) to four. The DataLoader arity dispatch in `_unpack_batch` retables from `{2, 3, 4, 5, 8, 9, 10, 11}` to `{2, 3, 4, 5, 6, 7, 8, 9}`; the unsupported-arity test re-pins against arity 10 so the negative-path coverage stays.
+
+**Loaders.** `target_topic_idx` and `target_topic_present` fields removed from `FeatureVector`. `_attach_rich_features` no longer parses `axis_topic` and no longer writes the topic targets. `_build_multi_task_target_tensors` no longer accumulates `topic_targets` / `topic_masks` and the returned dict drops the `topic` / `topic_mask` keys.
+
+**Inference.** `app.services.multi_axis_classifier.score_text` no longer computes `topic_probs` and no longer emits a topic card. `app.main._build_multi_axis_block` drops the `"topic": None` fallback dict entry. `MultiAxisAnalysisCard.topic` and `MultiAxisTopicCard` removed from `app.schemas`.
+
+**Retrieval.** `SHARED_AXIS_COLUMNS` on `app.retrieval.train` collapses from `("axis_stance", "axis_factor", "axis_topic")` to `("axis_stance", "axis_factor")`.
+
+**Frontend.** `MultiAxisTopic` interface, `TopicAxis` type, and the `MultiAxisResponse.topic` field removed from `frontend/lib/analyze/types.ts`. `TopicCard` / `TopicTile` components and their conditional render guards removed from `MultiAxisCards.tsx` and `MultiAxisInterpretation.tsx`. The 4-column grid on `MultiAxisCards` collapses to 3 columns. `multiAxisSummary` no longer surfaces a topic clause. PDF and CSV export rows lose their `multi_axis.topic.primary` entries. `MultiAxisDelta.topicChanged` and the `topicA / topicB` comparator branch removed from `frontend/lib/analyze/compare.ts`.
+
+**Tests.** 26 test fixtures across `tests/unit/` and `tests/regression/` updated: `"axis_topic": …` dict entries dropped, `target_topic_idx` / `target_topic_present` removed from `FeatureVector` constructors, `MULTI_TASK_TOPIC_*` imports removed, axis loops trimmed. The arity tests rebaseline on the new (6, 8) shapes.
+
+## Why this is recorded
+
+Removing a multi-task branch is the kind of change that the next reviewer (or future-me) will second-guess unless the audit trail is one click away. The audit numbers are the load-bearing fact: 0 / 7172 rows populated on the rebuilt TP, no upstream corpus shipping topic labels, the only synthetic path collapsing to a single class out of four. The earlier ADR 0018 framing flagged the same gap; this ADR closes it by removing the dead branch rather than carrying it for the rest of the project's lifetime.
+
+The decision is reversible if a future corpus does ship topic labels — the changes are localised and the git history retains the prior shapes. The cost of adding the branch back is bounded; the cost of carrying a dead branch indefinitely is unbounded and silently grows.
+
+## Consequences
+
+- The multi-task head is a 3-branch surface instead of 4. The per-axis loss is `lambda_stance * stance_loss + lambda_factor * factor_loss + lambda_certainty * certainty_loss`; no `lambda_topic` term, no `topic_weight` class weights, no fitted weights persisted on checkpoint payload's `multi_task_class_weights.topic` key.
+- Existing checkpoints that carry a topic head will fail strict state-dict load against the new module. This is acceptable: every active checkpoint we care about (canonical, B2, retrieval) is rebuildable from the source corpora, and the rebuild ride after this PR uses the new module shape.
+- The API response shape changes (`MultiAxisAnalysisCard.topic` removed). Frontend ships the corresponding change in the same PR, so the live deploy is consistent. Any external client that depended on the topic card now sees no field at all.
+- The deferred work in ADR 0021 (retrieval supervision rebuild on shared-axis pairs) loses `axis_topic` as a pair-policy axis. Shared-axis pairs now match on stance OR factor only. The recall@k probe set is small enough that the change is one config-file edit; no encoder retrain required to pick up the policy change.
+- ADR 0018 ("multi-task null + factor-axis disposition") is partially superseded: the topic-axis specific items are closed by this ADR. The factor-axis disposition (`MultiAxisFactorCard | None` gated on coverage) remains the live contract for factor.
+- ADR 0009 ("multi-axis label schema") becomes historically narrower: the four-axis schema it described is now three-axis. A short addendum on ADR 0009 captures this without rewriting the original framing.
+- The `_drop_axis_topic_no_upstream_source` branch in `quality_validation` does not need a special-case: any old events.parquet on disk that carries an `axis_topic` column will simply load with an unknown column (pandera permissive) or fail validation (pandera strict) — both are acceptable; the resolution is to rebuild from source.

--- a/frontend/components/analyze/MultiAxisCards.tsx
+++ b/frontend/components/analyze/MultiAxisCards.tsx
@@ -120,38 +120,8 @@ function CertaintyCard({ certainty }: { certainty: NonNullable<MultiAxisResponse
   );
 }
 
-function TopicCard({ topic }: { topic: NonNullable<MultiAxisResponse["topic"]> }) {
-  const display = (topic.label ?? topic.primary ?? "other").toString();
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <CardDescription>Topic</CardDescription>
-        <CardTitle className="text-xl capitalize">
-          {display.replace(/_/g, " ")}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-2">
-        <div className="flex items-center justify-between text-xs text-muted-foreground">
-          <span>Confidence in main topic</span>
-          <span className="font-medium text-foreground">{topic.confidence.toFixed(2)}</span>
-        </div>
-        <Progress value={topic.confidence} />
-        {topic.secondary?.length ? (
-          <div className="flex flex-wrap gap-1.5 pt-1">
-            {topic.secondary.map((t) => (
-              <Badge key={t} variant="outline" className="capitalize">
-                {t.replace(/_/g, " ")}
-              </Badge>
-            ))}
-          </div>
-        ) : null}
-      </CardContent>
-    </Card>
-  );
-}
-
 export function MultiAxisCards({ multiAxis, previewMode }: MultiAxisCardsProps) {
-  if (!multiAxis.stance && !multiAxis.factor && !multiAxis.certainty && !multiAxis.topic) {
+  if (!multiAxis.stance && !multiAxis.factor && !multiAxis.certainty) {
     return null;
   }
   return (
@@ -161,11 +131,10 @@ export function MultiAxisCards({ multiAxis, previewMode }: MultiAxisCardsProps) 
           Sentiment breakdown preview · sample data
         </Badge>
       ) : null}
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         {multiAxis.stance ? <StanceCard stance={multiAxis.stance} /> : null}
         {multiAxis.factor ? <FactorCard factor={multiAxis.factor} /> : null}
         {multiAxis.certainty ? <CertaintyCard certainty={multiAxis.certainty} /> : null}
-        {multiAxis.topic ? <TopicCard topic={multiAxis.topic} /> : null}
       </div>
     </div>
   );

--- a/frontend/components/analyze/MultiAxisInterpretation.tsx
+++ b/frontend/components/analyze/MultiAxisInterpretation.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Compass, Gauge, Layers, Target } from "lucide-react";
+import { Compass, Gauge, Target } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { KpiTile } from "@/components/ui/kpi-tile";
@@ -96,26 +96,6 @@ function CertaintyTile({
   );
 }
 
-function TopicTile({ topic }: { topic: NonNullable<MultiAxisResponse["topic"]> }) {
-  const display = (topic.label ?? topic.primary ?? "other").toString();
-  return (
-    <KpiTile
-      label="Topic"
-      icon={<Layers className="h-3.5 w-3.5" />}
-      value={
-        <span className="capitalize">{display.replace(/_/g, " ")}</span>
-      }
-      delta={topic.confidence}
-      deltaFormatter={(v) => v.toFixed(2)}
-      caption={
-        topic.secondary?.length
-          ? `also: ${topic.secondary.map((t) => t.replace(/_/g, " ")).join(", ")}`
-          : "main topic"
-      }
-    />
-  );
-}
-
 export function MultiAxisInterpretation({
   multiAxis,
   history,
@@ -124,7 +104,7 @@ export function MultiAxisInterpretation({
   const factorHistory = history?.factor;
   const certaintyHistory = history?.certainty;
   const allAxesNull =
-    !multiAxis.stance && !multiAxis.factor && !multiAxis.certainty && !multiAxis.topic;
+    !multiAxis.stance && !multiAxis.factor && !multiAxis.certainty;
 
   if (allAxesNull) {
     return (
@@ -136,7 +116,7 @@ export function MultiAxisInterpretation({
           The sentiment model ran but produced no labels for any axis. This usually means
           the active model file is missing, or the passage is too short for the model to
           read. Load a sentiment model, or paste a longer FOMC statement to populate stance,
-          factor, certainty, and topic.
+          factor, and certainty.
         </p>
       </div>
     );
@@ -161,7 +141,6 @@ export function MultiAxisInterpretation({
         {multiAxis.certainty ? (
           <CertaintyTile certainty={multiAxis.certainty} history={certaintyHistory} />
         ) : null}
-        {multiAxis.topic ? <TopicTile topic={multiAxis.topic} /> : null}
       </div>
     </div>
   );

--- a/frontend/components/analyze/PipelineTrace.tsx
+++ b/frontend/components/analyze/PipelineTrace.tsx
@@ -106,10 +106,6 @@ function multiAxisSummary(multiAxis: MultiAxisResponse): string {
   if (multiAxis.stance) parts.push(`stance ${multiAxis.stance.label}`);
   if (multiAxis.factor) parts.push(`factor ${multiAxis.factor.value.toFixed(2)}`);
   if (multiAxis.certainty) parts.push(`certainty ${multiAxis.certainty.label}`);
-  if (multiAxis.topic)
-    parts.push(
-      `topic ${(multiAxis.topic.label ?? multiAxis.topic.primary ?? "—").toString()}`,
-    );
   return parts.join(" · ") || "no sentiment labels";
 }
 
@@ -219,7 +215,7 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
     key: "multi-axis",
     title: "Sentiment breakdown",
     blurb:
-      "Four predictions from the same shared model — stance, hawkish / dovish score, certainty, and topic — calibrated against the labelled FOMC corpus.",
+      "Three predictions from the same shared model — stance, hawkish / dovish score, and certainty — calibrated against the labelled FOMC corpus.",
     icon: <Workflow className="h-3.5 w-3.5" />,
     state: multiAxis ? "ok" : "absent",
     summary: multiAxis ? multiAxisSummary(multiAxis) : "Sentiment model not loaded",
@@ -248,15 +244,6 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
               {multiAxis.certainty ? `· ${multiAxis.certainty.confidence.toFixed(2)}` : ""}
             </span>
           </li>
-          <li className="flex items-center justify-between">
-            <span className="text-muted-foreground">topic</span>
-            <span className="numeric capitalize">
-              {(multiAxis.topic?.label ?? multiAxis.topic?.primary ?? "—")
-                .toString()
-                .replace(/_/g, " ")}{" "}
-              {multiAxis.topic ? `· ${multiAxis.topic.confidence.toFixed(2)}` : ""}
-            </span>
-          </li>
         </ul>
         <div className="grid gap-2 sm:grid-cols-2">
           {multiAxis.stance ? (
@@ -281,9 +268,6 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
           ) : null}
           {multiAxis.certainty ? (
             <MiniBar label="certainty confidence" value={multiAxis.certainty.confidence} />
-          ) : null}
-          {multiAxis.topic ? (
-            <MiniBar label="topic confidence" value={multiAxis.topic.confidence} />
           ) : null}
         </div>
       </div>

--- a/frontend/lib/analyze/compare.ts
+++ b/frontend/lib/analyze/compare.ts
@@ -39,7 +39,6 @@ export interface MultiAxisDelta {
     | "more_tentative"
     | "unchanged"
     | "unknown";
-  topicChanged: boolean | null;
 }
 
 function asResult(detail: HistoryDetail): AnalyzeResult {
@@ -199,11 +198,6 @@ export function computeMultiAxisDelta(
       ? ma.certainty.confidence - mb.certainty.confidence
       : null;
 
-  const topicA = ma?.topic?.label ?? ma?.topic?.primary ?? null;
-  const topicB = mb?.topic?.label ?? mb?.topic?.primary ?? null;
-  const topicChanged =
-    topicA != null && topicB != null ? topicA !== topicB : null;
-
   return {
     stanceRankDelta,
     stanceConfidenceDelta,
@@ -211,7 +205,6 @@ export function computeMultiAxisDelta(
     factorConfidenceDelta,
     certaintyConfidenceDelta,
     certaintyShift,
-    topicChanged,
   };
 }
 

--- a/frontend/lib/analyze/fixtures.ts
+++ b/frontend/lib/analyze/fixtures.ts
@@ -20,13 +20,6 @@ export const SAMPLE_MULTI_AXIS: MultiAxisResponse = {
     confidence: 0.68,
     distribution: { certain: 0.68, uncertain: 0.18, neutral: 0.14 },
   },
-  topic: {
-    label: "macro",
-    primary: "macro",
-    confidence: 0.58,
-    secondary: ["forward_guidance", "market_reaction"],
-    distribution: { macro: 0.58, forward_guidance: 0.27, market_reaction: 0.1, other: 0.05 },
-  },
 };
 
 export const SAMPLE_XAI: XaiResponse = {

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -141,7 +141,6 @@ export interface ClassificationBreakdownResponse {
 
 export type StanceAxis = "hawkish" | "dovish" | "neutral";
 export type CertaintyAxis = "certain" | "uncertain" | "neutral";
-export type TopicAxis = "macro" | "forward_guidance" | "market_reaction" | "other";
 
 export interface MultiAxisStance {
   label: StanceAxis;
@@ -161,22 +160,10 @@ export interface MultiAxisCertainty {
   distribution?: Partial<Record<CertaintyAxis, number>>;
 }
 
-export interface MultiAxisTopic {
-  label: TopicAxis | string;
-  confidence: number;
-  distribution?: Partial<Record<string, number>>;
-  // Back-compat aliases that older fixtures use. ``primary`` mirrors
-  // ``label`` and ``secondary`` lists alternate topics the model
-  // considered. New code should prefer ``label`` + ``distribution``.
-  primary?: string;
-  secondary?: string[];
-}
-
 export interface MultiAxisResponse {
   stance: MultiAxisStance | null;
   factor: MultiAxisFactor | null;
   certainty: MultiAxisCertainty | null;
-  topic: MultiAxisTopic | null;
 }
 
 export interface XaiTokenAttribution {

--- a/frontend/lib/export/compare-export.ts
+++ b/frontend/lib/export/compare-export.ts
@@ -124,12 +124,6 @@ export function buildCompareRows(a: HistoryDetail, b: HistoryDetail): CsvRow[] {
     rb.multi_axis?.certainty?.confidence ?? null,
     maxis.certaintyConfidenceDelta,
   ));
-  rows.push(_row(
-    "multi_axis.topic.primary",
-    ra.multi_axis?.topic?.primary ?? null,
-    rb.multi_axis?.topic?.primary ?? null,
-    maxis.topicChanged == null ? "" : maxis.topicChanged ? "changed" : "unchanged",
-  ));
   return rows;
 }
 

--- a/frontend/lib/export/pdf.tsx
+++ b/frontend/lib/export/pdf.tsx
@@ -2,7 +2,7 @@
 //
 // Layout is intentionally text-only: title bar (date, symbol, horizon,
 // forecast mode), a multi-axis card grid (stance / factor / certainty /
-// topic), a forecast metrics block, and a model + series metadata footer.
+// certainty), a forecast metrics block, and a model + series metadata footer.
 // The forecast chart embed lives in the deferred bucket — @react-pdf does
 // not consume Recharts elements directly, and the cleanest path (snapshot
 // the DOM SVG via XMLSerializer and feed it back through <Svg>) collides
@@ -107,7 +107,6 @@ function MultiAxisCardGrid({ detail }: { detail: HistoryDetail }) {
   const stance = result.multi_axis?.stance;
   const factor = result.multi_axis?.factor;
   const certainty = result.multi_axis?.certainty;
-  const topic = result.multi_axis?.topic;
 
   return (
     <View style={styles.cardGrid}>
@@ -130,13 +129,6 @@ function MultiAxisCardGrid({ detail }: { detail: HistoryDetail }) {
         <Text style={styles.cardValue}>{certainty?.label ?? "—"}</Text>
         <Text style={styles.cardSubvalue}>
           confidence {fmtNumber(certainty?.confidence, 3)}
-        </Text>
-      </View>
-      <View style={styles.card}>
-        <Text style={styles.cardLabel}>Primary topic</Text>
-        <Text style={styles.cardValue}>{topic?.primary ?? "—"}</Text>
-        <Text style={styles.cardSubvalue}>
-          confidence {fmtNumber(topic?.confidence, 3)}
         </Text>
       </View>
     </View>
@@ -292,12 +284,6 @@ function CompareDocument({ a, b }: { a: HistoryDetail; b: HistoryDetail }) {
       fmtNumber(ra.multi_axis?.certainty?.confidence, 3),
       fmtNumber(rb.multi_axis?.certainty?.confidence, 3),
       fmtSigned(maxis.certaintyConfidenceDelta, 3),
-    ],
-    [
-      "topic.primary",
-      ra.multi_axis?.topic?.primary ?? "—",
-      rb.multi_axis?.topic?.primary ?? "—",
-      maxis.topicChanged == null ? "—" : maxis.topicChanged ? "changed" : "unchanged",
     ],
     [
       "regime.argmax",

--- a/frontend/lib/export/run-export.ts
+++ b/frontend/lib/export/run-export.ts
@@ -23,7 +23,6 @@ export function buildRunSummaryRows(detail: HistoryDetail): CsvRow[] {
   const stance = result.multi_axis?.stance;
   const factor = result.multi_axis?.factor;
   const certainty = result.multi_axis?.certainty;
-  const topic = result.multi_axis?.topic;
   const credibility = result.credibility;
   const regime = result.regime_classification;
 
@@ -58,8 +57,6 @@ export function buildRunSummaryRows(detail: HistoryDetail): CsvRow[] {
     ["multi_axis.factor.confidence", factor?.confidence ?? null],
     ["multi_axis.certainty.label", certainty?.label ?? null],
     ["multi_axis.certainty.confidence", certainty?.confidence ?? null],
-    ["multi_axis.topic.primary", topic?.label ?? topic?.primary ?? null],
-    ["multi_axis.topic.confidence", topic?.confidence ?? null],
     ["credibility.drift_score", credibility?.drift_score ?? null],
     ["credibility.realized_vs_stated_gap", credibility?.realized_vs_stated_gap ?? null],
     ["credibility.market_implied_gap", credibility?.market_implied_gap ?? null],

--- a/frontend/pages/compare.tsx
+++ b/frontend/pages/compare.tsx
@@ -159,8 +159,7 @@ function MultiAxisDeltaCard({ delta }: { delta: MultiAxisDelta }) {
   const hasSignal =
     delta.stanceRankDelta != null ||
     delta.factorDelta != null ||
-    delta.certaintyShift !== "unknown" ||
-    delta.topicChanged != null;
+    delta.certaintyShift !== "unknown";
   if (!hasSignal) return null;
   const stanceDir =
     delta.stanceRankDelta == null
@@ -228,16 +227,6 @@ function MultiAxisDeltaCard({ delta }: { delta: MultiAxisDelta }) {
                 {delta.certaintyConfidenceDelta != null
                   ? `${delta.certaintyConfidenceDelta >= 0 ? "+" : ""}${delta.certaintyConfidenceDelta.toFixed(2)}`
                   : "—"}
-              </td>
-            </tr>
-            <tr>
-              <td className="px-4 py-2 font-mono">topic</td>
-              <td className="px-4 py-2 text-right text-xs text-muted-foreground" colSpan={2}>
-                {delta.topicChanged == null
-                  ? "—"
-                  : delta.topicChanged
-                  ? "main topic changed"
-                  : "main topic unchanged"}
               </td>
             </tr>
           </tbody>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -507,7 +507,7 @@ export default function WorkspacePage() {
                   <EmptyState
                     variant="inline"
                     title="Sentiment breakdown unavailable."
-                    description="Load a sentiment model from the Settings page to populate stance, factor, certainty, and topic."
+                    description="Load a sentiment model from the Settings page to populate stance, factor, and certainty."
                   />
                 )}
                 {result.credibility ? (

--- a/frontend/tests/components/analyze/EmptyStateReasons.test.tsx
+++ b/frontend/tests/components/analyze/EmptyStateReasons.test.tsx
@@ -10,10 +10,10 @@ function render(ui: React.ReactElement) {
 }
 
 describe("Inline 'awaiting checkpoint' reasons", () => {
-  it("MultiAxisInterpretation explains why no axes are present when all four are null", () => {
+  it("MultiAxisInterpretation explains why no axes are present when all three are null", () => {
     render(
       <MultiAxisInterpretation
-        multiAxis={{ stance: null, factor: null, certainty: null, topic: null }}
+        multiAxis={{ stance: null, factor: null, certainty: null }}
       />,
     );
     expect(
@@ -29,7 +29,6 @@ describe("Inline 'awaiting checkpoint' reasons", () => {
           stance: { label: "hawkish", confidence: 0.7 },
           factor: null,
           certainty: null,
-          topic: null,
         }}
       />,
     );

--- a/frontend/tests/components/analyze/MultiAxisCards.test.tsx
+++ b/frontend/tests/components/analyze/MultiAxisCards.test.tsx
@@ -4,17 +4,16 @@ import { render, screen } from "@testing-library/react";
 import { MultiAxisCards } from "@/components/analyze/MultiAxisCards";
 import { SAMPLE_MULTI_AXIS } from "@/lib/analyze/fixtures";
 
-const EMPTY_AXIS = { stance: null, factor: null, certainty: null, topic: null };
+const EMPTY_AXIS = { stance: null, factor: null, certainty: null };
 
 describe("MultiAxisCards", () => {
-  it("renders four cards from the canonical fixture", () => {
+  it("renders three cards from the canonical fixture (topic retired in ADR 0044)", () => {
     render(<MultiAxisCards multiAxis={SAMPLE_MULTI_AXIS} />);
     expect(screen.getAllByText(/^stance$/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/^factor$/i)).toBeInTheDocument();
     expect(screen.getByText(/^certainty$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^topic$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^topic$/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/hawkish/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/^macro$/i)).toBeInTheDocument();
   });
 
   it("returns null when every axis is null", () => {
@@ -22,20 +21,18 @@ describe("MultiAxisCards", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("hides factor / certainty / topic when only stance is available", () => {
+  it("hides factor / certainty when only stance is available", () => {
     render(
       <MultiAxisCards
         multiAxis={{
           stance: SAMPLE_MULTI_AXIS.stance,
           factor: null,
           certainty: null,
-          topic: null,
         }}
       />,
     );
     expect(screen.queryByText(/^factor$/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/^certainty$/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/^topic$/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/^stance$/i).length).toBeGreaterThan(0);
   });
 });

--- a/frontend/tests/lib/analyze/compare.test.ts
+++ b/frontend/tests/lib/analyze/compare.test.ts
@@ -18,7 +18,6 @@ function makeMultiAxisDelta(overrides: Partial<MultiAxisDelta> = {}): MultiAxisD
     factorConfidenceDelta: null,
     certaintyConfidenceDelta: null,
     certaintyShift: "unknown",
-    topicChanged: null,
     ...overrides,
   };
 }
@@ -154,7 +153,6 @@ describe("computeMultiAxisDelta", () => {
           stance: { label: "hawkish", confidence: 0.9 },
           factor: { value: 0.4, confidence: 0.2 },
           certainty: { label: "decisive", confidence: 0.7 },
-          topic: { primary: "inflation", confidence: 0.6 },
         },
       },
     });
@@ -164,7 +162,6 @@ describe("computeMultiAxisDelta", () => {
           stance: { label: "dovish", confidence: 0.8 },
           factor: { value: -0.1, confidence: 0.25 },
           certainty: { label: "tentative", confidence: 0.55 },
-          topic: { primary: "growth", confidence: 0.5 },
         },
       },
     });
@@ -175,7 +172,6 @@ describe("computeMultiAxisDelta", () => {
     expect(d.factorConfidenceDelta).toBeCloseTo(-0.05, 5);
     expect(d.certaintyShift).toBe("more_decisive");
     expect(d.certaintyConfidenceDelta).toBeCloseTo(0.15, 5);
-    expect(d.topicChanged).toBe(true);
   });
 
   it("returns nulls when the axis is missing on either side", () => {
@@ -189,7 +185,6 @@ describe("computeMultiAxisDelta", () => {
     expect(d.stanceRankDelta).toBe(null);
     expect(d.factorDelta).toBe(null);
     expect(d.certaintyShift).toBe("unknown");
-    expect(d.topicChanged).toBe(null);
   });
 });
 

--- a/frontend/tests/lib/export/compare-export.test.ts
+++ b/frontend/tests/lib/export/compare-export.test.ts
@@ -33,7 +33,6 @@ describe("buildCompareRows", () => {
           stance: { label: "hawkish", confidence: 0.9 },
           factor: { value: 0.4, confidence: 0.2 },
           certainty: { label: "decisive", confidence: 0.75 },
-          topic: { primary: "inflation", confidence: 0.6 },
         },
         regime_classification: {
           argmax_class: "high",
@@ -60,7 +59,6 @@ describe("buildCompareRows", () => {
           stance: { label: "dovish", confidence: 0.8 },
           factor: { value: -0.1, confidence: 0.25 },
           certainty: { label: "tentative", confidence: 0.55 },
-          topic: { primary: "growth", confidence: 0.62 },
         },
         regime_classification: {
           argmax_class: "normal",
@@ -90,7 +88,6 @@ describe("buildCompareRows", () => {
     expect(asObject["regime.set"]?.[1]).toBe("calm|normal");
     expect(asObject["credibility.drift_score"]?.[2] as number).toBeCloseTo(0.14, 5);
     expect(asObject["multi_axis.stance.label"]).toEqual(["hawkish", "dovish", 2]);
-    expect(asObject["multi_axis.topic.primary"]?.[2]).toBe("changed");
     expect(asObject["stance.shift"]?.[2]).toBe("more_hawkish");
   });
 

--- a/frontend/tests/lib/export/pdf.test.ts
+++ b/frontend/tests/lib/export/pdf.test.ts
@@ -45,7 +45,6 @@ function makeDetail(overrides: Partial<HistoryDetail> = {}): HistoryDetail {
         stance: { label: "hawkish", confidence: 0.91 },
         factor: { value: 0.42, confidence: 0.18 },
         certainty: { label: "decisive", confidence: 0.74 },
-        topic: { primary: "inflation", confidence: 0.66 },
       },
       series: {
         forecast_band_source: "conformal",
@@ -95,7 +94,6 @@ describe("compare PDF export", () => {
           stance: { label: "dovish", confidence: 0.83 },
           factor: { value: -0.31, confidence: 0.22 },
           certainty: { label: "measured", confidence: 0.61 },
-          topic: { primary: "employment", confidence: 0.55 },
         },
       } as HistoryDetail["payload"],
     });

--- a/frontend/tests/lib/export/run-export.test.ts
+++ b/frontend/tests/lib/export/run-export.test.ts
@@ -34,7 +34,6 @@ function makeDetail(): HistoryDetail {
         stance: { label: "hawkish", confidence: 0.91 },
         factor: { value: 0.42, confidence: 0.18 },
         certainty: { label: "decisive", confidence: 0.74 },
-        topic: { primary: "inflation", confidence: 0.66 },
       },
       credibility: {
         drift_score: 0.21,

--- a/tests/regression/test_feature_provenance_as_of.py
+++ b/tests/regression/test_feature_provenance_as_of.py
@@ -223,7 +223,6 @@ def _event_row(
         "axis_time": None,
         "axis_certainty": None,
         "axis_factor": None,
-        "axis_topic": None,
         "axis_time_label": None,
         "axis_certain_label": None,
         "credibility_drift_score": 0.0,
@@ -355,8 +354,6 @@ def _audit_inventory_covers_every_field() -> set[str]:
         "target_factor_present",
         "target_certainty_idx",
         "target_certainty_present",
-        "target_topic_idx",
-        "target_topic_present",
     }
     declared = (
         set(_TRAINING_DELTA_COLUMNS)

--- a/tests/unit/test_analyze_response_multi_axis_block.py
+++ b/tests/unit/test_analyze_response_multi_axis_block.py
@@ -5,7 +5,7 @@ Two paths the builder routes between:
 - ``TextMultiAxisClassifier`` checkpoint present → all four cards
   populated from the classifier service.
 - No checkpoint → stance card sourced from the existing sentiment
-  classifier output; factor / certainty / topic stay None.
+  classifier output; factor / certainty stay None (topic retired in ADR 0044).
 
 The frontend renders None cards as absent (no placeholder), so the
 contract is "stance always present; the others fill when the
@@ -43,12 +43,12 @@ def test_multi_axis_block_falls_back_to_sentiment_when_classifier_absent(
     assert abs(distribution["hawkish"] - 0.82) < 1e-6
     assert block["factor"] is None
     assert block["certainty"] is None
-    assert block["topic"] is None
+    assert "topic" not in block
 
 
 def test_multi_axis_block_uses_classifier_when_checkpoint_loaded(monkeypatch) -> None:
     """When the classifier returns a populated block, the /analyze
-    response surfaces it verbatim (all four cards with real values)."""
+    response surfaces it verbatim (all three cards with real values)."""
 
     from app.main import _build_multi_axis_block
     from app.services import multi_axis_classifier as svc
@@ -64,16 +64,6 @@ def test_multi_axis_block_uses_classifier_when_checkpoint_loaded(monkeypatch) ->
             "label": "uncertain",
             "confidence": 0.65,
             "distribution": {"certain": 0.18, "uncertain": 0.65, "neutral": 0.17},
-        },
-        "topic": {
-            "label": "forward_guidance",
-            "confidence": 0.58,
-            "distribution": {
-                "macro": 0.20,
-                "forward_guidance": 0.58,
-                "market_reaction": 0.12,
-                "other": 0.10,
-            },
         },
     }
     monkeypatch.setattr(svc, "score_text", lambda _text: classifier_block)

--- a/tests/unit/test_config_default_head_mode.py
+++ b/tests/unit/test_config_default_head_mode.py
@@ -69,7 +69,6 @@ class _StubModelWithHeadMode:
     multi_task_lambda_stance = 1.0
     multi_task_lambda_factor = 0.3
     multi_task_lambda_certainty = 0.3
-    multi_task_lambda_topic = 0.3
     class_weight_power = 1.0
 
     # Dual-head joint-loss alpha (#304).

--- a/tests/unit/test_cross_asset_response.py
+++ b/tests/unit/test_cross_asset_response.py
@@ -101,7 +101,6 @@ def _make_events_df(
                         "axis_time": "neutral",
                         "axis_certainty": "neutral",
                         "axis_factor": "neutral",
-                        "axis_topic": "neutral",
                         "credibility_drift_score": 0.0,
                         "credibility_realized_vs_stated_gap": 0.0,
                         "credibility_market_implied_gap": 0.0,

--- a/tests/unit/test_derived_features_toggle.py
+++ b/tests/unit/test_derived_features_toggle.py
@@ -2,8 +2,8 @@
 
 The forecaster head currently reads two text paths in parallel:
 (a) the encoder-pooled embedding, and (b) lossy per-bar derived
-features (``sentiment_score``, multi-axis stance / certainty /
-topic). The #309 ablation toggles path (b) off so the three-way
+features (``sentiment_score``, multi-axis stance / certainty).
+The #309 ablation toggles path (b) off so the three-way
 comparison (baseline / ablation / replacement) can quantify whether
 the derived features carry forecaster-relevant signal over the
 document-level encoder path.
@@ -133,7 +133,7 @@ def test_zero_derived_text_features_legacy_6dim_skips_multi_axis() -> None:
 
 
 def test_zero_derived_text_features_masks_multi_task_aux() -> None:
-    """The factor / certainty / topic masks must all collapse to False."""
+    """The factor / certainty masks must all collapse to False (topic retired)."""
 
     n = 4
     aux = {
@@ -141,14 +141,11 @@ def test_zero_derived_text_features_masks_multi_task_aux() -> None:
         "factor_mask": torch.ones(n, dtype=torch.bool),
         "certainty": torch.zeros(n, dtype=torch.long),
         "certainty_mask": torch.ones(n, dtype=torch.bool),
-        "topic": torch.zeros(n, dtype=torch.long),
-        "topic_mask": torch.ones(n, dtype=torch.bool),
     }
     _x, new_aux = _zero_derived_text_features(None, aux)
     assert new_aux is not None
     assert not new_aux["factor_mask"].any()
     assert not new_aux["certainty_mask"].any()
-    assert not new_aux["topic_mask"].any()
     # Target tensors are NOT touched -- only the masks drop to False.
     assert torch.equal(new_aux["factor"], aux["factor"])
 

--- a/tests/unit/test_dual_head_loss.py
+++ b/tests/unit/test_dual_head_loss.py
@@ -96,22 +96,23 @@ def test_unknown_head_mode_raises() -> None:
 
 
 def test_forward_multi_task_emits_log_rv_branch_on_dual_head() -> None:
-    """The log_rv branch must appear alongside the 4 classification axes."""
+    """The log_rv branch must appear alongside the 3 classification axes
+    (topic was retired in ADR 0044)."""
 
     model = _build_model("dual")
     x = torch.zeros((4, 20, model.input_size))
     out = model.forward_multi_task(x)
-    assert set(out.keys()) == {"stance", "factor", "certainty", "topic", "log_rv"}
+    assert set(out.keys()) == {"stance", "factor", "certainty", "log_rv"}
     assert out["log_rv"].shape == (4,)
 
 
 def test_forward_multi_task_omits_log_rv_on_classification_only() -> None:
-    """Default head_mode must keep the existing 4-axis dict shape."""
+    """Default head_mode must keep the existing 3-axis dict shape."""
 
     model = _build_model("classification")
     x = torch.zeros((4, 20, model.input_size))
     out = model.forward_multi_task(x)
-    assert set(out.keys()) == {"stance", "factor", "certainty", "topic"}
+    assert set(out.keys()) == {"stance", "factor", "certainty"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_evaluate_model_multi_task_path.py
+++ b/tests/unit/test_evaluate_model_multi_task_path.py
@@ -3,7 +3,7 @@
 The single-task path delegated val loss to ``loss_fn(predictions, y)`` —
 the CrossEntropy term over the stance axis. The train side, when
 ``model_config.multi_task_loss=True``, optimises a lambda-weighted sum
-across stance + factor + certainty + topic, so the pre-fix eval ranked
+across stance + factor + certainty, so the pre-fix eval ranked
 checkpoints against a different objective than the train side. These
 tests pin the eval-side path:
 
@@ -32,7 +32,6 @@ from app.models.config import (
     FeatureVector,
     ModelConfig,
     MULTI_TASK_CERTAINTY_CLASSES,
-    MULTI_TASK_TOPIC_CLASSES,
 )
 from app.training.loop import (
     _evaluate_model,
@@ -49,7 +48,6 @@ def _dummy_feature_vector(
     stance: int,
     factor: float,
     certainty: int,
-    topic: int,
 ) -> FeatureVector:
     return FeatureVector(
         date=_dt.date(2025, 1, 1) + _dt.timedelta(days=day - 1),
@@ -66,13 +64,11 @@ def _dummy_feature_vector(
         target_factor_present=True,
         target_certainty_idx=certainty,
         target_certainty_present=True,
-        target_topic_idx=topic,
-        target_topic_present=True,
     )
 
 
 def _build_classification_groups(n: int = 40) -> list[list[FeatureVector]]:
-    """Synthetic walk-forward fold with all 4 axes populated per row."""
+    """Synthetic walk-forward fold with all 3 axes populated per row."""
 
     return [
         [
@@ -82,7 +78,6 @@ def _build_classification_groups(n: int = 40) -> list[list[FeatureVector]]:
                 stance=i % 3,
                 factor=((i % 5) - 2) / 5.0,
                 certainty=i % 3,
-                topic=i % 4,
             )
             for i in range(n)
         ]
@@ -106,7 +101,6 @@ class _ToyMultiTaskModel(nn.Module):
         *,
         factor_classes: int = 1,
         certainty_classes: int = MULTI_TASK_CERTAINTY_CLASSES,
-        topic_classes: int = MULTI_TASK_TOPIC_CLASSES,
     ) -> None:
         super().__init__()
         self.n_classes = int(n_classes)
@@ -114,7 +108,6 @@ class _ToyMultiTaskModel(nn.Module):
         self.stance = nn.Linear(16, n_classes)
         self.factor = nn.Linear(16, factor_classes)
         self.certainty = nn.Linear(16, certainty_classes)
-        self.topic = nn.Linear(16, topic_classes)
         self._text_path_active = False
 
     def _pool(self, x: torch.Tensor) -> torch.Tensor:
@@ -132,7 +125,6 @@ class _ToyMultiTaskModel(nn.Module):
             "stance": self.stance(pooled),
             "factor": torch.tanh(self.factor(pooled).squeeze(-1)),
             "certainty": self.certainty(pooled),
-            "topic": self.topic(pooled),
         }
 
 
@@ -160,8 +152,6 @@ def _make_eval_loader(
             "factor_mask": torch.tensor([i % 2 == 0 for i in range(n)], dtype=torch.bool),
             "certainty": torch.tensor([i % MULTI_TASK_CERTAINTY_CLASSES for i in range(n)], dtype=torch.long),
             "certainty_mask": torch.tensor([i % 3 != 0 for i in range(n)], dtype=torch.bool),
-            "topic": torch.tensor([i % MULTI_TASK_TOPIC_CLASSES for i in range(n)], dtype=torch.long),
-            "topic_mask": torch.tensor([i > 2 for i in range(n)], dtype=torch.bool),
         }
     dataset = _make_partition_dataset(x, y, None, None, mt_aux)
     loader = DataLoader(dataset, batch_size=batch_size, shuffle=False)
@@ -193,7 +183,6 @@ def test_evaluate_model_multi_task_dispatches_to_forward_multi_task() -> None:
         lambda_stance=1.0,
         lambda_factor=0.3,
         lambda_certainty=0.3,
-        lambda_topic=0.3,
     )
 
     metrics = _evaluate_model(
@@ -220,7 +209,7 @@ def test_evaluate_model_multi_task_loss_differs_from_single_task_ce() -> None:
     Same model + same batch but two eval calls: one with
     ``multi_task_loss_fn=None`` (single-task CE), one with the
     MultiTaskLoss configured. The lambda-weighted multi-task total
-    rolls in factor + certainty + topic terms with non-trivial lambdas,
+    rolls in factor + certainty terms with non-trivial lambdas,
     so the headline ``loss`` value must diverge from the single-task CE.
     """
 
@@ -238,14 +227,13 @@ def test_evaluate_model_multi_task_loss_differs_from_single_task_ce() -> None:
         lambda_stance=1.0,
         lambda_factor=0.5,
         lambda_certainty=0.5,
-        lambda_topic=0.5,
     )
     multi_task_metrics = _evaluate_model(
         model, loader2, torch.device("cpu"), loss_fn, multi_task_loss_fn=mt_loss_fn
     )
 
     # Single-task CE eval reports just the stance CE; multi-task eval
-    # adds factor + certainty + topic terms, so the values must differ.
+    # adds factor + certainty terms, so the values must differ.
     assert single_task_metrics.loss != pytest.approx(multi_task_metrics.loss, abs=1e-6), (
         "multi-task eval emitted the same loss as single-task CE; the "
         "eval branch did not dispatch to MultiTaskLoss"
@@ -270,7 +258,6 @@ def test_evaluate_model_multi_task_attaches_per_axis_breakdown() -> None:
         lambda_stance=1.0,
         lambda_factor=0.3,
         lambda_certainty=0.3,
-        lambda_topic=0.3,
     )
 
     metrics = _evaluate_model(
@@ -287,7 +274,7 @@ def test_evaluate_model_multi_task_attaches_per_axis_breakdown() -> None:
         "expected classification_breakdown[multi_task_axis_losses] dict; "
         f"got {type(axis_losses).__name__}"
     )
-    for axis in ("stance", "factor", "certainty", "topic"):
+    for axis in ("stance", "factor", "certainty"):
         assert axis in axis_losses
         assert isinstance(axis_losses[axis], float)
 
@@ -330,7 +317,7 @@ def test_evaluate_model_raises_when_aux_missing_under_multi_task() -> None:
 def test_evaluate_model_multi_task_mask_collapse_zeroes_axis_contribution() -> None:
     """A batch where every axis-mask is False contributes only stance loss.
 
-    Per-row masks must be honoured -- if all factor / certainty / topic
+    Per-row masks must be honoured -- if all factor / certainty
     masks are False, the multi-task total collapses to
     ``lambda_stance * stance_loss``. This pins the mask-honouring contract
     on the eval side (the train side already had this guarantee via
@@ -350,8 +337,6 @@ def test_evaluate_model_multi_task_mask_collapse_zeroes_axis_contribution() -> N
         "factor_mask": torch.zeros(n, dtype=torch.bool),
         "certainty": torch.zeros(n, dtype=torch.long),
         "certainty_mask": torch.zeros(n, dtype=torch.bool),
-        "topic": torch.zeros(n, dtype=torch.long),
-        "topic_mask": torch.zeros(n, dtype=torch.bool),
     }
     dataset = _make_partition_dataset(x, y, None, None, mt_aux)
     loader = DataLoader(dataset, batch_size=n, shuffle=False)
@@ -362,7 +347,6 @@ def test_evaluate_model_multi_task_mask_collapse_zeroes_axis_contribution() -> N
         lambda_stance=lambda_stance,
         lambda_factor=5.0,
         lambda_certainty=5.0,
-        lambda_topic=5.0,
     )
     metrics = _evaluate_model(
         model,
@@ -436,4 +420,4 @@ def test_train_model_multi_task_path_writes_per_axis_breakdown_into_val_metrics(
     assert val_metrics.classification_breakdown is not None
     assert "multi_task_axis_losses" in val_metrics.classification_breakdown
     axis_losses = val_metrics.classification_breakdown["multi_task_axis_losses"]
-    assert set(axis_losses.keys()) == {"stance", "factor", "certainty", "topic"}
+    assert set(axis_losses.keys()) == {"stance", "factor", "certainty"}

--- a/tests/unit/test_factor_axis_gating.py
+++ b/tests/unit/test_factor_axis_gating.py
@@ -1,7 +1,7 @@
 """Factor-axis gating on the multi-axis classifier (#328).
 
 The text multi-axis classifier ships with four output branches
-(stance / factor / certainty / topic), but the canonical training
+(stance / factor / certainty), but the canonical training
 package today has 0 % ``axis_factor`` label coverage — the factor
 regression branch trains almost exclusively on the masked-out path,
 so its outputs are noise. ADR 0018 documents the decision to gate
@@ -17,7 +17,7 @@ service:
   consistent with the new default behaviour rather than the legacy
   one.
 - A coverage stamp above the gate emits a real factor value.
-- The other three cards (stance / certainty / topic) keep emitting
+- The other two cards (stance / certainty) keep emitting
   regardless of the factor stamp — gating is scoped to the factor
   card only.
 """
@@ -59,7 +59,6 @@ class _StubModel:
             "stance": torch.tensor([[0.1, 0.7, 0.2]]),
             "factor": torch.tensor([self._factor_value]),
             "certainty": torch.tensor([[0.6, 0.3, 0.1]]),
-            "topic": torch.tensor([[0.5, 0.2, 0.2, 0.1]]),
         }
 
 
@@ -125,15 +124,9 @@ def test_factor_card_absent_when_coverage_is_zero(monkeypatch) -> None:
     block = svc.score_text("FOMC statement body")
     assert block is not None
     assert block["factor"] is None
-    # The other three axes stay populated — the gate is scoped to factor.
+    # The other two axes stay populated — the gate is scoped to factor.
     assert block["stance"]["label"] in {"hawkish", "dovish", "neutral"}
     assert block["certainty"]["label"] in {"certain", "uncertain", "neutral"}
-    assert block["topic"]["label"] in {
-        "macro",
-        "forward_guidance",
-        "market_reaction",
-        "other",
-    }
 
 
 def test_factor_card_absent_when_coverage_below_threshold(monkeypatch) -> None:
@@ -318,12 +311,11 @@ def test_factor_coverage_fraction_helper_on_trainer_rows() -> None:
     def _row(factor_present: bool) -> _AxisRow:
         return _AxisRow(
             text="x",
-            targets={"stance": 0, "factor": 0.0, "certainty": 0, "topic": 0},
+            targets={"stance": 0, "factor": 0.0, "certainty": 0},
             masks={
                 "stance": True,
                 "factor": factor_present,
                 "certainty": False,
-                "topic": False,
             },
         )
 

--- a/tests/unit/test_loader_emits_per_axis_targets.py
+++ b/tests/unit/test_loader_emits_per_axis_targets.py
@@ -17,7 +17,6 @@ from app.models.config import (
     FeatureVector,
     MULTI_TASK_CERTAINTY_LABELS,
     MULTI_TASK_STANCE_LABELS,
-    MULTI_TASK_TOPIC_LABELS,
     SEQUENCE_LENGTH,
 )
 from app.training.loaders import (
@@ -49,7 +48,6 @@ def test_attach_rich_features_populates_target_fields_from_event_row() -> None:
         "axis_stance": "hawkish",
         "axis_factor": 0.42,
         "axis_certain_label": "uncertain",
-        "axis_topic": "macro outlook",
     }
     _attach_rich_features(
         vectors,
@@ -72,8 +70,6 @@ def test_attach_rich_features_populates_target_fields_from_event_row() -> None:
     assert (
         target.target_certainty_idx == MULTI_TASK_CERTAINTY_LABELS.index("uncertain")
     )
-    assert target.target_topic_present is True
-    assert target.target_topic_idx == MULTI_TASK_TOPIC_LABELS.index("macro")
 
 
 def test_attach_rich_features_leaves_masks_false_when_row_has_no_labels() -> None:
@@ -94,7 +90,6 @@ def test_attach_rich_features_leaves_masks_false_when_row_has_no_labels() -> Non
     assert target.target_stance_present is False
     assert target.target_factor_present is False
     assert target.target_certainty_present is False
-    assert target.target_topic_present is False
 
 
 def test_certainty_float_falls_back_to_binned_class_label() -> None:
@@ -145,7 +140,7 @@ def test_target_tensor_builder_aligns_rows_with_classification_filter() -> None:
     # vol so vol_regime_class_for returns -1 and the row is dropped).
     assert out["stance"].shape == (1,)
     assert int(out["stance"][0]) == MULTI_TASK_STANCE_LABELS.index("dovish")
-    # Mask types: stance/cert/topic are bool, dtypes match the
+    # Mask types: stance/cert are bool, dtypes match the
     # CrossEntropyLoss + SmoothL1 contract.
     assert out["stance"].dtype == torch.long
     assert out["stance_mask"].dtype == torch.bool

--- a/tests/unit/test_macro_regime_features.py
+++ b/tests/unit/test_macro_regime_features.py
@@ -386,7 +386,6 @@ def _make_event_row(
         "axis_time": None,
         "axis_certainty": None,
         "axis_factor": None,
-        "axis_topic": None,
         "axis_time_label": None,
         "axis_certain_label": None,
         "credibility_drift_score": 0.0,

--- a/tests/unit/test_multi_task_checkpoint_persistence.py
+++ b/tests/unit/test_multi_task_checkpoint_persistence.py
@@ -1,7 +1,7 @@
 """Per-axis class weights + lambdas survive the checkpoint round-trip (#273).
 
 When ``multi_task_loss=True``, the training-loop builds per-axis class
-weights for stance / certainty / topic on the train slice and constructs
+weights for stance / certainty on the train slice and constructs
 a ``MultiTaskLoss`` with those weights plus the four lambda coefficients
 from the ModelConfig. The fitted weights + lambdas must land on the
 serialised checkpoint payload so a resume reads back the same loss
@@ -26,7 +26,6 @@ def _dummy_vec(
     stance: int,
     factor: float,
     certainty: int,
-    topic: int,
 ) -> FeatureVector:
     return FeatureVector(
         date=_dt.date(2025, 1, 1) + _dt.timedelta(days=day - 1),
@@ -43,8 +42,6 @@ def _dummy_vec(
         target_factor_present=True,
         target_certainty_idx=certainty,
         target_certainty_present=True,
-        target_topic_idx=topic,
-        target_topic_present=True,
     )
 
 
@@ -57,7 +54,6 @@ def _make_groups(n: int = 40) -> list[list[FeatureVector]]:
                 stance=i % 3,
                 factor=((i % 5) - 2) / 5.0,
                 certainty=i % 3,
-                topic=i % 4,
             )
             for i in range(n)
         ]
@@ -75,7 +71,6 @@ def test_checkpoint_carries_per_axis_class_weights_and_lambdas(tmp_path: Path) -
         multi_task_lambda_stance=1.0,
         multi_task_lambda_factor=0.25,
         multi_task_lambda_certainty=0.35,
-        multi_task_lambda_topic=0.40,
         n_classes=3,
     )
     groups = _make_groups()
@@ -100,14 +95,12 @@ def test_checkpoint_carries_per_axis_class_weights_and_lambdas(tmp_path: Path) -
     # aggregator can ingest them without re-loading the .pt file.
     mt = result.summary.multi_task_class_weights
     assert mt is not None
-    assert "certainty" in mt and "topic" in mt and "lambdas" in mt
+    assert "certainty" in mt and "lambdas" in mt
     assert isinstance(mt["certainty"], list) and len(mt["certainty"]) >= 2
-    assert isinstance(mt["topic"], list) and len(mt["topic"]) >= 2
     lambdas = mt["lambdas"]
     assert lambdas["stance"] == 1.0
     assert lambdas["factor"] == 0.25
     assert lambdas["certainty"] == 0.35
-    assert lambdas["topic"] == 0.40
 
     # The on-disk checkpoint must also carry the same payload so a
     # resume reads back the exact loss config the run trained under.
@@ -122,7 +115,6 @@ def test_checkpoint_carries_per_axis_class_weights_and_lambdas(tmp_path: Path) -
     )
     assert persisted["lambdas"] == lambdas
     assert persisted["certainty"] == mt["certainty"]
-    assert persisted["topic"] == mt["topic"]
 
 
 def test_coerce_payload_config_threads_multi_task_fields() -> None:
@@ -144,7 +136,6 @@ def test_coerce_payload_config_threads_multi_task_fields() -> None:
         multi_task_lambda_stance=1.0,
         multi_task_lambda_factor=0.25,
         multi_task_lambda_certainty=0.35,
-        multi_task_lambda_topic=0.40,
         n_classes=3,
     )
 
@@ -154,7 +145,6 @@ def test_coerce_payload_config_threads_multi_task_fields() -> None:
     assert rebuilt.multi_task_lambda_stance == 1.0
     assert rebuilt.multi_task_lambda_factor == 0.25
     assert rebuilt.multi_task_lambda_certainty == 0.35
-    assert rebuilt.multi_task_lambda_topic == 0.40
 
 
 def test_coerce_payload_config_defaults_when_multi_task_absent() -> None:
@@ -171,7 +161,6 @@ def test_coerce_payload_config_defaults_when_multi_task_absent() -> None:
     assert rebuilt.multi_task_lambda_stance == 1.0
     assert rebuilt.multi_task_lambda_factor == 0.3
     assert rebuilt.multi_task_lambda_certainty == 0.3
-    assert rebuilt.multi_task_lambda_topic == 0.3
 
 
 def test_coerce_payload_config_threads_vol_target_mode() -> None:

--- a/tests/unit/test_multi_task_head_shape.py
+++ b/tests/unit/test_multi_task_head_shape.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import torch
 
 
-def test_multi_task_head_emits_four_branches_with_expected_shapes() -> None:
+def test_multi_task_head_emits_three_branches_with_expected_shapes() -> None:
+    """Post-ADR-0044: topic branch retired; head emits stance / factor / certainty."""
     from app.models.multi_task_head import MultiTaskHead
 
     head = MultiTaskHead(
@@ -21,11 +22,10 @@ def test_multi_task_head_emits_four_branches_with_expected_shapes() -> None:
     pooled = torch.zeros(4, 32)
     out = head(pooled)
 
-    assert set(out.keys()) == {"stance", "factor", "certainty", "topic"}
+    assert set(out.keys()) == {"stance", "factor", "certainty"}
     assert out["stance"].shape == (4, 3)
     assert out["factor"].shape == (4,)
     assert out["certainty"].shape == (4, 3)
-    assert out["topic"].shape == (4, 4)
 
 
 def test_factor_branch_stays_in_minus_one_to_one_range() -> None:

--- a/tests/unit/test_multi_task_loop_wiring.py
+++ b/tests/unit/test_multi_task_loop_wiring.py
@@ -31,8 +31,6 @@ def _make_aux(n_rows: int) -> dict[str, torch.Tensor]:
         "factor_mask": torch.zeros(n_rows, dtype=torch.bool),
         "certainty": torch.zeros(n_rows, dtype=torch.long),
         "certainty_mask": torch.zeros(n_rows, dtype=torch.bool),
-        "topic": torch.zeros(n_rows, dtype=torch.long),
-        "topic_mask": torch.zeros(n_rows, dtype=torch.bool),
     }
 
 
@@ -76,7 +74,11 @@ def test_make_partition_dataset_text_arity() -> None:
 
 
 def test_make_partition_dataset_multi_task_arity() -> None:
-    """multi-task active, no text -> arity 8 with aux tensors packed."""
+    """multi-task active, no text -> arity 6 with aux tensors packed.
+
+    Post-ADR-0044 the aux block is 4 tensors (factor / factor_mask /
+    certainty / certainty_mask); the topic pair was retired.
+    """
 
     n = 8
     x = _rand((n, 5, 6))
@@ -85,7 +87,7 @@ def test_make_partition_dataset_multi_task_arity() -> None:
     ds = _make_partition_dataset(x, y, None, None, aux_in)
     loader = DataLoader(ds, batch_size=n, shuffle=False)
     batch = next(iter(loader))
-    assert len(batch) == 8
+    assert len(batch) == 6
     bx, by, btext, bmissing, aux_out, log_rv, _rates_idx = _unpack_batch(batch)
     assert btext is None
     assert bmissing is None
@@ -97,7 +99,7 @@ def test_make_partition_dataset_multi_task_arity() -> None:
 
 
 def test_make_partition_dataset_text_plus_multi_task_arity() -> None:
-    """text + multi-task -> arity 10."""
+    """text + multi-task -> arity 8 (post-ADR-0044 aux block is 4 tensors)."""
 
     n = 4
     x = _rand((n, 5, 6))
@@ -108,7 +110,7 @@ def test_make_partition_dataset_text_plus_multi_task_arity() -> None:
     ds = _make_partition_dataset(x, y, text, text_missing, aux_in)
     loader = DataLoader(ds, batch_size=n, shuffle=False)
     batch = next(iter(loader))
-    assert len(batch) == 10
+    assert len(batch) == 8
     bx, by, btext, bmissing, aux_out, log_rv, _rates_idx = _unpack_batch(batch)
     assert btext is not None
     assert aux_out is not None
@@ -129,15 +131,16 @@ def test_make_partition_dataset_rejects_missing_aux_key() -> None:
 
 
 def test_unpack_batch_rejects_unknown_arity() -> None:
-    """An unsupported arity (e.g. 6-tuple) raises with a clear message.
+    """An unsupported arity (e.g. 10-tuple) raises with a clear message.
 
-    Arity 3, 5, 9, 11 became valid post-#304 (the dual-head log_rv
-    slot composes with every prior shape); pick 6 -- still
-    unsupported -- so the negative-path coverage stays.
+    Arity 3, 5, 7, 9 became valid post-#304 (the dual-head log_rv slot
+    composes with every prior shape) and 6 / 8 took the old 8 / 10 mt
+    slots after ADR 0044 retired the topic axis pair. Pick 10 — outside
+    the valid range — so the negative-path coverage stays.
     """
 
     with pytest.raises(ValueError, match="unexpected batch arity"):
-        _unpack_batch(tuple(torch.zeros(1) for _ in range(6)))
+        _unpack_batch(tuple(torch.zeros(1) for _ in range(10)))
 
 
 def test_multi_task_loss_active_requires_classification_mode() -> None:
@@ -209,8 +212,6 @@ def _dummy_feature_vector(
     factor_present: bool = False,
     certainty: int = -1,
     certainty_present: bool = False,
-    topic: int = -1,
-    topic_present: bool = False,
 ):
     from app.models.config import FeatureVector
 
@@ -229,8 +230,6 @@ def _dummy_feature_vector(
         target_factor_present=factor_present,
         target_certainty_idx=certainty,
         target_certainty_present=certainty_present,
-        target_topic_idx=topic,
-        target_topic_present=topic_present,
     )
 
 
@@ -264,8 +263,6 @@ def test_multi_task_loss_actually_runs_one_training_step() -> None:
                 factor_present=True,
                 certainty=i % 3,
                 certainty_present=True,
-                topic=i % 4,
-                topic_present=True,
             )
             for i in range(n)
         ]
@@ -325,8 +322,6 @@ def test_multi_task_loss_regression_head_mode_keeps_axis_grads() -> None:
                 factor_present=True,
                 certainty=i % 3,
                 certainty_present=True,
-                topic=i % 4,
-                topic_present=True,
             )
             for i in range(n)
         ]
@@ -350,25 +345,21 @@ def test_multi_task_loss_regression_head_mode_keeps_axis_grads() -> None:
         use_amp=False,
     )
     assert result.summary.epochs_completed == 1
-    # The certainty axis head sits behind a `topic_head` / `certainty_head`
-    # branch on the MultiTaskHead; its weights would stay at their init
-    # values if the per-axis loss was being discarded. Iterate the model's
+    # The factor / certainty axis heads sit behind dedicated branches on
+    # the MultiTaskHead; their weights would stay at their init values
+    # if the per-axis loss was being discarded. Iterate the model's
     # parameters and assert at least one axis-head parameter has non-zero
     # gradient memory (the post-train ``.grad`` is cleared by AdamW, but
     # the post-train weights diverge from init if they trained at all).
     rebuilt = result.model
     head_module = getattr(rebuilt, "head", None)
     assert head_module is not None
-    # Pull a representative parameter off each non-stance axis branch and
-    # confirm at least one moved away from zero (all branches start with
-    # near-zero or small init; after a single epoch with the per-axis
-    # loss active they pick up non-trivial values).
     branches_seen: dict[str, bool] = {}
     for name, param in head_module.named_parameters():
-        for axis in ("factor", "certainty", "topic"):
+        for axis in ("factor", "certainty"):
             if axis in name and param.requires_grad:
                 branches_seen.setdefault(axis, bool(torch.any(param != 0.0).item()))
-    # All three non-stance axis branches must be reachable on the head.
-    assert set(branches_seen.keys()) == {"factor", "certainty", "topic"}, (
+    # Both non-stance axis branches must be reachable on the head.
+    assert set(branches_seen.keys()) == {"factor", "certainty"}, (
         f"expected axis branches missing from head module: {branches_seen}"
     )

--- a/tests/unit/test_multi_task_loss_config.py
+++ b/tests/unit/test_multi_task_loss_config.py
@@ -27,7 +27,6 @@ def test_default_modelconfig_keeps_multi_task_loss_off() -> None:
     assert cfg.multi_task_lambda_stance == 1.0
     assert cfg.multi_task_lambda_factor == 0.3
     assert cfg.multi_task_lambda_certainty == 0.3
-    assert cfg.multi_task_lambda_topic == 0.3
 
 
 def test_factory_stashes_multi_task_flags_on_built_model() -> None:
@@ -43,14 +42,12 @@ def test_factory_stashes_multi_task_flags_on_built_model() -> None:
         multi_task_lambda_stance=0.5,
         multi_task_lambda_factor=0.2,
         multi_task_lambda_certainty=0.4,
-        multi_task_lambda_topic=0.1,
     )
     model = build_forecaster(cfg)
     assert bool(getattr(model, "multi_task_loss")) is True
     assert float(getattr(model, "multi_task_lambda_stance")) == 0.5
     assert float(getattr(model, "multi_task_lambda_factor")) == 0.2
     assert float(getattr(model, "multi_task_lambda_certainty")) == 0.4
-    assert float(getattr(model, "multi_task_lambda_topic")) == 0.1
 
 
 def test_modelconfig_from_model_round_trips_multi_task_fields() -> None:

--- a/tests/unit/test_multi_task_loss_masking.py
+++ b/tests/unit/test_multi_task_loss_masking.py
@@ -1,6 +1,6 @@
 """Per-axis masking on the MultiTaskLoss (#78).
 
-The three sparse axes (factor / certainty / topic) carry labels on
+The two sparse axes (factor / certainty) carry labels on
 fewer than 5% of supervised rows. A naive un-masked loss would train
 those branches against a synthetic placeholder index — locking them
 on a meaningless mean. The masked-loss contract is the load-bearing
@@ -17,7 +17,6 @@ def _zero_logits_batch(batch: int = 4) -> dict[str, torch.Tensor]:
         "stance": torch.zeros(batch, 3, requires_grad=True),
         "factor": torch.zeros(batch, requires_grad=True),
         "certainty": torch.zeros(batch, 3, requires_grad=True),
-        "topic": torch.zeros(batch, 4, requires_grad=True),
     }
 
 
@@ -30,18 +29,15 @@ def test_axis_with_all_false_mask_contributes_zero_loss() -> None:
         "stance": torch.tensor([0, 1, 2, 0]),
         "factor": torch.zeros(4),
         "certainty": torch.tensor([0, 0, 0, 0]),
-        "topic": torch.tensor([0, 0, 0, 0]),
     }
     masks = {
         "stance_mask": torch.tensor([True, True, True, True]),
         "factor_mask": torch.tensor([False, False, False, False]),
         "certainty_mask": torch.tensor([False, False, False, False]),
-        "topic_mask": torch.tensor([False, False, False, False]),
     }
     total, breakdown = loss_fn(logits, targets, masks)
     assert float(breakdown["factor"]) == 0.0
     assert float(breakdown["certainty"]) == 0.0
-    assert float(breakdown["topic"]) == 0.0
     # Stance is the only contributing axis so the total equals its lambda * loss.
     assert float(total) > 0.0
 
@@ -55,25 +51,22 @@ def test_masked_classification_matches_filtered_cross_entropy() -> None:
     from torch.nn import functional as F
 
     torch.manual_seed(7)
-    loss_fn = MultiTaskLoss(lambda_factor=0.0, lambda_certainty=0.0, lambda_topic=0.0)
+    loss_fn = MultiTaskLoss(lambda_factor=0.0, lambda_certainty=0.0)
     logits = {
         "stance": torch.randn(8, 3, requires_grad=True),
         "factor": torch.zeros(8, requires_grad=True),
         "certainty": torch.zeros(8, 3, requires_grad=True),
-        "topic": torch.zeros(8, 4, requires_grad=True),
     }
     targets = {
         "stance": torch.tensor([0, 1, 2, 0, 1, 2, 0, 1]),
         "factor": torch.zeros(8),
         "certainty": torch.tensor([0, 0, 0, 0, 0, 0, 0, 0]),
-        "topic": torch.tensor([0, 0, 0, 0, 0, 0, 0, 0]),
     }
     mask = torch.tensor([True, False, True, True, False, True, True, False])
     masks = {
         "stance_mask": mask,
         "factor_mask": torch.zeros(8, dtype=torch.bool),
         "certainty_mask": torch.zeros(8, dtype=torch.bool),
-        "topic_mask": torch.zeros(8, dtype=torch.bool),
     }
     total, _ = loss_fn(logits, targets, masks)
 
@@ -82,7 +75,7 @@ def test_masked_classification_matches_filtered_cross_entropy() -> None:
 
 
 def test_total_loss_carries_gradients_back_to_logits() -> None:
-    """Even with all-False masks on three axes, the total loss must
+    """Even with all-False masks on two axes, the total loss must
     flow gradients back to the contributing axis's logits. A
     detached zero would prevent the optimiser from training the
     stance branch on its own."""
@@ -95,13 +88,11 @@ def test_total_loss_carries_gradients_back_to_logits() -> None:
         "stance": torch.tensor([0, 1, 2, 0]),
         "factor": torch.zeros(4),
         "certainty": torch.zeros(4, dtype=torch.long),
-        "topic": torch.zeros(4, dtype=torch.long),
     }
     masks = {
         "stance_mask": torch.tensor([True, True, True, True]),
         "factor_mask": torch.zeros(4, dtype=torch.bool),
         "certainty_mask": torch.zeros(4, dtype=torch.bool),
-        "topic_mask": torch.zeros(4, dtype=torch.bool),
     }
     total, _ = loss_fn(logits, targets, masks)
     total.backward()

--- a/tests/unit/test_next_fomc_decision.py
+++ b/tests/unit/test_next_fomc_decision.py
@@ -98,7 +98,6 @@ def _make_events_df(event_dates: list[str], stance_labels: list[str] | None = No
                 "axis_time": "neutral",
                 "axis_certainty": "neutral",
                 "axis_factor": "neutral",
-                "axis_topic": "neutral",
                 "credibility_drift_score": 0.0,
                 "credibility_realized_vs_stated_gap": 0.0,
                 "credibility_market_implied_gap": 0.0,

--- a/tests/unit/test_pipeline_schemas.py
+++ b/tests/unit/test_pipeline_schemas.py
@@ -96,7 +96,6 @@ def _event_row(**overrides) -> dict:
         "axis_time": None,
         "axis_certainty": None,
         "axis_factor": None,
-        "axis_topic": None,
         "credibility_drift_score": 0.0,
         "credibility_realized_vs_stated_gap": 0.0,
         "credibility_market_implied_gap": 0.0,

--- a/tests/unit/test_press_conf_features.py
+++ b/tests/unit/test_press_conf_features.py
@@ -277,7 +277,6 @@ def test_loader_concats_qa_onto_statement_raw_text_under_lora(
             "axis_time": None,
             "axis_certainty": None,
             "axis_factor": None,
-            "axis_topic": None,
             "axis_time_label": None,
             "axis_certain_label": None,
             "credibility_drift_score": 0.0,

--- a/tests/unit/test_retrieval_augmented_features.py
+++ b/tests/unit/test_retrieval_augmented_features.py
@@ -309,7 +309,6 @@ def _make_event_row(
         "axis_time": None,
         "axis_certainty": None,
         "axis_factor": None,
-        "axis_topic": None,
         "axis_time_label": None,
         "axis_certain_label": None,
         "credibility_drift_score": 0.0,

--- a/tests/unit/test_retrieval_train_pairs.py
+++ b/tests/unit/test_retrieval_train_pairs.py
@@ -183,7 +183,6 @@ def _shared_axis_events_frame() -> pd.DataFrame:
             ),
             "axis_stance": "dovish",
             "axis_factor": "labor",
-            "axis_topic": "crisis",
         },
         {
             **_make_row(
@@ -193,7 +192,6 @@ def _shared_axis_events_frame() -> pd.DataFrame:
             ),
             "axis_stance": "dovish",
             "axis_factor": "labor",
-            "axis_topic": "crisis",
         },
         {
             **_make_row(
@@ -203,7 +201,6 @@ def _shared_axis_events_frame() -> pd.DataFrame:
             ),
             "axis_stance": "hawkish",
             "axis_factor": "inflation",
-            "axis_topic": "normalization",
         },
         {
             **_make_row(
@@ -213,7 +210,6 @@ def _shared_axis_events_frame() -> pd.DataFrame:
             ),
             "axis_stance": "hawkish",
             "axis_factor": "inflation",
-            "axis_topic": "normalization",
         },
     ]
     return pd.DataFrame(rows)
@@ -239,7 +235,6 @@ def test_shared_axis_pair_policy_drops_unlabelled_rows() -> None:
     # Wipe one row's axis labels — it must contribute zero pairs.
     events.loc[events["text"] == "2008 crisis dovish statement", "axis_stance"] = None
     events.loc[events["text"] == "2008 crisis dovish statement", "axis_factor"] = None
-    events.loc[events["text"] == "2008 crisis dovish statement", "axis_topic"] = None
     pairs = ret_train.build_training_pairs(events, pair_policy="shared_axis")
     anchors = {p.anchor for p in pairs}
     positives = {p.positive for p in pairs}

--- a/tests/unit/test_sep_features.py
+++ b/tests/unit/test_sep_features.py
@@ -409,7 +409,6 @@ def _make_event_row(
         "axis_time": None,
         "axis_certainty": None,
         "axis_factor": None,
-        "axis_topic": None,
         "axis_time_label": None,
         "axis_certain_label": None,
         "credibility_drift_score": 0.0,

--- a/tests/unit/test_text_multi_axis_classifier.py
+++ b/tests/unit/test_text_multi_axis_classifier.py
@@ -36,7 +36,8 @@ class _StubEncoder(nn.Module):
         return out
 
 
-def test_classifier_emits_four_axis_dict_from_stub_encoder() -> None:
+def test_classifier_emits_three_axis_dict_from_stub_encoder() -> None:
+    """Post-ADR-0044: topic branch retired; classifier emits stance / factor / certainty."""
     torch.manual_seed(0)
     encoder = _StubEncoder(hidden_size=16, vocab_size=30)
     model = TextMultiAxisClassifier(
@@ -50,11 +51,10 @@ def test_classifier_emits_four_axis_dict_from_stub_encoder() -> None:
     input_ids = torch.randint(0, 30, (2, 12))
     attention_mask = torch.ones_like(input_ids)
     out = model(input_ids=input_ids, attention_mask=attention_mask)
-    assert set(out.keys()) == {"stance", "factor", "certainty", "topic"}
+    assert set(out.keys()) == {"stance", "factor", "certainty"}
     assert out["stance"].shape == (2, 3)
     assert out["factor"].shape == (2,)
     assert out["certainty"].shape == (2, 3)
-    assert out["topic"].shape == (2, 4)
 
 
 def test_metadata_round_trips_encoder_provenance() -> None:

--- a/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
+++ b/tests/unit/test_train_text_multi_axis_cross_bank_gate.py
@@ -105,27 +105,24 @@ def test_stance_masked_mode_drops_stance_for_cross_bank_only() -> None:
     assert fomc.masks["certainty"] is True
     assert fomc.stance_sample_weight == 1.0
 
-    # Pin the natural per-row factor / topic masks on a cross-bank
-    # row. The gtfintechlab schema does not carry factor or topic
-    # labels (the trainer maps only stance + certainty + time), so
-    # the natural masks are False here. Any future change that
-    # leaks a cross-bank stance label onto the factor or topic
-    # mask under ``stance_masked`` would flip these — the regression
-    # would show up as the assertion firing.
+    # Pin the natural per-row factor mask on a cross-bank row. The
+    # gtfintechlab schema does not carry factor labels (the trainer
+    # maps only stance + certainty + time), so the natural mask is
+    # False here. Any future change that leaks a cross-bank stance
+    # label onto the factor mask under ``stance_masked`` would flip
+    # this — the regression would show up as the assertion firing.
     assert cross_bank.masks["factor"] is False
-    assert cross_bank.masks["topic"] is False
     # FOMC rows under ``stance_masked`` follow the same natural
-    # per-row factor / topic masks the gtfintechlab schema produces;
+    # per-row factor mask the gtfintechlab schema produces;
     # ``stance_masked`` rewrites are scoped to cross-bank rows only.
     assert fomc.masks["factor"] is False
-    assert fomc.masks["topic"] is False
 
 
 def test_weighted_mode_scales_only_stance_for_cross_bank() -> None:
     """The ``weighted`` arm leaves every mask intact and scales the
     cross-bank rows' stance weight by ``cross_bank_stance_weight``.
-    Other axes (certainty, factor, topic) are NOT scaled — the
-    weight rides on the stance branch alone."""
+    Other axes (certainty, factor) are NOT scaled — the weight rides
+    on the stance branch alone."""
 
     cross_bank = _axis_row_from_gtf(
         provenance="peer_reviewed_cross_bank",
@@ -269,38 +266,33 @@ def test_per_axis_provenance_log_splits_by_corpus(
 def _make_two_row_two_class_logits(
     *, target_classes: tuple[int, int], stance_logits: list[list[float]]
 ) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor], dict[str, torch.Tensor]]:
-    """Tiny 2-row, 2-class fixture with stance + factor + certainty + topic.
+    """Tiny 2-row, 2-class fixture with stance + factor + certainty.
 
     Only the stance axis is exercised by the gradient assertions; the
     other axes carry False masks so they contribute graph-attached
     zeros (matching the MultiTaskLoss empty-mask contract). The
-    factor / certainty / topic tensors are still ``requires_grad``
-    so the loss can graph-attach a zero through them — the gradient
-    on those tensors must be zero everywhere when their masks are
-    all-False.
+    factor / certainty tensors are still ``requires_grad`` so the loss
+    can graph-attach a zero through them — the gradient on those
+    tensors must be zero everywhere when their masks are all-False.
     """
 
     stance = torch.tensor(stance_logits, dtype=torch.float32, requires_grad=True)
     factor = torch.zeros(2, dtype=torch.float32, requires_grad=True)
     certainty = torch.zeros(2, 3, dtype=torch.float32, requires_grad=True)
-    topic = torch.zeros(2, 4, dtype=torch.float32, requires_grad=True)
     logits = {
         "stance": stance,
         "factor": factor,
         "certainty": certainty,
-        "topic": topic,
     }
     targets = {
         "stance": torch.tensor(list(target_classes), dtype=torch.long),
         "factor": torch.zeros(2, dtype=torch.float32),
         "certainty": torch.zeros(2, dtype=torch.long),
-        "topic": torch.zeros(2, dtype=torch.long),
     }
     masks = {
         "stance_mask": torch.tensor([True, True], dtype=torch.bool),
         "factor_mask": torch.tensor([False, False], dtype=torch.bool),
         "certainty_mask": torch.tensor([False, False], dtype=torch.bool),
-        "topic_mask": torch.tensor([False, False], dtype=torch.bool),
     }
     return logits, targets, masks
 
@@ -325,7 +317,7 @@ def test_weighted_stance_gradient_matches_analytical_2row_2class() -> None:
         stance_logits=[[2.0, 0.0], [0.0, 1.0]],
     )
     loss_fn = MultiTaskLoss(lambda_stance=1.0, lambda_factor=0.0,
-                            lambda_certainty=0.0, lambda_topic=0.0)
+                            lambda_certainty=0.0)
     weights = torch.tensor([1.0, 0.25], dtype=torch.float32)
 
     total, _ = _compute_weighted_total_loss(
@@ -363,7 +355,7 @@ def test_all_zero_weight_batch_emits_zero_stance_gradient() -> None:
         stance_logits=[[2.0, 0.0], [0.0, 1.0]],
     )
     loss_fn = MultiTaskLoss(lambda_stance=1.0, lambda_factor=0.0,
-                            lambda_certainty=0.0, lambda_topic=0.0)
+                            lambda_certainty=0.0)
     weights = torch.zeros(2, dtype=torch.float32)
 
     total, _ = _compute_weighted_total_loss(
@@ -401,7 +393,7 @@ def test_fomc_only_batch_byte_identical_to_unweighted_loss() -> None:
         stance_logits=[[2.0, 0.0], [0.0, 1.0]],
     )
     loss_fn = MultiTaskLoss(lambda_stance=1.0, lambda_factor=0.3,
-                            lambda_certainty=0.3, lambda_topic=0.3)
+                            lambda_certainty=0.3)
     weights = torch.ones(2, dtype=torch.float32)
 
     weighted_total, _ = _compute_weighted_total_loss(
@@ -420,11 +412,11 @@ def test_fomc_only_batch_byte_identical_to_unweighted_loss() -> None:
 
 def test_weighted_arm_leaves_other_axis_gradients_unchanged() -> None:
     """The cross-bank ``weighted`` arm scales only the stance branch.
-    Gradients on logits["factor"], logits["certainty"], and
-    logits["topic"] must be identical to the gradients produced by
-    the ``off`` baseline (i.e. ``MultiTaskLoss`` called without any
-    per-row weight). Tested with a populated mask on each non-stance
-    axis so the comparison is non-trivial."""
+    Gradients on logits["factor"] and logits["certainty"] must be
+    identical to the gradients produced by the ``off`` baseline (i.e.
+    ``MultiTaskLoss`` called without any per-row weight). Tested with
+    a populated mask on each non-stance axis so the comparison is
+    non-trivial."""
 
     def _seeded_batch(seed: int) -> tuple[
         dict[str, torch.Tensor],
@@ -435,19 +427,16 @@ def test_weighted_arm_leaves_other_axis_gradients_unchanged() -> None:
         stance = torch.randn(3, 3, requires_grad=True)
         factor = torch.randn(3, requires_grad=True)
         certainty = torch.randn(3, 3, requires_grad=True)
-        topic = torch.randn(3, 4, requires_grad=True)
         return (
             {
                 "stance": stance,
                 "factor": factor,
                 "certainty": certainty,
-                "topic": topic,
             },
             {
                 "stance": torch.tensor([0, 1, 2], dtype=torch.long),
                 "factor": torch.tensor([0.1, -0.4, 0.7], dtype=torch.float32),
                 "certainty": torch.tensor([0, 2, 1], dtype=torch.long),
-                "topic": torch.tensor([1, 3, 0], dtype=torch.long),
             },
             {
                 "stance_mask": torch.tensor([True, True, True], dtype=torch.bool),
@@ -455,12 +444,11 @@ def test_weighted_arm_leaves_other_axis_gradients_unchanged() -> None:
                 "certainty_mask": torch.tensor(
                     [True, True, True], dtype=torch.bool
                 ),
-                "topic_mask": torch.tensor([True, True, True], dtype=torch.bool),
             },
         )
 
     loss_fn = MultiTaskLoss(lambda_stance=1.0, lambda_factor=0.3,
-                            lambda_certainty=0.3, lambda_topic=0.3)
+                            lambda_certainty=0.3)
 
     # Weighted (cross-bank arm with non-unit weights).
     logits_w, targets_w, masks_w = _seeded_batch(seed=17)
@@ -485,7 +473,7 @@ def test_weighted_arm_leaves_other_axis_gradients_unchanged() -> None:
     )
     total_o.backward()
 
-    for axis in ("factor", "certainty", "topic"):
+    for axis in ("factor", "certainty"):
         assert logits_w[axis].grad is not None
         assert logits_o[axis].grad is not None
         torch.testing.assert_close(
@@ -538,11 +526,9 @@ def _two_row_batch(weights: list[float]) -> dict[str, "torch.Tensor"]:
         "target_stance": torch.tensor([0, 1], dtype=torch.long),
         "target_factor": torch.zeros(2, dtype=torch.float32),
         "target_certainty": torch.zeros(2, dtype=torch.long),
-        "target_topic": torch.zeros(2, dtype=torch.long),
         "mask_stance": torch.tensor([True, True], dtype=torch.bool),
         "mask_factor": torch.tensor([False, False], dtype=torch.bool),
         "mask_certainty": torch.tensor([False, False], dtype=torch.bool),
-        "mask_topic": torch.tensor([False, False], dtype=torch.bool),
         "stance_sample_weight": torch.tensor(weights, dtype=torch.float32),
         "source": ["fomc", "fomc"],
         "provenance": ["peer_reviewed", "peer_reviewed"],
@@ -570,19 +556,16 @@ def test_evaluate_threads_stance_sample_weight_through_loss() -> None:
     )
     factor_logits = torch.zeros(2, dtype=torch.float32)
     certainty_logits = torch.zeros(2, 3, dtype=torch.float32)
-    topic_logits = torch.zeros(2, 4, dtype=torch.float32)
     logits = {
         "stance": stance_logits,
         "factor": factor_logits,
         "certainty": certainty_logits,
-        "topic": topic_logits,
     }
     model = _ConstantLogitsModel(logits)
     loss_fn = MultiTaskLoss(
         lambda_stance=1.0,
         lambda_factor=0.0,
         lambda_certainty=0.0,
-        lambda_topic=0.0,
     )
 
     batch = _two_row_batch([1.0, 0.25])
@@ -607,13 +590,11 @@ def test_evaluate_threads_stance_sample_weight_through_loss() -> None:
         "stance": batch["target_stance"],
         "factor": batch["target_factor"],
         "certainty": batch["target_certainty"],
-        "topic": batch["target_topic"],
     }
     masks = {
         "stance_mask": batch["mask_stance"],
         "factor_mask": batch["mask_factor"],
         "certainty_mask": batch["mask_certainty"],
-        "topic_mask": batch["mask_topic"],
     }
     train_total, _ = _compute_weighted_total_loss(
         loss_fn=loss_fn,
@@ -669,14 +650,12 @@ def test_evaluate_runs_under_no_grad() -> None:
                 "stance": stance,
                 "factor": torch.zeros(2) * scale,
                 "certainty": torch.zeros(2, 3) * scale,
-                "topic": torch.zeros(2, 4) * scale,
             }
 
     loss_fn = MultiTaskLoss(
         lambda_stance=1.0,
         lambda_factor=0.0,
         lambda_certainty=0.0,
-        lambda_topic=0.0,
     )
 
     class _OneShotLoader:

--- a/tests/unit/test_training_loop_helpers.py
+++ b/tests/unit/test_training_loop_helpers.py
@@ -213,11 +213,13 @@ def test_unpack_batch_four_element() -> None:
 
 
 def test_unpack_batch_rejects_unexpected_arity() -> None:
-    # Arity 3 / 5 / 9 / 11 became valid post-#304 (the dual-head log_rv
-    # slot composes with the prior shapes); pick 6 -- still
-    # unsupported -- so the negative-path coverage stays.
+    # Arity 3 / 5 / 7 / 9 became valid post-#304 (the dual-head log_rv
+    # slot composes with the prior shapes), and arity 6 / 8 collapsed
+    # into the prior 8 / 10 mt slots after ADR 0044 retired the topic
+    # axis pair. Pick 10 — outside the valid range — so the negative-
+    # path coverage stays.
     with pytest.raises(ValueError, match="unexpected batch arity"):
-        _unpack_batch(tuple(torch.zeros(1) for _ in range(6)))
+        _unpack_batch(tuple(torch.zeros(1) for _ in range(10)))
 
 
 def test_evaluate_model_returns_inf_metrics_on_empty_loader() -> None:

--- a/tests/unit/test_training_package_loader.py
+++ b/tests/unit/test_training_package_loader.py
@@ -82,7 +82,6 @@ def _event_row(
         "axis_time": None,
         "axis_certainty": None,
         "axis_factor": None,
-        "axis_topic": None,
         "axis_time_label": axis_time_label,
         "axis_certain_label": axis_certain_label,
         "credibility_drift_score": 0.0,


### PR DESCRIPTION
## Summary

- Topic axis retired end-to-end (schema + data pipeline + multi-task head + loss + inference + API + frontend + tests + ADR 0044).
- Audit on `tp_v3_full_rebuild_2026_05_30` reported `axis_topic` populated on 0 / 7172 rows. No upstream FOMC corpus or cross-bank gtfintechlab sibling ships topic labels; the only historical population path was an internal macro-release augmentation that emitted `"economic_indicator" → "macro"` — one bucket out of four, and the rebuild path no longer fires it.
- `MultiTaskHead` / `MultiTaskLoss` / `TextMultiAxisClassifier` collapse from 4 branches to 3 (stance / factor / certainty). Per-axis loops, class-weight fits, and breakdown dicts shrink accordingly.
- `_MULTI_TASK_AUX_KEYS` shrinks 6 → 4 tensors; loader arity dispatch retables `{8, 9, 10, 11}` → `{6, 7, 8, 9}`.
- API response shape change: `MultiAxisAnalysisCard.topic` and `MultiAxisTopicCard` removed; frontend `TopicTile` / `TopicCard` removed and the analyze grid collapses 4 → 3 columns.
- 26 test fixtures updated (drop `axis_topic` / `target_topic` / `mask_topic` entries, trim axis loops, rebaseline arity assertions).
- ADR 0044 records the audit numbers and reversal cost (changes are localised; git history retains the prior shapes).

## Test plan

- [x] `docker compose run --rm backend pytest tests/unit/ -q -k "topic or multi_task or factor_axis or training_loop_helpers or retrieval_train_pairs or loader_emits_per_axis_targets"` — 138 passed / 0 failed