### PR TITLE
eval: per-fold baselines, paired Wilcoxon, ordinal confusion decomposition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             --follow-imports=silent \
             app/config.py app/determinism.py app/schemas.py \
             app/data/sources app/data/label_schemas.py \
-            app/training app/models app/services app/evaluation
+            app/training app/models app/services app/evaluation app/eval
 
   pytest:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package pre-sweep-column-audit build-events-parquet pull-op-fed pull-swanson-three-factor pull-beige-book pull-press-conferences pull-speeches pull-testimonies pull-regional-research train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package pre-sweep-column-audit build-events-parquet pull-op-fed pull-swanson-three-factor pull-beige-book pull-press-conferences pull-speeches pull-testimonies pull-regional-research train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build per-fold-baselines paired-stats ordinal-confusion
 
 help:
 	@echo "Targets:"
@@ -1011,3 +1011,27 @@ cross-source-transfer:
 		--encoder-checkpoints "$$ENCODER_CHECKPOINTS" \
 		$(if $(SOURCE_TYPES),--source-types "$(SOURCE_TYPES)",) \
 		$(if $(OUTPUT_DIR),--output-dir "$(OUTPUT_DIR)",)
+
+# Per-fold class-distribution + dual baselines table (#500).
+per-fold-baselines:
+	docker compose run --rm backend \
+		python -m app.eval.per_fold_baselines \
+			--training-package-id canonical \
+			--sweep-artefact artifacts/experiments/dual_head_comparison_canonical.json \
+			--output artifacts/experiments/per_fold_baselines.json
+
+# Paired Wilcoxon + Holm-Bonferroni on head-mode comparisons (#497).
+paired-stats:
+	docker compose run --rm backend \
+		python -m app.eval.paired_comparisons \
+			--sweep-artefacts artifacts/experiments/dual_head_comparison_canonical.json \
+			--comparisons classification,dual classification,regression regression,dual \
+			--metric regime_f1_macro \
+			--output artifacts/experiments/paired_comparisons.json
+
+# Ordinal confusion-matrix decomposition (#496).
+ordinal-confusion:
+	docker compose run --rm backend \
+		python -m app.eval.ordinal_confusion \
+			--sweep-artefact artifacts/experiments/dual_head_comparison_canonical.json \
+			--output artifacts/experiments/ordinal_confusion.json

--- a/backend/app/eval/__init__.py
+++ b/backend/app/eval/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/backend/app/eval/ordinal_confusion.py
+++ b/backend/app/eval/ordinal_confusion.py
@@ -1,0 +1,265 @@
+"""Ordinal confusion-matrix decomposition for the regime classifier (#496).
+
+Reads per-cell classification_breakdown payloads from sweep artefacts.
+Post-#523 artefacts carry the breakdown; pre-#523 artefacts do not and
+are skipped with a structured warning.
+
+For cells with a breakdown, computes:
+  adjacent error rate    = off-by-1 errors / total errors
+  non-adjacent error rate = off-by-2 errors / total errors (calm <-> high)
+  ordinal accuracy        = 1 - non_adjacent_error_rate
+
+Aggregates per arm (head_mode): mean ± std across seed x fold cells.
+
+CLI::
+
+    python -m app.eval.ordinal_confusion \\
+        --sweep-artefact backend/artifacts/experiments/dual_head_comparison_canonical.json \\
+        --output backend/artifacts/experiments/ordinal_confusion.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import math
+import warnings
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Sequence
+
+from app.config import BACKEND_ROOT
+
+_DEFAULT_ARTEFACT = (
+    BACKEND_ROOT / "artifacts" / "experiments" / "dual_head_comparison_canonical.json"
+)
+_DEFAULT_OUTPUT = (
+    BACKEND_ROOT / "artifacts" / "experiments" / "ordinal_confusion.json"
+)
+
+
+def decompose_ordinal(
+    confusion: Sequence[Sequence[int]],
+) -> dict[str, float]:
+    """Adjacent / non-adjacent error rates and ordinal accuracy.
+
+    Rows = true class, columns = predicted class. Adjacent = |true-pred|==1;
+    non-adjacent = |true-pred|>=2.
+    """
+    n = len(confusion)
+    total_errors = 0
+    adjacent = 0
+    non_adjacent = 0
+    for r in range(n):
+        for c in range(n):
+            count = int(confusion[r][c])
+            if r == c:
+                continue
+            total_errors += count
+            dist = abs(r - c)
+            if dist == 1:
+                adjacent += count
+            else:
+                non_adjacent += count
+    adj_rate = adjacent / total_errors if total_errors > 0 else 0.0
+    nonadj_rate = non_adjacent / total_errors if total_errors > 0 else 0.0
+    return {
+        "total_errors": total_errors,
+        "adjacent_errors": adjacent,
+        "non_adjacent_errors": non_adjacent,
+        "adjacent_error_rate": adj_rate,
+        "non_adjacent_error_rate": nonadj_rate,
+        "ordinal_accuracy": 1.0 - nonadj_rate,
+    }
+
+
+@dataclasses.dataclass(frozen=True)
+class OrdinalCell:
+    head_mode: str
+    seed: int
+    fold_id: str
+    adjacent_error_rate: float
+    non_adjacent_error_rate: float
+    ordinal_accuracy: float
+    total_errors: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def extract_cells(sweep_path: Path) -> list[OrdinalCell]:
+    """Pull OrdinalCell records from a sweep artefact.
+
+    Cells missing classification_breakdown emit a warning and are skipped
+    (pre-#523 artefact format).
+    """
+    payload = json.loads(sweep_path.read_text(encoding="utf-8"))
+    trials_by_mode: dict[str, list[Any]] = payload.get("trials") or {}
+    cells: list[OrdinalCell] = []
+    for head_mode, mode_trials in trials_by_mode.items():
+        for trial in mode_trials:
+            seed = int(trial.get("seed", -1))
+            for fold in trial.get("folds") or []:
+                fold_id = str(fold.get("fold_id", ""))
+                metrics = fold.get("metrics") or {}
+                breakdown = metrics.get("classification_breakdown")
+                if breakdown is None:
+                    warnings.warn(
+                        f"[ordinal_confusion] {sweep_path.name} "
+                        f"head={head_mode} seed={seed} fold={fold_id}: "
+                        "no classification_breakdown; skipping (pre-#523 artefact)",
+                        stacklevel=2,
+                    )
+                    continue
+                cm_raw = breakdown.get("confusion_matrix")
+                if not cm_raw or not isinstance(cm_raw, list):
+                    warnings.warn(
+                        f"[ordinal_confusion] {sweep_path.name} "
+                        f"head={head_mode} seed={seed} fold={fold_id}: "
+                        "confusion_matrix missing or malformed; skipping",
+                        stacklevel=2,
+                    )
+                    continue
+                d = decompose_ordinal(cm_raw)
+                cells.append(OrdinalCell(
+                    head_mode=head_mode,
+                    seed=seed,
+                    fold_id=fold_id,
+                    adjacent_error_rate=d["adjacent_error_rate"],
+                    non_adjacent_error_rate=d["non_adjacent_error_rate"],
+                    ordinal_accuracy=d["ordinal_accuracy"],
+                    total_errors=int(d["total_errors"]),
+                ))
+    return cells
+
+
+def _mean_std(values: Sequence[float]) -> tuple[float, float]:
+    n = len(values)
+    if n == 0:
+        return float("nan"), float("nan")
+    mu = sum(values) / n
+    if n == 1:
+        return mu, 0.0
+    var = sum((v - mu) ** 2 for v in values) / (n - 1)
+    return mu, math.sqrt(var)
+
+
+@dataclasses.dataclass(frozen=True)
+class ArmSummary:
+    head_mode: str
+    n_cells: int
+    mean_adjacent_error_rate: float
+    std_adjacent_error_rate: float
+    mean_non_adjacent_error_rate: float
+    std_non_adjacent_error_rate: float
+    mean_ordinal_accuracy: float
+    std_ordinal_accuracy: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def aggregate_by_arm(cells: Sequence[OrdinalCell]) -> list[ArmSummary]:
+    by_arm: dict[str, list[OrdinalCell]] = defaultdict(list)
+    for c in cells:
+        by_arm[c.head_mode].append(c)
+    summaries: list[ArmSummary] = []
+    for head_mode in sorted(by_arm):
+        arm = by_arm[head_mode]
+        adj_mu, adj_sd = _mean_std([c.adjacent_error_rate for c in arm])
+        na_mu, na_sd = _mean_std([c.non_adjacent_error_rate for c in arm])
+        oa_mu, oa_sd = _mean_std([c.ordinal_accuracy for c in arm])
+        summaries.append(ArmSummary(
+            head_mode=head_mode,
+            n_cells=len(arm),
+            mean_adjacent_error_rate=adj_mu,
+            std_adjacent_error_rate=adj_sd,
+            mean_non_adjacent_error_rate=na_mu,
+            std_non_adjacent_error_rate=na_sd,
+            mean_ordinal_accuracy=oa_mu,
+            std_ordinal_accuracy=oa_sd,
+        ))
+    return summaries
+
+
+def compute_ordinal_confusion(sweep_paths: Sequence[Path]) -> dict[str, Any]:
+    all_cells: list[OrdinalCell] = []
+    for p in sweep_paths:
+        all_cells.extend(extract_cells(p))
+    summaries = aggregate_by_arm(all_cells)
+
+    def _f(v: float) -> float | None:
+        return None if v != v else round(v, 6)
+
+    return {
+        "n_cells_total": len(all_cells),
+        "cells": [c.to_dict() for c in all_cells],
+        "arm_summaries": [
+            {
+                "head_mode": s.head_mode,
+                "n_cells": s.n_cells,
+                "adjacent_error_rate": {
+                    "mean": _f(s.mean_adjacent_error_rate),
+                    "std": _f(s.std_adjacent_error_rate),
+                },
+                "non_adjacent_error_rate": {
+                    "mean": _f(s.mean_non_adjacent_error_rate),
+                    "std": _f(s.std_non_adjacent_error_rate),
+                },
+                "ordinal_accuracy": {
+                    "mean": _f(s.mean_ordinal_accuracy),
+                    "std": _f(s.std_ordinal_accuracy),
+                },
+            }
+            for s in summaries
+        ],
+    }
+
+
+def _render_markdown(result: dict[str, Any]) -> str:
+    lines = [
+        "| Head mode | n | Adj err (mean±std) | Non-adj err (mean±std) | Ordinal acc (mean±std) |",
+        "|---|---:|---|---|---|",
+    ]
+    for s in result.get("arm_summaries", []):
+        def _cell(d: dict[str, Any]) -> str:
+            mu, sd = d.get("mean"), d.get("std")
+            if mu is None:
+                return "n/a"
+            return f"{mu:.4f} ± {sd:.4f}" if sd is not None else f"{mu:.4f}"
+        lines.append(
+            f"| {s['head_mode']} | {s['n_cells']}"
+            f" | {_cell(s['adjacent_error_rate'])}"
+            f" | {_cell(s['non_adjacent_error_rate'])}"
+            f" | {_cell(s['ordinal_accuracy'])} |"
+        )
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Ordinal confusion-matrix decomposition for regime classifier."
+    )
+    p.add_argument("--sweep-artefact", nargs="+", default=[str(_DEFAULT_ARTEFACT)])
+    p.add_argument("--output", default=str(_DEFAULT_OUTPUT))
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    result = compute_ordinal_confusion([Path(s) for s in args.sweep_artefact])
+    result["markdown"] = _render_markdown(result)
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(f"Wrote {out}")
+    if result["n_cells_total"] == 0:
+        print("No cells with classification_breakdown (pre-#523 artefacts); table pending.")
+    else:
+        print(_render_markdown(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/eval/paired_comparisons.py
+++ b/backend/app/eval/paired_comparisons.py
@@ -1,0 +1,322 @@
+"""Paired statistical tests on sweep config comparisons (#497).
+
+Reads dual_head_comparison_*.json sweep artefacts, matches cells by
+(seed, fold_id), and reports:
+  - Paired Wilcoxon signed-rank p-value (two-sided) via scipy
+  - Cohen's d: mean(delta) / std(delta)
+  - Block-bootstrap CI on mean(delta), blocking by fold
+  - Holm-Bonferroni correction across the comparison family
+
+CLI::
+
+    python -m app.eval.paired_comparisons \\
+        --comparisons classification,dual classification,regression regression,dual \\
+        --metric regime_f1_macro \\
+        --output backend/artifacts/experiments/paired_comparisons.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import math
+import warnings
+from pathlib import Path
+from typing import Any, Sequence
+
+from app.config import BACKEND_ROOT
+
+_DEFAULT_ARTEFACT = (
+    BACKEND_ROOT / "artifacts" / "experiments" / "dual_head_comparison_canonical.json"
+)
+_DEFAULT_OUTPUT = (
+    BACKEND_ROOT / "artifacts" / "experiments" / "paired_comparisons.json"
+)
+
+
+def _extract_cells(
+    sweep_path: Path,
+    head_mode: str,
+    metric: str,
+) -> dict[tuple[int, str], float]:
+    payload = json.loads(sweep_path.read_text(encoding="utf-8"))
+    mode_trials: list[Any] = (payload.get("trials") or {}).get(head_mode) or []
+    cells: dict[tuple[int, str], float] = {}
+    for trial in mode_trials:
+        seed = int(trial.get("seed", -1))
+        for fold in trial.get("folds") or []:
+            fid = str(fold.get("fold_id", ""))
+            v = (fold.get("metrics") or {}).get(metric)
+            if v is not None and seed >= 0:
+                cells[(seed, fid)] = float(v)
+    return cells
+
+
+def extract_paired_deltas(
+    sweep_path: Path,
+    label_a: str,
+    label_b: str,
+    metric: str,
+) -> tuple[list[float], list[str]]:
+    """Extract paired (a - b) deltas matched by (seed, fold_id).
+
+    Sort order is (fold_id, seed) so the resulting deltas are grouped by
+    fold; the per-fold groups are the blocks the bootstrap below relies
+    on to respect within-fold correlation across seeds.
+    """
+    cells_a = _extract_cells(sweep_path, label_a, metric)
+    cells_b = _extract_cells(sweep_path, label_b, metric)
+    shared = sorted(set(cells_a) & set(cells_b), key=lambda k: (k[1], k[0]))
+    deltas = [cells_a[k] - cells_b[k] for k in shared]
+    fold_labels = [k[1] for k in shared]
+    return deltas, fold_labels
+
+
+def wilcoxon_signed_rank(
+    deltas: Sequence[float],
+) -> tuple[float, float]:
+    """Two-sided Wilcoxon signed-rank test via scipy.stats.wilcoxon.
+
+    Zero deltas are dropped per the standard convention. Returns NaN
+    for both statistic and p-value when fewer than 2 nonzero deltas
+    remain — scipy raises on n<2 in some versions and returns a
+    degenerate value in others, neither of which is a defensible
+    headline-table cell. The warning fires at <3 because n=2 is
+    technically valid but rank-tied and underpowered.
+    """
+    from scipy.stats import wilcoxon
+
+    nonzero = [d for d in deltas if d != 0.0]
+    if len(nonzero) < 2:
+        return float("nan"), float("nan")
+    if len(nonzero) < 3:
+        warnings.warn(
+            f"[paired_comparisons] only {len(nonzero)} nonzero deltas; "
+            "Wilcoxon p-value may be unreliable",
+            stacklevel=2,
+        )
+    stat, pval = wilcoxon(nonzero, alternative="two-sided")
+    return float(stat), float(pval)
+
+
+def effect_size(deltas: Sequence[float]) -> float:
+    """Cohen's d analogue: mean(delta) / std(delta, ddof=1).
+
+    Returns NaN when the deltas are constant (sd at or below float noise
+    against the mean magnitude); otherwise float64 round-off would let
+    a 0/0 case surface as a spurious huge ratio.
+    """
+    n = len(deltas)
+    if n < 2:
+        return float("nan")
+    mu = sum(deltas) / n
+    var = sum((d - mu) ** 2 for d in deltas) / (n - 1)
+    sd = math.sqrt(var) if var > 0 else 0.0
+    tol = 1e-12 * max(1.0, abs(mu))
+    if sd <= tol:
+        return float("nan")
+    return mu / sd
+
+
+def block_bootstrap_ci_deltas(
+    deltas: Sequence[float],
+    fold_labels: Sequence[str],
+    *,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    seed: int = 11,
+) -> tuple[float, float, float]:
+    """Block-bootstrap CI on mean(delta), one block per fold.
+
+    Relies on ``extract_paired_deltas`` returning deltas sorted by
+    ``(fold_id, seed)`` so contiguous slices map to per-fold groups.
+    ``block_size`` is set to the per-fold group size (deltas/n_folds);
+    a moving-blocks resample then preserves the within-fold seed
+    correlation. Returns (point, lo, hi).
+    """
+    from app.evaluation.bootstrap import block_bootstrap_ci
+
+    if not deltas:
+        return float("nan"), float("nan"), float("nan")
+    n_folds = len(set(fold_labels))
+    block_size = max(1, len(deltas) // max(1, n_folds))
+    ci = block_bootstrap_ci(
+        list(deltas),
+        block_size=block_size,
+        n_resamples=n_resamples,
+        coverage=coverage,
+        seed=seed,
+    )
+    return float(ci.point), float(ci.lo), float(ci.hi)
+
+
+def holm_bonferroni(p_values: Sequence[float]) -> list[float]:
+    """Holm-Bonferroni corrected p-values (in original input order)."""
+    n = len(p_values)
+    if n == 0:
+        return []
+    indexed = sorted(enumerate(p_values), key=lambda kv: kv[1])
+    corrected = [0.0] * n
+    running_max = 0.0
+    for rank, (orig_idx, pval) in enumerate(indexed):
+        adjusted = min(1.0, pval * (n - rank))
+        adjusted = max(adjusted, running_max)
+        running_max = adjusted
+        corrected[orig_idx] = adjusted
+    return corrected
+
+
+@dataclasses.dataclass(frozen=True)
+class ComparisonResult:
+    label_a: str
+    label_b: str
+    metric: str
+    n_pairs: int
+    mean_delta: float
+    std_delta: float
+    wilcoxon_stat: float
+    p_value: float
+    p_value_holm: float
+    effect_size_d: float
+    ci_lo: float
+    ci_hi: float
+    ci_coverage: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def compare_two(
+    sweep_path: Path,
+    label_a: str,
+    label_b: str,
+    metric: str,
+    *,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    bootstrap_seed: int = 11,
+    p_value_holm: float = float("nan"),
+) -> ComparisonResult:
+    deltas, fold_labels = extract_paired_deltas(sweep_path, label_a, label_b, metric)
+    n = len(deltas)
+    if n == 0:
+        return ComparisonResult(
+            label_a=label_a, label_b=label_b, metric=metric, n_pairs=0,
+            mean_delta=float("nan"), std_delta=float("nan"),
+            wilcoxon_stat=float("nan"), p_value=float("nan"),
+            p_value_holm=p_value_holm, effect_size_d=float("nan"),
+            ci_lo=float("nan"), ci_hi=float("nan"), ci_coverage=coverage,
+        )
+    mu = sum(deltas) / n
+    var = sum((d - mu) ** 2 for d in deltas) / (n - 1) if n > 1 else 0.0
+    sd = math.sqrt(var)
+    stat, pval = wilcoxon_signed_rank(deltas)
+    es = effect_size(deltas)
+    point, lo, hi = block_bootstrap_ci_deltas(
+        deltas, fold_labels,
+        n_resamples=n_resamples, coverage=coverage, seed=bootstrap_seed,
+    )
+    return ComparisonResult(
+        label_a=label_a, label_b=label_b, metric=metric, n_pairs=n,
+        mean_delta=mu, std_delta=sd,
+        wilcoxon_stat=stat, p_value=pval,
+        p_value_holm=p_value_holm, effect_size_d=es,
+        ci_lo=lo, ci_hi=hi, ci_coverage=coverage,
+    )
+
+
+def compute_paired_comparisons(
+    sweep_paths: Sequence[Path],
+    comparison_pairs: Sequence[tuple[str, str]],
+    metric: str,
+    *,
+    n_resamples: int = 1000,
+    coverage: float = 0.95,
+    bootstrap_seed: int = 11,
+) -> list[ComparisonResult]:
+    """Run Wilcoxon + bootstrap for every (a, b) pair, then apply Holm correction."""
+    raw: list[ComparisonResult] = []
+    for sweep_path in sweep_paths:
+        for label_a, label_b in comparison_pairs:
+            raw.append(compare_two(
+                sweep_path, label_a, label_b, metric,
+                n_resamples=n_resamples, coverage=coverage,
+                bootstrap_seed=bootstrap_seed,
+            ))
+    corrected = holm_bonferroni([r.p_value for r in raw])
+    return [dataclasses.replace(r, p_value_holm=corrected[i]) for i, r in enumerate(raw)]
+
+
+def _render_markdown(results: list[ComparisonResult]) -> str:
+    lines = [
+        "| A vs B | n | mean Δ | W | p | p (Holm) | d | CI lo | CI hi |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for r in results:
+        def _f(v: float) -> str:
+            return "n/a" if v != v else f"{v:.4f}"
+        lines.append(
+            f"| {r.label_a} vs {r.label_b} | {r.n_pairs}"
+            f" | {_f(r.mean_delta)} | {_f(r.wilcoxon_stat)}"
+            f" | {_f(r.p_value)} | {_f(r.p_value_holm)}"
+            f" | {_f(r.effect_size_d)} | {_f(r.ci_lo)} | {_f(r.ci_hi)} |"
+        )
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Paired statistical tests on sweep config comparisons."
+    )
+    p.add_argument(
+        "--sweep-artefacts",
+        nargs="+",
+        default=[str(_DEFAULT_ARTEFACT)],
+    )
+    p.add_argument(
+        "--comparisons",
+        nargs="+",
+        default=["classification,dual", "classification,regression", "regression,dual"],
+        help="Comma-separated head-mode pairs, e.g. 'classification,dual'.",
+    )
+    p.add_argument("--metric", default="regime_f1_macro")
+    p.add_argument("--n-resamples", type=int, default=1000)
+    p.add_argument("--coverage", type=float, default=0.95)
+    p.add_argument("--bootstrap-seed", type=int, default=11)
+    p.add_argument("--output", default=str(_DEFAULT_OUTPUT))
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    sweep_paths = [Path(s) for s in args.sweep_artefacts]
+    pairs: list[tuple[str, str]] = []
+    for token in args.comparisons:
+        parts = token.split(",")
+        if len(parts) != 2:
+            raise SystemExit(f"comparison must be 'a,b'; got {token!r}")
+        pairs.append((parts[0].strip(), parts[1].strip()))
+    results = compute_paired_comparisons(
+        sweep_paths=sweep_paths,
+        comparison_pairs=pairs,
+        metric=args.metric,
+        n_resamples=args.n_resamples,
+        coverage=args.coverage,
+        bootstrap_seed=args.bootstrap_seed,
+    )
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        "metric": args.metric,
+        "comparisons": [r.to_dict() for r in results],
+        "markdown": _render_markdown(results),
+    }
+    out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"Wrote {out}")
+    print(_render_markdown(results))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/eval/paired_comparisons.py
+++ b/backend/app/eval/paired_comparisons.py
@@ -187,7 +187,7 @@ class ComparisonResult:
         return dataclasses.asdict(self)
 
 
-def compare_two(
+def compare_two(  # noqa: PLR0913 -- bootstrap knobs + Holm placeholder are independent kwargs by design
     sweep_path: Path,
     label_a: str,
     label_b: str,
@@ -226,7 +226,7 @@ def compare_two(
     )
 
 
-def compute_paired_comparisons(
+def compute_paired_comparisons(  # noqa: PLR0913 -- bootstrap knobs surface as named kwargs by design
     sweep_paths: Sequence[Path],
     comparison_pairs: Sequence[tuple[str, str]],
     metric: str,

--- a/backend/app/eval/per_fold_baselines.py
+++ b/backend/app/eval/per_fold_baselines.py
@@ -1,0 +1,277 @@
+"""Per-fold class-distribution table with dual baselines (#500).
+
+Reads a training package and computes two baselines per fold's test slice:
+  majority_baseline_f1  -- predict train-partition mode for every test row
+  stratified_random_f1  -- sample from train prior; mean over 1 000 seeds
+
+Encoder macro-F1 is pulled from a sweep JSON when available.
+
+CLI::
+
+    python -m app.eval.per_fold_baselines \\
+        --training-package-id canonical \\
+        --sweep-artefact backend/artifacts/experiments/dual_head_comparison_canonical.json \\
+        --output backend/artifacts/experiments/per_fold_baselines.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import warnings
+from collections import Counter
+from pathlib import Path
+from typing import Any, Sequence
+
+from app.config import BACKEND_ROOT, DATA_DIR as _DEFAULT_DATA_DIR
+from app.evaluation.classification_breakdown import compute_classification_breakdown
+from app.training.loaders import fit_vol_regime_quantiles, vol_regime_class_for
+
+_PROCESSED_ROOT = _DEFAULT_DATA_DIR / "processed"
+_N_CLASSES = 3
+CLASS_NAMES: tuple[str, str, str] = ("calm", "normal", "high")
+_DEFAULT_SWEEP = (
+    BACKEND_ROOT / "artifacts" / "experiments" / "dual_head_comparison_canonical.json"
+)
+_DEFAULT_OUTPUT = (
+    BACKEND_ROOT / "artifacts" / "experiments" / "per_fold_baselines.json"
+)
+
+
+def _pkg_dir(training_package_id: str, processed_root: Path) -> Path:
+    if training_package_id == "canonical":
+        return processed_root / "canonical"
+    return processed_root / training_package_id
+
+
+def load_fold_manifest(package_dir: Path) -> dict[str, Any]:
+    path = package_dir / "fold_manifest_expanding_walk_forward.json"
+    if not path.exists():
+        raise FileNotFoundError(f"fold manifest not found: {path}")
+    payload: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    return payload
+
+
+def load_events(package_dir: Path) -> list[dict[str, Any]]:
+    import pandas as pd
+
+    parquet_path = package_dir / "events.parquet"
+    if not parquet_path.exists():
+        raise FileNotFoundError(f"events.parquet not found: {parquet_path}")
+    df = pd.read_parquet(parquet_path)
+    rows: list[dict[str, Any]] = df.to_dict("records")
+    return rows
+
+
+def _rows_in_range(
+    rows: list[dict[str, Any]], start: str, end: str
+) -> list[dict[str, Any]]:
+    return [r for r in rows if start <= str(r.get("event_date", "")) <= end]
+
+
+def label_rows(
+    rows: list[dict[str, Any]],
+    quantiles: Sequence[float],
+) -> list[int]:
+    """Assign vol-regime class index to each row with a valid forward vol."""
+    out: list[int] = []
+    for r in rows:
+        raw = r.get("forward_realized_vol_10d")
+        if raw is None or raw != raw:  # noqa: PLR0124
+            continue
+        cls = vol_regime_class_for(float(raw), quantiles)
+        if 0 <= cls < _N_CLASSES:
+            out.append(cls)
+    return out
+
+
+def majority_baseline_f1(
+    train_labels: list[int], test_labels: list[int]
+) -> float:
+    """Macro-F1 under constant majority-class prediction."""
+    if not train_labels or not test_labels:
+        return 0.0
+    counts = Counter(train_labels)
+    majority = max(counts, key=lambda c: counts[c])
+    bd = compute_classification_breakdown(
+        predictions=[majority] * len(test_labels),
+        targets=test_labels,
+        n_classes=_N_CLASSES,
+    )
+    return float(bd.macro_f1)
+
+
+def stratified_random_f1(
+    train_labels: list[int],
+    test_labels: list[int],
+    *,
+    n_seeds: int = 1000,
+    base_seed: int = 0,
+) -> float:
+    """Mean macro-F1 of a random classifier matched to the train prior."""
+    if not train_labels or not test_labels:
+        return 0.0
+    total = len(train_labels)
+    counts = Counter(train_labels)
+    priors = [counts.get(c, 0) / total for c in range(_N_CLASSES)]
+    n_test = len(test_labels)
+    f1_sum = 0.0
+    for s in range(n_seeds):
+        rng = random.Random(base_seed + s)
+        preds = rng.choices(range(_N_CLASSES), weights=priors, k=n_test)
+        bd = compute_classification_breakdown(
+            predictions=preds, targets=test_labels, n_classes=_N_CLASSES
+        )
+        f1_sum += float(bd.macro_f1)
+    return f1_sum / n_seeds
+
+
+def _encoder_f1_from_sweep(
+    sweep_path: Path,
+    fold_id: str,
+    head_mode: str,
+) -> float | None:
+    if not sweep_path.exists():
+        return None
+    try:
+        payload = json.loads(sweep_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    mode_trials: list[Any] = (payload.get("trials") or {}).get(head_mode) or []
+    vals: list[float] = []
+    for trial in mode_trials:
+        for fold in trial.get("folds") or []:
+            if fold.get("fold_id") == fold_id:
+                m = fold.get("metrics") or {}
+                v = m.get("regime_f1_macro")
+                if v is not None:
+                    vals.append(float(v))
+    return sum(vals) / len(vals) if vals else None
+
+
+def compute_per_fold_baselines(
+    training_package_id: str,
+    *,
+    processed_root: Path | None = None,
+    sweep_artefact: Path | None = None,
+    head_mode: str = "classification",
+    n_stratified_seeds: int = 1000,
+) -> dict[str, Any]:
+    """Return per-fold distribution, majority-class, and stratified-random baselines.
+
+    Each ``folds`` entry carries class_distribution (train/val/test),
+    quantile_edges fitted on the train slice, majority_baseline_f1,
+    stratified_random_f1, and encoder_f1 from the sweep artefact (None
+    when unavailable).
+    """
+    root = processed_root or _PROCESSED_ROOT
+    pkg_dir = _pkg_dir(training_package_id, root)
+    manifest = load_fold_manifest(pkg_dir)
+    events = load_events(pkg_dir)
+    sweep = sweep_artefact or _DEFAULT_SWEEP
+
+    folds_out: list[dict[str, Any]] = []
+    for fold in manifest.get("folds") or []:
+        fold_id = str(fold["fold_id"])
+        train_rows = _rows_in_range(events, fold["train_start"], fold["train_end"])
+        val_rows = _rows_in_range(events, fold["val_start"], fold["val_end"])
+        test_rows = _rows_in_range(events, fold["test_start"], fold["test_end"])
+
+        train_vols: list[float] = [
+            float(r["forward_realized_vol_10d"])
+            for r in train_rows
+            if r.get("forward_realized_vol_10d") is not None
+            and r["forward_realized_vol_10d"] == r["forward_realized_vol_10d"]
+        ]
+        quantiles = fit_vol_regime_quantiles(train_vols)
+        if not quantiles:
+            warnings.warn(
+                f"[per_fold_baselines] {fold_id}: no vol data in train slice; skipping",
+                stacklevel=2,
+            )
+            continue
+
+        train_labels = label_rows(train_rows, quantiles)
+        val_labels = label_rows(val_rows, quantiles)
+        test_labels = label_rows(test_rows, quantiles)
+
+        def _dist(labels: list[int]) -> dict[str, int]:
+            c = Counter(labels)
+            return {CLASS_NAMES[i]: c.get(i, 0) for i in range(_N_CLASSES)}
+
+        folds_out.append({
+            "fold_id": fold_id,
+            "class_distribution": {
+                "train": _dist(train_labels),
+                "val": _dist(val_labels),
+                "test": _dist(test_labels),
+            },
+            "quantile_edges": list(quantiles),
+            "majority_baseline_f1": majority_baseline_f1(train_labels, test_labels),
+            "stratified_random_f1": stratified_random_f1(
+                train_labels, test_labels, n_seeds=n_stratified_seeds
+            ),
+            "encoder_f1": _encoder_f1_from_sweep(sweep, fold_id, head_mode),
+            "head_mode": head_mode,
+        })
+
+    return {
+        "training_package_id": training_package_id,
+        "sweep_artefact": str(sweep),
+        "head_mode": head_mode,
+        "folds": folds_out,
+    }
+
+
+def print_summary(result: dict[str, Any]) -> None:
+    folds = result.get("folds") or []
+    if not folds:
+        print("No fold results.")
+        return
+    hdr = f"{'Fold':<14} {'Majority':>10} {'Stratified':>12} {'Encoder':>10}"
+    print(hdr)
+    print("-" * len(hdr))
+    for f in folds:
+        enc = f["encoder_f1"]
+        enc_s = f"{enc:.4f}" if enc is not None else "       n/a"
+        print(
+            f"{f['fold_id']:<14}"
+            f"{f['majority_baseline_f1']:>10.4f}"
+            f"{f['stratified_random_f1']:>12.4f}"
+            f"{enc_s:>10}"
+        )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Per-fold class-distribution + dual baselines table."
+    )
+    p.add_argument("--training-package-id", default="canonical")
+    p.add_argument("--processed-root", default=str(_PROCESSED_ROOT))
+    p.add_argument("--sweep-artefact", default=str(_DEFAULT_SWEEP))
+    p.add_argument("--head-mode", default="classification")
+    p.add_argument("--n-stratified-seeds", type=int, default=1000)
+    p.add_argument("--output", default=str(_DEFAULT_OUTPUT))
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    result = compute_per_fold_baselines(
+        training_package_id=args.training_package_id,
+        processed_root=Path(args.processed_root),
+        sweep_artefact=Path(args.sweep_artefact),
+        head_mode=args.head_mode,
+        n_stratified_seeds=args.n_stratified_seeds,
+    )
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(f"Wrote {out}")
+    print_summary(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_ordinal_confusion.py
+++ b/tests/unit/test_ordinal_confusion.py
@@ -1,0 +1,108 @@
+"""Unit tests for app.eval.ordinal_confusion (#496)."""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+
+import pytest
+
+from app.eval.ordinal_confusion import (
+    compute_ordinal_confusion,
+    decompose_ordinal,
+    extract_cells,
+)
+
+
+def test_perfect_matrix_zero_errors() -> None:
+    cm = [[5, 0, 0], [0, 4, 0], [0, 0, 3]]
+    d = decompose_ordinal(cm)
+    assert d["total_errors"] == 0
+    assert d["adjacent_error_rate"] == 0.0
+    assert d["ordinal_accuracy"] == 1.0
+
+
+def test_all_adjacent_errors() -> None:
+    cm = [[0, 2, 0], [0, 0, 3], [0, 0, 5]]
+    d = decompose_ordinal(cm)
+    assert d["adjacent_errors"] == 5
+    assert d["non_adjacent_errors"] == 0
+    assert d["adjacent_error_rate"] == pytest.approx(1.0)
+    assert d["ordinal_accuracy"] == pytest.approx(1.0)
+
+
+def test_all_non_adjacent_errors() -> None:
+    cm = [[0, 0, 4], [0, 5, 0], [0, 0, 0]]
+    d = decompose_ordinal(cm)
+    assert d["non_adjacent_errors"] == 4
+    assert d["non_adjacent_error_rate"] == pytest.approx(1.0)
+    assert d["ordinal_accuracy"] == pytest.approx(0.0)
+
+
+def test_mixed_errors_rates() -> None:
+    cm = [[0, 2, 1], [0, 3, 0], [0, 0, 2]]
+    d = decompose_ordinal(cm)
+    assert d["total_errors"] == 3
+    assert d["adjacent_error_rate"] == pytest.approx(2 / 3)
+    assert d["non_adjacent_error_rate"] == pytest.approx(1 / 3)
+    assert d["ordinal_accuracy"] == pytest.approx(2 / 3)
+
+
+def _write_no_breakdown(tmp_path: Path) -> Path:
+    p = tmp_path / "no_bd.json"
+    p.write_text(json.dumps({
+        "trials": {
+            "classification": [{
+                "seed": 11,
+                "folds": [{"fold_id": "wf_fold_1", "metrics": {"regime_f1_macro": 0.42}}],
+            }]
+        }
+    }), encoding="utf-8")
+    return p
+
+
+def test_skip_missing_breakdown_with_warning(tmp_path: Path) -> None:
+    path = _write_no_breakdown(tmp_path)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        cells = extract_cells(path)
+    assert cells == []
+    assert any("classification_breakdown" in str(warning.message) for warning in w)
+
+
+def _write_with_breakdown(tmp_path: Path) -> Path:
+    adj_cm = [[0, 2, 0], [0, 4, 1], [0, 0, 3]]
+    nonadj_cm = [[0, 0, 3], [0, 5, 0], [0, 0, 2]]
+    p = tmp_path / "with_bd.json"
+    p.write_text(json.dumps({
+        "trials": {
+            "classification": [
+                {
+                    "seed": 11,
+                    "folds": [{"fold_id": "wf_fold_1", "metrics": {
+                        "regime_f1_macro": 0.42,
+                        "classification_breakdown": {"confusion_matrix": adj_cm},
+                    }}],
+                },
+                {
+                    "seed": 29,
+                    "folds": [{"fold_id": "wf_fold_1", "metrics": {
+                        "regime_f1_macro": 0.40,
+                        "classification_breakdown": {"confusion_matrix": nonadj_cm},
+                    }}],
+                },
+            ]
+        }
+    }), encoding="utf-8")
+    return p
+
+
+def test_end_to_end_aggregation(tmp_path: Path) -> None:
+    path = _write_with_breakdown(tmp_path)
+    result = compute_ordinal_confusion([path])
+    assert result["n_cells_total"] == 2
+    assert len(result["arm_summaries"]) == 1
+    s = result["arm_summaries"][0]
+    assert s["head_mode"] == "classification"
+    assert s["ordinal_accuracy"]["mean"] == pytest.approx(0.5, abs=0.01)

--- a/tests/unit/test_paired_comparisons.py
+++ b/tests/unit/test_paired_comparisons.py
@@ -1,0 +1,137 @@
+"""Unit tests for app.eval.paired_comparisons (#497)."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from app.eval.paired_comparisons import (
+    compute_paired_comparisons,
+    effect_size,
+    extract_paired_deltas,
+    holm_bonferroni,
+    wilcoxon_signed_rank,
+)
+
+
+def test_wilcoxon_positive_shift_significant() -> None:
+    deltas = [0.05, 0.04, 0.06, 0.03, 0.05, 0.04, 0.06, 0.03, 0.05, 0.04]
+    _, pval = wilcoxon_signed_rank(deltas)
+    assert not math.isnan(pval)
+    assert pval < 0.05
+
+
+def test_wilcoxon_all_zero_returns_nan() -> None:
+    _, pval = wilcoxon_signed_rank([0.0, 0.0, 0.0])
+    assert math.isnan(pval)
+
+
+def test_wilcoxon_one_nonzero_returns_nan() -> None:
+    """scipy.stats.wilcoxon is undefined for n<2; the wrapper must early-return."""
+    stat, pval = wilcoxon_signed_rank([0.0, 0.05])
+    assert math.isnan(stat)
+    assert math.isnan(pval)
+
+
+def test_wilcoxon_symmetric_large_p() -> None:
+    deltas = [0.1, -0.1, 0.2, -0.2, 0.05, -0.05]
+    _, pval = wilcoxon_signed_rank(deltas)
+    assert pval > 0.1
+
+
+def test_effect_size_positive_deltas() -> None:
+    d = effect_size([0.05, 0.04, 0.06, 0.05, 0.03])
+    assert d > 0
+
+
+def test_effect_size_nan_for_single() -> None:
+    assert math.isnan(effect_size([0.1]))
+
+
+def test_effect_size_nan_for_constant() -> None:
+    assert math.isnan(effect_size([0.1, 0.1, 0.1]))
+
+
+def test_holm_inflates_p_values() -> None:
+    p_values = [0.01, 0.04, 0.02, 0.30]
+    corrected = holm_bonferroni(p_values)
+    for orig, corr in zip(p_values, corrected, strict=False):
+        assert corr >= orig - 1e-12
+
+
+def test_holm_single_unchanged() -> None:
+    assert holm_bonferroni([0.03])[0] == pytest.approx(0.03)
+
+
+def test_holm_most_significant_multiplied_by_n() -> None:
+    p = [0.05, 0.01, 0.02]
+    corrected = holm_bonferroni(p)
+    assert corrected[1] == pytest.approx(0.03)
+
+
+def _write_sweep(tmp_path: Path) -> Path:
+    sweep = {
+        "trials": {
+            "classification": [
+                {
+                    "seed": 11,
+                    "folds": [
+                        {"fold_id": "wf_fold_1", "metrics": {"regime_f1_macro": 0.40}},
+                        {"fold_id": "wf_fold_2", "metrics": {"regime_f1_macro": 0.45}},
+                    ],
+                },
+                {
+                    "seed": 29,
+                    "folds": [
+                        {"fold_id": "wf_fold_1", "metrics": {"regime_f1_macro": 0.42}},
+                        {"fold_id": "wf_fold_2", "metrics": {"regime_f1_macro": 0.47}},
+                    ],
+                },
+            ],
+            "dual": [
+                {
+                    "seed": 11,
+                    "folds": [
+                        {"fold_id": "wf_fold_1", "metrics": {"regime_f1_macro": 0.43}},
+                        {"fold_id": "wf_fold_2", "metrics": {"regime_f1_macro": 0.48}},
+                    ],
+                },
+                {
+                    "seed": 29,
+                    "folds": [
+                        {"fold_id": "wf_fold_1", "metrics": {"regime_f1_macro": 0.44}},
+                        {"fold_id": "wf_fold_2", "metrics": {"regime_f1_macro": 0.50}},
+                    ],
+                },
+            ],
+        }
+    }
+    p = tmp_path / "sweep.json"
+    p.write_text(json.dumps(sweep), encoding="utf-8")
+    return p
+
+
+def test_extract_deltas_count(tmp_path: Path) -> None:
+    sweep = _write_sweep(tmp_path)
+    deltas, _ = extract_paired_deltas(sweep, "classification", "dual", "regime_f1_macro")
+    assert len(deltas) == 4
+
+
+def test_extract_deltas_sign(tmp_path: Path) -> None:
+    sweep = _write_sweep(tmp_path)
+    deltas, _ = extract_paired_deltas(sweep, "classification", "dual", "regime_f1_macro")
+    assert all(d < 0 for d in deltas)
+
+
+def test_compute_paired_holm_applied(tmp_path: Path) -> None:
+    sweep = _write_sweep(tmp_path)
+    results = compute_paired_comparisons(
+        [sweep], [("classification", "dual")], "regime_f1_macro", n_resamples=100
+    )
+    assert len(results) == 1
+    r = results[0]
+    assert not math.isnan(r.mean_delta)
+    assert r.p_value_holm >= r.p_value - 1e-12

--- a/tests/unit/test_per_fold_baselines.py
+++ b/tests/unit/test_per_fold_baselines.py
@@ -1,0 +1,106 @@
+"""Unit tests for app.eval.per_fold_baselines (#500)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.eval.per_fold_baselines import (
+    CLASS_NAMES,
+    compute_per_fold_baselines,
+    majority_baseline_f1,
+    stratified_random_f1,
+)
+
+
+def test_majority_baseline_returns_nonzero_f1() -> None:
+    f1 = majority_baseline_f1([0, 0, 0, 1, 2], [0, 0, 1, 2])
+    assert 0.0 < f1 <= 1.0
+
+
+def test_majority_baseline_empty_returns_zero() -> None:
+    assert majority_baseline_f1([], [0, 1]) == 0.0
+    assert majority_baseline_f1([0, 1], []) == 0.0
+
+
+def test_majority_baseline_all_mode_class_in_test() -> None:
+    f1 = majority_baseline_f1([0, 0, 1, 2], [0, 0, 0])
+    assert f1 == pytest.approx(1.0)
+
+
+def test_stratified_random_f1_near_chance() -> None:
+    train = [0, 0, 1, 1, 2, 2]
+    test = list(range(3)) * 6
+    f1 = stratified_random_f1(train, test, n_seeds=300, base_seed=0)
+    assert 0.15 <= f1 <= 0.50
+
+
+def test_stratified_random_f1_deterministic() -> None:
+    train = [0, 1, 2] * 4
+    test = [0, 1, 2] * 4
+    a = stratified_random_f1(train, test, n_seeds=100, base_seed=7)
+    b = stratified_random_f1(train, test, n_seeds=100, base_seed=7)
+    assert a == b
+
+
+def test_stratified_random_f1_empty_returns_zero() -> None:
+    assert stratified_random_f1([], [0, 1]) == 0.0
+
+
+def _write_fixture_package(tmp_path: Path) -> tuple[Path, str]:
+    import pandas as pd
+
+    pkg_id = "test_pkg"
+    pkg_dir = tmp_path / pkg_id
+    pkg_dir.mkdir(parents=True)
+
+    rows = []
+    for i in range(15):
+        vol = 0.004 + i * 0.002
+        if i < 9:
+            date = f"2020-01-{i + 1:02d}"
+        elif i < 12:
+            date = f"2020-02-{i - 8:02d}"
+        else:
+            date = f"2020-03-{i - 11:02d}"
+        rows.append({"event_date": date, "forward_realized_vol_10d": vol})
+
+    pd.DataFrame(rows).to_parquet(pkg_dir / "events.parquet", index=False)
+    manifest = {
+        "folds": [{
+            "fold_id": "wf_fold_1",
+            "train_start": "2020-01-01",
+            "train_end": "2020-01-09",
+            "val_start": "2020-02-01",
+            "val_end": "2020-02-03",
+            "test_start": "2020-03-01",
+            "test_end": "2020-03-03",
+        }]
+    }
+    (pkg_dir / "fold_manifest_expanding_walk_forward.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+    return tmp_path, pkg_id
+
+
+def test_end_to_end_fixture(tmp_path: Path) -> None:
+    processed_root, pkg_id = _write_fixture_package(tmp_path)
+    result = compute_per_fold_baselines(
+        pkg_id,
+        processed_root=processed_root,
+        sweep_artefact=Path("/nonexistent.json"),
+        n_stratified_seeds=50,
+    )
+    assert result["training_package_id"] == pkg_id
+    folds = result["folds"]
+    assert len(folds) == 1
+    fold = folds[0]
+    assert fold["fold_id"] == "wf_fold_1"
+    assert 0.0 <= fold["majority_baseline_f1"] <= 1.0
+    assert 0.0 <= fold["stratified_random_f1"] <= 1.0
+    assert fold["encoder_f1"] is None
+    for partition in ("train", "val", "test"):
+        for cls in CLASS_NAMES:
+            assert cls in fold["class_distribution"][partition]


### PR DESCRIPTION
## Summary
- `app/eval/per_fold_baselines` (#500): majority-class + stratified-random F1 per fold, joined with encoder F1 from sweep artefact.
- `app/eval/paired_comparisons` (#497): paired Wilcoxon + Cohen's d + fold-blocked bootstrap CI + Holm-Bonferroni.
- `app/eval/ordinal_confusion` (#496): adjacent vs non-adjacent error decomposition on `classification_breakdown.confusion_matrix`; gracefully skips pre-#523 cells.
- Three Makefile targets, CI mypy scope extended to `app/eval`, wiki §6.26–6.28 with placeholder tables.

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit/test_per_fold_baselines.py tests/unit/test_paired_comparisons.py tests/unit/test_ordinal_confusion.py -q`
- [ ] CI mypy + pytest green