### PR TITLE
Pre-Runpod sweep-script fixes — rates-heads input_size + B2 encoder repo resolution

### DIFF
--- a/backend/app/data/finetune_pilot_b2.py
+++ b/backend/app/data/finetune_pilot_b2.py
@@ -51,7 +51,7 @@ import numpy as np
 
 from app.config import BACKEND_ROOT, DATA_DIR as DEFAULT_DATA_DIR
 from app.evaluation.classification_breakdown import compute_classification_breakdown
-from app.models.registry import resolve_by_role, revision_for
+from app.models.registry import encoder_ref, resolve_by_role, revision_for
 
 DEFAULT_OUTPUT_PATH = (
     BACKEND_ROOT.parent / "artifacts" / "experiments" / "finetune_pilot_b2.json"
@@ -440,13 +440,19 @@ def _train_and_eval_one_cell(  # noqa: PLR0913 — per-cell knobs surface as nam
 
     hf_token = _hf_token()
     revision = revision_for(encoder_alias)
+    # ``encoder_alias`` is the registry alias (e.g. ``finbert_fed_adjacent``);
+    # ``from_pretrained`` needs the underlying repo id (HF slug like
+    # ``yusufizzetmurat/finbert-fed-adjacent`` after #464, or a local
+    # path for unpinned-local entries). Look it up via ``encoder_ref``.
+    ref = encoder_ref(encoder_alias)
+    encoder_repo = ref.repo if ref is not None else encoder_alias
     tokenizer_kwargs: dict[str, Any] = {"token": hf_token} if hf_token else {}
     if revision:
         tokenizer_kwargs["revision"] = revision
-    tokenizer = AutoTokenizer.from_pretrained(encoder_alias, **tokenizer_kwargs)
+    tokenizer = AutoTokenizer.from_pretrained(encoder_repo, **tokenizer_kwargs)
 
     model = AutoModelForSequenceClassification.from_pretrained(
-        encoder_alias,
+        encoder_repo,
         num_labels=N_CLASSES,
         id2label=ID2LABEL,
         label2id=LABEL2ID,

--- a/scripts/run_rates_heads_sweep.py
+++ b/scripts/run_rates_heads_sweep.py
@@ -137,11 +137,18 @@ def _train_single(
     hidden_size: int,
     epochs: int,
 ) -> dict[str, Any]:
-    from app.models.config import ModelConfig
+    from app.models.config import RICH_FEATURE_SIZE, ModelConfig
     from app.training.loaders import load_walk_forward_split
     from app.training.loop import train_model
 
     config = ModelConfig(
+        # The loader emits RICH_FEATURE_SIZE per bar; defaulting to the
+        # legacy 6-dim ``FEATURE_SIZE`` crashes the LSTM at
+        # ``input.size(-1) must be equal to input_size``. Pin the rich
+        # width here so the rates-heads sweep matches what the
+        # canonical-comparison runner does (see
+        # ``scripts/run_dual_head_comparison.py``).
+        input_size=RICH_FEATURE_SIZE,
         output_mode="classification",
         n_classes=3,
         hidden_size=hidden_size,


### PR DESCRIPTION
## Summary

Two pre-existing bugs surfaced during the post-#519/#521 smoke pass on RTX 4080 SUPER. Both would crash the corresponding sweeps on Runpod before the first fold completed.

- `scripts/run_rates_heads_sweep.py` never threaded `input_size`. `ModelConfig` defaults to `FEATURE_SIZE` (6), but the loader emits `RICH_FEATURE_SIZE` (87). LSTM raises ``input.size(-1) must be equal to input_size`` on the first batch. Mirror the `input_size=RICH_FEATURE_SIZE` pattern already used in `run_dual_head_comparison.py:284`.
- `backend/app/data/finetune_pilot_b2.py` passed the registry alias (`finbert_fed_adjacent`) directly to `AutoTokenizer.from_pretrained` / `AutoModelForSequenceClassification.from_pretrained`. After #464 the alias resolves to a HF slug (`yusufizzetmurat/finbert-fed-adjacent`); the raw alias 404s. Look up via `encoder_ref(alias).repo` so the registry mapping rides through cleanly; fall back to the literal alias when the registry has no entry.

## Test plan

- [x] `docker compose --profile gpu run --rm backend-gpu python -m scripts.run_rates_heads_sweep --training-package-id tp_v3_full_rebuild_2026_05_30 --output artifacts/experiments/smoke_rates.json --seeds 11 --epochs 3 --folds wf_fold_1 --rates-heads 2y` — passes
- [x] `docker compose --profile gpu run --rm backend-gpu python -m app.data.finetune_pilot_b2 --training-package-id tp_v3_full_rebuild_2026_05_30 --output artifacts/experiments/smoke_b2.json --seeds 11 --epochs 1 --folds wf_fold_1` — passes