### PR TITLE
Re-add statement_delta / vote / press flags + wire delta-encoder CLI

### DIFF
--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -2400,7 +2400,78 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "first usable event moves later in the calendar."
         ),
     )
+    parser.add_argument(
+        "--delta-encoder",
+        default=None,
+        help=(
+            "Registry alias (or owner/repo HF id) of the encoder used to "
+            "embed the #443 statement-delta spans (inserted / deleted / "
+            "substituted) into the 768-d statement_delta_embedding column. "
+            "Resolves through models/registry.yaml when an alias is given "
+            "(picks up the pinned revision); a raw owner/repo id loads "
+            "at HEAD. Without this flag the column stays None on every "
+            "row and the loader collapses to the missing-1.0 slot."
+        ),
+    )
     return parser.parse_args(argv)
+
+
+def _build_delta_encoder_callable(repo_or_alias: str):
+    """Resolve ``repo_or_alias`` and return a ``Callable[[str], list[float]]``.
+
+    Loads the encoder once on import, mean-pools its last-hidden-state
+    over the non-pad tokens, and returns a 768-d list per call. CUDA
+    used opportunistically. The pooled width is asserted against
+    :data:`STATEMENT_DELTA_EMBEDDING_DIM` so a mismatched encoder fails
+    at build time rather than silently writing odd-width rows.
+    """
+
+    import torch
+    from transformers import AutoModel, AutoTokenizer
+
+    from app.models.registry import encoder_ref
+
+    ref = encoder_ref(repo_or_alias)
+    repo = ref.repo if ref is not None else repo_or_alias
+    revision = ref.revision if ref is not None else None
+
+    tokenizer = AutoTokenizer.from_pretrained(repo, revision=revision)
+    model = AutoModel.from_pretrained(repo, revision=revision)
+    model.eval()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device)
+    print(
+        f"[event-rows] delta encoder loaded: alias={repo_or_alias!r} "
+        f"repo={repo!r} revision={revision!r} device={device}"
+    )
+
+    @torch.no_grad()
+    def encode_text(text: str) -> list[float]:
+        inputs = tokenizer(
+            text,
+            return_tensors="pt",
+            truncation=True,
+            max_length=512,
+            padding=False,
+        )
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        outputs = model(**inputs)
+        hidden = outputs.last_hidden_state  # (1, T, H)
+        mask = inputs["attention_mask"].unsqueeze(-1).float()  # (1, T, 1)
+        summed = (hidden * mask).sum(dim=1)  # (1, H)
+        denom = mask.sum(dim=1).clamp(min=1.0)  # (1, 1)
+        pooled = (summed / denom).squeeze(0)  # (H,)
+        vec = pooled.detach().cpu().tolist()
+        if len(vec) != STATEMENT_DELTA_EMBEDDING_DIM:
+            raise SystemExit(
+                f"--delta-encoder produced width {len(vec)} but the "
+                f"statement_delta_embedding column expects "
+                f"{STATEMENT_DELTA_EMBEDDING_DIM}. Pin a BERT-base "
+                "encoder (e.g. finbert_fed_adjacent)."
+            )
+        return vec
+
+    return encode_text
 
 
 def _resolve_embedding_path(raw: str | None) -> Path | None:
@@ -2449,6 +2520,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         else None
     )
 
+    delta_encoder = (
+        _build_delta_encoder_callable(args.delta_encoder)
+        if args.delta_encoder
+        else None
+    )
+
     # Collapsed view
     summary = _BuildSummary()
     df = build_event_rows(
@@ -2464,6 +2541,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         macro_release_calendar=macro_calendar,
         rates_panel_path=args.rates_panel_path,
         rates_horizon=int(args.rates_horizon),
+        delta_encoder=delta_encoder,
         per_asset_target_cache_dir=per_asset_target_cache_dir,
         prior_window_days=int(args.prior_window),
     )
@@ -2505,6 +2583,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             keep_all_sources=True,
             rates_panel_path=args.rates_panel_path,
             rates_horizon=int(args.rates_horizon),
+            delta_encoder=delta_encoder,
             per_asset_target_cache_dir=per_asset_target_cache_dir,
             prior_window_days=int(args.prior_window),
         )

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -443,7 +443,7 @@ artefacts:
 
   training_package:
     hf_uri: hf://datasets/yusufizzetmurat/fed-pulse-training-package
-    revision: "b0320d8731753bc5bf4a05b9dcd57898c3f84fbd"
+    revision: "a045140c88506b7d0b86bd2f8e80101b65c078bf"
     eager: false
     description: |
       Canonical training package for ``make reproduce-all``. Pulled to
@@ -451,14 +451,18 @@ artefacts:
       ``huggingface_hub.snapshot_download(repo_type='dataset')``.
       Rebuilt 2026-05-30 against the fresh source-corpus pulls (#487-#489)
       with every optional family populated (rates panel, GARCH residual,
-      statement delta, vote tally, multi-horizon vol, per-asset vol).
-      Events.parquet carries the merged ``multi_axis_extras`` payload so
-      GSS / Swanson bp-scale factor decompositions reach the trainer
-      without a re-join to ``registry_normalized.parquet``; rates panel
-      extended back to 1990-01-01 so pre-2008 statements (~1.7k rows)
-      carry treas_2y / treas_10y features at 73.8% instead of 0%. The
-      pre-rebuild row at b9a71cc97a is preserved on the Hub for
-      reproducibility but is no longer the resolution target.
+      statement delta, vote tally, multi-horizon vol, per-asset vol) and
+      the #443 ``statement_delta_embedding`` column populated end-to-end
+      via ``--delta-encoder finbert_fed_adjacent`` (1427/7172 rows, every
+      statement event with a strict-prior statement). Events.parquet
+      carries the merged ``multi_axis_extras`` payload so GSS / Swanson
+      bp-scale factor decompositions reach the trainer without a re-join
+      to ``registry_normalized.parquet``; rates panel extended back to
+      1990-01-01 so pre-2008 statements (~1.7k rows) carry treas_2y /
+      treas_10y features at 73.8% instead of 0%. Prior rows at
+      b0320d8731 (pre-delta-encoder) and b9a71cc97a (pre-2026-05-30
+      rebuild) are preserved on the Hub for reproducibility but are no
+      longer the resolution target.
     inference_features: []
 
   embedding_caches:

--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -155,9 +155,47 @@ def _parse_args() -> argparse.Namespace:
         action="store_false",
         help="Disable the macro-regime block + gate (default).",
     )
+    # #443 / #444 / press-conf pass-through. Off by default so the
+    # canonical sweep stays byte-identical; on, each adds its own
+    # feature block to the rich-feature slice via the loader kwargs.
+    parser.add_argument(
+        "--use-statement-delta",
+        dest="use_statement_delta",
+        action="store_true",
+        help=(
+            "Attach the #443 statement-delta embedding (768-d) + missing "
+            "flag to every supervised event. Reads the "
+            "``statement_delta_embedding`` column on events.parquet; rows "
+            "without a strict-prior statement carry zeros + missing=1.0."
+        ),
+    )
+    parser.add_argument(
+        "--use-vote-features",
+        dest="use_vote_features",
+        action="store_true",
+        help=(
+            "Attach the #444 vote-tally feature block (votes_for_norm, "
+            "votes_against_norm, is_unanimous, direction_sign) to each "
+            "statement event. Non-statement rows carry zeros + missing=1.0."
+        ),
+    )
+    parser.add_argument(
+        "--use-press-conf",
+        dest="use_press_conf",
+        action="store_true",
+        help=(
+            "Attach the press-conference Q&A slot to each statement event "
+            "from press_conf_qa.parquet under the training package. "
+            "Statements without a matching press-conf row carry the "
+            "missing flag."
+        ),
+    )
     parser.set_defaults(
         use_retrieval_analogs=False,
         use_regime_conditioning=False,
+        use_statement_delta=False,
+        use_vote_features=False,
+        use_press_conf=False,
     )
     return parser.parse_args()
 
@@ -272,6 +310,9 @@ def _run_one_cell(
     rates_target_mode: str = "raw",
     use_retrieval_analogs: bool = False,
     use_regime_conditioning: bool = False,
+    use_statement_delta: bool = False,
+    use_vote_features: bool = False,
+    use_press_conf: bool = False,
 ) -> dict[str, Any]:
     # Imports happen here so the script is importable without a torch
     # install (useful for doc-only environments).
@@ -300,6 +341,9 @@ def _run_one_cell(
             rich_features=True,
             use_retrieval_analogs=use_retrieval_analogs,
             use_regime_conditioning=use_regime_conditioning,
+            use_statement_delta=use_statement_delta,
+            use_vote_features=use_vote_features,
+            use_press_conf=use_press_conf,
         )
         result = train_model(
             model_config=config,
@@ -362,6 +406,9 @@ def main() -> int:
                     rates_target_mode=str(args.rates_target_mode),
                     use_retrieval_analogs=bool(args.use_retrieval_analogs),
                     use_regime_conditioning=bool(args.use_regime_conditioning),
+                    use_statement_delta=bool(args.use_statement_delta),
+                    use_vote_features=bool(args.use_vote_features),
+                    use_press_conf=bool(args.use_press_conf),
                 )
             )
 
@@ -396,6 +443,9 @@ def main() -> int:
         ),
         "use_retrieval_analogs": bool(args.use_retrieval_analogs),
         "use_regime_conditioning": bool(args.use_regime_conditioning),
+        "use_statement_delta": bool(args.use_statement_delta),
+        "use_vote_features": bool(args.use_vote_features),
+        "use_press_conf": bool(args.use_press_conf),
         "trials": trials,
         "summary": summary,
     }

--- a/tests/unit/test_run_dual_head_comparison.py
+++ b/tests/unit/test_run_dual_head_comparison.py
@@ -46,6 +46,9 @@ def test_dual_head_runner_exposes_new_flags(monkeypatch):
     assert args.rates_target_mode == "raw"
     assert args.use_retrieval_analogs is False
     assert args.use_regime_conditioning is False
+    assert args.use_statement_delta is False
+    assert args.use_vote_features is False
+    assert args.use_press_conf is False
 
 
 def test_dual_head_runner_accepts_opt_in_flags(monkeypatch):
@@ -62,12 +65,18 @@ def test_dual_head_runner_accepts_opt_in_flags(monkeypatch):
             "fomc_attributable",
             "--use-retrieval-analogs",
             "--use-regime-conditioning",
+            "--use-statement-delta",
+            "--use-vote-features",
+            "--use-press-conf",
         ],
     )
     args = _parse_args()
     assert args.rates_target_mode == "fomc_attributable"
     assert args.use_retrieval_analogs is True
     assert args.use_regime_conditioning is True
+    assert args.use_statement_delta is True
+    assert args.use_vote_features is True
+    assert args.use_press_conf is True
 
 
 def test_dual_head_runner_rejects_unknown_rates_target_mode(monkeypatch):
@@ -210,9 +219,12 @@ def test_dual_head_runner_default_off_byte_identity(monkeypatch):
     assert result["head_mode"] == "dual"
     assert len(captured["loader_calls"]) == 1
     loader_kwargs = captured["loader_calls"][0]
-    # Default-off contract: both opt-in loader flags pass False.
+    # Default-off contract: every opt-in loader flag passes False.
     assert loader_kwargs["use_retrieval_analogs"] is False
     assert loader_kwargs["use_regime_conditioning"] is False
+    assert loader_kwargs["use_statement_delta"] is False
+    assert loader_kwargs["use_vote_features"] is False
+    assert loader_kwargs["use_press_conf"] is False
     assert loader_kwargs["rich_features"] is True
 
     train_kwargs = captured["train_calls"][0]
@@ -238,11 +250,17 @@ def test_dual_head_runner_opt_in_threads_through(monkeypatch):
         rates_target_mode="fomc_attributable",
         use_retrieval_analogs=True,
         use_regime_conditioning=True,
+        use_statement_delta=True,
+        use_vote_features=True,
+        use_press_conf=True,
     )
 
     loader_kwargs = captured["loader_calls"][0]
     assert loader_kwargs["use_retrieval_analogs"] is True
     assert loader_kwargs["use_regime_conditioning"] is True
+    assert loader_kwargs["use_statement_delta"] is True
+    assert loader_kwargs["use_vote_features"] is True
+    assert loader_kwargs["use_press_conf"] is True
 
     train_kwargs = captured["train_calls"][0]
     model_config = train_kwargs["model_config"]


### PR DESCRIPTION
## Summary
- Re-expose `--use-statement-delta`, `--use-vote-features`, `--use-press-conf` on the canonical sweep runner.
- Add `--delta-encoder` CLI to `event_dataset_builder` (registry-alias or repo, mean-pooled last-hidden-state, 768-d slot check).
- Repin `training_package` to the rebuilt SHA with `statement_delta_embedding` populated end-to-end via `--delta-encoder finbert_fed_adjacent` (1427/7172, 19.9%).
- Extend parser + loader-kwargs contract tests for the three re-added flags.

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit/test_run_dual_head_comparison.py -q`
- [ ] CI green