### PR TITLE
Zero-fill new feature blocks + widen LSTM input for them

### DIFF
--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -410,9 +410,13 @@ def build_forecaster(
     model.vol_target_mode = vol_target_mode_value  # type: ignore[assignment]
     # #443/#444 round-trip the two new opt-in flags. Default-off path
     # behaves byte-identically; flag-on a future sweep that resumes off
-    # this checkpoint rebuilds with the same loader-tail widths.
-    model.use_statement_delta = use_statement_delta_flag  # type: ignore[assignment]
-    model.use_vote_features = use_vote_features_flag  # type: ignore[assignment]
+    # this checkpoint rebuilds with the same loader-tail widths. The
+    # ctor wires these as ``ForecasterBase`` attrs already; the explicit
+    # assignment here covers the flat_mlp path (which doesn't go through
+    # the recurrent base) and serves as the round-trip source the
+    # persisted run summary reads via ``ModelConfig.from_model``.
+    model.use_statement_delta = use_statement_delta_flag
+    model.use_vote_features = use_vote_features_flag
     # #480 round-trip the symbol-embedding dim so
     # ``ModelConfig.from_model`` recovers it on resume. The research
     # class set this in its ctor; stash it on the serving instance too

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -362,6 +362,8 @@ def build_forecaster(
             use_regime_conditioning=use_regime_conditioning_flag,
             use_sep=use_sep_flag,
             use_press_conf=use_press_conf_flag,
+            use_statement_delta=use_statement_delta_flag,
+            use_vote_features=use_vote_features_flag,
             **kwargs,
         )
     else:
@@ -372,6 +374,8 @@ def build_forecaster(
             use_regime_conditioning=use_regime_conditioning_flag,
             use_sep=use_sep_flag,
             use_press_conf=use_press_conf_flag,
+            use_statement_delta=use_statement_delta_flag,
+            use_vote_features=use_vote_features_flag,
             symbol_embedding_dim=symbol_embedding_dim_value,
             **kwargs,
         )

--- a/backend/app/models/forecaster_base.py
+++ b/backend/app/models/forecaster_base.py
@@ -39,6 +39,10 @@ from app.models.config import (
     RICH_PRESS_CONF_DIM,
     RICH_SEP_DIM,
     RICH_SEP_MISSING_DIM,
+    RICH_STATEMENT_DELTA_DIM,
+    RICH_STATEMENT_DELTA_MISSING_DIM,
+    RICH_VOTE_FEATURES_DIM,
+    RICH_VOTE_FEATURES_MISSING_DIM,
     SEQUENCE_LENGTH,
 )
 from app.models.dlinear import DLinear
@@ -93,6 +97,8 @@ class ForecasterBase(nn.Module):
         use_regime_conditioning: bool = False,
         use_sep: bool = False,
         use_press_conf: bool = False,
+        use_statement_delta: bool = False,
+        use_vote_features: bool = False,
     ):
         super().__init__()
         if model_type not in _ALLOWED_MODEL_TYPES:
@@ -225,6 +231,30 @@ class ForecasterBase(nn.Module):
         else:
             press_conf_tail_dim = 0
         self.press_conf_tail_dim = press_conf_tail_dim
+        # #443 statement-delta tail. The loader appends
+        # ``RICH_STATEMENT_DELTA_DIM + RICH_STATEMENT_DELTA_MISSING_DIM``
+        # extra scalars past the press-conf tail on every per-bar tensor
+        # when the flag is on; the recurrent core has to widen by the
+        # same amount or the LSTM input projection rejects the tensor.
+        self.use_statement_delta = bool(use_statement_delta)
+        if self.use_statement_delta:
+            statement_delta_tail_dim = (
+                RICH_STATEMENT_DELTA_DIM + RICH_STATEMENT_DELTA_MISSING_DIM
+            )
+        else:
+            statement_delta_tail_dim = 0
+        self.statement_delta_tail_dim = statement_delta_tail_dim
+        # #444 vote-tally tail. Same uniform-width contract; appended
+        # after the statement-delta tail in the documented order
+        # (regime, SEP, press-conf, statement-delta, vote).
+        self.use_vote_features = bool(use_vote_features)
+        if self.use_vote_features:
+            vote_features_tail_dim = (
+                RICH_VOTE_FEATURES_DIM + RICH_VOTE_FEATURES_MISSING_DIM
+            )
+        else:
+            vote_features_tail_dim = 0
+        self.vote_features_tail_dim = vote_features_tail_dim
         self.text_embedding_dim = int(text_embedding_dim or 0)
         self.text_adapter_dim = int(text_adapter_dim or 0)
         self._text_path_active = self.text_embedding_dim > 0 and self.text_adapter_dim > 0
@@ -250,6 +280,8 @@ class ForecasterBase(nn.Module):
             + regime_tail_dim
             + sep_tail_dim
             + press_conf_tail_dim
+            + statement_delta_tail_dim
+            + vote_features_tail_dim
         )
         self.lstm_input_size = lstm_input_size
         lstm_dropout = dropout if num_layers > 1 else 0.0

--- a/backend/app/models/research_model.py
+++ b/backend/app/models/research_model.py
@@ -73,6 +73,8 @@ class ForecasterResearchModel(ForecasterBase):
         use_regime_conditioning: bool = False,
         use_sep: bool = False,
         use_press_conf: bool = False,
+        use_statement_delta: bool = False,
+        use_vote_features: bool = False,
         symbol_embedding_dim: int = 0,
         n_symbols: int = 0,
     ):
@@ -110,6 +112,8 @@ class ForecasterResearchModel(ForecasterBase):
             use_regime_conditioning=use_regime_conditioning,
             use_sep=use_sep,
             use_press_conf=use_press_conf,
+            use_statement_delta=use_statement_delta,
+            use_vote_features=use_vote_features,
         )
         # Head dispatch -- classification mounts the MultiTaskHead, the
         # optional log(RV) regression head, and the per-rates-head pair

--- a/backend/app/models/serving_model.py
+++ b/backend/app/models/serving_model.py
@@ -86,6 +86,8 @@ class ForecasterServingModel(ForecasterBase):
         use_regime_conditioning: bool = False,
         use_sep: bool = False,
         use_press_conf: bool = False,
+        use_statement_delta: bool = False,
+        use_vote_features: bool = False,
     ):
         if output_mode not in {"regression", "classification"}:
             raise ValueError(
@@ -117,6 +119,8 @@ class ForecasterServingModel(ForecasterBase):
             use_regime_conditioning=use_regime_conditioning,
             use_sep=use_sep,
             use_press_conf=use_press_conf,
+            use_statement_delta=use_statement_delta,
+            use_vote_features=use_vote_features,
         )
         self.output_mode = output_mode
         self.n_classes = int(n_classes)

--- a/backend/app/training/encoder_lora.py
+++ b/backend/app/training/encoder_lora.py
@@ -122,7 +122,7 @@ def build_lora_encoder(
             "encoder build"
         )
 
-    tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)
+    tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)  # type: ignore[no-untyped-call]
     base_encoder = AutoModel.from_pretrained(ref.repo, revision=ref.revision)
     base_encoder.requires_grad_(False)
 

--- a/backend/app/training/encoder_lora.py
+++ b/backend/app/training/encoder_lora.py
@@ -122,7 +122,7 @@ def build_lora_encoder(
             "encoder build"
         )
 
-    tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)  # type: ignore[no-untyped-call]
+    tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)
     base_encoder = AutoModel.from_pretrained(ref.repo, revision=ref.revision)
     base_encoder.requires_grad_(False)
 

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -24,6 +24,9 @@ from app.models.config import (
     MULTI_TASK_STANCE_LABELS,
     RICH_FEATURE_SIZE,
     RICH_LINGUISTIC_DIM,
+    RICH_PRESS_CONF_DIM,
+    RICH_STATEMENT_DELTA_DIM,
+    RICH_VOTE_FEATURES_DIM,
     RichFeatureScalerParams,
     SEQUENCE_LENGTH,
     FeatureVector,
@@ -2153,21 +2156,39 @@ def _load_package_sequences_with_metadata(
                 vector.sep_features = None
                 vector.sep_features_missing = 1.0
             # #214 press-conf Q&A block broadcast onto every bar.
+            # When the user opted in via ``use_press_conf`` but this
+            # specific event has no Q&A row, zero-fill instead of leaving
+            # the field at ``None`` -- otherwise ``as_rich_list`` skips
+            # the block and the per-bar tensor goes ragged across events.
             if press_conf_block_list is not None:
                 vector.press_conf_features = list(press_conf_block_list)
+            elif use_press_conf:
+                vector.press_conf_features = [0.0] * RICH_PRESS_CONF_DIM
             else:
                 vector.press_conf_features = None
-            # #443 statement-delta embedding broadcast.
+            # #443 statement-delta embedding broadcast. Same uniform-width
+            # contract as press-conf: when ``use_statement_delta`` is on
+            # but the row carries None (non-statement event or cold-start
+            # statement without a strict-prior), zero-fill the 768-d slot
+            # and flip missing=1.0 so the consumer's per-bar tensor stays
+            # uniform.
             if statement_delta_list is not None:
                 vector.statement_delta_embedding = list(statement_delta_list)
                 vector.statement_delta_embedding_missing = 0.0
+            elif use_statement_delta:
+                vector.statement_delta_embedding = [0.0] * RICH_STATEMENT_DELTA_DIM
+                vector.statement_delta_embedding_missing = 1.0
             else:
                 vector.statement_delta_embedding = None
                 vector.statement_delta_embedding_missing = 1.0
-            # #444 vote-tally feature broadcast.
+            # #444 vote-tally feature broadcast. Same uniform-width
+            # contract: opt-in + missing row -> zero block + missing=1.0.
             if vote_features_list is not None:
                 vector.vote_features = list(vote_features_list)
                 vector.vote_features_missing = 0.0
+            elif use_vote_features:
+                vector.vote_features = [0.0] * RICH_VOTE_FEATURES_DIM
+                vector.vote_features_missing = 1.0
             else:
                 vector.vote_features = None
                 vector.vote_features_missing = 1.0
@@ -2951,21 +2972,39 @@ def load_training_sequences_from_package(
                 vector.sep_features = None
                 vector.sep_features_missing = 1.0
             # #214 press-conf Q&A block broadcast onto every bar.
+            # When the user opted in via ``use_press_conf`` but this
+            # specific event has no Q&A row, zero-fill instead of leaving
+            # the field at ``None`` -- otherwise ``as_rich_list`` skips
+            # the block and the per-bar tensor goes ragged across events.
             if press_conf_block_list is not None:
                 vector.press_conf_features = list(press_conf_block_list)
+            elif use_press_conf:
+                vector.press_conf_features = [0.0] * RICH_PRESS_CONF_DIM
             else:
                 vector.press_conf_features = None
-            # #443 statement-delta embedding broadcast.
+            # #443 statement-delta embedding broadcast. Same uniform-width
+            # contract as press-conf: when ``use_statement_delta`` is on
+            # but the row carries None (non-statement event or cold-start
+            # statement without a strict-prior), zero-fill the 768-d slot
+            # and flip missing=1.0 so the consumer's per-bar tensor stays
+            # uniform.
             if statement_delta_list is not None:
                 vector.statement_delta_embedding = list(statement_delta_list)
                 vector.statement_delta_embedding_missing = 0.0
+            elif use_statement_delta:
+                vector.statement_delta_embedding = [0.0] * RICH_STATEMENT_DELTA_DIM
+                vector.statement_delta_embedding_missing = 1.0
             else:
                 vector.statement_delta_embedding = None
                 vector.statement_delta_embedding_missing = 1.0
-            # #444 vote-tally feature broadcast.
+            # #444 vote-tally feature broadcast. Same uniform-width
+            # contract: opt-in + missing row -> zero block + missing=1.0.
             if vote_features_list is not None:
                 vector.vote_features = list(vote_features_list)
                 vector.vote_features_missing = 0.0
+            elif use_vote_features:
+                vector.vote_features = [0.0] * RICH_VOTE_FEATURES_DIM
+                vector.vote_features_missing = 1.0
             else:
                 vector.vote_features = None
                 vector.vote_features_missing = 1.0

--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -331,6 +331,9 @@ def _run_one_cell(
         rates_heads=rates_heads,
         rates_target_mode=rates_target_mode,
         use_regime_conditioning=use_regime_conditioning,
+        use_press_conf=use_press_conf,
+        use_statement_delta=use_statement_delta,
+        use_vote_features=use_vote_features,
     )
 
     per_fold: list[dict[str, Any]] = []

--- a/tests/unit/test_feature_vector_delta_vote_byte_identity.py
+++ b/tests/unit/test_feature_vector_delta_vote_byte_identity.py
@@ -17,6 +17,7 @@ from app.models.config import (
     RICH_FEATURE_SIZE,
     RICH_MACRO_REGIME_DIM,
     RICH_MACRO_REGIME_MISSING_DIM,
+    RICH_PRESS_CONF_DIM,
     RICH_SEP_DIM,
     RICH_SEP_MISSING_DIM,
     RICH_STATEMENT_DELTA_DIM,
@@ -84,6 +85,45 @@ def test_vote_features_slot_appends_tail_when_populated() -> None:
     )
     assert len(rich) == expected
     assert rich[-1] == 0.0
+
+
+def test_statement_delta_uniform_width_across_populated_and_missing() -> None:
+    """Regression: opt-in row with missing data must match populated width.
+
+    Before #524, an event opted-in via ``use_statement_delta`` but
+    lacking a strict-prior statement left
+    ``statement_delta_embedding=None`` and ``as_rich_list`` skipped the
+    tail entirely. Statement events emitted +769 dims, non-statement
+    events emitted +0 → ragged ``torch.tensor`` build at sweep time.
+    The loader now zero-fills the slot whenever the flag is on, so the
+    two FeatureVectors below must produce identical-width rich lists.
+    """
+
+    populated = _bare_vector()
+    populated.statement_delta_embedding = [0.1] * RICH_STATEMENT_DELTA_DIM
+    populated.statement_delta_embedding_missing = 0.0
+    missing = _bare_vector()
+    missing.statement_delta_embedding = [0.0] * RICH_STATEMENT_DELTA_DIM
+    missing.statement_delta_embedding_missing = 1.0
+    assert len(populated.as_rich_list()) == len(missing.as_rich_list())
+
+
+def test_vote_features_uniform_width_across_populated_and_missing() -> None:
+    populated = _bare_vector()
+    populated.vote_features = [0.83, 0.08, 0.0, 1.0]
+    populated.vote_features_missing = 0.0
+    missing = _bare_vector()
+    missing.vote_features = [0.0] * RICH_VOTE_FEATURES_DIM
+    missing.vote_features_missing = 1.0
+    assert len(populated.as_rich_list()) == len(missing.as_rich_list())
+
+
+def test_press_conf_uniform_width_across_populated_and_missing() -> None:
+    populated = _bare_vector()
+    populated.press_conf_features = [1.0]
+    missing = _bare_vector()
+    missing.press_conf_features = [0.0] * RICH_PRESS_CONF_DIM
+    assert len(populated.as_rich_list()) == len(missing.as_rich_list())
 
 
 def test_all_opt_in_tails_compose_in_documented_order() -> None:


### PR DESCRIPTION
## Summary
- Loader (`backend/app/training/loaders.py`): when `use_press_conf` / `use_statement_delta` / `use_vote_features` is on but a row lacks the feature, zero-fill the slot + flip `missing=1.0` instead of leaving the field at `None`. Prior behavior left `as_rich_list` skipping the block on missing rows → ragged per-bar tensor (statement events `+769` dims, non-statement events `+0`).
- ForecasterBase: add `statement_delta_tail_dim` + `vote_features_tail_dim` accumulators alongside the existing `regime` / `sep` / `press_conf` widening so `lstm_input_size` matches the loader output width.
- ResearchModel + ServingModel + factory: thread `use_statement_delta` / `use_vote_features` through to the constructor (previously stashed as attributes only).
- `run_dual_head_comparison.py`: pass `use_press_conf` / `use_statement_delta` / `use_vote_features` to `ModelConfig` so the model widens to match.

Closes the runtime path #523 left half-wired.

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit/test_run_dual_head_comparison.py tests/unit/test_event_dataset_builder.py -q`
- [ ] Smoke each opt-in arm (canonical TP, 1 seed / 1 epoch / 1 fold) — exit 0 confirmed locally