### PR TITLE
runpod batch artefacts (2026-05-30) + cross-arm analysis + wiki §6.29

### DIFF
--- a/backend/artifacts/experiments/runpod_20260530/cross_arm_paired.json
+++ b/backend/artifacts/experiments/runpod_20260530/cross_arm_paired.json
@@ -1,0 +1,256 @@
+{
+  "reference_arm": "canonical",
+  "headline": [
+    {
+      "arm": "canonical",
+      "classification": {
+        "n": 25,
+        "mean": 0.39487964372360856,
+        "std": 0.09196177358561897
+      },
+      "dual": {
+        "n": 25,
+        "mean": 0.4497924679784498,
+        "std": 0.11131744788748818
+      },
+      "regression": {
+        "n": 25,
+        "mean": 0.19250931856343667,
+        "std": 0.08755529297414194
+      }
+    },
+    {
+      "arm": "statement_delta",
+      "classification": {
+        "n": 25,
+        "mean": 0.4005753924116641,
+        "std": 0.06191462281488251
+      },
+      "dual": {
+        "n": 25,
+        "mean": 0.3922527822561967,
+        "std": 0.0635749665499232
+      },
+      "regression": {
+        "n": 25,
+        "mean": 0.260192884795029,
+        "std": 0.08768542471558168
+      }
+    },
+    {
+      "arm": "vote_tally",
+      "classification": {
+        "n": 25,
+        "mean": 0.39442428402120483,
+        "std": 0.0703193122669556
+      },
+      "dual": {
+        "n": 25,
+        "mean": 0.38143724261562545,
+        "std": 0.06921394387210386
+      },
+      "regression": {
+        "n": 25,
+        "mean": 0.21276861163885222,
+        "std": 0.07506438728582615
+      }
+    },
+    {
+      "arm": "press_conf",
+      "classification": {
+        "n": 25,
+        "mean": 0.3768583021808598,
+        "std": 0.07147198457405785
+      },
+      "dual": {
+        "n": 25,
+        "mean": 0.3825770199423472,
+        "std": 0.06937183426215304
+      },
+      "regression": {
+        "n": 25,
+        "mean": 0.20660718297891725,
+        "std": 0.08006554842078246
+      }
+    },
+    {
+      "arm": "surprise",
+      "classification": {
+        "n": 25,
+        "mean": 0.38048619946753964,
+        "std": 0.06962182712062351
+      },
+      "dual": {
+        "n": 25,
+        "mean": 0.39327538503560605,
+        "std": 0.07176913786092598
+      },
+      "regression": {
+        "n": 25,
+        "mean": 0.37403188908419494,
+        "std": 0.08186288684420041
+      }
+    },
+    {
+      "arm": "retrieval",
+      "classification": {
+        "n": 25,
+        "mean": 0.39487964372360856,
+        "std": 0.09196177358561897
+      },
+      "dual": {
+        "n": 25,
+        "mean": 0.4321664109315001,
+        "std": 0.10763234441976764
+      },
+      "regression": {
+        "n": 25,
+        "mean": 0.19250931856343667,
+        "std": 0.08755529297414194
+      }
+    },
+    {
+      "arm": "regime",
+      "classification": {
+        "n": 25,
+        "mean": 0.357402469108447,
+        "std": 0.08110388568669263
+      },
+      "dual": {
+        "n": 25,
+        "mean": 0.3531107392367814,
+        "std": 0.08521724463928766
+      },
+      "regression": {
+        "n": 25,
+        "mean": 0.24891356142811497,
+        "std": 0.10137301798473977
+      }
+    }
+  ],
+  "paired_dual": [
+    {
+      "arm": "statement_delta",
+      "head_mode": "dual",
+      "n_pairs": 25,
+      "mean_delta": -0.05753968572225309,
+      "std_delta": 0.08982887205049371,
+      "wilcoxon_stat": 62.0,
+      "p_value": 0.005578815937042236,
+      "p_value_holm": 0.022315263748168945
+    },
+    {
+      "arm": "vote_tally",
+      "head_mode": "dual",
+      "n_pairs": 25,
+      "mean_delta": -0.06835522536282435,
+      "std_delta": 0.08443353096859407,
+      "wilcoxon_stat": 43.0,
+      "p_value": 0.0007149577140808105,
+      "p_value_holm": 0.0035747885704040527
+    },
+    {
+      "arm": "press_conf",
+      "head_mode": "dual",
+      "n_pairs": 25,
+      "mean_delta": -0.06721544803610256,
+      "std_delta": 0.1126080183359912,
+      "wilcoxon_stat": 70.0,
+      "p_value": 0.011453330516815186,
+      "p_value_holm": 0.02290666103363037
+    },
+    {
+      "arm": "surprise",
+      "head_mode": "dual",
+      "n_pairs": 25,
+      "mean_delta": -0.05651708294284379,
+      "std_delta": 0.0889813712993001,
+      "wilcoxon_stat": 63.0,
+      "p_value": 0.006129205226898193,
+      "p_value_holm": 0.022315263748168945
+    },
+    {
+      "arm": "retrieval",
+      "head_mode": "dual",
+      "n_pairs": 25,
+      "mean_delta": -0.017626057046949698,
+      "std_delta": 0.05596324991664659,
+      "wilcoxon_stat": 9.0,
+      "p_value": 0.12890625,
+      "p_value_holm": 0.12890625
+    },
+    {
+      "arm": "regime",
+      "head_mode": "dual",
+      "n_pairs": 25,
+      "mean_delta": -0.09668172874166847,
+      "std_delta": 0.1105555818569838,
+      "wilcoxon_stat": 35.0,
+      "p_value": 0.0002498030662536621,
+      "p_value_holm": 0.0014988183975219727
+    }
+  ],
+  "paired_classification": [
+    {
+      "arm": "statement_delta",
+      "head_mode": "classification",
+      "n_pairs": 25,
+      "mean_delta": 0.0056957486880555375,
+      "std_delta": 0.08059325519161732,
+      "wilcoxon_stat": 152.0,
+      "p_value": 0.7914759516716003,
+      "p_value_holm": 1.0
+    },
+    {
+      "arm": "vote_tally",
+      "head_mode": "classification",
+      "n_pairs": 25,
+      "mean_delta": -0.00045535970240369707,
+      "std_delta": 0.08006678719242304,
+      "wilcoxon_stat": 156.0,
+      "p_value": 0.8739878535270691,
+      "p_value_holm": 1.0
+    },
+    {
+      "arm": "press_conf",
+      "head_mode": "classification",
+      "n_pairs": 25,
+      "mean_delta": -0.0180213415427487,
+      "std_delta": 0.0794123500944516,
+      "wilcoxon_stat": 123.0,
+      "p_value": 0.2996123433113098,
+      "p_value_holm": 1.0
+    },
+    {
+      "arm": "surprise",
+      "head_mode": "classification",
+      "n_pairs": 25,
+      "mean_delta": -0.014393444256068859,
+      "std_delta": 0.08232413810963804,
+      "wilcoxon_stat": 133.0,
+      "p_value": 0.4418373703956604,
+      "p_value_holm": 1.0
+    },
+    {
+      "arm": "retrieval",
+      "head_mode": "classification",
+      "n_pairs": 25,
+      "mean_delta": 0.0,
+      "std_delta": 0.0,
+      "wilcoxon_stat": NaN,
+      "p_value": NaN,
+      "p_value_holm": 1.0
+    },
+    {
+      "arm": "regime",
+      "head_mode": "classification",
+      "n_pairs": 25,
+      "mean_delta": -0.03747717461516161,
+      "std_delta": 0.09358467040242642,
+      "wilcoxon_stat": 103.0,
+      "p_value": 0.1134914755821228,
+      "p_value_holm": 0.6809488534927368
+    }
+  ],
+  "markdown": "### Headline table: per-arm \u00d7 head_mode mean F1 (n=25 unless noted)\n\n| Arm | class | dual | regression |\n|---|---:|---:|---:|\n| canonical | 0.3949 \u00b1 0.0920 | 0.4498 \u00b1 0.1113 | 0.1925 \u00b1 0.0876 |\n| statement_delta | 0.4006 \u00b1 0.0619 | 0.3923 \u00b1 0.0636 | 0.2602 \u00b1 0.0877 |\n| vote_tally | 0.3944 \u00b1 0.0703 | 0.3814 \u00b1 0.0692 | 0.2128 \u00b1 0.0751 |\n| press_conf | 0.3769 \u00b1 0.0715 | 0.3826 \u00b1 0.0694 | 0.2066 \u00b1 0.0801 |\n| surprise | 0.3805 \u00b1 0.0696 | 0.3933 \u00b1 0.0718 | 0.3740 \u00b1 0.0819 |\n| retrieval | 0.3949 \u00b1 0.0920 | 0.4322 \u00b1 0.1076 | 0.1925 \u00b1 0.0876 |\n| regime | 0.3574 \u00b1 0.0811 | 0.3531 \u00b1 0.0852 | 0.2489 \u00b1 0.1014 |\n\n### Dual-head paired Wilcoxon vs canonical (Holm-corrected)\n\n| Arm | n | mean \u0394 | W | p | p (Holm) | verdict |\n|---|---:|---:|---:|---:|---:|---|\n| statement_delta | 25 | -0.0575 | 62.0 | 0.0056 | 0.0223 | significant \u2193 |\n| vote_tally | 25 | -0.0684 | 43.0 | 0.0007 | 0.0036 | significant \u2193 |\n| press_conf | 25 | -0.0672 | 70.0 | 0.0115 | 0.0229 | significant \u2193 |\n| surprise | 25 | -0.0565 | 63.0 | 0.0061 | 0.0223 | significant \u2193 |\n| retrieval | 25 | -0.0176 | 9.0 | 0.1289 | 0.1289 | null |\n| regime | 25 | -0.0967 | 35.0 | 0.0002 | 0.0015 | significant \u2193 |\n\n### Classification-only paired Wilcoxon vs canonical (Holm-corrected)\n\n| Arm | n | mean \u0394 | W | p | p (Holm) | verdict |\n|---|---:|---:|---:|---:|---:|---|\n| statement_delta | 25 | +0.0057 | 152.0 | 0.7915 | 1.0000 | null |\n| vote_tally | 25 | -0.0005 | 156.0 | 0.8740 | 1.0000 | null |\n| press_conf | 25 | -0.0180 | 123.0 | 0.2996 | 1.0000 | null |\n| surprise | 25 | -0.0144 | 133.0 | 0.4418 | 1.0000 | null |\n| retrieval | 25 | +0.0000 | nan | nan | 1.0000 | null |\n| regime | 25 | -0.0375 | 103.0 | 0.1135 | 0.6809 | null |"
+}

--- a/backend/artifacts/experiments/runpod_20260530/logs/STALE_n0rates_runpod_surprise_20260530T124014Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/logs/STALE_n0rates_runpod_surprise_20260530T124014Z.json
@@ -1,0 +1,5157 @@
+{
+  "head_modes": [
+    "classification",
+    "regression",
+    "dual"
+  ],
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "regression_alpha": 0.5,
+  "training_package_id": "canonical",
+  "rates_target_mode": "fomc_attributable",
+  "rates_heads": [
+    "2y",
+    "5y",
+    "terminal"
+  ],
+  "use_retrieval_analogs": false,
+  "use_regime_conditioning": false,
+  "use_statement_delta": false,
+  "use_vote_features": false,
+  "use_press_conf": false,
+  "trials": {
+    "classification": [
+      {
+        "head_mode": "classification",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.47174542095177013,
+              "regime_accuracy": 0.4749999940395355,
+              "regime_loss": 1.0598581133150158,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    9,
+                    6
+                  ],
+                  [
+                    6,
+                    13,
+                    26
+                  ],
+                  [
+                    2,
+                    14,
+                    31
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6190476190476191,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.5306122448979592,
+                    "support": 28,
+                    "roc_auc": 0.7410714285714286,
+                    "pr_auc": 0.39278179179488687
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3611111111111111,
+                    "recall": 0.28888888888888886,
+                    "f1": 0.32098765432098764,
+                    "support": 45,
+                    "roc_auc": 0.4562962962962963,
+                    "pr_auc": 0.4738502127761244
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.49206349206349204,
+                    "recall": 0.6595744680851063,
+                    "f1": 0.5636363636363635,
+                    "support": 47,
+                    "roc_auc": 0.6012824249489944,
+                    "pr_auc": 0.4485292184574269
+                  }
+                ],
+                "macro_precision": 0.49074074074074076,
+                "macro_recall": 0.4709163570865698,
+                "macro_f1": 0.47174542095177013,
+                "weighted_f1": 0.4649374699374699,
+                "macro_roc_auc": 0.5995500499389065,
+                "macro_pr_auc": 0.4383870743428127
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5695970695970696,
+              "regime_accuracy": 0.8135592937469482,
+              "regime_loss": 0.6480022077843294,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    12,
+                    0,
+                    84
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 1.0,
+                    "f1": 0.5,
+                    "support": 10,
+                    "roc_auc": 0.9546296296296296,
+                    "pr_auc": 0.6330028036268782
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.2857142857142857,
+                    "support": 12,
+                    "roc_auc": 0.7987421383647799,
+                    "pr_auc": 0.41962586836381677
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9767441860465116,
+                    "recall": 0.875,
+                    "f1": 0.923076923076923,
+                    "support": 96,
+                    "roc_auc": 0.8839962121212122,
+                    "pr_auc": 0.9670035438354386
+                  }
+                ],
+                "macro_precision": 0.7700258397932817,
+                "macro_recall": 0.6805555555555555,
+                "macro_f1": 0.5695970695970696,
+                "weighted_f1": 0.8224064071521698,
+                "macro_roc_auc": 0.8791226600385406,
+                "macro_pr_auc": 0.6732107386087112
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3281718789727943,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.0591562379490245,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    47,
+                    12,
+                    19
+                  ],
+                  [
+                    2,
+                    4,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.14035087719298245,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.2318840579710145,
+                    "support": 12,
+                    "roc_auc": 0.6275510204081632,
+                    "pr_auc": 0.13509882339918716
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7058823529411765,
+                    "recall": 0.15384615384615385,
+                    "f1": 0.25263157894736843,
+                    "support": 78,
+                    "roc_auc": 0.2860576923076923,
+                    "pr_auc": 0.647325112510624
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3888888888888889,
+                    "recall": 0.7,
+                    "f1": 0.5,
+                    "support": 20,
+                    "roc_auc": 0.82,
+                    "pr_auc": 0.3979475276959269
+                  }
+                ],
+                "macro_precision": 0.4117073730076826,
+                "macro_recall": 0.5068376068376068,
+                "macro_f1": 0.3281718789727943,
+                "weighted_f1": 0.2953442895776992,
+                "macro_roc_auc": 0.5778695709052851,
+                "macro_pr_auc": 0.39345715453524605
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4493285420251712,
+              "regime_accuracy": 0.4954954981803894,
+              "regime_loss": 1.0312240790722582,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    28,
+                    12,
+                    4
+                  ],
+                  [
+                    17,
+                    22,
+                    9
+                  ],
+                  [
+                    7,
+                    7,
+                    5
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5384615384615384,
+                    "recall": 0.6363636363636364,
+                    "f1": 0.5833333333333334,
+                    "support": 44,
+                    "roc_auc": 0.6136363636363636,
+                    "pr_auc": 0.4439257205822866
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5365853658536586,
+                    "recall": 0.4583333333333333,
+                    "f1": 0.49438202247191015,
+                    "support": 48,
+                    "roc_auc": 0.5426587301587301,
+                    "pr_auc": 0.5399653936431851
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2777777777777778,
+                    "recall": 0.2631578947368421,
+                    "f1": 0.27027027027027023,
+                    "support": 19,
+                    "roc_auc": 0.5589244851258581,
+                    "pr_auc": 0.24568019632841334
+                  }
+                ],
+                "macro_precision": 0.4509415606976583,
+                "macro_recall": 0.4526182881446039,
+                "macro_f1": 0.4493285420251712,
+                "weighted_f1": 0.4912805304545359,
+                "macro_roc_auc": 0.5717398596403173,
+                "macro_pr_auc": 0.4098571035179617
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.49230769230769234,
+              "regime_accuracy": 0.6346153616905212,
+              "regime_loss": 1.0478591185349684,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    26,
+                    0
+                  ],
+                  [
+                    0,
+                    46,
+                    6
+                  ],
+                  [
+                    0,
+                    6,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6503944773175543,
+                    "pr_auc": 0.4734688076999476
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5897435897435898,
+                    "recall": 0.8846153846153846,
+                    "f1": 0.7076923076923076,
+                    "support": 52,
+                    "roc_auc": 0.6571745562130178,
+                    "pr_auc": 0.639249006319671
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.7692307692307693,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.7692307692307693,
+                    "support": 26,
+                    "roc_auc": 0.8101577909270217,
+                    "pr_auc": 0.6809774182810079
+                  }
+                ],
+                "macro_precision": 0.452991452991453,
+                "macro_recall": 0.5512820512820512,
+                "macro_f1": 0.49230769230769234,
+                "weighted_f1": 0.5461538461538461,
+                "macro_roc_auc": 0.7059089414858647,
+                "macro_pr_auc": 0.5978984107668754
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.36370497308338096,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.093639855638879,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    5,
+                    13
+                  ],
+                  [
+                    6,
+                    4,
+                    35
+                  ],
+                  [
+                    5,
+                    6,
+                    36
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.47619047619047616,
+                    "recall": 0.35714285714285715,
+                    "f1": 0.40816326530612246,
+                    "support": 28,
+                    "roc_auc": 0.7434006211180124,
+                    "pr_auc": 0.4206442847187557
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.26666666666666666,
+                    "recall": 0.08888888888888889,
+                    "f1": 0.13333333333333333,
+                    "support": 45,
+                    "roc_auc": 0.3748148148148148,
+                    "pr_auc": 0.33919134577256527
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.7659574468085106,
+                    "f1": 0.5496183206106869,
+                    "support": 47,
+                    "roc_auc": 0.5406587000874381,
+                    "pr_auc": 0.3987476380464995
+                  }
+                ],
+                "macro_precision": 0.3904761904761904,
+                "macro_recall": 0.4039963976134189,
+                "macro_f1": 0.36370497308338096,
+                "weighted_f1": 0.36050527081061434,
+                "macro_roc_auc": 0.5529580453400884,
+                "macro_pr_auc": 0.3861944228459402
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.47416355095388746,
+              "regime_accuracy": 0.7796609997749329,
+              "regime_loss": 0.6720523884740927,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    11,
+                    3,
+                    82
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35714285714285715,
+                    "recall": 1.0,
+                    "f1": 0.5263157894736842,
+                    "support": 10,
+                    "roc_auc": 0.9601851851851851,
+                    "pr_auc": 0.6012600553041729
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7389937106918238,
+                    "pr_auc": 0.1732239065257933
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9425287356321839,
+                    "recall": 0.8541666666666666,
+                    "f1": 0.8961748633879782,
+                    "support": 96,
+                    "roc_auc": 0.890625,
+                    "pr_auc": 0.9707479513676655
+                  }
+                ],
+                "macro_precision": 0.433223864258347,
+                "macro_recall": 0.6180555555555555,
+                "macro_f1": 0.47416355095388746,
+                "weighted_f1": 0.7736944472879894,
+                "macro_roc_auc": 0.8632679652923363,
+                "macro_pr_auc": 0.5817439710658773
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4663076760637736,
+              "regime_accuracy": 0.48181816935539246,
+              "regime_loss": 0.9563660968433727,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    4,
+                    0
+                  ],
+                  [
+                    35,
+                    33,
+                    10
+                  ],
+                  [
+                    0,
+                    8,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18604651162790697,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.2909090909090909,
+                    "support": 12,
+                    "roc_auc": 0.6377551020408163,
+                    "pr_auc": 0.1398485481901123
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7333333333333333,
+                    "recall": 0.4230769230769231,
+                    "f1": 0.5365853658536585,
+                    "support": 78,
+                    "roc_auc": 0.4463141025641026,
+                    "pr_auc": 0.7140705580477305
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5454545454545454,
+                    "recall": 0.6,
+                    "f1": 0.5714285714285713,
+                    "support": 20,
+                    "roc_auc": 0.8588888888888889,
+                    "pr_auc": 0.4637990759292986
+                  }
+                ],
+                "macro_precision": 0.4882781301385952,
+                "macro_recall": 0.5632478632478632,
+                "macro_f1": 0.4663076760637736,
+                "weighted_f1": 0.5161194459642352,
+                "macro_roc_auc": 0.6476526978312692,
+                "macro_pr_auc": 0.43923939405571377
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.36462180894571433,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.1049209239080047,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    23,
+                    12,
+                    9
+                  ],
+                  [
+                    17,
+                    10,
+                    21
+                  ],
+                  [
+                    5,
+                    5,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5111111111111111,
+                    "recall": 0.5227272727272727,
+                    "f1": 0.5168539325842696,
+                    "support": 44,
+                    "roc_auc": 0.6200814111261872,
+                    "pr_auc": 0.4572923301619896
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.37037037037037035,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.26666666666666666,
+                    "support": 48,
+                    "roc_auc": 0.49834656084656087,
+                    "pr_auc": 0.4214988604462017
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.23076923076923078,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.3103448275862069,
+                    "support": 19,
+                    "roc_auc": 0.5749427917620137,
+                    "pr_auc": 0.23965285108403658
+                  }
+                ],
+                "macro_precision": 0.37075023741690405,
+                "macro_recall": 0.401581605528974,
+                "macro_f1": 0.36462180894571433,
+                "weighted_f1": 0.373316439259872,
+                "macro_roc_auc": 0.5644569212449205,
+                "macro_pr_auc": 0.37281468056407596
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.35089605734767026,
+              "regime_accuracy": 0.49038460850715637,
+              "regime_loss": 1.0677424852664654,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    17,
+                    9
+                  ],
+                  [
+                    0,
+                    38,
+                    14
+                  ],
+                  [
+                    0,
+                    13,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6257396449704142,
+                    "pr_auc": 0.4745514315859081
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5588235294117647,
+                    "recall": 0.7307692307692307,
+                    "f1": 0.6333333333333334,
+                    "support": 52,
+                    "roc_auc": 0.6708579881656804,
+                    "pr_auc": 0.6872993182592919
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3611111111111111,
+                    "recall": 0.5,
+                    "f1": 0.4193548387096774,
+                    "support": 26,
+                    "roc_auc": 0.6918145956607495,
+                    "pr_auc": 0.5111264840174728
+                  }
+                ],
+                "macro_precision": 0.306644880174292,
+                "macro_recall": 0.4102564102564103,
+                "macro_f1": 0.35089605734767026,
+                "weighted_f1": 0.4215053763440861,
+                "macro_roc_auc": 0.6628040762656148,
+                "macro_pr_auc": 0.5576590779542243
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.42763336249481615,
+              "regime_accuracy": 0.44999998807907104,
+              "regime_loss": 1.107179157849963,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    7,
+                    6
+                  ],
+                  [
+                    8,
+                    8,
+                    29
+                  ],
+                  [
+                    10,
+                    6,
+                    31
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.5357142857142857,
+                    "f1": 0.49180327868852464,
+                    "support": 28,
+                    "roc_auc": 0.764751552795031,
+                    "pr_auc": 0.466819716127552
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.38095238095238093,
+                    "recall": 0.17777777777777778,
+                    "f1": 0.24242424242424243,
+                    "support": 45,
+                    "roc_auc": 0.41274074074074074,
+                    "pr_auc": 0.3384302152905002
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4696969696969697,
+                    "recall": 0.6595744680851063,
+                    "f1": 0.5486725663716814,
+                    "support": 47,
+                    "roc_auc": 0.5616438356164384,
+                    "pr_auc": 0.40054027933948544
+                  }
+                ],
+                "macro_precision": 0.4350649350649351,
+                "macro_recall": 0.45768884385905656,
+                "macro_f1": 0.42763336249481615,
+                "weighted_f1": 0.4205599444319885,
+                "macro_roc_auc": 0.5797120430507366,
+                "macro_pr_auc": 0.40193007025251254
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4664224664224664,
+              "regime_accuracy": 0.7966101765632629,
+              "regime_loss": 0.580966409990343,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    12,
+                    0,
+                    84
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3125,
+                    "recall": 1.0,
+                    "f1": 0.47619047619047616,
+                    "support": 10,
+                    "roc_auc": 0.9388888888888889,
+                    "pr_auc": 0.5423478212608647
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7130503144654088,
+                    "pr_auc": 0.21010374222917266
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9767441860465116,
+                    "recall": 0.875,
+                    "f1": 0.923076923076923,
+                    "support": 96,
+                    "roc_auc": 0.8716856060606061,
+                    "pr_auc": 0.9539686192623033
+                  }
+                ],
+                "macro_precision": 0.42974806201550386,
+                "macro_recall": 0.625,
+                "macro_f1": 0.4664224664224664,
+                "weighted_f1": 0.7913329608244862,
+                "macro_roc_auc": 0.841208269804968,
+                "macro_pr_auc": 0.5688067275841135
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2685646643393122,
+              "regime_accuracy": 0.26363635063171387,
+              "regime_loss": 1.1348345409740102,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    3,
+                    1
+                  ],
+                  [
+                    47,
+                    14,
+                    17
+                  ],
+                  [
+                    4,
+                    9,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.13559322033898305,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.22535211267605634,
+                    "support": 12,
+                    "roc_auc": 0.608843537414966,
+                    "pr_auc": 0.12844052873060463
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5384615384615384,
+                    "recall": 0.1794871794871795,
+                    "f1": 0.2692307692307692,
+                    "support": 78,
+                    "roc_auc": 0.2588141025641026,
+                    "pr_auc": 0.5893373039284487
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.28,
+                    "recall": 0.35,
+                    "f1": 0.3111111111111111,
+                    "support": 20,
+                    "roc_auc": 0.775,
+                    "pr_auc": 0.32168008455014246
+                  }
+                ],
+                "macro_precision": 0.31801825293350716,
+                "macro_recall": 0.3987179487179487,
+                "macro_f1": 0.2685646643393122,
+                "weighted_f1": 0.2720586143121354,
+                "macro_roc_auc": 0.5475525466596896,
+                "macro_pr_auc": 0.3464859724030653
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.38552631578947366,
+              "regime_accuracy": 0.45045045018196106,
+              "regime_loss": 1.088392633337722,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    36,
+                    0,
+                    8
+                  ],
+                  [
+                    27,
+                    7,
+                    14
+                  ],
+                  [
+                    7,
+                    5,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5142857142857142,
+                    "recall": 0.8181818181818182,
+                    "f1": 0.6315789473684209,
+                    "support": 44,
+                    "roc_auc": 0.6353459972862958,
+                    "pr_auc": 0.48619902863211006
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5833333333333334,
+                    "recall": 0.14583333333333334,
+                    "f1": 0.23333333333333336,
+                    "support": 48,
+                    "roc_auc": 0.5502645502645502,
+                    "pr_auc": 0.5098743280489709
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2413793103448276,
+                    "recall": 0.3684210526315789,
+                    "f1": 0.2916666666666667,
+                    "support": 19,
+                    "roc_auc": 0.631578947368421,
+                    "pr_auc": 0.2674197876946415
+                  }
+                ],
+                "macro_precision": 0.4463327859879584,
+                "macro_recall": 0.4441454013822435,
+                "macro_f1": 0.38552631578947366,
+                "weighted_f1": 0.40118144460249716,
+                "macro_roc_auc": 0.6057298316397557,
+                "macro_pr_auc": 0.42116438145857416
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.375,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.2450268268585205,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    9
+                  ],
+                  [
+                    23,
+                    15,
+                    14
+                  ],
+                  [
+                    6,
+                    5,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23684210526315788,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.28125,
+                    "support": 26,
+                    "roc_auc": 0.5655818540433925,
+                    "pr_auc": 0.3327045908523259
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5357142857142857,
+                    "recall": 0.28846153846153844,
+                    "f1": 0.37499999999999994,
+                    "support": 52,
+                    "roc_auc": 0.6072485207100592,
+                    "pr_auc": 0.5661712023344639
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.39473684210526316,
+                    "recall": 0.5769230769230769,
+                    "f1": 0.46875,
+                    "support": 26,
+                    "roc_auc": 0.7095660749506904,
+                    "pr_auc": 0.46879776245706734
+                  }
+                ],
+                "macro_precision": 0.3890977443609023,
+                "macro_recall": 0.4038461538461538,
+                "macro_f1": 0.375,
+                "weighted_f1": 0.375,
+                "macro_roc_auc": 0.627465483234714,
+                "macro_pr_auc": 0.455891185214619
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3869829790986859,
+              "regime_accuracy": 0.44999998807907104,
+              "regime_loss": 1.1695197432778104,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    4,
+                    14
+                  ],
+                  [
+                    6,
+                    4,
+                    35
+                  ],
+                  [
+                    2,
+                    5,
+                    40
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.35714285714285715,
+                    "f1": 0.43478260869565216,
+                    "support": 28,
+                    "roc_auc": 0.7527173913043478,
+                    "pr_auc": 0.39127829960211485
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.08888888888888889,
+                    "f1": 0.13793103448275862,
+                    "support": 45,
+                    "roc_auc": 0.4074074074074074,
+                    "pr_auc": 0.32715019915441057
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.449438202247191,
+                    "recall": 0.851063829787234,
+                    "f1": 0.588235294117647,
+                    "support": 47,
+                    "roc_auc": 0.574468085106383,
+                    "pr_auc": 0.434977206805969
+                  }
+                ],
+                "macro_precision": 0.43756202183168474,
+                "macro_recall": 0.43236519193966005,
+                "macro_f1": 0.3869829790986859,
+                "weighted_f1": 0.3835655701560984,
+                "macro_roc_auc": 0.5781976279393793,
+                "macro_pr_auc": 0.3844685685208315
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.45351213282247765,
+              "regime_accuracy": 0.7288135886192322,
+              "regime_loss": 0.5674394454996464,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    5,
+                    12,
+                    79
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3684210526315789,
+                    "recall": 0.7,
+                    "f1": 0.48275862068965514,
+                    "support": 10,
+                    "roc_auc": 0.9722222222222222,
+                    "pr_auc": 0.5774042624042623
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.5935534591194969,
+                    "pr_auc": 0.12093397179885766
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9404761904761905,
+                    "recall": 0.8229166666666666,
+                    "f1": 0.8777777777777778,
+                    "support": 96,
+                    "roc_auc": 0.8574810606060606,
+                    "pr_auc": 0.9294123368744105
+                  }
+                ],
+                "macro_precision": 0.43629908103592313,
+                "macro_recall": 0.5076388888888889,
+                "macro_f1": 0.45351213282247765,
+                "weighted_f1": 0.7550360413013832,
+                "macro_roc_auc": 0.8077522473159265,
+                "macro_pr_auc": 0.5425835236925102
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3627904944958938,
+              "regime_accuracy": 0.3545454442501068,
+              "regime_loss": 1.1461639556017789,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    40,
+                    16,
+                    22
+                  ],
+                  [
+                    4,
+                    1,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.15384615384615385,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.25,
+                    "support": 12,
+                    "roc_auc": 0.6071428571428571,
+                    "pr_auc": 0.12731934757918112
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8421052631578947,
+                    "recall": 0.20512820512820512,
+                    "f1": 0.32989690721649484,
+                    "support": 78,
+                    "roc_auc": 0.3369391025641026,
+                    "pr_auc": 0.6547452813292387
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.38461538461538464,
+                    "recall": 0.75,
+                    "f1": 0.5084745762711865,
+                    "support": 20,
+                    "roc_auc": 0.7972222222222223,
+                    "pr_auc": 0.3479529922495087
+                  }
+                ],
+                "macro_precision": 0.4601889338731444,
+                "macro_recall": 0.5405982905982906,
+                "macro_f1": 0.3627904944958938,
+                "weighted_f1": 0.35364954807554844,
+                "macro_roc_auc": 0.5804347273097273,
+                "macro_pr_auc": 0.37667254038597614
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.31074596229676443,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.05187311146532,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    35,
+                    1,
+                    8
+                  ],
+                  [
+                    31,
+                    1,
+                    16
+                  ],
+                  [
+                    11,
+                    0,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.7954545454545454,
+                    "f1": 0.5785123966942148,
+                    "support": 44,
+                    "roc_auc": 0.6339891451831751,
+                    "pr_auc": 0.45786512894335923
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.020833333333333332,
+                    "f1": 0.039999999999999994,
+                    "support": 48,
+                    "roc_auc": 0.5165343915343915,
+                    "pr_auc": 0.4356917812549579
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.25,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.3137254901960784,
+                    "support": 19,
+                    "roc_auc": 0.5646453089244852,
+                    "pr_auc": 0.24931219444154168
+                  }
+                ],
+                "macro_precision": 0.40151515151515155,
+                "macro_recall": 0.412446836788942,
+                "macro_f1": 0.31074596229676443,
+                "weighted_f1": 0.30031828620063916,
+                "macro_roc_auc": 0.5717229485473506,
+                "macro_pr_auc": 0.3809563682132862
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3230501184884649,
+              "regime_accuracy": 0.3173076808452606,
+              "regime_loss": 1.0705165221140935,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    9
+                  ],
+                  [
+                    28,
+                    11,
+                    13
+                  ],
+                  [
+                    6,
+                    7,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.20930232558139536,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.2608695652173913,
+                    "support": 26,
+                    "roc_auc": 0.6000986193293886,
+                    "pr_auc": 0.4022733724203793
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4230769230769231,
+                    "recall": 0.21153846153846154,
+                    "f1": 0.28205128205128205,
+                    "support": 52,
+                    "roc_auc": 0.5994822485207101,
+                    "pr_auc": 0.5779147762361067
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37142857142857144,
+                    "recall": 0.5,
+                    "f1": 0.42622950819672134,
+                    "support": 26,
+                    "roc_auc": 0.7194280078895463,
+                    "pr_auc": 0.5552352612739501
+                  }
+                ],
+                "macro_precision": 0.33460260669562997,
+                "macro_recall": 0.3525641025641026,
+                "macro_f1": 0.3230501184884649,
+                "weighted_f1": 0.3128004093791692,
+                "macro_roc_auc": 0.6396696252465484,
+                "macro_pr_auc": 0.5118078033101453
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3692377369007804,
+              "regime_accuracy": 0.4333333373069763,
+              "regime_loss": 1.4237285155276829,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    5,
+                    16
+                  ],
+                  [
+                    9,
+                    7,
+                    29
+                  ],
+                  [
+                    2,
+                    7,
+                    38
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3888888888888889,
+                    "recall": 0.25,
+                    "f1": 0.30434782608695654,
+                    "support": 28,
+                    "roc_auc": 0.6257763975155279,
+                    "pr_auc": 0.2943069578367588
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3684210526315789,
+                    "recall": 0.15555555555555556,
+                    "f1": 0.21875,
+                    "support": 45,
+                    "roc_auc": 0.5416296296296297,
+                    "pr_auc": 0.40454615094616486
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4578313253012048,
+                    "recall": 0.8085106382978723,
+                    "f1": 0.5846153846153845,
+                    "support": 47,
+                    "roc_auc": 0.5945788399883416,
+                    "pr_auc": 0.42325450331121917
+                  }
+                ],
+                "macro_precision": 0.4050470889405575,
+                "macro_recall": 0.40468873128447597,
+                "macro_f1": 0.3692377369007804,
+                "weighted_f1": 0.3820201017279821,
+                "macro_roc_auc": 0.5873282890444997,
+                "macro_pr_auc": 0.3740358706980476
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.568100358422939,
+              "regime_accuracy": 0.7627118825912476,
+              "regime_loss": 0.5186836780127833,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    1,
+                    2,
+                    9
+                  ],
+                  [
+                    2,
+                    13,
+                    81
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.7,
+                    "recall": 0.7,
+                    "f1": 0.7,
+                    "support": 10,
+                    "roc_auc": 0.9851851851851852,
+                    "pr_auc": 0.8337275224775225
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.1111111111111111,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.13333333333333333,
+                    "support": 12,
+                    "roc_auc": 0.610062893081761,
+                    "pr_auc": 0.1267523572391785
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9,
+                    "recall": 0.84375,
+                    "f1": 0.870967741935484,
+                    "support": 96,
+                    "roc_auc": 0.8380681818181818,
+                    "pr_auc": 0.9275557805510697
+                  }
+                ],
+                "macro_precision": 0.5703703703703703,
+                "macro_recall": 0.5701388888888889,
+                "macro_f1": 0.568100358422939,
+                "weighted_f1": 0.781465281574631,
+                "macro_roc_auc": 0.811105420028376,
+                "macro_pr_auc": 0.6293452200892569
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.25724496426250815,
+              "regime_accuracy": 0.2454545497894287,
+              "regime_loss": 1.275763871453025,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    32,
+                    6,
+                    40
+                  ],
+                  [
+                    2,
+                    5,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.19047619047619047,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.2962962962962963,
+                    "support": 12,
+                    "roc_auc": 0.6666666666666666,
+                    "pr_auc": 0.1566519629242042
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.13333333333333336,
+                    "support": 78,
+                    "roc_auc": 0.24358974358974358,
+                    "pr_auc": 0.5808292243415459
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.23214285714285715,
+                    "recall": 0.65,
+                    "f1": 0.3421052631578948,
+                    "support": 20,
+                    "roc_auc": 0.7138888888888889,
+                    "pr_auc": 0.2611159198623152
+                  }
+                ],
+                "macro_precision": 0.30753968253968256,
+                "macro_recall": 0.4645299145299145,
+                "macro_f1": 0.25724496426250815,
+                "weighted_f1": 0.18906964380648594,
+                "macro_roc_auc": 0.5413817663817664,
+                "macro_pr_auc": 0.33286570237602175
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.32248198424669017,
+              "regime_accuracy": 0.3243243098258972,
+              "regime_loss": 1.1656622741458718,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    18,
+                    13
+                  ],
+                  [
+                    10,
+                    14,
+                    24
+                  ],
+                  [
+                    5,
+                    5,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4642857142857143,
+                    "recall": 0.29545454545454547,
+                    "f1": 0.36111111111111116,
+                    "support": 44,
+                    "roc_auc": 0.5987109905020352,
+                    "pr_auc": 0.4322149887022061
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3783783783783784,
+                    "recall": 0.2916666666666667,
+                    "f1": 0.3294117647058824,
+                    "support": 48,
+                    "roc_auc": 0.3974867724867725,
+                    "pr_auc": 0.3517967525294513
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1956521739130435,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.2769230769230769,
+                    "support": 19,
+                    "roc_auc": 0.5537757437070938,
+                    "pr_auc": 0.24224800347842268
+                  }
+                ],
+                "macro_precision": 0.3461054221923787,
+                "macro_recall": 0.353601807549176,
+                "macro_f1": 0.32248198424669017,
+                "weighted_f1": 0.3329927212280153,
+                "macro_roc_auc": 0.5166578355653005,
+                "macro_pr_auc": 0.3420865815700267
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5466979828681956,
+              "regime_accuracy": 0.5769230723381042,
+              "regime_loss": 1.0598734754782457,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    9
+                  ],
+                  [
+                    6,
+                    31,
+                    15
+                  ],
+                  [
+                    3,
+                    3,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.40909090909090906,
+                    "support": 26,
+                    "roc_auc": 0.6247534516765286,
+                    "pr_auc": 0.5058043780965723
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7380952380952381,
+                    "recall": 0.5961538461538461,
+                    "f1": 0.6595744680851063,
+                    "support": 52,
+                    "roc_auc": 0.6734467455621301,
+                    "pr_auc": 0.620680214762404
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5714285714285714,
+                    "support": 26,
+                    "roc_auc": 0.7322485207100592,
+                    "pr_auc": 0.5736810660487281
+                  }
+                ],
+                "macro_precision": 0.5642135642135643,
+                "macro_recall": 0.5705128205128206,
+                "macro_f1": 0.5466979828681956,
+                "weighted_f1": 0.5749171041724233,
+                "macro_roc_auc": 0.6768162393162394,
+                "macro_pr_auc": 0.5667218863025681
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "regression": [
+      {
+        "head_mode": "regression",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.43148125501066675,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.1207366833818762,
+              "regression_rmse_log_rv": 0.952620592327479,
+              "regression_mae_log_rv": 0.778288099263591,
+              "regression_loss": 0.9074859929263569,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    12,
+                    6
+                  ],
+                  [
+                    8,
+                    12,
+                    25
+                  ],
+                  [
+                    5,
+                    9,
+                    33
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.43478260869565216,
+                    "recall": 0.35714285714285715,
+                    "f1": 0.39215686274509803,
+                    "support": 28,
+                    "roc_auc": 0.7208850931677019,
+                    "pr_auc": 0.3413952557878093
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.36363636363636365,
+                    "recall": 0.26666666666666666,
+                    "f1": 0.30769230769230765,
+                    "support": 45,
+                    "roc_auc": 0.48918518518518517,
+                    "pr_auc": 0.4025118727634116
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.515625,
+                    "recall": 0.7021276595744681,
+                    "f1": 0.5945945945945946,
+                    "support": 47,
+                    "roc_auc": 0.64062955406587,
+                    "pr_auc": 0.48737986209129125
+                  }
+                ],
+                "macro_precision": 0.4380146574440053,
+                "macro_recall": 0.4419790611279973,
+                "macro_f1": 0.43148125501066675,
+                "weighted_f1": 0.43977076624135447,
+                "macro_roc_auc": 0.6168999441395857,
+                "macro_pr_auc": 0.4104289968808374
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4796296296296297,
+              "regime_accuracy": 0.7118644118309021,
+              "regime_loss": 0.6025576248007306,
+              "regression_rmse_log_rv": 1.0993941202108648,
+              "regression_mae_log_rv": 0.9949101044330746,
+              "regression_loss": 1.2086674315542214,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    5,
+                    0,
+                    7
+                  ],
+                  [
+                    2,
+                    17,
+                    77
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.7,
+                    "f1": 0.5833333333333334,
+                    "support": 10,
+                    "roc_auc": 0.9675925925925926,
+                    "pr_auc": 0.5938348416289592
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.5621069182389937,
+                    "pr_auc": 0.10998323449876815
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9166666666666666,
+                    "recall": 0.8020833333333334,
+                    "f1": 0.8555555555555556,
+                    "support": 96,
+                    "roc_auc": 0.8248106060606061,
+                    "pr_auc": 0.9356345148524405
+                  }
+                ],
+                "macro_precision": 0.47222222222222215,
+                "macro_recall": 0.5006944444444444,
+                "macro_f1": 0.4796296296296297,
+                "weighted_f1": 0.7454802259887006,
+                "macro_roc_auc": 0.7848367056307307,
+                "macro_pr_auc": 0.5464841969933892
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2442536364920209,
+              "regime_accuracy": 0.23636363446712494,
+              "regime_loss": 1.2206821311603893,
+              "regression_rmse_log_rv": 0.4556274861839038,
+              "regression_mae_log_rv": 0.365007665266603,
+              "regression_loss": 0.20759640616626346,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    1,
+                    4
+                  ],
+                  [
+                    28,
+                    10,
+                    40
+                  ],
+                  [
+                    3,
+                    8,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18421052631578946,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.27999999999999997,
+                    "support": 12,
+                    "roc_auc": 0.7006802721088435,
+                    "pr_auc": 0.2013020536962991
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5263157894736842,
+                    "recall": 0.1282051282051282,
+                    "f1": 0.20618556701030924,
+                    "support": 78,
+                    "roc_auc": 0.1999198717948718,
+                    "pr_auc": 0.5460616462678594
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.16981132075471697,
+                    "recall": 0.45,
+                    "f1": 0.2465753424657534,
+                    "support": 20,
+                    "roc_auc": 0.4955555555555556,
+                    "pr_auc": 0.16941896930548872
+                  }
+                ],
+                "macro_precision": 0.29344587884806356,
+                "macro_recall": 0.3871794871794872,
+                "macro_f1": 0.2442536364920209,
+                "weighted_f1": 0.22158164614653805,
+                "macro_roc_auc": 0.4653852331530903,
+                "macro_pr_auc": 0.30559422308988243
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4853725938631599,
+              "regime_accuracy": 0.5045045018196106,
+              "regime_loss": 1.0890331748861568,
+              "regression_rmse_log_rv": 0.7676069951733931,
+              "regression_mae_log_rv": 0.6465457154554315,
+              "regression_loss": 0.5892204990391257,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    31,
+                    6,
+                    7
+                  ],
+                  [
+                    25,
+                    15,
+                    8
+                  ],
+                  [
+                    6,
+                    3,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.7045454545454546,
+                    "f1": 0.5849056603773585,
+                    "support": 44,
+                    "roc_auc": 0.6373812754409769,
+                    "pr_auc": 0.5587709212188258
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.625,
+                    "recall": 0.3125,
+                    "f1": 0.4166666666666667,
+                    "support": 48,
+                    "roc_auc": 0.5433201058201058,
+                    "pr_auc": 0.48066594978641175
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.45454545454545453,
+                    "support": 19,
+                    "roc_auc": 0.6750572082379863,
+                    "pr_auc": 0.2632742779967416
+                  }
+                ],
+                "macro_precision": 0.5083333333333333,
+                "macro_recall": 0.5144537480063796,
+                "macro_f1": 0.4853725938631599,
+                "weighted_f1": 0.4898397539906974,
+                "macro_roc_auc": 0.6185861964996896,
+                "macro_pr_auc": 0.4342370496673264
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3780481985206395,
+              "regime_accuracy": 0.5288461446762085,
+              "regime_loss": 1.0752846231827369,
+              "regression_rmse_log_rv": 0.9949848567705296,
+              "regression_mae_log_rv": 0.7566069253953174,
+              "regression_loss": 0.9899948652026714,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    20,
+                    6
+                  ],
+                  [
+                    0,
+                    42,
+                    10
+                  ],
+                  [
+                    0,
+                    13,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5922090729783037,
+                    "pr_auc": 0.4096442486225504
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.56,
+                    "recall": 0.8076923076923077,
+                    "f1": 0.6614173228346457,
+                    "support": 52,
+                    "roc_auc": 0.6841715976331361,
+                    "pr_auc": 0.6791742838467943
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4482758620689655,
+                    "recall": 0.5,
+                    "f1": 0.4727272727272727,
+                    "support": 26,
+                    "roc_auc": 0.7761341222879684,
+                    "pr_auc": 0.6299662603051185
+                  }
+                ],
+                "macro_precision": 0.3360919540229885,
+                "macro_recall": 0.4358974358974359,
+                "macro_f1": 0.3780481985206395,
+                "weighted_f1": 0.448890479599141,
+                "macro_roc_auc": 0.6841715976331361,
+                "macro_pr_auc": 0.5729282642581545
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3983193277310924,
+              "regime_accuracy": 0.4416666626930237,
+              "regime_loss": 1.1530056465098495,
+              "regression_rmse_log_rv": 0.7796396741428372,
+              "regression_mae_log_rv": 0.6449559719294484,
+              "regression_loss": 0.6078380214975493,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    22,
+                    0,
+                    6
+                  ],
+                  [
+                    16,
+                    4,
+                    25
+                  ],
+                  [
+                    18,
+                    2,
+                    27
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.39285714285714285,
+                    "recall": 0.7857142857142857,
+                    "f1": 0.5238095238095237,
+                    "support": 28,
+                    "roc_auc": 0.7267080745341615,
+                    "pr_auc": 0.36885742259306203
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.08888888888888889,
+                    "f1": 0.1568627450980392,
+                    "support": 45,
+                    "roc_auc": 0.44651851851851854,
+                    "pr_auc": 0.44630201528390284
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.46551724137931033,
+                    "recall": 0.574468085106383,
+                    "f1": 0.5142857142857143,
+                    "support": 47,
+                    "roc_auc": 0.5631011366948412,
+                    "pr_auc": 0.4139920027113516
+                  }
+                ],
+                "macro_precision": 0.5083470169677066,
+                "macro_recall": 0.4830237532365192,
+                "macro_f1": 0.3983193277310924,
+                "weighted_f1": 0.38247432306255835,
+                "macro_roc_auc": 0.5787759099158404,
+                "macro_pr_auc": 0.4097171468627721
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5070652173913043,
+              "regime_accuracy": 0.7288135886192322,
+              "regime_loss": 0.5441565437842224,
+              "regression_rmse_log_rv": 0.8700252248481769,
+              "regression_mae_log_rv": 0.7476880706381053,
+              "regression_loss": 0.7569438918721209,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    4,
+                    0
+                  ],
+                  [
+                    2,
+                    1,
+                    9
+                  ],
+                  [
+                    2,
+                    15,
+                    79
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6,
+                    "recall": 0.6,
+                    "f1": 0.6,
+                    "support": 10,
+                    "roc_auc": 0.9787037037037037,
+                    "pr_auc": 0.7141766566766565
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.05,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.0625,
+                    "support": 12,
+                    "roc_auc": 0.6650943396226415,
+                    "pr_auc": 0.1519761368420468
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.8977272727272727,
+                    "recall": 0.8229166666666666,
+                    "f1": 0.8586956521739129,
+                    "support": 96,
+                    "roc_auc": 0.8418560606060606,
+                    "pr_auc": 0.9376637983129413
+                  }
+                ],
+                "macro_precision": 0.5159090909090909,
+                "macro_recall": 0.5020833333333333,
+                "macro_f1": 0.5070652173913043,
+                "weighted_f1": 0.7558032424465732,
+                "macro_roc_auc": 0.8285513679774686,
+                "macro_pr_auc": 0.6012721972772149
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.24781532471144485,
+              "regime_accuracy": 0.23636363446712494,
+              "regime_loss": 1.2697282422672618,
+              "regression_rmse_log_rv": 0.40277302348491856,
+              "regression_mae_log_rv": 0.31757642911179573,
+              "regression_loss": 0.16222610844718277,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    1,
+                    4
+                  ],
+                  [
+                    32,
+                    7,
+                    39
+                  ],
+                  [
+                    0,
+                    8,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1794871794871795,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.2745098039215686,
+                    "support": 12,
+                    "roc_auc": 0.6377551020408163,
+                    "pr_auc": 0.14425072684378085
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4375,
+                    "recall": 0.08974358974358974,
+                    "f1": 0.14893617021276595,
+                    "support": 78,
+                    "roc_auc": 0.21394230769230768,
+                    "pr_auc": 0.5589566297706043
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21818181818181817,
+                    "recall": 0.6,
+                    "f1": 0.32,
+                    "support": 20,
+                    "roc_auc": 0.6116666666666667,
+                    "pr_auc": 0.20895425805350654
+                  }
+                ],
+                "macro_precision": 0.2783896658896659,
+                "macro_recall": 0.42435897435897435,
+                "macro_f1": 0.24781532471144485,
+                "weighted_f1": 0.19373762657867788,
+                "macro_roc_auc": 0.4877880254665969,
+                "macro_pr_auc": 0.3040538715559639
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2794117647058823,
+              "regime_accuracy": 0.3513513505458832,
+              "regime_loss": 1.163944048078943,
+              "regression_rmse_log_rv": 0.779822043826107,
+              "regression_mae_log_rv": 0.6624571671709418,
+              "regression_loss": 0.6081224200371267,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    30,
+                    0,
+                    14
+                  ],
+                  [
+                    18,
+                    0,
+                    30
+                  ],
+                  [
+                    10,
+                    0,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5172413793103449,
+                    "recall": 0.6818181818181818,
+                    "f1": 0.5882352941176471,
+                    "support": 44,
+                    "roc_auc": 0.6187245590230664,
+                    "pr_auc": 0.45398634098771384
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.3521825396825397,
+                    "pr_auc": 0.3322154555741453
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.16981132075471697,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.24999999999999994,
+                    "support": 19,
+                    "roc_auc": 0.5509153318077803,
+                    "pr_auc": 0.24751720387203704
+                  }
+                ],
+                "macro_precision": 0.22901756668835394,
+                "macro_recall": 0.38516746411483255,
+                "macro_f1": 0.2794117647058823,
+                "weighted_f1": 0.27596714361420244,
+                "macro_roc_auc": 0.5072741435044622,
+                "macro_pr_auc": 0.34457300014463205
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3448490507314037,
+              "regime_accuracy": 0.48076921701431274,
+              "regime_loss": 1.0693718470059907,
+              "regression_rmse_log_rv": 0.9641143453758971,
+              "regression_mae_log_rv": 0.745395646605175,
+              "regression_loss": 0.9295164709595947,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    17,
+                    9
+                  ],
+                  [
+                    0,
+                    37,
+                    15
+                  ],
+                  [
+                    0,
+                    13,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6267258382642998,
+                    "pr_auc": 0.4576706320977977
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5522388059701493,
+                    "recall": 0.7115384615384616,
+                    "f1": 0.6218487394957983,
+                    "support": 52,
+                    "roc_auc": 0.6756656804733728,
+                    "pr_auc": 0.7268031306394442
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.35135135135135137,
+                    "recall": 0.5,
+                    "f1": 0.41269841269841273,
+                    "support": 26,
+                    "roc_auc": 0.6928007889546351,
+                    "pr_auc": 0.5124840497636197
+                  }
+                ],
+                "macro_precision": 0.3011967191071669,
+                "macro_recall": 0.4038461538461539,
+                "macro_f1": 0.3448490507314037,
+                "weighted_f1": 0.41409897292250236,
+                "macro_roc_auc": 0.6650641025641026,
+                "macro_pr_auc": 0.5656526041669538
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.26834898278560254,
+              "regime_accuracy": 0.38333332538604736,
+              "regime_loss": 1.3885423293609123,
+              "regression_rmse_log_rv": 0.9726189010985026,
+              "regression_mae_log_rv": 0.7906231582055625,
+              "regression_loss": 0.9459875267740587,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    1,
+                    22
+                  ],
+                  [
+                    11,
+                    1,
+                    33
+                  ],
+                  [
+                    6,
+                    1,
+                    40
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.22727272727272727,
+                    "recall": 0.17857142857142858,
+                    "f1": 0.2,
+                    "support": 28,
+                    "roc_auc": 0.672360248447205,
+                    "pr_auc": 0.29726816899243885
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.022222222222222223,
+                    "f1": 0.04166666666666667,
+                    "support": 45,
+                    "roc_auc": 0.5179259259259259,
+                    "pr_auc": 0.4008182959912312
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.42105263157894735,
+                    "recall": 0.851063829787234,
+                    "f1": 0.5633802816901409,
+                    "support": 47,
+                    "roc_auc": 0.6420868551442728,
+                    "pr_auc": 0.4685159400376414
+                  }
+                ],
+                "macro_precision": 0.3272195640616693,
+                "macro_recall": 0.3506191601936283,
+                "macro_f1": 0.26834898278560254,
+                "weighted_f1": 0.2829489436619718,
+                "macro_roc_auc": 0.6107910098391346,
+                "macro_pr_auc": 0.3888674683404372
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4664224664224664,
+              "regime_accuracy": 0.7966101765632629,
+              "regime_loss": 0.6024203194400012,
+              "regression_rmse_log_rv": 1.0508985308211287,
+              "regression_mae_log_rv": 0.9387374776997603,
+              "regression_loss": 1.1043877220820066,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    12,
+                    0,
+                    84
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3125,
+                    "recall": 1.0,
+                    "f1": 0.47619047619047616,
+                    "support": 10,
+                    "roc_auc": 0.9361111111111111,
+                    "pr_auc": 0.5552945967076401
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6682389937106918,
+                    "pr_auc": 0.15475108823479192
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9767441860465116,
+                    "recall": 0.875,
+                    "f1": 0.923076923076923,
+                    "support": 96,
+                    "roc_auc": 0.8650568181818182,
+                    "pr_auc": 0.9481203241306811
+                  }
+                ],
+                "macro_precision": 0.42974806201550386,
+                "macro_recall": 0.625,
+                "macro_f1": 0.4664224664224664,
+                "weighted_f1": 0.7913329608244862,
+                "macro_roc_auc": 0.8231356410012071,
+                "macro_pr_auc": 0.552722003024371
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.29790288272064097,
+              "regime_accuracy": 0.2545454502105713,
+              "regime_loss": 1.0673805345188487,
+              "regression_rmse_log_rv": 0.48143771975026234,
+              "regression_mae_log_rv": 0.3955049775504449,
+              "regression_loss": 0.23178227799833212,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    61,
+                    4,
+                    13
+                  ],
+                  [
+                    6,
+                    0,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.12987012987012986,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.2247191011235955,
+                    "support": 12,
+                    "roc_auc": 0.5654761904761905,
+                    "pr_auc": 0.11423705901963695
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.05128205128205128,
+                    "f1": 0.09756097560975609,
+                    "support": 78,
+                    "roc_auc": 0.4186698717948718,
+                    "pr_auc": 0.6703010955214799
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4827586206896552,
+                    "recall": 0.7,
+                    "f1": 0.5714285714285714,
+                    "support": 20,
+                    "roc_auc": 0.8383333333333334,
+                    "pr_auc": 0.4954919733906672
+                  }
+                ],
+                "macro_precision": 0.5375429168532616,
+                "macro_recall": 0.5282051282051282,
+                "macro_f1": 0.29790288272064097,
+                "weighted_f1": 0.1975905158146868,
+                "macro_roc_auc": 0.6074931318681319,
+                "macro_pr_auc": 0.4266767093105947
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3337358059789141,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.162817485812455,
+              "regression_rmse_log_rv": 0.786318419821776,
+              "regression_mae_log_rv": 0.6687996920663863,
+              "regression_loss": 0.6182966573510148,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    29,
+                    2,
+                    13
+                  ],
+                  [
+                    23,
+                    6,
+                    19
+                  ],
+                  [
+                    7,
+                    5,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4915254237288136,
+                    "recall": 0.6590909090909091,
+                    "f1": 0.5631067961165048,
+                    "support": 44,
+                    "roc_auc": 0.6319538670284939,
+                    "pr_auc": 0.49250556318513083
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.125,
+                    "f1": 0.19672131147540983,
+                    "support": 48,
+                    "roc_auc": 0.5456349206349206,
+                    "pr_auc": 0.49691439922641367
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1794871794871795,
+                    "recall": 0.3684210526315789,
+                    "f1": 0.2413793103448276,
+                    "support": 19,
+                    "roc_auc": 0.6693363844393593,
+                    "pr_auc": 0.24781969063851655
+                  }
+                ],
+                "macro_precision": 0.3775170215848182,
+                "macro_recall": 0.384170653907496,
+                "macro_f1": 0.3337358059789141,
+                "weighted_f1": 0.3495993592477262,
+                "macro_roc_auc": 0.6156417240342579,
+                "macro_pr_auc": 0.4124132176833537
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5174648332543069,
+              "regime_accuracy": 0.5769230723381042,
+              "regime_loss": 0.9775102688716009,
+              "regression_rmse_log_rv": 1.0175418661552305,
+              "regression_mae_log_rv": 0.7811314066348132,
+              "regression_loss": 1.0353914493786691,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    15,
+                    5
+                  ],
+                  [
+                    4,
+                    38,
+                    10
+                  ],
+                  [
+                    1,
+                    9,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5454545454545454,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.3243243243243243,
+                    "support": 26,
+                    "roc_auc": 0.628698224852071,
+                    "pr_auc": 0.4783290348087529
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6129032258064516,
+                    "recall": 0.7307692307692307,
+                    "f1": 0.6666666666666667,
+                    "support": 52,
+                    "roc_auc": 0.6775147928994083,
+                    "pr_auc": 0.6055962626508569
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5161290322580645,
+                    "recall": 0.6153846153846154,
+                    "f1": 0.5614035087719298,
+                    "support": 26,
+                    "roc_auc": 0.7830374753451677,
+                    "pr_auc": 0.6469672024468522
+                  }
+                ],
+                "macro_precision": 0.5581622678396871,
+                "macro_recall": 0.5256410256410257,
+                "macro_f1": 0.5174648332543069,
+                "weighted_f1": 0.5547652916073968,
+                "macro_roc_auc": 0.6964168310322156,
+                "macro_pr_auc": 0.5769641666354873
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4104560622914349,
+              "regime_accuracy": 0.44999998807907104,
+              "regime_loss": 1.1427329534795914,
+              "regression_rmse_log_rv": 0.8590115808929611,
+              "regression_mae_log_rv": 0.7282748403849837,
+              "regression_loss": 0.7379008961082243,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    6,
+                    8
+                  ],
+                  [
+                    12,
+                    6,
+                    27
+                  ],
+                  [
+                    8,
+                    5,
+                    34
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4117647058823529,
+                    "recall": 0.5,
+                    "f1": 0.45161290322580644,
+                    "support": 28,
+                    "roc_auc": 0.7107919254658385,
+                    "pr_auc": 0.33970949212290263
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.35294117647058826,
+                    "recall": 0.13333333333333333,
+                    "f1": 0.19354838709677416,
+                    "support": 45,
+                    "roc_auc": 0.49837037037037035,
+                    "pr_auc": 0.46628692121886484
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4927536231884058,
+                    "recall": 0.723404255319149,
+                    "f1": 0.5862068965517242,
+                    "support": 47,
+                    "roc_auc": 0.6318857475954532,
+                    "pr_auc": 0.48773192393187703
+                  }
+                ],
+                "macro_precision": 0.4191531685137823,
+                "macro_recall": 0.4522458628841608,
+                "macro_f1": 0.4104560622914349,
+                "weighted_f1": 0.40755469039673714,
+                "macro_roc_auc": 0.6136826811438874,
+                "macro_pr_auc": 0.43124277909121483
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.47713243546576883,
+              "regime_accuracy": 0.7033898234367371,
+              "regime_loss": 0.6084974372791032,
+              "regression_rmse_log_rv": 1.057699343150108,
+              "regression_mae_log_rv": 0.9365248365793377,
+              "regression_loss": 1.1187279005001698,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    6,
+                    1,
+                    5
+                  ],
+                  [
+                    4,
+                    17,
+                    75
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4117647058823529,
+                    "recall": 0.7,
+                    "f1": 0.5185185185185185,
+                    "support": 10,
+                    "roc_auc": 0.95,
+                    "pr_auc": 0.48304885989483504
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.047619047619047616,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.060606060606060615,
+                    "support": 12,
+                    "roc_auc": 0.6061320754716981,
+                    "pr_auc": 0.1250516267760067
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9375,
+                    "recall": 0.78125,
+                    "f1": 0.8522727272727273,
+                    "support": 96,
+                    "roc_auc": 0.8579545454545454,
+                    "pr_auc": 0.9351703443842391
+                  }
+                ],
+                "macro_precision": 0.46562791783380014,
+                "macro_recall": 0.5215277777777777,
+                "macro_f1": 0.47713243546576883,
+                "weighted_f1": 0.7434799977172858,
+                "macro_roc_auc": 0.8046955403087478,
+                "macro_pr_auc": 0.5144236103516936
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.28847926267281104,
+              "regime_accuracy": 0.2818181812763214,
+              "regime_loss": 1.107497356154702,
+              "regression_rmse_log_rv": 0.45084023510678267,
+              "regression_mae_log_rv": 0.3593339524268231,
+              "regression_loss": 0.20325691759113906,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    2,
+                    0
+                  ],
+                  [
+                    56,
+                    16,
+                    6
+                  ],
+                  [
+                    6,
+                    9,
+                    5
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1388888888888889,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.2380952380952381,
+                    "support": 12,
+                    "roc_auc": 0.6139455782312925,
+                    "pr_auc": 0.13656382128667843
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5925925925925926,
+                    "recall": 0.20512820512820512,
+                    "f1": 0.3047619047619048,
+                    "support": 78,
+                    "roc_auc": 0.3161057692307692,
+                    "pr_auc": 0.6367011116898715
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.25,
+                    "f1": 0.3225806451612903,
+                    "support": 20,
+                    "roc_auc": 0.8655555555555555,
+                    "pr_auc": 0.448507441953253
+                  }
+                ],
+                "macro_precision": 0.3953423120089787,
+                "macro_recall": 0.4294871794871795,
+                "macro_f1": 0.28847926267281104,
+                "weighted_f1": 0.30072894847088394,
+                "macro_roc_auc": 0.5985356343392058,
+                "macro_pr_auc": 0.40725745830993426
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.41665887486364345,
+              "regime_accuracy": 0.44144144654273987,
+              "regime_loss": 1.275453073885112,
+              "regression_rmse_log_rv": 0.7774843273934408,
+              "regression_mae_log_rv": 0.6648618964245543,
+              "regression_loss": 0.604481879342431,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    28,
+                    1,
+                    15
+                  ],
+                  [
+                    16,
+                    9,
+                    23
+                  ],
+                  [
+                    5,
+                    2,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5714285714285714,
+                    "recall": 0.6363636363636364,
+                    "f1": 0.6021505376344085,
+                    "support": 44,
+                    "roc_auc": 0.6506105834464043,
+                    "pr_auc": 0.5733159508207777
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.75,
+                    "recall": 0.1875,
+                    "f1": 0.3,
+                    "support": 48,
+                    "roc_auc": 0.5793650793650794,
+                    "pr_auc": 0.552907226617097
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.24,
+                    "recall": 0.631578947368421,
+                    "f1": 0.34782608695652173,
+                    "support": 19,
+                    "roc_auc": 0.6372997711670481,
+                    "pr_auc": 0.2656355746346994
+                  }
+                ],
+                "macro_precision": 0.5204761904761904,
+                "macro_recall": 0.4851475279106858,
+                "macro_f1": 0.41665887486364345,
+                "weighted_f1": 0.4279578316043954,
+                "macro_roc_auc": 0.6224251446595106,
+                "macro_pr_auc": 0.4639529173575247
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4211805119182272,
+              "regime_accuracy": 0.567307710647583,
+              "regime_loss": 1.1767302705691411,
+              "regression_rmse_log_rv": 1.0102187500117268,
+              "regression_mae_log_rv": 0.765457684523426,
+              "regression_loss": 1.0205419228752557,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    12,
+                    14
+                  ],
+                  [
+                    0,
+                    39,
+                    13
+                  ],
+                  [
+                    0,
+                    6,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5749506903353058,
+                    "pr_auc": 0.3829042325768735
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6842105263157895,
+                    "recall": 0.75,
+                    "f1": 0.7155963302752295,
+                    "support": 52,
+                    "roc_auc": 0.6553254437869822,
+                    "pr_auc": 0.6096257847475213
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.425531914893617,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.547945205479452,
+                    "support": 26,
+                    "roc_auc": 0.7692307692307693,
+                    "pr_auc": 0.6265080518780912
+                  }
+                ],
+                "macro_precision": 0.3699141470698022,
+                "macro_recall": 0.5064102564102564,
+                "macro_f1": 0.4211805119182272,
+                "weighted_f1": 0.49478446650747776,
+                "macro_roc_auc": 0.6665023011176857,
+                "macro_pr_auc": 0.5396793564008286
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4528236596197761,
+              "regime_accuracy": 0.46666666865348816,
+              "regime_loss": 1.1059085761206007,
+              "regression_rmse_log_rv": 0.8375148650297111,
+              "regression_mae_log_rv": 0.7006844606476079,
+              "regression_loss": 0.7014311491457352,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    18,
+                    4,
+                    6
+                  ],
+                  [
+                    11,
+                    11,
+                    23
+                  ],
+                  [
+                    20,
+                    0,
+                    27
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3673469387755102,
+                    "recall": 0.6428571428571429,
+                    "f1": 0.4675324675324675,
+                    "support": 28,
+                    "roc_auc": 0.7546583850931677,
+                    "pr_auc": 0.4150099019002512
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7333333333333333,
+                    "recall": 0.24444444444444444,
+                    "f1": 0.36666666666666664,
+                    "support": 45,
+                    "roc_auc": 0.448,
+                    "pr_auc": 0.46974843700788116
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.48214285714285715,
+                    "recall": 0.574468085106383,
+                    "f1": 0.5242718446601942,
+                    "support": 47,
+                    "roc_auc": 0.5610609151850773,
+                    "pr_auc": 0.40860921440107845
+                  }
+                ],
+                "macro_precision": 0.5276077097505669,
+                "macro_recall": 0.48725655746932345,
+                "macro_f1": 0.4528236596197761,
+                "weighted_f1": 0.4519307149161518,
+                "macro_roc_auc": 0.5879064334260816,
+                "macro_pr_auc": 0.4311225177697369
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.49401709401709404,
+              "regime_accuracy": 0.8389830589294434,
+              "regime_loss": 0.4756976563041493,
+              "regression_rmse_log_rv": 0.9940252599608552,
+              "regression_mae_log_rv": 0.8845638775965199,
+              "regression_loss": 0.9880862174402457,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    5,
+                    0,
+                    7
+                  ],
+                  [
+                    4,
+                    0,
+                    92
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4375,
+                    "recall": 0.7,
+                    "f1": 0.5384615384615384,
+                    "support": 10,
+                    "roc_auc": 0.9787037037037037,
+                    "pr_auc": 0.7764468864468865
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6446540880503144,
+                    "pr_auc": 0.13796738992512342
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9292929292929293,
+                    "recall": 0.9583333333333334,
+                    "f1": 0.9435897435897437,
+                    "support": 96,
+                    "roc_auc": 0.884469696969697,
+                    "pr_auc": 0.9504352594926848
+                  }
+                ],
+                "macro_precision": 0.4555976430976431,
+                "macro_recall": 0.5527777777777777,
+                "macro_f1": 0.49401709401709404,
+                "weighted_f1": 0.8132985658409387,
+                "macro_roc_auc": 0.8359424962412384,
+                "macro_pr_auc": 0.6216165119548983
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.33040466068335694,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.1468936725096268,
+              "regression_rmse_log_rv": 0.44419821511398017,
+              "regression_mae_log_rv": 0.36355797003852786,
+              "regression_loss": 0.1973120543104458,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    48,
+                    8,
+                    22
+                  ],
+                  [
+                    3,
+                    1,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16393442622950818,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.273972602739726,
+                    "support": 12,
+                    "roc_auc": 0.6870748299319728,
+                    "pr_auc": 0.16816159636793399
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8888888888888888,
+                    "recall": 0.10256410256410256,
+                    "f1": 0.1839080459770115,
+                    "support": 78,
+                    "roc_auc": 0.33253205128205127,
+                    "pr_auc": 0.6129373351979174
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4,
+                    "recall": 0.8,
+                    "f1": 0.5333333333333333,
+                    "support": 20,
+                    "roc_auc": 0.81,
+                    "pr_auc": 0.37961957097491633
+                  }
+                ],
+                "macro_precision": 0.48427443837279904,
+                "macro_recall": 0.5786324786324787,
+                "macro_f1": 0.33040466068335694,
+                "weighted_f1": 0.257265140779548,
+                "macro_roc_auc": 0.6098689604046746,
+                "macro_pr_auc": 0.38690616751358925
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3137206652996127,
+              "regime_accuracy": 0.36936935782432556,
+              "regime_loss": 1.2937833100692024,
+              "regression_rmse_log_rv": 0.7982284487443343,
+              "regression_mae_log_rv": 0.6745219848817214,
+              "regression_loss": 0.6371686563847864,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    28,
+                    0,
+                    16
+                  ],
+                  [
+                    17,
+                    1,
+                    30
+                  ],
+                  [
+                    6,
+                    1,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5490196078431373,
+                    "recall": 0.6363636363636364,
+                    "f1": 0.5894736842105264,
+                    "support": 44,
+                    "roc_auc": 0.6370420624151968,
+                    "pr_auc": 0.508994237159436
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.020833333333333332,
+                    "f1": 0.039999999999999994,
+                    "support": 48,
+                    "roc_auc": 0.5416666666666666,
+                    "pr_auc": 0.5232809863909569
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.20689655172413793,
+                    "recall": 0.631578947368421,
+                    "f1": 0.3116883116883117,
+                    "support": 19,
+                    "roc_auc": 0.6338672768878718,
+                    "pr_auc": 0.2700177330658671
+                  }
+                ],
+                "macro_precision": 0.4186387198557584,
+                "macro_recall": 0.42959197235513025,
+                "macro_f1": 0.3137206652996127,
+                "weighted_f1": 0.3043145948409106,
+                "macro_roc_auc": 0.6041920019899117,
+                "macro_pr_auc": 0.43409765220542
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5466979828681956,
+              "regime_accuracy": 0.5769230723381042,
+              "regime_loss": 1.0647363708569453,
+              "regression_rmse_log_rv": 0.9967559909821314,
+              "regression_mae_log_rv": 0.7686391380848363,
+              "regression_loss": 0.9935225055587709,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    9
+                  ],
+                  [
+                    6,
+                    31,
+                    15
+                  ],
+                  [
+                    3,
+                    3,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.40909090909090906,
+                    "support": 26,
+                    "roc_auc": 0.6267258382642998,
+                    "pr_auc": 0.5066339619980096
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7380952380952381,
+                    "recall": 0.5961538461538461,
+                    "f1": 0.6595744680851063,
+                    "support": 52,
+                    "roc_auc": 0.6789940828402367,
+                    "pr_auc": 0.6234244381848377
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5714285714285714,
+                    "support": 26,
+                    "roc_auc": 0.735207100591716,
+                    "pr_auc": 0.5756312562364254
+                  }
+                ],
+                "macro_precision": 0.5642135642135643,
+                "macro_recall": 0.5705128205128206,
+                "macro_f1": 0.5466979828681956,
+                "weighted_f1": 0.5749171041724233,
+                "macro_roc_auc": 0.6803090072320842,
+                "macro_pr_auc": 0.5685632188064242
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "dual": [
+      {
+        "head_mode": "dual",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.45280944561732744,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.062027881941888,
+              "regression_rmse_log_rv": 0.9790502972515387,
+              "regression_mae_log_rv": 0.7815387333284889,
+              "regression_loss": 0.9585394845483263,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    5,
+                    10
+                  ],
+                  [
+                    6,
+                    11,
+                    28
+                  ],
+                  [
+                    2,
+                    14,
+                    31
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6190476190476191,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.5306122448979592,
+                    "support": 28,
+                    "roc_auc": 0.7441770186335404,
+                    "pr_auc": 0.4072281546630531
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.36666666666666664,
+                    "recall": 0.24444444444444444,
+                    "f1": 0.29333333333333333,
+                    "support": 45,
+                    "roc_auc": 0.4441481481481481,
+                    "pr_auc": 0.4122017451495378
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4492753623188406,
+                    "recall": 0.6595744680851063,
+                    "f1": 0.5344827586206896,
+                    "support": 47,
+                    "roc_auc": 0.5893325561060915,
+                    "pr_auc": 0.43367412426865065
+                  }
+                ],
+                "macro_precision": 0.47832988267770876,
+                "macro_recall": 0.456101542271755,
+                "macro_f1": 0.45280944561732744,
+                "weighted_f1": 0.4431486042692939,
+                "macro_roc_auc": 0.5925525742959267,
+                "macro_pr_auc": 0.4177013413604138
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5695970695970696,
+              "regime_accuracy": 0.8135592937469482,
+              "regime_loss": 0.644087301472486,
+              "regression_rmse_log_rv": 1.1926496570897709,
+              "regression_mae_log_rv": 1.0765106756589375,
+              "regression_loss": 1.422413204556348,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    12,
+                    0,
+                    84
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 1.0,
+                    "f1": 0.5,
+                    "support": 10,
+                    "roc_auc": 0.9555555555555556,
+                    "pr_auc": 0.6199256814736691
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.2857142857142857,
+                    "support": 12,
+                    "roc_auc": 0.8042452830188679,
+                    "pr_auc": 0.44749580456741744
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9767441860465116,
+                    "recall": 0.875,
+                    "f1": 0.923076923076923,
+                    "support": 96,
+                    "roc_auc": 0.884469696969697,
+                    "pr_auc": 0.9682630707262301
+                  }
+                ],
+                "macro_precision": 0.7700258397932817,
+                "macro_recall": 0.6805555555555555,
+                "macro_f1": 0.5695970695970696,
+                "weighted_f1": 0.8224064071521698,
+                "macro_roc_auc": 0.8814235118480402,
+                "macro_pr_auc": 0.6785615189224389
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.20594220594220594,
+              "regime_accuracy": 0.1818181872367859,
+              "regime_loss": 1.3175232475454157,
+              "regression_rmse_log_rv": 0.47345713570123815,
+              "regression_mae_log_rv": 0.3772855264796817,
+              "regression_loss": 0.22416165934642066,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    1,
+                    1
+                  ],
+                  [
+                    62,
+                    4,
+                    12
+                  ],
+                  [
+                    6,
+                    8,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1282051282051282,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.2222222222222222,
+                    "support": 12,
+                    "roc_auc": 0.6887755102040817,
+                    "pr_auc": 0.18283909234647527
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.05128205128205128,
+                    "f1": 0.08791208791208792,
+                    "support": 78,
+                    "roc_auc": 0.2844551282051282,
+                    "pr_auc": 0.5772263119618063
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3157894736842105,
+                    "recall": 0.3,
+                    "f1": 0.3076923076923077,
+                    "support": 20,
+                    "roc_auc": 0.7766666666666666,
+                    "pr_auc": 0.34408918059655214
+                  }
+                ],
+                "macro_precision": 0.2505623031938821,
+                "macro_recall": 0.39487179487179486,
+                "macro_f1": 0.20594220594220594,
+                "weighted_f1": 0.14252414252414253,
+                "macro_roc_auc": 0.5832991016919588,
+                "macro_pr_auc": 0.36805152830161125
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4184008872756604,
+              "regime_accuracy": 0.45945945382118225,
+              "regime_loss": 1.0423885510977884,
+              "regression_rmse_log_rv": 0.7946501222230768,
+              "regression_mae_log_rv": 0.668702726092306,
+              "regression_loss": 0.6314688167491509,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    27,
+                    13,
+                    4
+                  ],
+                  [
+                    17,
+                    19,
+                    12
+                  ],
+                  [
+                    7,
+                    7,
+                    5
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5294117647058824,
+                    "recall": 0.6136363636363636,
+                    "f1": 0.5684210526315789,
+                    "support": 44,
+                    "roc_auc": 0.6075305291723202,
+                    "pr_auc": 0.4352906167490731
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.48717948717948717,
+                    "recall": 0.3958333333333333,
+                    "f1": 0.43678160919540227,
+                    "support": 48,
+                    "roc_auc": 0.5300925925925926,
+                    "pr_auc": 0.5336724157638135
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.23809523809523808,
+                    "recall": 0.2631578947368421,
+                    "f1": 0.25,
+                    "support": 19,
+                    "roc_auc": 0.5537757437070938,
+                    "pr_auc": 0.24193553741050797
+                  }
+                ],
+                "macro_precision": 0.4182288299935359,
+                "macro_recall": 0.42420919723551304,
+                "macro_f1": 0.4184008872756604,
+                "weighted_f1": 0.45699138339791695,
+                "macro_roc_auc": 0.5637996218240021,
+                "macro_pr_auc": 0.4036328566411315
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3709392655367232,
+              "regime_accuracy": 0.5096153616905212,
+              "regime_loss": 1.0550468930831323,
+              "regression_rmse_log_rv": 1.0493642359618853,
+              "regression_mae_log_rv": 0.8040743436649791,
+              "regression_loss": 1.1011652997158712,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    17,
+                    9
+                  ],
+                  [
+                    0,
+                    38,
+                    14
+                  ],
+                  [
+                    0,
+                    11,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5986193293885601,
+                    "pr_auc": 0.4572109721369477
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5757575757575758,
+                    "recall": 0.7307692307692307,
+                    "f1": 0.6440677966101696,
+                    "support": 52,
+                    "roc_auc": 0.7115384615384616,
+                    "pr_auc": 0.7319700782428626
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.39473684210526316,
+                    "recall": 0.5769230769230769,
+                    "f1": 0.46875,
+                    "support": 26,
+                    "roc_auc": 0.7169625246548323,
+                    "pr_auc": 0.5635937338060613
+                  }
+                ],
+                "macro_precision": 0.323498139287613,
+                "macro_recall": 0.43589743589743585,
+                "macro_f1": 0.3709392655367232,
+                "weighted_f1": 0.4392213983050848,
+                "macro_roc_auc": 0.675706771860618,
+                "macro_pr_auc": 0.5842582613952906
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4560127389948623,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.084414207249234,
+              "regression_rmse_log_rv": 0.7807937416349253,
+              "regression_mae_log_rv": 0.6493900054010737,
+              "regression_loss": 0.6096388669762666,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    6,
+                    6
+                  ],
+                  [
+                    9,
+                    13,
+                    23
+                  ],
+                  [
+                    9,
+                    12,
+                    26
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.47058823529411764,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.5161290322580646,
+                    "support": 28,
+                    "roc_auc": 0.764751552795031,
+                    "pr_auc": 0.4565886186628068
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.41935483870967744,
+                    "recall": 0.28888888888888886,
+                    "f1": 0.34210526315789475,
+                    "support": 45,
+                    "roc_auc": 0.44207407407407406,
+                    "pr_auc": 0.4382481489053925
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4727272727272727,
+                    "recall": 0.5531914893617021,
+                    "f1": 0.5098039215686275,
+                    "support": 47,
+                    "roc_auc": 0.586417953949286,
+                    "pr_auc": 0.43133343723970985
+                  }
+                ],
+                "macro_precision": 0.454223448910356,
+                "macro_recall": 0.47116964989305415,
+                "macro_f1": 0.4560127389948623,
+                "weighted_f1": 0.4483927838254714,
+                "macro_roc_auc": 0.597747860272797,
+                "macro_pr_auc": 0.4420567349359697
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.47416355095388746,
+              "regime_accuracy": 0.7796609997749329,
+              "regime_loss": 0.6601782431036739,
+              "regression_rmse_log_rv": 0.8401242043424147,
+              "regression_mae_log_rv": 0.7360493572778068,
+              "regression_loss": 0.7058086787219755,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    11,
+                    3,
+                    82
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35714285714285715,
+                    "recall": 1.0,
+                    "f1": 0.5263157894736842,
+                    "support": 10,
+                    "roc_auc": 0.9601851851851851,
+                    "pr_auc": 0.6373711664152841
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7264150943396226,
+                    "pr_auc": 0.1697139755580233
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9425287356321839,
+                    "recall": 0.8541666666666666,
+                    "f1": 0.8961748633879782,
+                    "support": 96,
+                    "roc_auc": 0.8835227272727273,
+                    "pr_auc": 0.9668020118053308
+                  }
+                ],
+                "macro_precision": 0.433223864258347,
+                "macro_recall": 0.6180555555555555,
+                "macro_f1": 0.47416355095388746,
+                "weighted_f1": 0.7736944472879894,
+                "macro_roc_auc": 0.8567076689325117,
+                "macro_pr_auc": 0.5912957179262127
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.49584512530248964,
+              "regime_accuracy": 0.5545454621315002,
+              "regime_loss": 0.9052342783321033,
+              "regression_rmse_log_rv": 0.40820569040996546,
+              "regression_mae_log_rv": 0.3357257324933016,
+              "regression_loss": 0.16663188568307655,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    6,
+                    0
+                  ],
+                  [
+                    25,
+                    43,
+                    10
+                  ],
+                  [
+                    0,
+                    8,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1935483870967742,
+                    "recall": 0.5,
+                    "f1": 0.27906976744186046,
+                    "support": 12,
+                    "roc_auc": 0.6777210884353742,
+                    "pr_auc": 0.17272646834837035
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7543859649122807,
+                    "recall": 0.5512820512820513,
+                    "f1": 0.6370370370370372,
+                    "support": 78,
+                    "roc_auc": 0.47876602564102566,
+                    "pr_auc": 0.7370269197550668
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5454545454545454,
+                    "recall": 0.6,
+                    "f1": 0.5714285714285713,
+                    "support": 20,
+                    "roc_auc": 0.8627777777777778,
+                    "pr_auc": 0.4733303468389351
+                  }
+                ],
+                "macro_precision": 0.49779629915453344,
+                "macro_recall": 0.5504273504273504,
+                "macro_f1": 0.49584512530248964,
+                "weighted_f1": 0.5860572502432968,
+                "macro_roc_auc": 0.673088297284726,
+                "macro_pr_auc": 0.46102791164745743
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3287400015839075,
+              "regime_accuracy": 0.36036035418510437,
+              "regime_loss": 1.12276655950188,
+              "regression_rmse_log_rv": 0.786600697004095,
+              "regression_mae_log_rv": 0.6691276236670092,
+              "regression_loss": 0.618740656527328,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    5,
+                    13
+                  ],
+                  [
+                    17,
+                    4,
+                    27
+                  ],
+                  [
+                    5,
+                    4,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5416666666666666,
+                    "recall": 0.5909090909090909,
+                    "f1": 0.5652173913043478,
+                    "support": 44,
+                    "roc_auc": 0.6170284938941656,
+                    "pr_auc": 0.4565887516041331
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.13114754098360656,
+                    "support": 48,
+                    "roc_auc": 0.4834656084656085,
+                    "pr_auc": 0.4011715483787839
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.28985507246376807,
+                    "support": 19,
+                    "roc_auc": 0.5743707093821511,
+                    "pr_auc": 0.2404117179282501
+                  }
+                ],
+                "macro_precision": 0.3497863247863248,
+                "macro_recall": 0.4001860712387028,
+                "macro_f1": 0.3287400015839075,
+                "weighted_f1": 0.3303774194722163,
+                "macro_roc_auc": 0.5582882705806417,
+                "macro_pr_auc": 0.36605733930372236
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.35695253579009173,
+              "regime_accuracy": 0.5,
+              "regime_loss": 1.0757055695240314,
+              "regression_rmse_log_rv": 0.9726120160744206,
+              "regression_mae_log_rv": 0.7524938024580479,
+              "regression_loss": 0.9459741338123491,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    17,
+                    9
+                  ],
+                  [
+                    0,
+                    39,
+                    13
+                  ],
+                  [
+                    0,
+                    13,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6597633136094675,
+                    "pr_auc": 0.4286367807332946
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5652173913043478,
+                    "recall": 0.75,
+                    "f1": 0.6446280991735538,
+                    "support": 52,
+                    "roc_auc": 0.6346153846153846,
+                    "pr_auc": 0.5891072311229327
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37142857142857144,
+                    "recall": 0.5,
+                    "f1": 0.42622950819672134,
+                    "support": 26,
+                    "roc_auc": 0.7391518737672583,
+                    "pr_auc": 0.5872508782602839
+                  }
+                ],
+                "macro_precision": 0.3122153209109731,
+                "macro_recall": 0.4166666666666667,
+                "macro_f1": 0.35695253579009173,
+                "weighted_f1": 0.4288714266359573,
+                "macro_roc_auc": 0.6778435239973701,
+                "macro_pr_auc": 0.5349982967055037
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.38633740355992957,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.111128145168796,
+              "regression_rmse_log_rv": 0.894982995767381,
+              "regression_mae_log_rv": 0.7335478966015216,
+              "regression_loss": 0.8009945627127559,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    4,
+                    9
+                  ],
+                  [
+                    8,
+                    5,
+                    32
+                  ],
+                  [
+                    11,
+                    6,
+                    30
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4411764705882353,
+                    "recall": 0.5357142857142857,
+                    "f1": 0.4838709677419355,
+                    "support": 28,
+                    "roc_auc": 0.7527173913043478,
+                    "pr_auc": 0.4493814719053112
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.1111111111111111,
+                    "f1": 0.16666666666666666,
+                    "support": 45,
+                    "roc_auc": 0.4005925925925926,
+                    "pr_auc": 0.32145525733410024
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4225352112676056,
+                    "recall": 0.6382978723404256,
+                    "f1": 0.5084745762711864,
+                    "support": 47,
+                    "roc_auc": 0.5482366656951326,
+                    "pr_auc": 0.3908092206380388
+                  }
+                ],
+                "macro_precision": 0.3990150050630581,
+                "macro_recall": 0.4283744230552741,
+                "macro_f1": 0.38633740355992957,
+                "weighted_f1": 0.37455576817933295,
+                "macro_roc_auc": 0.567182216530691,
+                "macro_pr_auc": 0.38721531662581676
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5670941625997806,
+              "regime_accuracy": 0.7288135886192322,
+              "regime_loss": 0.5599556999691462,
+              "regression_rmse_log_rv": 1.0659909648699517,
+              "regression_mae_log_rv": 0.958144021948101,
+              "regression_loss": 1.1363367371843704,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    1,
+                    4,
+                    7
+                  ],
+                  [
+                    4,
+                    17,
+                    75
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5833333333333334,
+                    "recall": 0.7,
+                    "f1": 0.6363636363636365,
+                    "support": 10,
+                    "roc_auc": 0.9842592592592593,
+                    "pr_auc": 0.8045608558108558
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.2222222222222222,
+                    "support": 12,
+                    "roc_auc": 0.6092767295597484,
+                    "pr_auc": 0.12927775160799496
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9146341463414634,
+                    "recall": 0.78125,
+                    "f1": 0.8426966292134832,
+                    "support": 96,
+                    "roc_auc": 0.8465909090909091,
+                    "pr_auc": 0.9129863246890966
+                  }
+                ],
+                "macro_precision": 0.5548780487804879,
+                "macro_recall": 0.6048611111111111,
+                "macro_f1": 0.5670941625997806,
+                "weighted_f1": 0.7621116901254018,
+                "macro_roc_auc": 0.8133756326366389,
+                "macro_pr_auc": 0.6156083107026491
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3670995670995671,
+              "regime_accuracy": 0.3636363744735718,
+              "regime_loss": 1.1099386540326206,
+              "regression_rmse_log_rv": 0.4604302000098779,
+              "regression_mae_log_rv": 0.3773412518166879,
+              "regression_loss": 0.21199596908113616,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    39,
+                    19,
+                    20
+                  ],
+                  [
+                    1,
+                    6,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.26666666666666666,
+                    "support": 12,
+                    "roc_auc": 0.6224489795918368,
+                    "pr_auc": 0.13360067520290236
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7037037037037037,
+                    "recall": 0.24358974358974358,
+                    "f1": 0.3619047619047619,
+                    "support": 78,
+                    "roc_auc": 0.3088942307692308,
+                    "pr_auc": 0.6264772580831284
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37142857142857144,
+                    "recall": 0.65,
+                    "f1": 0.4727272727272728,
+                    "support": 20,
+                    "roc_auc": 0.8016666666666666,
+                    "pr_auc": 0.35081197489487237
+                  }
+                ],
+                "macro_precision": 0.4139329805996473,
+                "macro_recall": 0.5200854700854701,
+                "macro_f1": 0.3670995670995671,
+                "weighted_f1": 0.3716646989374262,
+                "macro_roc_auc": 0.5776699590092448,
+                "macro_pr_auc": 0.37029663606030105
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3337358059789141,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.162817485812455,
+              "regression_rmse_log_rv": 0.786318419821776,
+              "regression_mae_log_rv": 0.6687996920663863,
+              "regression_loss": 0.6182966573510148,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    29,
+                    2,
+                    13
+                  ],
+                  [
+                    23,
+                    6,
+                    19
+                  ],
+                  [
+                    7,
+                    5,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4915254237288136,
+                    "recall": 0.6590909090909091,
+                    "f1": 0.5631067961165048,
+                    "support": 44,
+                    "roc_auc": 0.6319538670284939,
+                    "pr_auc": 0.49250556318513083
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.125,
+                    "f1": 0.19672131147540983,
+                    "support": 48,
+                    "roc_auc": 0.5456349206349206,
+                    "pr_auc": 0.49691439922641367
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1794871794871795,
+                    "recall": 0.3684210526315789,
+                    "f1": 0.2413793103448276,
+                    "support": 19,
+                    "roc_auc": 0.6693363844393593,
+                    "pr_auc": 0.24781969063851655
+                  }
+                ],
+                "macro_precision": 0.3775170215848182,
+                "macro_recall": 0.384170653907496,
+                "macro_f1": 0.3337358059789141,
+                "weighted_f1": 0.3495993592477262,
+                "macro_roc_auc": 0.6156417240342579,
+                "macro_pr_auc": 0.4124132176833537
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3473189759928111,
+              "regime_accuracy": 0.3461538553237915,
+              "regime_loss": 1.2157286313863902,
+              "regression_rmse_log_rv": 1.0295654179335298,
+              "regression_mae_log_rv": 0.7882346679689363,
+              "regression_loss": 1.0600049498046438,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    9
+                  ],
+                  [
+                    24,
+                    14,
+                    14
+                  ],
+                  [
+                    6,
+                    7,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23076923076923078,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.276923076923077,
+                    "support": 26,
+                    "roc_auc": 0.5670611439842209,
+                    "pr_auc": 0.3322720344391015
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4827586206896552,
+                    "recall": 0.2692307692307692,
+                    "f1": 0.345679012345679,
+                    "support": 52,
+                    "roc_auc": 0.6057692307692307,
+                    "pr_auc": 0.5710241881580828
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3611111111111111,
+                    "recall": 0.5,
+                    "f1": 0.4193548387096774,
+                    "support": 26,
+                    "roc_auc": 0.7100591715976331,
+                    "pr_auc": 0.47178733825440844
+                  }
+                ],
+                "macro_precision": 0.35821298752333236,
+                "macro_recall": 0.3717948717948718,
+                "macro_f1": 0.3473189759928111,
+                "weighted_f1": 0.3469089850810281,
+                "macro_roc_auc": 0.627629848783695,
+                "macro_pr_auc": 0.4583611869505309
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.35559492980782337,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.1733238495542353,
+              "regression_rmse_log_rv": 0.8551747260649307,
+              "regression_mae_log_rv": 0.7162549340755504,
+              "regression_loss": 0.7313238121002293,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    3,
+                    17
+                  ],
+                  [
+                    6,
+                    4,
+                    35
+                  ],
+                  [
+                    2,
+                    6,
+                    39
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.2857142857142857,
+                    "f1": 0.36363636363636365,
+                    "support": 28,
+                    "roc_auc": 0.750388198757764,
+                    "pr_auc": 0.37744657333617754
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.08888888888888889,
+                    "f1": 0.13793103448275862,
+                    "support": 45,
+                    "roc_auc": 0.4091851851851852,
+                    "pr_auc": 0.3278948426648517
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.8297872340425532,
+                    "f1": 0.5652173913043478,
+                    "support": 47,
+                    "roc_auc": 0.5858350335179248,
+                    "pr_auc": 0.44848618189694056
+                  }
+                ],
+                "macro_precision": 0.4120879120879121,
+                "macro_recall": 0.4014634695485759,
+                "macro_f1": 0.35559492980782337,
+                "weighted_f1": 0.35794943437372223,
+                "macro_roc_auc": 0.5818028058202913,
+                "macro_pr_auc": 0.38460919929932325
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5239596469104666,
+              "regime_accuracy": 0.805084764957428,
+              "regime_loss": 0.532729442341853,
+              "regression_rmse_log_rv": 1.0327385466863612,
+              "regression_mae_log_rv": 0.9128526839194819,
+              "regression_loss": 1.0665489058118576,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    12,
+                    0,
+                    84
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 1.0,
+                    "f1": 0.5,
+                    "support": 10,
+                    "roc_auc": 0.9537037037037037,
+                    "pr_auc": 0.5892697335344393
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.15384615384615385,
+                    "support": 12,
+                    "roc_auc": 0.7838050314465409,
+                    "pr_auc": 0.40402580167818564
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9655172413793104,
+                    "recall": 0.875,
+                    "f1": 0.9180327868852458,
+                    "support": 96,
+                    "roc_auc": 0.8693181818181818,
+                    "pr_auc": 0.9512710966742397
+                  }
+                ],
+                "macro_precision": 0.7662835249042145,
+                "macro_recall": 0.6527777777777778,
+                "macro_f1": 0.5239596469104666,
+                "weighted_f1": 0.8048923846367578,
+                "macro_roc_auc": 0.8689423056561422,
+                "macro_pr_auc": 0.6481888772956216
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.28847926267281104,
+              "regime_accuracy": 0.2818181812763214,
+              "regime_loss": 1.107497356154702,
+              "regression_rmse_log_rv": 0.45084023510678267,
+              "regression_mae_log_rv": 0.3593339524268231,
+              "regression_loss": 0.20325691759113906,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    2,
+                    0
+                  ],
+                  [
+                    56,
+                    16,
+                    6
+                  ],
+                  [
+                    6,
+                    9,
+                    5
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1388888888888889,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.2380952380952381,
+                    "support": 12,
+                    "roc_auc": 0.6139455782312925,
+                    "pr_auc": 0.13656382128667843
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5925925925925926,
+                    "recall": 0.20512820512820512,
+                    "f1": 0.3047619047619048,
+                    "support": 78,
+                    "roc_auc": 0.3161057692307692,
+                    "pr_auc": 0.6367011116898715
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.25,
+                    "f1": 0.3225806451612903,
+                    "support": 20,
+                    "roc_auc": 0.8655555555555555,
+                    "pr_auc": 0.448507441953253
+                  }
+                ],
+                "macro_precision": 0.3953423120089787,
+                "macro_recall": 0.4294871794871795,
+                "macro_f1": 0.28847926267281104,
+                "weighted_f1": 0.30072894847088394,
+                "macro_roc_auc": 0.5985356343392058,
+                "macro_pr_auc": 0.40725745830993426
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3651721897335933,
+              "regime_accuracy": 0.4324324429035187,
+              "regime_loss": 1.0653748831705558,
+              "regression_rmse_log_rv": 0.8681899045612113,
+              "regression_mae_log_rv": 0.732072891201824,
+              "regression_loss": 0.7537537103820051,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    35,
+                    1,
+                    8
+                  ],
+                  [
+                    24,
+                    5,
+                    19
+                  ],
+                  [
+                    11,
+                    0,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.7954545454545454,
+                    "f1": 0.6140350877192983,
+                    "support": 44,
+                    "roc_auc": 0.6363636363636364,
+                    "pr_auc": 0.4608278762913324
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8333333333333334,
+                    "recall": 0.10416666666666667,
+                    "f1": 0.1851851851851852,
+                    "support": 48,
+                    "roc_auc": 0.5023148148148148,
+                    "pr_auc": 0.4118268808303937
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.22857142857142856,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.2962962962962963,
+                    "support": 19,
+                    "roc_auc": 0.5646453089244852,
+                    "pr_auc": 0.24895358215140376
+                  }
+                ],
+                "macro_precision": 0.5206349206349207,
+                "macro_recall": 0.44022461456671985,
+                "macro_f1": 0.3651721897335933,
+                "weighted_f1": 0.37419876016367243,
+                "macro_roc_auc": 0.5677745867009788,
+                "macro_pr_auc": 0.3738694464243766
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.42243269812462186,
+              "regime_accuracy": 0.4326923191547394,
+              "regime_loss": 1.0552649177037752,
+              "regression_rmse_log_rv": 1.0546595573975552,
+              "regression_mae_log_rv": 0.8284566687652841,
+              "regression_loss": 1.1123067820100072,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    9
+                  ],
+                  [
+                    17,
+                    21,
+                    14
+                  ],
+                  [
+                    5,
+                    6,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2903225806451613,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.3157894736842105,
+                    "support": 26,
+                    "roc_auc": 0.6025641025641025,
+                    "pr_auc": 0.3856094673782529
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6,
+                    "recall": 0.40384615384615385,
+                    "f1": 0.4827586206896552,
+                    "support": 52,
+                    "roc_auc": 0.6116863905325444,
+                    "pr_auc": 0.6049424670930035
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.39473684210526316,
+                    "recall": 0.5769230769230769,
+                    "f1": 0.46875,
+                    "support": 26,
+                    "roc_auc": 0.7204142011834319,
+                    "pr_auc": 0.5701347335108976
+                  }
+                ],
+                "macro_precision": 0.42835314091680815,
+                "macro_recall": 0.4423076923076923,
+                "macro_f1": 0.42243269812462186,
+                "weighted_f1": 0.4375141787658802,
+                "macro_roc_auc": 0.6448882314266929,
+                "macro_pr_auc": 0.5202288893273846
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.31447268275912776,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.2778424830649247,
+              "regression_rmse_log_rv": 0.8433787153525703,
+              "regression_mae_log_rv": 0.7159245740513143,
+              "regression_loss": 0.7112876575097518,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    4,
+                    0,
+                    24
+                  ],
+                  [
+                    9,
+                    5,
+                    31
+                  ],
+                  [
+                    5,
+                    1,
+                    41
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.14285714285714285,
+                    "f1": 0.17391304347826086,
+                    "support": 28,
+                    "roc_auc": 0.6327639751552795,
+                    "pr_auc": 0.27162358992440455
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8333333333333334,
+                    "recall": 0.1111111111111111,
+                    "f1": 0.19607843137254902,
+                    "support": 45,
+                    "roc_auc": 0.5422222222222223,
+                    "pr_auc": 0.4993030819758479
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4270833333333333,
+                    "recall": 0.8723404255319149,
+                    "f1": 0.5734265734265734,
+                    "support": 47,
+                    "roc_auc": 0.5977849023608277,
+                    "pr_auc": 0.4339003231120521
+                  }
+                ],
+                "macro_precision": 0.49421296296296297,
+                "macro_recall": 0.3754362265000563,
+                "macro_f1": 0.31447268275912776,
+                "weighted_f1": 0.338701196501708,
+                "macro_roc_auc": 0.5909236999127765,
+                "macro_pr_auc": 0.40160899833743485
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4693941165010715,
+              "regime_accuracy": 0.7118644118309021,
+              "regime_loss": 0.5529564669576742,
+              "regression_rmse_log_rv": 1.0137721175678667,
+              "regression_mae_log_rv": 0.8987597948871553,
+              "regression_loss": 1.0277339063580366,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    6,
+                    1,
+                    5
+                  ],
+                  [
+                    6,
+                    14,
+                    76
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3684210526315789,
+                    "recall": 0.7,
+                    "f1": 0.48275862068965514,
+                    "support": 10,
+                    "roc_auc": 0.9731481481481481,
+                    "pr_auc": 0.7551832399626517
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.05555555555555555,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.06666666666666667,
+                    "support": 12,
+                    "roc_auc": 0.6069182389937107,
+                    "pr_auc": 0.12142626016397905
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9382716049382716,
+                    "recall": 0.7916666666666666,
+                    "f1": 0.8587570621468925,
+                    "support": 96,
+                    "roc_auc": 0.8589015151515151,
+                    "pr_auc": 0.9468197491073755
+                  }
+                ],
+                "macro_precision": 0.4540827377084687,
+                "macro_recall": 0.525,
+                "macro_f1": 0.4693941165010715,
+                "weighted_f1": 0.7463412218050697,
+                "macro_roc_auc": 0.8129893007644581,
+                "macro_pr_auc": 0.6078097497446687
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2306998556998557,
+              "regime_accuracy": 0.2181818187236786,
+              "regime_loss": 1.3045291033658115,
+              "regression_rmse_log_rv": 0.4537076601165185,
+              "regression_mae_log_rv": 0.3721671236016846,
+              "regression_loss": 0.20585064084840624,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    1,
+                    4
+                  ],
+                  [
+                    27,
+                    4,
+                    47
+                  ],
+                  [
+                    2,
+                    5,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.19444444444444445,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.2916666666666667,
+                    "support": 12,
+                    "roc_auc": 0.6794217687074829,
+                    "pr_auc": 0.16913219574918395
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.05128205128205128,
+                    "f1": 0.09090909090909091,
+                    "support": 78,
+                    "roc_auc": 0.2143429487179487,
+                    "pr_auc": 0.5603076649753481
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.203125,
+                    "recall": 0.65,
+                    "f1": 0.30952380952380953,
+                    "support": 20,
+                    "roc_auc": 0.6466666666666666,
+                    "pr_auc": 0.22162809780002485
+                  }
+                ],
+                "macro_precision": 0.2658564814814815,
+                "macro_recall": 0.42820512820512824,
+                "macro_f1": 0.2306998556998557,
+                "weighted_f1": 0.15255804801259348,
+                "macro_roc_auc": 0.5134771280306994,
+                "macro_pr_auc": 0.317022652841519
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.32215608465608464,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.1683526075655595,
+              "regression_rmse_log_rv": 0.7623969988301971,
+              "regression_mae_log_rv": 0.6409999481402338,
+              "regression_loss": 0.5812491838252914,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    22,
+                    12
+                  ],
+                  [
+                    5,
+                    19,
+                    24
+                  ],
+                  [
+                    5,
+                    6,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.22727272727272727,
+                    "f1": 0.3125,
+                    "support": 44,
+                    "roc_auc": 0.5997286295793759,
+                    "pr_auc": 0.4320773134543635
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.40425531914893614,
+                    "recall": 0.3958333333333333,
+                    "f1": 0.39999999999999997,
+                    "support": 48,
+                    "roc_auc": 0.3948412698412698,
+                    "pr_auc": 0.3503756520482201
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.18181818181818182,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.25396825396825395,
+                    "support": 19,
+                    "roc_auc": 0.5474828375286042,
+                    "pr_auc": 0.2408631480570953
+                  }
+                ],
+                "macro_precision": 0.3620245003223726,
+                "macro_recall": 0.3480528973950026,
+                "macro_f1": 0.32215608465608464,
+                "weighted_f1": 0.34031889031889034,
+                "macro_roc_auc": 0.5140175789830833,
+                "macro_pr_auc": 0.34110537118655965
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5466979828681956,
+              "regime_accuracy": 0.5769230723381042,
+              "regime_loss": 1.0647363708569453,
+              "regression_rmse_log_rv": 0.9967559909821314,
+              "regression_mae_log_rv": 0.7686391380848363,
+              "regression_loss": 0.9935225055587709,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    9
+                  ],
+                  [
+                    6,
+                    31,
+                    15
+                  ],
+                  [
+                    3,
+                    3,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.40909090909090906,
+                    "support": 26,
+                    "roc_auc": 0.6267258382642998,
+                    "pr_auc": 0.5066339619980096
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7380952380952381,
+                    "recall": 0.5961538461538461,
+                    "f1": 0.6595744680851063,
+                    "support": 52,
+                    "roc_auc": 0.6789940828402367,
+                    "pr_auc": 0.6234244381848377
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5714285714285714,
+                    "support": 26,
+                    "roc_auc": 0.735207100591716,
+                    "pr_auc": 0.5756312562364254
+                  }
+                ],
+                "macro_precision": 0.5642135642135643,
+                "macro_recall": 0.5705128205128206,
+                "macro_f1": 0.5466979828681956,
+                "weighted_f1": 0.5749171041724233,
+                "macro_roc_auc": 0.6803090072320842,
+                "macro_pr_auc": 0.5685632188064242
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "classification": {
+      "regime_f1_macro": {
+        "mean": 0.4061934477279357,
+        "std": 0.0854739152476884,
+        "min": 0.25724496426250815,
+        "max": 0.5695970695970696,
+        "n": 25
+      },
+      "regression_rmse_log_rv": null
+    },
+    "regression": {
+      "regime_f1_macro": {
+        "mean": 0.39326768718596383,
+        "std": 0.09065344321660603,
+        "min": 0.2442536364920209,
+        "max": 0.5466979828681956,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.8240560326550814,
+        "std": 0.21252568942720101,
+        "min": 0.40277302348491856,
+        "max": 1.0993941202108648,
+        "n": 25
+      }
+    },
+    "dual": {
+      "regime_f1_macro": {
+        "mean": 0.39880192766235517,
+        "std": 0.096194041665652,
+        "min": 0.20594220594220594,
+        "max": 0.5695970695970696,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.8338564099504789,
+        "std": 0.22055319307405197,
+        "min": 0.40820569040996546,
+        "max": 1.1926496570897709,
+        "n": 25
+      }
+    }
+  }
+}

--- a/backend/artifacts/experiments/runpod_20260530/logs/_DIAGNOSIS_523_arity.md
+++ b/backend/artifacts/experiments/runpod_20260530/logs/_DIAGNOSIS_523_arity.md
@@ -1,0 +1,81 @@
+# PR #523 regression — statement_delta / vote_tally / press_conf still fail at runtime
+
+Pod: dev @ 5923f8c (PR #523 "Re-add statement_delta / vote / press flags + wire delta-encoder CLI").
+TP: canonical @ a045140 (statement_delta_embedding populated 1427/7172, verified).
+
+The three CLI flags now parse, but the sweeps crash while building tensors.
+The other 9 arms are validated-green (canonical, surprise, retrieval, regime,
+derived[replacement arm now active], b2, phrasebank, mtl_verify, cross_source).
+
+## Symptoms (1 seed / 2 epochs smoke each)
+
+- statement_delta (`--use-statement-delta`):
+  `ValueError: expected sequence of length 87 at dim 2 (got 856)`
+  856 = 87 base + 768 (RICH_STATEMENT_DELTA_DIM) + 1 (missing flag)
+  raised at backend/app/training/loaders.py:3351  `torch.tensor(sequences, ...)`
+
+- vote_tally (`--use-vote-features`):
+  `ValueError: expected sequence of length 87 at dim 2 (got 92)`
+  92 = 87 base + 4 (RICH_VOTE_FEATURES_DIM) + 1 (missing flag)
+  same site (loaders.py:3351).
+
+- press_conf (`--use-press-conf`):
+  `RuntimeError: input.size(-1) must be equal to input_size. Expected 87, got 88`
+  88 = 87 base + 1 (RICH_PRESS_CONF_DIM, no missing flag per ADR 0037)
+  raised in torch RNN forward — model built with input_size=87 but a fed batch is 88.
+
+## Root cause
+
+`FeatureVector.as_rich_list` (backend/app/models/config.py ~L1257–1275) appends
+each of these blocks with a conditional `if self.<block> is not None:` guard —
+the same pattern used by the regime/SEP blocks. That pattern is only safe when
+the loader broadcasts the block to **every** event. The loader does that for
+regime/SEP, but for the three new blocks it leaves the field `None` on events
+that lack the data **even when the flag is on**:
+
+backend/app/training/loaders.py ~L2156–2173:
+```python
+if statement_delta_list is not None:          # statement events w/ strict-prior
+    vector.statement_delta_embedding = list(statement_delta_list)
+    vector.statement_delta_embedding_missing = 0.0
+else:
+    vector.statement_delta_embedding = None    # <-- non-statement / cold-start
+    vector.statement_delta_embedding_missing = 1.0
+# (same None-in-else for vote_features and press_conf_features)
+```
+
+So with the flag ON: statement events emit +769 dims, every other event emits
++0 → ragged batch → torch.tensor raises (statement_delta, vote). For press_conf
+the data side is uniform-ish but the model's `input_size` (from
+`expected_rich_feature_size`, config.py ~L310–331) and the per-event width
+disagree → RNN forward raises.
+
+## Suggested fix (laptop side decides)
+
+Mirror the `llm_features` / `analog_features` precedent (config.py ~L55–78),
+which ALWAYS emits a fixed-width block, zero-filling when the per-event value is
+missing. Cleanest: in the loader `else:` branches, when the flag is on, set the
+field to a zero vector of the documented dim with `*_missing = 1.0` instead of
+`None`:
+
+```python
+else:
+    vector.statement_delta_embedding = [0.0] * RICH_STATEMENT_DELTA_DIM
+    vector.statement_delta_embedding_missing = 1.0
+```
+
+…and likewise `[0.0]*RICH_VOTE_FEATURES_DIM` and `[0.0]*RICH_PRESS_CONF_DIM`.
+For press_conf also re-check that `expected_rich_feature_size(use_press_conf=…)`
+is plumbed into the model-construction path so input_size matches (the 87-vs-88
+RNN error suggests the press dim is added on the data side but not the model
+side, or vice-versa).
+
+A unit test asserting `len(as_rich_list())` is identical across a statement
+event and a non-statement event with each flag on would have caught all three.
+
+## Files in this bundle
+- _smoke_statement_delta.log  (full traceback)
+- _smoke_vote_tally.log       (full traceback)
+- _smoke_press_conf.log       (full traceback)
+- _smoke_derived2.log         (derived replacement arm now active — green)
+- _smoke_canonical2.log       (base path green post-pull)

--- a/backend/artifacts/experiments/runpod_20260530/logs/cross_source_out_20260530T124014Z/matrix.csv
+++ b/backend/artifacts/experiments/runpod_20260530/logs/cross_source_out_20260530T124014Z/matrix.csv
@@ -1,0 +1,11 @@
+encoder_alias,checkpoint,source_type,status,support,dovish_n,hawkish_n,neutral_n,macro_f1,weighted_f1,accuracy,latency_ms_p50,latency_ms_p95
+finbert_fed_adjacent,yusufizzetmurat/finbert-fed-adjacent,fomc_statement,ok,3364,1004,850,1510,0.289301,0.337274,0.394174,0.055299,0.062079
+finbert_fed_adjacent,yusufizzetmurat/finbert-fed-adjacent,fomc_minutes,no_rows,0,0,0,0,,,,,
+finbert_fed_adjacent,yusufizzetmurat/finbert-fed-adjacent,fomc_meeting_transcript,ok,156,92,46,18,0.244898,0.433281,0.576923,0.059567,0.081908
+finbert_fed_adjacent,yusufizzetmurat/finbert-fed-adjacent,fomc_press_conference,no_rows,0,0,0,0,,,,,
+finbert_fed_adjacent,yusufizzetmurat/finbert-fed-adjacent,chair_speech,no_rows,0,0,0,0,,,,,
+finbert_fed_adjacent,yusufizzetmurat/finbert-fed-adjacent,governor_speech,no_rows,0,0,0,0,,,,,
+finbert_fed_adjacent,yusufizzetmurat/finbert-fed-adjacent,congressional_testimony,no_rows,0,0,0,0,,,,,
+finbert_fed_adjacent,yusufizzetmurat/finbert-fed-adjacent,beige_book,no_rows,0,0,0,0,,,,,
+finbert_fed_adjacent,yusufizzetmurat/finbert-fed-adjacent,regional_research,no_rows,0,0,0,0,,,,,
+finbert_fed_adjacent,yusufizzetmurat/finbert-fed-adjacent,ny_fed_liberty_street,no_rows,0,0,0,0,,,,,

--- a/backend/artifacts/experiments/runpod_20260530/logs/cross_source_out_20260530T124014Z/matrix.json
+++ b/backend/artifacts/experiments/runpod_20260530/logs/cross_source_out_20260530T124014Z/matrix.json
@@ -1,0 +1,206 @@
+{
+  "generated_at_utc": "2026-05-30T14:23:36Z",
+  "training_package_id": "canonical",
+  "encoders": [
+    "finbert_fed_adjacent"
+  ],
+  "source_types": [
+    "fomc_statement",
+    "fomc_minutes",
+    "fomc_meeting_transcript",
+    "fomc_press_conference",
+    "chair_speech",
+    "governor_speech",
+    "congressional_testimony",
+    "beige_book",
+    "regional_research",
+    "ny_fed_liberty_street",
+    "gss_factor_decomposition"
+  ],
+  "per_source_counts": {
+    "fomc_statement": 3364,
+    "fomc_minutes": 0,
+    "fomc_meeting_transcript": 156,
+    "fomc_press_conference": 0,
+    "chair_speech": 0,
+    "governor_speech": 0,
+    "congressional_testimony": 0,
+    "beige_book": 0,
+    "regional_research": 0,
+    "ny_fed_liberty_street": 0,
+    "gss_factor_decomposition": 138
+  },
+  "cells": [
+    {
+      "source_type": "fomc_statement",
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "support": 3364,
+      "macro_f1": 0.2893005818012594,
+      "weighted_f1": 0.33727411321993517,
+      "accuracy": 0.39417360285374553,
+      "per_class": {
+        "dovish": {
+          "precision": 0.30623520126282555,
+          "recall": 0.38645418326693226,
+          "f1": 0.34169969176574194,
+          "support": 1004
+        },
+        "hawkish": {
+          "precision": 0.1111111111111111,
+          "recall": 0.002352941176470588,
+          "f1": 0.004608294930875576,
+          "support": 850
+        },
+        "neutral": {
+          "precision": 0.45021645021645024,
+          "recall": 0.6198675496688741,
+          "f1": 0.5215937587071607,
+          "support": 1510
+        }
+      },
+      "label_support": {
+        "hawkish": 850,
+        "dovish": 1004,
+        "neutral": 1510
+      },
+      "latency_ms": {
+        "p50": 0.0552986457478255,
+        "p95": 0.062078965129330754
+      },
+      "kind": "stance",
+      "status": "ok"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "fomc_minutes",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "source_type": "fomc_meeting_transcript",
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "support": 156,
+      "macro_f1": 0.2448979591836735,
+      "weighted_f1": 0.4332810047095762,
+      "accuracy": 0.5769230769230769,
+      "per_class": {
+        "dovish": {
+          "precision": 0.5882352941176471,
+          "recall": 0.9782608695652174,
+          "f1": 0.7346938775510204,
+          "support": 92
+        },
+        "hawkish": {
+          "precision": 0.0,
+          "recall": 0.0,
+          "f1": 0.0,
+          "support": 46
+        },
+        "neutral": {
+          "precision": 0.0,
+          "recall": 0.0,
+          "f1": 0.0,
+          "support": 18
+        }
+      },
+      "label_support": {
+        "dovish": 92,
+        "hawkish": 46,
+        "neutral": 18
+      },
+      "latency_ms": {
+        "p50": 0.0595668243477121,
+        "p95": 0.08190849621314555
+      },
+      "kind": "stance",
+      "status": "ok"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "fomc_press_conference",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "chair_speech",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "governor_speech",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "congressional_testimony",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "beige_book",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "regional_research",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "ny_fed_liberty_street",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "source_type": "gss_factor_decomposition",
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "support": 138,
+      "kind": "continuous",
+      "targets": {
+        "gss_target_factor": {
+          "support": 138,
+          "pearson_r": -0.011363996524564863,
+          "spearman_r": -0.03557887608222282,
+          "zscore_rmse": 1.4222264211612472
+        },
+        "gss_path_factor": {
+          "support": 138,
+          "pearson_r": 0.3357098593037053,
+          "spearman_r": 0.34626818699042017,
+          "zscore_rmse": 1.1526405690381496
+        }
+      },
+      "latency_ms": {
+        "p50": 0.06658027996309102,
+        "p95": 0.24042930454015732
+      },
+      "status": "ok"
+    }
+  ],
+  "failures": []
+}

--- a/backend/artifacts/experiments/runpod_20260530/logs/cross_source_out_20260530T124014Z/matrix_continuous.csv
+++ b/backend/artifacts/experiments/runpod_20260530/logs/cross_source_out_20260530T124014Z/matrix_continuous.csv
@@ -1,0 +1,3 @@
+encoder_alias,checkpoint,source_type,status,support,target_key,paired_support,pearson_r,spearman_r,zscore_rmse,latency_ms_p50,latency_ms_p95
+finbert_fed_adjacent,yusufizzetmurat/finbert-fed-adjacent,gss_factor_decomposition,ok,138,gss_target_factor,138,-0.011364,-0.035579,1.422226,0.066580,0.240429
+finbert_fed_adjacent,yusufizzetmurat/finbert-fed-adjacent,gss_factor_decomposition,ok,138,gss_path_factor,138,0.335710,0.346268,1.152641,0.066580,0.240429

--- a/backend/artifacts/experiments/runpod_20260530/ordinal_confusion.json
+++ b/backend/artifacts/experiments/runpod_20260530/ordinal_confusion.json
@@ -1,0 +1,731 @@
+{
+  "n_cells_total": 75,
+  "cells": [
+    {
+      "head_mode": "classification",
+      "seed": 11,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.8688524590163934,
+      "non_adjacent_error_rate": 0.13114754098360656,
+      "ordinal_accuracy": 0.8688524590163934,
+      "total_errors": 61
+    },
+    {
+      "head_mode": "classification",
+      "seed": 11,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.4782608695652174,
+      "non_adjacent_error_rate": 0.5217391304347826,
+      "ordinal_accuracy": 0.4782608695652174,
+      "total_errors": 23
+    },
+    {
+      "head_mode": "classification",
+      "seed": 11,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.9204545454545454,
+      "non_adjacent_error_rate": 0.07954545454545454,
+      "ordinal_accuracy": 0.9204545454545454,
+      "total_errors": 88
+    },
+    {
+      "head_mode": "classification",
+      "seed": 11,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.8461538461538461,
+      "non_adjacent_error_rate": 0.15384615384615385,
+      "ordinal_accuracy": 0.8461538461538461,
+      "total_errors": 65
+    },
+    {
+      "head_mode": "classification",
+      "seed": 11,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.8947368421052632,
+      "non_adjacent_error_rate": 0.10526315789473684,
+      "ordinal_accuracy": 0.8947368421052632,
+      "total_errors": 38
+    },
+    {
+      "head_mode": "classification",
+      "seed": 29,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.75,
+      "non_adjacent_error_rate": 0.25,
+      "ordinal_accuracy": 0.75,
+      "total_errors": 68
+    },
+    {
+      "head_mode": "classification",
+      "seed": 29,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.56,
+      "non_adjacent_error_rate": 0.44,
+      "ordinal_accuracy": 0.56,
+      "total_errors": 25
+    },
+    {
+      "head_mode": "classification",
+      "seed": 29,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 1.0,
+      "non_adjacent_error_rate": 0.0,
+      "ordinal_accuracy": 1.0,
+      "total_errors": 49
+    },
+    {
+      "head_mode": "classification",
+      "seed": 29,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.7464788732394366,
+      "non_adjacent_error_rate": 0.2535211267605634,
+      "ordinal_accuracy": 0.7464788732394366,
+      "total_errors": 71
+    },
+    {
+      "head_mode": "classification",
+      "seed": 29,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.8301886792452831,
+      "non_adjacent_error_rate": 0.16981132075471697,
+      "ordinal_accuracy": 0.8301886792452831,
+      "total_errors": 53
+    },
+    {
+      "head_mode": "classification",
+      "seed": 47,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.8307692307692308,
+      "non_adjacent_error_rate": 0.16923076923076924,
+      "ordinal_accuracy": 0.8307692307692307,
+      "total_errors": 65
+    },
+    {
+      "head_mode": "classification",
+      "seed": 47,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.5,
+      "non_adjacent_error_rate": 0.5,
+      "ordinal_accuracy": 0.5,
+      "total_errors": 24
+    },
+    {
+      "head_mode": "classification",
+      "seed": 47,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.9404761904761905,
+      "non_adjacent_error_rate": 0.05952380952380952,
+      "ordinal_accuracy": 0.9404761904761905,
+      "total_errors": 84
+    },
+    {
+      "head_mode": "classification",
+      "seed": 47,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.765625,
+      "non_adjacent_error_rate": 0.234375,
+      "ordinal_accuracy": 0.765625,
+      "total_errors": 64
+    },
+    {
+      "head_mode": "classification",
+      "seed": 47,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.765625,
+      "non_adjacent_error_rate": 0.234375,
+      "ordinal_accuracy": 0.765625,
+      "total_errors": 64
+    },
+    {
+      "head_mode": "classification",
+      "seed": 71,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.7681159420289855,
+      "non_adjacent_error_rate": 0.2318840579710145,
+      "ordinal_accuracy": 0.7681159420289855,
+      "total_errors": 69
+    },
+    {
+      "head_mode": "classification",
+      "seed": 71,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.4782608695652174,
+      "non_adjacent_error_rate": 0.5217391304347826,
+      "ordinal_accuracy": 0.4782608695652174,
+      "total_errors": 23
+    },
+    {
+      "head_mode": "classification",
+      "seed": 71,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.922077922077922,
+      "non_adjacent_error_rate": 0.07792207792207792,
+      "ordinal_accuracy": 0.922077922077922,
+      "total_errors": 77
+    },
+    {
+      "head_mode": "classification",
+      "seed": 71,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.6875,
+      "non_adjacent_error_rate": 0.3125,
+      "ordinal_accuracy": 0.6875,
+      "total_errors": 64
+    },
+    {
+      "head_mode": "classification",
+      "seed": 71,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.7794117647058824,
+      "non_adjacent_error_rate": 0.22058823529411764,
+      "ordinal_accuracy": 0.7794117647058824,
+      "total_errors": 68
+    },
+    {
+      "head_mode": "classification",
+      "seed": 97,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.7183098591549296,
+      "non_adjacent_error_rate": 0.28169014084507044,
+      "ordinal_accuracy": 0.7183098591549295,
+      "total_errors": 71
+    },
+    {
+      "head_mode": "classification",
+      "seed": 97,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.7857142857142857,
+      "non_adjacent_error_rate": 0.21428571428571427,
+      "ordinal_accuracy": 0.7857142857142857,
+      "total_errors": 28
+    },
+    {
+      "head_mode": "classification",
+      "seed": 97,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.948051948051948,
+      "non_adjacent_error_rate": 0.05194805194805195,
+      "ordinal_accuracy": 0.948051948051948,
+      "total_errors": 77
+    },
+    {
+      "head_mode": "classification",
+      "seed": 97,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.7848101265822784,
+      "non_adjacent_error_rate": 0.21518987341772153,
+      "ordinal_accuracy": 0.7848101265822784,
+      "total_errors": 79
+    },
+    {
+      "head_mode": "classification",
+      "seed": 97,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.7391304347826086,
+      "non_adjacent_error_rate": 0.2608695652173913,
+      "ordinal_accuracy": 0.7391304347826086,
+      "total_errors": 46
+    },
+    {
+      "head_mode": "regression",
+      "seed": 11,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.6164383561643836,
+      "non_adjacent_error_rate": 0.3835616438356164,
+      "ordinal_accuracy": 0.6164383561643836,
+      "total_errors": 73
+    },
+    {
+      "head_mode": "regression",
+      "seed": 11,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.944954128440367,
+      "non_adjacent_error_rate": 0.05504587155963303,
+      "ordinal_accuracy": 0.944954128440367,
+      "total_errors": 109
+    },
+    {
+      "head_mode": "regression",
+      "seed": 11,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.8522727272727273,
+      "non_adjacent_error_rate": 0.14772727272727273,
+      "ordinal_accuracy": 0.8522727272727273,
+      "total_errors": 88
+    },
+    {
+      "head_mode": "regression",
+      "seed": 11,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 1.0,
+      "non_adjacent_error_rate": 0.0,
+      "ordinal_accuracy": 1.0,
+      "total_errors": 63
+    },
+    {
+      "head_mode": "regression",
+      "seed": 11,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.9629629629629629,
+      "non_adjacent_error_rate": 0.037037037037037035,
+      "ordinal_accuracy": 0.962962962962963,
+      "total_errors": 54
+    },
+    {
+      "head_mode": "regression",
+      "seed": 29,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.6785714285714286,
+      "non_adjacent_error_rate": 0.32142857142857145,
+      "ordinal_accuracy": 0.6785714285714286,
+      "total_errors": 84
+    },
+    {
+      "head_mode": "regression",
+      "seed": 29,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.17708333333333334,
+      "non_adjacent_error_rate": 0.8229166666666666,
+      "ordinal_accuracy": 0.17708333333333337,
+      "total_errors": 96
+    },
+    {
+      "head_mode": "regression",
+      "seed": 29,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.9807692307692307,
+      "non_adjacent_error_rate": 0.019230769230769232,
+      "ordinal_accuracy": 0.9807692307692307,
+      "total_errors": 52
+    },
+    {
+      "head_mode": "regression",
+      "seed": 29,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.5274725274725275,
+      "non_adjacent_error_rate": 0.4725274725274725,
+      "ordinal_accuracy": 0.5274725274725275,
+      "total_errors": 91
+    },
+    {
+      "head_mode": "regression",
+      "seed": 29,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.7761194029850746,
+      "non_adjacent_error_rate": 0.22388059701492538,
+      "ordinal_accuracy": 0.7761194029850746,
+      "total_errors": 67
+    },
+    {
+      "head_mode": "regression",
+      "seed": 47,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.6973684210526315,
+      "non_adjacent_error_rate": 0.3026315789473684,
+      "ordinal_accuracy": 0.6973684210526316,
+      "total_errors": 76
+    },
+    {
+      "head_mode": "regression",
+      "seed": 47,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.8214285714285714,
+      "non_adjacent_error_rate": 0.17857142857142858,
+      "ordinal_accuracy": 0.8214285714285714,
+      "total_errors": 56
+    },
+    {
+      "head_mode": "regression",
+      "seed": 47,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.8666666666666667,
+      "non_adjacent_error_rate": 0.13333333333333333,
+      "ordinal_accuracy": 0.8666666666666667,
+      "total_errors": 90
+    },
+    {
+      "head_mode": "regression",
+      "seed": 47,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.5217391304347826,
+      "non_adjacent_error_rate": 0.4782608695652174,
+      "ordinal_accuracy": 0.5217391304347826,
+      "total_errors": 92
+    },
+    {
+      "head_mode": "regression",
+      "seed": 47,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.6666666666666666,
+      "non_adjacent_error_rate": 0.3333333333333333,
+      "ordinal_accuracy": 0.6666666666666667,
+      "total_errors": 78
+    },
+    {
+      "head_mode": "regression",
+      "seed": 71,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.4891304347826087,
+      "non_adjacent_error_rate": 0.5108695652173914,
+      "ordinal_accuracy": 0.48913043478260865,
+      "total_errors": 92
+    },
+    {
+      "head_mode": "regression",
+      "seed": 71,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.12727272727272726,
+      "non_adjacent_error_rate": 0.8727272727272727,
+      "ordinal_accuracy": 0.12727272727272732,
+      "total_errors": 110
+    },
+    {
+      "head_mode": "regression",
+      "seed": 71,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.7959183673469388,
+      "non_adjacent_error_rate": 0.20408163265306123,
+      "ordinal_accuracy": 0.7959183673469388,
+      "total_errors": 98
+    },
+    {
+      "head_mode": "regression",
+      "seed": 71,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.7164179104477612,
+      "non_adjacent_error_rate": 0.2835820895522388,
+      "ordinal_accuracy": 0.7164179104477613,
+      "total_errors": 67
+    },
+    {
+      "head_mode": "regression",
+      "seed": 71,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.6666666666666666,
+      "non_adjacent_error_rate": 0.3333333333333333,
+      "ordinal_accuracy": 0.6666666666666667,
+      "total_errors": 78
+    },
+    {
+      "head_mode": "regression",
+      "seed": 97,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.7586206896551724,
+      "non_adjacent_error_rate": 0.2413793103448276,
+      "ordinal_accuracy": 0.7586206896551724,
+      "total_errors": 87
+    },
+    {
+      "head_mode": "regression",
+      "seed": 97,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.6116504854368932,
+      "non_adjacent_error_rate": 0.3883495145631068,
+      "ordinal_accuracy": 0.6116504854368932,
+      "total_errors": 103
+    },
+    {
+      "head_mode": "regression",
+      "seed": 97,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.6984126984126984,
+      "non_adjacent_error_rate": 0.30158730158730157,
+      "ordinal_accuracy": 0.6984126984126984,
+      "total_errors": 63
+    },
+    {
+      "head_mode": "regression",
+      "seed": 97,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.796875,
+      "non_adjacent_error_rate": 0.203125,
+      "ordinal_accuracy": 0.796875,
+      "total_errors": 64
+    },
+    {
+      "head_mode": "regression",
+      "seed": 97,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.9066666666666666,
+      "non_adjacent_error_rate": 0.09333333333333334,
+      "ordinal_accuracy": 0.9066666666666666,
+      "total_errors": 75
+    },
+    {
+      "head_mode": "dual",
+      "seed": 11,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.6666666666666666,
+      "non_adjacent_error_rate": 0.3333333333333333,
+      "ordinal_accuracy": 0.6666666666666667,
+      "total_errors": 63
+    },
+    {
+      "head_mode": "dual",
+      "seed": 11,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.6470588235294118,
+      "non_adjacent_error_rate": 0.35294117647058826,
+      "ordinal_accuracy": 0.6470588235294117,
+      "total_errors": 17
+    },
+    {
+      "head_mode": "dual",
+      "seed": 11,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.9384615384615385,
+      "non_adjacent_error_rate": 0.06153846153846154,
+      "ordinal_accuracy": 0.9384615384615385,
+      "total_errors": 65
+    },
+    {
+      "head_mode": "dual",
+      "seed": 11,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.7719298245614035,
+      "non_adjacent_error_rate": 0.22807017543859648,
+      "ordinal_accuracy": 0.7719298245614035,
+      "total_errors": 57
+    },
+    {
+      "head_mode": "dual",
+      "seed": 11,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.7272727272727273,
+      "non_adjacent_error_rate": 0.2727272727272727,
+      "ordinal_accuracy": 0.7272727272727273,
+      "total_errors": 44
+    },
+    {
+      "head_mode": "dual",
+      "seed": 29,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.7419354838709677,
+      "non_adjacent_error_rate": 0.25806451612903225,
+      "ordinal_accuracy": 0.7419354838709677,
+      "total_errors": 62
+    },
+    {
+      "head_mode": "dual",
+      "seed": 29,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.6923076923076923,
+      "non_adjacent_error_rate": 0.3076923076923077,
+      "ordinal_accuracy": 0.6923076923076923,
+      "total_errors": 13
+    },
+    {
+      "head_mode": "dual",
+      "seed": 29,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.9433962264150944,
+      "non_adjacent_error_rate": 0.05660377358490566,
+      "ordinal_accuracy": 0.9433962264150944,
+      "total_errors": 53
+    },
+    {
+      "head_mode": "dual",
+      "seed": 29,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.7692307692307693,
+      "non_adjacent_error_rate": 0.23076923076923078,
+      "ordinal_accuracy": 0.7692307692307692,
+      "total_errors": 78
+    },
+    {
+      "head_mode": "dual",
+      "seed": 29,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.8269230769230769,
+      "non_adjacent_error_rate": 0.17307692307692307,
+      "ordinal_accuracy": 0.8269230769230769,
+      "total_errors": 52
+    },
+    {
+      "head_mode": "dual",
+      "seed": 47,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.6507936507936508,
+      "non_adjacent_error_rate": 0.3492063492063492,
+      "ordinal_accuracy": 0.6507936507936508,
+      "total_errors": 63
+    },
+    {
+      "head_mode": "dual",
+      "seed": 47,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.8571428571428571,
+      "non_adjacent_error_rate": 0.14285714285714285,
+      "ordinal_accuracy": 0.8571428571428572,
+      "total_errors": 28
+    },
+    {
+      "head_mode": "dual",
+      "seed": 47,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.9397590361445783,
+      "non_adjacent_error_rate": 0.060240963855421686,
+      "ordinal_accuracy": 0.9397590361445783,
+      "total_errors": 83
+    },
+    {
+      "head_mode": "dual",
+      "seed": 47,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.71875,
+      "non_adjacent_error_rate": 0.28125,
+      "ordinal_accuracy": 0.71875,
+      "total_errors": 64
+    },
+    {
+      "head_mode": "dual",
+      "seed": 47,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.8372093023255814,
+      "non_adjacent_error_rate": 0.16279069767441862,
+      "ordinal_accuracy": 0.8372093023255813,
+      "total_errors": 43
+    },
+    {
+      "head_mode": "dual",
+      "seed": 71,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.6610169491525424,
+      "non_adjacent_error_rate": 0.3389830508474576,
+      "ordinal_accuracy": 0.6610169491525424,
+      "total_errors": 59
+    },
+    {
+      "head_mode": "dual",
+      "seed": 71,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.6875,
+      "non_adjacent_error_rate": 0.3125,
+      "ordinal_accuracy": 0.6875,
+      "total_errors": 16
+    },
+    {
+      "head_mode": "dual",
+      "seed": 71,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.9558823529411765,
+      "non_adjacent_error_rate": 0.04411764705882353,
+      "ordinal_accuracy": 0.9558823529411765,
+      "total_errors": 68
+    },
+    {
+      "head_mode": "dual",
+      "seed": 71,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.7733333333333333,
+      "non_adjacent_error_rate": 0.22666666666666666,
+      "ordinal_accuracy": 0.7733333333333333,
+      "total_errors": 75
+    },
+    {
+      "head_mode": "dual",
+      "seed": 71,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.734375,
+      "non_adjacent_error_rate": 0.265625,
+      "ordinal_accuracy": 0.734375,
+      "total_errors": 64
+    },
+    {
+      "head_mode": "dual",
+      "seed": 97,
+      "fold_id": "wf_fold_1",
+      "adjacent_error_rate": 0.6323529411764706,
+      "non_adjacent_error_rate": 0.36764705882352944,
+      "ordinal_accuracy": 0.6323529411764706,
+      "total_errors": 68
+    },
+    {
+      "head_mode": "dual",
+      "seed": 97,
+      "fold_id": "wf_fold_2",
+      "adjacent_error_rate": 0.6666666666666666,
+      "non_adjacent_error_rate": 0.3333333333333333,
+      "ordinal_accuracy": 0.6666666666666667,
+      "total_errors": 18
+    },
+    {
+      "head_mode": "dual",
+      "seed": 97,
+      "fold_id": "wf_fold_3",
+      "adjacent_error_rate": 0.9333333333333333,
+      "non_adjacent_error_rate": 0.06666666666666667,
+      "ordinal_accuracy": 0.9333333333333333,
+      "total_errors": 75
+    },
+    {
+      "head_mode": "dual",
+      "seed": 97,
+      "fold_id": "wf_fold_4",
+      "adjacent_error_rate": 0.821917808219178,
+      "non_adjacent_error_rate": 0.1780821917808219,
+      "ordinal_accuracy": 0.821917808219178,
+      "total_errors": 73
+    },
+    {
+      "head_mode": "dual",
+      "seed": 97,
+      "fold_id": "wf_fold_5",
+      "adjacent_error_rate": 0.7083333333333334,
+      "non_adjacent_error_rate": 0.2916666666666667,
+      "ordinal_accuracy": 0.7083333333333333,
+      "total_errors": 48
+    }
+  ],
+  "arm_summaries": [
+    {
+      "head_mode": "classification",
+      "n_cells": 25,
+      "adjacent_error_rate": {
+        "mean": 0.77236,
+        "std": 0.143895
+      },
+      "non_adjacent_error_rate": {
+        "mean": 0.22764,
+        "std": 0.143895
+      },
+      "ordinal_accuracy": {
+        "mean": 0.77236,
+        "std": 0.143895
+      }
+    },
+    {
+      "head_mode": "dual",
+      "n_cells": 25,
+      "adjacent_error_rate": {
+        "mean": 0.772142,
+        "std": 0.106282
+      },
+      "non_adjacent_error_rate": {
+        "mean": 0.227858,
+        "std": 0.106282
+      },
+      "ordinal_accuracy": {
+        "mean": 0.772142,
+        "std": 0.106282
+      }
+    },
+    {
+      "head_mode": "regression",
+      "n_cells": 25,
+      "adjacent_error_rate": {
+        "mean": 0.706326,
+        "std": 0.2197
+      },
+      "non_adjacent_error_rate": {
+        "mean": 0.293674,
+        "std": 0.2197
+      },
+      "ordinal_accuracy": {
+        "mean": 0.706326,
+        "std": 0.2197
+      }
+    }
+  ],
+  "markdown": "| Head mode | n | Adj err (mean\u00b1std) | Non-adj err (mean\u00b1std) | Ordinal acc (mean\u00b1std) |\n|---|---:|---|---|---|\n| classification | 25 | 0.7724 \u00b1 0.1439 | 0.2276 \u00b1 0.1439 | 0.7724 \u00b1 0.1439 |\n| dual | 25 | 0.7721 \u00b1 0.1063 | 0.2279 \u00b1 0.1063 | 0.7721 \u00b1 0.1063 |\n| regression | 25 | 0.7063 \u00b1 0.2197 | 0.2937 \u00b1 0.2197 | 0.7063 \u00b1 0.2197 |"
+}

--- a/backend/artifacts/experiments/runpod_20260530/per_fold_baselines.json
+++ b/backend/artifacts/experiments/runpod_20260530/per_fold_baselines.json
@@ -1,0 +1,147 @@
+{
+  "training_package_id": "canonical",
+  "sweep_artefact": "artifacts/experiments/runpod_20260530/runpod_canonical_20260530T120517Z.json",
+  "head_mode": "classification",
+  "folds": [
+    {
+      "fold_id": "wf_fold_1",
+      "class_distribution": {
+        "train": {
+          "calm": 1480,
+          "normal": 1484,
+          "high": 1484
+        },
+        "val": {
+          "calm": 144,
+          "normal": 60,
+          "high": 268
+        },
+        "test": {
+          "calm": 112,
+          "normal": 180,
+          "high": 188
+        }
+      },
+      "quantile_edges": [
+        0.005756943799727098,
+        0.009169791805018562
+      ],
+      "majority_baseline_f1": 0.1818181818181818,
+      "stratified_random_f1": 0.32835053302434447,
+      "encoder_f1": 0.39557838303486015,
+      "head_mode": "classification"
+    },
+    {
+      "fold_id": "wf_fold_2",
+      "class_distribution": {
+        "train": {
+          "calm": 1640,
+          "normal": 1640,
+          "high": 1640
+        },
+        "val": {
+          "calm": 124,
+          "normal": 180,
+          "high": 176
+        },
+        "test": {
+          "calm": 40,
+          "normal": 48,
+          "high": 384
+        }
+      },
+      "quantile_edges": [
+        0.005787017739818774,
+        0.00963528924171301
+      ],
+      "majority_baseline_f1": 0.052083333333333336,
+      "stratified_random_f1": 0.25443228765457165,
+      "encoder_f1": 0.5035137020367066,
+      "head_mode": "classification"
+    },
+    {
+      "fold_id": "wf_fold_3",
+      "class_distribution": {
+        "train": {
+          "calm": 1800,
+          "normal": 1800,
+          "high": 1800
+        },
+        "val": {
+          "calm": 48,
+          "normal": 40,
+          "high": 384
+        },
+        "test": {
+          "calm": 48,
+          "normal": 312,
+          "high": 80
+        }
+      },
+      "quantile_edges": [
+        0.005837633004819972,
+        0.00967345162945777
+      ],
+      "majority_baseline_f1": 0.06557377049180328,
+      "stratified_random_f1": 0.28428157715896846,
+      "encoder_f1": 0.3150168033680959,
+      "head_mode": "classification"
+    },
+    {
+      "fold_id": "wf_fold_4",
+      "class_distribution": {
+        "train": {
+          "calm": 1956,
+          "normal": 1956,
+          "high": 1960
+        },
+        "val": {
+          "calm": 52,
+          "normal": 348,
+          "high": 40
+        },
+        "test": {
+          "calm": 176,
+          "normal": 192,
+          "high": 76
+        }
+      },
+      "quantile_edges": [
+        0.005922674151580698,
+        0.010218964606414662
+      ],
+      "majority_baseline_f1": 0.09743589743589744,
+      "stratified_random_f1": 0.32173461693828026,
+      "encoder_f1": 0.34073133886111157,
+      "head_mode": "classification"
+    },
+    {
+      "fold_id": "wf_fold_5",
+      "class_distribution": {
+        "train": {
+          "calm": 2104,
+          "normal": 2104,
+          "high": 2104
+        },
+        "val": {
+          "calm": 188,
+          "normal": 168,
+          "high": 88
+        },
+        "test": {
+          "calm": 104,
+          "normal": 203,
+          "high": 104
+        }
+      },
+      "quantile_edges": [
+        0.006068963081270213,
+        0.009995156571786089
+      ],
+      "majority_baseline_f1": 0.13462783171521034,
+      "stratified_random_f1": 0.32299654620385604,
+      "encoder_f1": 0.41955799131726845,
+      "head_mode": "classification"
+    }
+  ]
+}

--- a/backend/artifacts/experiments/runpod_20260530/runpod_b2_20260530T125712Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/runpod_b2_20260530T125712Z.json
@@ -1,0 +1,1307 @@
+{
+  "pipeline": "finetune_pilot_b2",
+  "training_package_id": "canonical",
+  "encoder_alias": "finbert_fed_adjacent",
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 5,
+  "train_batch_size": 16,
+  "eval_batch_size": 32,
+  "learning_rate": 2e-05,
+  "weight_decay": 0.01,
+  "max_length": 256,
+  "n_classes": 3,
+  "labels": [
+    "calm",
+    "normal",
+    "high"
+  ],
+  "started_at_utc": "20260530T131319Z",
+  "phrasebank_aux": {
+    "enabled": false
+  },
+  "trials": [
+    {
+      "seed": 11,
+      "folds": [
+        {
+          "fold_id": "wf_fold_1",
+          "metrics": {
+            "regime_f1_macro": 0.5378787878787878,
+            "regime_accuracy": 0.36787564766839376,
+            "regime_weighted_f1": 0.5378787878787878,
+            "train_loss": 0.9442829344318716
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.01231994222285423
+          ],
+          "train_rows": 2894,
+          "test_rows": 193,
+          "train_class_counts": [
+            878,
+            954,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            193,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                69,
+                71,
+                53
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.36787564766839376,
+                "f1": 0.5378787878787878,
+                "support": 193,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.36787564766839376,
+            "macro_f1": 0.5378787878787878,
+            "weighted_f1": 0.5378787878787878,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 59.63682625023648,
+          "eval_runtime_s": 0.31042930763214827
+        },
+        {
+          "fold_id": "wf_fold_2",
+          "metrics": {
+            "regime_f1_macro": 0.6531986531986532,
+            "regime_accuracy": 0.485,
+            "regime_weighted_f1": 0.6531986531986533,
+            "train_loss": 0.8680750163944112
+          },
+          "tertile_cutoffs": [
+            0.005142148291239123,
+            0.01231994222285423
+          ],
+          "train_rows": 3101,
+          "test_rows": 200,
+          "train_class_counts": [
+            853,
+            1186,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            200,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                35,
+                97,
+                68
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.485,
+                "f1": 0.6531986531986532,
+                "support": 200,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.485,
+            "macro_f1": 0.6531986531986532,
+            "weighted_f1": 0.6531986531986533,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 63.230600017122924,
+          "eval_runtime_s": 0.3427472379989922
+        },
+        {
+          "fold_id": "wf_fold_3",
+          "metrics": {
+            "regime_f1_macro": 0.2666666666666667,
+            "regime_accuracy": 0.15384615384615385,
+            "regime_weighted_f1": 0.2666666666666667,
+            "train_loss": 0.8505815046287856
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.011897883392381006
+          ],
+          "train_rows": 3294,
+          "test_rows": 26,
+          "train_class_counts": [
+            1085,
+            1042,
+            1167
+          ],
+          "test_class_counts": [
+            0,
+            26,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                12,
+                4,
+                10
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.15384615384615385,
+                "f1": 0.2666666666666667,
+                "support": 26,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.15384615384615385,
+            "macro_f1": 0.2666666666666667,
+            "weighted_f1": 0.2666666666666667,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 67.1124098431319,
+          "eval_runtime_s": 0.035936030093580484
+        }
+      ]
+    },
+    {
+      "seed": 29,
+      "folds": [
+        {
+          "fold_id": "wf_fold_1",
+          "metrics": {
+            "regime_f1_macro": 0.6408450704225352,
+            "regime_accuracy": 0.47150259067357514,
+            "regime_weighted_f1": 0.6408450704225352,
+            "train_loss": 0.8659522933689929
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.01231994222285423
+          ],
+          "train_rows": 2894,
+          "test_rows": 193,
+          "train_class_counts": [
+            878,
+            954,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            193,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                48,
+                91,
+                54
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.47150259067357514,
+                "f1": 0.6408450704225352,
+                "support": 193,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.47150259067357514,
+            "macro_f1": 0.6408450704225352,
+            "weighted_f1": 0.6408450704225352,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 58.929824500810355,
+          "eval_runtime_s": 0.28832817869260907
+        },
+        {
+          "fold_id": "wf_fold_2",
+          "metrics": {
+            "regime_f1_macro": 0.50187265917603,
+            "regime_accuracy": 0.335,
+            "regime_weighted_f1": 0.50187265917603,
+            "train_loss": 0.8499051182079561
+          },
+          "tertile_cutoffs": [
+            0.005142148291239123,
+            0.01231994222285423
+          ],
+          "train_rows": 3101,
+          "test_rows": 200,
+          "train_class_counts": [
+            853,
+            1186,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            200,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                50,
+                67,
+                83
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.335,
+                "f1": 0.50187265917603,
+                "support": 200,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.335,
+            "macro_f1": 0.50187265917603,
+            "weighted_f1": 0.50187265917603,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 63.084351358003914,
+          "eval_runtime_s": 0.35110702319070697
+        },
+        {
+          "fold_id": "wf_fold_3",
+          "metrics": {
+            "regime_f1_macro": 0.2666666666666667,
+            "regime_accuracy": 0.15384615384615385,
+            "regime_weighted_f1": 0.2666666666666667,
+            "train_loss": 0.8878174205862203
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.011897883392381006
+          ],
+          "train_rows": 3294,
+          "test_rows": 26,
+          "train_class_counts": [
+            1085,
+            1042,
+            1167
+          ],
+          "test_class_counts": [
+            0,
+            26,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                4,
+                4,
+                18
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.15384615384615385,
+                "f1": 0.2666666666666667,
+                "support": 26,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.15384615384615385,
+            "macro_f1": 0.2666666666666667,
+            "weighted_f1": 0.2666666666666667,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 67.15706165274605,
+          "eval_runtime_s": 0.03259871294721961
+        }
+      ]
+    },
+    {
+      "seed": 47,
+      "folds": [
+        {
+          "fold_id": "wf_fold_1",
+          "metrics": {
+            "regime_f1_macro": 0.6503496503496504,
+            "regime_accuracy": 0.48186528497409326,
+            "regime_weighted_f1": 0.6503496503496504,
+            "train_loss": 0.9131674937945045
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.01231994222285423
+          ],
+          "train_rows": 2894,
+          "test_rows": 193,
+          "train_class_counts": [
+            878,
+            954,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            193,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                26,
+                93,
+                74
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.48186528497409326,
+                "f1": 0.6503496503496504,
+                "support": 193,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.48186528497409326,
+            "macro_f1": 0.6503496503496504,
+            "weighted_f1": 0.6503496503496504,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 58.926014077849686,
+          "eval_runtime_s": 0.28750931192189455
+        },
+        {
+          "fold_id": "wf_fold_2",
+          "metrics": {
+            "regime_f1_macro": 0.47908745247148293,
+            "regime_accuracy": 0.315,
+            "regime_weighted_f1": 0.479087452471483,
+            "train_loss": 0.8822465906899
+          },
+          "tertile_cutoffs": [
+            0.005142148291239123,
+            0.01231994222285423
+          ],
+          "train_rows": 3101,
+          "test_rows": 200,
+          "train_class_counts": [
+            853,
+            1186,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            200,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                71,
+                63,
+                66
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.315,
+                "f1": 0.47908745247148293,
+                "support": 200,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.315,
+            "macro_f1": 0.47908745247148293,
+            "weighted_f1": 0.479087452471483,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 63.1966991960071,
+          "eval_runtime_s": 0.374053246807307
+        },
+        {
+          "fold_id": "wf_fold_3",
+          "metrics": {
+            "regime_f1_macro": 0.47058823529411764,
+            "regime_accuracy": 0.3076923076923077,
+            "regime_weighted_f1": 0.47058823529411764,
+            "train_loss": 0.8194842771780723
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.011897883392381006
+          ],
+          "train_rows": 3294,
+          "test_rows": 26,
+          "train_class_counts": [
+            1085,
+            1042,
+            1167
+          ],
+          "test_class_counts": [
+            0,
+            26,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                7,
+                8,
+                11
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.3076923076923077,
+                "f1": 0.47058823529411764,
+                "support": 26,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.3076923076923077,
+            "macro_f1": 0.47058823529411764,
+            "weighted_f1": 0.47058823529411764,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 67.30107030272484,
+          "eval_runtime_s": 0.03266707481816411
+        }
+      ]
+    },
+    {
+      "seed": 71,
+      "folds": [
+        {
+          "fold_id": "wf_fold_1",
+          "metrics": {
+            "regime_f1_macro": 0.456,
+            "regime_accuracy": 0.29533678756476683,
+            "regime_weighted_f1": 0.45600000000000007,
+            "train_loss": 0.9243508206875943
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.01231994222285423
+          ],
+          "train_rows": 2894,
+          "test_rows": 193,
+          "train_class_counts": [
+            878,
+            954,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            193,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                28,
+                57,
+                108
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.29533678756476683,
+                "f1": 0.456,
+                "support": 193,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.29533678756476683,
+            "macro_f1": 0.456,
+            "weighted_f1": 0.45600000000000007,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 58.946373210288584,
+          "eval_runtime_s": 0.32271919306367636
+        },
+        {
+          "fold_id": "wf_fold_2",
+          "metrics": {
+            "regime_f1_macro": 0.5663082437275986,
+            "regime_accuracy": 0.395,
+            "regime_weighted_f1": 0.5663082437275986,
+            "train_loss": 0.9123349522653315
+          },
+          "tertile_cutoffs": [
+            0.005142148291239123,
+            0.01231994222285423
+          ],
+          "train_rows": 3101,
+          "test_rows": 200,
+          "train_class_counts": [
+            853,
+            1186,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            200,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                44,
+                79,
+                77
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.395,
+                "f1": 0.5663082437275986,
+                "support": 200,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.395,
+            "macro_f1": 0.5663082437275986,
+            "weighted_f1": 0.5663082437275986,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 63.27908943966031,
+          "eval_runtime_s": 0.3277709851972759
+        },
+        {
+          "fold_id": "wf_fold_3",
+          "metrics": {
+            "regime_f1_macro": 0.07407407407407407,
+            "regime_accuracy": 0.038461538461538464,
+            "regime_weighted_f1": 0.07407407407407407,
+            "train_loss": 0.8495423666047819
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.011897883392381006
+          ],
+          "train_rows": 3294,
+          "test_rows": 26,
+          "train_class_counts": [
+            1085,
+            1042,
+            1167
+          ],
+          "test_class_counts": [
+            0,
+            26,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                16,
+                1,
+                9
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.038461538461538464,
+                "f1": 0.07407407407407407,
+                "support": 26,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.038461538461538464,
+            "macro_f1": 0.07407407407407407,
+            "weighted_f1": 0.07407407407407407,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 67.0150236748159,
+          "eval_runtime_s": 0.03236959595233202
+        }
+      ]
+    },
+    {
+      "seed": 97,
+      "folds": [
+        {
+          "fold_id": "wf_fold_1",
+          "metrics": {
+            "regime_f1_macro": 0.6360424028268552,
+            "regime_accuracy": 0.46632124352331605,
+            "regime_weighted_f1": 0.6360424028268552,
+            "train_loss": 0.8670162230565404
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.01231994222285423
+          ],
+          "train_rows": 2894,
+          "test_rows": 193,
+          "train_class_counts": [
+            878,
+            954,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            193,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                45,
+                90,
+                58
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.46632124352331605,
+                "f1": 0.6360424028268552,
+                "support": 193,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.46632124352331605,
+            "macro_f1": 0.6360424028268552,
+            "weighted_f1": 0.6360424028268552,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 58.892540426924825,
+          "eval_runtime_s": 0.3725952194072306
+        },
+        {
+          "fold_id": "wf_fold_2",
+          "metrics": {
+            "regime_f1_macro": 0.4615384615384615,
+            "regime_accuracy": 0.3,
+            "regime_weighted_f1": 0.4615384615384615,
+            "train_loss": 0.9447155446274993
+          },
+          "tertile_cutoffs": [
+            0.005142148291239123,
+            0.01231994222285423
+          ],
+          "train_rows": 3101,
+          "test_rows": 200,
+          "train_class_counts": [
+            853,
+            1186,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            200,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                39,
+                60,
+                101
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.3,
+                "f1": 0.4615384615384615,
+                "support": 200,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.3,
+            "macro_f1": 0.4615384615384615,
+            "weighted_f1": 0.4615384615384615,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 63.19927428942174,
+          "eval_runtime_s": 0.35457150591537356
+        },
+        {
+          "fold_id": "wf_fold_3",
+          "metrics": {
+            "regime_f1_macro": 0.20689655172413793,
+            "regime_accuracy": 0.11538461538461539,
+            "regime_weighted_f1": 0.20689655172413793,
+            "train_loss": 0.8832158925753195
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.011897883392381006
+          ],
+          "train_rows": 3294,
+          "test_rows": 26,
+          "train_class_counts": [
+            1085,
+            1042,
+            1167
+          ],
+          "test_class_counts": [
+            0,
+            26,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                10,
+                3,
+                13
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.11538461538461539,
+                "f1": 0.20689655172413793,
+                "support": 26,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.11538461538461539,
+            "macro_f1": 0.20689655172413793,
+            "weighted_f1": 0.20689655172413793,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 67.12856192793697,
+          "eval_runtime_s": 0.03248515725135803
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "regime_f1_macro": {
+      "mean": 0.4578675717343812,
+      "std": 0.17215434451131936,
+      "min": 0.07407407407407407,
+      "max": 0.6531986531986532,
+      "n": 15
+    },
+    "regime_f1_macro_ci": {
+      "lower": 0.4104300977184387,
+      "upper": 0.5034696756877383,
+      "confidence": 0.95,
+      "n_resamples": 1000
+    }
+  }
+}

--- a/backend/artifacts/experiments/runpod_20260530/runpod_canonical_20260530T120517Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/runpod_canonical_20260530T120517Z.json
@@ -1,0 +1,5153 @@
+{
+  "head_modes": [
+    "classification",
+    "regression",
+    "dual"
+  ],
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "regression_alpha": 0.5,
+  "training_package_id": "canonical",
+  "rates_target_mode": "raw",
+  "rates_heads": [],
+  "use_retrieval_analogs": false,
+  "use_regime_conditioning": false,
+  "use_statement_delta": false,
+  "use_vote_features": false,
+  "use_press_conf": false,
+  "trials": {
+    "classification": [
+      {
+        "head_mode": "classification",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.49104018966076995,
+              "regime_accuracy": 0.49166667461395264,
+              "regime_loss": 1.057173119762908,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    9,
+                    6
+                  ],
+                  [
+                    6,
+                    16,
+                    23
+                  ],
+                  [
+                    2,
+                    15,
+                    30
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6190476190476191,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.5306122448979592,
+                    "support": 28,
+                    "roc_auc": 0.7399068322981367,
+                    "pr_auc": 0.41069644827747054
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.35555555555555557,
+                    "f1": 0.3764705882352941,
+                    "support": 45,
+                    "roc_auc": 0.45896296296296296,
+                    "pr_auc": 0.4815032976533774
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5084745762711864,
+                    "recall": 0.6382978723404256,
+                    "f1": 0.5660377358490567,
+                    "support": 47,
+                    "roc_auc": 0.582337510929758,
+                    "pr_auc": 0.4267486991504996
+                  }
+                ],
+                "macro_precision": 0.5091740651062685,
+                "macro_recall": 0.4860463807272318,
+                "macro_f1": 0.49104018966076995,
+                "weighted_f1": 0.48668410760530634,
+                "macro_roc_auc": 0.5937357687302859,
+                "macro_pr_auc": 0.43964948169378254
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5215759849906191,
+              "regime_accuracy": 0.805084764957428,
+              "regime_loss": 0.6600751103991169,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    9,
+                    1,
+                    2
+                  ],
+                  [
+                    12,
+                    0,
+                    84
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3225806451612903,
+                    "recall": 1.0,
+                    "f1": 0.4878048780487805,
+                    "support": 10,
+                    "roc_auc": 0.9490740740740741,
+                    "pr_auc": 0.5939666314657062
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.15384615384615385,
+                    "support": 12,
+                    "roc_auc": 0.7830188679245284,
+                    "pr_auc": 0.28104431942244773
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9767441860465116,
+                    "recall": 0.875,
+                    "f1": 0.923076923076923,
+                    "support": 96,
+                    "roc_auc": 0.8821022727272727,
+                    "pr_auc": 0.9678377169586914
+                  }
+                ],
+                "macro_precision": 0.7664416104026007,
+                "macro_recall": 0.6527777777777778,
+                "macro_f1": 0.5215759849906191,
+                "weighted_f1": 0.8079626037459854,
+                "macro_roc_auc": 0.871398404908625,
+                "macro_pr_auc": 0.6142828892822817
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.23036223036223036,
+              "regime_accuracy": 0.20000000298023224,
+              "regime_loss": 1.3056917537342418,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    1,
+                    1
+                  ],
+                  [
+                    62,
+                    5,
+                    11
+                  ],
+                  [
+                    6,
+                    7,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1282051282051282,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.2222222222222222,
+                    "support": 12,
+                    "roc_auc": 0.6921768707482994,
+                    "pr_auc": 0.18098285156938665
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.38461538461538464,
+                    "recall": 0.0641025641025641,
+                    "f1": 0.10989010989010987,
+                    "support": 78,
+                    "roc_auc": 0.3056891025641026,
+                    "pr_auc": 0.6120075055320656
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3684210526315789,
+                    "recall": 0.35,
+                    "f1": 0.358974358974359,
+                    "support": 20,
+                    "roc_auc": 0.8222222222222222,
+                    "pr_auc": 0.39237655958480866
+                  }
+                ],
+                "macro_precision": 0.2937471884840306,
+                "macro_recall": 0.41581196581196583,
+                "macro_f1": 0.23036223036223036,
+                "weighted_f1": 0.16743256743256743,
+                "macro_roc_auc": 0.6066960651782081,
+                "macro_pr_auc": 0.39512230556208694
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3928526015465434,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.0444536948128054,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    21,
+                    19,
+                    4
+                  ],
+                  [
+                    17,
+                    19,
+                    12
+                  ],
+                  [
+                    6,
+                    7,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4772727272727273,
+                    "recall": 0.4772727272727273,
+                    "f1": 0.4772727272727273,
+                    "support": 44,
+                    "roc_auc": 0.608887381275441,
+                    "pr_auc": 0.43484336147448627
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4222222222222222,
+                    "recall": 0.3958333333333333,
+                    "f1": 0.40860215053763443,
+                    "support": 48,
+                    "roc_auc": 0.519510582010582,
+                    "pr_auc": 0.5323520731523351
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2727272727272727,
+                    "recall": 0.3157894736842105,
+                    "f1": 0.2926829268292683,
+                    "support": 19,
+                    "roc_auc": 0.5560640732265446,
+                    "pr_auc": 0.2422064755965488
+                  }
+                ],
+                "macro_precision": 0.3907407407407408,
+                "macro_recall": 0.39629851143009037,
+                "macro_f1": 0.3928526015465434,
+                "weighted_f1": 0.4159808904104734,
+                "macro_roc_auc": 0.5614873455041892,
+                "macro_pr_auc": 0.4031339700744567
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.48148148148148145,
+              "regime_accuracy": 0.6346153616905212,
+              "regime_loss": 1.0438685692273653,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    22,
+                    4
+                  ],
+                  [
+                    0,
+                    46,
+                    6
+                  ],
+                  [
+                    0,
+                    6,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6548323471400395,
+                    "pr_auc": 0.4175948639464275
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6216216216216216,
+                    "recall": 0.8846153846153846,
+                    "f1": 0.7301587301587302,
+                    "support": 52,
+                    "roc_auc": 0.6527366863905325,
+                    "pr_auc": 0.6477038656113402
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.7142857142857142,
+                    "support": 26,
+                    "roc_auc": 0.8131163708086785,
+                    "pr_auc": 0.6842390092988432
+                  }
+                ],
+                "macro_precision": 0.4294294294294294,
+                "macro_recall": 0.5512820512820512,
+                "macro_f1": 0.48148148148148145,
+                "weighted_f1": 0.5436507936507937,
+                "macro_roc_auc": 0.7068951347797502,
+                "macro_pr_auc": 0.583179246285537
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3697962774279399,
+              "regime_accuracy": 0.4333333373069763,
+              "regime_loss": 1.0968915469527623,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    3,
+                    15
+                  ],
+                  [
+                    6,
+                    3,
+                    36
+                  ],
+                  [
+                    2,
+                    6,
+                    39
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.35714285714285715,
+                    "f1": 0.43478260869565216,
+                    "support": 28,
+                    "roc_auc": 0.7461180124223602,
+                    "pr_auc": 0.4294366411284087
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.06666666666666667,
+                    "f1": 0.10526315789473685,
+                    "support": 45,
+                    "roc_auc": 0.4026666666666667,
+                    "pr_auc": 0.3618999793703469
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.43333333333333335,
+                    "recall": 0.8297872340425532,
+                    "f1": 0.5693430656934307,
+                    "support": 47,
+                    "roc_auc": 0.55727193238123,
+                    "pr_auc": 0.4079243568940444
+                  }
+                ],
+                "macro_precision": 0.412962962962963,
+                "macro_recall": 0.41786558595069234,
+                "macro_f1": 0.3697962774279399,
+                "weighted_f1": 0.36391566030277217,
+                "macro_roc_auc": 0.5686855371567523,
+                "macro_pr_auc": 0.39975365913093336
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5205718013095063,
+              "regime_accuracy": 0.7881355881690979,
+              "regime_loss": 0.6671108017533512,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    6,
+                    1,
+                    5
+                  ],
+                  [
+                    11,
+                    3,
+                    82
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.37037037037037035,
+                    "recall": 1.0,
+                    "f1": 0.5405405405405406,
+                    "support": 10,
+                    "roc_auc": 0.9638888888888889,
+                    "pr_auc": 0.611964073508191
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.125,
+                    "support": 12,
+                    "roc_auc": 0.7389937106918238,
+                    "pr_auc": 0.1722516777602401
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9425287356321839,
+                    "recall": 0.8541666666666666,
+                    "f1": 0.8961748633879782,
+                    "support": 96,
+                    "roc_auc": 0.8887310606060606,
+                    "pr_auc": 0.9706333218777943
+                  }
+                ],
+                "macro_precision": 0.520966368667518,
+                "macro_recall": 0.6458333333333334,
+                "macro_f1": 0.5205718013095063,
+                "weighted_f1": 0.7876117990733162,
+                "macro_roc_auc": 0.8638712200622578,
+                "macro_pr_auc": 0.5849496910487418
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.5012345679012346,
+              "regime_accuracy": 0.5545454621315002,
+              "regime_loss": 0.9209989298473705,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    6,
+                    0
+                  ],
+                  [
+                    27,
+                    43,
+                    8
+                  ],
+                  [
+                    0,
+                    8,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18181818181818182,
+                    "recall": 0.5,
+                    "f1": 0.26666666666666666,
+                    "support": 12,
+                    "roc_auc": 0.6751700680272109,
+                    "pr_auc": 0.1685387194921566
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7543859649122807,
+                    "recall": 0.5512820512820513,
+                    "f1": 0.6370370370370372,
+                    "support": 78,
+                    "roc_auc": 0.47115384615384615,
+                    "pr_auc": 0.735910067546634
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.6,
+                    "recall": 0.6,
+                    "f1": 0.6,
+                    "support": 20,
+                    "roc_auc": 0.8633333333333333,
+                    "pr_auc": 0.47264827528048775
+                  }
+                ],
+                "macro_precision": 0.5120680489101542,
+                "macro_recall": 0.5504273504273504,
+                "macro_f1": 0.5012345679012346,
+                "weighted_f1": 0.58989898989899,
+                "macro_roc_auc": 0.6698857491714634,
+                "macro_pr_auc": 0.4590323541064261
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.34500709729276763,
+              "regime_accuracy": 0.36036035418510437,
+              "regime_loss": 1.1540690989205586,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    22,
+                    10,
+                    12
+                  ],
+                  [
+                    17,
+                    10,
+                    21
+                  ],
+                  [
+                    6,
+                    5,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4888888888888889,
+                    "recall": 0.5,
+                    "f1": 0.4943820224719101,
+                    "support": 44,
+                    "roc_auc": 0.6153324287652646,
+                    "pr_auc": 0.453661506513426
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.273972602739726,
+                    "support": 48,
+                    "roc_auc": 0.5006613756613757,
+                    "pr_auc": 0.4649906436802491
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1951219512195122,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.26666666666666666,
+                    "support": 19,
+                    "roc_auc": 0.6024027459954233,
+                    "pr_auc": 0.25111762536163246
+                  }
+                ],
+                "macro_precision": 0.3613369467028004,
+                "macro_recall": 0.37646198830409355,
+                "macro_f1": 0.34500709729276763,
+                "weighted_f1": 0.3600915368192573,
+                "macro_roc_auc": 0.5727988501406879,
+                "macro_pr_auc": 0.38992325851843584
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.35089605734767026,
+              "regime_accuracy": 0.49038460850715637,
+              "regime_loss": 1.0540538155115569,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    17,
+                    9
+                  ],
+                  [
+                    0,
+                    38,
+                    14
+                  ],
+                  [
+                    0,
+                    13,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6272189349112426,
+                    "pr_auc": 0.4893681659013292
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5588235294117647,
+                    "recall": 0.7307692307692307,
+                    "f1": 0.6333333333333334,
+                    "support": 52,
+                    "roc_auc": 0.6974852071005917,
+                    "pr_auc": 0.7554048847357208
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3611111111111111,
+                    "recall": 0.5,
+                    "f1": 0.4193548387096774,
+                    "support": 26,
+                    "roc_auc": 0.7061143984220908,
+                    "pr_auc": 0.5410884261277908
+                  }
+                ],
+                "macro_precision": 0.306644880174292,
+                "macro_recall": 0.4102564102564103,
+                "macro_f1": 0.35089605734767026,
+                "weighted_f1": 0.4215053763440861,
+                "macro_roc_auc": 0.6769395134779751,
+                "macro_pr_auc": 0.5952871589216137
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.42898051112336827,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.1142148652587174,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    13,
+                    6
+                  ],
+                  [
+                    7,
+                    13,
+                    25
+                  ],
+                  [
+                    5,
+                    9,
+                    33
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.32142857142857145,
+                    "f1": 0.3673469387755102,
+                    "support": 28,
+                    "roc_auc": 0.7569875776397516,
+                    "pr_auc": 0.3982665895981918
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.37142857142857144,
+                    "recall": 0.28888888888888886,
+                    "f1": 0.325,
+                    "support": 45,
+                    "roc_auc": 0.4444444444444444,
+                    "pr_auc": 0.3849647109505644
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.515625,
+                    "recall": 0.7021276595744681,
+                    "f1": 0.5945945945945946,
+                    "support": 47,
+                    "roc_auc": 0.5849606528708832,
+                    "pr_auc": 0.43630846293056574
+                  }
+                ],
+                "macro_precision": 0.43854166666666666,
+                "macro_recall": 0.43748170663064284,
+                "macro_f1": 0.42898051112336827,
+                "weighted_f1": 0.44047216859716865,
+                "macro_roc_auc": 0.5954642249850264,
+                "macro_pr_auc": 0.4065132544931073
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4664224664224664,
+              "regime_accuracy": 0.7966101765632629,
+              "regime_loss": 0.5908749128802347,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    12,
+                    0,
+                    84
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3125,
+                    "recall": 1.0,
+                    "f1": 0.47619047619047616,
+                    "support": 10,
+                    "roc_auc": 0.9407407407407408,
+                    "pr_auc": 0.5662763926894361
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.684748427672956,
+                    "pr_auc": 0.16137715384170034
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9767441860465116,
+                    "recall": 0.875,
+                    "f1": 0.923076923076923,
+                    "support": 96,
+                    "roc_auc": 0.881155303030303,
+                    "pr_auc": 0.9599885628506086
+                  }
+                ],
+                "macro_precision": 0.42974806201550386,
+                "macro_recall": 0.625,
+                "macro_f1": 0.4664224664224664,
+                "weighted_f1": 0.7913329608244862,
+                "macro_roc_auc": 0.835548157148,
+                "macro_pr_auc": 0.5625473697939151
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2513098311055096,
+              "regime_accuracy": 0.23636363446712494,
+              "regime_loss": 1.221803320537914,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    3,
+                    1
+                  ],
+                  [
+                    52,
+                    11,
+                    15
+                  ],
+                  [
+                    4,
+                    9,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.125,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.21052631578947367,
+                    "support": 12,
+                    "roc_auc": 0.6198979591836735,
+                    "pr_auc": 0.1324145359687908
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4782608695652174,
+                    "recall": 0.14102564102564102,
+                    "f1": 0.21782178217821782,
+                    "support": 78,
+                    "roc_auc": 0.27283653846153844,
+                    "pr_auc": 0.5942973400466769
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.30434782608695654,
+                    "recall": 0.35,
+                    "f1": 0.3255813953488372,
+                    "support": 20,
+                    "roc_auc": 0.8,
+                    "pr_auc": 0.3451673232122606
+                  }
+                ],
+                "macro_precision": 0.302536231884058,
+                "macro_recall": 0.38589743589743586,
+                "macro_f1": 0.2513098311055096,
+                "weighted_f1": 0.23661857005774015,
+                "macro_roc_auc": 0.564244832548404,
+                "macro_pr_auc": 0.3572930664092428
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3564509750950429,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.110904071782944,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    35,
+                    1,
+                    8
+                  ],
+                  [
+                    25,
+                    5,
+                    18
+                  ],
+                  [
+                    7,
+                    5,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5223880597014925,
+                    "recall": 0.7954545454545454,
+                    "f1": 0.6306306306306306,
+                    "support": 44,
+                    "roc_auc": 0.6380597014925373,
+                    "pr_auc": 0.488901833639404
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.10416666666666667,
+                    "f1": 0.1694915254237288,
+                    "support": 48,
+                    "roc_auc": 0.541005291005291,
+                    "pr_auc": 0.4745513776685791
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21212121212121213,
+                    "recall": 0.3684210526315789,
+                    "f1": 0.2692307692307693,
+                    "support": 19,
+                    "roc_auc": 0.6430205949656751,
+                    "pr_auc": 0.2676458969125135
+                  }
+                ],
+                "macro_precision": 0.3963515754560531,
+                "macro_recall": 0.422680754917597,
+                "macro_f1": 0.3564509750950429,
+                "weighted_f1": 0.36935788813938153,
+                "macro_roc_auc": 0.6073618624878345,
+                "macro_pr_auc": 0.4103663694068322
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.38317533803644915,
+              "regime_accuracy": 0.38461539149284363,
+              "regime_loss": 1.23207504932697,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    9
+                  ],
+                  [
+                    22,
+                    16,
+                    14
+                  ],
+                  [
+                    6,
+                    5,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.24324324324324326,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.2857142857142857,
+                    "support": 26,
+                    "roc_auc": 0.5650887573964497,
+                    "pr_auc": 0.33164901076396897
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5517241379310345,
+                    "recall": 0.3076923076923077,
+                    "f1": 0.39506172839506176,
+                    "support": 52,
+                    "roc_auc": 0.6068786982248521,
+                    "pr_auc": 0.5671392921233509
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.39473684210526316,
+                    "recall": 0.5769230769230769,
+                    "f1": 0.46875,
+                    "support": 26,
+                    "roc_auc": 0.7085798816568047,
+                    "pr_auc": 0.4715026750403787
+                  }
+                ],
+                "macro_precision": 0.39656807442651365,
+                "macro_recall": 0.4102564102564103,
+                "macro_f1": 0.38317533803644915,
+                "weighted_f1": 0.3861469356261023,
+                "macro_roc_auc": 0.6268491124260355,
+                "macro_pr_auc": 0.45676365930923285
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.35692568028603405,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.1619335063353655,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    5,
+                    14
+                  ],
+                  [
+                    7,
+                    3,
+                    35
+                  ],
+                  [
+                    2,
+                    6,
+                    39
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.32142857142857145,
+                    "f1": 0.391304347826087,
+                    "support": 28,
+                    "roc_auc": 0.7507763975155279,
+                    "pr_auc": 0.4100274069244042
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.21428571428571427,
+                    "recall": 0.06666666666666667,
+                    "f1": 0.10169491525423728,
+                    "support": 45,
+                    "roc_auc": 0.42518518518518517,
+                    "pr_auc": 0.33688589457107054
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4431818181818182,
+                    "recall": 0.8297872340425532,
+                    "f1": 0.5777777777777778,
+                    "support": 47,
+                    "roc_auc": 0.5861264937336054,
+                    "pr_auc": 0.45237718095536805
+                  }
+                ],
+                "macro_precision": 0.38582251082251084,
+                "macro_recall": 0.4059608240459304,
+                "macro_f1": 0.35692568028603405,
+                "weighted_f1": 0.3557362373427223,
+                "macro_roc_auc": 0.5873626921447729,
+                "macro_pr_auc": 0.39976349415028095
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5215759849906191,
+              "regime_accuracy": 0.805084764957428,
+              "regime_loss": 0.5519579636343455,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    9,
+                    1,
+                    2
+                  ],
+                  [
+                    12,
+                    0,
+                    84
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3225806451612903,
+                    "recall": 1.0,
+                    "f1": 0.4878048780487805,
+                    "support": 10,
+                    "roc_auc": 0.9314814814814815,
+                    "pr_auc": 0.505724996649751
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.15384615384615385,
+                    "support": 12,
+                    "roc_auc": 0.7578616352201258,
+                    "pr_auc": 0.31044808678814134
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9767441860465116,
+                    "recall": 0.875,
+                    "f1": 0.923076923076923,
+                    "support": 96,
+                    "roc_auc": 0.8806818181818182,
+                    "pr_auc": 0.9618553256621396
+                  }
+                ],
+                "macro_precision": 0.7664416104026007,
+                "macro_recall": 0.6527777777777778,
+                "macro_f1": 0.5215759849906191,
+                "weighted_f1": 0.8079626037459854,
+                "macro_roc_auc": 0.8566749782944751,
+                "macro_pr_auc": 0.5926761363666774
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.28943228943228944,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.087765190818093,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    3,
+                    0
+                  ],
+                  [
+                    54,
+                    20,
+                    4
+                  ],
+                  [
+                    6,
+                    10,
+                    4
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.13043478260869565,
+                    "recall": 0.75,
+                    "f1": 0.22222222222222218,
+                    "support": 12,
+                    "roc_auc": 0.6011904761904762,
+                    "pr_auc": 0.12486200478102163
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6060606060606061,
+                    "recall": 0.2564102564102564,
+                    "f1": 0.36036036036036034,
+                    "support": 78,
+                    "roc_auc": 0.3229166666666667,
+                    "pr_auc": 0.6324895929271169
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.2,
+                    "f1": 0.28571428571428575,
+                    "support": 20,
+                    "roc_auc": 0.865,
+                    "pr_auc": 0.4583797745413363
+                  }
+                ],
+                "macro_precision": 0.4121651295564339,
+                "macro_recall": 0.4021367521367521,
+                "macro_f1": 0.28943228943228944,
+                "weighted_f1": 0.3317187317187317,
+                "macro_roc_auc": 0.5963690476190476,
+                "macro_pr_auc": 0.405243790749825
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3513389782602638,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.0866926700670283,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    35,
+                    0,
+                    9
+                  ],
+                  [
+                    23,
+                    4,
+                    21
+                  ],
+                  [
+                    11,
+                    0,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5072463768115942,
+                    "recall": 0.7954545454545454,
+                    "f1": 0.6194690265486726,
+                    "support": 44,
+                    "roc_auc": 0.6336499321573948,
+                    "pr_auc": 0.45916992914429544
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.15384615384615385,
+                    "support": 48,
+                    "roc_auc": 0.4460978835978836,
+                    "pr_auc": 0.3836787178745096
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21052631578947367,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.2807017543859649,
+                    "support": 19,
+                    "roc_auc": 0.5577803203661327,
+                    "pr_auc": 0.2482488668615146
+                  }
+                ],
+                "macro_precision": 0.5725908975336893,
+                "macro_recall": 0.4332801701222753,
+                "macro_f1": 0.3513389782602638,
+                "weighted_f1": 0.360131404379192,
+                "macro_roc_auc": 0.5458427120404704,
+                "macro_pr_auc": 0.36369917129343987
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.35096539162112933,
+              "regime_accuracy": 0.3461538553237915,
+              "regime_loss": 1.0644301634568434,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    5,
+                    9
+                  ],
+                  [
+                    28,
+                    11,
+                    13
+                  ],
+                  [
+                    6,
+                    7,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2608695652173913,
+                    "recall": 0.46153846153846156,
+                    "f1": 0.33333333333333337,
+                    "support": 26,
+                    "roc_auc": 0.606508875739645,
+                    "pr_auc": 0.3887023948757628
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4782608695652174,
+                    "recall": 0.21153846153846154,
+                    "f1": 0.29333333333333333,
+                    "support": 52,
+                    "roc_auc": 0.5728550295857988,
+                    "pr_auc": 0.5639445932978921
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37142857142857144,
+                    "recall": 0.5,
+                    "f1": 0.42622950819672134,
+                    "support": 26,
+                    "roc_auc": 0.7159763313609467,
+                    "pr_auc": 0.5431306528392813
+                  }
+                ],
+                "macro_precision": 0.3701863354037267,
+                "macro_recall": 0.391025641025641,
+                "macro_f1": 0.35096539162112933,
+                "weighted_f1": 0.3365573770491803,
+                "macro_roc_auc": 0.6317800788954635,
+                "macro_pr_auc": 0.49859254700431205
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3311492566761887,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.3136572075967778,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    5,
+                    17
+                  ],
+                  [
+                    12,
+                    5,
+                    28
+                  ],
+                  [
+                    3,
+                    6,
+                    38
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.21428571428571427,
+                    "f1": 0.24489795918367344,
+                    "support": 28,
+                    "roc_auc": 0.6486801242236024,
+                    "pr_auc": 0.2811586952355876
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3125,
+                    "recall": 0.1111111111111111,
+                    "f1": 0.1639344262295082,
+                    "support": 45,
+                    "roc_auc": 0.554962962962963,
+                    "pr_auc": 0.42695930811178034
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4578313253012048,
+                    "recall": 0.8085106382978723,
+                    "f1": 0.5846153846153845,
+                    "support": 47,
+                    "roc_auc": 0.623433401340717,
+                    "pr_auc": 0.46960950406949237
+                  }
+                ],
+                "macro_precision": 0.3520152036718302,
+                "macro_recall": 0.37796915456489927,
+                "macro_f1": 0.3311492566761887,
+                "weighted_f1": 0.34759262595328166,
+                "macro_roc_auc": 0.6090254961757608,
+                "macro_pr_auc": 0.3925758358056201
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.48742227247032227,
+              "regime_accuracy": 0.7627118825912476,
+              "regime_loss": 0.5187689899388006,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    6,
+                    1,
+                    5
+                  ],
+                  [
+                    6,
+                    8,
+                    82
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3684210526315789,
+                    "recall": 0.7,
+                    "f1": 0.48275862068965514,
+                    "support": 10,
+                    "roc_auc": 0.9722222222222222,
+                    "pr_auc": 0.7449649859943976
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.08333333333333333,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.08333333333333333,
+                    "support": 12,
+                    "roc_auc": 0.6132075471698113,
+                    "pr_auc": 0.12854551276495452
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9425287356321839,
+                    "recall": 0.8541666666666666,
+                    "f1": 0.8961748633879782,
+                    "support": 96,
+                    "roc_auc": 0.8697916666666666,
+                    "pr_auc": 0.9353171180366238
+                  }
+                ],
+                "macro_precision": 0.4647610405323654,
+                "macro_recall": 0.5458333333333333,
+                "macro_f1": 0.48742227247032227,
+                "weighted_f1": 0.778477738069004,
+                "macro_roc_auc": 0.8184071453529,
+                "macro_pr_auc": 0.602942538931992
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3027450980392157,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.2102537892081522,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    29,
+                    6,
+                    43
+                  ],
+                  [
+                    1,
+                    0,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.21052631578947367,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.32,
+                    "support": 12,
+                    "roc_auc": 0.6836734693877551,
+                    "pr_auc": 0.16885703320252046
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8571428571428571,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.1411764705882353,
+                    "support": 78,
+                    "roc_auc": 0.2708333333333333,
+                    "pr_auc": 0.6240750008882552
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2923076923076923,
+                    "recall": 0.95,
+                    "f1": 0.44705882352941173,
+                    "support": 20,
+                    "roc_auc": 0.7455555555555555,
+                    "pr_auc": 0.2977102649258036
+                  }
+                ],
+                "macro_precision": 0.45332562174667435,
+                "macro_recall": 0.5645299145299145,
+                "macro_f1": 0.3027450980392157,
+                "weighted_f1": 0.21629946524064173,
+                "macro_roc_auc": 0.5666874527588813,
+                "macro_pr_auc": 0.3635474330055264
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.25800704211093994,
+              "regime_accuracy": 0.28828829526901245,
+              "regime_loss": 1.1877096296152456,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    28,
+                    13
+                  ],
+                  [
+                    2,
+                    20,
+                    26
+                  ],
+                  [
+                    4,
+                    6,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.06818181818181818,
+                    "f1": 0.11320754716981131,
+                    "support": 44,
+                    "roc_auc": 0.5990502035278155,
+                    "pr_auc": 0.43177403204460174
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.37037037037037035,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.39215686274509803,
+                    "support": 48,
+                    "roc_auc": 0.38591269841269843,
+                    "pr_auc": 0.3460271178310176
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1875,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.2686567164179105,
+                    "support": 19,
+                    "roc_auc": 0.5537757437070938,
+                    "pr_auc": 0.24346698197950592
+                  }
+                ],
+                "macro_precision": 0.2970679012345679,
+                "macro_recall": 0.31951089845826686,
+                "macro_f1": 0.25800704211093994,
+                "weighted_f1": 0.2604426945871775,
+                "macro_roc_auc": 0.5129128818825359,
+                "macro_pr_auc": 0.3404227106183751
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5312716880996121,
+              "regime_accuracy": 0.557692289352417,
+              "regime_loss": 1.0842819534815276,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    9
+                  ],
+                  [
+                    7,
+                    29,
+                    16
+                  ],
+                  [
+                    3,
+                    3,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.47368421052631576,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.39999999999999997,
+                    "support": 26,
+                    "roc_auc": 0.6267258382642998,
+                    "pr_auc": 0.5114241654071762
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.725,
+                    "recall": 0.5576923076923077,
+                    "f1": 0.6304347826086957,
+                    "support": 52,
+                    "roc_auc": 0.6860207100591716,
+                    "pr_auc": 0.6553309947261193
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4444444444444444,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5633802816901408,
+                    "support": 26,
+                    "roc_auc": 0.7347140039447732,
+                    "pr_auc": 0.5728124142179422
+                  }
+                ],
+                "macro_precision": 0.54770955165692,
+                "macro_recall": 0.5576923076923077,
+                "macro_f1": 0.5312716880996121,
+                "weighted_f1": 0.556062461726883,
+                "macro_roc_auc": 0.6824868507560815,
+                "macro_pr_auc": 0.5798558581170793
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "regression": [
+      {
+        "head_mode": "regression",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3224996412684747,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.1181919964281894,
+              "regression_rmse_log_rv": 0.9253691923795623,
+              "regression_mae_log_rv": 0.7983834944102758,
+              "regression_loss": 0.8563081422052032,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    19,
+                    9,
+                    0
+                  ],
+                  [
+                    17,
+                    28,
+                    0
+                  ],
+                  [
+                    28,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.296875,
+                    "recall": 0.6785714285714286,
+                    "f1": 0.41304347826086957,
+                    "support": 28,
+                    "roc_auc": 0.7232142857142857,
+                    "pr_auc": 0.41802197483933407
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.6222222222222222,
+                    "f1": 0.5544554455445545,
+                    "support": 45,
+                    "roc_auc": 0.6145185185185185,
+                    "pr_auc": 0.579094861514338
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.6149810550859808,
+                    "pr_auc": 0.5133559349830922
+                  }
+                ],
+                "macro_precision": 0.265625,
+                "macro_recall": 0.4335978835978836,
+                "macro_f1": 0.3224996412684747,
+                "weighted_f1": 0.3042976036734108,
+                "macro_roc_auc": 0.6509046197729284,
+                "macro_pr_auc": 0.5034909237789215
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.0765639589169001,
+              "regime_accuracy": 0.0762711837887764,
+              "regime_loss": 1.3862393488318234,
+              "regression_rmse_log_rv": 0.5672231346967336,
+              "regression_mae_log_rv": 0.47540671201580664,
+              "regression_loss": 0.3217420845351887,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    9,
+                    0
+                  ],
+                  [
+                    4,
+                    8,
+                    0
+                  ],
+                  [
+                    6,
+                    90,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.09090909090909091,
+                    "recall": 0.1,
+                    "f1": 0.09523809523809525,
+                    "support": 10,
+                    "roc_auc": 0.5953703703703703,
+                    "pr_auc": 0.09490061698423807
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.07476635514018691,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.13445378151260504,
+                    "support": 12,
+                    "roc_auc": 0.2759433962264151,
+                    "pr_auc": 0.0651669777959366
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 96,
+                    "roc_auc": 0.5284090909090909,
+                    "pr_auc": 0.7724936805354825
+                  }
+                ],
+                "macro_precision": 0.055225148683092605,
+                "macro_recall": 0.25555555555555554,
+                "macro_f1": 0.0765639589169001,
+                "weighted_f1": 0.02174429093671367,
+                "macro_roc_auc": 0.46657428583529215,
+                "macro_pr_auc": 0.3108537584385524
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.14636591478696742,
+              "regime_accuracy": 0.20000000298023224,
+              "regime_loss": 1.0956518043171275,
+              "regression_rmse_log_rv": 0.4729703547549962,
+              "regression_mae_log_rv": 0.3391538807508451,
+              "regression_loss": 0.22370095647706695,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    68,
+                    10,
+                    0
+                  ],
+                  [
+                    13,
+                    7,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.12903225806451613,
+                    "recall": 1.0,
+                    "f1": 0.2285714285714286,
+                    "support": 12,
+                    "roc_auc": 0.7763605442176871,
+                    "pr_auc": 0.29832887778186584
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5882352941176471,
+                    "recall": 0.1282051282051282,
+                    "f1": 0.21052631578947367,
+                    "support": 78,
+                    "roc_auc": 0.3541666666666667,
+                    "pr_auc": 0.6348523294029341
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.3411111111111111,
+                    "pr_auc": 0.130122517552748
+                  }
+                ],
+                "macro_precision": 0.23908918406072108,
+                "macro_recall": 0.37606837606837606,
+                "macro_f1": 0.14636591478696742,
+                "weighted_f1": 0.17421736158578263,
+                "macro_roc_auc": 0.49054610733182163,
+                "macro_pr_auc": 0.354434574912516
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2012578616352201,
+              "regime_accuracy": 0.4324324429035187,
+              "regime_loss": 1.0458908113964196,
+              "regression_rmse_log_rv": 0.7380564580434743,
+              "regression_mae_log_rv": 0.5989737583928414,
+              "regression_loss": 0.5447273352596788,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    44,
+                    0
+                  ],
+                  [
+                    0,
+                    48,
+                    0
+                  ],
+                  [
+                    0,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.5495251017639078,
+                    "pr_auc": 0.3993121225263887
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.43243243243243246,
+                    "recall": 1.0,
+                    "f1": 0.6037735849056604,
+                    "support": 48,
+                    "roc_auc": 0.52744708994709,
+                    "pr_auc": 0.4816565349468012
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.4096109839816934,
+                    "pr_auc": 0.29132120710734843
+                  }
+                ],
+                "macro_precision": 0.14414414414414414,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.2012578616352201,
+                "weighted_f1": 0.2610912799592045,
+                "macro_roc_auc": 0.495527725230897,
+                "macro_pr_auc": 0.3907632881935128
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.33535353535353535,
+              "regime_accuracy": 0.48076921701431274,
+              "regime_loss": 1.0821539805485652,
+              "regression_rmse_log_rv": 0.7914587985720397,
+              "regression_mae_log_rv": 0.634356204715844,
+              "regression_loss": 0.6264070298370966,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    16,
+                    0
+                  ],
+                  [
+                    12,
+                    40,
+                    0
+                  ],
+                  [
+                    2,
+                    24,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4166666666666667,
+                    "recall": 0.38461538461538464,
+                    "f1": 0.4,
+                    "support": 26,
+                    "roc_auc": 0.710552268244576,
+                    "pr_auc": 0.449612637389439
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.6060606060606061,
+                    "support": 52,
+                    "roc_auc": 0.38461538461538464,
+                    "pr_auc": 0.43907578879338754
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.3806706114398422,
+                    "pr_auc": 0.25747799478877326
+                  }
+                ],
+                "macro_precision": 0.3055555555555556,
+                "macro_recall": 0.38461538461538464,
+                "macro_f1": 0.33535353535353535,
+                "weighted_f1": 0.403030303030303,
+                "macro_roc_auc": 0.4919460880999343,
+                "macro_pr_auc": 0.38205547365719994
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2920565033938727,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.1173044654611577,
+              "regression_rmse_log_rv": 0.9109584567008661,
+              "regression_mae_log_rv": 0.7785734920510247,
+              "regression_loss": 0.8298453098348237,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    3,
+                    9
+                  ],
+                  [
+                    30,
+                    6,
+                    9
+                  ],
+                  [
+                    18,
+                    15,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.34782608695652173,
+                    "support": 28,
+                    "roc_auc": 0.5493012422360248,
+                    "pr_auc": 0.2799002083738318
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.13333333333333333,
+                    "f1": 0.1739130434782609,
+                    "support": 45,
+                    "roc_auc": 0.4497777777777778,
+                    "pr_auc": 0.34068756646982923
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4375,
+                    "recall": 0.2978723404255319,
+                    "f1": 0.3544303797468354,
+                    "support": 47,
+                    "roc_auc": 0.42174293208976976,
+                    "pr_auc": 0.323943129614686
+                  }
+                ],
+                "macro_precision": 0.3125,
+                "macro_recall": 0.33421141506247887,
+                "macro_f1": 0.2920565033938727,
+                "weighted_f1": 0.28519537699504677,
+                "macro_roc_auc": 0.47360731736785744,
+                "macro_pr_auc": 0.314843634819449
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.18765468765468765,
+              "regime_accuracy": 0.18644067645072937,
+              "regime_loss": 1.106477201995203,
+              "regression_rmse_log_rv": 0.5338232401118315,
+              "regression_mae_log_rv": 0.4344986471963131,
+              "regression_loss": 0.284967251683494,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    5,
+                    2,
+                    5
+                  ],
+                  [
+                    79,
+                    7,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.10638297872340426,
+                    "recall": 1.0,
+                    "f1": 0.1923076923076923,
+                    "support": 10,
+                    "roc_auc": 0.8194444444444444,
+                    "pr_auc": 0.43106385878520903
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.1904761904761905,
+                    "support": 12,
+                    "roc_auc": 0.44261006289308175,
+                    "pr_auc": 0.1006724746714585
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.10416666666666667,
+                    "f1": 0.1801801801801802,
+                    "support": 96,
+                    "roc_auc": 0.3896780303030303,
+                    "pr_auc": 0.7689262526686136
+                  }
+                ],
+                "macro_precision": 0.3317572892040977,
+                "macro_recall": 0.4236111111111111,
+                "macro_f1": 0.18765468765468765,
+                "weighted_f1": 0.1822549873397331,
+                "macro_roc_auc": 0.5505775125468522,
+                "macro_pr_auc": 0.4335541953750937
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.34502923976608185,
+              "regime_accuracy": 0.5272727012634277,
+              "regime_loss": 1.0800297260284424,
+              "regression_rmse_log_rv": 0.406091532607048,
+              "regression_mae_log_rv": 0.30150903539351104,
+              "regression_loss": 0.16491033285514112,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    5,
+                    0
+                  ],
+                  [
+                    18,
+                    51,
+                    9
+                  ],
+                  [
+                    1,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2692307692307692,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.3684210526315789,
+                    "support": 12,
+                    "roc_auc": 0.6513605442176871,
+                    "pr_auc": 0.24115206700248398
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.68,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.6666666666666666,
+                    "support": 78,
+                    "roc_auc": 0.46794871794871795,
+                    "pr_auc": 0.7273816019433516
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.42055555555555557,
+                    "pr_auc": 0.14647398998256175
+                  }
+                ],
+                "macro_precision": 0.31641025641025644,
+                "macro_recall": 0.4123931623931624,
+                "macro_f1": 0.34502923976608185,
+                "weighted_f1": 0.5129186602870813,
+                "macro_roc_auc": 0.5132882725739868,
+                "macro_pr_auc": 0.3716692196427991
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.12344086021505378,
+              "regime_accuracy": 0.18018017709255219,
+              "regime_loss": 1.1330359076465533,
+              "regression_rmse_log_rv": 0.7518619034642103,
+              "regression_mae_log_rv": 0.6314311336289655,
+              "regression_loss": 0.5652963218808255,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    0,
+                    42
+                  ],
+                  [
+                    3,
+                    0,
+                    45
+                  ],
+                  [
+                    1,
+                    0,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.045454545454545456,
+                    "f1": 0.08,
+                    "support": 44,
+                    "roc_auc": 0.45454545454545453,
+                    "pr_auc": 0.36057302728146007
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.39814814814814814,
+                    "pr_auc": 0.3539406451577049
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.17142857142857143,
+                    "recall": 0.9473684210526315,
+                    "f1": 0.2903225806451613,
+                    "support": 19,
+                    "roc_auc": 0.36556064073226546,
+                    "pr_auc": 0.12763688686651972
+                  }
+                ],
+                "macro_precision": 0.16825396825396824,
+                "macro_recall": 0.33094098883572565,
+                "macro_f1": 0.12344086021505378,
+                "weighted_f1": 0.08140656785818078,
+                "macro_roc_auc": 0.4060847478086227,
+                "macro_pr_auc": 0.2807168531018949
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.26763920671243324,
+              "regime_accuracy": 0.35576921701431274,
+              "regime_loss": 1.0952969514406645,
+              "regression_rmse_log_rv": 0.7753127787191824,
+              "regression_mae_log_rv": 0.6077423670526164,
+              "regression_loss": 0.6011099048452598,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    11,
+                    10
+                  ],
+                  [
+                    10,
+                    31,
+                    11
+                  ],
+                  [
+                    5,
+                    20,
+                    1
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.19230769230769232,
+                    "f1": 0.2173913043478261,
+                    "support": 26,
+                    "roc_auc": 0.6326429980276134,
+                    "pr_auc": 0.28617508125532704
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.5961538461538461,
+                    "f1": 0.5438596491228069,
+                    "support": 52,
+                    "roc_auc": 0.4907544378698225,
+                    "pr_auc": 0.4795517308438847
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.045454545454545456,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.04166666666666667,
+                    "support": 26,
+                    "roc_auc": 0.17159763313609466,
+                    "pr_auc": 0.1539499214829477
+                  }
+                ],
+                "macro_precision": 0.26515151515151514,
+                "macro_recall": 0.2756410256410256,
+                "macro_f1": 0.26763920671243324,
+                "weighted_f1": 0.33669431731502664,
+                "macro_roc_auc": 0.4316650230111769,
+                "macro_pr_auc": 0.30655891119405315
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2583617193836172,
+              "regime_accuracy": 0.36666667461395264,
+              "regime_loss": 1.083690214209987,
+              "regression_rmse_log_rv": 0.882823403833108,
+              "regression_mae_log_rv": 0.7620029882818926,
+              "regression_loss": 0.7793771623554749,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    5,
+                    23
+                  ],
+                  [
+                    0,
+                    11,
+                    34
+                  ],
+                  [
+                    0,
+                    14,
+                    33
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 28,
+                    "roc_auc": 0.5535714285714286,
+                    "pr_auc": 0.2611798262358227
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.36666666666666664,
+                    "recall": 0.24444444444444444,
+                    "f1": 0.29333333333333333,
+                    "support": 45,
+                    "roc_auc": 0.5146666666666667,
+                    "pr_auc": 0.3993791662467735
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.36666666666666664,
+                    "recall": 0.7021276595744681,
+                    "f1": 0.4817518248175182,
+                    "support": 47,
+                    "roc_auc": 0.3978431944039639,
+                    "pr_auc": 0.3274572501129372
+                  }
+                ],
+                "macro_precision": 0.24444444444444444,
+                "macro_recall": 0.31552403467297085,
+                "macro_f1": 0.2583617193836172,
+                "weighted_f1": 0.29868613138686134,
+                "macro_roc_auc": 0.48869376321401975,
+                "macro_pr_auc": 0.3293387475318445
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.2741889175997703,
+              "regime_accuracy": 0.5254237055778503,
+              "regime_loss": 0.9784485717951241,
+              "regression_rmse_log_rv": 0.655735668539325,
+              "regression_mae_log_rv": 0.5632619093945723,
+              "regression_loss": 0.4299892669947154,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    10
+                  ],
+                  [
+                    0,
+                    4,
+                    8
+                  ],
+                  [
+                    0,
+                    38,
+                    58
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 10,
+                    "roc_auc": 0.5925925925925926,
+                    "pr_auc": 0.09729031127862786
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.09523809523809523,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.14814814814814814,
+                    "support": 12,
+                    "roc_auc": 0.3867924528301887,
+                    "pr_auc": 0.08885861192715723
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.7631578947368421,
+                    "recall": 0.6041666666666666,
+                    "f1": 0.6744186046511628,
+                    "support": 96,
+                    "roc_auc": 0.3248106060606061,
+                    "pr_auc": 0.73703379868787
+                  }
+                ],
+                "macro_precision": 0.28613199665831246,
+                "macro_recall": 0.3125,
+                "macro_f1": 0.2741889175997703,
+                "weighted_f1": 0.5637454561380457,
+                "macro_roc_auc": 0.43473188382779576,
+                "macro_pr_auc": 0.3077275739645517
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.10256410256410257,
+              "regime_accuracy": 0.1818181872367859,
+              "regime_loss": 1.1406257651068947,
+              "regression_rmse_log_rv": 0.46508253899994495,
+              "regression_mae_log_rv": 0.34428073459050873,
+              "regression_loss": 0.2163017680826353,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    12
+                  ],
+                  [
+                    0,
+                    0,
+                    78
+                  ],
+                  [
+                    0,
+                    0,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.4897959183673469,
+                    "pr_auc": 0.0964149088528005
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.35857371794871795,
+                    "pr_auc": 0.644616853438882
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.18181818181818182,
+                    "recall": 1.0,
+                    "f1": 0.3076923076923077,
+                    "support": 20,
+                    "roc_auc": 0.6388888888888888,
+                    "pr_auc": 0.23252429477861405
+                  }
+                ],
+                "macro_precision": 0.06060606060606061,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.10256410256410257,
+                "weighted_f1": 0.055944055944055944,
+                "macro_roc_auc": 0.4957528417349846,
+                "macro_pr_auc": 0.32451868569009884
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.09743589743589744,
+              "regime_accuracy": 0.171171173453331,
+              "regime_loss": 1.279401843890674,
+              "regression_rmse_log_rv": 0.7537306391341747,
+              "regression_mae_log_rv": 0.6246160070772644,
+              "regression_loss": 0.5681098763696115,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    44
+                  ],
+                  [
+                    0,
+                    0,
+                    48
+                  ],
+                  [
+                    0,
+                    0,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.40298507462686567,
+                    "pr_auc": 0.3226760192906858
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.5750661375661376,
+                    "pr_auc": 0.5107379727700777
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.17117117117117117,
+                    "recall": 1.0,
+                    "f1": 0.2923076923076923,
+                    "support": 19,
+                    "roc_auc": 0.41990846681922195,
+                    "pr_auc": 0.22715061366406436
+                  }
+                ],
+                "macro_precision": 0.057057057057057055,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.09743589743589744,
+                "weighted_f1": 0.05003465003465004,
+                "macro_roc_auc": 0.46598655967074176,
+                "macro_pr_auc": 0.3535215352416093
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.13333333333333333,
+              "regime_accuracy": 0.25,
+              "regime_loss": 1.1545937428107629,
+              "regression_rmse_log_rv": 0.8332617001082079,
+              "regression_mae_log_rv": 0.6883212072291196,
+              "regression_loss": 0.694325060867221,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    26
+                  ],
+                  [
+                    0,
+                    0,
+                    52
+                  ],
+                  [
+                    0,
+                    0,
+                    26
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.1893491124260355,
+                    "pr_auc": 0.15330775989395465
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.45968934911242604,
+                    "pr_auc": 0.4799107511944082
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.25,
+                    "recall": 1.0,
+                    "f1": 0.4,
+                    "support": 26,
+                    "roc_auc": 0.19674556213017752,
+                    "pr_auc": 0.1555456761645118
+                  }
+                ],
+                "macro_precision": 0.08333333333333333,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.13333333333333333,
+                "weighted_f1": 0.1,
+                "macro_roc_auc": 0.28192800788954636,
+                "macro_pr_auc": 0.2629213957509582
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.12612612612612611,
+              "regime_accuracy": 0.23333333432674408,
+              "regime_loss": 1.145439057118124,
+              "regression_rmse_log_rv": 0.8782855795553678,
+              "regression_mae_log_rv": 0.741432349079211,
+              "regression_loss": 0.7713855592549083,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    28,
+                    0,
+                    0
+                  ],
+                  [
+                    45,
+                    0,
+                    0
+                  ],
+                  [
+                    47,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23333333333333334,
+                    "recall": 1.0,
+                    "f1": 0.37837837837837834,
+                    "support": 28,
+                    "roc_auc": 0.5679347826086957,
+                    "pr_auc": 0.2779454495312597
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 45,
+                    "roc_auc": 0.6248888888888889,
+                    "pr_auc": 0.4875773969004311
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.6397551734188284,
+                    "pr_auc": 0.503130965924447
+                  }
+                ],
+                "macro_precision": 0.07777777777777778,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.12612612612612611,
+                "weighted_f1": 0.08828828828828827,
+                "macro_roc_auc": 0.6108596149721377,
+                "macro_pr_auc": 0.4228846041187126
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.042328042328042326,
+              "regime_accuracy": 0.06779661029577255,
+              "regime_loss": 1.2825893971879603,
+              "regression_rmse_log_rv": 0.5492817003623323,
+              "regression_mae_log_rv": 0.46160315905334587,
+              "regression_loss": 0.301710386352935,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    0
+                  ],
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    96,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.06896551724137931,
+                    "recall": 0.8,
+                    "f1": 0.12698412698412698,
+                    "support": 10,
+                    "roc_auc": 0.0712962962962963,
+                    "pr_auc": 0.04494063602781399
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.5943396226415094,
+                    "pr_auc": 0.13393839196516885
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 96,
+                    "roc_auc": 0.21638257575757575,
+                    "pr_auc": 0.6990832397303215
+                  }
+                ],
+                "macro_precision": 0.022988505747126436,
+                "macro_recall": 0.26666666666666666,
+                "macro_f1": 0.042328042328042326,
+                "weighted_f1": 0.010761366693570083,
+                "macro_roc_auc": 0.2940061648984605,
+                "macro_pr_auc": 0.2926540892411014
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.06557377049180328,
+              "regime_accuracy": 0.1090909093618393,
+              "regime_loss": 1.164477521722967,
+              "regression_rmse_log_rv": 0.504623164443196,
+              "regression_mae_log_rv": 0.37358850814529104,
+              "regression_loss": 0.2546445380926648,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    78,
+                    0,
+                    0
+                  ],
+                  [
+                    20,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.10909090909090909,
+                    "recall": 1.0,
+                    "f1": 0.19672131147540983,
+                    "support": 12,
+                    "roc_auc": 0.3877551020408163,
+                    "pr_auc": 0.08515934585734547
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.5572916666666666,
+                    "pr_auc": 0.7099598905112492
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.5822222222222222,
+                    "pr_auc": 0.1947815223827151
+                  }
+                ],
+                "macro_precision": 0.03636363636363636,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.06557377049180328,
+                "weighted_f1": 0.021460506706408346,
+                "macro_roc_auc": 0.509089663643235,
+                "macro_pr_auc": 0.32996691958376995
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.18924731182795698,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.0958238174762427,
+              "regression_rmse_log_rv": 0.7668549735911067,
+              "regression_mae_log_rv": 0.6360631068950301,
+              "regression_loss": 0.5880665505214169,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    44,
+                    0,
+                    0
+                  ],
+                  [
+                    48,
+                    0,
+                    0
+                  ],
+                  [
+                    19,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3963963963963964,
+                    "recall": 1.0,
+                    "f1": 0.567741935483871,
+                    "support": 44,
+                    "roc_auc": 0.33175033921302577,
+                    "pr_auc": 0.295012173499506
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.582010582010582,
+                    "pr_auc": 0.4869544148703561
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.38615560640732266,
+                    "pr_auc": 0.13466156471890256
+                  }
+                ],
+                "macro_precision": 0.13213213213213212,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.18924731182795698,
+                "weighted_f1": 0.22505085730892183,
+                "macro_roc_auc": 0.43330550921031014,
+                "macro_pr_auc": 0.3055427176962549
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.13333333333333333,
+              "regime_accuracy": 0.25,
+              "regime_loss": 1.1361829592631414,
+              "regression_rmse_log_rv": 0.7595124559448658,
+              "regression_mae_log_rv": 0.624443788967955,
+              "regression_loss": 0.5768591707354018,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    0,
+                    0
+                  ],
+                  [
+                    52,
+                    0,
+                    0
+                  ],
+                  [
+                    26,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 1.0,
+                    "f1": 0.4,
+                    "support": 26,
+                    "roc_auc": 0.46794871794871795,
+                    "pr_auc": 0.24252892056015074
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.5673076923076923,
+                    "pr_auc": 0.5216868424203811
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5034516765285996,
+                    "pr_auc": 0.2401474688200467
+                  }
+                ],
+                "macro_precision": 0.08333333333333333,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.13333333333333333,
+                "weighted_f1": 0.1,
+                "macro_roc_auc": 0.5129026955950032,
+                "macro_pr_auc": 0.3347877439335262
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.22802867383512546,
+              "regime_accuracy": 0.2750000059604645,
+              "regime_loss": 1.1125378203692682,
+              "regression_rmse_log_rv": 0.9592428943159441,
+              "regression_mae_log_rv": 0.8240884851722512,
+              "regression_loss": 0.9201469302956296,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    12,
+                    0
+                  ],
+                  [
+                    28,
+                    17,
+                    0
+                  ],
+                  [
+                    21,
+                    26,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.24615384615384617,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.34408602150537637,
+                    "support": 28,
+                    "roc_auc": 0.609083850931677,
+                    "pr_auc": 0.2584773620103417
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3090909090909091,
+                    "recall": 0.37777777777777777,
+                    "f1": 0.33999999999999997,
+                    "support": 45,
+                    "roc_auc": 0.4237037037037037,
+                    "pr_auc": 0.3483137243736432
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.6977557563392597,
+                    "pr_auc": 0.6585193093916181
+                  }
+                ],
+                "macro_precision": 0.1850815850815851,
+                "macro_recall": 0.3164021164021164,
+                "macro_f1": 0.22802867383512546,
+                "weighted_f1": 0.20778673835125447,
+                "macro_roc_auc": 0.5768477703248801,
+                "macro_pr_auc": 0.42177013192520096
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.13534061295255326,
+              "regime_accuracy": 0.12711864709854126,
+              "regime_loss": 1.1301409612267703,
+              "regression_rmse_log_rv": 0.5707589113598517,
+              "regression_mae_log_rv": 0.4861656887046361,
+              "regression_loss": 0.325765734896683,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    10,
+                    2,
+                    0
+                  ],
+                  [
+                    40,
+                    53,
+                    3
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16666666666666666,
+                    "recall": 1.0,
+                    "f1": 0.2857142857142857,
+                    "support": 10,
+                    "roc_auc": 0.9537037037037037,
+                    "pr_auc": 0.49013631793043555
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.03636363636363636,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.05970149253731343,
+                    "support": 12,
+                    "roc_auc": 0.3639937106918239,
+                    "pr_auc": 0.09507538771687922
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.03125,
+                    "f1": 0.06060606060606061,
+                    "support": 96,
+                    "roc_auc": 0.8470643939393939,
+                    "pr_auc": 0.95986320767
+                  }
+                ],
+                "macro_precision": 0.40101010101010104,
+                "macro_recall": 0.3993055555555556,
+                "macro_f1": 0.13534061295255326,
+                "weighted_f1": 0.07959103886247827,
+                "macro_roc_auc": 0.7215872694449739,
+                "macro_pr_auc": 0.5150249711057716
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.27645727221279004,
+              "regime_accuracy": 0.4272727370262146,
+              "regime_loss": 1.0780223001133311,
+              "regression_rmse_log_rv": 0.6405857541234046,
+              "regression_mae_log_rv": 0.4836283300643448,
+              "regression_loss": 0.4103501083858509,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    5,
+                    0
+                  ],
+                  [
+                    38,
+                    40,
+                    0
+                  ],
+                  [
+                    19,
+                    1,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.109375,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.1842105263157895,
+                    "support": 12,
+                    "roc_auc": 0.5884353741496599,
+                    "pr_auc": 0.1460899141694872
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8695652173913043,
+                    "recall": 0.5128205128205128,
+                    "f1": 0.6451612903225806,
+                    "support": 78,
+                    "roc_auc": 0.7011217948717948,
+                    "pr_auc": 0.860112295609012
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.17166666666666666,
+                    "pr_auc": 0.10674626960584431
+                  }
+                ],
+                "macro_precision": 0.32631340579710144,
+                "macro_recall": 0.3653846153846154,
+                "macro_f1": 0.27645727221279004,
+                "weighted_f1": 0.4775736996450069,
+                "macro_roc_auc": 0.48707461189604045,
+                "macro_pr_auc": 0.37098282646144787
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2650315867707172,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.06165495916456,
+              "regression_rmse_log_rv": 0.7624058894866381,
+              "regression_mae_log_rv": 0.6310186578078313,
+              "regression_loss": 0.5812627403239119,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    40,
+                    4,
+                    0
+                  ],
+                  [
+                    41,
+                    7,
+                    0
+                  ],
+                  [
+                    13,
+                    6,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.425531914893617,
+                    "recall": 0.9090909090909091,
+                    "f1": 0.5797101449275361,
+                    "support": 44,
+                    "roc_auc": 0.580393487109905,
+                    "pr_auc": 0.41852451210988806
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4117647058823529,
+                    "recall": 0.14583333333333334,
+                    "f1": 0.2153846153846154,
+                    "support": 48,
+                    "roc_auc": 0.49206349206349204,
+                    "pr_auc": 0.46714173632100175
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.5429061784897025,
+                    "pr_auc": 0.3785451016125356
+                  }
+                ],
+                "macro_precision": 0.27909887359199,
+                "macro_recall": 0.35164141414141414,
+                "macro_f1": 0.2650315867707172,
+                "weighted_f1": 0.3229343055430012,
+                "macro_roc_auc": 0.5384543858876999,
+                "macro_pr_auc": 0.4214037833478084
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.18752085418752085,
+              "regime_accuracy": 0.2788461446762085,
+              "regime_loss": 1.0868556866279016,
+              "regression_rmse_log_rv": 0.7899096840355817,
+              "regression_mae_log_rv": 0.6381389850016254,
+              "regression_loss": 0.6239573089331926,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    0,
+                    0
+                  ],
+                  [
+                    49,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3170731707317073,
+                    "recall": 1.0,
+                    "f1": 0.48148148148148145,
+                    "support": 26,
+                    "roc_auc": 0.6863905325443787,
+                    "pr_auc": 0.34898454222659403
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.13636363636363635,
+                    "recall": 0.057692307692307696,
+                    "f1": 0.08108108108108107,
+                    "support": 52,
+                    "roc_auc": 0.39607988165680474,
+                    "pr_auc": 0.4154536156102833
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.834319526627219,
+                    "pr_auc": 0.7546135008103508
+                  }
+                ],
+                "macro_precision": 0.15114560236511457,
+                "macro_recall": 0.3525641025641026,
+                "macro_f1": 0.18752085418752085,
+                "weighted_f1": 0.1609109109109109,
+                "macro_roc_auc": 0.6389299802761341,
+                "macro_pr_auc": 0.5063505528824094
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "dual": [
+      {
+        "head_mode": "dual",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.45951989931825366,
+              "regime_accuracy": 0.4749999940395355,
+              "regime_loss": 1.086518207802881,
+              "regression_rmse_log_rv": 0.8882262802945523,
+              "regression_mae_log_rv": 0.7624463549407665,
+              "regression_loss": 0.7889459250058966,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    5,
+                    6
+                  ],
+                  [
+                    9,
+                    11,
+                    25
+                  ],
+                  [
+                    15,
+                    3,
+                    29
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4146341463414634,
+                    "recall": 0.6071428571428571,
+                    "f1": 0.49275362318840576,
+                    "support": 28,
+                    "roc_auc": 0.7321428571428571,
+                    "pr_auc": 0.3616151837137954
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5789473684210527,
+                    "recall": 0.24444444444444444,
+                    "f1": 0.34375,
+                    "support": 45,
+                    "roc_auc": 0.5045925925925926,
+                    "pr_auc": 0.5055258894604635
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.48333333333333334,
+                    "recall": 0.6170212765957447,
+                    "f1": 0.5420560747663552,
+                    "support": 47,
+                    "roc_auc": 0.5884581754590499,
+                    "pr_auc": 0.4399912510791402
+                  }
+                ],
+                "macro_precision": 0.49230494936528313,
+                "macro_recall": 0.48953619272768206,
+                "macro_f1": 0.45951989931825366,
+                "weighted_f1": 0.4561873913607838,
+                "macro_roc_auc": 0.6083978750648332,
+                "macro_pr_auc": 0.43571077475113307
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.6908622908622909,
+              "regime_accuracy": 0.8559321761131287,
+              "regime_loss": 0.5061676244614488,
+              "regression_rmse_log_rv": 0.5398276056350455,
+              "regression_mae_log_rv": 0.4375298877791265,
+              "regression_loss": 0.2914138438056662,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    4,
+                    5,
+                    3
+                  ],
+                  [
+                    6,
+                    4,
+                    86
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 1.0,
+                    "f1": 0.6666666666666666,
+                    "support": 10,
+                    "roc_auc": 0.9805555555555555,
+                    "pr_auc": 0.7205935730935731
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.4761904761904762,
+                    "support": 12,
+                    "roc_auc": 0.8176100628930818,
+                    "pr_auc": 0.41358867322226367
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9662921348314607,
+                    "recall": 0.8958333333333334,
+                    "f1": 0.9297297297297298,
+                    "support": 96,
+                    "roc_auc": 0.8925189393939394,
+                    "pr_auc": 0.9654354272541719
+                  }
+                ],
+                "macro_precision": 0.6739492301290054,
+                "macro_recall": 0.7708333333333334,
+                "macro_f1": 0.6908622908622909,
+                "weighted_f1": 0.8613136138559867,
+                "macro_roc_auc": 0.8968948526141922,
+                "macro_pr_auc": 0.6998725578566695
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.42018966422636145,
+              "regime_accuracy": 0.40909090638160706,
+              "regime_loss": 1.019151864268563,
+              "regression_rmse_log_rv": 0.4112689392344413,
+              "regression_mae_log_rv": 0.3307299418480728,
+              "regression_loss": 0.1691421403790226,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    44,
+                    24,
+                    10
+                  ],
+                  [
+                    2,
+                    5,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.14814814814814814,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.24242424242424243,
+                    "support": 12,
+                    "roc_auc": 0.6309523809523809,
+                    "pr_auc": 0.13944362115482434
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7741935483870968,
+                    "recall": 0.3076923076923077,
+                    "f1": 0.44036697247706424,
+                    "support": 78,
+                    "roc_auc": 0.3401442307692308,
+                    "pr_auc": 0.6819107721179267
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.52,
+                    "recall": 0.65,
+                    "f1": 0.5777777777777778,
+                    "support": 20,
+                    "roc_auc": 0.8022222222222222,
+                    "pr_auc": 0.3661908495605961
+                  }
+                ],
+                "macro_precision": 0.4807805655117483,
+                "macro_recall": 0.5414529914529914,
+                "macro_f1": 0.42018966422636145,
+                "weighted_f1": 0.4437570028896134,
+                "macro_roc_auc": 0.591106277981278,
+                "macro_pr_auc": 0.39584841427778245
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4806746668704935,
+              "regime_accuracy": 0.4864864945411682,
+              "regime_loss": 1.104238425204992,
+              "regression_rmse_log_rv": 0.7849707010798197,
+              "regression_mae_log_rv": 0.6467976693382805,
+              "regression_loss": 0.6161790015537437,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    23,
+                    13,
+                    8
+                  ],
+                  [
+                    17,
+                    20,
+                    11
+                  ],
+                  [
+                    5,
+                    3,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5111111111111111,
+                    "recall": 0.5227272727272727,
+                    "f1": 0.5168539325842696,
+                    "support": 44,
+                    "roc_auc": 0.6221166892808684,
+                    "pr_auc": 0.516519470206842
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.4761904761904762,
+                    "support": 48,
+                    "roc_auc": 0.5406746031746031,
+                    "pr_auc": 0.4919222910886782
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.36666666666666664,
+                    "recall": 0.5789473684210527,
+                    "f1": 0.44897959183673464,
+                    "support": 19,
+                    "roc_auc": 0.6939359267734554,
+                    "pr_auc": 0.26279728665937463
+                  }
+                ],
+                "macro_precision": 0.4777777777777778,
+                "macro_recall": 0.5061137692716641,
+                "macro_f1": 0.4806746668704935,
+                "weighted_f1": 0.48765160482656467,
+                "macro_roc_auc": 0.6189090730763089,
+                "macro_pr_auc": 0.42374634931829824
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5464282043375476,
+              "regime_accuracy": 0.5769230723381042,
+              "regime_loss": 1.051191623394306,
+              "regression_rmse_log_rv": 0.7882193793946239,
+              "regression_mae_log_rv": 0.6335321887566422,
+              "regression_loss": 0.6212897900532461,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    9
+                  ],
+                  [
+                    7,
+                    31,
+                    14
+                  ],
+                  [
+                    3,
+                    3,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.47368421052631576,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.39999999999999997,
+                    "support": 26,
+                    "roc_auc": 0.5976331360946746,
+                    "pr_auc": 0.472754348220824
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7380952380952381,
+                    "recall": 0.5961538461538461,
+                    "f1": 0.6595744680851063,
+                    "support": 52,
+                    "roc_auc": 0.6701183431952663,
+                    "pr_auc": 0.6305161374709436
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.46511627906976744,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5797101449275363,
+                    "support": 26,
+                    "roc_auc": 0.7204142011834319,
+                    "pr_auc": 0.5561482793847918
+                  }
+                ],
+                "macro_precision": 0.5589652425637738,
+                "macro_recall": 0.5705128205128206,
+                "macro_f1": 0.5464282043375476,
+                "weighted_f1": 0.5747147702744372,
+                "macro_roc_auc": 0.6627218934911242,
+                "macro_pr_auc": 0.5531395883588531
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.47380952380952374,
+              "regime_accuracy": 0.4833333194255829,
+              "regime_loss": 1.0893260659834714,
+              "regression_rmse_log_rv": 0.878242779839032,
+              "regression_mae_log_rv": 0.7469319637302154,
+              "regression_loss": 0.7713103803393904,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    6,
+                    6
+                  ],
+                  [
+                    9,
+                    13,
+                    23
+                  ],
+                  [
+                    10,
+                    8,
+                    29
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.45714285714285713,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.5079365079365079,
+                    "support": 28,
+                    "roc_auc": 0.7593167701863354,
+                    "pr_auc": 0.43009965726405996
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.48148148148148145,
+                    "recall": 0.28888888888888886,
+                    "f1": 0.36111111111111105,
+                    "support": 45,
+                    "roc_auc": 0.4471111111111111,
+                    "pr_auc": 0.44257416947196615
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.6170212765957447,
+                    "f1": 0.5523809523809523,
+                    "support": 47,
+                    "roc_auc": 0.5750510055377441,
+                    "pr_auc": 0.4257990536762825
+                  }
+                ],
+                "macro_precision": 0.4795414462081129,
+                "macro_recall": 0.492446245637735,
+                "macro_f1": 0.47380952380952374,
+                "weighted_f1": 0.47028439153439144,
+                "macro_roc_auc": 0.5938262956117302,
+                "macro_pr_auc": 0.43282429347076956
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.7309941520467836,
+              "regime_accuracy": 0.8898305296897888,
+              "regime_loss": 0.5192295206805407,
+              "regression_rmse_log_rv": 0.5425350744148841,
+              "regression_mae_log_rv": 0.4459124235594172,
+              "regression_loss": 0.2943443069703639,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    4,
+                    5,
+                    3
+                  ],
+                  [
+                    4,
+                    2,
+                    90
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5555555555555556,
+                    "recall": 1.0,
+                    "f1": 0.7142857142857143,
+                    "support": 10,
+                    "roc_auc": 0.9722222222222222,
+                    "pr_auc": 0.6272394272394273
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7142857142857143,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.5263157894736842,
+                    "support": 12,
+                    "roc_auc": 0.7185534591194969,
+                    "pr_auc": 0.2062906455062557
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.967741935483871,
+                    "recall": 0.9375,
+                    "f1": 0.9523809523809523,
+                    "support": 96,
+                    "roc_auc": 0.8802083333333334,
+                    "pr_auc": 0.9429624293906697
+                  }
+                ],
+                "macro_precision": 0.7458610684417136,
+                "macro_recall": 0.7847222222222222,
+                "macro_f1": 0.7309941520467836,
+                "weighted_f1": 0.888874729195871,
+                "macro_roc_auc": 0.8569946715583509,
+                "macro_pr_auc": 0.5921641673787842
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4230143670371374,
+              "regime_accuracy": 0.5181818008422852,
+              "regime_loss": 0.9350457700816068,
+              "regression_rmse_log_rv": 0.46059491327393975,
+              "regression_mae_log_rv": 0.33298308786470443,
+              "regression_loss": 0.2121476741338281,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    7,
+                    3
+                  ],
+                  [
+                    14,
+                    37,
+                    27
+                  ],
+                  [
+                    0,
+                    2,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.125,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.14285714285714288,
+                    "support": 12,
+                    "roc_auc": 0.6751700680272109,
+                    "pr_auc": 0.16243143977737734
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8043478260869565,
+                    "recall": 0.47435897435897434,
+                    "f1": 0.596774193548387,
+                    "support": 78,
+                    "roc_auc": 0.6614583333333334,
+                    "pr_auc": 0.8227202337506334
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.375,
+                    "recall": 0.9,
+                    "f1": 0.5294117647058825,
+                    "support": 20,
+                    "roc_auc": 0.8611111111111112,
+                    "pr_auc": 0.4620944264649294
+                  }
+                ],
+                "macro_precision": 0.43478260869565216,
+                "macro_recall": 0.5136752136752137,
+                "macro_f1": 0.4230143670371374,
+                "weighted_f1": 0.535008255501614,
+                "macro_roc_auc": 0.7325798374905519,
+                "macro_pr_auc": 0.4824153666643134
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2989547038327526,
+              "regime_accuracy": 0.29729729890823364,
+              "regime_loss": 1.1541091093642395,
+              "regression_rmse_log_rv": 0.7875857965032979,
+              "regression_mae_log_rv": 0.6659566973512238,
+              "regression_loss": 0.6202913868537341,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    18,
+                    14
+                  ],
+                  [
+                    10,
+                    11,
+                    27
+                  ],
+                  [
+                    4,
+                    5,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.2727272727272727,
+                    "f1": 0.3428571428571428,
+                    "support": 44,
+                    "roc_auc": 0.6204206241519674,
+                    "pr_auc": 0.46177982903412534
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3235294117647059,
+                    "recall": 0.22916666666666666,
+                    "f1": 0.26829268292682923,
+                    "support": 48,
+                    "roc_auc": 0.4041005291005291,
+                    "pr_auc": 0.35375521173516306
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19607843137254902,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.2857142857142857,
+                    "support": 19,
+                    "roc_auc": 0.5778032036613272,
+                    "pr_auc": 0.2406993059881364
+                  }
+                ],
+                "macro_precision": 0.3270487682252388,
+                "macro_recall": 0.34273657628920784,
+                "macro_f1": 0.2989547038327526,
+                "weighted_f1": 0.3008318422952569,
+                "macro_roc_auc": 0.5341081189712745,
+                "macro_pr_auc": 0.3520781155858083
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3646723646723647,
+              "regime_accuracy": 0.5,
+              "regime_loss": 1.0388684960512014,
+              "regression_rmse_log_rv": 0.8610407059310611,
+              "regression_mae_log_rv": 0.6945608330872626,
+              "regression_loss": 0.74139109727026,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    17,
+                    9
+                  ],
+                  [
+                    0,
+                    37,
+                    15
+                  ],
+                  [
+                    0,
+                    11,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6637080867850098,
+                    "pr_auc": 0.5105561952646497
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5692307692307692,
+                    "recall": 0.7115384615384616,
+                    "f1": 0.6324786324786325,
+                    "support": 52,
+                    "roc_auc": 0.6357248520710059,
+                    "pr_auc": 0.63386210729976
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.38461538461538464,
+                    "recall": 0.5769230769230769,
+                    "f1": 0.46153846153846156,
+                    "support": 26,
+                    "roc_auc": 0.7149901380670611,
+                    "pr_auc": 0.5440630706714212
+                  }
+                ],
+                "macro_precision": 0.31794871794871793,
+                "macro_recall": 0.42948717948717946,
+                "macro_f1": 0.3646723646723647,
+                "weighted_f1": 0.4316239316239316,
+                "macro_roc_auc": 0.6714743589743589,
+                "macro_pr_auc": 0.5628271244119437
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.43655205811138015,
+              "regime_accuracy": 0.4749999940395355,
+              "regime_loss": 1.1532665673963929,
+              "regression_rmse_log_rv": 0.8771573283877092,
+              "regression_mae_log_rv": 0.7568178312911187,
+              "regression_loss": 0.7694049787442635,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    2,
+                    14
+                  ],
+                  [
+                    8,
+                    9,
+                    28
+                  ],
+                  [
+                    8,
+                    3,
+                    36
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.42857142857142855,
+                    "f1": 0.42857142857142855,
+                    "support": 28,
+                    "roc_auc": 0.6983695652173914,
+                    "pr_auc": 0.3137328068220562
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6428571428571429,
+                    "recall": 0.2,
+                    "f1": 0.3050847457627119,
+                    "support": 45,
+                    "roc_auc": 0.5345185185185185,
+                    "pr_auc": 0.4899192796490858
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.7659574468085106,
+                    "f1": 0.5760000000000001,
+                    "support": 47,
+                    "roc_auc": 0.6365491110463422,
+                    "pr_auc": 0.4971005421575046
+                  }
+                ],
+                "macro_precision": 0.5109890109890111,
+                "macro_recall": 0.46484295845997975,
+                "macro_f1": 0.43655205811138015,
+                "weighted_f1": 0.440006779661017,
+                "macro_roc_auc": 0.623145731594084,
+                "macro_pr_auc": 0.4335842095428822
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5238095238095238,
+              "regime_accuracy": 0.7627118825912476,
+              "regime_loss": 0.5245255595546657,
+              "regression_rmse_log_rv": 0.6033015480409598,
+              "regression_mae_log_rv": 0.5026331299884339,
+              "regression_loss": 0.36397275786861855,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    5,
+                    2,
+                    5
+                  ],
+                  [
+                    4,
+                    11,
+                    81
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4375,
+                    "recall": 0.7,
+                    "f1": 0.5384615384615384,
+                    "support": 10,
+                    "roc_auc": 0.9879629629629629,
+                    "pr_auc": 0.8514864302364302
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.125,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.14285714285714288,
+                    "support": 12,
+                    "roc_auc": 0.6360062893081762,
+                    "pr_auc": 0.13614350648461965
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9418604651162791,
+                    "recall": 0.84375,
+                    "f1": 0.8901098901098902,
+                    "support": 96,
+                    "roc_auc": 0.8821022727272727,
+                    "pr_auc": 0.9465911450130298
+                  }
+                ],
+                "macro_precision": 0.501453488372093,
+                "macro_recall": 0.5701388888888889,
+                "macro_f1": 0.5238095238095238,
+                "weighted_f1": 0.7843173775377166,
+                "macro_roc_auc": 0.8353571749994706,
+                "macro_pr_auc": 0.6447403605780265
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2564484126984127,
+              "regime_accuracy": 0.2454545497894287,
+              "regime_loss": 1.3361250985752453,
+              "regression_rmse_log_rv": 0.49653987215322076,
+              "regression_mae_log_rv": 0.3716366116994653,
+              "regression_loss": 0.24655184463793683,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    41,
+                    3,
+                    34
+                  ],
+                  [
+                    2,
+                    3,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.17307692307692307,
+                    "recall": 0.75,
+                    "f1": 0.28124999999999994,
+                    "support": 12,
+                    "roc_auc": 0.7363945578231292,
+                    "pr_auc": 0.22860776703076569
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.07142857142857144,
+                    "support": 78,
+                    "roc_auc": 0.29607371794871795,
+                    "pr_auc": 0.5997382903430508
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.28846153846153844,
+                    "recall": 0.75,
+                    "f1": 0.4166666666666667,
+                    "support": 20,
+                    "roc_auc": 0.7366666666666667,
+                    "pr_auc": 0.3515526252036837
+                  }
+                ],
+                "macro_precision": 0.3205128205128205,
+                "macro_recall": 0.5128205128205129,
+                "macro_f1": 0.2564484126984127,
+                "weighted_f1": 0.15708874458874458,
+                "macro_roc_auc": 0.5897116474795047,
+                "macro_pr_auc": 0.39329956085916673
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.38387838783878386,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.0924718107010083,
+              "regression_rmse_log_rv": 0.7644938106983346,
+              "regression_mae_log_rv": 0.6311027863176187,
+              "regression_loss": 0.584450786596061,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    30,
+                    3,
+                    11
+                  ],
+                  [
+                    20,
+                    10,
+                    18
+                  ],
+                  [
+                    7,
+                    5,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5263157894736842,
+                    "recall": 0.6818181818181818,
+                    "f1": 0.594059405940594,
+                    "support": 44,
+                    "roc_auc": 0.6380597014925373,
+                    "pr_auc": 0.5256340214851083
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.30303030303030304,
+                    "support": 48,
+                    "roc_auc": 0.5291005291005291,
+                    "pr_auc": 0.5238536977331405
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19444444444444445,
+                    "recall": 0.3684210526315789,
+                    "f1": 0.2545454545454545,
+                    "support": 19,
+                    "roc_auc": 0.6630434782608695,
+                    "pr_auc": 0.26800324440132195
+                  }
+                ],
+                "macro_precision": 0.4254385964912281,
+                "macro_recall": 0.41952418926103135,
+                "macro_f1": 0.38387838783878386,
+                "weighted_f1": 0.41009398237121014,
+                "macro_roc_auc": 0.610067902951312,
+                "macro_pr_auc": 0.4391636545398569
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.49583481035093935,
+              "regime_accuracy": 0.5865384340286255,
+              "regime_loss": 1.0160247683525085,
+              "regression_rmse_log_rv": 0.7823004907002757,
+              "regression_mae_log_rv": 0.6371318833060706,
+              "regression_loss": 0.6119940577498922,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    17,
+                    6
+                  ],
+                  [
+                    1,
+                    38,
+                    13
+                  ],
+                  [
+                    1,
+                    5,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.1935483870967742,
+                    "support": 26,
+                    "roc_auc": 0.6030571992110454,
+                    "pr_auc": 0.4328419198706522
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6333333333333333,
+                    "recall": 0.7307692307692307,
+                    "f1": 0.6785714285714285,
+                    "support": 52,
+                    "roc_auc": 0.7078402366863905,
+                    "pr_auc": 0.6379138437189728
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5128205128205128,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.6153846153846154,
+                    "support": 26,
+                    "roc_auc": 0.764792899408284,
+                    "pr_auc": 0.6251287883379191
+                  }
+                ],
+                "macro_precision": 0.5820512820512821,
+                "macro_recall": 0.5384615384615384,
+                "macro_f1": 0.49583481035093935,
+                "weighted_f1": 0.5415189649060617,
+                "macro_roc_auc": 0.69189677843524,
+                "macro_pr_auc": 0.5652948506425147
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.45775953792369656,
+              "regime_accuracy": 0.5083333253860474,
+              "regime_loss": 1.1344677886434535,
+              "regression_rmse_log_rv": 0.8685502425704887,
+              "regression_mae_log_rv": 0.7456214006427521,
+              "regression_loss": 0.7543795238692549,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    0,
+                    12
+                  ],
+                  [
+                    8,
+                    6,
+                    31
+                  ],
+                  [
+                    8,
+                    0,
+                    39
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.5333333333333333,
+                    "support": 28,
+                    "roc_auc": 0.7527173913043478,
+                    "pr_auc": 0.39503459079747594
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.13333333333333333,
+                    "f1": 0.23529411764705882,
+                    "support": 45,
+                    "roc_auc": 0.45481481481481484,
+                    "pr_auc": 0.3734810175516774
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.47560975609756095,
+                    "recall": 0.8297872340425532,
+                    "f1": 0.6046511627906976,
+                    "support": 47,
+                    "roc_auc": 0.5983678227921889,
+                    "pr_auc": 0.45133251222511084
+                  }
+                ],
+                "macro_precision": 0.6585365853658537,
+                "macro_recall": 0.511516379601486,
+                "macro_f1": 0.45775953792369656,
+                "weighted_f1": 0.4495014439884481,
+                "macro_roc_auc": 0.6019666763037839,
+                "macro_pr_auc": 0.4066160401914214
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5823080369451338,
+              "regime_accuracy": 0.8644067645072937,
+              "regime_loss": 0.4888604551048602,
+              "regression_rmse_log_rv": 0.5446515435420614,
+              "regression_mae_log_rv": 0.46283448411751604,
+              "regression_loss": 0.29664530388274996,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    6,
+                    1,
+                    5
+                  ],
+                  [
+                    5,
+                    0,
+                    91
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.47619047619047616,
+                    "recall": 1.0,
+                    "f1": 0.6451612903225806,
+                    "support": 10,
+                    "roc_auc": 0.9777777777777777,
+                    "pr_auc": 0.727504995004995
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.15384615384615385,
+                    "support": 12,
+                    "roc_auc": 0.7665094339622641,
+                    "pr_auc": 0.3333718399508808
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9479166666666666,
+                    "recall": 0.9479166666666666,
+                    "f1": 0.9479166666666666,
+                    "support": 96,
+                    "roc_auc": 0.8958333333333334,
+                    "pr_auc": 0.9643499068590592
+                  }
+                ],
+                "macro_precision": 0.8080357142857143,
+                "macro_recall": 0.6770833333333334,
+                "macro_f1": 0.5823080369451338,
+                "weighted_f1": 0.8415064978760987,
+                "macro_roc_auc": 0.8800401816911251,
+                "macro_pr_auc": 0.6750755806049783
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4008778236314198,
+              "regime_accuracy": 0.38181817531585693,
+              "regime_loss": 1.0472259348089046,
+              "regression_rmse_log_rv": 0.4181605071818039,
+              "regression_mae_log_rv": 0.346644287194464,
+              "regression_loss": 0.1748582097665435,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    3,
+                    1
+                  ],
+                  [
+                    44,
+                    18,
+                    16
+                  ],
+                  [
+                    2,
+                    2,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.14814814814814814,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.24242424242424243,
+                    "support": 12,
+                    "roc_auc": 0.6377551020408163,
+                    "pr_auc": 0.13565696509347905
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.782608695652174,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.3564356435643565,
+                    "support": 78,
+                    "roc_auc": 0.3918269230769231,
+                    "pr_auc": 0.6809560826404233
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.48484848484848486,
+                    "recall": 0.8,
+                    "f1": 0.6037735849056605,
+                    "support": 20,
+                    "roc_auc": 0.8227777777777778,
+                    "pr_auc": 0.40519693425507713
+                  }
+                ],
+                "macro_precision": 0.47186844288293567,
+                "macro_recall": 0.5658119658119658,
+                "macro_f1": 0.4008778236314198,
+                "weighted_f1": 0.3889685709565811,
+                "macro_roc_auc": 0.617453267631839,
+                "macro_pr_auc": 0.40726999399632646
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3144540644540645,
+              "regime_accuracy": 0.3243243098258972,
+              "regime_loss": 1.1355565417095608,
+              "regression_rmse_log_rv": 0.8427452101659592,
+              "regression_mae_log_rv": 0.7182666294880815,
+              "regression_loss": 0.7102194892576666,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    20,
+                    11,
+                    13
+                  ],
+                  [
+                    16,
+                    7,
+                    25
+                  ],
+                  [
+                    4,
+                    6,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.45454545454545453,
+                    "f1": 0.47619047619047616,
+                    "support": 44,
+                    "roc_auc": 0.6292401628222524,
+                    "pr_auc": 0.47988970379475565
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2916666666666667,
+                    "recall": 0.14583333333333334,
+                    "f1": 0.19444444444444448,
+                    "support": 48,
+                    "roc_auc": 0.43683862433862436,
+                    "pr_auc": 0.3777226539147837
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19148936170212766,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.2727272727272727,
+                    "support": 19,
+                    "roc_auc": 0.5903890160183066,
+                    "pr_auc": 0.2462823187365963
+                  }
+                ],
+                "macro_precision": 0.32771867612293143,
+                "macro_recall": 0.35802099946836785,
+                "macro_f1": 0.3144540644540645,
+                "weighted_f1": 0.31952731952731955,
+                "macro_roc_auc": 0.5521559343930611,
+                "macro_pr_auc": 0.3679648921487119
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3798376859722899,
+              "regime_accuracy": 0.38461539149284363,
+              "regime_loss": 1.08516368499169,
+              "regression_rmse_log_rv": 0.8442480685464688,
+              "regression_mae_log_rv": 0.6868151849261127,
+              "regression_loss": 0.7127548012444431,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    6,
+                    11
+                  ],
+                  [
+                    25,
+                    11,
+                    16
+                  ],
+                  [
+                    6,
+                    0,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.225,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.27272727272727276,
+                    "support": 26,
+                    "roc_auc": 0.5976331360946746,
+                    "pr_auc": 0.4138397606097658
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6470588235294118,
+                    "recall": 0.21153846153846154,
+                    "f1": 0.31884057971014496,
+                    "support": 52,
+                    "roc_auc": 0.6989644970414202,
+                    "pr_auc": 0.6838486379170461
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.425531914893617,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.547945205479452,
+                    "support": 26,
+                    "roc_auc": 0.7199211045364892,
+                    "pr_auc": 0.5650617017515884
+                  }
+                ],
+                "macro_precision": 0.4325302461410096,
+                "macro_recall": 0.4423076923076923,
+                "macro_f1": 0.3798376859722899,
+                "weighted_f1": 0.3645884094067537,
+                "macro_roc_auc": 0.672172912557528,
+                "macro_pr_auc": 0.5542500334261334
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4279874599604716,
+              "regime_accuracy": 0.4333333373069763,
+              "regime_loss": 1.1098518684852927,
+              "regression_rmse_log_rv": 0.883747153984777,
+              "regression_mae_log_rv": 0.7628226671426092,
+              "regression_loss": 0.7810090321761932,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    5,
+                    6
+                  ],
+                  [
+                    9,
+                    12,
+                    24
+                  ],
+                  [
+                    19,
+                    5,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.37777777777777777,
+                    "recall": 0.6071428571428571,
+                    "f1": 0.4657534246575342,
+                    "support": 28,
+                    "roc_auc": 0.7360248447204969,
+                    "pr_auc": 0.37208188094007083
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5454545454545454,
+                    "recall": 0.26666666666666666,
+                    "f1": 0.35820895522388063,
+                    "support": 45,
+                    "roc_auc": 0.43022222222222223,
+                    "pr_auc": 0.4747035264510429
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4339622641509434,
+                    "recall": 0.48936170212765956,
+                    "f1": 0.45999999999999996,
+                    "support": 47,
+                    "roc_auc": 0.5505683474205771,
+                    "pr_auc": 0.39824537659061154
+                  }
+                ],
+                "macro_precision": 0.45239819579442225,
+                "macro_recall": 0.4543904086457278,
+                "macro_f1": 0.4279874599604716,
+                "weighted_f1": 0.42317082396237987,
+                "macro_roc_auc": 0.5722718047877654,
+                "macro_pr_auc": 0.4150102613272417
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5161563276746522,
+              "regime_accuracy": 0.8474576473236084,
+              "regime_loss": 0.4440438805495278,
+              "regression_rmse_log_rv": 0.5986430945878826,
+              "regression_mae_log_rv": 0.4530329872238434,
+              "regression_loss": 0.35837355469775645,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    6,
+                    0,
+                    90
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.43478260869565216,
+                    "recall": 1.0,
+                    "f1": 0.6060606060606061,
+                    "support": 10,
+                    "roc_auc": 0.9842592592592593,
+                    "pr_auc": 0.8045608558108558
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7460691823899371,
+                    "pr_auc": 0.24591188590940125
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9473684210526315,
+                    "recall": 0.9375,
+                    "f1": 0.9424083769633508,
+                    "support": 96,
+                    "roc_auc": 0.890625,
+                    "pr_auc": 0.9546333187005808
+                  }
+                ],
+                "macro_precision": 0.4607170099160946,
+                "macro_recall": 0.6458333333333334,
+                "macro_f1": 0.5161563276746522,
+                "weighted_f1": 0.8180661885515911,
+                "macro_roc_auc": 0.8736511472163988,
+                "macro_pr_auc": 0.6683686868069459
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3237373737373737,
+              "regime_accuracy": 0.3181818127632141,
+              "regime_loss": 1.04415649284016,
+              "regression_rmse_log_rv": 0.44443520028809635,
+              "regression_mae_log_rv": 0.3386969613186507,
+              "regression_loss": 0.1975226472551203,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    38,
+                    9,
+                    31
+                  ],
+                  [
+                    2,
+                    0,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.26666666666666666,
+                    "support": 12,
+                    "roc_auc": 0.7091836734693877,
+                    "pr_auc": 0.18313599589128227
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.9,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.20454545454545456,
+                    "support": 78,
+                    "roc_auc": 0.4595352564102564,
+                    "pr_auc": 0.6976166421311548
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.34615384615384615,
+                    "recall": 0.9,
+                    "f1": 0.5,
+                    "support": 20,
+                    "roc_auc": 0.8016666666666666,
+                    "pr_auc": 0.36463757117295875
+                  }
+                ],
+                "macro_precision": 0.470940170940171,
+                "macro_recall": 0.5606837606837607,
+                "macro_f1": 0.3237373737373737,
+                "weighted_f1": 0.2650413223140496,
+                "macro_roc_auc": 0.6567951988487702,
+                "macro_pr_auc": 0.4151300697317986
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.339702671939275,
+              "regime_accuracy": 0.342342346906662,
+              "regime_loss": 1.1063105328314702,
+              "regression_rmse_log_rv": 0.7712992168191648,
+              "regression_mae_log_rv": 0.6436351437692169,
+              "regression_loss": 0.5949024818658569,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    22,
+                    9
+                  ],
+                  [
+                    10,
+                    16,
+                    22
+                  ],
+                  [
+                    4,
+                    6,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.48148148148148145,
+                    "recall": 0.29545454545454547,
+                    "f1": 0.3661971830985915,
+                    "support": 44,
+                    "roc_auc": 0.6065128900949797,
+                    "pr_auc": 0.44136520297378606
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.36363636363636365,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.34782608695652173,
+                    "support": 48,
+                    "roc_auc": 0.38326719576719576,
+                    "pr_auc": 0.34432982907430315
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.225,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.30508474576271183,
+                    "support": 19,
+                    "roc_auc": 0.5680778032036613,
+                    "pr_auc": 0.24463833916313413
+                  }
+                ],
+                "macro_precision": 0.356705948372615,
+                "macro_recall": 0.36749069643806487,
+                "macro_f1": 0.339702671939275,
+                "weighted_f1": 0.3477922378355189,
+                "macro_roc_auc": 0.5192859630219456,
+                "macro_pr_auc": 0.34344445707040777
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.516347687400319,
+              "regime_accuracy": 0.5384615659713745,
+              "regime_loss": 1.0706049845768855,
+              "regression_rmse_log_rv": 0.8026589384291044,
+              "regression_mae_log_rv": 0.6463979452830524,
+              "regression_loss": 0.6442613714401367,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    6,
+                    11
+                  ],
+                  [
+                    6,
+                    27,
+                    19
+                  ],
+                  [
+                    3,
+                    3,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.40909090909090906,
+                    "support": 26,
+                    "roc_auc": 0.6351084812623274,
+                    "pr_auc": 0.5047519423805761
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.75,
+                    "recall": 0.5192307692307693,
+                    "f1": 0.6136363636363638,
+                    "support": 52,
+                    "roc_auc": 0.6934171597633136,
+                    "pr_auc": 0.6941841202372916
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5263157894736842,
+                    "support": 26,
+                    "roc_auc": 0.7391518737672583,
+                    "pr_auc": 0.5888360723111019
+                  }
+                ],
+                "macro_precision": 0.5499999999999999,
+                "macro_recall": 0.5448717948717948,
+                "macro_f1": 0.516347687400319,
+                "weighted_f1": 0.5406698564593302,
+                "macro_roc_auc": 0.6892258382642998,
+                "macro_pr_auc": 0.5959240449763232
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "classification": {
+      "regime_f1_macro": {
+        "mean": 0.39487964372360856,
+        "std": 0.09196177358561897,
+        "min": 0.23036223036223036,
+        "max": 0.5312716880996121,
+        "n": 25
+      },
+      "regression_rmse_log_rv": null
+    },
+    "regression": {
+      "regime_f1_macro": {
+        "mean": 0.19250931856343667,
+        "std": 0.08755529297414194,
+        "min": 0.042328042328042326,
+        "max": 0.34502923976608185,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7058088323153197,
+        "std": 0.15583505863805522,
+        "min": 0.406091532607048,
+        "max": 0.9592428943159441,
+        "n": 25
+      }
+    },
+    "dual": {
+      "regime_f1_macro": {
+        "mean": 0.4497924679784498,
+        "std": 0.11131744788748818,
+        "min": 0.2564484126984127,
+        "max": 0.7309941520467836,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.6994177760678802,
+        "std": 0.16710783948386868,
+        "min": 0.4112689392344413,
+        "max": 0.8882262802945523,
+        "n": 25
+      }
+    }
+  }
+}

--- a/backend/artifacts/experiments/runpod_20260530/runpod_cross_source_20260530T124014Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/runpod_cross_source_20260530T124014Z.json
@@ -1,0 +1,206 @@
+{
+  "generated_at_utc": "2026-05-30T14:23:36Z",
+  "training_package_id": "canonical",
+  "encoders": [
+    "finbert_fed_adjacent"
+  ],
+  "source_types": [
+    "fomc_statement",
+    "fomc_minutes",
+    "fomc_meeting_transcript",
+    "fomc_press_conference",
+    "chair_speech",
+    "governor_speech",
+    "congressional_testimony",
+    "beige_book",
+    "regional_research",
+    "ny_fed_liberty_street",
+    "gss_factor_decomposition"
+  ],
+  "per_source_counts": {
+    "fomc_statement": 3364,
+    "fomc_minutes": 0,
+    "fomc_meeting_transcript": 156,
+    "fomc_press_conference": 0,
+    "chair_speech": 0,
+    "governor_speech": 0,
+    "congressional_testimony": 0,
+    "beige_book": 0,
+    "regional_research": 0,
+    "ny_fed_liberty_street": 0,
+    "gss_factor_decomposition": 138
+  },
+  "cells": [
+    {
+      "source_type": "fomc_statement",
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "support": 3364,
+      "macro_f1": 0.2893005818012594,
+      "weighted_f1": 0.33727411321993517,
+      "accuracy": 0.39417360285374553,
+      "per_class": {
+        "dovish": {
+          "precision": 0.30623520126282555,
+          "recall": 0.38645418326693226,
+          "f1": 0.34169969176574194,
+          "support": 1004
+        },
+        "hawkish": {
+          "precision": 0.1111111111111111,
+          "recall": 0.002352941176470588,
+          "f1": 0.004608294930875576,
+          "support": 850
+        },
+        "neutral": {
+          "precision": 0.45021645021645024,
+          "recall": 0.6198675496688741,
+          "f1": 0.5215937587071607,
+          "support": 1510
+        }
+      },
+      "label_support": {
+        "hawkish": 850,
+        "dovish": 1004,
+        "neutral": 1510
+      },
+      "latency_ms": {
+        "p50": 0.0552986457478255,
+        "p95": 0.062078965129330754
+      },
+      "kind": "stance",
+      "status": "ok"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "fomc_minutes",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "source_type": "fomc_meeting_transcript",
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "support": 156,
+      "macro_f1": 0.2448979591836735,
+      "weighted_f1": 0.4332810047095762,
+      "accuracy": 0.5769230769230769,
+      "per_class": {
+        "dovish": {
+          "precision": 0.5882352941176471,
+          "recall": 0.9782608695652174,
+          "f1": 0.7346938775510204,
+          "support": 92
+        },
+        "hawkish": {
+          "precision": 0.0,
+          "recall": 0.0,
+          "f1": 0.0,
+          "support": 46
+        },
+        "neutral": {
+          "precision": 0.0,
+          "recall": 0.0,
+          "f1": 0.0,
+          "support": 18
+        }
+      },
+      "label_support": {
+        "dovish": 92,
+        "hawkish": 46,
+        "neutral": 18
+      },
+      "latency_ms": {
+        "p50": 0.0595668243477121,
+        "p95": 0.08190849621314555
+      },
+      "kind": "stance",
+      "status": "ok"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "fomc_press_conference",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "chair_speech",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "governor_speech",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "congressional_testimony",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "beige_book",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "regional_research",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "source_type": "ny_fed_liberty_street",
+      "support": 0,
+      "status": "no_rows",
+      "kind": "stance"
+    },
+    {
+      "source_type": "gss_factor_decomposition",
+      "encoder_alias": "finbert_fed_adjacent",
+      "checkpoint": "yusufizzetmurat/finbert-fed-adjacent",
+      "support": 138,
+      "kind": "continuous",
+      "targets": {
+        "gss_target_factor": {
+          "support": 138,
+          "pearson_r": -0.011363996524564863,
+          "spearman_r": -0.03557887608222282,
+          "zscore_rmse": 1.4222264211612472
+        },
+        "gss_path_factor": {
+          "support": 138,
+          "pearson_r": 0.3357098593037053,
+          "spearman_r": 0.34626818699042017,
+          "zscore_rmse": 1.1526405690381496
+        }
+      },
+      "latency_ms": {
+        "p50": 0.06658027996309102,
+        "p95": 0.24042930454015732
+      },
+      "status": "ok"
+    }
+  ],
+  "failures": []
+}

--- a/backend/artifacts/experiments/runpod_20260530/runpod_derived_20260530T125401Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/runpod_derived_20260530T125401Z.json
@@ -1,0 +1,806 @@
+{
+  "configurations": [
+    "baseline",
+    "derived_ablation",
+    "derived_replacement"
+  ],
+  "arm_choices": [
+    "baseline",
+    "derived_ablation",
+    "derived_replacement"
+  ],
+  "arm_aliases": {
+    "ablation": "derived_ablation",
+    "replacement": "derived_replacement"
+  },
+  "arm": null,
+  "five_derived_columns": [
+    "sentiment_score",
+    "stance_label",
+    "factor_labels",
+    "certainty_score",
+    "topic_label"
+  ],
+  "five_derived_fv_attrs": [
+    "sentiment_score",
+    "stance_hawk",
+    "stance_dove",
+    "stance_neutral",
+    "certain_label_certain"
+  ],
+  "five_derived_mt_aux_axes": [
+    "factor",
+    "topic"
+  ],
+  "skipped": {},
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "bootstrap_samples": 500,
+  "bootstrap_seed": 11,
+  "training_package_id": "canonical",
+  "trials": {
+    "baseline": [
+      {
+        "configuration": "baseline",
+        "seed": 11,
+        "use_derived_text_features": true,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.38361086170426567,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.0965324048019345
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.46434108527131784,
+              "regime_accuracy": 0.6355932354927063,
+              "regime_loss": 0.644370133088807
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3676516011577839,
+              "regime_accuracy": 0.37272727489471436,
+              "regime_loss": 1.0686483014713635
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.38340851027418194,
+              "regime_accuracy": 0.44144144654273987,
+              "regime_loss": 1.045460862073056
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.29239060489060487,
+              "regime_accuracy": 0.29807692766189575,
+              "regime_loss": 1.0844683280357947
+            }
+          }
+        ]
+      },
+      {
+        "configuration": "baseline",
+        "seed": 29,
+        "use_derived_text_features": true,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2949100015603541,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.1535907150267437
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.48837695997939407,
+              "regime_accuracy": 0.7033898234367371,
+              "regime_loss": 0.5808135220559977
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4479809061167243,
+              "regime_accuracy": 0.5272727012634277,
+              "regime_loss": 1.039546368338845
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3000949667616334,
+              "regime_accuracy": 0.30630630254745483,
+              "regime_loss": 1.3029215825307798
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3588588588588588,
+              "regime_accuracy": 0.4711538553237915,
+              "regime_loss": 1.0694444454633272
+            }
+          }
+        ]
+      },
+      {
+        "configuration": "baseline",
+        "seed": 47,
+        "use_derived_text_features": true,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.39158730158730154,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.2419893689987502
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4342228464419476,
+              "regime_accuracy": 0.7118644118309021,
+              "regime_loss": 0.6073085049451408
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.21891806390382793,
+              "regime_accuracy": 0.20000000298023224,
+              "regime_loss": 2.1235778916965833
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.39271566011803705,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.0716231450615248
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5080446046240815,
+              "regime_accuracy": 0.557692289352417,
+              "regime_loss": 1.0501814576295705
+            }
+          }
+        ]
+      },
+      {
+        "configuration": "baseline",
+        "seed": 71,
+        "use_derived_text_features": true,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.34457829450125294,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.2738524331985954
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4437849162011173,
+              "regime_accuracy": 0.7372881174087524,
+              "regime_loss": 0.5474764735011731
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.31161541149746635,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.0832756822759455
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3962962962962963,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.1660935258055736
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.36461102250575933,
+              "regime_accuracy": 0.4134615361690521,
+              "regime_loss": 1.111283696614779
+            }
+          }
+        ]
+      },
+      {
+        "configuration": "baseline",
+        "seed": 97,
+        "use_derived_text_features": true,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3727346096096096,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.152744539246389
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3910515934807433,
+              "regime_accuracy": 0.6355932354927063,
+              "regime_loss": 0.6637399247137167
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.41221370941505625,
+              "regime_accuracy": 0.4272727370262146,
+              "regime_loss": 1.019977376677773
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.30854676489269656,
+              "regime_accuracy": 0.315315306186676,
+              "regime_loss": 1.118956965707632
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3599033816425121,
+              "regime_accuracy": 0.4038461446762085,
+              "regime_loss": 1.0740910676809459
+            }
+          }
+        ]
+      }
+    ],
+    "derived_ablation": [
+      {
+        "configuration": "derived_ablation",
+        "seed": 11,
+        "use_derived_text_features": false,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4861811391223156,
+              "regime_accuracy": 0.4833333194255829,
+              "regime_loss": 1.0557075786985275
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.6582970066841035,
+              "regime_accuracy": 0.8474576473236084,
+              "regime_loss": 0.5057715884709763
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4165483302076531,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.0241876721382142
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.46230936819172114,
+              "regime_accuracy": 0.46846845746040344,
+              "regime_loss": 1.1158474356160435
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5541617548482537,
+              "regime_accuracy": 0.5865384340286255,
+              "regime_loss": 1.0480782343791082
+            }
+          }
+        ]
+      },
+      {
+        "configuration": "derived_ablation",
+        "seed": 29,
+        "use_derived_text_features": false,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.46455026455026455,
+              "regime_accuracy": 0.4749999940395355,
+              "regime_loss": 1.0877336653600065
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.7309941520467836,
+              "regime_accuracy": 0.8898305296897888,
+              "regime_loss": 0.5214682625511945
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.49447216063069727,
+              "regime_accuracy": 0.5545454621315002,
+              "regime_loss": 0.9305824875831604
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.29929325460726425,
+              "regime_accuracy": 0.29729729890823364,
+              "regime_loss": 1.1438873230353848
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3646723646723647,
+              "regime_accuracy": 0.5,
+              "regime_loss": 1.0387747929646418
+            }
+          }
+        ]
+      },
+      {
+        "configuration": "derived_ablation",
+        "seed": 47,
+        "use_derived_text_features": false,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4261631248735074,
+              "regime_accuracy": 0.46666666865348816,
+              "regime_loss": 1.1371087941922593
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5683760683760684,
+              "regime_accuracy": 0.7796609997749329,
+              "regime_loss": 0.5340805149684518
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.24111793971319873,
+              "regime_accuracy": 0.22727273404598236,
+              "regime_loss": 1.3277138926766134
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3524795833618666,
+              "regime_accuracy": 0.36936935782432556,
+              "regime_loss": 1.0847058188781642
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4736002966258806,
+              "regime_accuracy": 0.567307710647583,
+              "regime_loss": 1.0141640534767737
+            }
+          }
+        ]
+      },
+      {
+        "configuration": "derived_ablation",
+        "seed": 71,
+        "use_derived_text_features": false,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.45775953792369656,
+              "regime_accuracy": 0.5083333253860474,
+              "regime_loss": 1.12871497832648
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5823080369451338,
+              "regime_accuracy": 0.8644067645072937,
+              "regime_loss": 0.44867544356039013
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3973055692189977,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.058294770934365
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3234360410830999,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.13994837394434
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.37023985631872863,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.0882562674008882
+            }
+          }
+        ]
+      },
+      {
+        "configuration": "derived_ablation",
+        "seed": 97,
+        "use_derived_text_features": false,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2636622409389561,
+              "regime_accuracy": 0.38333332538604736,
+              "regime_loss": 1.2571061835395998
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5161563276746522,
+              "regime_accuracy": 0.8474576473236084,
+              "regime_loss": 0.4436723599999638
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.35340693654510985,
+              "regime_accuracy": 0.34545454382896423,
+              "regime_loss": 1.0103444814682008
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3392814028407249,
+              "regime_accuracy": 0.342342346906662,
+              "regime_loss": 1.104686117008108
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5238792418567699,
+              "regime_accuracy": 0.5480769276618958,
+              "regime_loss": 1.0682159112049983
+            }
+          }
+        ]
+      }
+    ],
+    "derived_replacement": [
+      {
+        "configuration": "derived_replacement",
+        "seed": 11,
+        "use_derived_text_features": false,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4861811391223156,
+              "regime_accuracy": 0.4833333194255829,
+              "regime_loss": 1.0557075786985275
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.6582970066841035,
+              "regime_accuracy": 0.8474576473236084,
+              "regime_loss": 0.5057715884709763
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4165483302076531,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.0241876721382142
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.46230936819172114,
+              "regime_accuracy": 0.46846845746040344,
+              "regime_loss": 1.1158474356160435
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5541617548482537,
+              "regime_accuracy": 0.5865384340286255,
+              "regime_loss": 1.0480782343791082
+            }
+          }
+        ]
+      },
+      {
+        "configuration": "derived_replacement",
+        "seed": 29,
+        "use_derived_text_features": false,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.46455026455026455,
+              "regime_accuracy": 0.4749999940395355,
+              "regime_loss": 1.0877336653600065
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.7309941520467836,
+              "regime_accuracy": 0.8898305296897888,
+              "regime_loss": 0.5214682625511945
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.49447216063069727,
+              "regime_accuracy": 0.5545454621315002,
+              "regime_loss": 0.9305824875831604
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.29929325460726425,
+              "regime_accuracy": 0.29729729890823364,
+              "regime_loss": 1.1438873230353848
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3646723646723647,
+              "regime_accuracy": 0.5,
+              "regime_loss": 1.0387747929646418
+            }
+          }
+        ]
+      },
+      {
+        "configuration": "derived_replacement",
+        "seed": 47,
+        "use_derived_text_features": false,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4261631248735074,
+              "regime_accuracy": 0.46666666865348816,
+              "regime_loss": 1.1371087941922593
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5683760683760684,
+              "regime_accuracy": 0.7796609997749329,
+              "regime_loss": 0.5340805149684518
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.24111793971319873,
+              "regime_accuracy": 0.22727273404598236,
+              "regime_loss": 1.3277138926766134
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3524795833618666,
+              "regime_accuracy": 0.36936935782432556,
+              "regime_loss": 1.0847058188781642
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4736002966258806,
+              "regime_accuracy": 0.567307710647583,
+              "regime_loss": 1.0141640534767737
+            }
+          }
+        ]
+      },
+      {
+        "configuration": "derived_replacement",
+        "seed": 71,
+        "use_derived_text_features": false,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.45775953792369656,
+              "regime_accuracy": 0.5083333253860474,
+              "regime_loss": 1.12871497832648
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5823080369451338,
+              "regime_accuracy": 0.8644067645072937,
+              "regime_loss": 0.44867544356039013
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3973055692189977,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.058294770934365
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3234360410830999,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.13994837394434
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.37023985631872863,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.0882562674008882
+            }
+          }
+        ]
+      },
+      {
+        "configuration": "derived_replacement",
+        "seed": 97,
+        "use_derived_text_features": false,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2636622409389561,
+              "regime_accuracy": 0.38333332538604736,
+              "regime_loss": 1.2571061835395998
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5161563276746522,
+              "regime_accuracy": 0.8474576473236084,
+              "regime_loss": 0.4436723599999638
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.35340693654510985,
+              "regime_accuracy": 0.34545454382896423,
+              "regime_loss": 1.0103444814682008
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3392814028407249,
+              "regime_accuracy": 0.342342346906662,
+              "regime_loss": 1.104686117008108
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5238792418567699,
+              "regime_accuracy": 0.5480769276618958,
+              "regime_loss": 1.0682159112049983
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "baseline": {
+      "mean": 0.37729795333171295,
+      "std": 0.06708995776355044,
+      "lo": 0.3511161340481329,
+      "hi": 0.39970592561459667,
+      "n": 25
+    },
+    "derived_ablation": {
+      "mean": 0.4448260799943125,
+      "std": 0.11979775669435842,
+      "lo": 0.4008102678900452,
+      "hi": 0.4907007081203508,
+      "n": 25
+    },
+    "derived_replacement": {
+      "mean": 0.4448260799943125,
+      "std": 0.11979775669435842,
+      "lo": 0.4008102678900452,
+      "hi": 0.4907007081203508,
+      "n": 25
+    }
+  },
+  "replacement_arm": "deferred: pre-meeting wiring tracked in #315"
+}

--- a/backend/artifacts/experiments/runpod_20260530/runpod_lm_20260530T135613Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/runpod_lm_20260530T135613Z.json
@@ -1,0 +1,4330 @@
+{
+  "families": [
+    "linguistic",
+    "credibility",
+    "mp_surprise",
+    "multi_axis",
+    "realised_vol",
+    "cross_asset",
+    "llm_features"
+  ],
+  "cells": [
+    "baseline",
+    "zero_linguistic",
+    "zero_credibility",
+    "zero_mp_surprise",
+    "zero_multi_axis",
+    "zero_realised_vol",
+    "zero_cross_asset",
+    "zero_llm_features",
+    "cumulative_drop_text",
+    "cumulative_drop_text_market_aux",
+    "cumulative_drop_text_market_aux_cred_mp"
+  ],
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "hidden_size": 64,
+  "head_mode": "dual",
+  "regression_alpha": 0.5,
+  "bootstrap_samples": 500,
+  "bootstrap_seed": 11,
+  "training_package_id": "canonical",
+  "text_encoder": "finbert_fed_adjacent",
+  "rates_target_mode": "raw",
+  "rates_heads": [],
+  "use_retrieval_analogs": false,
+  "use_regime_conditioning": false,
+  "arm": "lm_lexicon",
+  "lm_lexicon_sha": "lm_master_2025",
+  "post_350_status": "pre-#350",
+  "cumulative_chain": [
+    {
+      "label": "cumulative_drop_text",
+      "families": [
+        "linguistic",
+        "multi_axis",
+        "llm_features"
+      ]
+    },
+    {
+      "label": "cumulative_drop_text_market_aux",
+      "families": [
+        "linguistic",
+        "multi_axis",
+        "llm_features",
+        "realised_vol",
+        "cross_asset"
+      ]
+    },
+    {
+      "label": "cumulative_drop_text_market_aux_cred_mp",
+      "families": [
+        "linguistic",
+        "multi_axis",
+        "llm_features",
+        "realised_vol",
+        "cross_asset",
+        "credibility",
+        "mp_surprise"
+      ]
+    }
+  ],
+  "trials": {
+    "baseline": [
+      {
+        "cell": "baseline",
+        "seed": 11,
+        "zeroed_families": [],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.40686274509803927,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.053127282329706,
+              "regression_rmse_log_rv": 0.8868903963930647,
+              "regression_mae_log_rv": 0.738910097758829,
+              "regression_loss": 0.7865745752142473
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.40776779163609683,
+              "regime_accuracy": 0.6101694703102112,
+              "regime_loss": 0.9310872453754231,
+              "regression_rmse_log_rv": 0.7211876098381103,
+              "regression_mae_log_rv": 0.5551299633363546,
+              "regression_loss": 0.5201115685840063
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.34324267341345144,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.6276919776743108,
+              "regression_rmse_log_rv": 0.8550415818766878,
+              "regression_mae_log_rv": 0.6889422807990658,
+              "regression_loss": 0.7310961067381885
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3732689456517135,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.1447594079012717,
+              "regression_rmse_log_rv": 0.894494629914135,
+              "regression_mae_log_rv": 0.710721214410958,
+              "regression_loss": 0.8001206429452252
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5120886282176605,
+              "regime_accuracy": 0.567307710647583,
+              "regime_loss": 1.045199834383451,
+              "regression_rmse_log_rv": 0.7209237163685761,
+              "regression_mae_log_rv": 0.583956377607627,
+              "regression_loss": 0.5197310048226792
+            }
+          }
+        ]
+      },
+      {
+        "cell": "baseline",
+        "seed": 29,
+        "zeroed_families": [],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3921982779125636,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.1492033412738563,
+              "regression_rmse_log_rv": 0.9484849097813159,
+              "regression_mae_log_rv": 0.7998699004664862,
+              "regression_loss": 0.899623624082871
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4197028671673702,
+              "regime_accuracy": 0.6525423526763916,
+              "regime_loss": 0.601044946807926,
+              "regression_rmse_log_rv": 0.8200398318015903,
+              "regression_mae_log_rv": 0.6280820915885901,
+              "regression_loss": 0.6724653257411807
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4301147279752448,
+              "regime_accuracy": 0.4636363685131073,
+              "regime_loss": 1.037862101468173,
+              "regression_rmse_log_rv": 0.43608849020037466,
+              "regression_mae_log_rv": 0.342689630061134,
+              "regression_loss": 0.19017317128524228
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4395545872670055,
+              "regime_accuracy": 0.45945945382118225,
+              "regime_loss": 1.0766728574688276,
+              "regression_rmse_log_rv": 0.8488525116137114,
+              "regression_mae_log_rv": 0.6719486115852723,
+              "regression_loss": 0.720550586472906
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5242512643997509,
+              "regime_accuracy": 0.5769230723381042,
+              "regime_loss": 1.0075969420946562,
+              "regression_rmse_log_rv": 0.7378048838313912,
+              "regression_mae_log_rv": 0.5687440689384508,
+              "regression_loss": 0.5443560466054527
+            }
+          }
+        ]
+      },
+      {
+        "cell": "baseline",
+        "seed": 47,
+        "zeroed_families": [],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3386724140604407,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.1632575618463157,
+              "regression_rmse_log_rv": 0.8927111743222509,
+              "regression_mae_log_rv": 0.7648936764084889,
+              "regression_loss": 0.7969332407598123
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4813311688311688,
+              "regime_accuracy": 0.7203390002250671,
+              "regime_loss": 0.6359883056858838,
+              "regression_rmse_log_rv": 0.8095143691360009,
+              "regression_mae_log_rv": 0.6208211450000941,
+              "regression_loss": 0.6553135138376576
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3817078346490111,
+              "regime_accuracy": 0.38181817531585693,
+              "regime_loss": 1.2291519013318148,
+              "regression_rmse_log_rv": 0.5483684292740214,
+              "regression_mae_log_rv": 0.4336194414793598,
+              "regression_loss": 0.30070793422445746
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3870229926567954,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.1133360426075634,
+              "regression_rmse_log_rv": 0.9097967444035988,
+              "regression_mae_log_rv": 0.737730937162498,
+              "regression_loss": 0.8277301161273873
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2912394765358006,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.1585957270402174,
+              "regression_rmse_log_rv": 0.881746510124701,
+              "regression_mae_log_rv": 0.7274367844668002,
+              "regression_loss": 0.7774769081170894
+            }
+          }
+        ]
+      },
+      {
+        "cell": "baseline",
+        "seed": 71,
+        "zeroed_families": [],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.40419157123085575,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.1461221173896352,
+              "regression_rmse_log_rv": 0.8661325212165173,
+              "regression_mae_log_rv": 0.7241591544259184,
+              "regression_loss": 0.7501855443088807
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3510224837455958,
+              "regime_accuracy": 0.6101694703102112,
+              "regime_loss": 0.7947095420400975,
+              "regression_rmse_log_rv": 0.8040188711323625,
+              "regression_mae_log_rv": 0.5984087261860653,
+              "regression_loss": 0.6464463451369585
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.41308440317626577,
+              "regime_accuracy": 0.4545454680919647,
+              "regime_loss": 1.0653191523118453,
+              "regression_rmse_log_rv": 0.41037948472060454,
+              "regression_mae_log_rv": 0.3138894712192599,
+              "regression_loss": 0.1684113214795489
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.36857825567502983,
+              "regime_accuracy": 0.4054054021835327,
+              "regime_loss": 1.0290479275807827,
+              "regression_rmse_log_rv": 0.829679524422724,
+              "regression_mae_log_rv": 0.6798140973121196,
+              "regression_loss": 0.6883681132463174
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4052996758177026,
+              "regime_accuracy": 0.45192307233810425,
+              "regime_loss": 1.0837723475236158,
+              "regression_rmse_log_rv": 0.7923107107176047,
+              "regression_mae_log_rv": 0.6445177495031833,
+              "regression_loss": 0.6277562623178359
+            }
+          }
+        ]
+      },
+      {
+        "cell": "baseline",
+        "seed": 97,
+        "zeroed_families": [],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3761425576519916,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.1353435234175488,
+              "regression_rmse_log_rv": 0.9317794073106658,
+              "regression_mae_log_rv": 0.8092405786019905,
+              "regression_loss": 0.8682128638882156
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.40642915642915645,
+              "regime_accuracy": 0.6864407062530518,
+              "regime_loss": 0.6269271363646297,
+              "regression_rmse_log_rv": 0.9064901470427753,
+              "regression_mae_log_rv": 0.6990948597253379,
+              "regression_loss": 0.8217243866856324
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2449203823379772,
+              "regime_accuracy": 0.23636363446712494,
+              "regime_loss": 1.594475769996643,
+              "regression_rmse_log_rv": 0.6367646113524226,
+              "regression_mae_log_rv": 0.46109580217902973,
+              "regression_loss": 0.4054691702708018
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4304412641621944,
+              "regime_accuracy": 0.45045045018196106,
+              "regime_loss": 1.0606441068301578,
+              "regression_rmse_log_rv": 0.8367447767472769,
+              "regression_mae_log_rv": 0.6823233985635746,
+              "regression_loss": 0.7001418214138503
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.446096306685367,
+              "regime_accuracy": 0.5480769276618958,
+              "regime_loss": 1.072254465176509,
+              "regression_rmse_log_rv": 0.7352318856555368,
+              "regression_mae_log_rv": 0.5589003713461212,
+              "regression_loss": 0.5405659256845963
+            }
+          }
+        ]
+      }
+    ],
+    "zero_linguistic": [
+      {
+        "cell": "zero_linguistic",
+        "seed": 11,
+        "zeroed_families": [
+          "linguistic"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.40686274509803927,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.053127282329706,
+              "regression_rmse_log_rv": 0.8868903963930647,
+              "regression_mae_log_rv": 0.738910097758829,
+              "regression_loss": 0.7865745752142473
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.40776779163609683,
+              "regime_accuracy": 0.6101694703102112,
+              "regime_loss": 0.9310872453754231,
+              "regression_rmse_log_rv": 0.7211876098381103,
+              "regression_mae_log_rv": 0.5551299633363546,
+              "regression_loss": 0.5201115685840063
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.34324267341345144,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.6276919776743108,
+              "regression_rmse_log_rv": 0.8550415818766878,
+              "regression_mae_log_rv": 0.6889422807990658,
+              "regression_loss": 0.7310961067381885
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3732689456517135,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.1447594079012717,
+              "regression_rmse_log_rv": 0.894494629914135,
+              "regression_mae_log_rv": 0.710721214410958,
+              "regression_loss": 0.8001206429452252
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5120886282176605,
+              "regime_accuracy": 0.567307710647583,
+              "regime_loss": 1.045199834383451,
+              "regression_rmse_log_rv": 0.7209237163685761,
+              "regression_mae_log_rv": 0.583956377607627,
+              "regression_loss": 0.5197310048226792
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_linguistic",
+        "seed": 29,
+        "zeroed_families": [
+          "linguistic"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3921982779125636,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.1492033412738563,
+              "regression_rmse_log_rv": 0.9484849097813159,
+              "regression_mae_log_rv": 0.7998699004664862,
+              "regression_loss": 0.899623624082871
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4197028671673702,
+              "regime_accuracy": 0.6525423526763916,
+              "regime_loss": 0.601044946807926,
+              "regression_rmse_log_rv": 0.8200398318015903,
+              "regression_mae_log_rv": 0.6280820915885901,
+              "regression_loss": 0.6724653257411807
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4301147279752448,
+              "regime_accuracy": 0.4636363685131073,
+              "regime_loss": 1.037862101468173,
+              "regression_rmse_log_rv": 0.43608849020037466,
+              "regression_mae_log_rv": 0.342689630061134,
+              "regression_loss": 0.19017317128524228
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4395545872670055,
+              "regime_accuracy": 0.45945945382118225,
+              "regime_loss": 1.0766728574688276,
+              "regression_rmse_log_rv": 0.8488525116137114,
+              "regression_mae_log_rv": 0.6719486115852723,
+              "regression_loss": 0.720550586472906
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5242512643997509,
+              "regime_accuracy": 0.5769230723381042,
+              "regime_loss": 1.0075969420946562,
+              "regression_rmse_log_rv": 0.7378048838313912,
+              "regression_mae_log_rv": 0.5687440689384508,
+              "regression_loss": 0.5443560466054527
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_linguistic",
+        "seed": 47,
+        "zeroed_families": [
+          "linguistic"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3386724140604407,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.1632575618463157,
+              "regression_rmse_log_rv": 0.8927111743222509,
+              "regression_mae_log_rv": 0.7648936764084889,
+              "regression_loss": 0.7969332407598123
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4813311688311688,
+              "regime_accuracy": 0.7203390002250671,
+              "regime_loss": 0.6359883056858838,
+              "regression_rmse_log_rv": 0.8095143691360009,
+              "regression_mae_log_rv": 0.6208211450000941,
+              "regression_loss": 0.6553135138376576
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3817078346490111,
+              "regime_accuracy": 0.38181817531585693,
+              "regime_loss": 1.2291519013318148,
+              "regression_rmse_log_rv": 0.5483684292740214,
+              "regression_mae_log_rv": 0.4336194414793598,
+              "regression_loss": 0.30070793422445746
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3870229926567954,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.1133360426075634,
+              "regression_rmse_log_rv": 0.9097967444035988,
+              "regression_mae_log_rv": 0.737730937162498,
+              "regression_loss": 0.8277301161273873
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2912394765358006,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.1585957270402174,
+              "regression_rmse_log_rv": 0.881746510124701,
+              "regression_mae_log_rv": 0.7274367844668002,
+              "regression_loss": 0.7774769081170894
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_linguistic",
+        "seed": 71,
+        "zeroed_families": [
+          "linguistic"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.40419157123085575,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.1461221173896352,
+              "regression_rmse_log_rv": 0.8661325212165173,
+              "regression_mae_log_rv": 0.7241591544259184,
+              "regression_loss": 0.7501855443088807
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3510224837455958,
+              "regime_accuracy": 0.6101694703102112,
+              "regime_loss": 0.7947095420400975,
+              "regression_rmse_log_rv": 0.8040188711323625,
+              "regression_mae_log_rv": 0.5984087261860653,
+              "regression_loss": 0.6464463451369585
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.41308440317626577,
+              "regime_accuracy": 0.4545454680919647,
+              "regime_loss": 1.0653191523118453,
+              "regression_rmse_log_rv": 0.41037948472060454,
+              "regression_mae_log_rv": 0.3138894712192599,
+              "regression_loss": 0.1684113214795489
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.36857825567502983,
+              "regime_accuracy": 0.4054054021835327,
+              "regime_loss": 1.0290479275807827,
+              "regression_rmse_log_rv": 0.829679524422724,
+              "regression_mae_log_rv": 0.6798140973121196,
+              "regression_loss": 0.6883681132463174
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4052996758177026,
+              "regime_accuracy": 0.45192307233810425,
+              "regime_loss": 1.0837723475236158,
+              "regression_rmse_log_rv": 0.7923107107176047,
+              "regression_mae_log_rv": 0.6445177495031833,
+              "regression_loss": 0.6277562623178359
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_linguistic",
+        "seed": 97,
+        "zeroed_families": [
+          "linguistic"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3761425576519916,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.1353435234175488,
+              "regression_rmse_log_rv": 0.9317794073106658,
+              "regression_mae_log_rv": 0.8092405786019905,
+              "regression_loss": 0.8682128638882156
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.40642915642915645,
+              "regime_accuracy": 0.6864407062530518,
+              "regime_loss": 0.6269271363646297,
+              "regression_rmse_log_rv": 0.9064901470427753,
+              "regression_mae_log_rv": 0.6990948597253379,
+              "regression_loss": 0.8217243866856324
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2449203823379772,
+              "regime_accuracy": 0.23636363446712494,
+              "regime_loss": 1.594475769996643,
+              "regression_rmse_log_rv": 0.6367646113524226,
+              "regression_mae_log_rv": 0.46109580217902973,
+              "regression_loss": 0.4054691702708018
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4304412641621944,
+              "regime_accuracy": 0.45045045018196106,
+              "regime_loss": 1.0606441068301578,
+              "regression_rmse_log_rv": 0.8367447767472769,
+              "regression_mae_log_rv": 0.6823233985635746,
+              "regression_loss": 0.7001418214138503
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.446096306685367,
+              "regime_accuracy": 0.5480769276618958,
+              "regime_loss": 1.072254465176509,
+              "regression_rmse_log_rv": 0.7352318856555368,
+              "regression_mae_log_rv": 0.5589003713461212,
+              "regression_loss": 0.5405659256845963
+            }
+          }
+        ]
+      }
+    ],
+    "zero_credibility": [
+      {
+        "cell": "zero_credibility",
+        "seed": 11,
+        "zeroed_families": [
+          "credibility"
+        ],
+        "loader_flags": {
+          "use_credibility": false,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3834121626792794,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.043160901065972,
+              "regression_rmse_log_rv": 0.8814205097385116,
+              "regression_mae_log_rv": 0.7287422612988546,
+              "regression_loss": 0.7769021149876977
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.407843137254902,
+              "regime_accuracy": 0.6525423526763916,
+              "regime_loss": 0.6414023274082249,
+              "regression_rmse_log_rv": 0.8144695475022188,
+              "regression_mae_log_rv": 0.6310250369547787,
+              "regression_loss": 0.6633606438084689
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2464782435034547,
+              "regime_accuracy": 0.22727273404598236,
+              "regime_loss": 1.4257822080091997,
+              "regression_rmse_log_rv": 0.7274169521195908,
+              "regression_mae_log_rv": 0.588571049457162,
+              "regression_loss": 0.529135422230955
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.41494936231778334,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.129110260020521,
+              "regression_rmse_log_rv": 0.8963286760149323,
+              "regression_mae_log_rv": 0.7165277741245322,
+              "regression_loss": 0.8034050954466814
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.431961438635521,
+              "regime_accuracy": 0.5865384340286255,
+              "regime_loss": 0.9841726834957416,
+              "regression_rmse_log_rv": 0.7084597978984949,
+              "regression_mae_log_rv": 0.563280927688958,
+              "regression_loss": 0.5019152852383763
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_credibility",
+        "seed": 29,
+        "zeroed_families": [
+          "credibility"
+        ],
+        "loader_flags": {
+          "use_credibility": false,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4743242253314775,
+              "regime_accuracy": 0.4833333194255829,
+              "regime_loss": 1.149843328521022,
+              "regression_rmse_log_rv": 0.9128547184538642,
+              "regression_mae_log_rv": 0.7386153338224782,
+              "regression_loss": 0.8333037370034837
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4901504305425874,
+              "regime_accuracy": 0.694915235042572,
+              "regime_loss": 0.5450712523217929,
+              "regression_rmse_log_rv": 0.7610903744572199,
+              "regression_mae_log_rv": 0.6036310801440377,
+              "regression_loss": 0.5792585580914312
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4375826719576719,
+              "regime_accuracy": 0.4727272689342499,
+              "regime_loss": 1.1185999870300294,
+              "regression_rmse_log_rv": 0.591426532869905,
+              "regression_mae_log_rv": 0.4127057280031626,
+              "regression_loss": 0.34978534378251686
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.42589347795855925,
+              "regime_accuracy": 0.44144144654273987,
+              "regime_loss": 1.0704307090811775,
+              "regression_rmse_log_rv": 0.847303053947512,
+              "regression_mae_log_rv": 0.6648508738558572,
+              "regression_loss": 0.7179224652287804
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.31823251823251825,
+              "regime_accuracy": 0.4134615361690521,
+              "regime_loss": 1.0703747730988722,
+              "regression_rmse_log_rv": 0.7558655866005689,
+              "regression_mae_log_rv": 0.6019473958026188,
+              "regression_loss": 0.5713327850070221
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_credibility",
+        "seed": 47,
+        "zeroed_families": [
+          "credibility"
+        ],
+        "loader_flags": {
+          "use_credibility": false,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3440626330353342,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.0879980219978669,
+              "regression_rmse_log_rv": 0.8855875543666898,
+              "regression_mae_log_rv": 0.7481314962167137,
+              "regression_loss": 0.7842653164491747
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5495210727969349,
+              "regime_accuracy": 0.7457627058029175,
+              "regime_loss": 0.5862482973074509,
+              "regression_rmse_log_rv": 0.7570868522111176,
+              "regression_mae_log_rv": 0.5753729510736667,
+              "regression_loss": 0.5731805017909386
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4381171851662186,
+              "regime_accuracy": 0.44545453786849976,
+              "regime_loss": 1.092546692761508,
+              "regression_rmse_log_rv": 0.48146168957490687,
+              "regression_mae_log_rv": 0.39133719853760507,
+              "regression_loss": 0.23180535852832398
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3867912029676736,
+              "regime_accuracy": 0.38738739490509033,
+              "regime_loss": 1.115598773047325,
+              "regression_rmse_log_rv": 0.8837799345103241,
+              "regression_mae_log_rv": 0.7227539620152464,
+              "regression_loss": 0.7810669726430727
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.26623322497290985,
+              "regime_accuracy": 0.3461538553237915,
+              "regime_loss": 1.204553246498108,
+              "regression_rmse_log_rv": 0.8833918070341861,
+              "regression_mae_log_rv": 0.7241151318795835,
+              "regression_loss": 0.7803810847351247
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_credibility",
+        "seed": 71,
+        "zeroed_families": [
+          "credibility"
+        ],
+        "loader_flags": {
+          "use_credibility": false,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3950171343891822,
+              "regime_accuracy": 0.4333333373069763,
+              "regime_loss": 1.1386091368871945,
+              "regression_rmse_log_rv": 0.8631442209222776,
+              "regression_mae_log_rv": 0.7270738013146911,
+              "regression_loss": 0.7450179461115255
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.460573476702509,
+              "regime_accuracy": 0.7542372941970825,
+              "regime_loss": 0.5032668101080393,
+              "regression_rmse_log_rv": 0.6987475297813758,
+              "regression_mae_log_rv": 0.5456500084344613,
+              "regression_loss": 0.48824811037557464
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.43099159196720166,
+              "regime_accuracy": 0.4636363685131073,
+              "regime_loss": 1.0738708127628673,
+              "regression_rmse_log_rv": 0.4087292615643367,
+              "regression_mae_log_rv": 0.30643320880957287,
+              "regression_loss": 0.16705960925892796
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4632388548639795,
+              "regime_accuracy": 0.4864864945411682,
+              "regime_loss": 1.0162978244733034,
+              "regression_rmse_log_rv": 0.8256083228426895,
+              "regression_mae_log_rv": 0.6761344680646518,
+              "regression_loss": 0.6816291027471185
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.43577814267469445,
+              "regime_accuracy": 0.567307710647583,
+              "regime_loss": 0.9936181490237896,
+              "regression_rmse_log_rv": 0.750814835274282,
+              "regression_mae_log_rv": 0.6024372314299958,
+              "regression_loss": 0.5637229168679473
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_credibility",
+        "seed": 97,
+        "zeroed_families": [
+          "credibility"
+        ],
+        "loader_flags": {
+          "use_credibility": false,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.31826156299840513,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.1069349220325464,
+              "regression_rmse_log_rv": 0.8592550964184834,
+              "regression_mae_log_rv": 0.7021100481719865,
+              "regression_loss": 0.7383193207211373
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.47727840199750315,
+              "regime_accuracy": 0.7203390002250671,
+              "regime_loss": 0.5148737779108145,
+              "regression_rmse_log_rv": 0.6938060518878008,
+              "regression_mae_log_rv": 0.560623143310264,
+              "regression_loss": 0.4813668376361377
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3434343434343434,
+              "regime_accuracy": 0.34545454382896423,
+              "regime_loss": 1.1912274208935825,
+              "regression_rmse_log_rv": 0.625111998148002,
+              "regression_mae_log_rv": 0.44856996136844496,
+              "regression_loss": 0.3907650102285877
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3499322493224932,
+              "regime_accuracy": 0.3513513505458832,
+              "regime_loss": 1.1248543034476,
+              "regression_rmse_log_rv": 0.8830667848987259,
+              "regression_mae_log_rv": 0.711018520887723,
+              "regression_loss": 0.7798069465913727
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5182781825541388,
+              "regime_accuracy": 0.625,
+              "regime_loss": 0.966482414649083,
+              "regression_rmse_log_rv": 0.7156818966616434,
+              "regression_mae_log_rv": 0.5624871531427533,
+              "regression_loss": 0.5122005772092072
+            }
+          }
+        ]
+      }
+    ],
+    "zero_mp_surprise": [
+      {
+        "cell": "zero_mp_surprise",
+        "seed": 11,
+        "zeroed_families": [
+          "mp_surprise"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": false,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4795959595959595,
+              "regime_accuracy": 0.4833333194255829,
+              "regime_loss": 1.0630402052173904,
+              "regression_rmse_log_rv": 0.8517667792201054,
+              "regression_mae_log_rv": 0.7295832431002054,
+              "regression_loss": 0.7255066461829917
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4664224664224664,
+              "regime_accuracy": 0.7966101765632629,
+              "regime_loss": 0.8192824367749489,
+              "regression_rmse_log_rv": 0.5738227202749855,
+              "regression_mae_log_rv": 0.4448312397541131,
+              "regression_loss": 0.32927251430378424
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.27659932659932657,
+              "regime_accuracy": 0.26363635063171387,
+              "regime_loss": 1.155975207415494,
+              "regression_rmse_log_rv": 0.48513958137778895,
+              "regression_mae_log_rv": 0.360680242202414,
+              "regression_loss": 0.23536041341941633
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.39304611985639326,
+              "regime_accuracy": 0.4054054021835327,
+              "regime_loss": 1.1312267295020946,
+              "regression_rmse_log_rv": 0.7742482469240902,
+              "regression_mae_log_rv": 0.6338625801307661,
+              "regression_loss": 0.599460347865027
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.42509193164611725,
+              "regime_accuracy": 0.567307710647583,
+              "regime_loss": 1.0149753322968116,
+              "regression_rmse_log_rv": 0.7450043252200353,
+              "regression_mae_log_rv": 0.5979553417642959,
+              "regression_loss": 0.5550314445965602
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_mp_surprise",
+        "seed": 29,
+        "zeroed_families": [
+          "mp_surprise"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": false,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.43000097153405226,
+              "regime_accuracy": 0.4333333373069763,
+              "regime_loss": 1.118716508261723,
+              "regression_rmse_log_rv": 0.896633033039021,
+              "regression_mae_log_rv": 0.7624545083749884,
+              "regression_loss": 0.8039507959367541
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.7332788763363798,
+              "regime_accuracy": 0.8389830589294434,
+              "regime_loss": 0.659688436883991,
+              "regression_rmse_log_rv": 0.5471726097201208,
+              "regression_mae_log_rv": 0.45266452501133336,
+              "regression_loss": 0.29939786482792763
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3849275362318841,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 0.9754921739751642,
+              "regression_rmse_log_rv": 0.4201687307364905,
+              "regression_mae_log_rv": 0.3165380901720544,
+              "regression_loss": 0.17654176228871346
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3899868247694334,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.0670042084733984,
+              "regression_rmse_log_rv": 0.7574786422536856,
+              "regression_mae_log_rv": 0.6346523086330643,
+              "regression_loss": 0.5737738934704869
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5164259386503647,
+              "regime_accuracy": 0.5480769276618958,
+              "regime_loss": 1.0994639717615569,
+              "regression_rmse_log_rv": 0.8285790698206801,
+              "regression_mae_log_rv": 0.6654972775678079,
+              "regression_loss": 0.6865432749449035
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_mp_surprise",
+        "seed": 47,
+        "zeroed_families": [
+          "mp_surprise"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": false,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4447415329768271,
+              "regime_accuracy": 0.44999998807907104,
+              "regime_loss": 1.0738407796399494,
+              "regression_rmse_log_rv": 0.9139787877419034,
+              "regression_mae_log_rv": 0.7645510621427093,
+              "regression_loss": 0.8353572244421593
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4729654403567447,
+              "regime_accuracy": 0.7457627058029175,
+              "regime_loss": 0.5417720397650185,
+              "regression_rmse_log_rv": 0.5966082948425104,
+              "regression_mae_log_rv": 0.5037686533089412,
+              "regression_loss": 0.3559414574748878
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4673096937258401,
+              "regime_accuracy": 0.5181818008422852,
+              "regime_loss": 0.9398609215562994,
+              "regression_rmse_log_rv": 0.42826576539669925,
+              "regression_mae_log_rv": 0.3263398987092924,
+              "regression_loss": 0.18341156581082063
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.40273672687465795,
+              "regime_accuracy": 0.4054054021835327,
+              "regime_loss": 1.209674844502984,
+              "regression_rmse_log_rv": 0.8187738415766084,
+              "regression_mae_log_rv": 0.6890909459676828,
+              "regression_loss": 0.670390603650117
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3217054263565891,
+              "regime_accuracy": 0.42307692766189575,
+              "regime_loss": 1.1329890076930706,
+              "regression_rmse_log_rv": 0.9187041333394264,
+              "regression_mae_log_rv": 0.7566661069868132,
+              "regression_loss": 0.8440172846149464
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_mp_surprise",
+        "seed": 71,
+        "zeroed_families": [
+          "mp_surprise"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": false,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.44173979173979167,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.1657051432481704,
+              "regression_rmse_log_rv": 0.9033425378208386,
+              "regression_mae_log_rv": 0.7709391612617764,
+              "regression_loss": 0.8160277406365933
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4664224664224664,
+              "regime_accuracy": 0.7966101765632629,
+              "regime_loss": 0.5403443703712043,
+              "regression_rmse_log_rv": 0.5707851324290111,
+              "regression_mae_log_rv": 0.47313049410359337,
+              "regression_loss": 0.3257956674020038
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4200650118203309,
+              "regime_accuracy": 0.5,
+              "regime_loss": 0.939775678244504,
+              "regression_rmse_log_rv": 0.38811558396649704,
+              "regression_mae_log_rv": 0.2774042308140038,
+              "regression_loss": 0.150633706517655
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3070235644017387,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.0502406039908418,
+              "regression_rmse_log_rv": 0.8105950020321973,
+              "regression_mae_log_rv": 0.6902875717695769,
+              "regression_loss": 0.6570642573195778
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.37761422136422135,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.0966722690142119,
+              "regression_rmse_log_rv": 0.7956121246710012,
+              "regression_mae_log_rv": 0.6432180860026094,
+              "regression_loss": 0.6329986529235048
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_mp_surprise",
+        "seed": 97,
+        "zeroed_families": [
+          "mp_surprise"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": false,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4395711500974659,
+              "regime_accuracy": 0.46666666865348816,
+              "regime_loss": 1.0627136743796088,
+              "regression_rmse_log_rv": 0.8382552304823725,
+              "regression_mae_log_rv": 0.7167356903237911,
+              "regression_loss": 0.7026718314310554
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5734020310633214,
+              "regime_accuracy": 0.8305084705352783,
+              "regime_loss": 0.522670062921815,
+              "regression_rmse_log_rv": 0.5964747646262261,
+              "regression_mae_log_rv": 0.4801134443605098,
+              "regression_loss": 0.3557821448359118
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.32283858070964516,
+              "regime_accuracy": 0.33636364340782166,
+              "regime_loss": 1.032813835144043,
+              "regression_rmse_log_rv": 0.4120434622600832,
+              "regression_mae_log_rv": 0.3348065476293083,
+              "regression_loss": 0.16977981479127663
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3894027913015255,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.1072992689323486,
+              "regression_rmse_log_rv": 0.7594128128080657,
+              "regression_mae_log_rv": 0.6223047105511567,
+              "regression_loss": 0.5767078202570582
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.30429126633932385,
+              "regime_accuracy": 0.3173076808452606,
+              "regime_loss": 1.112514587549063,
+              "regression_rmse_log_rv": 0.7763201534054152,
+              "regression_mae_log_rv": 0.6300808861941243,
+              "regression_loss": 0.6026729805834073
+            }
+          }
+        ]
+      }
+    ],
+    "zero_multi_axis": [
+      {
+        "cell": "zero_multi_axis",
+        "seed": 11,
+        "zeroed_families": [
+          "multi_axis"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4173947364711521,
+              "regime_accuracy": 0.4333333373069763,
+              "regime_loss": 1.053417990469528,
+              "regression_rmse_log_rv": 0.8871008865774099,
+              "regression_mae_log_rv": 0.7378607179406875,
+              "regression_loss": 0.7869479829664267
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4073501771127015,
+              "regime_accuracy": 0.6101694703102112,
+              "regime_loss": 0.9048826371209097,
+              "regression_rmse_log_rv": 0.7232475253005359,
+              "regression_mae_log_rv": 0.5520552344999071,
+              "regression_loss": 0.5230869828533494
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.28500724471898115,
+              "regime_accuracy": 0.26363635063171387,
+              "regime_loss": 1.4315726041793824,
+              "regression_rmse_log_rv": 0.7184967134942767,
+              "regression_mae_log_rv": 0.5476370840396901,
+              "regression_loss": 0.5162375273020767
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3943560451516388,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.2012988971514593,
+              "regression_rmse_log_rv": 0.9352667499313861,
+              "regression_mae_log_rv": 0.7798620996375879,
+              "regression_loss": 0.8747238935272179
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.39250842310590944,
+              "regime_accuracy": 0.45192307233810425,
+              "regime_loss": 1.1214215938861554,
+              "regression_rmse_log_rv": 0.773076654321268,
+              "regression_mae_log_rv": 0.6308943759560441,
+              "regression_loss": 0.5976475134565653
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_multi_axis",
+        "seed": 29,
+        "zeroed_families": [
+          "multi_axis"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3845524464081165,
+              "regime_accuracy": 0.38333332538604736,
+              "regime_loss": 1.1517392687508978,
+              "regression_rmse_log_rv": 0.9553266995245014,
+              "regression_mae_log_rv": 0.805350493862837,
+              "regression_loss": 0.9126491028243772
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3967618726654871,
+              "regime_accuracy": 0.6271186470985413,
+              "regime_loss": 0.7862562133094012,
+              "regression_rmse_log_rv": 0.7763209339446375,
+              "regression_mae_log_rv": 0.5884032137376272,
+              "regression_loss": 0.6026741924806742
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4037429502566205,
+              "regime_accuracy": 0.44545453786849976,
+              "regime_loss": 1.0354307629845358,
+              "regression_rmse_log_rv": 0.43636672501145995,
+              "regression_mae_log_rv": 0.34357580474196847,
+              "regression_loss": 0.19041591869722713
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4477687443541101,
+              "regime_accuracy": 0.46846845746040344,
+              "regime_loss": 1.0755797184278757,
+              "regression_rmse_log_rv": 0.8506570017814464,
+              "regression_mae_log_rv": 0.6738636634975403,
+              "regression_loss": 0.7236173346797998
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5242512643997509,
+              "regime_accuracy": 0.5769230723381042,
+              "regime_loss": 1.0100931708629315,
+              "regression_rmse_log_rv": 0.7384535806247361,
+              "regression_mae_log_rv": 0.5708749119926674,
+              "regression_loss": 0.5453136907374936
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_multi_axis",
+        "seed": 47,
+        "zeroed_families": [
+          "multi_axis"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.42928885301766656,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.1294674544003382,
+              "regression_rmse_log_rv": 0.9355249800313947,
+              "regression_mae_log_rv": 0.8141581289528403,
+              "regression_loss": 0.8752069882627415
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4567770454069889,
+              "regime_accuracy": 0.7118644118309021,
+              "regime_loss": 0.6389204768811242,
+              "regression_rmse_log_rv": 0.7894395582839859,
+              "regression_mae_log_rv": 0.6109528131783009,
+              "regression_loss": 0.6232148161836147
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.34798287130944333,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.1329043193296953,
+              "regression_rmse_log_rv": 0.5196083258539145,
+              "regression_mae_log_rv": 0.4229222632754086,
+              "regression_loss": 0.2699928122967078
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.35650059359991365,
+              "regime_accuracy": 0.36036035418510437,
+              "regime_loss": 1.1194101557846416,
+              "regression_rmse_log_rv": 0.9158403063081735,
+              "regression_mae_log_rv": 0.7430960323225271,
+              "regression_loss": 0.838763466658649
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.28369148758953855,
+              "regime_accuracy": 0.36538460850715637,
+              "regime_loss": 1.164431434411269,
+              "regression_rmse_log_rv": 0.8907830083340904,
+              "regression_mae_log_rv": 0.7364697924439008,
+              "regression_loss": 0.7934943679367321
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_multi_axis",
+        "seed": 71,
+        "zeroed_families": [
+          "multi_axis"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3858774402338449,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.1500993517907574,
+              "regression_rmse_log_rv": 0.8699905573159628,
+              "regression_mae_log_rv": 0.7260796679552489,
+              "regression_loss": 0.7568835698189395
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3510224837455958,
+              "regime_accuracy": 0.6101694703102112,
+              "regime_loss": 0.7951312519736209,
+              "regression_rmse_log_rv": 0.8018065227220849,
+              "regression_mae_log_rv": 0.5956804229546402,
+              "regression_loss": 0.6428936998796813
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4034017971758665,
+              "regime_accuracy": 0.44545453786849976,
+              "regime_loss": 1.065337324142456,
+              "regression_rmse_log_rv": 0.41212326916037867,
+              "regression_mae_log_rv": 0.3131940835388377,
+              "regression_loss": 0.16984558898343793
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3827103601297149,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.0292070891892748,
+              "regression_rmse_log_rv": 0.8279058377993528,
+              "regression_mae_log_rv": 0.6773367443600217,
+              "regression_loss": 0.6854280762622482
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4380273321449792,
+              "regime_accuracy": 0.49038460850715637,
+              "regime_loss": 1.0523055791854858,
+              "regression_rmse_log_rv": 0.7702439378516541,
+              "regression_mae_log_rv": 0.6207391457327713,
+              "regression_loss": 0.5932757237972228
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_multi_axis",
+        "seed": 97,
+        "zeroed_families": [
+          "multi_axis"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.39444444444444443,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.1390900714245003,
+              "regression_rmse_log_rv": 0.9204401391266137,
+              "regression_mae_log_rv": 0.7828881399395565,
+              "regression_loss": 0.8472100497154199
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.44098883572567776,
+              "regime_accuracy": 0.7118644118309021,
+              "regime_loss": 0.628870884745808,
+              "regression_rmse_log_rv": 0.8706592828695447,
+              "regression_mae_log_rv": 0.6622240781641991,
+              "regression_loss": 0.75804758684691
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.31582125603864736,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.6395618005232377,
+              "regression_rmse_log_rv": 0.644663216321033,
+              "regression_mae_log_rv": 0.46996987079566516,
+              "regression_loss": 0.41559066247737897
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.43422025129342195,
+              "regime_accuracy": 0.45045045018196106,
+              "regime_loss": 1.0633834993600952,
+              "regression_rmse_log_rv": 0.8375669172953706,
+              "regression_mae_log_rv": 0.6844573787723979,
+              "regression_loss": 0.7015183409476701
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.40737628384687213,
+              "regime_accuracy": 0.5384615659713745,
+              "regime_loss": 1.0391515676791852,
+              "regression_rmse_log_rv": 0.7337133202599974,
+              "regression_mae_log_rv": 0.5584924598582662,
+              "regression_loss": 0.5383352363269495
+            }
+          }
+        ]
+      }
+    ],
+    "zero_realised_vol": [
+      {
+        "cell": "zero_realised_vol",
+        "seed": 11,
+        "zeroed_families": [
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3748845010520325,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.1909853465352038,
+              "regression_rmse_log_rv": 0.9004009982983682,
+              "regression_mae_log_rv": 0.777441820508102,
+              "regression_loss": 0.810721957736698
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4377675055641157,
+              "regime_accuracy": 0.7288135886192322,
+              "regime_loss": 0.6212150333291393,
+              "regression_rmse_log_rv": 0.7026093961058115,
+              "regression_mae_log_rv": 0.542461289787444,
+              "regression_loss": 0.4936599634961731
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3423356370724792,
+              "regime_accuracy": 0.33636364340782166,
+              "regime_loss": 1.2362631992860273,
+              "regression_rmse_log_rv": 0.7191702367724158,
+              "regression_mae_log_rv": 0.5054248852972788,
+              "regression_loss": 0.5172058294592925
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.45008938557325656,
+              "regime_accuracy": 0.45945945382118225,
+              "regime_loss": 1.1159164080988626,
+              "regression_rmse_log_rv": 0.8537759915145606,
+              "regression_mae_log_rv": 0.6759207650079383,
+              "regression_loss": 0.7289334436866711
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4853360147477795,
+              "regime_accuracy": 0.4615384638309479,
+              "regime_loss": 1.0362852536714995,
+              "regression_rmse_log_rv": 0.6904788342337728,
+              "regression_mae_log_rv": 0.537386956741102,
+              "regression_loss": 0.4767610205248298
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_realised_vol",
+        "seed": 29,
+        "zeroed_families": [
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3758542413381123,
+              "regime_accuracy": 0.38333332538604736,
+              "regime_loss": 1.0812667856403655,
+              "regression_rmse_log_rv": 0.8491811939550481,
+              "regression_mae_log_rv": 0.6909452308027539,
+              "regression_loss": 0.7211087001669211
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.46687757645479816,
+              "regime_accuracy": 0.7627118825912476,
+              "regime_loss": 0.5295100090867382,
+              "regression_rmse_log_rv": 0.769252213098911,
+              "regression_mae_log_rv": 0.5884071311960786,
+              "regression_loss": 0.5917489673575724
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.43352186579385715,
+              "regime_accuracy": 0.4272727370262146,
+              "regime_loss": 1.2063490997661244,
+              "regression_rmse_log_rv": 0.6411773102358274,
+              "regression_mae_log_rv": 0.4557302582479844,
+              "regression_loss": 0.41110834316125044
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3509103624172117,
+              "regime_accuracy": 0.3513513505458832,
+              "regime_loss": 1.1949264746345218,
+              "regression_rmse_log_rv": 0.9063554284483731,
+              "regression_mae_log_rv": 0.7045518908616122,
+              "regression_loss": 0.821480162677834
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.459051031188278,
+              "regime_accuracy": 0.6057692170143127,
+              "regime_loss": 0.9444814049280607,
+              "regression_rmse_log_rv": 0.7033974431842758,
+              "regression_mae_log_rv": 0.5361698193457693,
+              "regression_loss": 0.4947679630781765
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_realised_vol",
+        "seed": 47,
+        "zeroed_families": [
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4134680134680135,
+              "regime_accuracy": 0.44999998807907104,
+              "regime_loss": 1.0902478441249128,
+              "regression_rmse_log_rv": 0.9357924511160836,
+              "regression_mae_log_rv": 0.8085462831018958,
+              "regression_loss": 0.8757075115658476
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.36808080808080806,
+              "regime_accuracy": 0.6355932354927063,
+              "regime_loss": 0.850717175815065,
+              "regression_rmse_log_rv": 0.8080861747337272,
+              "regression_mae_log_rv": 0.6099688579975548,
+              "regression_loss": 0.6530032657957879
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4326135183611819,
+              "regime_accuracy": 0.4363636374473572,
+              "regime_loss": 1.1054250001907349,
+              "regression_rmse_log_rv": 0.5625758110873247,
+              "regression_mae_log_rv": 0.43544124559372327,
+              "regression_loss": 0.3164915432205612
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.35313536407523305,
+              "regime_accuracy": 0.36036035418510437,
+              "regime_loss": 1.3509502982977615,
+              "regression_rmse_log_rv": 1.0711301302547929,
+              "regression_mae_log_rv": 0.8609914775635745,
+              "regression_loss": 1.1473197559396497
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2214973594283939,
+              "regime_accuracy": 0.2884615361690521,
+              "regime_loss": 1.2355393629807692,
+              "regression_rmse_log_rv": 0.9466437748605182,
+              "regression_mae_log_rv": 0.7783304370778541,
+              "regression_loss": 0.8961344364821715
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_realised_vol",
+        "seed": 71,
+        "zeroed_families": [
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4186091686091686,
+              "regime_accuracy": 0.4833333194255829,
+              "regime_loss": 1.2162251807599902,
+              "regression_rmse_log_rv": 0.9325271246286929,
+              "regression_mae_log_rv": 0.81499100967582,
+              "regression_loss": 0.8696068381682577
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5289568006036597,
+              "regime_accuracy": 0.805084764957428,
+              "regime_loss": 0.44581749227087375,
+              "regression_rmse_log_rv": 0.5850950639371345,
+              "regression_mae_log_rv": 0.46508075347391226,
+              "regression_loss": 0.34233623384359957
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3717845117845118,
+              "regime_accuracy": 0.4909090995788574,
+              "regime_loss": 1.1938787547024814,
+              "regression_rmse_log_rv": 0.5907928651221056,
+              "regression_mae_log_rv": 0.4477297107413919,
+              "regression_loss": 0.3490362094791865
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.24667729930887825,
+              "regime_accuracy": 0.29729729890823364,
+              "regime_loss": 1.6234349708895097,
+              "regression_rmse_log_rv": 1.0517867412172321,
+              "regression_mae_log_rv": 0.8640299253501333,
+              "regression_loss": 1.1062553490003648
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4333513708513708,
+              "regime_accuracy": 0.4711538553237915,
+              "regime_loss": 1.019321322441101,
+              "regression_rmse_log_rv": 0.7650505934806491,
+              "regression_mae_log_rv": 0.6094880818586367,
+              "regression_loss": 0.5853024105850934
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_realised_vol",
+        "seed": 97,
+        "zeroed_families": [
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3200613676212741,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.2272899124084107,
+              "regression_rmse_log_rv": 0.888050563928442,
+              "regression_mae_log_rv": 0.7728407562302891,
+              "regression_loss": 0.7886338040936238
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4551701022289258,
+              "regime_accuracy": 0.7457627058029175,
+              "regime_loss": 0.5866145764367056,
+              "regression_rmse_log_rv": 0.8607606774936077,
+              "regression_mae_log_rv": 0.6715286119635833,
+              "regression_loss": 0.7409089439192547
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3267913491880243,
+              "regime_accuracy": 0.5,
+              "regime_loss": 1.2624822529879483,
+              "regression_rmse_log_rv": 0.5930278801750276,
+              "regression_mae_log_rv": 0.4321452376496216,
+              "regression_loss": 0.35168206666488694
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.43397693525570763,
+              "regime_accuracy": 0.45045045018196106,
+              "regime_loss": 1.1784482602926472,
+              "regression_rmse_log_rv": 0.9232645628789956,
+              "regression_mae_log_rv": 0.7225438387443622,
+              "regression_loss": 0.8524174530681429
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4515625761786359,
+              "regime_accuracy": 0.6057692170143127,
+              "regime_loss": 1.0175105654276335,
+              "regression_rmse_log_rv": 0.7032475935540302,
+              "regression_mae_log_rv": 0.5445948069503245,
+              "regression_loss": 0.4945571778395345
+            }
+          }
+        ]
+      }
+    ],
+    "zero_cross_asset": [
+      {
+        "cell": "zero_cross_asset",
+        "seed": 11,
+        "zeroed_families": [
+          "cross_asset"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3544109133014908,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.1519861784116752,
+              "regression_rmse_log_rv": 0.9247215269296606,
+              "regression_mae_log_rv": 0.7727548388822469,
+              "regression_loss": 0.855109902367123
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4168324060320738,
+              "regime_accuracy": 0.5932203531265259,
+              "regime_loss": 0.9957998314146268,
+              "regression_rmse_log_rv": 0.7944515347091373,
+              "regression_mae_log_rv": 0.6199794351991456,
+              "regression_loss": 0.6311532410017037
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.32250779612978514,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.1657301729375666,
+              "regression_rmse_log_rv": 0.49603322237113817,
+              "regression_mae_log_rv": 0.38752745140386236,
+              "regression_loss": 0.246048957695895
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3619002463626644,
+              "regime_accuracy": 0.36936935782432556,
+              "regime_loss": 1.1027395665568813,
+              "regression_rmse_log_rv": 0.9204670024136168,
+              "regression_mae_log_rv": 0.7624804775255758,
+              "regression_loss": 0.8472595025323093
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3969342893393526,
+              "regime_accuracy": 0.4038461446762085,
+              "regime_loss": 1.343638906112084,
+              "regression_rmse_log_rv": 0.9405782645096865,
+              "regression_mae_log_rv": 0.7739451032293101,
+              "regression_loss": 0.8846874716680537
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_cross_asset",
+        "seed": 29,
+        "zeroed_families": [
+          "cross_asset"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3768443529322047,
+              "regime_accuracy": 0.38333332538604736,
+              "regime_loss": 1.1749567426026528,
+              "regression_rmse_log_rv": 0.9408408978967938,
+              "regression_mae_log_rv": 0.792909873034417,
+              "regression_loss": 0.8851815951552453
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.45962532299741604,
+              "regime_accuracy": 0.7033898234367371,
+              "regime_loss": 0.7187534530284041,
+              "regression_rmse_log_rv": 0.8497842643354927,
+              "regression_mae_log_rv": 0.6530586684406814,
+              "regression_loss": 0.7221332959122145
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.29856541567788747,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.2040214386853305,
+              "regression_rmse_log_rv": 0.568698560700302,
+              "regression_mae_log_rv": 0.4238533217946745,
+              "regression_loss": 0.32341805294259507
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4144911504424778,
+              "regime_accuracy": 0.44144144654273987,
+              "regime_loss": 1.0383002923778275,
+              "regression_rmse_log_rv": 0.8702338174135829,
+              "regression_mae_log_rv": 0.6912038291695418,
+              "regression_loss": 0.757306896970217
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.36275862068965514,
+              "regime_accuracy": 0.35576921701431274,
+              "regime_loss": 1.161458895756648,
+              "regression_rmse_log_rv": 0.8463994398253255,
+              "regression_mae_log_rv": 0.6845549065351056,
+              "regression_loss": 0.7163920117366248
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_cross_asset",
+        "seed": 47,
+        "zeroed_families": [
+          "cross_asset"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3486331930052762,
+              "regime_accuracy": 0.34166666865348816,
+              "regime_loss": 1.1763766323375537,
+              "regression_rmse_log_rv": 0.9468264631027288,
+              "regression_mae_log_rv": 0.8026632251897051,
+              "regression_loss": 0.8964803512316231
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.49285464709993015,
+              "regime_accuracy": 0.6440678238868713,
+              "regime_loss": 0.9041731589931553,
+              "regression_rmse_log_rv": 0.9997707204527017,
+              "regression_mae_log_rv": 0.7745558548781831,
+              "regression_loss": 0.999541493474514
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2353818938043537,
+              "regime_accuracy": 0.2818181812763214,
+              "regime_loss": 1.2088823361830279,
+              "regression_rmse_log_rv": 0.5965240593312039,
+              "regression_mae_log_rv": 0.4922408221607012,
+              "regression_loss": 0.35584095336097765
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4895943628133921,
+              "regime_accuracy": 0.4954954981803894,
+              "regime_loss": 1.0135168903372709,
+              "regression_rmse_log_rv": 0.8329770167234958,
+              "regression_mae_log_rv": 0.681217511025098,
+              "regression_loss": 0.6938507103895749
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3416322228359057,
+              "regime_accuracy": 0.3365384638309479,
+              "regime_loss": 1.1148038460658147,
+              "regression_rmse_log_rv": 0.8258000759668547,
+              "regression_mae_log_rv": 0.6518909636472997,
+              "regression_loss": 0.6819457654668629
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_cross_asset",
+        "seed": 71,
+        "zeroed_families": [
+          "cross_asset"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.35349315846249924,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.1896413027073338,
+              "regression_rmse_log_rv": 0.9227922181283497,
+              "regression_mae_log_rv": 0.7548352992220316,
+              "regression_loss": 0.8515454778382398
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.38730456535334584,
+              "regime_accuracy": 0.6186440587043762,
+              "regime_loss": 0.7469632716502174,
+              "regression_rmse_log_rv": 0.8839124174581886,
+              "regression_mae_log_rv": 0.7033997904193603,
+              "regression_loss": 0.781301161736779
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.31052107345115115,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.1916952046481046,
+              "regression_rmse_log_rv": 0.5185922481783654,
+              "regression_mae_log_rv": 0.4201678686965765,
+              "regression_loss": 0.2689379198706913
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3566455107639373,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.1036749925141667,
+              "regression_rmse_log_rv": 0.8701441783076663,
+              "regression_mae_log_rv": 0.7295897762114937,
+              "regression_loss": 0.7571508910427238
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3622913786292712,
+              "regime_accuracy": 0.36538460850715637,
+              "regime_loss": 1.3062479129204383,
+              "regression_rmse_log_rv": 0.9208603377817263,
+              "regression_mae_log_rv": 0.7476009835148804,
+              "regression_loss": 0.8479837616994751
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_cross_asset",
+        "seed": 97,
+        "zeroed_families": [
+          "cross_asset"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": true
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.36416122004357293,
+              "regime_accuracy": 0.3583333194255829,
+              "regime_loss": 1.203234183263623,
+              "regression_rmse_log_rv": 0.9620792023403079,
+              "regression_mae_log_rv": 0.8206909265078138,
+              "regression_loss": 0.925596391575763
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.36808080808080806,
+              "regime_accuracy": 0.6355932354927063,
+              "regime_loss": 0.8461540341377258,
+              "regression_rmse_log_rv": 0.8603474985109619,
+              "regression_mae_log_rv": 0.6518004203957143,
+              "regression_loss": 0.7401978181940697
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3457700124366791,
+              "regime_accuracy": 0.3636363744735718,
+              "regime_loss": 1.2947601296684959,
+              "regression_rmse_log_rv": 0.694533025744704,
+              "regression_mae_log_rv": 0.506555979585656,
+              "regression_loss": 0.4823761238500937
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.42437480839136343,
+              "regime_accuracy": 0.46846845746040344,
+              "regime_loss": 1.0814106730930773,
+              "regression_rmse_log_rv": 0.8930410307760043,
+              "regression_mae_log_rv": 0.724119677862807,
+              "regression_loss": 0.7975222826494681
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.35417119663695007,
+              "regime_accuracy": 0.35576921701431274,
+              "regime_loss": 1.273742437362671,
+              "regression_rmse_log_rv": 0.9275434918339088,
+              "regression_mae_log_rv": 0.7601441214031254,
+              "regression_loss": 0.8603369292434405
+            }
+          }
+        ]
+      }
+    ],
+    "zero_llm_features": [
+      {
+        "cell": "zero_llm_features",
+        "seed": 11,
+        "zeroed_families": [
+          "llm_features"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.40686274509803927,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.053127282329706,
+              "regression_rmse_log_rv": 0.8868903963930647,
+              "regression_mae_log_rv": 0.738910097758829,
+              "regression_loss": 0.7865745752142473
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.40776779163609683,
+              "regime_accuracy": 0.6101694703102112,
+              "regime_loss": 0.9310872453754231,
+              "regression_rmse_log_rv": 0.7211876098381103,
+              "regression_mae_log_rv": 0.5551299633363546,
+              "regression_loss": 0.5201115685840063
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.34324267341345144,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.6276919776743108,
+              "regression_rmse_log_rv": 0.8550415818766878,
+              "regression_mae_log_rv": 0.6889422807990658,
+              "regression_loss": 0.7310961067381885
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3732689456517135,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.1447594079012717,
+              "regression_rmse_log_rv": 0.894494629914135,
+              "regression_mae_log_rv": 0.710721214410958,
+              "regression_loss": 0.8001206429452252
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5120886282176605,
+              "regime_accuracy": 0.567307710647583,
+              "regime_loss": 1.045199834383451,
+              "regression_rmse_log_rv": 0.7209237163685761,
+              "regression_mae_log_rv": 0.583956377607627,
+              "regression_loss": 0.5197310048226792
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_llm_features",
+        "seed": 29,
+        "zeroed_families": [
+          "llm_features"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3921982779125636,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.1492033412738563,
+              "regression_rmse_log_rv": 0.9484849097813159,
+              "regression_mae_log_rv": 0.7998699004664862,
+              "regression_loss": 0.899623624082871
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4197028671673702,
+              "regime_accuracy": 0.6525423526763916,
+              "regime_loss": 0.601044946807926,
+              "regression_rmse_log_rv": 0.8200398318015903,
+              "regression_mae_log_rv": 0.6280820915885901,
+              "regression_loss": 0.6724653257411807
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4301147279752448,
+              "regime_accuracy": 0.4636363685131073,
+              "regime_loss": 1.037862101468173,
+              "regression_rmse_log_rv": 0.43608849020037466,
+              "regression_mae_log_rv": 0.342689630061134,
+              "regression_loss": 0.19017317128524228
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4395545872670055,
+              "regime_accuracy": 0.45945945382118225,
+              "regime_loss": 1.0766728574688276,
+              "regression_rmse_log_rv": 0.8488525116137114,
+              "regression_mae_log_rv": 0.6719486115852723,
+              "regression_loss": 0.720550586472906
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5242512643997509,
+              "regime_accuracy": 0.5769230723381042,
+              "regime_loss": 1.0075969420946562,
+              "regression_rmse_log_rv": 0.7378048838313912,
+              "regression_mae_log_rv": 0.5687440689384508,
+              "regression_loss": 0.5443560466054527
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_llm_features",
+        "seed": 47,
+        "zeroed_families": [
+          "llm_features"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3386724140604407,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.1632575618463157,
+              "regression_rmse_log_rv": 0.8927111743222509,
+              "regression_mae_log_rv": 0.7648936764084889,
+              "regression_loss": 0.7969332407598123
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4813311688311688,
+              "regime_accuracy": 0.7203390002250671,
+              "regime_loss": 0.6359883056858838,
+              "regression_rmse_log_rv": 0.8095143691360009,
+              "regression_mae_log_rv": 0.6208211450000941,
+              "regression_loss": 0.6553135138376576
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3817078346490111,
+              "regime_accuracy": 0.38181817531585693,
+              "regime_loss": 1.2291519013318148,
+              "regression_rmse_log_rv": 0.5483684292740214,
+              "regression_mae_log_rv": 0.4336194414793598,
+              "regression_loss": 0.30070793422445746
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3870229926567954,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.1133360426075634,
+              "regression_rmse_log_rv": 0.9097967444035988,
+              "regression_mae_log_rv": 0.737730937162498,
+              "regression_loss": 0.8277301161273873
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2912394765358006,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.1585957270402174,
+              "regression_rmse_log_rv": 0.881746510124701,
+              "regression_mae_log_rv": 0.7274367844668002,
+              "regression_loss": 0.7774769081170894
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_llm_features",
+        "seed": 71,
+        "zeroed_families": [
+          "llm_features"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.40419157123085575,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.1461221173896352,
+              "regression_rmse_log_rv": 0.8661325212165173,
+              "regression_mae_log_rv": 0.7241591544259184,
+              "regression_loss": 0.7501855443088807
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3510224837455958,
+              "regime_accuracy": 0.6101694703102112,
+              "regime_loss": 0.7947095420400975,
+              "regression_rmse_log_rv": 0.8040188711323625,
+              "regression_mae_log_rv": 0.5984087261860653,
+              "regression_loss": 0.6464463451369585
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.41308440317626577,
+              "regime_accuracy": 0.4545454680919647,
+              "regime_loss": 1.0653191523118453,
+              "regression_rmse_log_rv": 0.41037948472060454,
+              "regression_mae_log_rv": 0.3138894712192599,
+              "regression_loss": 0.1684113214795489
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.36857825567502983,
+              "regime_accuracy": 0.4054054021835327,
+              "regime_loss": 1.0290479275807827,
+              "regression_rmse_log_rv": 0.829679524422724,
+              "regression_mae_log_rv": 0.6798140973121196,
+              "regression_loss": 0.6883681132463174
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4052996758177026,
+              "regime_accuracy": 0.45192307233810425,
+              "regime_loss": 1.0837723475236158,
+              "regression_rmse_log_rv": 0.7923107107176047,
+              "regression_mae_log_rv": 0.6445177495031833,
+              "regression_loss": 0.6277562623178359
+            }
+          }
+        ]
+      },
+      {
+        "cell": "zero_llm_features",
+        "seed": 97,
+        "zeroed_families": [
+          "llm_features"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": true,
+          "use_mp_surprise": true,
+          "use_multi_axis": true,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3761425576519916,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.1353435234175488,
+              "regression_rmse_log_rv": 0.9317794073106658,
+              "regression_mae_log_rv": 0.8092405786019905,
+              "regression_loss": 0.8682128638882156
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.40642915642915645,
+              "regime_accuracy": 0.6864407062530518,
+              "regime_loss": 0.6269271363646297,
+              "regression_rmse_log_rv": 0.9064901470427753,
+              "regression_mae_log_rv": 0.6990948597253379,
+              "regression_loss": 0.8217243866856324
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2449203823379772,
+              "regime_accuracy": 0.23636363446712494,
+              "regime_loss": 1.594475769996643,
+              "regression_rmse_log_rv": 0.6367646113524226,
+              "regression_mae_log_rv": 0.46109580217902973,
+              "regression_loss": 0.4054691702708018
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4304412641621944,
+              "regime_accuracy": 0.45045045018196106,
+              "regime_loss": 1.0606441068301578,
+              "regression_rmse_log_rv": 0.8367447767472769,
+              "regression_mae_log_rv": 0.6823233985635746,
+              "regression_loss": 0.7001418214138503
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.446096306685367,
+              "regime_accuracy": 0.5480769276618958,
+              "regime_loss": 1.072254465176509,
+              "regression_rmse_log_rv": 0.7352318856555368,
+              "regression_mae_log_rv": 0.5589003713461212,
+              "regression_loss": 0.5405659256845963
+            }
+          }
+        ]
+      }
+    ],
+    "cumulative_drop_text": [
+      {
+        "cell": "cumulative_drop_text",
+        "seed": 11,
+        "zeroed_families": [
+          "linguistic",
+          "llm_features",
+          "multi_axis"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4173947364711521,
+              "regime_accuracy": 0.4333333373069763,
+              "regime_loss": 1.053417990469528,
+              "regression_rmse_log_rv": 0.8871008865774099,
+              "regression_mae_log_rv": 0.7378607179406875,
+              "regression_loss": 0.7869479829664267
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4073501771127015,
+              "regime_accuracy": 0.6101694703102112,
+              "regime_loss": 0.9048826371209097,
+              "regression_rmse_log_rv": 0.7232475253005359,
+              "regression_mae_log_rv": 0.5520552344999071,
+              "regression_loss": 0.5230869828533494
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.28500724471898115,
+              "regime_accuracy": 0.26363635063171387,
+              "regime_loss": 1.4315726041793824,
+              "regression_rmse_log_rv": 0.7184967134942767,
+              "regression_mae_log_rv": 0.5476370840396901,
+              "regression_loss": 0.5162375273020767
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3943560451516388,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.2012988971514593,
+              "regression_rmse_log_rv": 0.9352667499313861,
+              "regression_mae_log_rv": 0.7798620996375879,
+              "regression_loss": 0.8747238935272179
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.39250842310590944,
+              "regime_accuracy": 0.45192307233810425,
+              "regime_loss": 1.1214215938861554,
+              "regression_rmse_log_rv": 0.773076654321268,
+              "regression_mae_log_rv": 0.6308943759560441,
+              "regression_loss": 0.5976475134565653
+            }
+          }
+        ]
+      },
+      {
+        "cell": "cumulative_drop_text",
+        "seed": 29,
+        "zeroed_families": [
+          "linguistic",
+          "llm_features",
+          "multi_axis"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3845524464081165,
+              "regime_accuracy": 0.38333332538604736,
+              "regime_loss": 1.1517392687508978,
+              "regression_rmse_log_rv": 0.9553266995245014,
+              "regression_mae_log_rv": 0.805350493862837,
+              "regression_loss": 0.9126491028243772
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3967618726654871,
+              "regime_accuracy": 0.6271186470985413,
+              "regime_loss": 0.7862562133094012,
+              "regression_rmse_log_rv": 0.7763209339446375,
+              "regression_mae_log_rv": 0.5884032137376272,
+              "regression_loss": 0.6026741924806742
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4037429502566205,
+              "regime_accuracy": 0.44545453786849976,
+              "regime_loss": 1.0354307629845358,
+              "regression_rmse_log_rv": 0.43636672501145995,
+              "regression_mae_log_rv": 0.34357580474196847,
+              "regression_loss": 0.19041591869722713
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4477687443541101,
+              "regime_accuracy": 0.46846845746040344,
+              "regime_loss": 1.0755797184278757,
+              "regression_rmse_log_rv": 0.8506570017814464,
+              "regression_mae_log_rv": 0.6738636634975403,
+              "regression_loss": 0.7236173346797998
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5242512643997509,
+              "regime_accuracy": 0.5769230723381042,
+              "regime_loss": 1.0100931708629315,
+              "regression_rmse_log_rv": 0.7384535806247361,
+              "regression_mae_log_rv": 0.5708749119926674,
+              "regression_loss": 0.5453136907374936
+            }
+          }
+        ]
+      },
+      {
+        "cell": "cumulative_drop_text",
+        "seed": 47,
+        "zeroed_families": [
+          "linguistic",
+          "llm_features",
+          "multi_axis"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.42928885301766656,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.1294674544003382,
+              "regression_rmse_log_rv": 0.9355249800313947,
+              "regression_mae_log_rv": 0.8141581289528403,
+              "regression_loss": 0.8752069882627415
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4567770454069889,
+              "regime_accuracy": 0.7118644118309021,
+              "regime_loss": 0.6389204768811242,
+              "regression_rmse_log_rv": 0.7894395582839859,
+              "regression_mae_log_rv": 0.6109528131783009,
+              "regression_loss": 0.6232148161836147
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.34798287130944333,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.1329043193296953,
+              "regression_rmse_log_rv": 0.5196083258539145,
+              "regression_mae_log_rv": 0.4229222632754086,
+              "regression_loss": 0.2699928122967078
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.35650059359991365,
+              "regime_accuracy": 0.36036035418510437,
+              "regime_loss": 1.1194101557846416,
+              "regression_rmse_log_rv": 0.9158403063081735,
+              "regression_mae_log_rv": 0.7430960323225271,
+              "regression_loss": 0.838763466658649
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.28369148758953855,
+              "regime_accuracy": 0.36538460850715637,
+              "regime_loss": 1.164431434411269,
+              "regression_rmse_log_rv": 0.8907830083340904,
+              "regression_mae_log_rv": 0.7364697924439008,
+              "regression_loss": 0.7934943679367321
+            }
+          }
+        ]
+      },
+      {
+        "cell": "cumulative_drop_text",
+        "seed": 71,
+        "zeroed_families": [
+          "linguistic",
+          "llm_features",
+          "multi_axis"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3858774402338449,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.1500993517907574,
+              "regression_rmse_log_rv": 0.8699905573159628,
+              "regression_mae_log_rv": 0.7260796679552489,
+              "regression_loss": 0.7568835698189395
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3510224837455958,
+              "regime_accuracy": 0.6101694703102112,
+              "regime_loss": 0.7951312519736209,
+              "regression_rmse_log_rv": 0.8018065227220849,
+              "regression_mae_log_rv": 0.5956804229546402,
+              "regression_loss": 0.6428936998796813
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4034017971758665,
+              "regime_accuracy": 0.44545453786849976,
+              "regime_loss": 1.065337324142456,
+              "regression_rmse_log_rv": 0.41212326916037867,
+              "regression_mae_log_rv": 0.3131940835388377,
+              "regression_loss": 0.16984558898343793
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3827103601297149,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.0292070891892748,
+              "regression_rmse_log_rv": 0.8279058377993528,
+              "regression_mae_log_rv": 0.6773367443600217,
+              "regression_loss": 0.6854280762622482
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4380273321449792,
+              "regime_accuracy": 0.49038460850715637,
+              "regime_loss": 1.0523055791854858,
+              "regression_rmse_log_rv": 0.7702439378516541,
+              "regression_mae_log_rv": 0.6207391457327713,
+              "regression_loss": 0.5932757237972228
+            }
+          }
+        ]
+      },
+      {
+        "cell": "cumulative_drop_text",
+        "seed": 97,
+        "zeroed_families": [
+          "linguistic",
+          "llm_features",
+          "multi_axis"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": false,
+        "zero_cross_asset": false,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.39444444444444443,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.1390900714245003,
+              "regression_rmse_log_rv": 0.9204401391266137,
+              "regression_mae_log_rv": 0.7828881399395565,
+              "regression_loss": 0.8472100497154199
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.44098883572567776,
+              "regime_accuracy": 0.7118644118309021,
+              "regime_loss": 0.628870884745808,
+              "regression_rmse_log_rv": 0.8706592828695447,
+              "regression_mae_log_rv": 0.6622240781641991,
+              "regression_loss": 0.75804758684691
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.31582125603864736,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.6395618005232377,
+              "regression_rmse_log_rv": 0.644663216321033,
+              "regression_mae_log_rv": 0.46996987079566516,
+              "regression_loss": 0.41559066247737897
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.43422025129342195,
+              "regime_accuracy": 0.45045045018196106,
+              "regime_loss": 1.0633834993600952,
+              "regression_rmse_log_rv": 0.8375669172953706,
+              "regression_mae_log_rv": 0.6844573787723979,
+              "regression_loss": 0.7015183409476701
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.40737628384687213,
+              "regime_accuracy": 0.5384615659713745,
+              "regime_loss": 1.0391515676791852,
+              "regression_rmse_log_rv": 0.7337133202599974,
+              "regression_mae_log_rv": 0.5584924598582662,
+              "regression_loss": 0.5383352363269495
+            }
+          }
+        ]
+      }
+    ],
+    "cumulative_drop_text_market_aux": [
+      {
+        "cell": "cumulative_drop_text_market_aux",
+        "seed": 11,
+        "zeroed_families": [
+          "cross_asset",
+          "linguistic",
+          "llm_features",
+          "multi_axis",
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.26165106882960437,
+              "regime_accuracy": 0.2750000059604645,
+              "regime_loss": 1.16023815652556,
+              "regression_rmse_log_rv": 0.9724692951223821,
+              "regression_mae_log_rv": 0.799602266146879,
+              "regression_loss": 0.9456965299558228
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.22916397328162033,
+              "regime_accuracy": 0.31355932354927063,
+              "regime_loss": 1.1070445210246715,
+              "regression_rmse_log_rv": 1.025922225907544,
+              "regression_mae_log_rv": 0.8981710573247934,
+              "regression_loss": 1.0525164136110898
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.1300489940368427,
+              "regime_accuracy": 0.12727272510528564,
+              "regime_loss": 1.1399105223742398,
+              "regression_rmse_log_rv": 0.5556962566277381,
+              "regression_mae_log_rv": 0.44747668652244926,
+              "regression_loss": 0.30879832963008097
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2714285714285714,
+              "regime_accuracy": 0.4324324429035187,
+              "regime_loss": 1.0945126019793512,
+              "regression_rmse_log_rv": 0.8897307292424853,
+              "regression_mae_log_rv": 0.7196720096844811,
+              "regression_loss": 0.7916207705583648
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.21021021021021022,
+              "regime_accuracy": 0.2788461446762085,
+              "regime_loss": 1.1121962712361262,
+              "regression_rmse_log_rv": 0.8509217104998484,
+              "regression_mae_log_rv": 0.6368285713699431,
+              "regression_loss": 0.724067757399988
+            }
+          }
+        ]
+      },
+      {
+        "cell": "cumulative_drop_text_market_aux",
+        "seed": 29,
+        "zeroed_families": [
+          "cross_asset",
+          "linguistic",
+          "llm_features",
+          "multi_axis",
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.26446134694670004,
+              "regime_accuracy": 0.28333333134651184,
+              "regime_loss": 1.1049887384185582,
+              "regression_rmse_log_rv": 0.9133185640250588,
+              "regression_mae_log_rv": 0.7408666269795503,
+              "regression_loss": 0.8341507993927955
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.23743848743848742,
+              "regime_accuracy": 0.38983049988746643,
+              "regime_loss": 1.1083372225195676,
+              "regression_rmse_log_rv": 1.1650851160299651,
+              "regression_mae_log_rv": 1.0012537861969006,
+              "regression_loss": 1.357423327594557
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.13248216747587366,
+              "regime_accuracy": 0.12727272510528564,
+              "regime_loss": 1.2454697717319836,
+              "regression_rmse_log_rv": 0.5823218427911993,
+              "regression_mae_log_rv": 0.5031900447729806,
+              "regression_loss": 0.3390987285917382
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.1423692765776441,
+              "regime_accuracy": 0.18018017709255219,
+              "regime_loss": 1.1302841270518365,
+              "regression_rmse_log_rv": 0.9061660371007878,
+              "regression_mae_log_rv": 0.7450595990427442,
+              "regression_loss": 0.8211368867949463
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.29589072980807885,
+              "regime_accuracy": 0.3076923191547394,
+              "regime_loss": 1.1609014364389272,
+              "regression_rmse_log_rv": 0.864256231675723,
+              "regression_mae_log_rv": 0.6455688605962607,
+              "regression_loss": 0.746938833990321
+            }
+          }
+        ]
+      },
+      {
+        "cell": "cumulative_drop_text_market_aux",
+        "seed": 47,
+        "zeroed_families": [
+          "cross_asset",
+          "linguistic",
+          "llm_features",
+          "multi_axis",
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.25125675358233496,
+              "regime_accuracy": 0.25833332538604736,
+              "regime_loss": 1.1588152089799733,
+              "regression_rmse_log_rv": 0.9965106027480629,
+              "regression_mae_log_rv": 0.8152071788227961,
+              "regression_loss": 0.9930333813893076
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.23768327110463527,
+              "regime_accuracy": 0.3813559412956238,
+              "regime_loss": 1.0854670657949932,
+              "regression_rmse_log_rv": 1.0882639025766092,
+              "regression_mae_log_rv": 0.9512190196852562,
+              "regression_loss": 1.1843183216512716
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.17259900593233926,
+              "regime_accuracy": 0.17272727191448212,
+              "regime_loss": 1.1795031330802224,
+              "regression_rmse_log_rv": 0.5033079905062716,
+              "regression_mae_log_rv": 0.4174009173621678,
+              "regression_loss": 0.2533189333074612
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.16704863763687294,
+              "regime_accuracy": 0.21621622145175934,
+              "regime_loss": 1.3534411150353587,
+              "regression_rmse_log_rv": 1.1591074191517972,
+              "regression_mae_log_rv": 0.919982908612436,
+              "regression_loss": 1.34353000913274
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.35175574091236744,
+              "regime_accuracy": 0.36538460850715637,
+              "regime_loss": 1.089876963542058,
+              "regression_rmse_log_rv": 0.8274618441464782,
+              "regression_mae_log_rv": 0.6179032358251368,
+              "regression_loss": 0.6846931035182906
+            }
+          }
+        ]
+      },
+      {
+        "cell": "cumulative_drop_text_market_aux",
+        "seed": 71,
+        "zeroed_families": [
+          "cross_asset",
+          "linguistic",
+          "llm_features",
+          "multi_axis",
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2755916634379439,
+              "regime_accuracy": 0.2750000059604645,
+              "regime_loss": 1.159698637592035,
+              "regression_rmse_log_rv": 0.9423298809340183,
+              "regression_mae_log_rv": 0.7833023826223022,
+              "regression_loss": 0.887985604501121
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.22443395401695954,
+              "regime_accuracy": 0.2881355881690979,
+              "regime_loss": 1.1932082539897855,
+              "regression_rmse_log_rv": 1.1619742334633947,
+              "regression_mae_log_rv": 1.026534079747685,
+              "regression_loss": 1.3501841192328439
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.06356837606837608,
+              "regime_accuracy": 0.06363636255264282,
+              "regime_loss": 1.2758059523322365,
+              "regression_rmse_log_rv": 0.5112959670259286,
+              "regression_mae_log_rv": 0.41749394957865166,
+              "regression_loss": 0.2614235658969795
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.18538545853123858,
+              "regime_accuracy": 0.21621622145175934,
+              "regime_loss": 1.1363762465895746,
+              "regression_rmse_log_rv": 0.9552344712884624,
+              "regression_mae_log_rv": 0.7589277973113296,
+              "regression_loss": 0.9124728951377482
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2924040195935047,
+              "regime_accuracy": 0.3076923191547394,
+              "regime_loss": 1.2200370201697717,
+              "regression_rmse_log_rv": 0.8712804820806535,
+              "regression_mae_log_rv": 0.680957442552496,
+              "regression_loss": 0.7591296784546959
+            }
+          }
+        ]
+      },
+      {
+        "cell": "cumulative_drop_text_market_aux",
+        "seed": 97,
+        "zeroed_families": [
+          "cross_asset",
+          "linguistic",
+          "llm_features",
+          "multi_axis",
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": true,
+          "use_linguistic": false,
+          "use_mp_surprise": true,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2751918158567775,
+              "regime_accuracy": 0.2750000059604645,
+              "regime_loss": 1.1434219429125632,
+              "regression_rmse_log_rv": 0.9588723218055071,
+              "regression_mae_log_rv": 0.7865985066106077,
+              "regression_loss": 0.919436129524684
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.19164604689525155,
+              "regime_accuracy": 0.27966102957725525,
+              "regime_loss": 1.0792741310798515,
+              "regression_rmse_log_rv": 1.0682098722631963,
+              "regression_mae_log_rv": 0.9439208987011116,
+              "regression_loss": 1.1410723312005542
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.1330552163885497,
+              "regime_accuracy": 0.145454540848732,
+              "regime_loss": 1.180354857444763,
+              "regression_rmse_log_rv": 0.5269619611214834,
+              "regression_mae_log_rv": 0.4147593107476661,
+              "regression_loss": 0.27768890846899985
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.24044277074061393,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.2923918809896766,
+              "regression_rmse_log_rv": 1.0000180346725,
+              "regression_mae_log_rv": 0.7698596225262763,
+              "regression_loss": 1.0000360696702497
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.24608946608946614,
+              "regime_accuracy": 0.2788461446762085,
+              "regime_loss": 1.2001527364437397,
+              "regression_rmse_log_rv": 0.8947715584263788,
+              "regression_mae_log_rv": 0.6632537036650599,
+              "regression_loss": 0.8006161417687706
+            }
+          }
+        ]
+      }
+    ],
+    "cumulative_drop_text_market_aux_cred_mp": [
+      {
+        "cell": "cumulative_drop_text_market_aux_cred_mp",
+        "seed": 11,
+        "zeroed_families": [
+          "credibility",
+          "cross_asset",
+          "linguistic",
+          "llm_features",
+          "mp_surprise",
+          "multi_axis",
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": false,
+          "use_linguistic": false,
+          "use_mp_surprise": false,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.27272727272727276,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.0948855587406585,
+              "regression_rmse_log_rv": 0.8342537738772864,
+              "regression_mae_log_rv": 0.6960754798162573,
+              "regression_loss": 0.6959793592284945
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.2575438596491228,
+              "regime_accuracy": 0.5423728823661804,
+              "regime_loss": 1.0928281767893646,
+              "regression_rmse_log_rv": 1.0196842007755336,
+              "regression_mae_log_rv": 0.9181017284360478,
+              "regression_loss": 1.0397558693112385
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.149895178197065,
+              "regime_accuracy": 0.16363635659217834,
+              "regime_loss": 1.1048017913644963,
+              "regression_rmse_log_rv": 0.4424187395331207,
+              "regression_mae_log_rv": 0.34419700580183415,
+              "regression_loss": 0.19573434109007531
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.33962826618969383,
+              "regime_accuracy": 0.3513513505458832,
+              "regime_loss": 1.0946333151875758,
+              "regression_rmse_log_rv": 0.827834567679952,
+              "regression_mae_log_rv": 0.6635663373110531,
+              "regression_loss": 0.685310071445853
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.35656565656565653,
+              "regime_accuracy": 0.4038461446762085,
+              "regime_loss": 1.0877026227804332,
+              "regression_rmse_log_rv": 0.8488998618173004,
+              "regression_mae_log_rv": 0.6419223544922156,
+              "regression_loss": 0.7206309753934317
+            }
+          }
+        ]
+      },
+      {
+        "cell": "cumulative_drop_text_market_aux_cred_mp",
+        "seed": 29,
+        "zeroed_families": [
+          "credibility",
+          "cross_asset",
+          "linguistic",
+          "llm_features",
+          "mp_surprise",
+          "multi_axis",
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": false,
+          "use_linguistic": false,
+          "use_mp_surprise": false,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2378472222222222,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.104892819560617,
+              "regression_rmse_log_rv": 0.8403477212507747,
+              "regression_mae_log_rv": 0.6985291106374159,
+              "regression_loss": 0.7061842926113698
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.18523260776781902,
+              "regime_accuracy": 0.3050847351551056,
+              "regime_loss": 1.1146822905136367,
+              "regression_rmse_log_rv": 1.0597480531640875,
+              "regression_mae_log_rv": 0.9577332778944302,
+              "regression_loss": 1.1230659361850737
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.20578332343038228,
+              "regime_accuracy": 0.2818181812763214,
+              "regime_loss": 1.0898594509471546,
+              "regression_rmse_log_rv": 0.4476130704484881,
+              "regression_mae_log_rv": 0.3472391761648892,
+              "regression_loss": 0.20035746083632316
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2639054825434754,
+              "regime_accuracy": 0.30630630254745483,
+              "regime_loss": 1.1130443693904473,
+              "regression_rmse_log_rv": 0.8332904198703935,
+              "regression_mae_log_rv": 0.67083232153442,
+              "regression_loss": 0.6943729238477768
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.26062248644867986,
+              "regime_accuracy": 0.3076923191547394,
+              "regime_loss": 1.1063839839054987,
+              "regression_rmse_log_rv": 0.859067997794942,
+              "regression_mae_log_rv": 0.6520362831204414,
+              "regression_loss": 0.7379978248354105
+            }
+          }
+        ]
+      },
+      {
+        "cell": "cumulative_drop_text_market_aux_cred_mp",
+        "seed": 47,
+        "zeroed_families": [
+          "credibility",
+          "cross_asset",
+          "linguistic",
+          "llm_features",
+          "mp_surprise",
+          "multi_axis",
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": false,
+          "use_linguistic": false,
+          "use_mp_surprise": false,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3021294539321105,
+              "regime_accuracy": 0.36666667461395264,
+              "regime_loss": 1.097337364117779,
+              "regression_rmse_log_rv": 0.8300723183507811,
+              "regression_mae_log_rv": 0.694897833969056,
+              "regression_loss": 0.6890200536922404
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.27102808865481676,
+              "regime_accuracy": 0.43220338225364685,
+              "regime_loss": 1.1271340240866452,
+              "regression_rmse_log_rv": 1.0816067985536133,
+              "regression_mae_log_rv": 0.9866993553557638,
+              "regression_loss": 1.1698732666773968
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2135467499512005,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.0927569432692095,
+              "regression_rmse_log_rv": 0.4383694217225911,
+              "regression_mae_log_rv": 0.34197473623154856,
+              "regression_loss": 0.1921677499013989
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2668268291730146,
+              "regime_accuracy": 0.27927929162979126,
+              "regime_loss": 1.1017125594936823,
+              "regression_rmse_log_rv": 0.8564013657093529,
+              "regression_mae_log_rv": 0.6930041217186429,
+              "regression_loss": 0.7334232991888447
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.34390321927780065,
+              "regime_accuracy": 0.36538460850715637,
+              "regime_loss": 1.0997351866502028,
+              "regression_rmse_log_rv": 0.8496884214751027,
+              "regression_mae_log_rv": 0.642656609084672,
+              "regression_loss": 0.7219704135888517
+            }
+          }
+        ]
+      },
+      {
+        "cell": "cumulative_drop_text_market_aux_cred_mp",
+        "seed": 71,
+        "zeroed_families": [
+          "credibility",
+          "cross_asset",
+          "linguistic",
+          "llm_features",
+          "mp_surprise",
+          "multi_axis",
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": false,
+          "use_linguistic": false,
+          "use_mp_surprise": false,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2783858238403693,
+              "regime_accuracy": 0.34166666865348816,
+              "regime_loss": 1.0898374372275355,
+              "regression_rmse_log_rv": 0.8395512488910056,
+              "regression_mae_log_rv": 0.6975408379046713,
+              "regression_loss": 0.7048462995144473
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.21873847685951522,
+              "regime_accuracy": 0.3813559412956238,
+              "regime_loss": 1.0981568239502988,
+              "regression_rmse_log_rv": 1.0299104125573717,
+              "regression_mae_log_rv": 0.9327947564928208,
+              "regression_loss": 1.0607154578940956
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.28275174476570286,
+              "regime_accuracy": 0.40909090638160706,
+              "regime_loss": 1.0866724924607711,
+              "regression_rmse_log_rv": 0.4422549830129597,
+              "regression_mae_log_rv": 0.34451201587534425,
+              "regression_loss": 0.19558946999979324
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.1635870904163587,
+              "regime_accuracy": 0.21621622145175934,
+              "regime_loss": 1.101456528683472,
+              "regression_rmse_log_rv": 0.8198989340327897,
+              "regression_mae_log_rv": 0.6524066318934029,
+              "regression_loss": 0.6722342620281048
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.23884497145366712,
+              "regime_accuracy": 0.26923078298568726,
+              "regime_loss": 1.0963334303635817,
+              "regression_rmse_log_rv": 0.8580495451257639,
+              "regression_mae_log_rv": 0.6433606874645472,
+              "regression_loss": 0.7362490218905303
+            }
+          }
+        ]
+      },
+      {
+        "cell": "cumulative_drop_text_market_aux_cred_mp",
+        "seed": 97,
+        "zeroed_families": [
+          "credibility",
+          "cross_asset",
+          "linguistic",
+          "llm_features",
+          "mp_surprise",
+          "multi_axis",
+          "realised_vol"
+        ],
+        "loader_flags": {
+          "use_credibility": false,
+          "use_linguistic": false,
+          "use_mp_surprise": false,
+          "use_multi_axis": false,
+          "use_llm_features": false
+        },
+        "zero_realised_vol": true,
+        "zero_cross_asset": true,
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.294927536231884,
+              "regime_accuracy": 0.3583333194255829,
+              "regime_loss": 1.0965507649616322,
+              "regression_rmse_log_rv": 0.835538335058319,
+              "regression_mae_log_rv": 0.699001045282542,
+              "regression_loss": 0.6981243093520277
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3278437811906371,
+              "regime_accuracy": 0.5762711763381958,
+              "regime_loss": 1.057886335809352,
+              "regression_rmse_log_rv": 1.0316097654126577,
+              "regression_mae_log_rv": 0.9353493140789412,
+              "regression_loss": 1.0642187080947585
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.14878542510121456,
+              "regime_accuracy": 0.16363635659217834,
+              "regime_loss": 1.1360709450461648,
+              "regression_rmse_log_rv": 0.46350866173435556,
+              "regression_mae_log_rv": 0.35550397035284814,
+              "regression_loss": 0.21484027950277323
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.19831223628691985,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.101597618921053,
+              "regression_rmse_log_rv": 0.8635251693102504,
+              "regression_mae_log_rv": 0.6989547245640744,
+              "regression_loss": 0.7456757180322966
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.21734156943491192,
+              "regime_accuracy": 0.25,
+              "regime_loss": 1.1190457894251897,
+              "regression_rmse_log_rv": 0.8544042955423116,
+              "regression_mae_log_rv": 0.6490723471282623,
+              "regression_loss": 0.7300067002411537
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "baseline": {
+      "regime_f1_macro": {
+        "mean": 0.39900929809536995,
+        "lo": 0.37618162113126713,
+        "hi": 0.42246286916089715,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7864591091679207,
+        "lo": 0.7248609309275713,
+        "hi": 0.8375103614220203,
+        "n": 25
+      }
+    },
+    "zero_linguistic": {
+      "regime_f1_macro": {
+        "mean": 0.39900929809536995,
+        "lo": 0.37618162113126713,
+        "hi": 0.42246286916089715,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7864591091679207,
+        "lo": 0.7248609309275713,
+        "hi": 0.8375103614220203,
+        "n": 25
+      }
+    },
+    "zero_credibility": {
+      "regime_f1_macro": {
+        "mean": 0.40833347713029106,
+        "lo": 0.37751554414802263,
+        "hi": 0.43697122903112984,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7644763834279864,
+        "lo": 0.7081842297261545,
+        "hi": 0.8064748813967536,
+        "n": 25
+      }
+    },
+    "zero_mp_surprise": {
+      "regime_f1_macro": {
+        "mean": 0.4258882258877147,
+        "lo": 0.39179493382814473,
+        "hi": 0.4709451556866439,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.6962920546394343,
+        "lo": 0.6271148705650921,
+        "hi": 0.7621441754347331,
+        "n": 25
+      }
+    },
+    "zero_multi_axis": {
+      "regime_f1_macro": {
+        "mean": 0.39527300961388334,
+        "lo": 0.375941941411632,
+        "hi": 0.41795000258691345,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7813849060018084,
+        "lo": 0.7170322986666443,
+        "hi": 0.8309582869590798,
+        "n": 25
+      }
+    },
+    "zero_realised_vol": {
+      "regime_f1_macro": {
+        "mean": 0.39809458664982833,
+        "lo": 0.37049464665590454,
+        "hi": 0.4249545829900304,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7981452421726292,
+        "lo": 0.7439871227298839,
+        "hi": 0.8475946572258359,
+        "n": 25
+      }
+    },
+    "zero_cross_asset": {
+      "regime_f1_macro": {
+        "mean": 0.3719912226285378,
+        "lo": 0.3497539150589973,
+        "hi": 0.39386215349917597,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.8323181006296761,
+        "lo": 0.7670918447712549,
+        "hi": 0.8818928549694229,
+        "n": 25
+      }
+    },
+    "zero_llm_features": {
+      "regime_f1_macro": {
+        "mean": 0.39900929809536995,
+        "lo": 0.37618162113126713,
+        "hi": 0.42246286916089715,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7864591091679207,
+        "lo": 0.7248609309275713,
+        "hi": 0.8375103614220203,
+        "n": 25
+      }
+    },
+    "cumulative_drop_text": {
+      "regime_f1_macro": {
+        "mean": 0.39527300961388334,
+        "lo": 0.375941941411632,
+        "hi": 0.41795000258691345,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7813849060018084,
+        "lo": 0.7170322986666443,
+        "hi": 0.8309582869590798,
+        "n": 25
+      }
+    },
+    "cumulative_drop_text_market_aux": {
+      "regime_f1_macro": {
+        "mean": 0.2193318809128346,
+        "lo": 0.19005062264056086,
+        "hi": 0.2451554184647168,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.887659542049339,
+        "lo": 0.8057056474244386,
+        "hi": 0.9589856045239816,
+        "n": 25
+      }
+    },
+    "cumulative_drop_text_market_aux_cred_mp": {
+      "regime_f1_macro": {
+        "mean": 0.25186817409246054,
+        "lo": 0.22976255549942362,
+        "hi": 0.2731725646466209,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.8043019233080442,
+        "lo": 0.7212584929728125,
+        "hi": 0.878199141417001,
+        "n": 25
+      }
+    }
+  }
+}

--- a/backend/artifacts/experiments/runpod_20260530/runpod_mtl_verify_20260530T142258Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/runpod_mtl_verify_20260530T142258Z.json
@@ -1,0 +1,379 @@
+{
+  "head_modes": [
+    "classification"
+  ],
+  "seeds": [
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "regression_alpha": 0.5,
+  "training_package_id": "canonical",
+  "rates_target_mode": "raw",
+  "rates_heads": [],
+  "use_retrieval_analogs": false,
+  "use_regime_conditioning": false,
+  "use_statement_delta": false,
+  "use_vote_features": false,
+  "use_press_conf": false,
+  "trials": {
+    "classification": [
+      {
+        "head_mode": "classification",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4144754055468341,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.1300680716289773,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    18,
+                    5,
+                    5
+                  ],
+                  [
+                    12,
+                    10,
+                    23
+                  ],
+                  [
+                    20,
+                    4,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.36,
+                    "recall": 0.6428571428571429,
+                    "f1": 0.4615384615384615,
+                    "support": 28,
+                    "roc_auc": 0.7329192546583851,
+                    "pr_auc": 0.42244918944643
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5263157894736842,
+                    "recall": 0.2222222222222222,
+                    "f1": 0.3125,
+                    "support": 45,
+                    "roc_auc": 0.48,
+                    "pr_auc": 0.4277864288857386
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.45098039215686275,
+                    "recall": 0.48936170212765956,
+                    "f1": 0.46938775510204084,
+                    "support": 47,
+                    "roc_auc": 0.5785485281259108,
+                    "pr_auc": 0.4263245418449821
+                  }
+                ],
+                "macro_precision": 0.44576539387684894,
+                "macro_recall": 0.45148035573567485,
+                "macro_f1": 0.4144754055468341,
+                "weighted_f1": 0.40872334510727365,
+                "macro_roc_auc": 0.5971559275947653,
+                "macro_pr_auc": 0.4255200533923835
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.38868003341687546,
+              "regime_accuracy": 0.6271186470985413,
+              "regime_loss": 0.7867684990672742,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    14,
+                    15,
+                    67
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.7,
+                    "f1": 0.3684210526315789,
+                    "support": 10,
+                    "roc_auc": 0.8731481481481481,
+                    "pr_auc": 0.47509156338945785
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6202830188679245,
+                    "pr_auc": 0.11741644997709921
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9305555555555556,
+                    "recall": 0.6979166666666666,
+                    "f1": 0.7976190476190476,
+                    "support": 96,
+                    "roc_auc": 0.8508522727272727,
+                    "pr_auc": 0.9652268003225161
+                  }
+                ],
+                "macro_precision": 0.39351851851851855,
+                "macro_recall": 0.46597222222222223,
+                "macro_f1": 0.38868003341687546,
+                "weighted_f1": 0.6801325347266471,
+                "macro_roc_auc": 0.7814278132477818,
+                "macro_pr_auc": 0.5192449378963577
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3540788062732794,
+              "regime_accuracy": 0.3545454442501068,
+              "regime_loss": 1.032730063525113,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    30,
+                    17,
+                    31
+                  ],
+                  [
+                    2,
+                    4,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.30769230769230765,
+                    "support": 12,
+                    "roc_auc": 0.7482993197278912,
+                    "pr_auc": 0.28986953232844115
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7391304347826086,
+                    "recall": 0.21794871794871795,
+                    "f1": 0.3366336633663366,
+                    "support": 78,
+                    "roc_auc": 0.5308493589743589,
+                    "pr_auc": 0.7525290038915953
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2978723404255319,
+                    "recall": 0.7,
+                    "f1": 0.417910447761194,
+                    "support": 20,
+                    "roc_auc": 0.7605555555555555,
+                    "pr_auc": 0.42489670736446766
+                  }
+                ],
+                "macro_precision": 0.4123342584027135,
+                "macro_recall": 0.5282051282051282,
+                "macro_f1": 0.3540788062732794,
+                "weighted_f1": 0.34825402172823483,
+                "macro_roc_auc": 0.6799014114192685,
+                "macro_pr_auc": 0.48909841452816805
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.30670615821300756,
+              "regime_accuracy": 0.30630630254745483,
+              "regime_loss": 1.135963371215634,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    15,
+                    16
+                  ],
+                  [
+                    13,
+                    9,
+                    26
+                  ],
+                  [
+                    4,
+                    3,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.43333333333333335,
+                    "recall": 0.29545454545454547,
+                    "f1": 0.3513513513513514,
+                    "support": 44,
+                    "roc_auc": 0.5603799185888738,
+                    "pr_auc": 0.4184185693285398
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.1875,
+                    "f1": 0.24000000000000005,
+                    "support": 48,
+                    "roc_auc": 0.5634920634920635,
+                    "pr_auc": 0.4269988455328579
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.631578947368421,
+                    "f1": 0.3287671232876712,
+                    "support": 19,
+                    "roc_auc": 0.5818077803203662,
+                    "pr_auc": 0.315295705031337
+                  }
+                ],
+                "macro_precision": 0.32962962962962966,
+                "macro_recall": 0.3715111642743221,
+                "macro_f1": 0.30670615821300756,
+                "weighted_f1": 0.2993336468641912,
+                "macro_roc_auc": 0.5685599208004345,
+                "macro_pr_auc": 0.38690437329757826
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5554839059870814,
+              "regime_accuracy": 0.567307710647583,
+              "regime_loss": 1.1022147215329683,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    7,
+                    7
+                  ],
+                  [
+                    9,
+                    27,
+                    16
+                  ],
+                  [
+                    3,
+                    3,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.46153846153846156,
+                    "f1": 0.48000000000000004,
+                    "support": 26,
+                    "roc_auc": 0.6632149901380671,
+                    "pr_auc": 0.38449630506651655
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7297297297297297,
+                    "recall": 0.5192307692307693,
+                    "f1": 0.6067415730337079,
+                    "support": 52,
+                    "roc_auc": 0.6357248520710059,
+                    "pr_auc": 0.6763143630361763
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.46511627906976744,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5797101449275363,
+                    "support": 26,
+                    "roc_auc": 0.6987179487179487,
+                    "pr_auc": 0.5136743357156033
+                  }
+                ],
+                "macro_precision": 0.5649486695998324,
+                "macro_recall": 0.5833333333333334,
+                "macro_f1": 0.5554839059870814,
+                "weighted_f1": 0.568298322748738,
+                "macro_roc_auc": 0.6658859303090072,
+                "macro_pr_auc": 0.5248283346060987
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "classification": {
+      "regime_f1_macro": {
+        "mean": 0.4038848618874156,
+        "std": 0.08396423074075038,
+        "min": 0.30670615821300756,
+        "max": 0.5554839059870814,
+        "n": 5
+      },
+      "regression_rmse_log_rv": null
+    }
+  }
+}

--- a/backend/artifacts/experiments/runpod_20260530/runpod_phrasebank_20260530T131320Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/runpod_phrasebank_20260530T131320Z.json
@@ -1,0 +1,1390 @@
+{
+  "pipeline": "finetune_pilot_b2",
+  "training_package_id": "canonical",
+  "encoder_alias": "finbert_fed_adjacent",
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 5,
+  "train_batch_size": 16,
+  "eval_batch_size": 32,
+  "learning_rate": 2e-05,
+  "weight_decay": 0.01,
+  "max_length": 256,
+  "n_classes": 3,
+  "labels": [
+    "calm",
+    "normal",
+    "high"
+  ],
+  "started_at_utc": "20260530T134346Z",
+  "phrasebank_aux": {
+    "enabled": true,
+    "subset": "sentences_allagree",
+    "n_rows": 2264,
+    "class_counts": [
+      303,
+      1391,
+      570
+    ],
+    "aux_lambda": 0.3
+  },
+  "trials": [
+    {
+      "seed": 11,
+      "folds": [
+        {
+          "fold_id": "wf_fold_1",
+          "metrics": {
+            "regime_f1_macro": 0.4921875,
+            "regime_accuracy": 0.32642487046632124,
+            "regime_weighted_f1": 0.4921875,
+            "train_loss": 0.9579746353198152
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.01231994222285423
+          ],
+          "train_rows": 2894,
+          "test_rows": 193,
+          "train_class_counts": [
+            878,
+            954,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            193,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                60,
+                63,
+                70
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.32642487046632124,
+                "f1": 0.4921875,
+                "support": 193,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.32642487046632124,
+            "macro_f1": 0.4921875,
+            "weighted_f1": 0.4921875,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 111.69224789785221,
+          "eval_runtime_s": 0.29380426136776805,
+          "phrasebank_aux": {
+            "train_loss": 0.08533804478916181,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        },
+        {
+          "fold_id": "wf_fold_2",
+          "metrics": {
+            "regime_f1_macro": 0.7096774193548387,
+            "regime_accuracy": 0.55,
+            "regime_weighted_f1": 0.7096774193548387,
+            "train_loss": 0.918518604276721
+          },
+          "tertile_cutoffs": [
+            0.005142148291239123,
+            0.01231994222285423
+          ],
+          "train_rows": 3101,
+          "test_rows": 200,
+          "train_class_counts": [
+            853,
+            1186,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            200,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                42,
+                110,
+                48
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.55,
+                "f1": 0.7096774193548387,
+                "support": 200,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.55,
+            "macro_f1": 0.7096774193548387,
+            "weighted_f1": 0.7096774193548387,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 119.6080754972063,
+          "eval_runtime_s": 0.337270125746727,
+          "phrasebank_aux": {
+            "train_loss": 0.08525914903682148,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        },
+        {
+          "fold_id": "wf_fold_3",
+          "metrics": {
+            "regime_f1_macro": 0.2666666666666667,
+            "regime_accuracy": 0.15384615384615385,
+            "regime_weighted_f1": 0.2666666666666667,
+            "train_loss": 0.9156762671846788
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.011897883392381006
+          ],
+          "train_rows": 3294,
+          "test_rows": 26,
+          "train_class_counts": [
+            1085,
+            1042,
+            1167
+          ],
+          "test_class_counts": [
+            0,
+            26,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                13,
+                4,
+                9
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.15384615384615385,
+                "f1": 0.2666666666666667,
+                "support": 26,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.15384615384615385,
+            "macro_f1": 0.2666666666666667,
+            "weighted_f1": 0.2666666666666667,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 127.07647950062528,
+          "eval_runtime_s": 0.03294146992266178,
+          "phrasebank_aux": {
+            "train_loss": 0.07917443031978622,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        }
+      ]
+    },
+    {
+      "seed": 29,
+      "folds": [
+        {
+          "fold_id": "wf_fold_1",
+          "metrics": {
+            "regime_f1_macro": 0.4921875,
+            "regime_accuracy": 0.32642487046632124,
+            "regime_weighted_f1": 0.4921875,
+            "train_loss": 0.955695823477118
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.01231994222285423
+          ],
+          "train_rows": 2894,
+          "test_rows": 193,
+          "train_class_counts": [
+            878,
+            954,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            193,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                57,
+                63,
+                73
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.32642487046632124,
+                "f1": 0.4921875,
+                "support": 193,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.32642487046632124,
+            "macro_f1": 0.4921875,
+            "weighted_f1": 0.4921875,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 111.7957620038651,
+          "eval_runtime_s": 0.3902927888557315,
+          "phrasebank_aux": {
+            "train_loss": 0.10399265924767072,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        },
+        {
+          "fold_id": "wf_fold_2",
+          "metrics": {
+            "regime_f1_macro": 0.615916955017301,
+            "regime_accuracy": 0.445,
+            "regime_weighted_f1": 0.615916955017301,
+            "train_loss": 0.9251293352430628
+          },
+          "tertile_cutoffs": [
+            0.005142148291239123,
+            0.01231994222285423
+          ],
+          "train_rows": 3101,
+          "test_rows": 200,
+          "train_class_counts": [
+            853,
+            1186,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            200,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                68,
+                89,
+                43
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.445,
+                "f1": 0.615916955017301,
+                "support": 200,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.445,
+            "macro_f1": 0.615916955017301,
+            "weighted_f1": 0.615916955017301,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 119.6886573289521,
+          "eval_runtime_s": 0.373166318051517,
+          "phrasebank_aux": {
+            "train_loss": 0.09317268302289712,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        },
+        {
+          "fold_id": "wf_fold_3",
+          "metrics": {
+            "regime_f1_macro": 0.5142857142857142,
+            "regime_accuracy": 0.34615384615384615,
+            "regime_weighted_f1": 0.5142857142857142,
+            "train_loss": 0.8704742872309916
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.011897883392381006
+          ],
+          "train_rows": 3294,
+          "test_rows": 26,
+          "train_class_counts": [
+            1085,
+            1042,
+            1167
+          ],
+          "test_class_counts": [
+            0,
+            26,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                6,
+                9,
+                11
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.34615384615384615,
+                "f1": 0.5142857142857142,
+                "support": 26,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.34615384615384615,
+            "macro_f1": 0.5142857142857142,
+            "weighted_f1": 0.5142857142857142,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 126.91884664678946,
+          "eval_runtime_s": 0.03718980774283409,
+          "phrasebank_aux": {
+            "train_loss": 0.08550660422035647,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        }
+      ]
+    },
+    {
+      "seed": 47,
+      "folds": [
+        {
+          "fold_id": "wf_fold_1",
+          "metrics": {
+            "regime_f1_macro": 0.6115107913669064,
+            "regime_accuracy": 0.44041450777202074,
+            "regime_weighted_f1": 0.6115107913669064,
+            "train_loss": 0.9148732901113468
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.01231994222285423
+          ],
+          "train_rows": 2894,
+          "test_rows": 193,
+          "train_class_counts": [
+            878,
+            954,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            193,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                37,
+                85,
+                71
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.44041450777202074,
+                "f1": 0.6115107913669064,
+                "support": 193,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.44041450777202074,
+            "macro_f1": 0.6115107913669064,
+            "weighted_f1": 0.6115107913669064,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 111.67668747389689,
+          "eval_runtime_s": 0.30378496600314975,
+          "phrasebank_aux": {
+            "train_loss": 0.09412179828379612,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        },
+        {
+          "fold_id": "wf_fold_2",
+          "metrics": {
+            "regime_f1_macro": 0.6206896551724138,
+            "regime_accuracy": 0.45,
+            "regime_weighted_f1": 0.6206896551724138,
+            "train_loss": 0.9247398308103847
+          },
+          "tertile_cutoffs": [
+            0.005142148291239123,
+            0.01231994222285423
+          ],
+          "train_rows": 3101,
+          "test_rows": 200,
+          "train_class_counts": [
+            853,
+            1186,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            200,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                53,
+                90,
+                57
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.45,
+                "f1": 0.6206896551724138,
+                "support": 200,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.45,
+            "macro_f1": 0.6206896551724138,
+            "weighted_f1": 0.6206896551724138,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 119.71793535165489,
+          "eval_runtime_s": 0.3564214389771223,
+          "phrasebank_aux": {
+            "train_loss": 0.08558731123603419,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        },
+        {
+          "fold_id": "wf_fold_3",
+          "metrics": {
+            "regime_f1_macro": 0.07407407407407407,
+            "regime_accuracy": 0.038461538461538464,
+            "regime_weighted_f1": 0.07407407407407407,
+            "train_loss": 0.9191373851837463
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.011897883392381006
+          ],
+          "train_rows": 3294,
+          "test_rows": 26,
+          "train_class_counts": [
+            1085,
+            1042,
+            1167
+          ],
+          "test_class_counts": [
+            0,
+            26,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                13,
+                1,
+                12
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.038461538461538464,
+                "f1": 0.07407407407407407,
+                "support": 26,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.038461538461538464,
+            "macro_f1": 0.07407407407407407,
+            "weighted_f1": 0.07407407407407407,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 127.30671892501414,
+          "eval_runtime_s": 0.03668642835691571,
+          "phrasebank_aux": {
+            "train_loss": 0.0827778523543723,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        }
+      ]
+    },
+    {
+      "seed": 71,
+      "folds": [
+        {
+          "fold_id": "wf_fold_1",
+          "metrics": {
+            "regime_f1_macro": 0.5543071161048688,
+            "regime_accuracy": 0.38341968911917096,
+            "regime_weighted_f1": 0.5543071161048688,
+            "train_loss": 0.9360458789115452
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.01231994222285423
+          ],
+          "train_rows": 2894,
+          "test_rows": 193,
+          "train_class_counts": [
+            878,
+            954,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            193,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                29,
+                74,
+                90
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.38341968911917096,
+                "f1": 0.5543071161048688,
+                "support": 193,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.38341968911917096,
+            "macro_f1": 0.5543071161048688,
+            "weighted_f1": 0.5543071161048688,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 111.2516335779801,
+          "eval_runtime_s": 0.30095297610387206,
+          "phrasebank_aux": {
+            "train_loss": 0.1002621198464082,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        },
+        {
+          "fold_id": "wf_fold_2",
+          "metrics": {
+            "regime_f1_macro": 0.6348122866894198,
+            "regime_accuracy": 0.465,
+            "regime_weighted_f1": 0.6348122866894198,
+            "train_loss": 0.9377153187836569
+          },
+          "tertile_cutoffs": [
+            0.005142148291239123,
+            0.01231994222285423
+          ],
+          "train_rows": 3101,
+          "test_rows": 200,
+          "train_class_counts": [
+            853,
+            1186,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            200,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                21,
+                93,
+                86
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.465,
+                "f1": 0.6348122866894198,
+                "support": 200,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.465,
+            "macro_f1": 0.6348122866894198,
+            "weighted_f1": 0.6348122866894198,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 119.80922033730894,
+          "eval_runtime_s": 0.3529375931248069,
+          "phrasebank_aux": {
+            "train_loss": 0.09259126721113228,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        },
+        {
+          "fold_id": "wf_fold_3",
+          "metrics": {
+            "regime_f1_macro": 0.07407407407407407,
+            "regime_accuracy": 0.038461538461538464,
+            "regime_weighted_f1": 0.07407407407407407,
+            "train_loss": 0.9569154213499097
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.011897883392381006
+          ],
+          "train_rows": 3294,
+          "test_rows": 26,
+          "train_class_counts": [
+            1085,
+            1042,
+            1167
+          ],
+          "test_class_counts": [
+            0,
+            26,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                11,
+                1,
+                14
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.038461538461538464,
+                "f1": 0.07407407407407407,
+                "support": 26,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.038461538461538464,
+            "macro_f1": 0.07407407407407407,
+            "weighted_f1": 0.07407407407407407,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 127.15113937202841,
+          "eval_runtime_s": 0.03481798619031906,
+          "phrasebank_aux": {
+            "train_loss": 0.09218962371747182,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        }
+      ]
+    },
+    {
+      "seed": 97,
+      "folds": [
+        {
+          "fold_id": "wf_fold_1",
+          "metrics": {
+            "regime_f1_macro": 0.6735395189003437,
+            "regime_accuracy": 0.5077720207253886,
+            "regime_weighted_f1": 0.6735395189003437,
+            "train_loss": 0.9532562029954478
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.01231994222285423
+          ],
+          "train_rows": 2894,
+          "test_rows": 193,
+          "train_class_counts": [
+            878,
+            954,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            193,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                39,
+                98,
+                56
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.5077720207253886,
+                "f1": 0.6735395189003437,
+                "support": 193,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.5077720207253886,
+            "macro_f1": 0.6735395189003437,
+            "weighted_f1": 0.6735395189003437,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 111.96142358100042,
+          "eval_runtime_s": 0.34094542497769,
+          "phrasebank_aux": {
+            "train_loss": 0.10212551824367755,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        },
+        {
+          "fold_id": "wf_fold_2",
+          "metrics": {
+            "regime_f1_macro": 0.6111111111111112,
+            "regime_accuracy": 0.44,
+            "regime_weighted_f1": 0.6111111111111112,
+            "train_loss": 0.9448980168890707
+          },
+          "tertile_cutoffs": [
+            0.005142148291239123,
+            0.01231994222285423
+          ],
+          "train_rows": 3101,
+          "test_rows": 200,
+          "train_class_counts": [
+            853,
+            1186,
+            1062
+          ],
+          "test_class_counts": [
+            0,
+            200,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                40,
+                88,
+                72
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.44,
+                "f1": 0.6111111111111112,
+                "support": 200,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.44,
+            "macro_f1": 0.6111111111111112,
+            "weighted_f1": 0.6111111111111112,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 119.16985135199502,
+          "eval_runtime_s": 0.29165281541645527,
+          "phrasebank_aux": {
+            "train_loss": 0.09517548318217825,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        },
+        {
+          "fold_id": "wf_fold_3",
+          "metrics": {
+            "regime_f1_macro": 0.20689655172413793,
+            "regime_accuracy": 0.11538461538461539,
+            "regime_weighted_f1": 0.20689655172413793,
+            "train_loss": 0.9115705945827428
+          },
+          "tertile_cutoffs": [
+            0.006211735555404685,
+            0.011897883392381006
+          ],
+          "train_rows": 3294,
+          "test_rows": 26,
+          "train_class_counts": [
+            1085,
+            1042,
+            1167
+          ],
+          "test_class_counts": [
+            0,
+            26,
+            0
+          ],
+          "classification_breakdown": {
+            "n_classes": 3,
+            "confusion_matrix": [
+              [
+                0,
+                0,
+                0
+              ],
+              [
+                12,
+                3,
+                11
+              ],
+              [
+                0,
+                0,
+                0
+              ]
+            ],
+            "per_class": [
+              {
+                "class_id": 0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              },
+              {
+                "class_id": 1,
+                "precision": 1.0,
+                "recall": 0.11538461538461539,
+                "f1": 0.20689655172413793,
+                "support": 26,
+                "roc_auc": null,
+                "pr_auc": 1.0
+              },
+              {
+                "class_id": 2,
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "support": 0,
+                "roc_auc": null,
+                "pr_auc": null
+              }
+            ],
+            "macro_precision": 1.0,
+            "macro_recall": 0.11538461538461539,
+            "macro_f1": 0.20689655172413793,
+            "weighted_f1": 0.20689655172413793,
+            "macro_roc_auc": null,
+            "macro_pr_auc": 1.0
+          },
+          "train_runtime_s": 126.84874949790537,
+          "eval_runtime_s": 0.03581859963014722,
+          "phrasebank_aux": {
+            "train_loss": 0.08563334855513231,
+            "aux_lambda": 0.3,
+            "n_rows": 2264
+          }
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "regime_f1_macro": {
+      "mean": 0.47679579563612473,
+      "std": 0.20710975500434065,
+      "min": 0.07407407407407407,
+      "max": 0.7096774193548387,
+      "n": 15
+    },
+    "regime_f1_macro_ci": {
+      "lower": 0.41885857032230944,
+      "upper": 0.5299145863049692,
+      "confidence": 0.95,
+      "n_resamples": 1000
+    }
+  }
+}

--- a/backend/artifacts/experiments/runpod_20260530/runpod_press_conf_20260530T141754Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/runpod_press_conf_20260530T141754Z.json
@@ -1,0 +1,5153 @@
+{
+  "head_modes": [
+    "classification",
+    "regression",
+    "dual"
+  ],
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "regression_alpha": 0.5,
+  "training_package_id": "canonical",
+  "rates_target_mode": "raw",
+  "rates_heads": [],
+  "use_retrieval_analogs": false,
+  "use_regime_conditioning": false,
+  "use_statement_delta": false,
+  "use_vote_features": false,
+  "use_press_conf": true,
+  "trials": {
+    "classification": [
+      {
+        "head_mode": "classification",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.369365009223604,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.115595499797371,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    6,
+                    6
+                  ],
+                  [
+                    12,
+                    6,
+                    27
+                  ],
+                  [
+                    17,
+                    5,
+                    25
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35555555555555557,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.4383561643835616,
+                    "support": 28,
+                    "roc_auc": 0.6906055900621118,
+                    "pr_auc": 0.36677628113574473
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.35294117647058826,
+                    "recall": 0.13333333333333333,
+                    "f1": 0.19354838709677416,
+                    "support": 45,
+                    "roc_auc": 0.4065185185185185,
+                    "pr_auc": 0.3887848317342641
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.43103448275862066,
+                    "recall": 0.5319148936170213,
+                    "f1": 0.4761904761904762,
+                    "support": 47,
+                    "roc_auc": 0.5115126785193821,
+                    "pr_auc": 0.37664504179907804
+                  }
+                ],
+                "macro_precision": 0.3798437382615882,
+                "macro_recall": 0.412225599459642,
+                "macro_f1": 0.369365009223604,
+                "weighted_f1": 0.3613716866920579,
+                "macro_roc_auc": 0.5362122623666709,
+                "macro_pr_auc": 0.3774020515563623
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.42992424242424243,
+              "regime_accuracy": 0.694915235042572,
+              "regime_loss": 0.5861991664110604,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    8,
+                    13,
+                    75
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 10,
+                    "roc_auc": 0.8925925925925926,
+                    "pr_auc": 0.3297097845627257
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7177672955974843,
+                    "pr_auc": 0.15449871591105965
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9375,
+                    "recall": 0.78125,
+                    "f1": 0.8522727272727273,
+                    "support": 96,
+                    "roc_auc": 0.9005681818181818,
+                    "pr_auc": 0.9781129721584237
+                  }
+                ],
+                "macro_precision": 0.418560606060606,
+                "macro_recall": 0.49374999999999997,
+                "macro_f1": 0.42992424242424243,
+                "weighted_f1": 0.7304506933744221,
+                "macro_roc_auc": 0.8369760233360862,
+                "macro_pr_auc": 0.48744049087740304
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2618090790133801,
+              "regime_accuracy": 0.2454545497894287,
+              "regime_loss": 1.1816419753161345,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    49,
+                    3,
+                    26
+                  ],
+                  [
+                    6,
+                    0,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.15384615384615385,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.25974025974025977,
+                    "support": 12,
+                    "roc_auc": 0.7202380952380952,
+                    "pr_auc": 0.20210008839877253
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.07407407407407407,
+                    "support": 78,
+                    "roc_auc": 0.3457532051282051,
+                    "pr_auc": 0.6418079983893249
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.7,
+                    "f1": 0.45161290322580644,
+                    "support": 20,
+                    "roc_auc": 0.6738888888888889,
+                    "pr_auc": 0.24381470649864984
+                  }
+                ],
+                "macro_precision": 0.49572649572649574,
+                "macro_recall": 0.523931623931624,
+                "macro_f1": 0.2618090790133801,
+                "weighted_f1": 0.16297199053797293,
+                "macro_roc_auc": 0.5799600630850631,
+                "macro_pr_auc": 0.36257426442891577
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3945645669783601,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.0972699824173806,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    28,
+                    5,
+                    11
+                  ],
+                  [
+                    19,
+                    10,
+                    19
+                  ],
+                  [
+                    8,
+                    2,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.509090909090909,
+                    "recall": 0.6363636363636364,
+                    "f1": 0.5656565656565656,
+                    "support": 44,
+                    "roc_auc": 0.6258480325644504,
+                    "pr_auc": 0.4490315888969803
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5882352941176471,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.3076923076923077,
+                    "support": 48,
+                    "roc_auc": 0.5482804232804233,
+                    "pr_auc": 0.49518240566918
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.23076923076923078,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.3103448275862069,
+                    "support": 19,
+                    "roc_auc": 0.6018306636155606,
+                    "pr_auc": 0.2550741407155042
+                  }
+                ],
+                "macro_precision": 0.4426984779925956,
+                "macro_recall": 0.43946039340776183,
+                "macro_f1": 0.3945645669783601,
+                "weighted_f1": 0.4104024448852035,
+                "macro_roc_auc": 0.5919863731534781,
+                "macro_pr_auc": 0.39976271176055483
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4265341400172861,
+              "regime_accuracy": 0.45192307233810425,
+              "regime_loss": 1.130948318884923,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    11,
+                    9
+                  ],
+                  [
+                    6,
+                    21,
+                    25
+                  ],
+                  [
+                    1,
+                    5,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.30769230769230776,
+                    "support": 26,
+                    "roc_auc": 0.6232741617357002,
+                    "pr_auc": 0.33623477846474936
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5675675675675675,
+                    "recall": 0.40384615384615385,
+                    "f1": 0.47191011235955055,
+                    "support": 52,
+                    "roc_auc": 0.5950443786982249,
+                    "pr_auc": 0.5608684539458362
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37037037037037035,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5,
+                    "support": 26,
+                    "roc_auc": 0.754930966469428,
+                    "pr_auc": 0.6123282416320628
+                  }
+                ],
+                "macro_precision": 0.46649213315879984,
+                "macro_recall": 0.467948717948718,
+                "macro_f1": 0.4265341400172861,
+                "weighted_f1": 0.4378781331028522,
+                "macro_roc_auc": 0.657749835634451,
+                "macro_pr_auc": 0.5031438246808828
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.28131434585921106,
+              "regime_accuracy": 0.3166666626930237,
+              "regime_loss": 1.1797789588793341,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    9,
+                    3
+                  ],
+                  [
+                    18,
+                    1,
+                    26
+                  ],
+                  [
+                    23,
+                    3,
+                    21
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2807017543859649,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.3764705882352941,
+                    "support": 28,
+                    "roc_auc": 0.6987577639751553,
+                    "pr_auc": 0.47999921358689485
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.07692307692307693,
+                    "recall": 0.022222222222222223,
+                    "f1": 0.034482758620689655,
+                    "support": 45,
+                    "roc_auc": 0.4915555555555556,
+                    "pr_auc": 0.3793542629701484
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.42,
+                    "recall": 0.44680851063829785,
+                    "f1": 0.43298969072164945,
+                    "support": 47,
+                    "roc_auc": 0.52608568930341,
+                    "pr_auc": 0.39943749423627867
+                  }
+                ],
+                "macro_precision": 0.2592082771030139,
+                "macro_recall": 0.34681976809636383,
+                "macro_f1": 0.28131434585921106,
+                "weighted_f1": 0.27036180060363996,
+                "macro_roc_auc": 0.572133002944707,
+                "macro_pr_auc": 0.4195969902644407
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.42020063839489286,
+              "regime_accuracy": 0.6779661178588867,
+              "regime_loss": 0.6229344338683759,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    8,
+                    15,
+                    73
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2916666666666667,
+                    "recall": 0.7,
+                    "f1": 0.4117647058823529,
+                    "support": 10,
+                    "roc_auc": 0.899074074074074,
+                    "pr_auc": 0.5443423590495342
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.639937106918239,
+                    "pr_auc": 0.12457448543251015
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9605263157894737,
+                    "recall": 0.7604166666666666,
+                    "f1": 0.8488372093023255,
+                    "support": 96,
+                    "roc_auc": 0.9119318181818182,
+                    "pr_auc": 0.9758725662197393
+                  }
+                ],
+                "macro_precision": 0.4173976608187135,
+                "macro_recall": 0.48680555555555555,
+                "macro_f1": 0.42020063839489286,
+                "weighted_f1": 0.7254747385749728,
+                "macro_roc_auc": 0.8169809997247105,
+                "macro_pr_auc": 0.5482631369005945
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.37851584067836236,
+              "regime_accuracy": 0.38181817531585693,
+              "regime_loss": 1.3209989612752742,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    22,
+                    20,
+                    36
+                  ],
+                  [
+                    2,
+                    4,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.36363636363636365,
+                    "support": 12,
+                    "roc_auc": 0.7227891156462585,
+                    "pr_auc": 0.20683150305560266
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8,
+                    "recall": 0.2564102564102564,
+                    "f1": 0.3883495145631068,
+                    "support": 78,
+                    "roc_auc": 0.3858173076923077,
+                    "pr_auc": 0.6857392514912706
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2641509433962264,
+                    "recall": 0.7,
+                    "f1": 0.3835616438356165,
+                    "support": 20,
+                    "roc_auc": 0.6833333333333333,
+                    "pr_auc": 0.245092217331293
+                  }
+                ],
+                "macro_precision": 0.4380503144654088,
+                "macro_recall": 0.541025641025641,
+                "macro_f1": 0.37851584067836236,
+                "weighted_f1": 0.3847830125115547,
+                "macro_roc_auc": 0.5973132522239665,
+                "macro_pr_auc": 0.37922099062605535
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3055588060912438,
+              "regime_accuracy": 0.36936935782432556,
+              "regime_loss": 1.131507019055567,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    29,
+                    0,
+                    15
+                  ],
+                  [
+                    28,
+                    1,
+                    19
+                  ],
+                  [
+                    8,
+                    0,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4461538461538462,
+                    "recall": 0.6590909090909091,
+                    "f1": 0.5321100917431192,
+                    "support": 44,
+                    "roc_auc": 0.58921302578019,
+                    "pr_auc": 0.4322035596403335
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.020833333333333332,
+                    "f1": 0.04081632653061225,
+                    "support": 48,
+                    "roc_auc": 0.595568783068783,
+                    "pr_auc": 0.5164285151598504
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.24444444444444444,
+                    "recall": 0.5789473684210527,
+                    "f1": 0.34375,
+                    "support": 19,
+                    "roc_auc": 0.5703661327231121,
+                    "pr_auc": 0.23806387190287678
+                  }
+                ],
+                "macro_precision": 0.5635327635327635,
+                "macro_recall": 0.419623870281765,
+                "macro_f1": 0.3055588060912438,
+                "weighted_f1": 0.28741691630780747,
+                "macro_roc_auc": 0.5850493138573617,
+                "macro_pr_auc": 0.39556531556768687
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3848684210526316,
+              "regime_accuracy": 0.38461539149284363,
+              "regime_loss": 1.076765408882728,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    8,
+                    8
+                  ],
+                  [
+                    22,
+                    13,
+                    17
+                  ],
+                  [
+                    6,
+                    3,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2631578947368421,
+                    "recall": 0.38461538461538464,
+                    "f1": 0.3125,
+                    "support": 26,
+                    "roc_auc": 0.5877712031558185,
+                    "pr_auc": 0.3931139772867937
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5416666666666666,
+                    "recall": 0.25,
+                    "f1": 0.34210526315789475,
+                    "support": 52,
+                    "roc_auc": 0.6438609467455622,
+                    "pr_auc": 0.6251681044388787
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.40476190476190477,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.5,
+                    "support": 26,
+                    "roc_auc": 0.72534516765286,
+                    "pr_auc": 0.6063899024440614
+                  }
+                ],
+                "macro_precision": 0.4031954887218045,
+                "macro_recall": 0.4294871794871795,
+                "macro_f1": 0.3848684210526316,
+                "weighted_f1": 0.3741776315789474,
+                "macro_roc_auc": 0.6523257725180802,
+                "macro_pr_auc": 0.541557328056578
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2757046354530632,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.4979291555863368,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    4,
+                    17
+                  ],
+                  [
+                    12,
+                    0,
+                    33
+                  ],
+                  [
+                    6,
+                    3,
+                    38
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.28,
+                    "recall": 0.25,
+                    "f1": 0.2641509433962264,
+                    "support": 28,
+                    "roc_auc": 0.6168478260869565,
+                    "pr_auc": 0.2658978864787673
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 45,
+                    "roc_auc": 0.541037037037037,
+                    "pr_auc": 0.3889060977814399
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4318181818181818,
+                    "recall": 0.8085106382978723,
+                    "f1": 0.562962962962963,
+                    "support": 47,
+                    "roc_auc": 0.6091518507723696,
+                    "pr_auc": 0.49402138806624224
+                  }
+                ],
+                "macro_precision": 0.2372727272727273,
+                "macro_recall": 0.35283687943262415,
+                "macro_f1": 0.2757046354530632,
+                "weighted_f1": 0.28212904728628,
+                "macro_roc_auc": 0.5890122379654543,
+                "macro_pr_auc": 0.3829417907754831
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.44612653023081955,
+              "regime_accuracy": 0.7118644118309021,
+              "regime_loss": 0.702882217148603,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    8,
+                    0,
+                    4
+                  ],
+                  [
+                    13,
+                    9,
+                    74
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3225806451612903,
+                    "recall": 1.0,
+                    "f1": 0.4878048780487805,
+                    "support": 10,
+                    "roc_auc": 0.925,
+                    "pr_auc": 0.3738568019527772
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.77437106918239,
+                    "pr_auc": 0.1845097525173157
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9487179487179487,
+                    "recall": 0.7708333333333334,
+                    "f1": 0.8505747126436781,
+                    "support": 96,
+                    "roc_auc": 0.875,
+                    "pr_auc": 0.9727246378138829
+                  }
+                ],
+                "macro_precision": 0.4237661979597463,
+                "macro_recall": 0.5902777777777778,
+                "macro_f1": 0.44612653023081955,
+                "weighted_f1": 0.7333323830023805,
+                "macro_roc_auc": 0.8581236897274632,
+                "macro_pr_auc": 0.5103637307613252
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.27032483342431096,
+              "regime_accuracy": 0.2545454502105713,
+              "regime_loss": 1.2146265311674638,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    46,
+                    5,
+                    27
+                  ],
+                  [
+                    5,
+                    2,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16393442622950818,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.273972602739726,
+                    "support": 12,
+                    "roc_auc": 0.7525510204081632,
+                    "pr_auc": 0.2273761499690265
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7142857142857143,
+                    "recall": 0.0641025641025641,
+                    "f1": 0.1176470588235294,
+                    "support": 78,
+                    "roc_auc": 0.33533653846153844,
+                    "pr_auc": 0.6321584834367627
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.30952380952380953,
+                    "recall": 0.65,
+                    "f1": 0.41935483870967744,
+                    "support": 20,
+                    "roc_auc": 0.6922222222222222,
+                    "pr_auc": 0.24826594186177353
+                  }
+                ],
+                "macro_precision": 0.3959146500130107,
+                "macro_recall": 0.5158119658119659,
+                "macro_f1": 0.27032483342431096,
+                "weighted_f1": 0.18955671450277775,
+                "macro_roc_auc": 0.5933699270306413,
+                "macro_pr_auc": 0.36926685842252094
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.35521496047811835,
+              "regime_accuracy": 0.4324324429035187,
+              "regime_loss": 1.090121522451479,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    36,
+                    0,
+                    8
+                  ],
+                  [
+                    27,
+                    2,
+                    19
+                  ],
+                  [
+                    7,
+                    2,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5142857142857142,
+                    "recall": 0.8181818181818182,
+                    "f1": 0.6315789473684209,
+                    "support": 44,
+                    "roc_auc": 0.6339891451831751,
+                    "pr_auc": 0.45889067965424346
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.041666666666666664,
+                    "f1": 0.07692307692307693,
+                    "support": 48,
+                    "roc_auc": 0.5965608465608465,
+                    "pr_auc": 0.4997207623710535
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2702702702702703,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.35714285714285715,
+                    "support": 19,
+                    "roc_auc": 0.6464530892448512,
+                    "pr_auc": 0.25850095892753444
+                  }
+                ],
+                "macro_precision": 0.4281853281853281,
+                "macro_recall": 0.4620547581073897,
+                "macro_f1": 0.35521496047811835,
+                "weighted_f1": 0.34475221317326576,
+                "macro_roc_auc": 0.6256676936629576,
+                "macro_pr_auc": 0.40570413365094377
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4747332014480466,
+              "regime_accuracy": 0.5096153616905212,
+              "regime_loss": 1.006494742173415,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    13,
+                    7
+                  ],
+                  [
+                    10,
+                    27,
+                    15
+                  ],
+                  [
+                    5,
+                    1,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.25531914893617025,
+                    "support": 26,
+                    "roc_auc": 0.6158777120315582,
+                    "pr_auc": 0.3833732700262465
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6585365853658537,
+                    "recall": 0.5192307692307693,
+                    "f1": 0.5806451612903226,
+                    "support": 52,
+                    "roc_auc": 0.6645710059171598,
+                    "pr_auc": 0.5604060386002284
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.47619047619047616,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.588235294117647,
+                    "support": 26,
+                    "roc_auc": 0.8032544378698225,
+                    "pr_auc": 0.6938405566292023
+                  }
+                ],
+                "macro_precision": 0.4734804490902052,
+                "macro_recall": 0.5064102564102565,
+                "macro_f1": 0.4747332014480466,
+                "weighted_f1": 0.5012111914086156,
+                "macro_roc_auc": 0.6945677186061802,
+                "macro_pr_auc": 0.5458732884185591
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4169215969215969,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.103214200607789,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    6,
+                    5
+                  ],
+                  [
+                    9,
+                    11,
+                    25
+                  ],
+                  [
+                    23,
+                    1,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3469387755102041,
+                    "recall": 0.6071428571428571,
+                    "f1": 0.4415584415584415,
+                    "support": 28,
+                    "roc_auc": 0.7531055900621118,
+                    "pr_auc": 0.3754997028288399
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6111111111111112,
+                    "recall": 0.24444444444444444,
+                    "f1": 0.3492063492063492,
+                    "support": 45,
+                    "roc_auc": 0.4311111111111111,
+                    "pr_auc": 0.39703105967738367
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4339622641509434,
+                    "recall": 0.48936170212765956,
+                    "f1": 0.45999999999999996,
+                    "support": 47,
+                    "roc_auc": 0.5919556980472166,
+                    "pr_auc": 0.4341371596769157
+                  }
+                ],
+                "macro_precision": 0.4640040502574196,
+                "macro_recall": 0.4469830012383204,
+                "macro_f1": 0.4169215969215969,
+                "weighted_f1": 0.4141493506493506,
+                "macro_roc_auc": 0.5920574664068131,
+                "macro_pr_auc": 0.402222640727713
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.41077032088268045,
+              "regime_accuracy": 0.7033898234367371,
+              "regime_loss": 0.6574472976943194,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    6,
+                    0,
+                    6
+                  ],
+                  [
+                    14,
+                    6,
+                    76
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25925925925925924,
+                    "recall": 0.7,
+                    "f1": 0.37837837837837834,
+                    "support": 10,
+                    "roc_auc": 0.9074074074074074,
+                    "pr_auc": 0.4477829360182301
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.8191823899371069,
+                    "pr_auc": 0.21529879037411453
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.926829268292683,
+                    "recall": 0.7916666666666666,
+                    "f1": 0.8539325842696629,
+                    "support": 96,
+                    "roc_auc": 0.8821022727272727,
+                    "pr_auc": 0.9730722397426692
+                  }
+                ],
+                "macro_precision": 0.3953628425173141,
+                "macro_recall": 0.49722222222222223,
+                "macro_f1": 0.41077032088268045,
+                "weighted_f1": 0.7267907785904358,
+                "macro_roc_auc": 0.8695640233572624,
+                "macro_pr_auc": 0.545384655378338
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.27761957730812015,
+              "regime_accuracy": 0.27272728085517883,
+              "regime_loss": 1.4129823836413298,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    3,
+                    3
+                  ],
+                  [
+                    41,
+                    13,
+                    24
+                  ],
+                  [
+                    3,
+                    6,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.12,
+                    "recall": 0.5,
+                    "f1": 0.1935483870967742,
+                    "support": 12,
+                    "roc_auc": 0.6139455782312925,
+                    "pr_auc": 0.13167353846315627
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5909090909090909,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.26,
+                    "support": 78,
+                    "roc_auc": 0.2828525641025641,
+                    "pr_auc": 0.5750411245258633
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2894736842105263,
+                    "recall": 0.55,
+                    "f1": 0.37931034482758624,
+                    "support": 20,
+                    "roc_auc": 0.6583333333333333,
+                    "pr_auc": 0.2592136778956198
+                  }
+                ],
+                "macro_precision": 0.3334609250398724,
+                "macro_recall": 0.4055555555555556,
+                "macro_f1": 0.27761957730812015,
+                "weighted_f1": 0.27444352310648196,
+                "macro_roc_auc": 0.51837715855573,
+                "macro_pr_auc": 0.3219761136282131
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4564571231237898,
+              "regime_accuracy": 0.46846845746040344,
+              "regime_loss": 1.0276251237076308,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    23,
+                    8,
+                    13
+                  ],
+                  [
+                    17,
+                    19,
+                    12
+                  ],
+                  [
+                    7,
+                    2,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.48936170212765956,
+                    "recall": 0.5227272727272727,
+                    "f1": 0.5054945054945055,
+                    "support": 44,
+                    "roc_auc": 0.6289009497964722,
+                    "pr_auc": 0.48110321130180156
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6551724137931034,
+                    "recall": 0.3958333333333333,
+                    "f1": 0.49350649350649356,
+                    "support": 48,
+                    "roc_auc": 0.6501322751322751,
+                    "pr_auc": 0.5786581212271217
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.37037037037037035,
+                    "support": 19,
+                    "roc_auc": 0.6132723112128147,
+                    "pr_auc": 0.42169091113407653
+                  }
+                ],
+                "macro_precision": 0.47674946721168293,
+                "macro_recall": 0.48162546517809673,
+                "macro_f1": 0.4564571231237898,
+                "weighted_f1": 0.4771811438478106,
+                "macro_roc_auc": 0.6307685120471873,
+                "macro_pr_auc": 0.49381741455433326
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4519317160826595,
+              "regime_accuracy": 0.5961538553237915,
+              "regime_loss": 1.0725471010574927,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    20,
+                    6
+                  ],
+                  [
+                    3,
+                    45,
+                    4
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5133136094674556,
+                    "pr_auc": 0.2881559851596681
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6081081081081081,
+                    "recall": 0.8653846153846154,
+                    "f1": 0.7142857142857144,
+                    "support": 52,
+                    "roc_auc": 0.680103550295858,
+                    "pr_auc": 0.6353923211298232
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.6296296296296297,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.6415094339622641,
+                    "support": 26,
+                    "roc_auc": 0.782051282051282,
+                    "pr_auc": 0.6552971917317609
+                  }
+                ],
+                "macro_precision": 0.4125792459125792,
+                "macro_recall": 0.5064102564102564,
+                "macro_f1": 0.4519317160826595,
+                "weighted_f1": 0.5175202156334233,
+                "macro_roc_auc": 0.6584894806048652,
+                "macro_pr_auc": 0.5262818326737507
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3989887779010976,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.1482610066789047,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    12,
+                    6
+                  ],
+                  [
+                    7,
+                    14,
+                    24
+                  ],
+                  [
+                    8,
+                    14,
+                    25
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4,
+                    "recall": 0.35714285714285715,
+                    "f1": 0.3773584905660378,
+                    "support": 28,
+                    "roc_auc": 0.672748447204969,
+                    "pr_auc": 0.35582867933978474
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.35,
+                    "recall": 0.3111111111111111,
+                    "f1": 0.32941176470588235,
+                    "support": 45,
+                    "roc_auc": 0.44325925925925924,
+                    "pr_auc": 0.33371664262925843
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.5319148936170213,
+                    "f1": 0.4901960784313725,
+                    "support": 47,
+                    "roc_auc": 0.5601865345380356,
+                    "pr_auc": 0.42962216363767947
+                  }
+                ],
+                "macro_precision": 0.40151515151515155,
+                "macro_recall": 0.4000562872903299,
+                "macro_f1": 0.3989887779010976,
+                "weighted_f1": 0.40357319028240224,
+                "macro_roc_auc": 0.5587314136674212,
+                "macro_pr_auc": 0.37305582853557423
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4944607363962203,
+              "regime_accuracy": 0.7711864113807678,
+              "regime_loss": 0.6049912627470695,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    4,
+                    1,
+                    7
+                  ],
+                  [
+                    7,
+                    6,
+                    83
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3888888888888889,
+                    "recall": 0.7,
+                    "f1": 0.5,
+                    "support": 10,
+                    "roc_auc": 0.9314814814814815,
+                    "pr_auc": 0.4240667641537207
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.1,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.0909090909090909,
+                    "support": 12,
+                    "roc_auc": 0.7413522012578616,
+                    "pr_auc": 0.19753594911007397
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9222222222222223,
+                    "recall": 0.8645833333333334,
+                    "f1": 0.89247311827957,
+                    "support": 96,
+                    "roc_auc": 0.9057765151515151,
+                    "pr_auc": 0.9799630027939645
+                  }
+                ],
+                "macro_precision": 0.4703703703703704,
+                "macro_recall": 0.5493055555555556,
+                "macro_f1": 0.4944607363962203,
+                "weighted_f1": 0.777697698692778,
+                "macro_roc_auc": 0.8595367326302861,
+                "macro_pr_auc": 0.5338552386859198
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2516713209782517,
+              "regime_accuracy": 0.2454545497894287,
+              "regime_loss": 1.3655057083476674,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    2,
+                    3
+                  ],
+                  [
+                    20,
+                    0,
+                    58
+                  ],
+                  [
+                    0,
+                    0,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25925925925925924,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.358974358974359,
+                    "support": 12,
+                    "roc_auc": 0.6828231292517006,
+                    "pr_auc": 0.16652741129429366
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.40705128205128205,
+                    "pr_auc": 0.6829275546612296
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.24691358024691357,
+                    "recall": 1.0,
+                    "f1": 0.396039603960396,
+                    "support": 20,
+                    "roc_auc": 0.7905555555555556,
+                    "pr_auc": 0.36886211516191203
+                  }
+                ],
+                "macro_precision": 0.16872427983539096,
+                "macro_recall": 0.5277777777777778,
+                "macro_f1": 0.2516713209782517,
+                "weighted_f1": 0.11116803988091116,
+                "macro_roc_auc": 0.6268099889528461,
+                "macro_pr_auc": 0.4061056937058118
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.37069525666016895,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.093945319111884,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    21,
+                    15,
+                    8
+                  ],
+                  [
+                    15,
+                    12,
+                    21
+                  ],
+                  [
+                    4,
+                    6,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.525,
+                    "recall": 0.4772727272727273,
+                    "f1": 0.5,
+                    "support": 44,
+                    "roc_auc": 0.6645183175033921,
+                    "pr_auc": 0.5187436831405741
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.36363636363636365,
+                    "recall": 0.25,
+                    "f1": 0.2962962962962963,
+                    "support": 48,
+                    "roc_auc": 0.5744047619047619,
+                    "pr_auc": 0.4456448529468197
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.23684210526315788,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.3157894736842105,
+                    "support": 19,
+                    "roc_auc": 0.6006864988558352,
+                    "pr_auc": 0.35734204076641335
+                  }
+                ],
+                "macro_precision": 0.37515948963317386,
+                "macro_recall": 0.4003189792663477,
+                "macro_f1": 0.37069525666016895,
+                "weighted_f1": 0.38038038038038036,
+                "macro_roc_auc": 0.6132031927546631,
+                "macro_pr_auc": 0.440576858951269
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4171818774993378,
+              "regime_accuracy": 0.4423076808452606,
+              "regime_loss": 1.1692694058785071,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    4,
+                    16
+                  ],
+                  [
+                    13,
+                    20,
+                    19
+                  ],
+                  [
+                    4,
+                    2,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2608695652173913,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.24489795918367346,
+                    "support": 26,
+                    "roc_auc": 0.5552268244575936,
+                    "pr_auc": 0.28056554611455686
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7692307692307693,
+                    "recall": 0.38461538461538464,
+                    "f1": 0.5128205128205128,
+                    "support": 52,
+                    "roc_auc": 0.6013313609467456,
+                    "pr_auc": 0.6398082130766072
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.36363636363636365,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.4938271604938272,
+                    "support": 26,
+                    "roc_auc": 0.6617357001972387,
+                    "pr_auc": 0.42939202414635913
+                  }
+                ],
+                "macro_precision": 0.4645788993615081,
+                "macro_recall": 0.4615384615384615,
+                "macro_f1": 0.4171818774993378,
+                "weighted_f1": 0.44109153632963155,
+                "macro_roc_auc": 0.6060979618671927,
+                "macro_pr_auc": 0.4499219277791744
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "regression": [
+      {
+        "head_mode": "regression",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.27310974876788074,
+              "regime_accuracy": 0.36666667461395264,
+              "regime_loss": 1.0879130544244902,
+              "regression_rmse_log_rv": 0.9657506688737695,
+              "regression_mae_log_rv": 0.8181683683826122,
+              "regression_loss": 0.9326743544301332,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    16,
+                    12
+                  ],
+                  [
+                    0,
+                    27,
+                    18
+                  ],
+                  [
+                    0,
+                    30,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 28,
+                    "roc_auc": 0.40139751552795033,
+                    "pr_auc": 0.18437809377247724
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3698630136986301,
+                    "recall": 0.6,
+                    "f1": 0.45762711864406774,
+                    "support": 45,
+                    "roc_auc": 0.4776296296296296,
+                    "pr_auc": 0.3394105559054807
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3617021276595745,
+                    "recall": 0.3617021276595745,
+                    "f1": 0.3617021276595745,
+                    "support": 47,
+                    "roc_auc": 0.5459049839696881,
+                    "pr_auc": 0.5195780939632177
+                  }
+                ],
+                "macro_precision": 0.24385504711940154,
+                "macro_recall": 0.32056737588652484,
+                "macro_f1": 0.27310974876788074,
+                "weighted_f1": 0.313276836158192,
+                "macro_roc_auc": 0.47497737637575604,
+                "macro_pr_auc": 0.34778891454705857
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.14444444444444443,
+              "regime_accuracy": 0.23728813230991364,
+              "regime_loss": 1.1116947501392689,
+              "regression_rmse_log_rv": 0.76517516939968,
+              "regression_mae_log_rv": 0.6094886284574108,
+              "regression_loss": 0.5854930398658289,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    3,
+                    7
+                  ],
+                  [
+                    1,
+                    1,
+                    10
+                  ],
+                  [
+                    43,
+                    26,
+                    27
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 10,
+                    "roc_auc": 0.412962962962963,
+                    "pr_auc": 0.06820938353761645
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.03333333333333333,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.04761904761904761,
+                    "support": 12,
+                    "roc_auc": 0.470125786163522,
+                    "pr_auc": 0.08898128515764497
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.6136363636363636,
+                    "recall": 0.28125,
+                    "f1": 0.3857142857142857,
+                    "support": 96,
+                    "roc_auc": 0.3503787878787879,
+                    "pr_auc": 0.792818369596394
+                  }
+                ],
+                "macro_precision": 0.21565656565656566,
+                "macro_recall": 0.12152777777777778,
+                "macro_f1": 0.14444444444444443,
+                "weighted_f1": 0.31864406779661014,
+                "macro_roc_auc": 0.4111558456684243,
+                "macro_pr_auc": 0.3166696794305518
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2819548872180451,
+              "regime_accuracy": 0.4909090995788574,
+              "regime_loss": 1.072783257744529,
+              "regression_rmse_log_rv": 0.7206551261507355,
+              "regression_mae_log_rv": 0.5887736373051832,
+              "regression_loss": 0.5193438108473324,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    12,
+                    0
+                  ],
+                  [
+                    0,
+                    48,
+                    30
+                  ],
+                  [
+                    0,
+                    14,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.4039115646258503,
+                    "pr_auc": 0.08477743167199214
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6486486486486487,
+                    "recall": 0.6153846153846154,
+                    "f1": 0.631578947368421,
+                    "support": 78,
+                    "roc_auc": 0.3766025641025641,
+                    "pr_auc": 0.6309677030672707
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.3,
+                    "f1": 0.21428571428571427,
+                    "support": 20,
+                    "roc_auc": 0.30444444444444446,
+                    "pr_auc": 0.13210809615568123
+                  }
+                ],
+                "macro_precision": 0.27177177177177175,
+                "macro_recall": 0.30512820512820515,
+                "macro_f1": 0.2819548872180451,
+                "weighted_f1": 0.4868079289131921,
+                "macro_roc_auc": 0.3616528577242863,
+                "macro_pr_auc": 0.282617743631648
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.23430735930735933,
+              "regime_accuracy": 0.27927929162979126,
+              "regime_loss": 1.1213485368632858,
+              "regression_rmse_log_rv": 0.8130267295667064,
+              "regression_mae_log_rv": 0.6652637337510651,
+              "regression_loss": 0.6610124629899343,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    6,
+                    38
+                  ],
+                  [
+                    0,
+                    12,
+                    36
+                  ],
+                  [
+                    0,
+                    0,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.49796472184531887,
+                    "pr_auc": 0.439372146112667
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.25,
+                    "f1": 0.36363636363636365,
+                    "support": 48,
+                    "roc_auc": 0.5962301587301587,
+                    "pr_auc": 0.5600813476805616
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.20430107526881722,
+                    "recall": 1.0,
+                    "f1": 0.3392857142857143,
+                    "support": 19,
+                    "roc_auc": 0.39416475972540044,
+                    "pr_auc": 0.16271535563231956
+                  }
+                ],
+                "macro_precision": 0.2903225806451613,
+                "macro_recall": 0.4166666666666667,
+                "macro_f1": 0.23430735930735933,
+                "weighted_f1": 0.21532409032409033,
+                "macro_roc_auc": 0.4961198801002927,
+                "macro_pr_auc": 0.3873896164751827
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2440353763883176,
+              "regime_accuracy": 0.25,
+              "regime_loss": 1.108001158787654,
+              "regression_rmse_log_rv": 0.818423629009254,
+              "regression_mae_log_rv": 0.6576303101699943,
+              "regression_loss": 0.6698172365206772,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    4,
+                    16
+                  ],
+                  [
+                    12,
+                    7,
+                    33
+                  ],
+                  [
+                    8,
+                    5,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23076923076923078,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.23076923076923078,
+                    "support": 26,
+                    "roc_auc": 0.3757396449704142,
+                    "pr_auc": 0.19272635722118786
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4375,
+                    "recall": 0.1346153846153846,
+                    "f1": 0.2058823529411765,
+                    "support": 52,
+                    "roc_auc": 0.46005917159763315,
+                    "pr_auc": 0.5356449187174057
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.20967741935483872,
+                    "recall": 0.5,
+                    "f1": 0.29545454545454547,
+                    "support": 26,
+                    "roc_auc": 0.45759368836291914,
+                    "pr_auc": 0.2442416995054808
+                  }
+                ],
+                "macro_precision": 0.2926488833746898,
+                "macro_recall": 0.2884615384615385,
+                "macro_f1": 0.2440353763883176,
+                "weighted_f1": 0.23449712052653232,
+                "macro_roc_auc": 0.43113083497698884,
+                "macro_pr_auc": 0.32420432514802483
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.27877436573088743,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.0705502470145618,
+              "regression_rmse_log_rv": 0.916205984027016,
+              "regression_mae_log_rv": 0.7698485784911706,
+              "regression_loss": 0.8394334051669127,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    25,
+                    3
+                  ],
+                  [
+                    0,
+                    37,
+                    8
+                  ],
+                  [
+                    0,
+                    36,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 28,
+                    "roc_auc": 0.7150621118012422,
+                    "pr_auc": 0.3901908647891606
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.37755102040816324,
+                    "recall": 0.8222222222222222,
+                    "f1": 0.5174825174825174,
+                    "support": 45,
+                    "roc_auc": 0.4885925925925926,
+                    "pr_auc": 0.3640740346055932
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.23404255319148937,
+                    "f1": 0.31884057971014496,
+                    "support": 47,
+                    "roc_auc": 0.5220052462838822,
+                    "pr_auc": 0.44078953553906586
+                  }
+                ],
+                "macro_precision": 0.2925170068027211,
+                "macro_recall": 0.3520882584712372,
+                "macro_f1": 0.27877436573088743,
+                "weighted_f1": 0.3189351711090841,
+                "macro_roc_auc": 0.575219983559239,
+                "macro_pr_auc": 0.3983514783112732
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.2592436974789916,
+              "regime_accuracy": 0.508474588394165,
+              "regime_loss": 0.9921044080944385,
+              "regression_rmse_log_rv": 0.7426975941698502,
+              "regression_mae_log_rv": 0.5742906512282158,
+              "regression_loss": 0.5515997163856834,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    2,
+                    8
+                  ],
+                  [
+                    0,
+                    3,
+                    9
+                  ],
+                  [
+                    0,
+                    39,
+                    57
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 10,
+                    "roc_auc": 0.9481481481481482,
+                    "pr_auc": 0.7723485958485958
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.06818181818181818,
+                    "recall": 0.25,
+                    "f1": 0.10714285714285714,
+                    "support": 12,
+                    "roc_auc": 0.3639937106918239,
+                    "pr_auc": 0.13313349022407805
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.7702702702702703,
+                    "recall": 0.59375,
+                    "f1": 0.6705882352941177,
+                    "support": 96,
+                    "roc_auc": 0.7154356060606061,
+                    "pr_auc": 0.8954885902390158
+                  }
+                ],
+                "macro_precision": 0.2794840294840295,
+                "macro_recall": 0.28125,
+                "macro_f1": 0.2592436974789916,
+                "weighted_f1": 0.5564591938470304,
+                "macro_roc_auc": 0.6758591549668593,
+                "macro_pr_auc": 0.6003235587705632
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2982456140350877,
+              "regime_accuracy": 0.5090909004211426,
+              "regime_loss": 0.9962081800807606,
+              "regression_rmse_log_rv": 0.7117772925188844,
+              "regression_mae_log_rv": 0.5574204853799364,
+              "regression_loss": 0.5066269141455136,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    12,
+                    0
+                  ],
+                  [
+                    0,
+                    49,
+                    29
+                  ],
+                  [
+                    0,
+                    13,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.5535714285714286,
+                    "pr_auc": 0.1250878679647357
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6621621621621622,
+                    "recall": 0.6282051282051282,
+                    "f1": 0.644736842105263,
+                    "support": 78,
+                    "roc_auc": 0.4623397435897436,
+                    "pr_auc": 0.7178448415199511
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19444444444444445,
+                    "recall": 0.35,
+                    "f1": 0.25,
+                    "support": 20,
+                    "roc_auc": 0.6733333333333333,
+                    "pr_auc": 0.2370810841371572
+                  }
+                ],
+                "macro_precision": 0.2855355355355355,
+                "macro_recall": 0.3260683760683761,
+                "macro_f1": 0.2982456140350877,
+                "weighted_f1": 0.5026315789473683,
+                "macro_roc_auc": 0.5630815018315019,
+                "macro_pr_auc": 0.36000459787394795
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.15181115181115182,
+              "regime_accuracy": 0.20720720291137695,
+              "regime_loss": 1.1651742481967982,
+              "regression_rmse_log_rv": 0.8224613828926101,
+              "regression_mae_log_rv": 0.6339367587152902,
+              "regression_loss": 0.6764427263496245,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    44
+                  ],
+                  [
+                    0,
+                    4,
+                    44
+                  ],
+                  [
+                    0,
+                    0,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.5027137042062415,
+                    "pr_auc": 0.3854254369491595
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.15384615384615385,
+                    "support": 48,
+                    "roc_auc": 0.419973544973545,
+                    "pr_auc": 0.44460374015100484
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.17757009345794392,
+                    "recall": 1.0,
+                    "f1": 0.30158730158730157,
+                    "support": 19,
+                    "roc_auc": 0.4622425629290618,
+                    "pr_auc": 0.14481654180037667
+                  }
+                ],
+                "macro_precision": 0.3925233644859813,
+                "macro_recall": 0.3611111111111111,
+                "macro_f1": 0.15181115181115182,
+                "weighted_f1": 0.11815111815111815,
+                "macro_roc_auc": 0.4616432707029494,
+                "macro_pr_auc": 0.32494857296684704
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2933977455716586,
+              "regime_accuracy": 0.38461539149284363,
+              "regime_loss": 1.0744098241512592,
+              "regression_rmse_log_rv": 0.8147975615703055,
+              "regression_mae_log_rv": 0.6454785846334954,
+              "regression_loss": 0.6638950663409157,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    8,
+                    18
+                  ],
+                  [
+                    0,
+                    22,
+                    30
+                  ],
+                  [
+                    0,
+                    8,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5187376725838264,
+                    "pr_auc": 0.23015721743561998
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5789473684210527,
+                    "recall": 0.4230769230769231,
+                    "f1": 0.4888888888888889,
+                    "support": 52,
+                    "roc_auc": 0.6516272189349113,
+                    "pr_auc": 0.6694468785855563
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2727272727272727,
+                    "recall": 0.6923076923076923,
+                    "f1": 0.391304347826087,
+                    "support": 26,
+                    "roc_auc": 0.6143984220907298,
+                    "pr_auc": 0.4183494274391389
+                  }
+                ],
+                "macro_precision": 0.2838915470494418,
+                "macro_recall": 0.3717948717948718,
+                "macro_f1": 0.2933977455716586,
+                "weighted_f1": 0.3422705314009662,
+                "macro_roc_auc": 0.5949211045364892,
+                "macro_pr_auc": 0.4393178411534384
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3719429748694241,
+              "regime_accuracy": 0.4333333373069763,
+              "regime_loss": 1.0928357197924974,
+              "regression_rmse_log_rv": 0.8977059141613196,
+              "regression_mae_log_rv": 0.7640139493839039,
+              "regression_loss": 0.8058759083202105,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    20,
+                    5
+                  ],
+                  [
+                    6,
+                    32,
+                    7
+                  ],
+                  [
+                    6,
+                    24,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2,
+                    "recall": 0.10714285714285714,
+                    "f1": 0.13953488372093023,
+                    "support": 28,
+                    "roc_auc": 0.42080745341614906,
+                    "pr_auc": 0.286203959502453
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.42105263157894735,
+                    "recall": 0.7111111111111111,
+                    "f1": 0.5289256198347106,
+                    "support": 45,
+                    "roc_auc": 0.5182222222222223,
+                    "pr_auc": 0.41052876502414526
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5862068965517241,
+                    "recall": 0.3617021276595745,
+                    "f1": 0.4473684210526315,
+                    "support": 47,
+                    "roc_auc": 0.6173127368114253,
+                    "pr_auc": 0.44091688611849184
+                  }
+                ],
+                "macro_precision": 0.40241984271022385,
+                "macro_recall": 0.3933186986378476,
+                "macro_f1": 0.3719429748694241,
+                "weighted_f1": 0.4061245452185142,
+                "macro_roc_auc": 0.5187808041499322,
+                "macro_pr_auc": 0.3792165368816967
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.15262515262515264,
+              "regime_accuracy": 0.17796610295772552,
+              "regime_loss": 1.1071081201908952,
+              "regression_rmse_log_rv": 0.7876347317130533,
+              "regression_mae_log_rv": 0.6138495267132076,
+              "regression_loss": 0.6203684706006934,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    9,
+                    0
+                  ],
+                  [
+                    1,
+                    11,
+                    0
+                  ],
+                  [
+                    14,
+                    73,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0625,
+                    "recall": 0.1,
+                    "f1": 0.07692307692307693,
+                    "support": 10,
+                    "roc_auc": 0.6129629629629629,
+                    "pr_auc": 0.11075323024309038
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.11827956989247312,
+                    "recall": 0.9166666666666666,
+                    "f1": 0.20952380952380953,
+                    "support": 12,
+                    "roc_auc": 0.5982704402515723,
+                    "pr_auc": 0.14175041237149305
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.09375,
+                    "f1": 0.17142857142857143,
+                    "support": 96,
+                    "roc_auc": 0.8205492424242424,
+                    "pr_auc": 0.9550068912545254
+                  }
+                ],
+                "macro_precision": 0.39359318996415765,
+                "macro_recall": 0.37013888888888885,
+                "macro_f1": 0.15262515262515264,
+                "weighted_f1": 0.1672937232259266,
+                "macro_roc_auc": 0.6772608818795925,
+                "macro_pr_auc": 0.4025035112897029
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.17582274356467906,
+              "regime_accuracy": 0.2454545497894287,
+              "regime_loss": 1.127741924199191,
+              "regression_rmse_log_rv": 0.7640644053509984,
+              "regression_mae_log_rv": 0.5362480202329938,
+              "regression_loss": 0.5837944155243748,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    1,
+                    11
+                  ],
+                  [
+                    4,
+                    11,
+                    63
+                  ],
+                  [
+                    1,
+                    3,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.4005102040816326,
+                    "pr_auc": 0.08471831338977613
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7333333333333333,
+                    "recall": 0.14102564102564102,
+                    "f1": 0.23655913978494622,
+                    "support": 78,
+                    "roc_auc": 0.4014423076923077,
+                    "pr_auc": 0.7028329074120877
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.17777777777777778,
+                    "recall": 0.8,
+                    "f1": 0.2909090909090909,
+                    "support": 20,
+                    "roc_auc": 0.245,
+                    "pr_auc": 0.11713063734941265
+                  }
+                ],
+                "macro_precision": 0.3037037037037037,
+                "macro_recall": 0.31367521367521367,
+                "macro_f1": 0.17582274356467906,
+                "weighted_f1": 0.220634497467342,
+                "macro_roc_auc": 0.3489841705913134,
+                "macro_pr_auc": 0.30156061938375883
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.30841993072208895,
+              "regime_accuracy": 0.45045045018196106,
+              "regime_loss": 1.0880229326926536,
+              "regression_rmse_log_rv": 0.8130580741090551,
+              "regression_mae_log_rv": 0.6521746157123162,
+              "regression_loss": 0.6610634318739257,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    35,
+                    9
+                  ],
+                  [
+                    0,
+                    45,
+                    3
+                  ],
+                  [
+                    3,
+                    11,
+                    5
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.43419267299864317,
+                    "pr_auc": 0.425062702257734
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4945054945054945,
+                    "recall": 0.9375,
+                    "f1": 0.6474820143884892,
+                    "support": 48,
+                    "roc_auc": 0.5737433862433863,
+                    "pr_auc": 0.5038935797423499
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.29411764705882354,
+                    "recall": 0.2631578947368421,
+                    "f1": 0.27777777777777773,
+                    "support": 19,
+                    "roc_auc": 0.5732265446224256,
+                    "pr_auc": 0.19084294924431255
+                  }
+                ],
+                "macro_precision": 0.26287438052143935,
+                "macro_recall": 0.40021929824561403,
+                "macro_f1": 0.30841993072208895,
+                "weighted_f1": 0.32753976998581313,
+                "macro_roc_auc": 0.5270542012881517,
+                "macro_pr_auc": 0.37326641041479885
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2098513552900029,
+              "regime_accuracy": 0.25961539149284363,
+              "regime_loss": 1.1043492463918834,
+              "regression_rmse_log_rv": 0.8022739498352124,
+              "regression_mae_log_rv": 0.6516311294488752,
+              "regression_loss": 0.6436434905841929,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    15,
+                    11
+                  ],
+                  [
+                    7,
+                    18,
+                    27
+                  ],
+                  [
+                    8,
+                    9,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.3900394477317554,
+                    "pr_auc": 0.1969775275887591
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.3829787234042554,
+                    "support": 52,
+                    "roc_auc": 0.46264792899408286,
+                    "pr_auc": 0.5385355681824243
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19148936170212766,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.2465753424657534,
+                    "support": 26,
+                    "roc_auc": 0.46646942800788954,
+                    "pr_auc": 0.2600554655631121
+                  }
+                ],
+                "macro_precision": 0.2066869300911854,
+                "macro_recall": 0.23076923076923075,
+                "macro_f1": 0.2098513552900029,
+                "weighted_f1": 0.25313319731856604,
+                "macro_roc_auc": 0.43971893491124264,
+                "macro_pr_auc": 0.33185618711143183
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.1587509077705156,
+              "regime_accuracy": 0.21666666865348816,
+              "regime_loss": 1.1337236137389866,
+              "regression_rmse_log_rv": 0.9039313923089441,
+              "regression_mae_log_rv": 0.7697772443973615,
+              "regression_loss": 0.8170919620015863,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    22,
+                    3,
+                    3
+                  ],
+                  [
+                    42,
+                    3,
+                    0
+                  ],
+                  [
+                    43,
+                    3,
+                    1
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.205607476635514,
+                    "recall": 0.7857142857142857,
+                    "f1": 0.3259259259259259,
+                    "support": 28,
+                    "roc_auc": 0.5892857142857143,
+                    "pr_auc": 0.30462457915330576
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.06666666666666667,
+                    "f1": 0.1111111111111111,
+                    "support": 45,
+                    "roc_auc": 0.6234074074074074,
+                    "pr_auc": 0.48016106341737075
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.25,
+                    "recall": 0.02127659574468085,
+                    "f1": 0.0392156862745098,
+                    "support": 47,
+                    "roc_auc": 0.5129699795977849,
+                    "pr_auc": 0.43242939523715634
+                  }
+                ],
+                "macro_precision": 0.26298026998961577,
+                "macro_recall": 0.2912191827085444,
+                "macro_f1": 0.1587509077705156,
+                "weighted_f1": 0.13307552650689905,
+                "macro_roc_auc": 0.5752210337636355,
+                "macro_pr_auc": 0.40573834593594427
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.12222222222222223,
+              "regime_accuracy": 0.10169491171836853,
+              "regime_loss": 1.1714021735272164,
+              "regression_rmse_log_rv": 0.641611894375149,
+              "regression_mae_log_rv": 0.4826494219823409,
+              "regression_loss": 0.4116658230036674,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    10,
+                    2,
+                    0
+                  ],
+                  [
+                    90,
+                    6,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.09090909090909091,
+                    "recall": 1.0,
+                    "f1": 0.16666666666666669,
+                    "support": 10,
+                    "roc_auc": 0.6722222222222223,
+                    "pr_auc": 0.15389001987276565
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.2,
+                    "support": 12,
+                    "roc_auc": 0.3026729559748428,
+                    "pr_auc": 0.22556583993810234
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 96,
+                    "roc_auc": 0.5189393939393939,
+                    "pr_auc": 0.8368440996509501
+                  }
+                ],
+                "macro_precision": 0.11363636363636365,
+                "macro_recall": 0.3888888888888889,
+                "macro_f1": 0.12222222222222223,
+                "weighted_f1": 0.0344632768361582,
+                "macro_roc_auc": 0.49794485737881966,
+                "macro_pr_auc": 0.405433319820606
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.06722689075630252,
+              "regime_accuracy": 0.1090909093618393,
+              "regime_loss": 1.2118729482997548,
+              "regression_rmse_log_rv": 0.5108194220969481,
+              "regression_mae_log_rv": 0.38189499545630745,
+              "regression_loss": 0.26093648199145997,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    75,
+                    0,
+                    3
+                  ],
+                  [
+                    20,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.11214953271028037,
+                    "recall": 1.0,
+                    "f1": 0.20168067226890757,
+                    "support": 12,
+                    "roc_auc": 0.6054421768707483,
+                    "pr_auc": 0.12621559919936545
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.3701923076923077,
+                    "pr_auc": 0.6649847048975138
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.69,
+                    "pr_auc": 0.28478320285356695
+                  }
+                ],
+                "macro_precision": 0.037383177570093455,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.06722689075630252,
+                "weighted_f1": 0.022001527883880826,
+                "macro_roc_auc": 0.555211494854352,
+                "macro_pr_auc": 0.35866116898348205
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.18924731182795698,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.0882560120000657,
+              "regression_rmse_log_rv": 0.7701067816920929,
+              "regression_mae_log_rv": 0.6217102978277851,
+              "regression_loss": 0.5930644552081528,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    44,
+                    0,
+                    0
+                  ],
+                  [
+                    48,
+                    0,
+                    0
+                  ],
+                  [
+                    19,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3963963963963964,
+                    "recall": 1.0,
+                    "f1": 0.567741935483871,
+                    "support": 44,
+                    "roc_auc": 0.6099050203527816,
+                    "pr_auc": 0.5340040936310483
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.5211640211640212,
+                    "pr_auc": 0.5360138530295685
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.5040045766590389,
+                    "pr_auc": 0.1760366780874145
+                  }
+                ],
+                "macro_precision": 0.13213213213213212,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.18924731182795698,
+                "weighted_f1": 0.22505085730892183,
+                "macro_roc_auc": 0.5450245393919472,
+                "macro_pr_auc": 0.4153515415826771
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.10752688172043011,
+              "regime_accuracy": 0.19230769574642181,
+              "regime_loss": 1.1673019665938158,
+              "regression_rmse_log_rv": 0.8062579055266951,
+              "regression_mae_log_rv": 0.635569547347796,
+              "regression_loss": 0.6500518102242931,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    20,
+                    6,
+                    0
+                  ],
+                  [
+                    52,
+                    0,
+                    0
+                  ],
+                  [
+                    26,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.20408163265306123,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.3225806451612903,
+                    "support": 26,
+                    "roc_auc": 0.4807692307692308,
+                    "pr_auc": 0.25981209855445914
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.4452662721893491,
+                    "pr_auc": 0.43917528537058237
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.3338264299802761,
+                    "pr_auc": 0.17874142504394752
+                  }
+                ],
+                "macro_precision": 0.06802721088435375,
+                "macro_recall": 0.25641025641025644,
+                "macro_f1": 0.10752688172043011,
+                "weighted_f1": 0.08064516129032258,
+                "macro_roc_auc": 0.41995397764628534,
+                "macro_pr_auc": 0.29257626965632966
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2782526115859449,
+              "regime_accuracy": 0.2916666567325592,
+              "regime_loss": 1.1083600009722994,
+              "regression_rmse_log_rv": 0.8810626630484648,
+              "regression_mae_log_rv": 0.7351264094371194,
+              "regression_loss": 0.7762714162180527,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    18
+                  ],
+                  [
+                    15,
+                    7,
+                    23
+                  ],
+                  [
+                    27,
+                    0,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16,
+                    "recall": 0.2857142857142857,
+                    "f1": 0.20512820512820512,
+                    "support": 28,
+                    "roc_auc": 0.3932453416149068,
+                    "pr_auc": 0.18190358621764144
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7777777777777778,
+                    "recall": 0.15555555555555556,
+                    "f1": 0.25925925925925924,
+                    "support": 45,
+                    "roc_auc": 0.6293333333333333,
+                    "pr_auc": 0.5358597174843753
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.32786885245901637,
+                    "recall": 0.425531914893617,
+                    "f1": 0.37037037037037035,
+                    "support": 47,
+                    "roc_auc": 0.45059749344214517,
+                    "pr_auc": 0.4106601879377292
+                  }
+                ],
+                "macro_precision": 0.4218822100789314,
+                "macro_recall": 0.28893391872115276,
+                "macro_f1": 0.2782526115859449,
+                "weighted_f1": 0.2901471984805318,
+                "macro_roc_auc": 0.4910587227967951,
+                "macro_pr_auc": 0.3761411638799153
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.24294871794871795,
+              "regime_accuracy": 0.39830508828163147,
+              "regime_loss": 1.066961945113489,
+              "regression_rmse_log_rv": 0.6402449544578755,
+              "regression_mae_log_rv": 0.5188268730574745,
+              "regression_loss": 0.4099136017087672,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    10
+                  ],
+                  [
+                    3,
+                    1,
+                    8
+                  ],
+                  [
+                    50,
+                    0,
+                    46
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 10,
+                    "roc_auc": 0.17962962962962964,
+                    "pr_auc": 0.049569505871260695
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.15384615384615385,
+                    "support": 12,
+                    "roc_auc": 0.535377358490566,
+                    "pr_auc": 0.2561152569959689
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.71875,
+                    "recall": 0.4791666666666667,
+                    "f1": 0.575,
+                    "support": 96,
+                    "roc_auc": 0.3106060606060606,
+                    "pr_auc": 0.7776243658510453
+                  }
+                ],
+                "macro_precision": 0.5729166666666666,
+                "macro_recall": 0.1875,
+                "macro_f1": 0.24294871794871795,
+                "weighted_f1": 0.4834419817470665,
+                "macro_roc_auc": 0.34187101624208543,
+                "macro_pr_auc": 0.3611030429060917
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.12467617642236432,
+              "regime_accuracy": 0.17272727191448212,
+              "regime_loss": 1.119084241173484,
+              "regression_rmse_log_rv": 0.7427145739665169,
+              "regression_mae_log_rv": 0.5655113799814981,
+              "regression_loss": 0.5516249383822646,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    2,
+                    10
+                  ],
+                  [
+                    4,
+                    8,
+                    66
+                  ],
+                  [
+                    2,
+                    7,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.3622448979591837,
+                    "pr_auc": 0.08107745467324196
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.47058823529411764,
+                    "recall": 0.10256410256410256,
+                    "f1": 0.16842105263157894,
+                    "support": 78,
+                    "roc_auc": 0.3717948717948718,
+                    "pr_auc": 0.6653119404868543
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.12643678160919541,
+                    "recall": 0.55,
+                    "f1": 0.20560747663551404,
+                    "support": 20,
+                    "roc_auc": 0.2627777777777778,
+                    "pr_auc": 0.11976878257013635
+                  }
+                ],
+                "macro_precision": 0.19900833896777104,
+                "macro_recall": 0.21752136752136753,
+                "macro_f1": 0.12467617642236432,
+                "weighted_f1": 0.15680901489066762,
+                "macro_roc_auc": 0.3322725158439444,
+                "macro_pr_auc": 0.28871939257674417
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.09973753280839893,
+              "regime_accuracy": 0.171171173453331,
+              "regime_loss": 1.1567002927795003,
+              "regression_rmse_log_rv": 0.8208111117913935,
+              "regression_mae_log_rv": 0.6859858181025531,
+              "regression_loss": 0.6737308812402236,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    44
+                  ],
+                  [
+                    3,
+                    0,
+                    45
+                  ],
+                  [
+                    0,
+                    0,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.41994572591587515,
+                    "pr_auc": 0.3417455617164806
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.5191798941798942,
+                    "pr_auc": 0.5367013002508332
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.17592592592592593,
+                    "recall": 1.0,
+                    "f1": 0.2992125984251968,
+                    "support": 19,
+                    "roc_auc": 0.488558352402746,
+                    "pr_auc": 0.4232153710561101
+                  }
+                ],
+                "macro_precision": 0.05864197530864198,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.09973753280839893,
+                "weighted_f1": 0.05121657090161027,
+                "macro_roc_auc": 0.4758946574995051,
+                "macro_pr_auc": 0.433887411007808
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.09660377358490567,
+              "regime_accuracy": 0.11538461595773697,
+              "regime_loss": 1.1234027972588172,
+              "regression_rmse_log_rv": 0.843643283999708,
+              "regression_mae_log_rv": 0.6667320171926314,
+              "regression_loss": 0.711733990637812,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    0,
+                    23
+                  ],
+                  [
+                    4,
+                    0,
+                    48
+                  ],
+                  [
+                    17,
+                    0,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.125,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.12000000000000001,
+                    "support": 26,
+                    "roc_auc": 0.47928994082840237,
+                    "pr_auc": 0.2243525588029118
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.7089497041420119,
+                    "pr_auc": 0.7107417432885562
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1125,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.169811320754717,
+                    "support": 26,
+                    "roc_auc": 0.28303747534516766,
+                    "pr_auc": 0.1821339418400476
+                  }
+                ],
+                "macro_precision": 0.07916666666666666,
+                "macro_recall": 0.15384615384615385,
+                "macro_f1": 0.09660377358490567,
+                "weighted_f1": 0.07245283018867925,
+                "macro_roc_auc": 0.49042570677186065,
+                "macro_pr_auc": 0.37240941464383853
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "dual": [
+      {
+        "head_mode": "dual",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3861414472992024,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.1690408420095069,
+              "regression_rmse_log_rv": 0.9480217637280095,
+              "regression_mae_log_rv": 0.7997093913514012,
+              "regression_loss": 0.8987452645019658,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    4,
+                    9
+                  ],
+                  [
+                    11,
+                    9,
+                    25
+                  ],
+                  [
+                    19,
+                    4,
+                    24
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.5357142857142857,
+                    "f1": 0.41095890410958896,
+                    "support": 28,
+                    "roc_auc": 0.7170031055900621,
+                    "pr_auc": 0.40217187438252666
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5294117647058824,
+                    "recall": 0.2,
+                    "f1": 0.2903225806451613,
+                    "support": 45,
+                    "roc_auc": 0.48118518518518516,
+                    "pr_auc": 0.39448659718078666
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.41379310344827586,
+                    "recall": 0.5106382978723404,
+                    "f1": 0.4571428571428571,
+                    "support": 47,
+                    "roc_auc": 0.5584377732439522,
+                    "pr_auc": 0.42597612594186257
+                  }
+                ],
+                "macro_precision": 0.4255127338291638,
+                "macro_recall": 0.41545086119554203,
+                "macro_f1": 0.3861414472992024,
+                "weighted_f1": 0.3838089977484586,
+                "macro_roc_auc": 0.5855420213397332,
+                "macro_pr_auc": 0.4075448658350586
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.41564993564993563,
+              "regime_accuracy": 0.7033898234367371,
+              "regime_loss": 0.6015408837189109,
+              "regression_rmse_log_rv": 0.8531906798170041,
+              "regression_mae_log_rv": 0.6368772501473204,
+              "regression_loss": 0.7279343361266016,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    11,
+                    9,
+                    76
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25925925925925924,
+                    "recall": 0.7,
+                    "f1": 0.37837837837837834,
+                    "support": 10,
+                    "roc_auc": 0.8870370370370371,
+                    "pr_auc": 0.34221004586136156
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7303459119496856,
+                    "pr_auc": 0.16270297857539218
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9620253164556962,
+                    "recall": 0.7916666666666666,
+                    "f1": 0.8685714285714285,
+                    "support": 96,
+                    "roc_auc": 0.9109848484848485,
+                    "pr_auc": 0.9801577826573183
+                  }
+                ],
+                "macro_precision": 0.40709485857165184,
+                "macro_recall": 0.49722222222222223,
+                "macro_f1": 0.41564993564993563,
+                "weighted_f1": 0.7387003468359401,
+                "macro_roc_auc": 0.842789265823857,
+                "macro_pr_auc": 0.49502360236469073
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3192870908590337,
+              "regime_accuracy": 0.290909081697464,
+              "regime_loss": 1.8338572350415316,
+              "regression_rmse_log_rv": 0.85493931509159,
+              "regression_mae_log_rv": 0.7187518443467773,
+              "regression_loss": 0.7309212324892771,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    1,
+                    5
+                  ],
+                  [
+                    10,
+                    8,
+                    60
+                  ],
+                  [
+                    0,
+                    2,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.375,
+                    "recall": 0.5,
+                    "f1": 0.42857142857142855,
+                    "support": 12,
+                    "roc_auc": 0.7474489795918368,
+                    "pr_auc": 0.34109590122460165
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7272727272727273,
+                    "recall": 0.10256410256410256,
+                    "f1": 0.1797752808988764,
+                    "support": 78,
+                    "roc_auc": 0.43669871794871795,
+                    "pr_auc": 0.6632390940958007
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21686746987951808,
+                    "recall": 0.9,
+                    "f1": 0.34951456310679613,
+                    "support": 20,
+                    "roc_auc": 0.6044444444444445,
+                    "pr_auc": 0.23689368121470955
+                  }
+                ],
+                "macro_precision": 0.43971339905074847,
+                "macro_recall": 0.5008547008547009,
+                "macro_f1": 0.3192870908590337,
+                "weighted_f1": 0.2377783665009584,
+                "macro_roc_auc": 0.5961973806616664,
+                "macro_pr_auc": 0.4137428921783706
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3750631116644188,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.1651330293484055,
+              "regression_rmse_log_rv": 0.8840705102172548,
+              "regression_mae_log_rv": 0.7077728672339035,
+              "regression_loss": 0.7815806670357972,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    19,
+                    17,
+                    8
+                  ],
+                  [
+                    16,
+                    13,
+                    19
+                  ],
+                  [
+                    6,
+                    3,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4634146341463415,
+                    "recall": 0.4318181818181818,
+                    "f1": 0.4470588235294118,
+                    "support": 44,
+                    "roc_auc": 0.6373812754409769,
+                    "pr_auc": 0.480967301577652
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3939393939393939,
+                    "recall": 0.2708333333333333,
+                    "f1": 0.32098765432098764,
+                    "support": 48,
+                    "roc_auc": 0.48908730158730157,
+                    "pr_auc": 0.440985412941209
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2702702702702703,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.35714285714285715,
+                    "support": 19,
+                    "roc_auc": 0.6401601830663616,
+                    "pr_auc": 0.23658394412237196
+                  }
+                ],
+                "macro_precision": 0.37587476611866855,
+                "macro_recall": 0.4096557682083997,
+                "macro_f1": 0.3750631116644188,
+                "weighted_f1": 0.3771505398956379,
+                "macro_roc_auc": 0.58887625336488,
+                "macro_pr_auc": 0.3861788862137443
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3282828282828283,
+              "regime_accuracy": 0.42307692766189575,
+              "regime_loss": 1.0741237493661733,
+              "regression_rmse_log_rv": 0.8558475307742007,
+              "regression_mae_log_rv": 0.701195268255945,
+              "regression_loss": 0.7324749959322965,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    17,
+                    9
+                  ],
+                  [
+                    3,
+                    24,
+                    25
+                  ],
+                  [
+                    0,
+                    6,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6661735700197239,
+                    "pr_auc": 0.4600839129235239
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5106382978723404,
+                    "recall": 0.46153846153846156,
+                    "f1": 0.48484848484848486,
+                    "support": 52,
+                    "roc_auc": 0.6105769230769231,
+                    "pr_auc": 0.5752689310379546
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37037037037037035,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5,
+                    "support": 26,
+                    "roc_auc": 0.8338264299802761,
+                    "pr_auc": 0.7110454016955359
+                  }
+                ],
+                "macro_precision": 0.29366955608090356,
+                "macro_recall": 0.4102564102564103,
+                "macro_f1": 0.3282828282828283,
+                "weighted_f1": 0.36742424242424243,
+                "macro_roc_auc": 0.7035256410256411,
+                "macro_pr_auc": 0.5821327485523381
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2998084291187739,
+              "regime_accuracy": 0.3583333194255829,
+              "regime_loss": 1.1655034512191011,
+              "regression_rmse_log_rv": 0.8988806510482853,
+              "regression_mae_log_rv": 0.7700476994175308,
+              "regression_loss": 0.8079864248289893,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    3,
+                    10
+                  ],
+                  [
+                    14,
+                    0,
+                    31
+                  ],
+                  [
+                    15,
+                    4,
+                    28
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3409090909090909,
+                    "recall": 0.5357142857142857,
+                    "f1": 0.41666666666666663,
+                    "support": 28,
+                    "roc_auc": 0.6645962732919255,
+                    "pr_auc": 0.3112784784107739
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 45,
+                    "roc_auc": 0.5277037037037037,
+                    "pr_auc": 0.40083073891423804
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4057971014492754,
+                    "recall": 0.5957446808510638,
+                    "f1": 0.48275862068965514,
+                    "support": 47,
+                    "roc_auc": 0.6012824249489944,
+                    "pr_auc": 0.468504755002042
+                  }
+                ],
+                "macro_precision": 0.2489020641194554,
+                "macro_recall": 0.37715298885511644,
+                "macro_f1": 0.2998084291187739,
+                "weighted_f1": 0.28630268199233716,
+                "macro_roc_auc": 0.5978608006482079,
+                "macro_pr_auc": 0.39353799077568463
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.41779279279279286,
+              "regime_accuracy": 0.7118644118309021,
+              "regime_loss": 0.5655983428833848,
+              "regression_rmse_log_rv": 0.7085917285824193,
+              "regression_mae_log_rv": 0.5595383635264332,
+              "regression_loss": 0.5021022378154208,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    11,
+                    8,
+                    77
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25925925925925924,
+                    "recall": 0.7,
+                    "f1": 0.37837837837837834,
+                    "support": 10,
+                    "roc_auc": 0.9083333333333333,
+                    "pr_auc": 0.42261053568672413
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6863207547169812,
+                    "pr_auc": 0.1457341051240013
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9625,
+                    "recall": 0.8020833333333334,
+                    "f1": 0.8750000000000001,
+                    "support": 96,
+                    "roc_auc": 0.9242424242424242,
+                    "pr_auc": 0.9812693586214019
+                  }
+                ],
+                "macro_precision": 0.40725308641975305,
+                "macro_recall": 0.5006944444444444,
+                "macro_f1": 0.41779279279279286,
+                "weighted_f1": 0.7439303710490153,
+                "macro_roc_auc": 0.8396321707642462,
+                "macro_pr_auc": 0.516537999810709
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.262471076629917,
+              "regime_accuracy": 0.2545454502105713,
+              "regime_loss": 1.8425332676280628,
+              "regression_rmse_log_rv": 0.7640546384326726,
+              "regression_mae_log_rv": 0.6111993484008549,
+              "regression_loss": 0.5837794905104822,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    25,
+                    1,
+                    52
+                  ],
+                  [
+                    2,
+                    0,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.75,
+                    "f1": 0.375,
+                    "support": 12,
+                    "roc_auc": 0.6964285714285714,
+                    "pr_auc": 0.19182233650811248
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.01282051282051282,
+                    "f1": 0.02531645569620253,
+                    "support": 78,
+                    "roc_auc": 0.4407051282051282,
+                    "pr_auc": 0.6987143891529441
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2465753424657534,
+                    "recall": 0.9,
+                    "f1": 0.3870967741935484,
+                    "support": 20,
+                    "roc_auc": 0.6622222222222223,
+                    "pr_auc": 0.24029434390680413
+                  }
+                ],
+                "macro_precision": 0.4988584474885845,
+                "macro_recall": 0.5542735042735043,
+                "macro_f1": 0.262471076629917,
+                "weighted_f1": 0.12924199116522514,
+                "macro_roc_auc": 0.5997853072853073,
+                "macro_pr_auc": 0.37694368985595356
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.34216450216450217,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.1346466614672772,
+              "regression_rmse_log_rv": 0.8863292703170931,
+              "regression_mae_log_rv": 0.7067622047353972,
+              "regression_loss": 0.7855795754208307,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    4,
+                    14
+                  ],
+                  [
+                    23,
+                    4,
+                    21
+                  ],
+                  [
+                    7,
+                    0,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4642857142857143,
+                    "recall": 0.5909090909090909,
+                    "f1": 0.52,
+                    "support": 44,
+                    "roc_auc": 0.5722523744911805,
+                    "pr_auc": 0.4223185860466787
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.14285714285714285,
+                    "support": 48,
+                    "roc_auc": 0.6160714285714286,
+                    "pr_auc": 0.47845141518708456
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2553191489361702,
+                    "recall": 0.631578947368421,
+                    "f1": 0.3636363636363636,
+                    "support": 19,
+                    "roc_auc": 0.5806636155606407,
+                    "pr_auc": 0.21635671106456983
+                  }
+                ],
+                "macro_precision": 0.40653495440729487,
+                "macro_recall": 0.4352737905369484,
+                "macro_f1": 0.34216450216450217,
+                "weighted_f1": 0.3301462501462502,
+                "macro_roc_auc": 0.5896624728744166,
+                "macro_pr_auc": 0.372375570766111
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4743632521410299,
+              "regime_accuracy": 0.5096153616905212,
+              "regime_loss": 1.050729173880357,
+              "regression_rmse_log_rv": 0.8086052458212776,
+              "regression_mae_log_rv": 0.6318421362666413,
+              "regression_loss": 0.6538424435696887,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    10,
+                    10
+                  ],
+                  [
+                    4,
+                    25,
+                    23
+                  ],
+                  [
+                    1,
+                    3,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5454545454545454,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.3243243243243243,
+                    "support": 26,
+                    "roc_auc": 0.5946745562130178,
+                    "pr_auc": 0.40175738437884506
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6578947368421053,
+                    "recall": 0.4807692307692308,
+                    "f1": 0.5555555555555556,
+                    "support": 52,
+                    "roc_auc": 0.6479289940828402,
+                    "pr_auc": 0.6669357982053571
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4,
+                    "recall": 0.8461538461538461,
+                    "f1": 0.5432098765432098,
+                    "support": 26,
+                    "roc_auc": 0.7889546351084813,
+                    "pr_auc": 0.6784252676669822
+                  }
+                ],
+                "macro_precision": 0.5344497607655502,
+                "macro_recall": 0.5192307692307693,
+                "macro_f1": 0.4743632521410299,
+                "weighted_f1": 0.49466132799466134,
+                "macro_roc_auc": 0.6771860618014465,
+                "macro_pr_auc": 0.5823728167503948
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3823447507658034,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.0862068676734937,
+              "regression_rmse_log_rv": 0.8970456559520203,
+              "regression_mae_log_rv": 0.7520796172999932,
+              "regression_loss": 0.8046909088623904,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    9,
+                    6
+                  ],
+                  [
+                    9,
+                    6,
+                    30
+                  ],
+                  [
+                    13,
+                    3,
+                    31
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.37142857142857144,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.41269841269841273,
+                    "support": 28,
+                    "roc_auc": 0.7368012422360248,
+                    "pr_auc": 0.43869309736347606
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.13333333333333333,
+                    "f1": 0.19047619047619044,
+                    "support": 45,
+                    "roc_auc": 0.4237037037037037,
+                    "pr_auc": 0.3362590859478053
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4626865671641791,
+                    "recall": 0.6595744680851063,
+                    "f1": 0.5438596491228069,
+                    "support": 47,
+                    "roc_auc": 0.5837948120081609,
+                    "pr_auc": 0.4399233809655528
+                  }
+                ],
+                "macro_precision": 0.3891494906420279,
+                "macro_recall": 0.419064505234718,
+                "macro_f1": 0.3823447507658034,
+                "weighted_f1": 0.38073656363130043,
+                "macro_roc_auc": 0.5814332526492965,
+                "macro_pr_auc": 0.40495852142561134
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4174242424242425,
+              "regime_accuracy": 0.694915235042572,
+              "regime_loss": 0.6398378752045712,
+              "regression_rmse_log_rv": 0.7823102149247868,
+              "regression_mae_log_rv": 0.6069685129796044,
+              "regression_loss": 0.612009272375666,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    11,
+                    10,
+                    75
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.28,
+                    "recall": 0.7,
+                    "f1": 0.4,
+                    "support": 10,
+                    "roc_auc": 0.9277777777777778,
+                    "pr_auc": 0.5458580962974734
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6823899371069182,
+                    "pr_auc": 0.1381149961601678
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9375,
+                    "recall": 0.78125,
+                    "f1": 0.8522727272727273,
+                    "support": 96,
+                    "roc_auc": 0.8972537878787878,
+                    "pr_auc": 0.9773421859395215
+                  }
+                ],
+                "macro_precision": 0.4058333333333333,
+                "macro_recall": 0.49374999999999997,
+                "macro_f1": 0.4174242424242425,
+                "weighted_f1": 0.7272727272727272,
+                "macro_roc_auc": 0.835807167587828,
+                "macro_pr_auc": 0.5537717594657209
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3265588875288998,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.226130606911399,
+              "regression_rmse_log_rv": 0.6652059152907821,
+              "regression_mae_log_rv": 0.45044882529288194,
+              "regression_loss": 0.4424989097378471,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    17,
+                    7,
+                    54
+                  ],
+                  [
+                    1,
+                    0,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.42105263157894735,
+                    "support": 12,
+                    "roc_auc": 0.7772108843537415,
+                    "pr_auc": 0.3301229458821794
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.875,
+                    "recall": 0.08974358974358974,
+                    "f1": 0.1627906976744186,
+                    "support": 78,
+                    "roc_auc": 0.43469551282051283,
+                    "pr_auc": 0.7069934364636059
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.25,
+                    "recall": 0.95,
+                    "f1": 0.3958333333333333,
+                    "support": 20,
+                    "roc_auc": 0.74,
+                    "pr_auc": 0.2930197399525594
+                  }
+                ],
+                "macro_precision": 0.4775641025641026,
+                "macro_recall": 0.5688034188034188,
+                "macro_f1": 0.3265588875288998,
+                "weighted_f1": 0.23333611512926075,
+                "macro_roc_auc": 0.6506354657247514,
+                "macro_pr_auc": 0.44337870743278157
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3554191222104253,
+              "regime_accuracy": 0.36036035418510437,
+              "regime_loss": 1.09739330782195,
+              "regression_rmse_log_rv": 0.8495559008635043,
+              "regression_mae_log_rv": 0.686879023171223,
+              "regression_loss": 0.7217452286920004,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    15,
+                    14
+                  ],
+                  [
+                    16,
+                    16,
+                    16
+                  ],
+                  [
+                    6,
+                    4,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.40540540540540543,
+                    "recall": 0.3409090909090909,
+                    "f1": 0.37037037037037035,
+                    "support": 44,
+                    "roc_auc": 0.5868385345997287,
+                    "pr_auc": 0.42742727070351305
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.45714285714285713,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.38554216867469876,
+                    "support": 48,
+                    "roc_auc": 0.5942460317460317,
+                    "pr_auc": 0.4667494727011781
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.23076923076923078,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.3103448275862069,
+                    "support": 19,
+                    "roc_auc": 0.5989702517162472,
+                    "pr_auc": 0.25415339862723346
+                  }
+                ],
+                "macro_precision": 0.36443916443916446,
+                "macro_recall": 0.38264221158958,
+                "macro_f1": 0.3554191222104253,
+                "weighted_f1": 0.3666565055569348,
+                "macro_roc_auc": 0.5933516060206693,
+                "macro_pr_auc": 0.3827767140106415
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.43413885692366705,
+              "regime_accuracy": 0.5,
+              "regime_loss": 1.0278685001226573,
+              "regression_rmse_log_rv": 0.7515613359347457,
+              "regression_mae_log_rv": 0.590553006506525,
+              "regression_loss": 0.5648444416720196,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    16,
+                    7
+                  ],
+                  [
+                    1,
+                    27,
+                    24
+                  ],
+                  [
+                    0,
+                    4,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.75,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.19999999999999998,
+                    "support": 26,
+                    "roc_auc": 0.653353057199211,
+                    "pr_auc": 0.43476409303902813
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.574468085106383,
+                    "recall": 0.5192307692307693,
+                    "f1": 0.5454545454545454,
+                    "support": 52,
+                    "roc_auc": 0.6238905325443787,
+                    "pr_auc": 0.5374633344027784
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.41509433962264153,
+                    "recall": 0.8461538461538461,
+                    "f1": 0.5569620253164558,
+                    "support": 26,
+                    "roc_auc": 0.8298816568047337,
+                    "pr_auc": 0.6773372235863448
+                  }
+                ],
+                "macro_precision": 0.5798541415763415,
+                "macro_recall": 0.4935897435897436,
+                "macro_f1": 0.43413885692366705,
+                "weighted_f1": 0.46196777905638664,
+                "macro_roc_auc": 0.7023750821827744,
+                "macro_pr_auc": 0.5498548836760505
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.38821757952192737,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.0975712621581521,
+              "regression_rmse_log_rv": 0.8785457297077746,
+              "regression_mae_log_rv": 0.7358813288369371,
+              "regression_loss": 0.7718425991877661,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    6,
+                    7
+                  ],
+                  [
+                    9,
+                    9,
+                    27
+                  ],
+                  [
+                    17,
+                    6,
+                    24
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.36585365853658536,
+                    "recall": 0.5357142857142857,
+                    "f1": 0.43478260869565216,
+                    "support": 28,
+                    "roc_auc": 0.720108695652174,
+                    "pr_auc": 0.3716173620471066
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.2,
+                    "f1": 0.27272727272727276,
+                    "support": 45,
+                    "roc_auc": 0.5122962962962962,
+                    "pr_auc": 0.40045316937625863
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.41379310344827586,
+                    "recall": 0.5106382978723404,
+                    "f1": 0.4571428571428571,
+                    "support": 47,
+                    "roc_auc": 0.5983678227921889,
+                    "pr_auc": 0.4679732950253753
+                  }
+                ],
+                "macro_precision": 0.40273939685209664,
+                "macro_recall": 0.41545086119554203,
+                "macro_f1": 0.38821757952192737,
+                "weighted_f1": 0.38276962168266515,
+                "macro_roc_auc": 0.610257604913553,
+                "macro_pr_auc": 0.4133479421495802
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5130007254714409,
+              "regime_accuracy": 0.7372881174087524,
+              "regime_loss": 0.5704446530948251,
+              "regression_rmse_log_rv": 0.6468102676049085,
+              "regression_mae_log_rv": 0.5165127474120108,
+              "regression_loss": 0.4183635222791333,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    5,
+                    2,
+                    5
+                  ],
+                  [
+                    4,
+                    14,
+                    78
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4375,
+                    "recall": 0.7,
+                    "f1": 0.5384615384615384,
+                    "support": 10,
+                    "roc_auc": 0.9490740740740741,
+                    "pr_auc": 0.7825668498168499
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.10526315789473684,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.12903225806451615,
+                    "support": 12,
+                    "roc_auc": 0.6635220125786163,
+                    "pr_auc": 0.13013042726886653
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9397590361445783,
+                    "recall": 0.8125,
+                    "f1": 0.8715083798882681,
+                    "support": 96,
+                    "roc_auc": 0.9365530303030303,
+                    "pr_auc": 0.9849927718680084
+                  }
+                ],
+                "macro_precision": 0.4941740646797717,
+                "macro_recall": 0.5597222222222222,
+                "macro_f1": 0.5130007254714409,
+                "weighted_f1": 0.7677780250056214,
+                "macro_roc_auc": 0.8497163723185736,
+                "macro_pr_auc": 0.6325633496512416
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.38628817665514914,
+              "regime_accuracy": 0.3909091055393219,
+              "regime_loss": 1.0883540803735907,
+              "regression_rmse_log_rv": 0.3946633269051463,
+              "regression_mae_log_rv": 0.3085459460356188,
+              "regression_loss": 0.1557591416038384,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    4,
+                    0
+                  ],
+                  [
+                    33,
+                    22,
+                    23
+                  ],
+                  [
+                    2,
+                    5,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18604651162790697,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.2909090909090909,
+                    "support": 12,
+                    "roc_auc": 0.6760204081632653,
+                    "pr_auc": 0.1682973904770847
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7096774193548387,
+                    "recall": 0.28205128205128205,
+                    "f1": 0.40366972477064217,
+                    "support": 78,
+                    "roc_auc": 0.41907051282051283,
+                    "pr_auc": 0.7114222459165772
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3611111111111111,
+                    "recall": 0.65,
+                    "f1": 0.4642857142857143,
+                    "support": 20,
+                    "roc_auc": 0.7416666666666667,
+                    "pr_auc": 0.29265819077687616
+                  }
+                ],
+                "macro_precision": 0.4189450140312856,
+                "macro_recall": 0.5329059829059829,
+                "macro_f1": 0.38628817665514914,
+                "weighted_f1": 0.4023896537157588,
+                "macro_roc_auc": 0.612252529216815,
+                "macro_pr_auc": 0.39079260905684604
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.41209851322210883,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.0621607782941762,
+              "regression_rmse_log_rv": 0.7942411082991773,
+              "regression_mae_log_rv": 0.6527176921566328,
+              "regression_loss": 0.6308189381123054,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    24,
+                    12,
+                    8
+                  ],
+                  [
+                    17,
+                    13,
+                    18
+                  ],
+                  [
+                    4,
+                    5,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5333333333333333,
+                    "recall": 0.5454545454545454,
+                    "f1": 0.5393258426966293,
+                    "support": 44,
+                    "roc_auc": 0.6438263229308006,
+                    "pr_auc": 0.470955560958356
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.43333333333333335,
+                    "recall": 0.2708333333333333,
+                    "f1": 0.33333333333333337,
+                    "support": 48,
+                    "roc_auc": 0.5634920634920635,
+                    "pr_auc": 0.4523623800118792
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2777777777777778,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.36363636363636365,
+                    "support": 19,
+                    "roc_auc": 0.6332951945080092,
+                    "pr_auc": 0.376042287558214
+                  }
+                ],
+                "macro_precision": 0.4148148148148148,
+                "macro_recall": 0.4475345560871877,
+                "macro_f1": 0.41209851322210883,
+                "weighted_f1": 0.4201750269166,
+                "macro_roc_auc": 0.6135378603102911,
+                "macro_pr_auc": 0.4331200761761497
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4985153256704981,
+              "regime_accuracy": 0.6057692170143127,
+              "regime_loss": 1.0376843214035034,
+              "regression_rmse_log_rv": 0.769162185064812,
+              "regression_mae_log_rv": 0.5836027238356809,
+              "regression_loss": 0.5916104669336761,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    12,
+                    11
+                  ],
+                  [
+                    3,
+                    43,
+                    6
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.1875,
+                    "support": 26,
+                    "roc_auc": 0.5256410256410257,
+                    "pr_auc": 0.29951099500368333
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.671875,
+                    "recall": 0.8269230769230769,
+                    "f1": 0.7413793103448276,
+                    "support": 52,
+                    "roc_auc": 0.7437130177514792,
+                    "pr_auc": 0.7511867715702493
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.5666666666666668,
+                    "support": 26,
+                    "roc_auc": 0.7815581854043393,
+                    "pr_auc": 0.6485409298838356
+                  }
+                ],
+                "macro_precision": 0.5572916666666666,
+                "macro_recall": 0.532051282051282,
+                "macro_f1": 0.4985153256704981,
+                "weighted_f1": 0.5592313218390805,
+                "macro_roc_auc": 0.683637409598948,
+                "macro_pr_auc": 0.566412898819256
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.297024625539477,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.110738093988837,
+              "regression_rmse_log_rv": 0.867850604762115,
+              "regression_mae_log_rv": 0.7345265240777129,
+              "regression_loss": 0.7531646721859687,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    20,
+                    5
+                  ],
+                  [
+                    6,
+                    14,
+                    25
+                  ],
+                  [
+                    2,
+                    22,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2727272727272727,
+                    "recall": 0.10714285714285714,
+                    "f1": 0.15384615384615383,
+                    "support": 28,
+                    "roc_auc": 0.6797360248447205,
+                    "pr_auc": 0.34554591587671096
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.3111111111111111,
+                    "f1": 0.27722772277227725,
+                    "support": 45,
+                    "roc_auc": 0.44325925925925924,
+                    "pr_auc": 0.3236486711124539
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4339622641509434,
+                    "recall": 0.48936170212765956,
+                    "f1": 0.45999999999999996,
+                    "support": 47,
+                    "roc_auc": 0.5904983969688138,
+                    "pr_auc": 0.46613321478618386
+                  }
+                ],
+                "macro_precision": 0.3188965122927387,
+                "macro_recall": 0.3025385567938759,
+                "macro_f1": 0.297024625539477,
+                "weighted_f1": 0.3200244986037065,
+                "macro_roc_auc": 0.5711645603575978,
+                "macro_pr_auc": 0.3784426005917829
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.524968106433388,
+              "regime_accuracy": 0.7457627058029175,
+              "regime_loss": 0.5852284522379859,
+              "regression_rmse_log_rv": 0.6289156187874947,
+              "regression_mae_log_rv": 0.5218720624886327,
+              "regression_loss": 0.3955348555548574,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    6,
+                    3,
+                    3
+                  ],
+                  [
+                    5,
+                    13,
+                    78
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3888888888888889,
+                    "recall": 0.7,
+                    "f1": 0.5,
+                    "support": 10,
+                    "roc_auc": 0.9472222222222222,
+                    "pr_auc": 0.48956560951126166
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.15789473684210525,
+                    "recall": 0.25,
+                    "f1": 0.1935483870967742,
+                    "support": 12,
+                    "roc_auc": 0.684748427672956,
+                    "pr_auc": 0.144217077734638
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9629629629629629,
+                    "recall": 0.8125,
+                    "f1": 0.8813559322033898,
+                    "support": 96,
+                    "roc_auc": 0.9048295454545454,
+                    "pr_auc": 0.9773949744496299
+                  }
+                ],
+                "macro_precision": 0.5032488628979856,
+                "macro_recall": 0.5875,
+                "macro_f1": 0.524968106433388,
+                "weighted_f1": 0.7790911028532773,
+                "macro_roc_auc": 0.8456000651165745,
+                "macro_pr_auc": 0.5370592205651765
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.27958152958152954,
+              "regime_accuracy": 0.27272728085517883,
+              "regime_loss": 1.4479293303056198,
+              "regression_rmse_log_rv": 0.7886802497991353,
+              "regression_mae_log_rv": 0.6022398985477841,
+              "regression_loss": 0.6220165364232265,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    25,
+                    5,
+                    48
+                  ],
+                  [
+                    3,
+                    0,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.3333333333333333,
+                    "support": 12,
+                    "roc_auc": 0.6377551020408163,
+                    "pr_auc": 0.13879821276345355
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8333333333333334,
+                    "recall": 0.0641025641025641,
+                    "f1": 0.11904761904761904,
+                    "support": 78,
+                    "roc_auc": 0.3245192307692308,
+                    "pr_auc": 0.6644906996276934
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.25,
+                    "recall": 0.85,
+                    "f1": 0.3863636363636363,
+                    "support": 20,
+                    "roc_auc": 0.6666666666666666,
+                    "pr_auc": 0.2545169663484498
+                  }
+                ],
+                "macro_precision": 0.4351851851851852,
+                "macro_recall": 0.5269230769230769,
+                "macro_f1": 0.27958152958152954,
+                "weighted_f1": 0.19102715466351827,
+                "macro_roc_auc": 0.5429803331589046,
+                "macro_pr_auc": 0.35260195957986556
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.39222627476221134,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.0715466519821577,
+              "regression_rmse_log_rv": 0.8191249837729384,
+              "regression_mae_log_rv": 0.674115935491549,
+              "regression_loss": 0.6709657390410165,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    21,
+                    15,
+                    8
+                  ],
+                  [
+                    15,
+                    12,
+                    21
+                  ],
+                  [
+                    4,
+                    4,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.525,
+                    "recall": 0.4772727272727273,
+                    "f1": 0.5,
+                    "support": 44,
+                    "roc_auc": 0.6441655359565808,
+                    "pr_auc": 0.4618593642044814
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3870967741935484,
+                    "recall": 0.25,
+                    "f1": 0.3037974683544304,
+                    "support": 48,
+                    "roc_auc": 0.5598544973544973,
+                    "pr_auc": 0.46926568335453683
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.275,
+                    "recall": 0.5789473684210527,
+                    "f1": 0.37288135593220345,
+                    "support": 19,
+                    "roc_auc": 0.5938215102974829,
+                    "pr_auc": 0.40392772769039026
+                  }
+                ],
+                "macro_precision": 0.3956989247311828,
+                "macro_recall": 0.4354066985645933,
+                "macro_f1": 0.39222627476221134,
+                "weighted_f1": 0.39339661480832905,
+                "macro_roc_auc": 0.5992805145361869,
+                "macro_pr_auc": 0.4450175917498029
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.33559431524547806,
+              "regime_accuracy": 0.4423076808452606,
+              "regime_loss": 1.1202088915384734,
+              "regression_rmse_log_rv": 0.7949337384047457,
+              "regression_mae_log_rv": 0.614936867254213,
+              "regression_loss": 0.6319196484541446,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    12,
+                    14
+                  ],
+                  [
+                    0,
+                    26,
+                    26
+                  ],
+                  [
+                    0,
+                    6,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5581854043392505,
+                    "pr_auc": 0.3655336281982617
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5909090909090909,
+                    "recall": 0.5,
+                    "f1": 0.5416666666666667,
+                    "support": 52,
+                    "roc_auc": 0.6997041420118343,
+                    "pr_auc": 0.6717442261396133
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.4651162790697674,
+                    "support": 26,
+                    "roc_auc": 0.8022682445759369,
+                    "pr_auc": 0.6792493307173402
+                  }
+                ],
+                "macro_precision": 0.3080808080808081,
+                "macro_recall": 0.4230769230769231,
+                "macro_f1": 0.33559431524547806,
+                "weighted_f1": 0.3871124031007752,
+                "macro_roc_auc": 0.6867192636423406,
+                "macro_pr_auc": 0.5721757283517384
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "classification": {
+      "regime_f1_macro": {
+        "mean": 0.3768583021808598,
+        "std": 0.07147198457405785,
+        "min": 0.2516713209782517,
+        "max": 0.4944607363962203,
+        "n": 25
+      },
+      "regression_rmse_log_rv": null
+    },
+    "regression": {
+      "regime_f1_macro": {
+        "mean": 0.20660718297891725,
+        "std": 0.08006554842078246,
+        "min": 0.06722689075630252,
+        "max": 0.3719429748694241,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7886764878644895,
+        "std": 0.09526903963105232,
+        "min": 0.5108194220969481,
+        "max": 0.9657506688737695,
+        "n": 25
+      }
+    },
+    "dual": {
+      "regime_f1_macro": {
+        "mean": 0.3825770199423472,
+        "std": 0.06937183426215304,
+        "min": 0.262471076629917,
+        "max": 0.524968106433388,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7916455267961559,
+        "std": 0.11404657766686954,
+        "min": 0.3946633269051463,
+        "max": 0.9480217637280095,
+        "n": 25
+      }
+    }
+  }
+}

--- a/backend/artifacts/experiments/runpod_20260530/runpod_regime_20260530T124847Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/runpod_regime_20260530T124847Z.json
@@ -1,0 +1,5153 @@
+{
+  "head_modes": [
+    "classification",
+    "regression",
+    "dual"
+  ],
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "regression_alpha": 0.5,
+  "training_package_id": "canonical",
+  "rates_target_mode": "raw",
+  "rates_heads": [],
+  "use_retrieval_analogs": false,
+  "use_regime_conditioning": true,
+  "use_statement_delta": false,
+  "use_vote_features": false,
+  "use_press_conf": false,
+  "trials": {
+    "classification": [
+      {
+        "head_mode": "classification",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.405716891022425,
+              "regime_accuracy": 0.44999998807907104,
+              "regime_loss": 1.089518337402714,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    9,
+                    11
+                  ],
+                  [
+                    4,
+                    9,
+                    32
+                  ],
+                  [
+                    2,
+                    8,
+                    37
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5714285714285714,
+                    "recall": 0.2857142857142857,
+                    "f1": 0.38095238095238093,
+                    "support": 28,
+                    "roc_auc": 0.7014751552795031,
+                    "pr_auc": 0.458611502256847
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.34615384615384615,
+                    "recall": 0.2,
+                    "f1": 0.2535211267605634,
+                    "support": 45,
+                    "roc_auc": 0.49925925925925924,
+                    "pr_auc": 0.36304087151300907
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4625,
+                    "recall": 0.7872340425531915,
+                    "f1": 0.5826771653543308,
+                    "support": 47,
+                    "roc_auc": 0.6531623433401341,
+                    "pr_auc": 0.48186258297116197
+                  }
+                ],
+                "macro_precision": 0.4600274725274725,
+                "macro_recall": 0.42431610942249237,
+                "macro_f1": 0.405716891022425,
+                "weighted_f1": 0.41217453452121305,
+                "macro_roc_auc": 0.6179655859596321,
+                "macro_pr_auc": 0.43450498558033934
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.38065535595475714,
+              "regime_accuracy": 0.6610169410705566,
+              "regime_loss": 0.7498158964060121,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    19,
+                    6,
+                    71
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18421052631578946,
+                    "recall": 0.7,
+                    "f1": 0.29166666666666663,
+                    "support": 10,
+                    "roc_auc": 0.9037037037037037,
+                    "pr_auc": 0.5187150055763663
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7617924528301887,
+                    "pr_auc": 0.1761714525911056
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.7395833333333334,
+                    "f1": 0.8502994011976047,
+                    "support": 96,
+                    "roc_auc": 0.9242424242424242,
+                    "pr_auc": 0.9831395235493811
+                  }
+                ],
+                "macro_precision": 0.3947368421052631,
+                "macro_recall": 0.47986111111111107,
+                "macro_f1": 0.38065535595475714,
+                "weighted_f1": 0.7164865184884468,
+                "macro_roc_auc": 0.8632461935921055,
+                "macro_pr_auc": 0.5593419939056177
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2610627560619648,
+              "regime_accuracy": 0.2454545497894287,
+              "regime_loss": 1.2581246896223588,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    2,
+                    0
+                  ],
+                  [
+                    43,
+                    6,
+                    29
+                  ],
+                  [
+                    6,
+                    3,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1694915254237288,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.2816901408450704,
+                    "support": 12,
+                    "roc_auc": 0.7840136054421769,
+                    "pr_auc": 0.24264233203098212
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5454545454545454,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.13483146067415733,
+                    "support": 78,
+                    "roc_auc": 0.4443108974358974,
+                    "pr_auc": 0.6597613615640454
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.275,
+                    "recall": 0.55,
+                    "f1": 0.3666666666666667,
+                    "support": 20,
+                    "roc_auc": 0.6444444444444445,
+                    "pr_auc": 0.26734170297013043
+                  }
+                ],
+                "macro_precision": 0.3299820236260914,
+                "macro_recall": 0.4867521367521368,
+                "macro_f1": 0.2610627560619648,
+                "weighted_f1": 0.193004263236895,
+                "macro_roc_auc": 0.624256315774173,
+                "macro_pr_auc": 0.38991513218838597
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.36691017316017316,
+              "regime_accuracy": 0.38738739490509033,
+              "regime_loss": 1.2466207068624064,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    1,
+                    17
+                  ],
+                  [
+                    13,
+                    9,
+                    26
+                  ],
+                  [
+                    5,
+                    6,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5909090909090909,
+                    "recall": 0.5909090909090909,
+                    "f1": 0.5909090909090909,
+                    "support": 44,
+                    "roc_auc": 0.6394165535956581,
+                    "pr_auc": 0.5005463275076267
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5625,
+                    "recall": 0.1875,
+                    "f1": 0.28125,
+                    "support": 48,
+                    "roc_auc": 0.5128968253968254,
+                    "pr_auc": 0.480377789426899
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1568627450980392,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.22857142857142856,
+                    "support": 19,
+                    "roc_auc": 0.5789473684210527,
+                    "pr_auc": 0.189160501693937
+                  }
+                ],
+                "macro_precision": 0.4367572786690434,
+                "macro_recall": 0.3998205741626794,
+                "macro_f1": 0.36691017316017316,
+                "weighted_f1": 0.394980694980695,
+                "macro_roc_auc": 0.5770869158045121,
+                "macro_pr_auc": 0.3900282062094876
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2817484961939067,
+              "regime_accuracy": 0.3461538553237915,
+              "regime_loss": 1.1937057605156531,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    11,
+                    14
+                  ],
+                  [
+                    0,
+                    15,
+                    37
+                  ],
+                  [
+                    1,
+                    5,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.07142857142857144,
+                    "support": 26,
+                    "roc_auc": 0.6148915187376726,
+                    "pr_auc": 0.35389221205265353
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4838709677419355,
+                    "recall": 0.28846153846153844,
+                    "f1": 0.36144578313253006,
+                    "support": 52,
+                    "roc_auc": 0.5502958579881657,
+                    "pr_auc": 0.4940039553015737
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.28169014084507044,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.4123711340206186,
+                    "support": 26,
+                    "roc_auc": 0.6760355029585798,
+                    "pr_auc": 0.4871197859913373
+                  }
+                ],
+                "macro_precision": 0.4218537028623353,
+                "macro_recall": 0.3653846153846154,
+                "macro_f1": 0.2817484961939067,
+                "weighted_f1": 0.30167281792856254,
+                "macro_roc_auc": 0.613740959894806,
+                "macro_pr_auc": 0.44500531778185487
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.39153439153439157,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.0980707494273405,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    9,
+                    6
+                  ],
+                  [
+                    13,
+                    5,
+                    27
+                  ],
+                  [
+                    2,
+                    13,
+                    32
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4642857142857143,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.4642857142857143,
+                    "support": 28,
+                    "roc_auc": 0.7422360248447205,
+                    "pr_auc": 0.48215169373425404
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.18518518518518517,
+                    "recall": 0.1111111111111111,
+                    "f1": 0.13888888888888887,
+                    "support": 45,
+                    "roc_auc": 0.5496296296296296,
+                    "pr_auc": 0.38306710172424435
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.49230769230769234,
+                    "recall": 0.6808510638297872,
+                    "f1": 0.5714285714285714,
+                    "support": 47,
+                    "roc_auc": 0.696881375692218,
+                    "pr_auc": 0.5540620011337605
+                  }
+                ],
+                "macro_precision": 0.3805928639261973,
+                "macro_recall": 0.4187492964088709,
+                "macro_f1": 0.39153439153439157,
+                "weighted_f1": 0.38422619047619044,
+                "macro_roc_auc": 0.6629156767221893,
+                "macro_pr_auc": 0.4730935988640863
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5026049973418395,
+              "regime_accuracy": 0.6864407062530518,
+              "regime_loss": 0.7419961701005192,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    5,
+                    0
+                  ],
+                  [
+                    14,
+                    13,
+                    69
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.7,
+                    "f1": 0.3684210526315789,
+                    "support": 10,
+                    "roc_auc": 0.9055555555555556,
+                    "pr_auc": 0.4655972984262457
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.23809523809523808,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.30303030303030304,
+                    "support": 12,
+                    "roc_auc": 0.7083333333333334,
+                    "pr_auc": 0.15028632741094117
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.71875,
+                    "f1": 0.8363636363636363,
+                    "support": 96,
+                    "roc_auc": 0.9232954545454546,
+                    "pr_auc": 0.9832938653331197
+                  }
+                ],
+                "macro_precision": 0.49603174603174605,
+                "macro_recall": 0.6118055555555556,
+                "macro_f1": 0.5026049973418395,
+                "weighted_f1": 0.7424701970643094,
+                "macro_roc_auc": 0.8457281144781145,
+                "macro_pr_auc": 0.5330591637234355
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2310131344739724,
+              "regime_accuracy": 0.2181818187236786,
+              "regime_loss": 1.1513518051667646,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    47,
+                    1,
+                    30
+                  ],
+                  [
+                    7,
+                    2,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18181818181818182,
+                    "recall": 1.0,
+                    "f1": 0.3076923076923077,
+                    "support": 12,
+                    "roc_auc": 0.8086734693877551,
+                    "pr_auc": 0.24315168184034106
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.01282051282051282,
+                    "f1": 0.024691358024691357,
+                    "support": 78,
+                    "roc_auc": 0.41786858974358976,
+                    "pr_auc": 0.6449092981744501
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2682926829268293,
+                    "recall": 0.55,
+                    "f1": 0.36065573770491804,
+                    "support": 20,
+                    "roc_auc": 0.68,
+                    "pr_auc": 0.3465542353769452
+                  }
+                ],
+                "macro_precision": 0.2611480660261148,
+                "macro_recall": 0.520940170940171,
+                "macro_f1": 0.2310131344739724,
+                "weighted_f1": 0.11664862156665436,
+                "macro_roc_auc": 0.6355140197104483,
+                "macro_pr_auc": 0.41153840513057877
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.387486203464353,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.0835223274930785,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    27,
+                    3,
+                    14
+                  ],
+                  [
+                    22,
+                    10,
+                    16
+                  ],
+                  [
+                    8,
+                    2,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.47368421052631576,
+                    "recall": 0.6136363636363636,
+                    "f1": 0.5346534653465346,
+                    "support": 44,
+                    "roc_auc": 0.6404341926729986,
+                    "pr_auc": 0.5305369930961454
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.3174603174603175,
+                    "support": 48,
+                    "roc_auc": 0.6504629629629629,
+                    "pr_auc": 0.5572178281371312
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.23076923076923078,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.3103448275862069,
+                    "support": 19,
+                    "roc_auc": 0.6384439359267735,
+                    "pr_auc": 0.22971735112663574
+                  }
+                ],
+                "macro_precision": 0.45704003598740445,
+                "macro_recall": 0.43188463583200426,
+                "macro_f1": 0.387486203464353,
+                "weighted_f1": 0.40233693186919545,
+                "macro_roc_auc": 0.6431136971875784,
+                "macro_pr_auc": 0.43915739078663746
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.1966604823747681,
+              "regime_accuracy": 0.24038460850715637,
+              "regime_loss": 1.2743992255284236,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    7,
+                    17
+                  ],
+                  [
+                    14,
+                    3,
+                    35
+                  ],
+                  [
+                    2,
+                    4,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1111111111111111,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.09090909090909093,
+                    "support": 26,
+                    "roc_auc": 0.5004930966469427,
+                    "pr_auc": 0.23820917264573807
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.21428571428571427,
+                    "recall": 0.057692307692307696,
+                    "f1": 0.09090909090909091,
+                    "support": 52,
+                    "roc_auc": 0.5669378698224852,
+                    "pr_auc": 0.5366116761993306
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2777777777777778,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.40816326530612246,
+                    "support": 26,
+                    "roc_auc": 0.6671597633136095,
+                    "pr_auc": 0.42109139168020676
+                  }
+                ],
+                "macro_precision": 0.20105820105820105,
+                "macro_recall": 0.30128205128205127,
+                "macro_f1": 0.1966604823747681,
+                "weighted_f1": 0.1702226345083488,
+                "macro_roc_auc": 0.5781969099276791,
+                "macro_pr_auc": 0.39863741350842513
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3723441309648206,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.1101464797108513,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    6,
+                    10
+                  ],
+                  [
+                    13,
+                    5,
+                    27
+                  ],
+                  [
+                    5,
+                    10,
+                    32
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4,
+                    "recall": 0.42857142857142855,
+                    "f1": 0.4137931034482759,
+                    "support": 28,
+                    "roc_auc": 0.6859472049689441,
+                    "pr_auc": 0.3652279540024783
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.23809523809523808,
+                    "recall": 0.1111111111111111,
+                    "f1": 0.15151515151515152,
+                    "support": 45,
+                    "roc_auc": 0.453037037037037,
+                    "pr_auc": 0.33282050811679464
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.463768115942029,
+                    "recall": 0.6808510638297872,
+                    "f1": 0.5517241379310345,
+                    "support": 47,
+                    "roc_auc": 0.6420868551442728,
+                    "pr_auc": 0.4693267550294428
+                  }
+                ],
+                "macro_precision": 0.367287784679089,
+                "macro_recall": 0.40684453450410896,
+                "macro_f1": 0.3723441309648206,
+                "weighted_f1": 0.36946185997910136,
+                "macro_roc_auc": 0.5936903657167513,
+                "macro_pr_auc": 0.3891250723829052
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.49190650271407993,
+              "regime_accuracy": 0.7542372941970825,
+              "regime_loss": 0.5820860312146655,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    2,
+                    1
+                  ],
+                  [
+                    8,
+                    8,
+                    80
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2916666666666667,
+                    "recall": 0.7,
+                    "f1": 0.4117647058823529,
+                    "support": 10,
+                    "roc_auc": 0.9231481481481482,
+                    "pr_auc": 0.7153604354742874
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.15384615384615385,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.16,
+                    "support": 12,
+                    "roc_auc": 0.6328616352201258,
+                    "pr_auc": 0.12119331965415346
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9876543209876543,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.903954802259887,
+                    "support": 96,
+                    "roc_auc": 0.9696969696969697,
+                    "pr_auc": 0.993434792599474
+                  }
+                ],
+                "macro_precision": 0.47772238050015825,
+                "macro_recall": 0.5666666666666667,
+                "macro_f1": 0.49190650271407993,
+                "weighted_f1": 0.7865873565743446,
+                "macro_roc_auc": 0.8419022510217479,
+                "macro_pr_auc": 0.6099961825759715
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.27074799453831716,
+              "regime_accuracy": 0.2545454502105713,
+              "regime_loss": 1.282823744687167,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    2,
+                    0
+                  ],
+                  [
+                    39,
+                    7,
+                    32
+                  ],
+                  [
+                    3,
+                    6,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.19230769230769232,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.3125,
+                    "support": 12,
+                    "roc_auc": 0.7772108843537415,
+                    "pr_auc": 0.20734808619854414
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4666666666666667,
+                    "recall": 0.08974358974358974,
+                    "f1": 0.15053763440860216,
+                    "support": 78,
+                    "roc_auc": 0.43830128205128205,
+                    "pr_auc": 0.6596658097693879
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2558139534883721,
+                    "recall": 0.55,
+                    "f1": 0.34920634920634924,
+                    "support": 20,
+                    "roc_auc": 0.665,
+                    "pr_auc": 0.26848433948731815
+                  }
+                ],
+                "macro_precision": 0.304929437487577,
+                "macro_recall": 0.49102564102564106,
+                "macro_f1": 0.27074799453831716,
+                "weighted_f1": 0.2043278406181632,
+                "macro_roc_auc": 0.6268373888016745,
+                "macro_pr_auc": 0.3784994118184168
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3465109314165918,
+              "regime_accuracy": 0.4054054021835327,
+              "regime_loss": 1.1331886774632882,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    33,
+                    3,
+                    8
+                  ],
+                  [
+                    22,
+                    6,
+                    20
+                  ],
+                  [
+                    7,
+                    6,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.532258064516129,
+                    "recall": 0.75,
+                    "f1": 0.6226415094339622,
+                    "support": 44,
+                    "roc_auc": 0.6828358208955224,
+                    "pr_auc": 0.5493180314459231
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.125,
+                    "f1": 0.19047619047619047,
+                    "support": 48,
+                    "roc_auc": 0.5717592592592593,
+                    "pr_auc": 0.48867020377412984
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.17647058823529413,
+                    "recall": 0.3157894736842105,
+                    "f1": 0.22641509433962262,
+                    "support": 19,
+                    "roc_auc": 0.601258581235698,
+                    "pr_auc": 0.2379834832404995
+                  }
+                ],
+                "macro_precision": 0.3695762175838077,
+                "macro_recall": 0.3969298245614035,
+                "macro_f1": 0.3465109314165918,
+                "weighted_f1": 0.3679366698234623,
+                "macro_roc_auc": 0.6186178871301599,
+                "macro_pr_auc": 0.42532390615351745
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.33121641426477777,
+              "regime_accuracy": 0.4326923191547394,
+              "regime_loss": 1.202139478463393,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    15,
+                    11
+                  ],
+                  [
+                    0,
+                    21,
+                    31
+                  ],
+                  [
+                    1,
+                    1,
+                    24
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6208086785009862,
+                    "pr_auc": 0.3327568982822469
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5675675675675675,
+                    "recall": 0.40384615384615385,
+                    "f1": 0.47191011235955055,
+                    "support": 52,
+                    "roc_auc": 0.5532544378698225,
+                    "pr_auc": 0.5323831870380291
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.36363636363636365,
+                    "recall": 0.9230769230769231,
+                    "f1": 0.5217391304347827,
+                    "support": 26,
+                    "roc_auc": 0.7283037475345168,
+                    "pr_auc": 0.4968767729317875
+                  }
+                ],
+                "macro_precision": 0.3104013104013104,
+                "macro_recall": 0.44230769230769235,
+                "macro_f1": 0.33121641426477777,
+                "weighted_f1": 0.3663898387884709,
+                "macro_roc_auc": 0.6341222879684418,
+                "macro_pr_auc": 0.4540056194173545
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.43481985386747296,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.0258231265038518,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    12,
+                    6
+                  ],
+                  [
+                    9,
+                    12,
+                    24
+                  ],
+                  [
+                    2,
+                    12,
+                    33
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.47619047619047616,
+                    "recall": 0.35714285714285715,
+                    "f1": 0.40816326530612246,
+                    "support": 28,
+                    "roc_auc": 0.7329192546583851,
+                    "pr_auc": 0.4447775593013982
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.26666666666666666,
+                    "f1": 0.2962962962962963,
+                    "support": 45,
+                    "roc_auc": 0.5357037037037037,
+                    "pr_auc": 0.3739578366149715
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5238095238095238,
+                    "recall": 0.7021276595744681,
+                    "f1": 0.6,
+                    "support": 47,
+                    "roc_auc": 0.6860973477120373,
+                    "pr_auc": 0.5262292945177417
+                  }
+                ],
+                "macro_precision": 0.4444444444444444,
+                "macro_recall": 0.4419790611279973,
+                "macro_f1": 0.43481985386747296,
+                "weighted_f1": 0.4413492063492063,
+                "macro_roc_auc": 0.651573435358042,
+                "macro_pr_auc": 0.4483215634780371
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3943541488451668,
+              "regime_accuracy": 0.5847457647323608,
+              "regime_loss": 0.8687141567973767,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    3,
+                    1
+                  ],
+                  [
+                    5,
+                    0,
+                    7
+                  ],
+                  [
+                    7,
+                    26,
+                    63
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.6,
+                    "f1": 0.42857142857142855,
+                    "support": 10,
+                    "roc_auc": 0.8398148148148148,
+                    "pr_auc": 0.6697109628070547
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.4441823899371069,
+                    "pr_auc": 0.08461113392178249
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.8873239436619719,
+                    "recall": 0.65625,
+                    "f1": 0.7544910179640718,
+                    "support": 96,
+                    "roc_auc": 0.8333333333333334,
+                    "pr_auc": 0.9591310548389614
+                  }
+                ],
+                "macro_precision": 0.4068857589984351,
+                "macro_recall": 0.41875,
+                "macro_f1": 0.3943541488451668,
+                "weighted_f1": 0.6501428136463151,
+                "macro_roc_auc": 0.7057768460284183,
+                "macro_pr_auc": 0.5711510505225995
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2942857142857143,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.1995183727957985,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    3,
+                    0
+                  ],
+                  [
+                    46,
+                    18,
+                    14
+                  ],
+                  [
+                    8,
+                    6,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.14285714285714285,
+                    "recall": 0.75,
+                    "f1": 0.24,
+                    "support": 12,
+                    "roc_auc": 0.6802721088435374,
+                    "pr_auc": 0.16401571793837366
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.3428571428571429,
+                    "support": 78,
+                    "roc_auc": 0.390224358974359,
+                    "pr_auc": 0.641799153715425
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3,
+                    "recall": 0.3,
+                    "f1": 0.3,
+                    "support": 20,
+                    "roc_auc": 0.6383333333333333,
+                    "pr_auc": 0.3367697005677753
+                  }
+                ],
+                "macro_precision": 0.36984126984126986,
+                "macro_recall": 0.4269230769230769,
+                "macro_f1": 0.2942857142857143,
+                "weighted_f1": 0.32384415584415593,
+                "macro_roc_auc": 0.5696099337170766,
+                "macro_pr_auc": 0.380861524073858
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.33908503364139503,
+              "regime_accuracy": 0.342342346906662,
+              "regime_loss": 1.0757900988053162,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    12,
+                    15
+                  ],
+                  [
+                    15,
+                    10,
+                    23
+                  ],
+                  [
+                    5,
+                    3,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4594594594594595,
+                    "recall": 0.38636363636363635,
+                    "f1": 0.41975308641975306,
+                    "support": 44,
+                    "roc_auc": 0.6777476255088195,
+                    "pr_auc": 0.5407600963809496
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.273972602739726,
+                    "support": 48,
+                    "roc_auc": 0.542989417989418,
+                    "pr_auc": 0.4304826683257705
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.22448979591836735,
+                    "recall": 0.5789473684210527,
+                    "f1": 0.32352941176470584,
+                    "support": 19,
+                    "roc_auc": 0.6464530892448512,
+                    "pr_auc": 0.2667996759471782
+                  }
+                ],
+                "macro_precision": 0.36131641845927565,
+                "macro_recall": 0.3912147793726741,
+                "macro_f1": 0.33908503364139503,
+                "weighted_f1": 0.3402421581757243,
+                "macro_roc_auc": 0.622396710914363,
+                "macro_pr_auc": 0.41268081355129943
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.34541723666210666,
+              "regime_accuracy": 0.4038461446762085,
+              "regime_loss": 1.169912420786344,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    14,
+                    10
+                  ],
+                  [
+                    4,
+                    18,
+                    30
+                  ],
+                  [
+                    2,
+                    2,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.11764705882352941,
+                    "support": 26,
+                    "roc_auc": 0.5907297830374754,
+                    "pr_auc": 0.28695416523901257
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5294117647058824,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.41860465116279066,
+                    "support": 52,
+                    "roc_auc": 0.6257396449704142,
+                    "pr_auc": 0.6040777939414996
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3548387096774194,
+                    "recall": 0.8461538461538461,
+                    "f1": 0.5,
+                    "support": 26,
+                    "roc_auc": 0.7495069033530573,
+                    "pr_auc": 0.5122770889839428
+                  }
+                ],
+                "macro_precision": 0.3780834914611006,
+                "macro_recall": 0.4230769230769231,
+                "macro_f1": 0.34541723666210666,
+                "weighted_f1": 0.3637140902872777,
+                "macro_roc_auc": 0.6553254437869823,
+                "macro_pr_auc": 0.467769682721485
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4287179487179487,
+              "regime_accuracy": 0.49166667461395264,
+              "regime_loss": 1.0549625848797837,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    11,
+                    6,
+                    11
+                  ],
+                  [
+                    9,
+                    6,
+                    30
+                  ],
+                  [
+                    2,
+                    3,
+                    42
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.39285714285714285,
+                    "f1": 0.44,
+                    "support": 28,
+                    "roc_auc": 0.7872670807453416,
+                    "pr_auc": 0.49907995682162054
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.13333333333333333,
+                    "f1": 0.2,
+                    "support": 45,
+                    "roc_auc": 0.4583703703703704,
+                    "pr_auc": 0.4040013855283713
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5060240963855421,
+                    "recall": 0.8936170212765957,
+                    "f1": 0.6461538461538462,
+                    "support": 47,
+                    "roc_auc": 0.6756047799475372,
+                    "pr_auc": 0.5299460990000482
+                  }
+                ],
+                "macro_precision": 0.4686746987951807,
+                "macro_recall": 0.4732691658223573,
+                "macro_f1": 0.4287179487179487,
+                "weighted_f1": 0.4307435897435898,
+                "macro_roc_auc": 0.640414077021083,
+                "macro_pr_auc": 0.4776758137833467
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.47086789684555047,
+              "regime_accuracy": 0.7542372941970825,
+              "regime_loss": 0.5799510554742004,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    1,
+                    2
+                  ],
+                  [
+                    7,
+                    8,
+                    81
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.30434782608695654,
+                    "recall": 0.7,
+                    "f1": 0.42424242424242425,
+                    "support": 10,
+                    "roc_auc": 0.8842592592592593,
+                    "pr_auc": 0.6325480611400731
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.08333333333333333,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.08333333333333333,
+                    "support": 12,
+                    "roc_auc": 0.72562893081761,
+                    "pr_auc": 0.15409365437055594
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9759036144578314,
+                    "recall": 0.84375,
+                    "f1": 0.9050279329608939,
+                    "support": 96,
+                    "roc_auc": 0.9450757575757576,
+                    "pr_auc": 0.9875074942217915
+                  }
+                ],
+                "macro_precision": 0.45452825795937374,
+                "macro_recall": 0.5423611111111111,
+                "macro_f1": 0.47086789684555047,
+                "weighted_f1": 0.7807212356497463,
+                "macro_roc_auc": 0.8516546492175423,
+                "macro_pr_auc": 0.5913830699108068
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.210555325892242,
+              "regime_accuracy": 0.20000000298023224,
+              "regime_loss": 1.3401082190600309,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    49,
+                    0,
+                    29
+                  ],
+                  [
+                    9,
+                    1,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.17142857142857143,
+                    "recall": 1.0,
+                    "f1": 0.2926829268292683,
+                    "support": 12,
+                    "roc_auc": 0.8375850340136054,
+                    "pr_auc": 0.2741583793094493
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.39903846153846156,
+                    "pr_auc": 0.6420110293295906
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2564102564102564,
+                    "recall": 0.5,
+                    "f1": 0.3389830508474576,
+                    "support": 20,
+                    "roc_auc": 0.6122222222222222,
+                    "pr_auc": 0.2303274841183056
+                  }
+                ],
+                "macro_precision": 0.1426129426129426,
+                "macro_recall": 0.5,
+                "macro_f1": 0.210555325892242,
+                "weighted_f1": 0.09356232853545791,
+                "macro_roc_auc": 0.6162819059247631,
+                "macro_pr_auc": 0.3821656309191152
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.40095579450418156,
+              "regime_accuracy": 0.4324324429035187,
+              "regime_loss": 1.2092436765574965,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    27,
+                    4,
+                    13
+                  ],
+                  [
+                    17,
+                    15,
+                    16
+                  ],
+                  [
+                    5,
+                    8,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5510204081632653,
+                    "recall": 0.6136363636363636,
+                    "f1": 0.5806451612903225,
+                    "support": 44,
+                    "roc_auc": 0.6526458616010855,
+                    "pr_auc": 0.5339233980822901
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.3125,
+                    "f1": 0.39999999999999997,
+                    "support": 48,
+                    "roc_auc": 0.5823412698412699,
+                    "pr_auc": 0.48606926498963043
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.17142857142857143,
+                    "recall": 0.3157894736842105,
+                    "f1": 0.22222222222222224,
+                    "support": 19,
+                    "roc_auc": 0.5251716247139588,
+                    "pr_auc": 0.16792760500909082
+                  }
+                ],
+                "macro_precision": 0.4260015117157974,
+                "macro_recall": 0.41397527910685805,
+                "macro_f1": 0.40095579450418156,
+                "weighted_f1": 0.44117666053149923,
+                "macro_roc_auc": 0.586719585385438,
+                "macro_pr_auc": 0.3959734226936704
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3978839189682563,
+              "regime_accuracy": 0.45192307233810425,
+              "regime_loss": 1.1280320974496694,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    5,
+                    18
+                  ],
+                  [
+                    6,
+                    23,
+                    23
+                  ],
+                  [
+                    2,
+                    3,
+                    21
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2727272727272727,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.16216216216216214,
+                    "support": 26,
+                    "roc_auc": 0.5192307692307693,
+                    "pr_auc": 0.26208916919047
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7419354838709677,
+                    "recall": 0.4423076923076923,
+                    "f1": 0.5542168674698795,
+                    "support": 52,
+                    "roc_auc": 0.6708579881656804,
+                    "pr_auc": 0.6910320541850563
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3387096774193548,
+                    "recall": 0.8076923076923077,
+                    "f1": 0.4772727272727273,
+                    "support": 26,
+                    "roc_auc": 0.6642011834319527,
+                    "pr_auc": 0.4069706094519101
+                  }
+                ],
+                "macro_precision": 0.45112414467253176,
+                "macro_recall": 0.4551282051282051,
+                "macro_f1": 0.3978839189682563,
+                "weighted_f1": 0.43696715609366216,
+                "macro_roc_auc": 0.6180966469428008,
+                "macro_pr_auc": 0.45336394427581217
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "regression": [
+      {
+        "head_mode": "regression",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.44647284201036735,
+              "regime_accuracy": 0.46666666865348816,
+              "regime_loss": 1.084045531943364,
+              "regression_rmse_log_rv": 0.8891218743944974,
+              "regression_mae_log_rv": 0.7386112421188348,
+              "regression_loss": 0.7905377075267844,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    25,
+                    3,
+                    0
+                  ],
+                  [
+                    24,
+                    6,
+                    15
+                  ],
+                  [
+                    8,
+                    14,
+                    25
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.43859649122807015,
+                    "recall": 0.8928571428571429,
+                    "f1": 0.5882352941176471,
+                    "support": 28,
+                    "roc_auc": 0.7336956521739131,
+                    "pr_auc": 0.3471727214194586
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2608695652173913,
+                    "recall": 0.13333333333333333,
+                    "f1": 0.1764705882352941,
+                    "support": 45,
+                    "roc_auc": 0.4625185185185185,
+                    "pr_auc": 0.3442462694325419
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.625,
+                    "recall": 0.5319148936170213,
+                    "f1": 0.5747126436781609,
+                    "support": 47,
+                    "roc_auc": 0.7169921305741767,
+                    "pr_auc": 0.6376572263588758
+                  }
+                ],
+                "macro_precision": 0.44148868548182046,
+                "macro_recall": 0.5193684566024992,
+                "macro_f1": 0.44647284201036735,
+                "weighted_f1": 0.42852715798963265,
+                "macro_roc_auc": 0.6377354337555361,
+                "macro_pr_auc": 0.44302540573695876
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.2504525177792504,
+              "regime_accuracy": 0.20338982343673706,
+              "regime_loss": 1.145913732253899,
+              "regression_rmse_log_rv": 0.8893636743642136,
+              "regression_mae_log_rv": 0.6588568958943173,
+              "regression_loss": 0.790967745278615,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    1,
+                    0
+                  ],
+                  [
+                    2,
+                    10,
+                    0
+                  ],
+                  [
+                    70,
+                    21,
+                    5
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1111111111111111,
+                    "recall": 0.9,
+                    "f1": 0.1978021978021978,
+                    "support": 10,
+                    "roc_auc": 0.5898148148148148,
+                    "pr_auc": 0.11631978872464993
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3125,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.45454545454545453,
+                    "support": 12,
+                    "roc_auc": 0.7366352201257862,
+                    "pr_auc": 0.16727035887855865
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.052083333333333336,
+                    "f1": 0.09900990099009901,
+                    "support": 96,
+                    "roc_auc": 0.3778409090909091,
+                    "pr_auc": 0.779230310480863
+                  }
+                ],
+                "macro_precision": 0.47453703703703703,
+                "macro_recall": 0.5951388888888889,
+                "macro_f1": 0.2504525177792504,
+                "weighted_f1": 0.14353828752217743,
+                "macro_roc_auc": 0.5680969813438367,
+                "macro_pr_auc": 0.3542734860280239
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.06557377049180328,
+              "regime_accuracy": 0.1090909093618393,
+              "regime_loss": 1.1780742753635753,
+              "regression_rmse_log_rv": 0.45443750236928054,
+              "regression_mae_log_rv": 0.3659946313445372,
+              "regression_loss": 0.20651344355962986,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    78,
+                    0,
+                    0
+                  ],
+                  [
+                    20,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.10909090909090909,
+                    "recall": 1.0,
+                    "f1": 0.19672131147540983,
+                    "support": 12,
+                    "roc_auc": 0.5867346938775511,
+                    "pr_auc": 0.14025982320782582
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.5344551282051282,
+                    "pr_auc": 0.7331062881939756
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.6738888888888889,
+                    "pr_auc": 0.2751106962114176
+                  }
+                ],
+                "macro_precision": 0.03636363636363636,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.06557377049180328,
+                "weighted_f1": 0.021460506706408346,
+                "macro_roc_auc": 0.598359570323856,
+                "macro_pr_auc": 0.3828256025377397
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.31467345207803227,
+              "regime_accuracy": 0.46846845746040344,
+              "regime_loss": 1.0801506770878553,
+              "regression_rmse_log_rv": 0.8324378401158677,
+              "regression_mae_log_rv": 0.6639691322773427,
+              "regression_loss": 0.692952757656771,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    40,
+                    4,
+                    0
+                  ],
+                  [
+                    36,
+                    12,
+                    0
+                  ],
+                  [
+                    11,
+                    8,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.45977011494252873,
+                    "recall": 0.9090909090909091,
+                    "f1": 0.6106870229007634,
+                    "support": 44,
+                    "roc_auc": 0.6309362279511533,
+                    "pr_auc": 0.443227767806262
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.25,
+                    "f1": 0.3333333333333333,
+                    "support": 48,
+                    "roc_auc": 0.5747354497354498,
+                    "pr_auc": 0.5615520762296892
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.4731121281464531,
+                    "pr_auc": 0.19526612496190482
+                  }
+                ],
+                "macro_precision": 0.31992337164750956,
+                "macro_recall": 0.3863636363636364,
+                "macro_f1": 0.31467345207803227,
+                "weighted_f1": 0.38621827934805036,
+                "macro_roc_auc": 0.5595946019443521,
+                "macro_pr_auc": 0.4000153229992853
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.35444687382671874,
+              "regime_accuracy": 0.48076921701431274,
+              "regime_loss": 1.0925747156143188,
+              "regression_rmse_log_rv": 0.8884875374002658,
+              "regression_mae_log_rv": 0.7126979613945318,
+              "regression_loss": 0.7894101041155887,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    16,
+                    0
+                  ],
+                  [
+                    13,
+                    39,
+                    0
+                  ],
+                  [
+                    3,
+                    22,
+                    1
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.38461538461538464,
+                    "recall": 0.38461538461538464,
+                    "f1": 0.38461538461538464,
+                    "support": 26,
+                    "roc_auc": 0.5848126232741617,
+                    "pr_auc": 0.2867066472200448
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5064935064935064,
+                    "recall": 0.75,
+                    "f1": 0.6046511627906975,
+                    "support": 52,
+                    "roc_auc": 0.4992603550295858,
+                    "pr_auc": 0.54596324133056
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.07407407407407407,
+                    "support": 26,
+                    "roc_auc": 0.5936883629191322,
+                    "pr_auc": 0.31208787475128497
+                  }
+                ],
+                "macro_precision": 0.6303696303696303,
+                "macro_recall": 0.391025641025641,
+                "macro_f1": 0.35444687382671874,
+                "weighted_f1": 0.4169979460677134,
+                "macro_roc_auc": 0.5592537804076266,
+                "macro_pr_auc": 0.3815859211006299
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2835983522870231,
+              "regime_accuracy": 0.36666667461395264,
+              "regime_loss": 1.0869695322786648,
+              "regression_rmse_log_rv": 0.8119247173045238,
+              "regression_mae_log_rv": 0.6878877098419859,
+              "regression_loss": 0.6592217465700309,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    24,
+                    1
+                  ],
+                  [
+                    5,
+                    35,
+                    5
+                  ],
+                  [
+                    2,
+                    39,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3,
+                    "recall": 0.10714285714285714,
+                    "f1": 0.15789473684210525,
+                    "support": 28,
+                    "roc_auc": 0.702639751552795,
+                    "pr_auc": 0.39455967552054666
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.35714285714285715,
+                    "recall": 0.7777777777777778,
+                    "f1": 0.48951048951048953,
+                    "support": 45,
+                    "roc_auc": 0.4820740740740741,
+                    "pr_auc": 0.43984999003233627
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.1276595744680851,
+                    "f1": 0.20338983050847456,
+                    "support": 47,
+                    "roc_auc": 0.6044884873214806,
+                    "pr_auc": 0.5030321050054184
+                  }
+                ],
+                "macro_precision": 0.3857142857142857,
+                "macro_recall": 0.33752673646290665,
+                "macro_f1": 0.2835983522870231,
+                "weighted_f1": 0.300069555778744,
+                "macro_roc_auc": 0.5964007709827833,
+                "macro_pr_auc": 0.4458139235194338
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.14339798473993826,
+              "regime_accuracy": 0.19491524994373322,
+              "regime_loss": 1.1361679323649003,
+              "regression_rmse_log_rv": 0.8053181512318586,
+              "regression_mae_log_rv": 0.5977784362700531,
+              "regression_loss": 0.6485373247034986,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    1,
+                    9
+                  ],
+                  [
+                    0,
+                    11,
+                    1
+                  ],
+                  [
+                    11,
+                    73,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 10,
+                    "roc_auc": 0.4009259259259259,
+                    "pr_auc": 0.06829232546195703
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.12941176470588237,
+                    "recall": 0.9166666666666666,
+                    "f1": 0.2268041237113402,
+                    "support": 12,
+                    "roc_auc": 0.5605345911949685,
+                    "pr_auc": 0.10941639781184319
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5454545454545454,
+                    "recall": 0.125,
+                    "f1": 0.20338983050847456,
+                    "support": 96,
+                    "roc_auc": 0.2779356060606061,
+                    "pr_auc": 0.7306559911506949
+                  }
+                ],
+                "macro_precision": 0.2249554367201426,
+                "macro_recall": 0.34722222222222215,
+                "macro_f1": 0.14339798473993826,
+                "weighted_f1": 0.18853451875720034,
+                "macro_roc_auc": 0.41313204106050017,
+                "macro_pr_auc": 0.30278823814149836
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3060372511239563,
+              "regime_accuracy": 0.6090909242630005,
+              "regime_loss": 1.0310052221471613,
+              "regression_rmse_log_rv": 0.616444737488838,
+              "regression_mae_log_rv": 0.45966746110511436,
+              "regression_loss": 0.38000411437768233,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    10,
+                    0
+                  ],
+                  [
+                    10,
+                    65,
+                    3
+                  ],
+                  [
+                    0,
+                    20,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.16666666666666666,
+                    "support": 12,
+                    "roc_auc": 0.6615646258503401,
+                    "pr_auc": 0.13988481241922665
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6842105263157895,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.7514450867052023,
+                    "support": 78,
+                    "roc_auc": 0.5733173076923077,
+                    "pr_auc": 0.8128586022294951
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.5061111111111111,
+                    "pr_auc": 0.16723831158259078
+                  }
+                ],
+                "macro_precision": 0.28362573099415206,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.3060372511239563,
+                "weighted_f1": 0.5510246978455071,
+                "macro_roc_auc": 0.5803310148845863,
+                "macro_pr_auc": 0.37332724207710416
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.29769392033542974,
+              "regime_accuracy": 0.4864864945411682,
+              "regime_loss": 1.0783610194245765,
+              "regression_rmse_log_rv": 0.7909473041668357,
+              "regression_mae_log_rv": 0.644205097612497,
+              "regression_loss": 0.6255976379687849,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    32,
+                    6
+                  ],
+                  [
+                    0,
+                    48,
+                    0
+                  ],
+                  [
+                    3,
+                    16,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.13636363636363635,
+                    "f1": 0.22641509433962262,
+                    "support": 44,
+                    "roc_auc": 0.5644504748982361,
+                    "pr_auc": 0.4151513377339569
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 1.0,
+                    "f1": 0.6666666666666666,
+                    "support": 48,
+                    "roc_auc": 0.6775793650793651,
+                    "pr_auc": 0.6502671464176524
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.3707093821510298,
+                    "pr_auc": 0.1292489709748303
+                  }
+                ],
+                "macro_precision": 0.38888888888888884,
+                "macro_recall": 0.37878787878787873,
+                "macro_f1": 0.29769392033542974,
+                "weighted_f1": 0.37803841577426484,
+                "macro_roc_auc": 0.5375797407095436,
+                "macro_pr_auc": 0.3982224850421465
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.20547945205479454,
+              "regime_accuracy": 0.4326923191547394,
+              "regime_loss": 1.091500163078308,
+              "regression_rmse_log_rv": 0.9012554377635805,
+              "regression_mae_log_rv": 0.7077280311540772,
+              "regression_loss": 0.8122613640984231,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    26,
+                    0
+                  ],
+                  [
+                    4,
+                    45,
+                    3
+                  ],
+                  [
+                    3,
+                    23,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.3722879684418146,
+                    "pr_auc": 0.1916182166241667
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4787234042553192,
+                    "recall": 0.8653846153846154,
+                    "f1": 0.6164383561643836,
+                    "support": 52,
+                    "roc_auc": 0.41346153846153844,
+                    "pr_auc": 0.4235553776013428
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5113412228796844,
+                    "pr_auc": 0.23755612034779808
+                  }
+                ],
+                "macro_precision": 0.1595744680851064,
+                "macro_recall": 0.2884615384615385,
+                "macro_f1": 0.20547945205479454,
+                "weighted_f1": 0.3082191780821918,
+                "macro_roc_auc": 0.4323635765943458,
+                "macro_pr_auc": 0.28424323819110253
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2692307692307692,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.1269072687082093,
+              "regression_rmse_log_rv": 0.896769211071124,
+              "regression_mae_log_rv": 0.7723102434596513,
+              "regression_loss": 0.8041950179251262,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    0,
+                    23
+                  ],
+                  [
+                    2,
+                    0,
+                    43
+                  ],
+                  [
+                    4,
+                    0,
+                    43
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.17857142857142858,
+                    "f1": 0.25641025641025644,
+                    "support": 28,
+                    "roc_auc": 0.655667701863354,
+                    "pr_auc": 0.3234784576146648
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 45,
+                    "roc_auc": 0.3605925925925926,
+                    "pr_auc": 0.3492691913054888
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3944954128440367,
+                    "recall": 0.9148936170212766,
+                    "f1": 0.5512820512820513,
+                    "support": 47,
+                    "roc_auc": 0.5202564849897989,
+                    "pr_auc": 0.3892363408595224
+                  }
+                ],
+                "macro_precision": 0.28301362246316375,
+                "macro_recall": 0.3644883485309017,
+                "macro_f1": 0.2692307692307692,
+                "weighted_f1": 0.27574786324786327,
+                "macro_roc_auc": 0.5121722598152485,
+                "macro_pr_auc": 0.35399466325989204
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.40449924291585554,
+              "regime_accuracy": 0.7711864113807678,
+              "regime_loss": 0.9415951320680521,
+              "regression_rmse_log_rv": 0.7596644429162811,
+              "regression_mae_log_rv": 0.5865320006417016,
+              "regression_loss": 0.5770900658313037,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    4,
+                    0,
+                    6
+                  ],
+                  [
+                    0,
+                    0,
+                    12
+                  ],
+                  [
+                    9,
+                    0,
+                    87
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.4,
+                    "f1": 0.34782608695652173,
+                    "support": 10,
+                    "roc_auc": 0.9259259259259259,
+                    "pr_auc": 0.41904173896279157
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.2059748427672956,
+                    "pr_auc": 0.06094290466605584
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.8285714285714286,
+                    "recall": 0.90625,
+                    "f1": 0.8656716417910447,
+                    "support": 96,
+                    "roc_auc": 0.5146780303030303,
+                    "pr_auc": 0.8180356343122985
+                  }
+                ],
+                "macro_precision": 0.37875457875457874,
+                "macro_recall": 0.4354166666666666,
+                "macro_f1": 0.40449924291585554,
+                "weighted_f1": 0.7337520210297077,
+                "macro_roc_auc": 0.5488595996654172,
+                "macro_pr_auc": 0.43267342598038194
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.09523809523809523,
+              "regime_accuracy": 0.15454545617103577,
+              "regime_loss": 1.2209392374212091,
+              "regression_rmse_log_rv": 0.44570792794173225,
+              "regression_mae_log_rv": 0.3653074448187412,
+              "regression_loss": 0.1986555570301124,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    12
+                  ],
+                  [
+                    8,
+                    0,
+                    70
+                  ],
+                  [
+                    3,
+                    0,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.8690476190476191,
+                    "pr_auc": 0.33470028795151185
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.5693108974358975,
+                    "pr_auc": 0.7815228557453129
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1717171717171717,
+                    "recall": 0.85,
+                    "f1": 0.2857142857142857,
+                    "support": 20,
+                    "roc_auc": 0.7183333333333334,
+                    "pr_auc": 0.36322007230559794
+                  }
+                ],
+                "macro_precision": 0.057239057239057235,
+                "macro_recall": 0.2833333333333333,
+                "macro_f1": 0.09523809523809523,
+                "weighted_f1": 0.051948051948051945,
+                "macro_roc_auc": 0.7188972832722834,
+                "macro_pr_auc": 0.49314773866747424
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.12915479582146247,
+              "regime_accuracy": 0.1621621549129486,
+              "regime_loss": 1.1637924755313678,
+              "regression_rmse_log_rv": 0.8373902031325287,
+              "regression_mae_log_rv": 0.6609633026292195,
+              "regression_loss": 0.7012223523023376,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    4,
+                    0,
+                    40
+                  ],
+                  [
+                    4,
+                    0,
+                    44
+                  ],
+                  [
+                    2,
+                    3,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4,
+                    "recall": 0.09090909090909091,
+                    "f1": 0.14814814814814814,
+                    "support": 44,
+                    "roc_auc": 0.6044776119402985,
+                    "pr_auc": 0.4376929375052329
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.45072751322751325,
+                    "pr_auc": 0.39055907155837216
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.14285714285714285,
+                    "recall": 0.7368421052631579,
+                    "f1": 0.2393162393162393,
+                    "support": 19,
+                    "roc_auc": 0.4342105263157895,
+                    "pr_auc": 0.145748007107282
+                  }
+                ],
+                "macro_precision": 0.18095238095238098,
+                "macro_recall": 0.2759170653907496,
+                "macro_f1": 0.12915479582146247,
+                "weighted_f1": 0.09968943302276634,
+                "macro_roc_auc": 0.49647188382786706,
+                "macro_pr_auc": 0.32466667205696237
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2595206306821794,
+              "regime_accuracy": 0.29807692766189575,
+              "regime_loss": 1.1441728243461022,
+              "regression_rmse_log_rv": 1.0044211968429826,
+              "regression_mae_log_rv": 0.8414984523372439,
+              "regression_loss": 1.0088619406674897,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    0,
+                    17
+                  ],
+                  [
+                    10,
+                    0,
+                    42
+                  ],
+                  [
+                    4,
+                    0,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.391304347826087,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.36734693877551017,
+                    "support": 26,
+                    "roc_auc": 0.6928007889546351,
+                    "pr_auc": 0.4257215498508222
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.544008875739645,
+                    "pr_auc": 0.49370949965507643
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2716049382716049,
+                    "recall": 0.8461538461538461,
+                    "f1": 0.411214953271028,
+                    "support": 26,
+                    "roc_auc": 0.4319526627218935,
+                    "pr_auc": 0.20530106927480737
+                  }
+                ],
+                "macro_precision": 0.220969762032564,
+                "macro_recall": 0.3974358974358974,
+                "macro_f1": 0.2595206306821794,
+                "weighted_f1": 0.19464047301163456,
+                "macro_roc_auc": 0.5562541091387245,
+                "macro_pr_auc": 0.3749107062602353
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.29567382508558976,
+              "regime_accuracy": 0.4333333373069763,
+              "regime_loss": 1.097522230540202,
+              "regression_rmse_log_rv": 0.8441241181376156,
+              "regression_mae_log_rv": 0.693796204564084,
+              "regression_loss": 0.7125455268216072,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    0,
+                    22
+                  ],
+                  [
+                    7,
+                    0,
+                    38
+                  ],
+                  [
+                    1,
+                    0,
+                    46
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.21428571428571427,
+                    "f1": 0.2857142857142857,
+                    "support": 28,
+                    "roc_auc": 0.5209627329192547,
+                    "pr_auc": 0.2468913326227042
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 45,
+                    "roc_auc": 0.30933333333333335,
+                    "pr_auc": 0.33093200271503426
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4339622641509434,
+                    "recall": 0.9787234042553191,
+                    "f1": 0.6013071895424836,
+                    "support": 47,
+                    "roc_auc": 0.667152433692801,
+                    "pr_auc": 0.45834241066979386
+                  }
+                ],
+                "macro_precision": 0.2875112309074573,
+                "macro_recall": 0.3976697061803445,
+                "macro_f1": 0.29567382508558976,
+                "weighted_f1": 0.3021786492374728,
+                "macro_roc_auc": 0.4991494999817963,
+                "macro_pr_auc": 0.3453885820025108
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3912529550827424,
+              "regime_accuracy": 0.7203390002250671,
+              "regime_loss": 0.9968506128101026,
+              "regression_rmse_log_rv": 0.6936310456135207,
+              "regression_mae_log_rv": 0.5856129152353032,
+              "regression_loss": 0.48112402743890614,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    0,
+                    4
+                  ],
+                  [
+                    3,
+                    0,
+                    9
+                  ],
+                  [
+                    17,
+                    0,
+                    79
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23076923076923078,
+                    "recall": 0.6,
+                    "f1": 0.33333333333333337,
+                    "support": 10,
+                    "roc_auc": 0.6833333333333333,
+                    "pr_auc": 0.3090296490406408
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.4528301886792453,
+                    "pr_auc": 0.09102598078494298
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.8586956521739131,
+                    "recall": 0.8229166666666666,
+                    "f1": 0.8404255319148937,
+                    "support": 96,
+                    "roc_auc": 0.6453598484848485,
+                    "pr_auc": 0.8836419612294053
+                  }
+                ],
+                "macro_precision": 0.363154960981048,
+                "macro_recall": 0.47430555555555554,
+                "macro_f1": 0.3912529550827424,
+                "weighted_f1": 0.7119846135352806,
+                "macro_roc_auc": 0.5938411234991424,
+                "macro_pr_auc": 0.4278991970183297
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2470588235294118,
+              "regime_accuracy": 0.5727272629737854,
+              "regime_loss": 1.042084288597107,
+              "regression_rmse_log_rv": 0.687586317901322,
+              "regression_mae_log_rv": 0.4606309161373329,
+              "regression_loss": 0.4727749445650978,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    12,
+                    0
+                  ],
+                  [
+                    12,
+                    63,
+                    3
+                  ],
+                  [
+                    3,
+                    17,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.54421768707483,
+                    "pr_auc": 0.10706461484362213
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6847826086956522,
+                    "recall": 0.8076923076923077,
+                    "f1": 0.7411764705882354,
+                    "support": 78,
+                    "roc_auc": 0.5100160256410257,
+                    "pr_auc": 0.7625978700659148
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.5616666666666666,
+                    "pr_auc": 0.2255437378956023
+                  }
+                ],
+                "macro_precision": 0.2282608695652174,
+                "macro_recall": 0.2692307692307692,
+                "macro_f1": 0.2470588235294118,
+                "weighted_f1": 0.5255614973262033,
+                "macro_roc_auc": 0.5386334597941741,
+                "macro_pr_auc": 0.36506874093504643
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.39181286549707606,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.0776132667292604,
+              "regression_rmse_log_rv": 0.8234663571630494,
+              "regression_mae_log_rv": 0.6586250679584237,
+              "regression_loss": 0.6780968413793828,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    11,
+                    28,
+                    5
+                  ],
+                  [
+                    8,
+                    29,
+                    11
+                  ],
+                  [
+                    3,
+                    9,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.25,
+                    "f1": 0.3333333333333333,
+                    "support": 44,
+                    "roc_auc": 0.6265264586160109,
+                    "pr_auc": 0.5297408950433583
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4393939393939394,
+                    "recall": 0.6041666666666666,
+                    "f1": 0.5087719298245614,
+                    "support": 48,
+                    "roc_auc": 0.5555555555555556,
+                    "pr_auc": 0.5757987208764048
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.30434782608695654,
+                    "recall": 0.3684210526315789,
+                    "f1": 0.3333333333333333,
+                    "support": 19,
+                    "roc_auc": 0.6292906178489702,
+                    "pr_auc": 0.32646462847340935
+                  }
+                ],
+                "macro_precision": 0.414580588493632,
+                "macro_recall": 0.40752923976608185,
+                "macro_f1": 0.39181286549707606,
+                "weighted_f1": 0.4091986723565671,
+                "macro_roc_auc": 0.6037908773401789,
+                "macro_pr_auc": 0.4773347481310575
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.1324681136719624,
+              "regime_accuracy": 0.19230769574642181,
+              "regime_loss": 1.1880070796379676,
+              "regression_rmse_log_rv": 0.8341692085977502,
+              "regression_mae_log_rv": 0.6528454030989311,
+              "regression_loss": 0.695838268572597,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    3,
+                    22
+                  ],
+                  [
+                    10,
+                    0,
+                    42
+                  ],
+                  [
+                    4,
+                    3,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.06666666666666667,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.04878048780487805,
+                    "support": 26,
+                    "roc_auc": 0.4161735700197239,
+                    "pr_auc": 0.20727035029972152
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.3783284023668639,
+                    "pr_auc": 0.4048319111299132
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2289156626506024,
+                    "recall": 0.7307692307692307,
+                    "f1": 0.3486238532110092,
+                    "support": 26,
+                    "roc_auc": 0.4906311637080868,
+                    "pr_auc": 0.2479322809658692
+                  }
+                ],
+                "macro_precision": 0.09852744310575635,
+                "macro_recall": 0.2564102564102564,
+                "macro_f1": 0.1324681136719624,
+                "weighted_f1": 0.0993510852539718,
+                "macro_roc_auc": 0.42837771203155817,
+                "macro_pr_auc": 0.2866781807985013
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.1915155999506721,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.1531196263272596,
+              "regression_rmse_log_rv": 0.8435274786965031,
+              "regression_mae_log_rv": 0.696170612896094,
+              "regression_loss": 0.7115386073160795,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    27,
+                    0
+                  ],
+                  [
+                    4,
+                    41,
+                    0
+                  ],
+                  [
+                    1,
+                    46,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.03571428571428571,
+                    "f1": 0.058823529411764705,
+                    "support": 28,
+                    "roc_auc": 0.4701086956521739,
+                    "pr_auc": 0.20476359921095486
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.35964912280701755,
+                    "recall": 0.9111111111111111,
+                    "f1": 0.5157232704402516,
+                    "support": 45,
+                    "roc_auc": 0.31555555555555553,
+                    "pr_auc": 0.27842509113453356
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.5514427280676187,
+                    "pr_auc": 0.395465746251116
+                  }
+                ],
+                "macro_precision": 0.17543859649122806,
+                "macro_recall": 0.3156084656084656,
+                "macro_f1": 0.1915155999506721,
+                "weighted_f1": 0.2071217166111728,
+                "macro_roc_auc": 0.4457023264251161,
+                "macro_pr_auc": 0.29288481219886814
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.09615384615384615,
+              "regime_accuracy": 0.10169491171836853,
+              "regime_loss": 1.4038959499132835,
+              "regression_rmse_log_rv": 0.7057559294088129,
+              "regression_mae_log_rv": 0.5523353473488557,
+              "regression_loss": 0.4980914318956974,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    9,
+                    0
+                  ],
+                  [
+                    1,
+                    11,
+                    0
+                  ],
+                  [
+                    40,
+                    56,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.023809523809523808,
+                    "recall": 0.1,
+                    "f1": 0.038461538461538464,
+                    "support": 10,
+                    "roc_auc": 0.34629629629629627,
+                    "pr_auc": 0.06298697611598181
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.14473684210526316,
+                    "recall": 0.9166666666666666,
+                    "f1": 0.25,
+                    "support": 12,
+                    "roc_auc": 0.6477987421383647,
+                    "pr_auc": 0.1444016275887361
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 96,
+                    "roc_auc": 0.2196969696969697,
+                    "pr_auc": 0.7156621878591285
+                  }
+                ],
+                "macro_precision": 0.05618212197159566,
+                "macro_recall": 0.33888888888888885,
+                "macro_f1": 0.09615384615384615,
+                "weighted_f1": 0.028683181225554105,
+                "macro_roc_auc": 0.4045973360438769,
+                "macro_pr_auc": 0.3076835971879488
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.21888755502200882,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.0623743772506713,
+              "regression_rmse_log_rv": 0.7079872677646174,
+              "regression_mae_log_rv": 0.5359985053729774,
+              "regression_loss": 0.501245971316808,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    57,
+                    21,
+                    0
+                  ],
+                  [
+                    17,
+                    3,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.13953488372093023,
+                    "recall": 1.0,
+                    "f1": 0.24489795918367346,
+                    "support": 12,
+                    "roc_auc": 0.477891156462585,
+                    "pr_auc": 0.0951526497176385
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.875,
+                    "recall": 0.2692307692307692,
+                    "f1": 0.411764705882353,
+                    "support": 78,
+                    "roc_auc": 0.7588141025641025,
+                    "pr_auc": 0.8394783484070288
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.3927777777777778,
+                    "pr_auc": 0.1509544649798854
+                  }
+                ],
+                "macro_precision": 0.3381782945736434,
+                "macro_recall": 0.4230769230769231,
+                "macro_f1": 0.21888755502200882,
+                "weighted_f1": 0.3186947506275237,
+                "macro_roc_auc": 0.543161012268155,
+                "macro_pr_auc": 0.36186182103485093
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.20743727598566308,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.0457342206446965,
+              "regression_rmse_log_rv": 0.8110687786352065,
+              "regression_mae_log_rv": 0.6424093811294517,
+              "regression_loss": 0.6578325636768056,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    43,
+                    0
+                  ],
+                  [
+                    3,
+                    45,
+                    0
+                  ],
+                  [
+                    0,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.022727272727272728,
+                    "f1": 0.04166666666666667,
+                    "support": 44,
+                    "roc_auc": 0.5172998643147897,
+                    "pr_auc": 0.3896693810706878
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4205607476635514,
+                    "recall": 0.9375,
+                    "f1": 0.5806451612903226,
+                    "support": 48,
+                    "roc_auc": 0.5773809523809523,
+                    "pr_auc": 0.48584512517549133
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.44565217391304346,
+                    "pr_auc": 0.1431508920904799
+                  }
+                ],
+                "macro_precision": 0.22352024922118377,
+                "macro_recall": 0.32007575757575757,
+                "macro_f1": 0.20743727598566308,
+                "weighted_f1": 0.2676063159934128,
+                "macro_roc_auc": 0.5134443302029285,
+                "macro_pr_auc": 0.3395551327788864
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.22510822510822512,
+              "regime_accuracy": 0.5,
+              "regime_loss": 1.0540082592230577,
+              "regression_rmse_log_rv": 0.8493463519820518,
+              "regression_mae_log_rv": 0.6777261950057716,
+              "regression_loss": 0.7213892256252195,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    26,
+                    0
+                  ],
+                  [
+                    0,
+                    52,
+                    0
+                  ],
+                  [
+                    2,
+                    24,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.48717948717948717,
+                    "pr_auc": 0.2205042676216013
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5098039215686274,
+                    "recall": 1.0,
+                    "f1": 0.6753246753246753,
+                    "support": 52,
+                    "roc_auc": 0.6401627218934911,
+                    "pr_auc": 0.721386569979511
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.41222879684418146,
+                    "pr_auc": 0.22470615320937276
+                  }
+                ],
+                "macro_precision": 0.1699346405228758,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.22510822510822512,
+                "weighted_f1": 0.33766233766233766,
+                "macro_roc_auc": 0.5131903353057199,
+                "macro_pr_auc": 0.388865663603495
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "dual": [
+      {
+        "head_mode": "dual",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.38701996927803384,
+              "regime_accuracy": 0.4416666626930237,
+              "regime_loss": 1.1168898199325021,
+              "regression_rmse_log_rv": 0.8449972359637135,
+              "regression_mae_log_rv": 0.7133252073758437,
+              "regression_loss": 0.7140203287863156,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    4,
+                    11
+                  ],
+                  [
+                    13,
+                    3,
+                    29
+                  ],
+                  [
+                    2,
+                    8,
+                    37
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4642857142857143,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.4642857142857143,
+                    "support": 28,
+                    "roc_auc": 0.7278726708074534,
+                    "pr_auc": 0.4633731685245943
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2,
+                    "recall": 0.06666666666666667,
+                    "f1": 0.1,
+                    "support": 45,
+                    "roc_auc": 0.49362962962962964,
+                    "pr_auc": 0.3971949379646979
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4805194805194805,
+                    "recall": 0.7872340425531915,
+                    "f1": 0.5967741935483871,
+                    "support": 47,
+                    "roc_auc": 0.6677353541241621,
+                    "pr_auc": 0.5213197336197061
+                  }
+                ],
+                "macro_precision": 0.38160173160173166,
+                "macro_recall": 0.4393954745018575,
+                "macro_f1": 0.38701996927803384,
+                "weighted_f1": 0.3795698924731183,
+                "macro_roc_auc": 0.6297458848537484,
+                "macro_pr_auc": 0.46062928003633274
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.36493827160493825,
+              "regime_accuracy": 0.6186440587043762,
+              "regime_loss": 0.8361021108546499,
+              "regression_rmse_log_rv": 0.8167337723605783,
+              "regression_mae_log_rv": 0.5974355756731357,
+              "regression_loss": 0.667054054914341,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    21,
+                    9,
+                    66
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.175,
+                    "recall": 0.7,
+                    "f1": 0.27999999999999997,
+                    "support": 10,
+                    "roc_auc": 0.9018518518518519,
+                    "pr_auc": 0.582037516398877
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7555031446540881,
+                    "pr_auc": 0.1752583589395369
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.6875,
+                    "f1": 0.8148148148148148,
+                    "support": 96,
+                    "roc_auc": 0.881155303030303,
+                    "pr_auc": 0.9734371014105216
+                  }
+                ],
+                "macro_precision": 0.39166666666666666,
+                "macro_recall": 0.46249999999999997,
+                "macro_f1": 0.36493827160493825,
+                "weighted_f1": 0.686629001883239,
+                "macro_roc_auc": 0.8461700998454144,
+                "macro_pr_auc": 0.5769109922496453
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.1889130961026386,
+              "regime_accuracy": 0.17272727191448212,
+              "regime_loss": 1.3792160922830754,
+              "regression_rmse_log_rv": 0.5673079657368306,
+              "regression_mae_log_rv": 0.47898889303588393,
+              "regression_loss": 0.32183832798846096,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    2,
+                    0
+                  ],
+                  [
+                    51,
+                    1,
+                    26
+                  ],
+                  [
+                    8,
+                    4,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.14492753623188406,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.2469135802469136,
+                    "support": 12,
+                    "roc_auc": 0.75,
+                    "pr_auc": 0.25568965860726367
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.14285714285714285,
+                    "recall": 0.01282051282051282,
+                    "f1": 0.02352941176470588,
+                    "support": 78,
+                    "roc_auc": 0.44911858974358976,
+                    "pr_auc": 0.644351810922525
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.23529411764705882,
+                    "recall": 0.4,
+                    "f1": 0.29629629629629634,
+                    "support": 20,
+                    "roc_auc": 0.615,
+                    "pr_auc": 0.30411840743572727
+                  }
+                ],
+                "macro_precision": 0.17435959891202857,
+                "macro_recall": 0.4153846153846154,
+                "macro_f1": 0.1889130961026386,
+                "weighted_f1": 0.09749257278669045,
+                "macro_roc_auc": 0.6047061965811965,
+                "macro_pr_auc": 0.40138662565517197
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.39444444444444443,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.207081574469172,
+              "regression_rmse_log_rv": 0.9392580525840194,
+              "regression_mae_log_rv": 0.7577391465504965,
+              "regression_loss": 0.8822056893439246,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    8,
+                    10
+                  ],
+                  [
+                    15,
+                    11,
+                    22
+                  ],
+                  [
+                    5,
+                    5,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5652173913043478,
+                    "recall": 0.5909090909090909,
+                    "f1": 0.5777777777777778,
+                    "support": 44,
+                    "roc_auc": 0.6631614654002713,
+                    "pr_auc": 0.5137915826096137
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4583333333333333,
+                    "recall": 0.22916666666666666,
+                    "f1": 0.3055555555555555,
+                    "support": 48,
+                    "roc_auc": 0.4781746031746032,
+                    "pr_auc": 0.4795345950711625
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21951219512195122,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.3,
+                    "support": 19,
+                    "roc_auc": 0.5915331807780321,
+                    "pr_auc": 0.19893613170984353
+                  }
+                ],
+                "macro_precision": 0.4143543065865441,
+                "macro_recall": 0.4312533227006911,
+                "macro_f1": 0.39444444444444443,
+                "weighted_f1": 0.41251251251251253,
+                "macro_roc_auc": 0.5776230831176355,
+                "macro_pr_auc": 0.39742076979687324
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.346247866795812,
+              "regime_accuracy": 0.35576921701431274,
+              "regime_loss": 1.1380638709435096,
+              "regression_rmse_log_rv": 0.8821020386072542,
+              "regression_mae_log_rv": 0.6948045009585957,
+              "regression_loss": 0.7781040065150738,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    6,
+                    14
+                  ],
+                  [
+                    2,
+                    11,
+                    39
+                  ],
+                  [
+                    2,
+                    4,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.33333333333333337,
+                    "support": 26,
+                    "roc_auc": 0.6084812623274162,
+                    "pr_auc": 0.3629913631201007
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5238095238095238,
+                    "recall": 0.21153846153846154,
+                    "f1": 0.3013698630136986,
+                    "support": 52,
+                    "roc_auc": 0.5451183431952663,
+                    "pr_auc": 0.49742752001484736
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.273972602739726,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.404040404040404,
+                    "support": 26,
+                    "roc_auc": 0.6720907297830375,
+                    "pr_auc": 0.41839390081411415
+                  }
+                ],
+                "macro_precision": 0.4659273755164166,
+                "macro_recall": 0.4038461538461539,
+                "macro_f1": 0.346247866795812,
+                "weighted_f1": 0.33502836585028367,
+                "macro_roc_auc": 0.6085634451019066,
+                "macro_pr_auc": 0.42627092798302074
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.382104763296318,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.0943058843524835,
+              "regression_rmse_log_rv": 0.845253305898426,
+              "regression_mae_log_rv": 0.7323013763932977,
+              "regression_loss": 0.7144531511322181,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    6,
+                    10
+                  ],
+                  [
+                    13,
+                    5,
+                    27
+                  ],
+                  [
+                    5,
+                    8,
+                    34
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4,
+                    "recall": 0.42857142857142855,
+                    "f1": 0.4137931034482759,
+                    "support": 28,
+                    "roc_auc": 0.7115683229813664,
+                    "pr_auc": 0.42377754212759605
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2631578947368421,
+                    "recall": 0.1111111111111111,
+                    "f1": 0.15625,
+                    "support": 45,
+                    "roc_auc": 0.5001481481481481,
+                    "pr_auc": 0.4048443719714971
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4788732394366197,
+                    "recall": 0.723404255319149,
+                    "f1": 0.576271186440678,
+                    "support": 47,
+                    "roc_auc": 0.6828912853395511,
+                    "pr_auc": 0.5380964376849271
+                  }
+                ],
+                "macro_precision": 0.3806770447244873,
+                "macro_recall": 0.42102893166722954,
+                "macro_f1": 0.382104763296318,
+                "weighted_f1": 0.3808516888271966,
+                "macro_roc_auc": 0.631535918823022,
+                "macro_pr_auc": 0.45557278392800676
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4880618074196435,
+              "regime_accuracy": 0.6864407062530518,
+              "regime_loss": 0.6248701997732712,
+              "regression_rmse_log_rv": 0.7662958485067904,
+              "regression_mae_log_rv": 0.5951540848334967,
+              "regression_loss": 0.587209327438742,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    4,
+                    1
+                  ],
+                  [
+                    16,
+                    10,
+                    70
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23333333333333334,
+                    "recall": 0.7,
+                    "f1": 0.35,
+                    "support": 10,
+                    "roc_auc": 0.9185185185185185,
+                    "pr_auc": 0.5824736275856964
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.23529411764705882,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.27586206896551724,
+                    "support": 12,
+                    "roc_auc": 0.77437106918239,
+                    "pr_auc": 0.1819875209674768
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9859154929577465,
+                    "recall": 0.7291666666666666,
+                    "f1": 0.8383233532934132,
+                    "support": 96,
+                    "roc_auc": 0.9232954545454546,
+                    "pr_auc": 0.9825547621658793
+                  }
+                ],
+                "macro_precision": 0.48484764797937957,
+                "macro_recall": 0.5875,
+                "macro_f1": 0.4880618074196435,
+                "weighted_f1": 0.7397405656250329,
+                "macro_roc_auc": 0.8720616807487876,
+                "macro_pr_auc": 0.5823386369063509
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2636858636858637,
+              "regime_accuracy": 0.2545454502105713,
+              "regime_loss": 1.4450513557954268,
+              "regression_rmse_log_rv": 0.708143915014507,
+              "regression_mae_log_rv": 0.5368952966358682,
+              "regression_loss": 0.5014678043720733,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    31,
+                    8,
+                    39
+                  ],
+                  [
+                    4,
+                    4,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18604651162790697,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.2909090909090909,
+                    "support": 12,
+                    "roc_auc": 0.7474489795918368,
+                    "pr_auc": 0.22611941153146153
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6153846153846154,
+                    "recall": 0.10256410256410256,
+                    "f1": 0.17582417582417584,
+                    "support": 78,
+                    "roc_auc": 0.3681891025641026,
+                    "pr_auc": 0.6339596797895899
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.6,
+                    "f1": 0.32432432432432434,
+                    "support": 20,
+                    "roc_auc": 0.5433333333333333,
+                    "pr_auc": 0.18164981748812564
+                  }
+                ],
+                "macro_precision": 0.3412177830782482,
+                "macro_recall": 0.4564102564102564,
+                "macro_f1": 0.2636858636858637,
+                "weighted_f1": 0.2153789208334663,
+                "macro_roc_auc": 0.5529904718297576,
+                "macro_pr_auc": 0.347242969603059
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.41125541125541126,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.3125921544247765,
+              "regression_rmse_log_rv": 0.9722072700244938,
+              "regression_mae_log_rv": 0.8094635429951522,
+              "regression_loss": 0.945186975888479,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    20,
+                    7,
+                    17
+                  ],
+                  [
+                    10,
+                    15,
+                    23
+                  ],
+                  [
+                    3,
+                    5,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6060606060606061,
+                    "recall": 0.45454545454545453,
+                    "f1": 0.5194805194805195,
+                    "support": 44,
+                    "roc_auc": 0.6468792401628223,
+                    "pr_auc": 0.4879209712097351
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.3125,
+                    "f1": 0.39999999999999997,
+                    "support": 48,
+                    "roc_auc": 0.47453703703703703,
+                    "pr_auc": 0.4641581425017583
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21568627450980393,
+                    "recall": 0.5789473684210527,
+                    "f1": 0.3142857142857143,
+                    "support": 19,
+                    "roc_auc": 0.5983981693363845,
+                    "pr_auc": 0.20056690051207182
+                  }
+                ],
+                "macro_precision": 0.45910081204198855,
+                "macro_recall": 0.4486642743221691,
+                "macro_f1": 0.41125541125541126,
+                "weighted_f1": 0.43268983268983274,
+                "macro_roc_auc": 0.5732714821787479,
+                "macro_pr_auc": 0.38421533807452174
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.29821138211382114,
+              "regime_accuracy": 0.39423078298568726,
+              "regime_loss": 1.3000966768998365,
+              "regression_rmse_log_rv": 0.9364338663724427,
+              "regression_mae_log_rv": 0.7333314106351911,
+              "regression_loss": 0.8769083860892419,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    11,
+                    15
+                  ],
+                  [
+                    0,
+                    17,
+                    35
+                  ],
+                  [
+                    0,
+                    2,
+                    24
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5695266272189349,
+                    "pr_auc": 0.32240052843581496
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5666666666666667,
+                    "recall": 0.3269230769230769,
+                    "f1": 0.41463414634146345,
+                    "support": 52,
+                    "roc_auc": 0.6579142011834319,
+                    "pr_auc": 0.6446086028648723
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.32432432432432434,
+                    "recall": 0.9230769230769231,
+                    "f1": 0.48,
+                    "support": 26,
+                    "roc_auc": 0.7795857988165681,
+                    "pr_auc": 0.6062417230968579
+                  }
+                ],
+                "macro_precision": 0.296996996996997,
+                "macro_recall": 0.4166666666666667,
+                "macro_f1": 0.29821138211382114,
+                "weighted_f1": 0.3273170731707318,
+                "macro_roc_auc": 0.669008875739645,
+                "macro_pr_auc": 0.5244169514658484
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.35694506534615206,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.2609729335487758,
+              "regression_rmse_log_rv": 0.9056231451846265,
+              "regression_mae_log_rv": 0.7684355543674125,
+              "regression_loss": 0.8201532810940951,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    9,
+                    13
+                  ],
+                  [
+                    11,
+                    8,
+                    26
+                  ],
+                  [
+                    2,
+                    9,
+                    36
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3157894736842105,
+                    "recall": 0.21428571428571427,
+                    "f1": 0.2553191489361702,
+                    "support": 28,
+                    "roc_auc": 0.6125776397515528,
+                    "pr_auc": 0.2781147463710158
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.17777777777777778,
+                    "f1": 0.22535211267605634,
+                    "support": 45,
+                    "roc_auc": 0.5303703703703704,
+                    "pr_auc": 0.4327379367710679
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.48,
+                    "recall": 0.7659574468085106,
+                    "f1": 0.5901639344262295,
+                    "support": 47,
+                    "roc_auc": 0.6910521713786069,
+                    "pr_auc": 0.5194622297393368
+                  }
+                ],
+                "macro_precision": 0.36782726045883934,
+                "macro_recall": 0.3860069796240009,
+                "macro_f1": 0.35694506534615206,
+                "weighted_f1": 0.3752290513222341,
+                "macro_roc_auc": 0.61133339383351,
+                "macro_pr_auc": 0.41010497096047355
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.49878470917141865,
+              "regime_accuracy": 0.7033898234367371,
+              "regime_loss": 0.6258650427147493,
+              "regression_rmse_log_rv": 0.7736699489117422,
+              "regression_mae_log_rv": 0.5956460328425391,
+              "regression_loss": 0.5985651898490979,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    4,
+                    1
+                  ],
+                  [
+                    14,
+                    10,
+                    72
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.7,
+                    "f1": 0.3684210526315789,
+                    "support": 10,
+                    "roc_auc": 0.9166666666666666,
+                    "pr_auc": 0.5850126856694541
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.23529411764705882,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.27586206896551724,
+                    "support": 12,
+                    "roc_auc": 0.6823899371069182,
+                    "pr_auc": 0.14229496648727724
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9863013698630136,
+                    "recall": 0.75,
+                    "f1": 0.8520710059171598,
+                    "support": 96,
+                    "roc_auc": 0.9408143939393939,
+                    "pr_auc": 0.9868296944938678
+                  }
+                ],
+                "macro_precision": 0.4905318291700242,
+                "macro_recall": 0.5944444444444444,
+                "macro_f1": 0.49878470917141865,
+                "weighted_f1": 0.7524862027283843,
+                "macro_roc_auc": 0.8466236659043261,
+                "macro_pr_auc": 0.5713791155501997
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.28034188034188035,
+              "regime_accuracy": 0.26363635063171387,
+              "regime_loss": 1.3587703249671244,
+              "regression_rmse_log_rv": 0.6718092177462232,
+              "regression_mae_log_rv": 0.5319907699224793,
+              "regression_loss": 0.45132762504879226,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    2,
+                    0
+                  ],
+                  [
+                    40,
+                    6,
+                    32
+                  ],
+                  [
+                    3,
+                    4,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18867924528301888,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.3076923076923077,
+                    "support": 12,
+                    "roc_auc": 0.7636054421768708,
+                    "pr_auc": 0.19831655860225797
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.13333333333333336,
+                    "support": 78,
+                    "roc_auc": 0.39142628205128205,
+                    "pr_auc": 0.6441780092421006
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.28888888888888886,
+                    "recall": 0.65,
+                    "f1": 0.39999999999999997,
+                    "support": 20,
+                    "roc_auc": 0.6761111111111111,
+                    "pr_auc": 0.27290526900940787
+                  }
+                ],
+                "macro_precision": 0.3258560447239693,
+                "macro_recall": 0.5200854700854701,
+                "macro_f1": 0.28034188034188035,
+                "weighted_f1": 0.20083916083916084,
+                "macro_roc_auc": 0.6103809451130879,
+                "macro_pr_auc": 0.3717999456179221
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.29904761904761906,
+              "regime_accuracy": 0.30630630254745483,
+              "regime_loss": 1.4435680065761052,
+              "regression_rmse_log_rv": 1.0872825661619385,
+              "regression_mae_log_rv": 0.8945165467154872,
+              "regression_loss": 1.1821833786796903,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    8,
+                    22
+                  ],
+                  [
+                    13,
+                    6,
+                    29
+                  ],
+                  [
+                    4,
+                    1,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.45161290322580644,
+                    "recall": 0.3181818181818182,
+                    "f1": 0.3733333333333333,
+                    "support": 44,
+                    "roc_auc": 0.6468792401628223,
+                    "pr_auc": 0.4627636658241368
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.125,
+                    "f1": 0.19047619047619047,
+                    "support": 48,
+                    "roc_auc": 0.4537037037037037,
+                    "pr_auc": 0.4434250010787035
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2153846153846154,
+                    "recall": 0.7368421052631579,
+                    "f1": 0.33333333333333337,
+                    "support": 19,
+                    "roc_auc": 0.6138443935926774,
+                    "pr_auc": 0.24570066476135324
+                  }
+                ],
+                "macro_precision": 0.3556658395368073,
+                "macro_recall": 0.39334130781499205,
+                "macro_f1": 0.29904761904761906,
+                "weighted_f1": 0.2874131274131274,
+                "macro_roc_auc": 0.5714757791530678,
+                "macro_pr_auc": 0.3839631105547312
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.18069909512654447,
+              "regime_accuracy": 0.2788461446762085,
+              "regime_loss": 1.5436521676870494,
+              "regression_rmse_log_rv": 1.1463279490248492,
+              "regression_mae_log_rv": 0.9798340450238007,
+              "regression_loss": 1.3140677667155174,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    2,
+                    24
+                  ],
+                  [
+                    0,
+                    4,
+                    48
+                  ],
+                  [
+                    0,
+                    1,
+                    25
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5793885601577909,
+                    "pr_auc": 0.32742411723873205
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5714285714285714,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.13559322033898308,
+                    "support": 52,
+                    "roc_auc": 0.6164940828402367,
+                    "pr_auc": 0.6094053667740166
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.25773195876288657,
+                    "recall": 0.9615384615384616,
+                    "f1": 0.40650406504065034,
+                    "support": 26,
+                    "roc_auc": 0.7490138067061144,
+                    "pr_auc": 0.5935665031842845
+                  }
+                ],
+                "macro_precision": 0.27638684339715264,
+                "macro_recall": 0.3461538461538462,
+                "macro_f1": 0.18069909512654447,
+                "weighted_f1": 0.16942262642965414,
+                "macro_roc_auc": 0.6482988165680473,
+                "macro_pr_auc": 0.5101319957323444
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4303991373964891,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.0365750610110698,
+              "regression_rmse_log_rv": 0.8087274609007261,
+              "regression_mae_log_rv": 0.6954311299506419,
+              "regression_loss": 0.6540401060149355,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    9,
+                    6
+                  ],
+                  [
+                    10,
+                    7,
+                    28
+                  ],
+                  [
+                    2,
+                    10,
+                    35
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.52,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.49056603773584906,
+                    "support": 28,
+                    "roc_auc": 0.7480590062111802,
+                    "pr_auc": 0.4894041041063489
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2692307692307692,
+                    "recall": 0.15555555555555556,
+                    "f1": 0.19718309859154928,
+                    "support": 45,
+                    "roc_auc": 0.5288888888888889,
+                    "pr_auc": 0.3800943478036644
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5072463768115942,
+                    "recall": 0.7446808510638298,
+                    "f1": 0.603448275862069,
+                    "support": 47,
+                    "roc_auc": 0.6919265520256485,
+                    "pr_auc": 0.5346955353269557
+                  }
+                ],
+                "macro_precision": 0.4321590486807878,
+                "macro_recall": 0.4548407069683666,
+                "macro_f1": 0.4303991373964891,
+                "weighted_f1": 0.4247596454895061,
+                "macro_roc_auc": 0.6562914823752392,
+                "macro_pr_auc": 0.468064662412323
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.47519379844961246,
+              "regime_accuracy": 0.6694915294647217,
+              "regime_loss": 0.6872876675452216,
+              "regression_rmse_log_rv": 0.6468986004689414,
+              "regression_mae_log_rv": 0.5473241988506358,
+              "regression_loss": 0.41847779928867507,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    4,
+                    0
+                  ],
+                  [
+                    5,
+                    2,
+                    5
+                  ],
+                  [
+                    3,
+                    22,
+                    71
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.6,
+                    "f1": 0.5,
+                    "support": 10,
+                    "roc_auc": 0.887962962962963,
+                    "pr_auc": 0.6853396117967869
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.07142857142857142,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.1,
+                    "support": 12,
+                    "roc_auc": 0.5385220125786163,
+                    "pr_auc": 0.10155807975635454
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9342105263157895,
+                    "recall": 0.7395833333333334,
+                    "f1": 0.8255813953488373,
+                    "support": 96,
+                    "roc_auc": 0.8650568181818182,
+                    "pr_auc": 0.9646197741939672
+                  }
+                ],
+                "macro_precision": 0.4780701754385965,
+                "macro_recall": 0.5020833333333333,
+                "macro_f1": 0.47519379844961246,
+                "weighted_f1": 0.7242018131651559,
+                "macro_roc_auc": 0.763847264574466,
+                "macro_pr_auc": 0.5838391552490362
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2508986511335461,
+              "regime_accuracy": 0.2454545497894287,
+              "regime_loss": 1.3482772328636863,
+              "regression_rmse_log_rv": 0.5831432760878125,
+              "regression_mae_log_rv": 0.4336377170042727,
+              "regression_loss": 0.3400560804464267,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    2,
+                    0
+                  ],
+                  [
+                    49,
+                    11,
+                    18
+                  ],
+                  [
+                    8,
+                    6,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.14925373134328357,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.2531645569620253,
+                    "support": 12,
+                    "roc_auc": 0.701530612244898,
+                    "pr_auc": 0.1710281689494856
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5789473684210527,
+                    "recall": 0.14102564102564102,
+                    "f1": 0.22680412371134023,
+                    "support": 78,
+                    "roc_auc": 0.4110576923076923,
+                    "pr_auc": 0.6485116647030148
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.25,
+                    "recall": 0.3,
+                    "f1": 0.2727272727272727,
+                    "support": 20,
+                    "roc_auc": 0.6322222222222222,
+                    "pr_auc": 0.24240871025054825
+                  }
+                ],
+                "macro_precision": 0.32606703325477876,
+                "macro_recall": 0.4247863247863248,
+                "macro_f1": 0.2508986511335461,
+                "weighted_f1": 0.23802947079612996,
+                "macro_roc_auc": 0.5816035089249375,
+                "macro_pr_auc": 0.3539828479676829
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3826012049875245,
+              "regime_accuracy": 0.38738739490509033,
+              "regime_loss": 1.0418870743802222,
+              "regression_rmse_log_rv": 0.8463180157043467,
+              "regression_mae_log_rv": 0.6880313428538339,
+              "regression_loss": 0.7162541837057429,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    10,
+                    17
+                  ],
+                  [
+                    16,
+                    16,
+                    16
+                  ],
+                  [
+                    6,
+                    3,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4358974358974359,
+                    "recall": 0.38636363636363635,
+                    "f1": 0.40963855421686746,
+                    "support": 44,
+                    "roc_auc": 0.6746947082767978,
+                    "pr_auc": 0.5481568944292782
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5517241379310345,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.4155844155844156,
+                    "support": 48,
+                    "roc_auc": 0.5162037037037037,
+                    "pr_auc": 0.40238423753042607
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.23255813953488372,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.3225806451612903,
+                    "support": 19,
+                    "roc_auc": 0.6287185354691075,
+                    "pr_auc": 0.29646390902917685
+                  }
+                ],
+                "macro_precision": 0.40672657112111804,
+                "macro_recall": 0.41533758639021795,
+                "macro_f1": 0.3826012049875245,
+                "weighted_f1": 0.39730793325818586,
+                "macro_roc_auc": 0.6065389824832029,
+                "macro_pr_auc": 0.4156683469962937
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.38894523888704136,
+              "regime_accuracy": 0.48076921701431274,
+              "regime_loss": 1.0728559081371014,
+              "regression_rmse_log_rv": 0.7871621801044926,
+              "regression_mae_log_rv": 0.6386828090046317,
+              "regression_loss": 0.6196242977868576,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    13,
+                    12
+                  ],
+                  [
+                    3,
+                    28,
+                    21
+                  ],
+                  [
+                    1,
+                    4,
+                    21
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.06451612903225806,
+                    "support": 26,
+                    "roc_auc": 0.6341222879684418,
+                    "pr_auc": 0.3197749224885977
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6222222222222222,
+                    "recall": 0.5384615384615384,
+                    "f1": 0.577319587628866,
+                    "support": 52,
+                    "roc_auc": 0.6808431952662722,
+                    "pr_auc": 0.698279767326027
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3888888888888889,
+                    "recall": 0.8076923076923077,
+                    "f1": 0.525,
+                    "support": 26,
+                    "roc_auc": 0.8264299802761341,
+                    "pr_auc": 0.6540606980892025
+                  }
+                ],
+                "macro_precision": 0.40370370370370373,
+                "macro_recall": 0.4615384615384615,
+                "macro_f1": 0.38894523888704136,
+                "weighted_f1": 0.4360388260724975,
+                "macro_roc_auc": 0.7137984878369493,
+                "macro_pr_auc": 0.5573717959679424
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.37815099290509124,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.0437052683697745,
+              "regression_rmse_log_rv": 0.830571742043058,
+              "regression_mae_log_rv": 0.7015775301862353,
+              "regression_loss": 0.6898494186804399,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    11,
+                    7,
+                    10
+                  ],
+                  [
+                    12,
+                    4,
+                    29
+                  ],
+                  [
+                    1,
+                    10,
+                    36
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4583333333333333,
+                    "recall": 0.39285714285714285,
+                    "f1": 0.4230769230769231,
+                    "support": 28,
+                    "roc_auc": 0.7399068322981367,
+                    "pr_auc": 0.4596692886880078
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.19047619047619047,
+                    "recall": 0.08888888888888889,
+                    "f1": 0.12121212121212122,
+                    "support": 45,
+                    "roc_auc": 0.4711111111111111,
+                    "pr_auc": 0.34235193048975726
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.48,
+                    "recall": 0.7659574468085106,
+                    "f1": 0.5901639344262295,
+                    "support": 47,
+                    "roc_auc": 0.6878461090061206,
+                    "pr_auc": 0.546247360004913
+                  }
+                ],
+                "macro_precision": 0.37626984126984125,
+                "macro_recall": 0.4159011595181808,
+                "macro_f1": 0.37815099290509124,
+                "weighted_f1": 0.37532003515610074,
+                "macro_roc_auc": 0.6329546841384561,
+                "macro_pr_auc": 0.44942285972755935
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.40174812267835525,
+              "regime_accuracy": 0.5677965879440308,
+              "regime_loss": 0.9823173840167159,
+              "regression_rmse_log_rv": 0.67922611098236,
+              "regression_mae_log_rv": 0.53256869183506,
+              "regression_loss": 0.4613481098402212,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    10,
+                    2,
+                    0
+                  ],
+                  [
+                    12,
+                    26,
+                    58
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2413793103448276,
+                    "recall": 0.7,
+                    "f1": 0.358974358974359,
+                    "support": 10,
+                    "roc_auc": 0.9388888888888889,
+                    "pr_auc": 0.6880889576579231
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.06451612903225806,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.09302325581395349,
+                    "support": 12,
+                    "roc_auc": 0.13757861635220126,
+                    "pr_auc": 0.05871139445527847
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.6041666666666666,
+                    "f1": 0.7532467532467533,
+                    "support": 96,
+                    "roc_auc": 0.931344696969697,
+                    "pr_auc": 0.9845307234613665
+                  }
+                ],
+                "macro_precision": 0.43529847979236186,
+                "macro_recall": 0.49027777777777776,
+                "macro_f1": 0.40174812267835525,
+                "weighted_f1": 0.6526924658576216,
+                "macro_roc_auc": 0.6692707340702624,
+                "macro_pr_auc": 0.577110358524856
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.21898401133373813,
+              "regime_accuracy": 0.20909090340137482,
+              "regime_loss": 1.2285922332243486,
+              "regression_rmse_log_rv": 0.6019243563945892,
+              "regression_mae_log_rv": 0.4512161936716769,
+              "regression_loss": 0.3623129308210404,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    48,
+                    0,
+                    30
+                  ],
+                  [
+                    9,
+                    0,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.17391304347826086,
+                    "recall": 1.0,
+                    "f1": 0.29629629629629634,
+                    "support": 12,
+                    "roc_auc": 0.8273809523809523,
+                    "pr_auc": 0.2742805763575636
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.48157051282051283,
+                    "pr_auc": 0.6789124569410269
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2682926829268293,
+                    "recall": 0.55,
+                    "f1": 0.36065573770491804,
+                    "support": 20,
+                    "roc_auc": 0.6266666666666667,
+                    "pr_auc": 0.23929716650581098
+                  }
+                ],
+                "macro_precision": 0.1474019088016967,
+                "macro_recall": 0.5166666666666667,
+                "macro_f1": 0.21898401133373813,
+                "weighted_f1": 0.0978970028150356,
+                "macro_roc_auc": 0.645206043956044,
+                "macro_pr_auc": 0.39749673326813384
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4188312525922442,
+              "regime_accuracy": 0.45045045018196106,
+              "regime_loss": 1.0238608374738294,
+              "regression_rmse_log_rv": 0.8113052728416879,
+              "regression_mae_log_rv": 0.6447174571253158,
+              "regression_loss": 0.6582162457407256,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    30,
+                    4,
+                    10
+                  ],
+                  [
+                    27,
+                    12,
+                    9
+                  ],
+                  [
+                    8,
+                    3,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.6818181818181818,
+                    "f1": 0.5504587155963303,
+                    "support": 44,
+                    "roc_auc": 0.6604477611940298,
+                    "pr_auc": 0.5299373529294081
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.631578947368421,
+                    "recall": 0.25,
+                    "f1": 0.3582089552238806,
+                    "support": 48,
+                    "roc_auc": 0.6124338624338624,
+                    "pr_auc": 0.5466779666663673
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2962962962962963,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.34782608695652173,
+                    "support": 19,
+                    "roc_auc": 0.6453089244851259,
+                    "pr_auc": 0.3204034736461687
+                  }
+                ],
+                "macro_precision": 0.4631379017343929,
+                "macro_recall": 0.450956937799043,
+                "macro_f1": 0.4188312525922442,
+                "weighted_f1": 0.43263881972215057,
+                "macro_roc_auc": 0.639396849371006,
+                "macro_pr_auc": 0.46567293108064806
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3413148255253518,
+              "regime_accuracy": 0.4134615361690521,
+              "regime_loss": 1.0539748668670654,
+              "regression_rmse_log_rv": 0.8526151336005862,
+              "regression_mae_log_rv": 0.6817975071742415,
+              "regression_loss": 0.7269525660447455,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    13,
+                    12
+                  ],
+                  [
+                    6,
+                    24,
+                    22
+                  ],
+                  [
+                    2,
+                    6,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1111111111111111,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.05714285714285715,
+                    "support": 26,
+                    "roc_auc": 0.6420118343195266,
+                    "pr_auc": 0.3194654931975427
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5581395348837209,
+                    "recall": 0.46153846153846156,
+                    "f1": 0.5052631578947369,
+                    "support": 52,
+                    "roc_auc": 0.5806213017751479,
+                    "pr_auc": 0.5262683475876935
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.34615384615384615,
+                    "recall": 0.6923076923076923,
+                    "f1": 0.46153846153846156,
+                    "support": 26,
+                    "roc_auc": 0.6918145956607495,
+                    "pr_auc": 0.4196431803437555
+                  }
+                ],
+                "macro_precision": 0.33846816404955943,
+                "macro_recall": 0.3974358974358974,
+                "macro_f1": 0.3413148255253518,
+                "weighted_f1": 0.3823019086176981,
+                "macro_roc_auc": 0.6381492439184747,
+                "macro_pr_auc": 0.42179234037633057
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "classification": {
+      "regime_f1_macro": {
+        "mean": 0.357402469108447,
+        "std": 0.08110388568669263,
+        "min": 0.1966604823747681,
+        "max": 0.5026049973418395,
+        "n": 25
+      },
+      "regression_rmse_log_rv": null
+    },
+    "regression": {
+      "regime_f1_macro": {
+        "mean": 0.24891356142811497,
+        "std": 0.10137301798473977,
+        "min": 0.06557377049180328,
+        "max": 0.44647284201036735,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7849741844961945,
+        "std": 0.12835801963005555,
+        "min": 0.44570792794173225,
+        "max": 1.0044211968429826,
+        "n": 25
+      }
+    },
+    "dual": {
+      "regime_f1_macro": {
+        "mean": 0.3531107392367814,
+        "std": 0.08521724463928766,
+        "min": 0.18069909512654447,
+        "max": 0.49878470917141865,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.8124535298890814,
+        "std": 0.14140135451899455,
+        "min": 0.5673079657368306,
+        "max": 1.1463279490248492,
+        "n": 25
+      }
+    }
+  }
+}

--- a/backend/artifacts/experiments/runpod_20260530/runpod_retrieval_20260530T124410Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/runpod_retrieval_20260530T124410Z.json
@@ -1,0 +1,5153 @@
+{
+  "head_modes": [
+    "classification",
+    "regression",
+    "dual"
+  ],
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "regression_alpha": 0.5,
+  "training_package_id": "canonical",
+  "rates_target_mode": "raw",
+  "rates_heads": [],
+  "use_retrieval_analogs": true,
+  "use_regime_conditioning": false,
+  "use_statement_delta": false,
+  "use_vote_features": false,
+  "use_press_conf": false,
+  "trials": {
+    "classification": [
+      {
+        "head_mode": "classification",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.49104018966076995,
+              "regime_accuracy": 0.49166667461395264,
+              "regime_loss": 1.057173119762908,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    9,
+                    6
+                  ],
+                  [
+                    6,
+                    16,
+                    23
+                  ],
+                  [
+                    2,
+                    15,
+                    30
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6190476190476191,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.5306122448979592,
+                    "support": 28,
+                    "roc_auc": 0.7399068322981367,
+                    "pr_auc": 0.41069644827747054
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.35555555555555557,
+                    "f1": 0.3764705882352941,
+                    "support": 45,
+                    "roc_auc": 0.45896296296296296,
+                    "pr_auc": 0.4815032976533774
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5084745762711864,
+                    "recall": 0.6382978723404256,
+                    "f1": 0.5660377358490567,
+                    "support": 47,
+                    "roc_auc": 0.582337510929758,
+                    "pr_auc": 0.4267486991504996
+                  }
+                ],
+                "macro_precision": 0.5091740651062685,
+                "macro_recall": 0.4860463807272318,
+                "macro_f1": 0.49104018966076995,
+                "weighted_f1": 0.48668410760530634,
+                "macro_roc_auc": 0.5937357687302859,
+                "macro_pr_auc": 0.43964948169378254
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5215759849906191,
+              "regime_accuracy": 0.805084764957428,
+              "regime_loss": 0.6600751103991169,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    9,
+                    1,
+                    2
+                  ],
+                  [
+                    12,
+                    0,
+                    84
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3225806451612903,
+                    "recall": 1.0,
+                    "f1": 0.4878048780487805,
+                    "support": 10,
+                    "roc_auc": 0.9490740740740741,
+                    "pr_auc": 0.5939666314657062
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.15384615384615385,
+                    "support": 12,
+                    "roc_auc": 0.7830188679245284,
+                    "pr_auc": 0.28104431942244773
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9767441860465116,
+                    "recall": 0.875,
+                    "f1": 0.923076923076923,
+                    "support": 96,
+                    "roc_auc": 0.8821022727272727,
+                    "pr_auc": 0.9678377169586914
+                  }
+                ],
+                "macro_precision": 0.7664416104026007,
+                "macro_recall": 0.6527777777777778,
+                "macro_f1": 0.5215759849906191,
+                "weighted_f1": 0.8079626037459854,
+                "macro_roc_auc": 0.871398404908625,
+                "macro_pr_auc": 0.6142828892822817
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.23036223036223036,
+              "regime_accuracy": 0.20000000298023224,
+              "regime_loss": 1.3056917537342418,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    1,
+                    1
+                  ],
+                  [
+                    62,
+                    5,
+                    11
+                  ],
+                  [
+                    6,
+                    7,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1282051282051282,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.2222222222222222,
+                    "support": 12,
+                    "roc_auc": 0.6921768707482994,
+                    "pr_auc": 0.18098285156938665
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.38461538461538464,
+                    "recall": 0.0641025641025641,
+                    "f1": 0.10989010989010987,
+                    "support": 78,
+                    "roc_auc": 0.3056891025641026,
+                    "pr_auc": 0.6120075055320656
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3684210526315789,
+                    "recall": 0.35,
+                    "f1": 0.358974358974359,
+                    "support": 20,
+                    "roc_auc": 0.8222222222222222,
+                    "pr_auc": 0.39237655958480866
+                  }
+                ],
+                "macro_precision": 0.2937471884840306,
+                "macro_recall": 0.41581196581196583,
+                "macro_f1": 0.23036223036223036,
+                "weighted_f1": 0.16743256743256743,
+                "macro_roc_auc": 0.6066960651782081,
+                "macro_pr_auc": 0.39512230556208694
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3928526015465434,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.0444536948128054,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    21,
+                    19,
+                    4
+                  ],
+                  [
+                    17,
+                    19,
+                    12
+                  ],
+                  [
+                    6,
+                    7,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4772727272727273,
+                    "recall": 0.4772727272727273,
+                    "f1": 0.4772727272727273,
+                    "support": 44,
+                    "roc_auc": 0.608887381275441,
+                    "pr_auc": 0.43484336147448627
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4222222222222222,
+                    "recall": 0.3958333333333333,
+                    "f1": 0.40860215053763443,
+                    "support": 48,
+                    "roc_auc": 0.519510582010582,
+                    "pr_auc": 0.5323520731523351
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2727272727272727,
+                    "recall": 0.3157894736842105,
+                    "f1": 0.2926829268292683,
+                    "support": 19,
+                    "roc_auc": 0.5560640732265446,
+                    "pr_auc": 0.2422064755965488
+                  }
+                ],
+                "macro_precision": 0.3907407407407408,
+                "macro_recall": 0.39629851143009037,
+                "macro_f1": 0.3928526015465434,
+                "weighted_f1": 0.4159808904104734,
+                "macro_roc_auc": 0.5614873455041892,
+                "macro_pr_auc": 0.4031339700744567
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.48148148148148145,
+              "regime_accuracy": 0.6346153616905212,
+              "regime_loss": 1.0438685692273653,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    22,
+                    4
+                  ],
+                  [
+                    0,
+                    46,
+                    6
+                  ],
+                  [
+                    0,
+                    6,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6548323471400395,
+                    "pr_auc": 0.4175948639464275
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6216216216216216,
+                    "recall": 0.8846153846153846,
+                    "f1": 0.7301587301587302,
+                    "support": 52,
+                    "roc_auc": 0.6527366863905325,
+                    "pr_auc": 0.6477038656113402
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.7142857142857142,
+                    "support": 26,
+                    "roc_auc": 0.8131163708086785,
+                    "pr_auc": 0.6842390092988432
+                  }
+                ],
+                "macro_precision": 0.4294294294294294,
+                "macro_recall": 0.5512820512820512,
+                "macro_f1": 0.48148148148148145,
+                "weighted_f1": 0.5436507936507937,
+                "macro_roc_auc": 0.7068951347797502,
+                "macro_pr_auc": 0.583179246285537
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3697962774279399,
+              "regime_accuracy": 0.4333333373069763,
+              "regime_loss": 1.0968915469527623,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    3,
+                    15
+                  ],
+                  [
+                    6,
+                    3,
+                    36
+                  ],
+                  [
+                    2,
+                    6,
+                    39
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.35714285714285715,
+                    "f1": 0.43478260869565216,
+                    "support": 28,
+                    "roc_auc": 0.7461180124223602,
+                    "pr_auc": 0.4294366411284087
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.06666666666666667,
+                    "f1": 0.10526315789473685,
+                    "support": 45,
+                    "roc_auc": 0.4026666666666667,
+                    "pr_auc": 0.3618999793703469
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.43333333333333335,
+                    "recall": 0.8297872340425532,
+                    "f1": 0.5693430656934307,
+                    "support": 47,
+                    "roc_auc": 0.55727193238123,
+                    "pr_auc": 0.4079243568940444
+                  }
+                ],
+                "macro_precision": 0.412962962962963,
+                "macro_recall": 0.41786558595069234,
+                "macro_f1": 0.3697962774279399,
+                "weighted_f1": 0.36391566030277217,
+                "macro_roc_auc": 0.5686855371567523,
+                "macro_pr_auc": 0.39975365913093336
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5205718013095063,
+              "regime_accuracy": 0.7881355881690979,
+              "regime_loss": 0.6671108017533512,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    6,
+                    1,
+                    5
+                  ],
+                  [
+                    11,
+                    3,
+                    82
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.37037037037037035,
+                    "recall": 1.0,
+                    "f1": 0.5405405405405406,
+                    "support": 10,
+                    "roc_auc": 0.9638888888888889,
+                    "pr_auc": 0.611964073508191
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.125,
+                    "support": 12,
+                    "roc_auc": 0.7389937106918238,
+                    "pr_auc": 0.1722516777602401
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9425287356321839,
+                    "recall": 0.8541666666666666,
+                    "f1": 0.8961748633879782,
+                    "support": 96,
+                    "roc_auc": 0.8887310606060606,
+                    "pr_auc": 0.9706333218777943
+                  }
+                ],
+                "macro_precision": 0.520966368667518,
+                "macro_recall": 0.6458333333333334,
+                "macro_f1": 0.5205718013095063,
+                "weighted_f1": 0.7876117990733162,
+                "macro_roc_auc": 0.8638712200622578,
+                "macro_pr_auc": 0.5849496910487418
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.5012345679012346,
+              "regime_accuracy": 0.5545454621315002,
+              "regime_loss": 0.9209989298473705,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    6,
+                    0
+                  ],
+                  [
+                    27,
+                    43,
+                    8
+                  ],
+                  [
+                    0,
+                    8,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18181818181818182,
+                    "recall": 0.5,
+                    "f1": 0.26666666666666666,
+                    "support": 12,
+                    "roc_auc": 0.6751700680272109,
+                    "pr_auc": 0.1685387194921566
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7543859649122807,
+                    "recall": 0.5512820512820513,
+                    "f1": 0.6370370370370372,
+                    "support": 78,
+                    "roc_auc": 0.47115384615384615,
+                    "pr_auc": 0.735910067546634
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.6,
+                    "recall": 0.6,
+                    "f1": 0.6,
+                    "support": 20,
+                    "roc_auc": 0.8633333333333333,
+                    "pr_auc": 0.47264827528048775
+                  }
+                ],
+                "macro_precision": 0.5120680489101542,
+                "macro_recall": 0.5504273504273504,
+                "macro_f1": 0.5012345679012346,
+                "weighted_f1": 0.58989898989899,
+                "macro_roc_auc": 0.6698857491714634,
+                "macro_pr_auc": 0.4590323541064261
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.34500709729276763,
+              "regime_accuracy": 0.36036035418510437,
+              "regime_loss": 1.1540690989205586,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    22,
+                    10,
+                    12
+                  ],
+                  [
+                    17,
+                    10,
+                    21
+                  ],
+                  [
+                    6,
+                    5,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4888888888888889,
+                    "recall": 0.5,
+                    "f1": 0.4943820224719101,
+                    "support": 44,
+                    "roc_auc": 0.6153324287652646,
+                    "pr_auc": 0.453661506513426
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.273972602739726,
+                    "support": 48,
+                    "roc_auc": 0.5006613756613757,
+                    "pr_auc": 0.4649906436802491
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1951219512195122,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.26666666666666666,
+                    "support": 19,
+                    "roc_auc": 0.6024027459954233,
+                    "pr_auc": 0.25111762536163246
+                  }
+                ],
+                "macro_precision": 0.3613369467028004,
+                "macro_recall": 0.37646198830409355,
+                "macro_f1": 0.34500709729276763,
+                "weighted_f1": 0.3600915368192573,
+                "macro_roc_auc": 0.5727988501406879,
+                "macro_pr_auc": 0.38992325851843584
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.35089605734767026,
+              "regime_accuracy": 0.49038460850715637,
+              "regime_loss": 1.0540538155115569,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    17,
+                    9
+                  ],
+                  [
+                    0,
+                    38,
+                    14
+                  ],
+                  [
+                    0,
+                    13,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6272189349112426,
+                    "pr_auc": 0.4893681659013292
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5588235294117647,
+                    "recall": 0.7307692307692307,
+                    "f1": 0.6333333333333334,
+                    "support": 52,
+                    "roc_auc": 0.6974852071005917,
+                    "pr_auc": 0.7554048847357208
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3611111111111111,
+                    "recall": 0.5,
+                    "f1": 0.4193548387096774,
+                    "support": 26,
+                    "roc_auc": 0.7061143984220908,
+                    "pr_auc": 0.5410884261277908
+                  }
+                ],
+                "macro_precision": 0.306644880174292,
+                "macro_recall": 0.4102564102564103,
+                "macro_f1": 0.35089605734767026,
+                "weighted_f1": 0.4215053763440861,
+                "macro_roc_auc": 0.6769395134779751,
+                "macro_pr_auc": 0.5952871589216137
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.42898051112336827,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.1142148652587174,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    13,
+                    6
+                  ],
+                  [
+                    7,
+                    13,
+                    25
+                  ],
+                  [
+                    5,
+                    9,
+                    33
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.32142857142857145,
+                    "f1": 0.3673469387755102,
+                    "support": 28,
+                    "roc_auc": 0.7569875776397516,
+                    "pr_auc": 0.3982665895981918
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.37142857142857144,
+                    "recall": 0.28888888888888886,
+                    "f1": 0.325,
+                    "support": 45,
+                    "roc_auc": 0.4444444444444444,
+                    "pr_auc": 0.3849647109505644
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.515625,
+                    "recall": 0.7021276595744681,
+                    "f1": 0.5945945945945946,
+                    "support": 47,
+                    "roc_auc": 0.5849606528708832,
+                    "pr_auc": 0.43630846293056574
+                  }
+                ],
+                "macro_precision": 0.43854166666666666,
+                "macro_recall": 0.43748170663064284,
+                "macro_f1": 0.42898051112336827,
+                "weighted_f1": 0.44047216859716865,
+                "macro_roc_auc": 0.5954642249850264,
+                "macro_pr_auc": 0.4065132544931073
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4664224664224664,
+              "regime_accuracy": 0.7966101765632629,
+              "regime_loss": 0.5908749128802347,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    12,
+                    0,
+                    84
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3125,
+                    "recall": 1.0,
+                    "f1": 0.47619047619047616,
+                    "support": 10,
+                    "roc_auc": 0.9407407407407408,
+                    "pr_auc": 0.5662763926894361
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.684748427672956,
+                    "pr_auc": 0.16137715384170034
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9767441860465116,
+                    "recall": 0.875,
+                    "f1": 0.923076923076923,
+                    "support": 96,
+                    "roc_auc": 0.881155303030303,
+                    "pr_auc": 0.9599885628506086
+                  }
+                ],
+                "macro_precision": 0.42974806201550386,
+                "macro_recall": 0.625,
+                "macro_f1": 0.4664224664224664,
+                "weighted_f1": 0.7913329608244862,
+                "macro_roc_auc": 0.835548157148,
+                "macro_pr_auc": 0.5625473697939151
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2513098311055096,
+              "regime_accuracy": 0.23636363446712494,
+              "regime_loss": 1.221803320537914,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    3,
+                    1
+                  ],
+                  [
+                    52,
+                    11,
+                    15
+                  ],
+                  [
+                    4,
+                    9,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.125,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.21052631578947367,
+                    "support": 12,
+                    "roc_auc": 0.6198979591836735,
+                    "pr_auc": 0.1324145359687908
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4782608695652174,
+                    "recall": 0.14102564102564102,
+                    "f1": 0.21782178217821782,
+                    "support": 78,
+                    "roc_auc": 0.27283653846153844,
+                    "pr_auc": 0.5942973400466769
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.30434782608695654,
+                    "recall": 0.35,
+                    "f1": 0.3255813953488372,
+                    "support": 20,
+                    "roc_auc": 0.8,
+                    "pr_auc": 0.3451673232122606
+                  }
+                ],
+                "macro_precision": 0.302536231884058,
+                "macro_recall": 0.38589743589743586,
+                "macro_f1": 0.2513098311055096,
+                "weighted_f1": 0.23661857005774015,
+                "macro_roc_auc": 0.564244832548404,
+                "macro_pr_auc": 0.3572930664092428
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3564509750950429,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.110904071782944,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    35,
+                    1,
+                    8
+                  ],
+                  [
+                    25,
+                    5,
+                    18
+                  ],
+                  [
+                    7,
+                    5,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5223880597014925,
+                    "recall": 0.7954545454545454,
+                    "f1": 0.6306306306306306,
+                    "support": 44,
+                    "roc_auc": 0.6380597014925373,
+                    "pr_auc": 0.488901833639404
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.10416666666666667,
+                    "f1": 0.1694915254237288,
+                    "support": 48,
+                    "roc_auc": 0.541005291005291,
+                    "pr_auc": 0.4745513776685791
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21212121212121213,
+                    "recall": 0.3684210526315789,
+                    "f1": 0.2692307692307693,
+                    "support": 19,
+                    "roc_auc": 0.6430205949656751,
+                    "pr_auc": 0.2676458969125135
+                  }
+                ],
+                "macro_precision": 0.3963515754560531,
+                "macro_recall": 0.422680754917597,
+                "macro_f1": 0.3564509750950429,
+                "weighted_f1": 0.36935788813938153,
+                "macro_roc_auc": 0.6073618624878345,
+                "macro_pr_auc": 0.4103663694068322
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.38317533803644915,
+              "regime_accuracy": 0.38461539149284363,
+              "regime_loss": 1.23207504932697,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    9
+                  ],
+                  [
+                    22,
+                    16,
+                    14
+                  ],
+                  [
+                    6,
+                    5,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.24324324324324326,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.2857142857142857,
+                    "support": 26,
+                    "roc_auc": 0.5650887573964497,
+                    "pr_auc": 0.33164901076396897
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5517241379310345,
+                    "recall": 0.3076923076923077,
+                    "f1": 0.39506172839506176,
+                    "support": 52,
+                    "roc_auc": 0.6068786982248521,
+                    "pr_auc": 0.5671392921233509
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.39473684210526316,
+                    "recall": 0.5769230769230769,
+                    "f1": 0.46875,
+                    "support": 26,
+                    "roc_auc": 0.7085798816568047,
+                    "pr_auc": 0.4715026750403787
+                  }
+                ],
+                "macro_precision": 0.39656807442651365,
+                "macro_recall": 0.4102564102564103,
+                "macro_f1": 0.38317533803644915,
+                "weighted_f1": 0.3861469356261023,
+                "macro_roc_auc": 0.6268491124260355,
+                "macro_pr_auc": 0.45676365930923285
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.35692568028603405,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.1619335063353655,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    5,
+                    14
+                  ],
+                  [
+                    7,
+                    3,
+                    35
+                  ],
+                  [
+                    2,
+                    6,
+                    39
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.32142857142857145,
+                    "f1": 0.391304347826087,
+                    "support": 28,
+                    "roc_auc": 0.7507763975155279,
+                    "pr_auc": 0.4100274069244042
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.21428571428571427,
+                    "recall": 0.06666666666666667,
+                    "f1": 0.10169491525423728,
+                    "support": 45,
+                    "roc_auc": 0.42518518518518517,
+                    "pr_auc": 0.33688589457107054
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4431818181818182,
+                    "recall": 0.8297872340425532,
+                    "f1": 0.5777777777777778,
+                    "support": 47,
+                    "roc_auc": 0.5861264937336054,
+                    "pr_auc": 0.45237718095536805
+                  }
+                ],
+                "macro_precision": 0.38582251082251084,
+                "macro_recall": 0.4059608240459304,
+                "macro_f1": 0.35692568028603405,
+                "weighted_f1": 0.3557362373427223,
+                "macro_roc_auc": 0.5873626921447729,
+                "macro_pr_auc": 0.39976349415028095
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5215759849906191,
+              "regime_accuracy": 0.805084764957428,
+              "regime_loss": 0.5519579636343455,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    9,
+                    1,
+                    2
+                  ],
+                  [
+                    12,
+                    0,
+                    84
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3225806451612903,
+                    "recall": 1.0,
+                    "f1": 0.4878048780487805,
+                    "support": 10,
+                    "roc_auc": 0.9314814814814815,
+                    "pr_auc": 0.505724996649751
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.15384615384615385,
+                    "support": 12,
+                    "roc_auc": 0.7578616352201258,
+                    "pr_auc": 0.31044808678814134
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9767441860465116,
+                    "recall": 0.875,
+                    "f1": 0.923076923076923,
+                    "support": 96,
+                    "roc_auc": 0.8806818181818182,
+                    "pr_auc": 0.9618553256621396
+                  }
+                ],
+                "macro_precision": 0.7664416104026007,
+                "macro_recall": 0.6527777777777778,
+                "macro_f1": 0.5215759849906191,
+                "weighted_f1": 0.8079626037459854,
+                "macro_roc_auc": 0.8566749782944751,
+                "macro_pr_auc": 0.5926761363666774
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.28943228943228944,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.087765190818093,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    3,
+                    0
+                  ],
+                  [
+                    54,
+                    20,
+                    4
+                  ],
+                  [
+                    6,
+                    10,
+                    4
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.13043478260869565,
+                    "recall": 0.75,
+                    "f1": 0.22222222222222218,
+                    "support": 12,
+                    "roc_auc": 0.6011904761904762,
+                    "pr_auc": 0.12486200478102163
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6060606060606061,
+                    "recall": 0.2564102564102564,
+                    "f1": 0.36036036036036034,
+                    "support": 78,
+                    "roc_auc": 0.3229166666666667,
+                    "pr_auc": 0.6324895929271169
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.2,
+                    "f1": 0.28571428571428575,
+                    "support": 20,
+                    "roc_auc": 0.865,
+                    "pr_auc": 0.4583797745413363
+                  }
+                ],
+                "macro_precision": 0.4121651295564339,
+                "macro_recall": 0.4021367521367521,
+                "macro_f1": 0.28943228943228944,
+                "weighted_f1": 0.3317187317187317,
+                "macro_roc_auc": 0.5963690476190476,
+                "macro_pr_auc": 0.405243790749825
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3513389782602638,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.0866926700670283,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    35,
+                    0,
+                    9
+                  ],
+                  [
+                    23,
+                    4,
+                    21
+                  ],
+                  [
+                    11,
+                    0,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5072463768115942,
+                    "recall": 0.7954545454545454,
+                    "f1": 0.6194690265486726,
+                    "support": 44,
+                    "roc_auc": 0.6336499321573948,
+                    "pr_auc": 0.45916992914429544
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.15384615384615385,
+                    "support": 48,
+                    "roc_auc": 0.4460978835978836,
+                    "pr_auc": 0.3836787178745096
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21052631578947367,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.2807017543859649,
+                    "support": 19,
+                    "roc_auc": 0.5577803203661327,
+                    "pr_auc": 0.2482488668615146
+                  }
+                ],
+                "macro_precision": 0.5725908975336893,
+                "macro_recall": 0.4332801701222753,
+                "macro_f1": 0.3513389782602638,
+                "weighted_f1": 0.360131404379192,
+                "macro_roc_auc": 0.5458427120404704,
+                "macro_pr_auc": 0.36369917129343987
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.35096539162112933,
+              "regime_accuracy": 0.3461538553237915,
+              "regime_loss": 1.0644301634568434,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    5,
+                    9
+                  ],
+                  [
+                    28,
+                    11,
+                    13
+                  ],
+                  [
+                    6,
+                    7,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2608695652173913,
+                    "recall": 0.46153846153846156,
+                    "f1": 0.33333333333333337,
+                    "support": 26,
+                    "roc_auc": 0.606508875739645,
+                    "pr_auc": 0.3887023948757628
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4782608695652174,
+                    "recall": 0.21153846153846154,
+                    "f1": 0.29333333333333333,
+                    "support": 52,
+                    "roc_auc": 0.5728550295857988,
+                    "pr_auc": 0.5639445932978921
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37142857142857144,
+                    "recall": 0.5,
+                    "f1": 0.42622950819672134,
+                    "support": 26,
+                    "roc_auc": 0.7159763313609467,
+                    "pr_auc": 0.5431306528392813
+                  }
+                ],
+                "macro_precision": 0.3701863354037267,
+                "macro_recall": 0.391025641025641,
+                "macro_f1": 0.35096539162112933,
+                "weighted_f1": 0.3365573770491803,
+                "macro_roc_auc": 0.6317800788954635,
+                "macro_pr_auc": 0.49859254700431205
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3311492566761887,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.3136572075967778,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    5,
+                    17
+                  ],
+                  [
+                    12,
+                    5,
+                    28
+                  ],
+                  [
+                    3,
+                    6,
+                    38
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.21428571428571427,
+                    "f1": 0.24489795918367344,
+                    "support": 28,
+                    "roc_auc": 0.6486801242236024,
+                    "pr_auc": 0.2811586952355876
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3125,
+                    "recall": 0.1111111111111111,
+                    "f1": 0.1639344262295082,
+                    "support": 45,
+                    "roc_auc": 0.554962962962963,
+                    "pr_auc": 0.42695930811178034
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4578313253012048,
+                    "recall": 0.8085106382978723,
+                    "f1": 0.5846153846153845,
+                    "support": 47,
+                    "roc_auc": 0.623433401340717,
+                    "pr_auc": 0.46960950406949237
+                  }
+                ],
+                "macro_precision": 0.3520152036718302,
+                "macro_recall": 0.37796915456489927,
+                "macro_f1": 0.3311492566761887,
+                "weighted_f1": 0.34759262595328166,
+                "macro_roc_auc": 0.6090254961757608,
+                "macro_pr_auc": 0.3925758358056201
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.48742227247032227,
+              "regime_accuracy": 0.7627118825912476,
+              "regime_loss": 0.5187689899388006,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    6,
+                    1,
+                    5
+                  ],
+                  [
+                    6,
+                    8,
+                    82
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3684210526315789,
+                    "recall": 0.7,
+                    "f1": 0.48275862068965514,
+                    "support": 10,
+                    "roc_auc": 0.9722222222222222,
+                    "pr_auc": 0.7449649859943976
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.08333333333333333,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.08333333333333333,
+                    "support": 12,
+                    "roc_auc": 0.6132075471698113,
+                    "pr_auc": 0.12854551276495452
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9425287356321839,
+                    "recall": 0.8541666666666666,
+                    "f1": 0.8961748633879782,
+                    "support": 96,
+                    "roc_auc": 0.8697916666666666,
+                    "pr_auc": 0.9353171180366238
+                  }
+                ],
+                "macro_precision": 0.4647610405323654,
+                "macro_recall": 0.5458333333333333,
+                "macro_f1": 0.48742227247032227,
+                "weighted_f1": 0.778477738069004,
+                "macro_roc_auc": 0.8184071453529,
+                "macro_pr_auc": 0.602942538931992
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3027450980392157,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.2102537892081522,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    29,
+                    6,
+                    43
+                  ],
+                  [
+                    1,
+                    0,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.21052631578947367,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.32,
+                    "support": 12,
+                    "roc_auc": 0.6836734693877551,
+                    "pr_auc": 0.16885703320252046
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8571428571428571,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.1411764705882353,
+                    "support": 78,
+                    "roc_auc": 0.2708333333333333,
+                    "pr_auc": 0.6240750008882552
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2923076923076923,
+                    "recall": 0.95,
+                    "f1": 0.44705882352941173,
+                    "support": 20,
+                    "roc_auc": 0.7455555555555555,
+                    "pr_auc": 0.2977102649258036
+                  }
+                ],
+                "macro_precision": 0.45332562174667435,
+                "macro_recall": 0.5645299145299145,
+                "macro_f1": 0.3027450980392157,
+                "weighted_f1": 0.21629946524064173,
+                "macro_roc_auc": 0.5666874527588813,
+                "macro_pr_auc": 0.3635474330055264
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.25800704211093994,
+              "regime_accuracy": 0.28828829526901245,
+              "regime_loss": 1.1877096296152456,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    28,
+                    13
+                  ],
+                  [
+                    2,
+                    20,
+                    26
+                  ],
+                  [
+                    4,
+                    6,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.06818181818181818,
+                    "f1": 0.11320754716981131,
+                    "support": 44,
+                    "roc_auc": 0.5990502035278155,
+                    "pr_auc": 0.43177403204460174
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.37037037037037035,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.39215686274509803,
+                    "support": 48,
+                    "roc_auc": 0.38591269841269843,
+                    "pr_auc": 0.3460271178310176
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1875,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.2686567164179105,
+                    "support": 19,
+                    "roc_auc": 0.5537757437070938,
+                    "pr_auc": 0.24346698197950592
+                  }
+                ],
+                "macro_precision": 0.2970679012345679,
+                "macro_recall": 0.31951089845826686,
+                "macro_f1": 0.25800704211093994,
+                "weighted_f1": 0.2604426945871775,
+                "macro_roc_auc": 0.5129128818825359,
+                "macro_pr_auc": 0.3404227106183751
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5312716880996121,
+              "regime_accuracy": 0.557692289352417,
+              "regime_loss": 1.0842819534815276,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    9
+                  ],
+                  [
+                    7,
+                    29,
+                    16
+                  ],
+                  [
+                    3,
+                    3,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.47368421052631576,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.39999999999999997,
+                    "support": 26,
+                    "roc_auc": 0.6267258382642998,
+                    "pr_auc": 0.5114241654071762
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.725,
+                    "recall": 0.5576923076923077,
+                    "f1": 0.6304347826086957,
+                    "support": 52,
+                    "roc_auc": 0.6860207100591716,
+                    "pr_auc": 0.6553309947261193
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4444444444444444,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5633802816901408,
+                    "support": 26,
+                    "roc_auc": 0.7347140039447732,
+                    "pr_auc": 0.5728124142179422
+                  }
+                ],
+                "macro_precision": 0.54770955165692,
+                "macro_recall": 0.5576923076923077,
+                "macro_f1": 0.5312716880996121,
+                "weighted_f1": 0.556062461726883,
+                "macro_roc_auc": 0.6824868507560815,
+                "macro_pr_auc": 0.5798558581170793
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "regression": [
+      {
+        "head_mode": "regression",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3224996412684747,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.1181919964281894,
+              "regression_rmse_log_rv": 0.9253691923795623,
+              "regression_mae_log_rv": 0.7983834944102758,
+              "regression_loss": 0.8563081422052032,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    19,
+                    9,
+                    0
+                  ],
+                  [
+                    17,
+                    28,
+                    0
+                  ],
+                  [
+                    28,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.296875,
+                    "recall": 0.6785714285714286,
+                    "f1": 0.41304347826086957,
+                    "support": 28,
+                    "roc_auc": 0.7232142857142857,
+                    "pr_auc": 0.41802197483933407
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.6222222222222222,
+                    "f1": 0.5544554455445545,
+                    "support": 45,
+                    "roc_auc": 0.6145185185185185,
+                    "pr_auc": 0.579094861514338
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.6149810550859808,
+                    "pr_auc": 0.5133559349830922
+                  }
+                ],
+                "macro_precision": 0.265625,
+                "macro_recall": 0.4335978835978836,
+                "macro_f1": 0.3224996412684747,
+                "weighted_f1": 0.3042976036734108,
+                "macro_roc_auc": 0.6509046197729284,
+                "macro_pr_auc": 0.5034909237789215
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.0765639589169001,
+              "regime_accuracy": 0.0762711837887764,
+              "regime_loss": 1.3862393488318234,
+              "regression_rmse_log_rv": 0.5672231346967336,
+              "regression_mae_log_rv": 0.47540671201580664,
+              "regression_loss": 0.3217420845351887,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    9,
+                    0
+                  ],
+                  [
+                    4,
+                    8,
+                    0
+                  ],
+                  [
+                    6,
+                    90,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.09090909090909091,
+                    "recall": 0.1,
+                    "f1": 0.09523809523809525,
+                    "support": 10,
+                    "roc_auc": 0.5953703703703703,
+                    "pr_auc": 0.09490061698423807
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.07476635514018691,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.13445378151260504,
+                    "support": 12,
+                    "roc_auc": 0.2759433962264151,
+                    "pr_auc": 0.0651669777959366
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 96,
+                    "roc_auc": 0.5284090909090909,
+                    "pr_auc": 0.7724936805354825
+                  }
+                ],
+                "macro_precision": 0.055225148683092605,
+                "macro_recall": 0.25555555555555554,
+                "macro_f1": 0.0765639589169001,
+                "weighted_f1": 0.02174429093671367,
+                "macro_roc_auc": 0.46657428583529215,
+                "macro_pr_auc": 0.3108537584385524
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.14636591478696742,
+              "regime_accuracy": 0.20000000298023224,
+              "regime_loss": 1.0956518043171275,
+              "regression_rmse_log_rv": 0.4729703547549962,
+              "regression_mae_log_rv": 0.3391538807508451,
+              "regression_loss": 0.22370095647706695,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    68,
+                    10,
+                    0
+                  ],
+                  [
+                    13,
+                    7,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.12903225806451613,
+                    "recall": 1.0,
+                    "f1": 0.2285714285714286,
+                    "support": 12,
+                    "roc_auc": 0.7763605442176871,
+                    "pr_auc": 0.29832887778186584
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5882352941176471,
+                    "recall": 0.1282051282051282,
+                    "f1": 0.21052631578947367,
+                    "support": 78,
+                    "roc_auc": 0.3541666666666667,
+                    "pr_auc": 0.6348523294029341
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.3411111111111111,
+                    "pr_auc": 0.130122517552748
+                  }
+                ],
+                "macro_precision": 0.23908918406072108,
+                "macro_recall": 0.37606837606837606,
+                "macro_f1": 0.14636591478696742,
+                "weighted_f1": 0.17421736158578263,
+                "macro_roc_auc": 0.49054610733182163,
+                "macro_pr_auc": 0.354434574912516
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2012578616352201,
+              "regime_accuracy": 0.4324324429035187,
+              "regime_loss": 1.0458908113964196,
+              "regression_rmse_log_rv": 0.7380564580434743,
+              "regression_mae_log_rv": 0.5989737583928414,
+              "regression_loss": 0.5447273352596788,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    44,
+                    0
+                  ],
+                  [
+                    0,
+                    48,
+                    0
+                  ],
+                  [
+                    0,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.5495251017639078,
+                    "pr_auc": 0.3993121225263887
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.43243243243243246,
+                    "recall": 1.0,
+                    "f1": 0.6037735849056604,
+                    "support": 48,
+                    "roc_auc": 0.52744708994709,
+                    "pr_auc": 0.4816565349468012
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.4096109839816934,
+                    "pr_auc": 0.29132120710734843
+                  }
+                ],
+                "macro_precision": 0.14414414414414414,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.2012578616352201,
+                "weighted_f1": 0.2610912799592045,
+                "macro_roc_auc": 0.495527725230897,
+                "macro_pr_auc": 0.3907632881935128
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.33535353535353535,
+              "regime_accuracy": 0.48076921701431274,
+              "regime_loss": 1.0821539805485652,
+              "regression_rmse_log_rv": 0.7914587985720397,
+              "regression_mae_log_rv": 0.634356204715844,
+              "regression_loss": 0.6264070298370966,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    16,
+                    0
+                  ],
+                  [
+                    12,
+                    40,
+                    0
+                  ],
+                  [
+                    2,
+                    24,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4166666666666667,
+                    "recall": 0.38461538461538464,
+                    "f1": 0.4,
+                    "support": 26,
+                    "roc_auc": 0.710552268244576,
+                    "pr_auc": 0.449612637389439
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.6060606060606061,
+                    "support": 52,
+                    "roc_auc": 0.38461538461538464,
+                    "pr_auc": 0.43907578879338754
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.3806706114398422,
+                    "pr_auc": 0.25747799478877326
+                  }
+                ],
+                "macro_precision": 0.3055555555555556,
+                "macro_recall": 0.38461538461538464,
+                "macro_f1": 0.33535353535353535,
+                "weighted_f1": 0.403030303030303,
+                "macro_roc_auc": 0.4919460880999343,
+                "macro_pr_auc": 0.38205547365719994
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2920565033938727,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.1173044654611577,
+              "regression_rmse_log_rv": 0.9109584567008661,
+              "regression_mae_log_rv": 0.7785734920510247,
+              "regression_loss": 0.8298453098348237,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    3,
+                    9
+                  ],
+                  [
+                    30,
+                    6,
+                    9
+                  ],
+                  [
+                    18,
+                    15,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.34782608695652173,
+                    "support": 28,
+                    "roc_auc": 0.5493012422360248,
+                    "pr_auc": 0.2799002083738318
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.13333333333333333,
+                    "f1": 0.1739130434782609,
+                    "support": 45,
+                    "roc_auc": 0.4497777777777778,
+                    "pr_auc": 0.34068756646982923
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4375,
+                    "recall": 0.2978723404255319,
+                    "f1": 0.3544303797468354,
+                    "support": 47,
+                    "roc_auc": 0.42174293208976976,
+                    "pr_auc": 0.323943129614686
+                  }
+                ],
+                "macro_precision": 0.3125,
+                "macro_recall": 0.33421141506247887,
+                "macro_f1": 0.2920565033938727,
+                "weighted_f1": 0.28519537699504677,
+                "macro_roc_auc": 0.47360731736785744,
+                "macro_pr_auc": 0.314843634819449
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.18765468765468765,
+              "regime_accuracy": 0.18644067645072937,
+              "regime_loss": 1.106477201995203,
+              "regression_rmse_log_rv": 0.5338232401118315,
+              "regression_mae_log_rv": 0.4344986471963131,
+              "regression_loss": 0.284967251683494,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    5,
+                    2,
+                    5
+                  ],
+                  [
+                    79,
+                    7,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.10638297872340426,
+                    "recall": 1.0,
+                    "f1": 0.1923076923076923,
+                    "support": 10,
+                    "roc_auc": 0.8194444444444444,
+                    "pr_auc": 0.43106385878520903
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.1904761904761905,
+                    "support": 12,
+                    "roc_auc": 0.44261006289308175,
+                    "pr_auc": 0.1006724746714585
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.10416666666666667,
+                    "f1": 0.1801801801801802,
+                    "support": 96,
+                    "roc_auc": 0.3896780303030303,
+                    "pr_auc": 0.7689262526686136
+                  }
+                ],
+                "macro_precision": 0.3317572892040977,
+                "macro_recall": 0.4236111111111111,
+                "macro_f1": 0.18765468765468765,
+                "weighted_f1": 0.1822549873397331,
+                "macro_roc_auc": 0.5505775125468522,
+                "macro_pr_auc": 0.4335541953750937
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.34502923976608185,
+              "regime_accuracy": 0.5272727012634277,
+              "regime_loss": 1.0800297260284424,
+              "regression_rmse_log_rv": 0.406091532607048,
+              "regression_mae_log_rv": 0.30150903539351104,
+              "regression_loss": 0.16491033285514112,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    5,
+                    0
+                  ],
+                  [
+                    18,
+                    51,
+                    9
+                  ],
+                  [
+                    1,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2692307692307692,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.3684210526315789,
+                    "support": 12,
+                    "roc_auc": 0.6513605442176871,
+                    "pr_auc": 0.24115206700248398
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.68,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.6666666666666666,
+                    "support": 78,
+                    "roc_auc": 0.46794871794871795,
+                    "pr_auc": 0.7273816019433516
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.42055555555555557,
+                    "pr_auc": 0.14647398998256175
+                  }
+                ],
+                "macro_precision": 0.31641025641025644,
+                "macro_recall": 0.4123931623931624,
+                "macro_f1": 0.34502923976608185,
+                "weighted_f1": 0.5129186602870813,
+                "macro_roc_auc": 0.5132882725739868,
+                "macro_pr_auc": 0.3716692196427991
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.12344086021505378,
+              "regime_accuracy": 0.18018017709255219,
+              "regime_loss": 1.1330359076465533,
+              "regression_rmse_log_rv": 0.7518619034642103,
+              "regression_mae_log_rv": 0.6314311336289655,
+              "regression_loss": 0.5652963218808255,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    0,
+                    42
+                  ],
+                  [
+                    3,
+                    0,
+                    45
+                  ],
+                  [
+                    1,
+                    0,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.045454545454545456,
+                    "f1": 0.08,
+                    "support": 44,
+                    "roc_auc": 0.45454545454545453,
+                    "pr_auc": 0.36057302728146007
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.39814814814814814,
+                    "pr_auc": 0.3539406451577049
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.17142857142857143,
+                    "recall": 0.9473684210526315,
+                    "f1": 0.2903225806451613,
+                    "support": 19,
+                    "roc_auc": 0.36556064073226546,
+                    "pr_auc": 0.12763688686651972
+                  }
+                ],
+                "macro_precision": 0.16825396825396824,
+                "macro_recall": 0.33094098883572565,
+                "macro_f1": 0.12344086021505378,
+                "weighted_f1": 0.08140656785818078,
+                "macro_roc_auc": 0.4060847478086227,
+                "macro_pr_auc": 0.2807168531018949
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.26763920671243324,
+              "regime_accuracy": 0.35576921701431274,
+              "regime_loss": 1.0952969514406645,
+              "regression_rmse_log_rv": 0.7753127787191824,
+              "regression_mae_log_rv": 0.6077423670526164,
+              "regression_loss": 0.6011099048452598,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    11,
+                    10
+                  ],
+                  [
+                    10,
+                    31,
+                    11
+                  ],
+                  [
+                    5,
+                    20,
+                    1
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.19230769230769232,
+                    "f1": 0.2173913043478261,
+                    "support": 26,
+                    "roc_auc": 0.6326429980276134,
+                    "pr_auc": 0.28617508125532704
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.5961538461538461,
+                    "f1": 0.5438596491228069,
+                    "support": 52,
+                    "roc_auc": 0.4907544378698225,
+                    "pr_auc": 0.4795517308438847
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.045454545454545456,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.04166666666666667,
+                    "support": 26,
+                    "roc_auc": 0.17159763313609466,
+                    "pr_auc": 0.1539499214829477
+                  }
+                ],
+                "macro_precision": 0.26515151515151514,
+                "macro_recall": 0.2756410256410256,
+                "macro_f1": 0.26763920671243324,
+                "weighted_f1": 0.33669431731502664,
+                "macro_roc_auc": 0.4316650230111769,
+                "macro_pr_auc": 0.30655891119405315
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2583617193836172,
+              "regime_accuracy": 0.36666667461395264,
+              "regime_loss": 1.083690214209987,
+              "regression_rmse_log_rv": 0.882823403833108,
+              "regression_mae_log_rv": 0.7620029882818926,
+              "regression_loss": 0.7793771623554749,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    5,
+                    23
+                  ],
+                  [
+                    0,
+                    11,
+                    34
+                  ],
+                  [
+                    0,
+                    14,
+                    33
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 28,
+                    "roc_auc": 0.5535714285714286,
+                    "pr_auc": 0.2611798262358227
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.36666666666666664,
+                    "recall": 0.24444444444444444,
+                    "f1": 0.29333333333333333,
+                    "support": 45,
+                    "roc_auc": 0.5146666666666667,
+                    "pr_auc": 0.3993791662467735
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.36666666666666664,
+                    "recall": 0.7021276595744681,
+                    "f1": 0.4817518248175182,
+                    "support": 47,
+                    "roc_auc": 0.3978431944039639,
+                    "pr_auc": 0.3274572501129372
+                  }
+                ],
+                "macro_precision": 0.24444444444444444,
+                "macro_recall": 0.31552403467297085,
+                "macro_f1": 0.2583617193836172,
+                "weighted_f1": 0.29868613138686134,
+                "macro_roc_auc": 0.48869376321401975,
+                "macro_pr_auc": 0.3293387475318445
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.2741889175997703,
+              "regime_accuracy": 0.5254237055778503,
+              "regime_loss": 0.9784485717951241,
+              "regression_rmse_log_rv": 0.655735668539325,
+              "regression_mae_log_rv": 0.5632619093945723,
+              "regression_loss": 0.4299892669947154,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    10
+                  ],
+                  [
+                    0,
+                    4,
+                    8
+                  ],
+                  [
+                    0,
+                    38,
+                    58
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 10,
+                    "roc_auc": 0.5925925925925926,
+                    "pr_auc": 0.09729031127862786
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.09523809523809523,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.14814814814814814,
+                    "support": 12,
+                    "roc_auc": 0.3867924528301887,
+                    "pr_auc": 0.08885861192715723
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.7631578947368421,
+                    "recall": 0.6041666666666666,
+                    "f1": 0.6744186046511628,
+                    "support": 96,
+                    "roc_auc": 0.3248106060606061,
+                    "pr_auc": 0.73703379868787
+                  }
+                ],
+                "macro_precision": 0.28613199665831246,
+                "macro_recall": 0.3125,
+                "macro_f1": 0.2741889175997703,
+                "weighted_f1": 0.5637454561380457,
+                "macro_roc_auc": 0.43473188382779576,
+                "macro_pr_auc": 0.3077275739645517
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.10256410256410257,
+              "regime_accuracy": 0.1818181872367859,
+              "regime_loss": 1.1406257651068947,
+              "regression_rmse_log_rv": 0.46508253899994495,
+              "regression_mae_log_rv": 0.34428073459050873,
+              "regression_loss": 0.2163017680826353,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    12
+                  ],
+                  [
+                    0,
+                    0,
+                    78
+                  ],
+                  [
+                    0,
+                    0,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.4897959183673469,
+                    "pr_auc": 0.0964149088528005
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.35857371794871795,
+                    "pr_auc": 0.644616853438882
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.18181818181818182,
+                    "recall": 1.0,
+                    "f1": 0.3076923076923077,
+                    "support": 20,
+                    "roc_auc": 0.6388888888888888,
+                    "pr_auc": 0.23252429477861405
+                  }
+                ],
+                "macro_precision": 0.06060606060606061,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.10256410256410257,
+                "weighted_f1": 0.055944055944055944,
+                "macro_roc_auc": 0.4957528417349846,
+                "macro_pr_auc": 0.32451868569009884
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.09743589743589744,
+              "regime_accuracy": 0.171171173453331,
+              "regime_loss": 1.279401843890674,
+              "regression_rmse_log_rv": 0.7537306391341747,
+              "regression_mae_log_rv": 0.6246160070772644,
+              "regression_loss": 0.5681098763696115,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    44
+                  ],
+                  [
+                    0,
+                    0,
+                    48
+                  ],
+                  [
+                    0,
+                    0,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.40298507462686567,
+                    "pr_auc": 0.3226760192906858
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.5750661375661376,
+                    "pr_auc": 0.5107379727700777
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.17117117117117117,
+                    "recall": 1.0,
+                    "f1": 0.2923076923076923,
+                    "support": 19,
+                    "roc_auc": 0.41990846681922195,
+                    "pr_auc": 0.22715061366406436
+                  }
+                ],
+                "macro_precision": 0.057057057057057055,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.09743589743589744,
+                "weighted_f1": 0.05003465003465004,
+                "macro_roc_auc": 0.46598655967074176,
+                "macro_pr_auc": 0.3535215352416093
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.13333333333333333,
+              "regime_accuracy": 0.25,
+              "regime_loss": 1.1545937428107629,
+              "regression_rmse_log_rv": 0.8332617001082079,
+              "regression_mae_log_rv": 0.6883212072291196,
+              "regression_loss": 0.694325060867221,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    26
+                  ],
+                  [
+                    0,
+                    0,
+                    52
+                  ],
+                  [
+                    0,
+                    0,
+                    26
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.1893491124260355,
+                    "pr_auc": 0.15330775989395465
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.45968934911242604,
+                    "pr_auc": 0.4799107511944082
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.25,
+                    "recall": 1.0,
+                    "f1": 0.4,
+                    "support": 26,
+                    "roc_auc": 0.19674556213017752,
+                    "pr_auc": 0.1555456761645118
+                  }
+                ],
+                "macro_precision": 0.08333333333333333,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.13333333333333333,
+                "weighted_f1": 0.1,
+                "macro_roc_auc": 0.28192800788954636,
+                "macro_pr_auc": 0.2629213957509582
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.12612612612612611,
+              "regime_accuracy": 0.23333333432674408,
+              "regime_loss": 1.145439057118124,
+              "regression_rmse_log_rv": 0.8782855795553678,
+              "regression_mae_log_rv": 0.741432349079211,
+              "regression_loss": 0.7713855592549083,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    28,
+                    0,
+                    0
+                  ],
+                  [
+                    45,
+                    0,
+                    0
+                  ],
+                  [
+                    47,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23333333333333334,
+                    "recall": 1.0,
+                    "f1": 0.37837837837837834,
+                    "support": 28,
+                    "roc_auc": 0.5679347826086957,
+                    "pr_auc": 0.2779454495312597
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 45,
+                    "roc_auc": 0.6248888888888889,
+                    "pr_auc": 0.4875773969004311
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.6397551734188284,
+                    "pr_auc": 0.503130965924447
+                  }
+                ],
+                "macro_precision": 0.07777777777777778,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.12612612612612611,
+                "weighted_f1": 0.08828828828828827,
+                "macro_roc_auc": 0.6108596149721377,
+                "macro_pr_auc": 0.4228846041187126
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.042328042328042326,
+              "regime_accuracy": 0.06779661029577255,
+              "regime_loss": 1.2825893971879603,
+              "regression_rmse_log_rv": 0.5492817003623323,
+              "regression_mae_log_rv": 0.46160315905334587,
+              "regression_loss": 0.301710386352935,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    0
+                  ],
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    96,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.06896551724137931,
+                    "recall": 0.8,
+                    "f1": 0.12698412698412698,
+                    "support": 10,
+                    "roc_auc": 0.0712962962962963,
+                    "pr_auc": 0.04494063602781399
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.5943396226415094,
+                    "pr_auc": 0.13393839196516885
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 96,
+                    "roc_auc": 0.21638257575757575,
+                    "pr_auc": 0.6990832397303215
+                  }
+                ],
+                "macro_precision": 0.022988505747126436,
+                "macro_recall": 0.26666666666666666,
+                "macro_f1": 0.042328042328042326,
+                "weighted_f1": 0.010761366693570083,
+                "macro_roc_auc": 0.2940061648984605,
+                "macro_pr_auc": 0.2926540892411014
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.06557377049180328,
+              "regime_accuracy": 0.1090909093618393,
+              "regime_loss": 1.164477521722967,
+              "regression_rmse_log_rv": 0.504623164443196,
+              "regression_mae_log_rv": 0.37358850814529104,
+              "regression_loss": 0.2546445380926648,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    78,
+                    0,
+                    0
+                  ],
+                  [
+                    20,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.10909090909090909,
+                    "recall": 1.0,
+                    "f1": 0.19672131147540983,
+                    "support": 12,
+                    "roc_auc": 0.3877551020408163,
+                    "pr_auc": 0.08515934585734547
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.5572916666666666,
+                    "pr_auc": 0.7099598905112492
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.5822222222222222,
+                    "pr_auc": 0.1947815223827151
+                  }
+                ],
+                "macro_precision": 0.03636363636363636,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.06557377049180328,
+                "weighted_f1": 0.021460506706408346,
+                "macro_roc_auc": 0.509089663643235,
+                "macro_pr_auc": 0.32996691958376995
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.18924731182795698,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.0958238174762427,
+              "regression_rmse_log_rv": 0.7668549735911067,
+              "regression_mae_log_rv": 0.6360631068950301,
+              "regression_loss": 0.5880665505214169,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    44,
+                    0,
+                    0
+                  ],
+                  [
+                    48,
+                    0,
+                    0
+                  ],
+                  [
+                    19,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3963963963963964,
+                    "recall": 1.0,
+                    "f1": 0.567741935483871,
+                    "support": 44,
+                    "roc_auc": 0.33175033921302577,
+                    "pr_auc": 0.295012173499506
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.582010582010582,
+                    "pr_auc": 0.4869544148703561
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.38615560640732266,
+                    "pr_auc": 0.13466156471890256
+                  }
+                ],
+                "macro_precision": 0.13213213213213212,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.18924731182795698,
+                "weighted_f1": 0.22505085730892183,
+                "macro_roc_auc": 0.43330550921031014,
+                "macro_pr_auc": 0.3055427176962549
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.13333333333333333,
+              "regime_accuracy": 0.25,
+              "regime_loss": 1.1361829592631414,
+              "regression_rmse_log_rv": 0.7595124559448658,
+              "regression_mae_log_rv": 0.624443788967955,
+              "regression_loss": 0.5768591707354018,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    0,
+                    0
+                  ],
+                  [
+                    52,
+                    0,
+                    0
+                  ],
+                  [
+                    26,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 1.0,
+                    "f1": 0.4,
+                    "support": 26,
+                    "roc_auc": 0.46794871794871795,
+                    "pr_auc": 0.24252892056015074
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.5673076923076923,
+                    "pr_auc": 0.5216868424203811
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5034516765285996,
+                    "pr_auc": 0.2401474688200467
+                  }
+                ],
+                "macro_precision": 0.08333333333333333,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.13333333333333333,
+                "weighted_f1": 0.1,
+                "macro_roc_auc": 0.5129026955950032,
+                "macro_pr_auc": 0.3347877439335262
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.22802867383512546,
+              "regime_accuracy": 0.2750000059604645,
+              "regime_loss": 1.1125378203692682,
+              "regression_rmse_log_rv": 0.9592428943159441,
+              "regression_mae_log_rv": 0.8240884851722512,
+              "regression_loss": 0.9201469302956296,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    12,
+                    0
+                  ],
+                  [
+                    28,
+                    17,
+                    0
+                  ],
+                  [
+                    21,
+                    26,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.24615384615384617,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.34408602150537637,
+                    "support": 28,
+                    "roc_auc": 0.609083850931677,
+                    "pr_auc": 0.2584773620103417
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3090909090909091,
+                    "recall": 0.37777777777777777,
+                    "f1": 0.33999999999999997,
+                    "support": 45,
+                    "roc_auc": 0.4237037037037037,
+                    "pr_auc": 0.3483137243736432
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.6977557563392597,
+                    "pr_auc": 0.6585193093916181
+                  }
+                ],
+                "macro_precision": 0.1850815850815851,
+                "macro_recall": 0.3164021164021164,
+                "macro_f1": 0.22802867383512546,
+                "weighted_f1": 0.20778673835125447,
+                "macro_roc_auc": 0.5768477703248801,
+                "macro_pr_auc": 0.42177013192520096
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.13534061295255326,
+              "regime_accuracy": 0.12711864709854126,
+              "regime_loss": 1.1301409612267703,
+              "regression_rmse_log_rv": 0.5707589113598517,
+              "regression_mae_log_rv": 0.4861656887046361,
+              "regression_loss": 0.325765734896683,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    10,
+                    2,
+                    0
+                  ],
+                  [
+                    40,
+                    53,
+                    3
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16666666666666666,
+                    "recall": 1.0,
+                    "f1": 0.2857142857142857,
+                    "support": 10,
+                    "roc_auc": 0.9537037037037037,
+                    "pr_auc": 0.49013631793043555
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.03636363636363636,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.05970149253731343,
+                    "support": 12,
+                    "roc_auc": 0.3639937106918239,
+                    "pr_auc": 0.09507538771687922
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.03125,
+                    "f1": 0.06060606060606061,
+                    "support": 96,
+                    "roc_auc": 0.8470643939393939,
+                    "pr_auc": 0.95986320767
+                  }
+                ],
+                "macro_precision": 0.40101010101010104,
+                "macro_recall": 0.3993055555555556,
+                "macro_f1": 0.13534061295255326,
+                "weighted_f1": 0.07959103886247827,
+                "macro_roc_auc": 0.7215872694449739,
+                "macro_pr_auc": 0.5150249711057716
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.27645727221279004,
+              "regime_accuracy": 0.4272727370262146,
+              "regime_loss": 1.0780223001133311,
+              "regression_rmse_log_rv": 0.6405857541234046,
+              "regression_mae_log_rv": 0.4836283300643448,
+              "regression_loss": 0.4103501083858509,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    5,
+                    0
+                  ],
+                  [
+                    38,
+                    40,
+                    0
+                  ],
+                  [
+                    19,
+                    1,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.109375,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.1842105263157895,
+                    "support": 12,
+                    "roc_auc": 0.5884353741496599,
+                    "pr_auc": 0.1460899141694872
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8695652173913043,
+                    "recall": 0.5128205128205128,
+                    "f1": 0.6451612903225806,
+                    "support": 78,
+                    "roc_auc": 0.7011217948717948,
+                    "pr_auc": 0.860112295609012
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.17166666666666666,
+                    "pr_auc": 0.10674626960584431
+                  }
+                ],
+                "macro_precision": 0.32631340579710144,
+                "macro_recall": 0.3653846153846154,
+                "macro_f1": 0.27645727221279004,
+                "weighted_f1": 0.4775736996450069,
+                "macro_roc_auc": 0.48707461189604045,
+                "macro_pr_auc": 0.37098282646144787
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2650315867707172,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.06165495916456,
+              "regression_rmse_log_rv": 0.7624058894866381,
+              "regression_mae_log_rv": 0.6310186578078313,
+              "regression_loss": 0.5812627403239119,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    40,
+                    4,
+                    0
+                  ],
+                  [
+                    41,
+                    7,
+                    0
+                  ],
+                  [
+                    13,
+                    6,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.425531914893617,
+                    "recall": 0.9090909090909091,
+                    "f1": 0.5797101449275361,
+                    "support": 44,
+                    "roc_auc": 0.580393487109905,
+                    "pr_auc": 0.41852451210988806
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4117647058823529,
+                    "recall": 0.14583333333333334,
+                    "f1": 0.2153846153846154,
+                    "support": 48,
+                    "roc_auc": 0.49206349206349204,
+                    "pr_auc": 0.46714173632100175
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.5429061784897025,
+                    "pr_auc": 0.3785451016125356
+                  }
+                ],
+                "macro_precision": 0.27909887359199,
+                "macro_recall": 0.35164141414141414,
+                "macro_f1": 0.2650315867707172,
+                "weighted_f1": 0.3229343055430012,
+                "macro_roc_auc": 0.5384543858876999,
+                "macro_pr_auc": 0.4214037833478084
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.18752085418752085,
+              "regime_accuracy": 0.2788461446762085,
+              "regime_loss": 1.0868556866279016,
+              "regression_rmse_log_rv": 0.7899096840355817,
+              "regression_mae_log_rv": 0.6381389850016254,
+              "regression_loss": 0.6239573089331926,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    0,
+                    0
+                  ],
+                  [
+                    49,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3170731707317073,
+                    "recall": 1.0,
+                    "f1": 0.48148148148148145,
+                    "support": 26,
+                    "roc_auc": 0.6863905325443787,
+                    "pr_auc": 0.34898454222659403
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.13636363636363635,
+                    "recall": 0.057692307692307696,
+                    "f1": 0.08108108108108107,
+                    "support": 52,
+                    "roc_auc": 0.39607988165680474,
+                    "pr_auc": 0.4154536156102833
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.834319526627219,
+                    "pr_auc": 0.7546135008103508
+                  }
+                ],
+                "macro_precision": 0.15114560236511457,
+                "macro_recall": 0.3525641025641026,
+                "macro_f1": 0.18752085418752085,
+                "weighted_f1": 0.1609109109109109,
+                "macro_roc_auc": 0.6389299802761341,
+                "macro_pr_auc": 0.5063505528824094
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "dual": [
+      {
+        "head_mode": "dual",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.45951989931825366,
+              "regime_accuracy": 0.4749999940395355,
+              "regime_loss": 1.086518207802881,
+              "regression_rmse_log_rv": 0.8882262802945523,
+              "regression_mae_log_rv": 0.7624463549407665,
+              "regression_loss": 0.7889459250058966,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    5,
+                    6
+                  ],
+                  [
+                    9,
+                    11,
+                    25
+                  ],
+                  [
+                    15,
+                    3,
+                    29
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4146341463414634,
+                    "recall": 0.6071428571428571,
+                    "f1": 0.49275362318840576,
+                    "support": 28,
+                    "roc_auc": 0.7321428571428571,
+                    "pr_auc": 0.3616151837137954
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5789473684210527,
+                    "recall": 0.24444444444444444,
+                    "f1": 0.34375,
+                    "support": 45,
+                    "roc_auc": 0.5045925925925926,
+                    "pr_auc": 0.5055258894604635
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.48333333333333334,
+                    "recall": 0.6170212765957447,
+                    "f1": 0.5420560747663552,
+                    "support": 47,
+                    "roc_auc": 0.5884581754590499,
+                    "pr_auc": 0.4399912510791402
+                  }
+                ],
+                "macro_precision": 0.49230494936528313,
+                "macro_recall": 0.48953619272768206,
+                "macro_f1": 0.45951989931825366,
+                "weighted_f1": 0.4561873913607838,
+                "macro_roc_auc": 0.6083978750648332,
+                "macro_pr_auc": 0.43571077475113307
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.6908622908622909,
+              "regime_accuracy": 0.8559321761131287,
+              "regime_loss": 0.5061676244614488,
+              "regression_rmse_log_rv": 0.5398276056350455,
+              "regression_mae_log_rv": 0.4375298877791265,
+              "regression_loss": 0.2914138438056662,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    4,
+                    5,
+                    3
+                  ],
+                  [
+                    6,
+                    4,
+                    86
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 1.0,
+                    "f1": 0.6666666666666666,
+                    "support": 10,
+                    "roc_auc": 0.9805555555555555,
+                    "pr_auc": 0.7205935730935731
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.4761904761904762,
+                    "support": 12,
+                    "roc_auc": 0.8176100628930818,
+                    "pr_auc": 0.41358867322226367
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9662921348314607,
+                    "recall": 0.8958333333333334,
+                    "f1": 0.9297297297297298,
+                    "support": 96,
+                    "roc_auc": 0.8925189393939394,
+                    "pr_auc": 0.9654354272541719
+                  }
+                ],
+                "macro_precision": 0.6739492301290054,
+                "macro_recall": 0.7708333333333334,
+                "macro_f1": 0.6908622908622909,
+                "weighted_f1": 0.8613136138559867,
+                "macro_roc_auc": 0.8968948526141922,
+                "macro_pr_auc": 0.6998725578566695
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.42018966422636145,
+              "regime_accuracy": 0.40909090638160706,
+              "regime_loss": 1.019151864268563,
+              "regression_rmse_log_rv": 0.4112689392344413,
+              "regression_mae_log_rv": 0.3307299418480728,
+              "regression_loss": 0.1691421403790226,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    44,
+                    24,
+                    10
+                  ],
+                  [
+                    2,
+                    5,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.14814814814814814,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.24242424242424243,
+                    "support": 12,
+                    "roc_auc": 0.6309523809523809,
+                    "pr_auc": 0.13944362115482434
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7741935483870968,
+                    "recall": 0.3076923076923077,
+                    "f1": 0.44036697247706424,
+                    "support": 78,
+                    "roc_auc": 0.3401442307692308,
+                    "pr_auc": 0.6819107721179267
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.52,
+                    "recall": 0.65,
+                    "f1": 0.5777777777777778,
+                    "support": 20,
+                    "roc_auc": 0.8022222222222222,
+                    "pr_auc": 0.3661908495605961
+                  }
+                ],
+                "macro_precision": 0.4807805655117483,
+                "macro_recall": 0.5414529914529914,
+                "macro_f1": 0.42018966422636145,
+                "weighted_f1": 0.4437570028896134,
+                "macro_roc_auc": 0.591106277981278,
+                "macro_pr_auc": 0.39584841427778245
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4806746668704935,
+              "regime_accuracy": 0.4864864945411682,
+              "regime_loss": 1.104238425204992,
+              "regression_rmse_log_rv": 0.7849707010798197,
+              "regression_mae_log_rv": 0.6467976693382805,
+              "regression_loss": 0.6161790015537437,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    23,
+                    13,
+                    8
+                  ],
+                  [
+                    17,
+                    20,
+                    11
+                  ],
+                  [
+                    5,
+                    3,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5111111111111111,
+                    "recall": 0.5227272727272727,
+                    "f1": 0.5168539325842696,
+                    "support": 44,
+                    "roc_auc": 0.6221166892808684,
+                    "pr_auc": 0.516519470206842
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.4761904761904762,
+                    "support": 48,
+                    "roc_auc": 0.5406746031746031,
+                    "pr_auc": 0.4919222910886782
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.36666666666666664,
+                    "recall": 0.5789473684210527,
+                    "f1": 0.44897959183673464,
+                    "support": 19,
+                    "roc_auc": 0.6939359267734554,
+                    "pr_auc": 0.26279728665937463
+                  }
+                ],
+                "macro_precision": 0.4777777777777778,
+                "macro_recall": 0.5061137692716641,
+                "macro_f1": 0.4806746668704935,
+                "weighted_f1": 0.48765160482656467,
+                "macro_roc_auc": 0.6189090730763089,
+                "macro_pr_auc": 0.42374634931829824
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5464282043375476,
+              "regime_accuracy": 0.5769230723381042,
+              "regime_loss": 1.051191623394306,
+              "regression_rmse_log_rv": 0.7882193793946239,
+              "regression_mae_log_rv": 0.6335321887566422,
+              "regression_loss": 0.6212897900532461,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    9
+                  ],
+                  [
+                    7,
+                    31,
+                    14
+                  ],
+                  [
+                    3,
+                    3,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.47368421052631576,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.39999999999999997,
+                    "support": 26,
+                    "roc_auc": 0.5976331360946746,
+                    "pr_auc": 0.472754348220824
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7380952380952381,
+                    "recall": 0.5961538461538461,
+                    "f1": 0.6595744680851063,
+                    "support": 52,
+                    "roc_auc": 0.6701183431952663,
+                    "pr_auc": 0.6305161374709436
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.46511627906976744,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5797101449275363,
+                    "support": 26,
+                    "roc_auc": 0.7204142011834319,
+                    "pr_auc": 0.5561482793847918
+                  }
+                ],
+                "macro_precision": 0.5589652425637738,
+                "macro_recall": 0.5705128205128206,
+                "macro_f1": 0.5464282043375476,
+                "weighted_f1": 0.5747147702744372,
+                "macro_roc_auc": 0.6627218934911242,
+                "macro_pr_auc": 0.5531395883588531
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.47380952380952374,
+              "regime_accuracy": 0.4833333194255829,
+              "regime_loss": 1.0893260659834714,
+              "regression_rmse_log_rv": 0.878242779839032,
+              "regression_mae_log_rv": 0.7469319637302154,
+              "regression_loss": 0.7713103803393904,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    6,
+                    6
+                  ],
+                  [
+                    9,
+                    13,
+                    23
+                  ],
+                  [
+                    10,
+                    8,
+                    29
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.45714285714285713,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.5079365079365079,
+                    "support": 28,
+                    "roc_auc": 0.7593167701863354,
+                    "pr_auc": 0.43009965726405996
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.48148148148148145,
+                    "recall": 0.28888888888888886,
+                    "f1": 0.36111111111111105,
+                    "support": 45,
+                    "roc_auc": 0.4471111111111111,
+                    "pr_auc": 0.44257416947196615
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.6170212765957447,
+                    "f1": 0.5523809523809523,
+                    "support": 47,
+                    "roc_auc": 0.5750510055377441,
+                    "pr_auc": 0.4257990536762825
+                  }
+                ],
+                "macro_precision": 0.4795414462081129,
+                "macro_recall": 0.492446245637735,
+                "macro_f1": 0.47380952380952374,
+                "weighted_f1": 0.47028439153439144,
+                "macro_roc_auc": 0.5938262956117302,
+                "macro_pr_auc": 0.43282429347076956
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.7309941520467836,
+              "regime_accuracy": 0.8898305296897888,
+              "regime_loss": 0.5192295206805407,
+              "regression_rmse_log_rv": 0.5425350744148841,
+              "regression_mae_log_rv": 0.4459124235594172,
+              "regression_loss": 0.2943443069703639,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    4,
+                    5,
+                    3
+                  ],
+                  [
+                    4,
+                    2,
+                    90
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5555555555555556,
+                    "recall": 1.0,
+                    "f1": 0.7142857142857143,
+                    "support": 10,
+                    "roc_auc": 0.9722222222222222,
+                    "pr_auc": 0.6272394272394273
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7142857142857143,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.5263157894736842,
+                    "support": 12,
+                    "roc_auc": 0.7185534591194969,
+                    "pr_auc": 0.2062906455062557
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.967741935483871,
+                    "recall": 0.9375,
+                    "f1": 0.9523809523809523,
+                    "support": 96,
+                    "roc_auc": 0.8802083333333334,
+                    "pr_auc": 0.9429624293906697
+                  }
+                ],
+                "macro_precision": 0.7458610684417136,
+                "macro_recall": 0.7847222222222222,
+                "macro_f1": 0.7309941520467836,
+                "weighted_f1": 0.888874729195871,
+                "macro_roc_auc": 0.8569946715583509,
+                "macro_pr_auc": 0.5921641673787842
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4230143670371374,
+              "regime_accuracy": 0.5181818008422852,
+              "regime_loss": 0.9350457700816068,
+              "regression_rmse_log_rv": 0.46059491327393975,
+              "regression_mae_log_rv": 0.33298308786470443,
+              "regression_loss": 0.2121476741338281,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    7,
+                    3
+                  ],
+                  [
+                    14,
+                    37,
+                    27
+                  ],
+                  [
+                    0,
+                    2,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.125,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.14285714285714288,
+                    "support": 12,
+                    "roc_auc": 0.6751700680272109,
+                    "pr_auc": 0.16243143977737734
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8043478260869565,
+                    "recall": 0.47435897435897434,
+                    "f1": 0.596774193548387,
+                    "support": 78,
+                    "roc_auc": 0.6614583333333334,
+                    "pr_auc": 0.8227202337506334
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.375,
+                    "recall": 0.9,
+                    "f1": 0.5294117647058825,
+                    "support": 20,
+                    "roc_auc": 0.8611111111111112,
+                    "pr_auc": 0.4620944264649294
+                  }
+                ],
+                "macro_precision": 0.43478260869565216,
+                "macro_recall": 0.5136752136752137,
+                "macro_f1": 0.4230143670371374,
+                "weighted_f1": 0.535008255501614,
+                "macro_roc_auc": 0.7325798374905519,
+                "macro_pr_auc": 0.4824153666643134
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2989547038327526,
+              "regime_accuracy": 0.29729729890823364,
+              "regime_loss": 1.1541091093642395,
+              "regression_rmse_log_rv": 0.7875857965032979,
+              "regression_mae_log_rv": 0.6659566973512238,
+              "regression_loss": 0.6202913868537341,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    18,
+                    14
+                  ],
+                  [
+                    10,
+                    11,
+                    27
+                  ],
+                  [
+                    4,
+                    5,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.2727272727272727,
+                    "f1": 0.3428571428571428,
+                    "support": 44,
+                    "roc_auc": 0.6204206241519674,
+                    "pr_auc": 0.46177982903412534
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3235294117647059,
+                    "recall": 0.22916666666666666,
+                    "f1": 0.26829268292682923,
+                    "support": 48,
+                    "roc_auc": 0.4041005291005291,
+                    "pr_auc": 0.35375521173516306
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19607843137254902,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.2857142857142857,
+                    "support": 19,
+                    "roc_auc": 0.5778032036613272,
+                    "pr_auc": 0.2406993059881364
+                  }
+                ],
+                "macro_precision": 0.3270487682252388,
+                "macro_recall": 0.34273657628920784,
+                "macro_f1": 0.2989547038327526,
+                "weighted_f1": 0.3008318422952569,
+                "macro_roc_auc": 0.5341081189712745,
+                "macro_pr_auc": 0.3520781155858083
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3646723646723647,
+              "regime_accuracy": 0.5,
+              "regime_loss": 1.0388684960512014,
+              "regression_rmse_log_rv": 0.8610407059310611,
+              "regression_mae_log_rv": 0.6945608330872626,
+              "regression_loss": 0.74139109727026,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    17,
+                    9
+                  ],
+                  [
+                    0,
+                    37,
+                    15
+                  ],
+                  [
+                    0,
+                    11,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6637080867850098,
+                    "pr_auc": 0.5105561952646497
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5692307692307692,
+                    "recall": 0.7115384615384616,
+                    "f1": 0.6324786324786325,
+                    "support": 52,
+                    "roc_auc": 0.6357248520710059,
+                    "pr_auc": 0.63386210729976
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.38461538461538464,
+                    "recall": 0.5769230769230769,
+                    "f1": 0.46153846153846156,
+                    "support": 26,
+                    "roc_auc": 0.7149901380670611,
+                    "pr_auc": 0.5440630706714212
+                  }
+                ],
+                "macro_precision": 0.31794871794871793,
+                "macro_recall": 0.42948717948717946,
+                "macro_f1": 0.3646723646723647,
+                "weighted_f1": 0.4316239316239316,
+                "macro_roc_auc": 0.6714743589743589,
+                "macro_pr_auc": 0.5628271244119437
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.43655205811138015,
+              "regime_accuracy": 0.4749999940395355,
+              "regime_loss": 1.1532665673963929,
+              "regression_rmse_log_rv": 0.8771573283877092,
+              "regression_mae_log_rv": 0.7568178312911187,
+              "regression_loss": 0.7694049787442635,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    2,
+                    14
+                  ],
+                  [
+                    8,
+                    9,
+                    28
+                  ],
+                  [
+                    8,
+                    3,
+                    36
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.42857142857142855,
+                    "f1": 0.42857142857142855,
+                    "support": 28,
+                    "roc_auc": 0.6983695652173914,
+                    "pr_auc": 0.3137328068220562
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6428571428571429,
+                    "recall": 0.2,
+                    "f1": 0.3050847457627119,
+                    "support": 45,
+                    "roc_auc": 0.5345185185185185,
+                    "pr_auc": 0.4899192796490858
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.7659574468085106,
+                    "f1": 0.5760000000000001,
+                    "support": 47,
+                    "roc_auc": 0.6365491110463422,
+                    "pr_auc": 0.4971005421575046
+                  }
+                ],
+                "macro_precision": 0.5109890109890111,
+                "macro_recall": 0.46484295845997975,
+                "macro_f1": 0.43655205811138015,
+                "weighted_f1": 0.440006779661017,
+                "macro_roc_auc": 0.623145731594084,
+                "macro_pr_auc": 0.4335842095428822
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5238095238095238,
+              "regime_accuracy": 0.7627118825912476,
+              "regime_loss": 0.5245255595546657,
+              "regression_rmse_log_rv": 0.6033015480409598,
+              "regression_mae_log_rv": 0.5026331299884339,
+              "regression_loss": 0.36397275786861855,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    5,
+                    2,
+                    5
+                  ],
+                  [
+                    4,
+                    11,
+                    81
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4375,
+                    "recall": 0.7,
+                    "f1": 0.5384615384615384,
+                    "support": 10,
+                    "roc_auc": 0.9879629629629629,
+                    "pr_auc": 0.8514864302364302
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.125,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.14285714285714288,
+                    "support": 12,
+                    "roc_auc": 0.6360062893081762,
+                    "pr_auc": 0.13614350648461965
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9418604651162791,
+                    "recall": 0.84375,
+                    "f1": 0.8901098901098902,
+                    "support": 96,
+                    "roc_auc": 0.8821022727272727,
+                    "pr_auc": 0.9465911450130298
+                  }
+                ],
+                "macro_precision": 0.501453488372093,
+                "macro_recall": 0.5701388888888889,
+                "macro_f1": 0.5238095238095238,
+                "weighted_f1": 0.7843173775377166,
+                "macro_roc_auc": 0.8353571749994706,
+                "macro_pr_auc": 0.6447403605780265
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2564484126984127,
+              "regime_accuracy": 0.2454545497894287,
+              "regime_loss": 1.3361250985752453,
+              "regression_rmse_log_rv": 0.49653987215322076,
+              "regression_mae_log_rv": 0.3716366116994653,
+              "regression_loss": 0.24655184463793683,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    41,
+                    3,
+                    34
+                  ],
+                  [
+                    2,
+                    3,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.17307692307692307,
+                    "recall": 0.75,
+                    "f1": 0.28124999999999994,
+                    "support": 12,
+                    "roc_auc": 0.7363945578231292,
+                    "pr_auc": 0.22860776703076569
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.07142857142857144,
+                    "support": 78,
+                    "roc_auc": 0.29607371794871795,
+                    "pr_auc": 0.5997382903430508
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.28846153846153844,
+                    "recall": 0.75,
+                    "f1": 0.4166666666666667,
+                    "support": 20,
+                    "roc_auc": 0.7366666666666667,
+                    "pr_auc": 0.3515526252036837
+                  }
+                ],
+                "macro_precision": 0.3205128205128205,
+                "macro_recall": 0.5128205128205129,
+                "macro_f1": 0.2564484126984127,
+                "weighted_f1": 0.15708874458874458,
+                "macro_roc_auc": 0.5897116474795047,
+                "macro_pr_auc": 0.39329956085916673
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.38387838783878386,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.0924718107010083,
+              "regression_rmse_log_rv": 0.7644938106983346,
+              "regression_mae_log_rv": 0.6311027863176187,
+              "regression_loss": 0.584450786596061,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    30,
+                    3,
+                    11
+                  ],
+                  [
+                    20,
+                    10,
+                    18
+                  ],
+                  [
+                    7,
+                    5,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5263157894736842,
+                    "recall": 0.6818181818181818,
+                    "f1": 0.594059405940594,
+                    "support": 44,
+                    "roc_auc": 0.6380597014925373,
+                    "pr_auc": 0.5256340214851083
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.30303030303030304,
+                    "support": 48,
+                    "roc_auc": 0.5291005291005291,
+                    "pr_auc": 0.5238536977331405
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19444444444444445,
+                    "recall": 0.3684210526315789,
+                    "f1": 0.2545454545454545,
+                    "support": 19,
+                    "roc_auc": 0.6630434782608695,
+                    "pr_auc": 0.26800324440132195
+                  }
+                ],
+                "macro_precision": 0.4254385964912281,
+                "macro_recall": 0.41952418926103135,
+                "macro_f1": 0.38387838783878386,
+                "weighted_f1": 0.41009398237121014,
+                "macro_roc_auc": 0.610067902951312,
+                "macro_pr_auc": 0.4391636545398569
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.49583481035093935,
+              "regime_accuracy": 0.5865384340286255,
+              "regime_loss": 1.0160247683525085,
+              "regression_rmse_log_rv": 0.7823004907002757,
+              "regression_mae_log_rv": 0.6371318833060706,
+              "regression_loss": 0.6119940577498922,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    17,
+                    6
+                  ],
+                  [
+                    1,
+                    38,
+                    13
+                  ],
+                  [
+                    1,
+                    5,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.1935483870967742,
+                    "support": 26,
+                    "roc_auc": 0.6030571992110454,
+                    "pr_auc": 0.4328419198706522
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6333333333333333,
+                    "recall": 0.7307692307692307,
+                    "f1": 0.6785714285714285,
+                    "support": 52,
+                    "roc_auc": 0.7078402366863905,
+                    "pr_auc": 0.6379138437189728
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5128205128205128,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.6153846153846154,
+                    "support": 26,
+                    "roc_auc": 0.764792899408284,
+                    "pr_auc": 0.6251287883379191
+                  }
+                ],
+                "macro_precision": 0.5820512820512821,
+                "macro_recall": 0.5384615384615384,
+                "macro_f1": 0.49583481035093935,
+                "weighted_f1": 0.5415189649060617,
+                "macro_roc_auc": 0.69189677843524,
+                "macro_pr_auc": 0.5652948506425147
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.45775953792369656,
+              "regime_accuracy": 0.5083333253860474,
+              "regime_loss": 1.1344677886434535,
+              "regression_rmse_log_rv": 0.8685502425704887,
+              "regression_mae_log_rv": 0.7456214006427521,
+              "regression_loss": 0.7543795238692549,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    0,
+                    12
+                  ],
+                  [
+                    8,
+                    6,
+                    31
+                  ],
+                  [
+                    8,
+                    0,
+                    39
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.5333333333333333,
+                    "support": 28,
+                    "roc_auc": 0.7527173913043478,
+                    "pr_auc": 0.39503459079747594
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.13333333333333333,
+                    "f1": 0.23529411764705882,
+                    "support": 45,
+                    "roc_auc": 0.45481481481481484,
+                    "pr_auc": 0.3734810175516774
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.47560975609756095,
+                    "recall": 0.8297872340425532,
+                    "f1": 0.6046511627906976,
+                    "support": 47,
+                    "roc_auc": 0.5983678227921889,
+                    "pr_auc": 0.45133251222511084
+                  }
+                ],
+                "macro_precision": 0.6585365853658537,
+                "macro_recall": 0.511516379601486,
+                "macro_f1": 0.45775953792369656,
+                "weighted_f1": 0.4495014439884481,
+                "macro_roc_auc": 0.6019666763037839,
+                "macro_pr_auc": 0.4066160401914214
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4437849162011173,
+              "regime_accuracy": 0.7372881174087524,
+              "regime_loss": 0.5474764735011731,
+              "regression_rmse_log_rv": 0.7103571337191649,
+              "regression_mae_log_rv": 0.5822619760440568,
+              "regression_loss": 0.5046072574257076,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    6,
+                    10,
+                    80
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 10,
+                    "roc_auc": 0.9416666666666667,
+                    "pr_auc": 0.5320012234142669
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7075471698113207,
+                    "pr_auc": 0.14708769330573807
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.963855421686747,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.8938547486033519,
+                    "support": 96,
+                    "roc_auc": 0.9564393939393939,
+                    "pr_auc": 0.9901128706454561
+                  }
+                ],
+                "macro_precision": 0.427345746622855,
+                "macro_recall": 0.5111111111111111,
+                "macro_f1": 0.4437849162011173,
+                "weighted_f1": 0.7642801344569643,
+                "macro_roc_auc": 0.8685510768057938,
+                "macro_pr_auc": 0.556400595788487
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.31161541149746635,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.0832756822759455,
+              "regression_rmse_log_rv": 0.41653511032248086,
+              "regression_mae_log_rv": 0.3334796794203364,
+              "regression_loss": 0.1735014981313613,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    34,
+                    14,
+                    30
+                  ],
+                  [
+                    5,
+                    3,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1702127659574468,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.2711864406779661,
+                    "support": 12,
+                    "roc_auc": 0.6938775510204082,
+                    "pr_auc": 0.17813927940147928
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7368421052631579,
+                    "recall": 0.1794871794871795,
+                    "f1": 0.288659793814433,
+                    "support": 78,
+                    "roc_auc": 0.49238782051282054,
+                    "pr_auc": 0.7684654768180346
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2727272727272727,
+                    "recall": 0.6,
+                    "f1": 0.37499999999999994,
+                    "support": 20,
+                    "roc_auc": 0.7633333333333333,
+                    "pr_auc": 0.36817567599633
+                  }
+                ],
+                "macro_precision": 0.3932607146492924,
+                "macro_recall": 0.48205128205128206,
+                "macro_f1": 0.31161541149746635,
+                "weighted_f1": 0.3024518291423761,
+                "macro_roc_auc": 0.6498662349555206,
+                "macro_pr_auc": 0.43826014407194797
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3962962962962963,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.1660935258055736,
+              "regression_rmse_log_rv": 0.9610065991537114,
+              "regression_mae_log_rv": 0.7735907105175225,
+              "regression_loss": 0.9235336836169823,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    9,
+                    9
+                  ],
+                  [
+                    16,
+                    10,
+                    22
+                  ],
+                  [
+                    4,
+                    5,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5652173913043478,
+                    "recall": 0.5909090909090909,
+                    "f1": 0.5777777777777778,
+                    "support": 44,
+                    "roc_auc": 0.6275440976933514,
+                    "pr_auc": 0.45511150841228715
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4166666666666667,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.2777777777777778,
+                    "support": 48,
+                    "roc_auc": 0.5277777777777778,
+                    "pr_auc": 0.49813854648053363
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.24390243902439024,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.3333333333333333,
+                    "support": 19,
+                    "roc_auc": 0.6281464530892449,
+                    "pr_auc": 0.250695304842582
+                  }
+                ],
+                "macro_precision": 0.4085954989984682,
+                "macro_recall": 0.44185273790536944,
+                "macro_f1": 0.3962962962962963,
+                "weighted_f1": 0.4062062062062062,
+                "macro_roc_auc": 0.5944894428534581,
+                "macro_pr_auc": 0.40131511991180097
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.36461102250575933,
+              "regime_accuracy": 0.4134615361690521,
+              "regime_loss": 1.111283696614779,
+              "regression_rmse_log_rv": 0.79006357980604,
+              "regression_mae_log_rv": 0.6265051550357245,
+              "regression_loss": 0.624200460135935,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    15,
+                    8
+                  ],
+                  [
+                    4,
+                    23,
+                    25
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.18181818181818182,
+                    "support": 26,
+                    "roc_auc": 0.6272189349112426,
+                    "pr_auc": 0.4059993910485284
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.48936170212765956,
+                    "recall": 0.4423076923076923,
+                    "f1": 0.46464646464646464,
+                    "support": 52,
+                    "roc_auc": 0.5928254437869822,
+                    "pr_auc": 0.5210257808618893
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.34,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.4473684210526316,
+                    "support": 26,
+                    "roc_auc": 0.7223865877712031,
+                    "pr_auc": 0.6266909556708464
+                  }
+                ],
+                "macro_precision": 0.41931104356636273,
+                "macro_recall": 0.4038461538461538,
+                "macro_f1": 0.36461102250575933,
+                "weighted_f1": 0.3896198830409357,
+                "macro_roc_auc": 0.6474769888231426,
+                "macro_pr_auc": 0.5179053758604214
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3727346096096096,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.152744539246389,
+              "regression_rmse_log_rv": 0.9049669501934383,
+              "regression_mae_log_rv": 0.7779374349920545,
+              "regression_loss": 0.818965180942413,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    11,
+                    14
+                  ],
+                  [
+                    4,
+                    13,
+                    28
+                  ],
+                  [
+                    2,
+                    6,
+                    39
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.10714285714285714,
+                    "f1": 0.16216216216216214,
+                    "support": 28,
+                    "roc_auc": 0.6354813664596274,
+                    "pr_auc": 0.28465054210563395
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.43333333333333335,
+                    "recall": 0.28888888888888886,
+                    "f1": 0.3466666666666666,
+                    "support": 45,
+                    "roc_auc": 0.46074074074074073,
+                    "pr_auc": 0.3731789343751325
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.48148148148148145,
+                    "recall": 0.8297872340425532,
+                    "f1": 0.609375,
+                    "support": 47,
+                    "roc_auc": 0.5969105217137861,
+                    "pr_auc": 0.4577753566376586
+                  }
+                ],
+                "macro_precision": 0.41604938271604935,
+                "macro_recall": 0.40860632669143304,
+                "macro_f1": 0.3727346096096096,
+                "weighted_f1": 0.4065097128378378,
+                "macro_roc_auc": 0.5643775429713848,
+                "macro_pr_auc": 0.3718682777061417
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3910515934807433,
+              "regime_accuracy": 0.6355932354927063,
+              "regime_loss": 0.6637399247137167,
+              "regression_rmse_log_rv": 0.868540882830326,
+              "regression_mae_log_rv": 0.6572068160620786,
+              "regression_loss": 0.7543632651476821,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    14,
+                    14,
+                    68
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.7,
+                    "f1": 0.3684210526315789,
+                    "support": 10,
+                    "roc_auc": 0.8675925925925926,
+                    "pr_auc": 0.35083010635642214
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7114779874213837,
+                    "pr_auc": 0.1483285419587466
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9315068493150684,
+                    "recall": 0.7083333333333334,
+                    "f1": 0.804733727810651,
+                    "support": 96,
+                    "roc_auc": 0.8816287878787878,
+                    "pr_auc": 0.9722272636443302
+                  }
+                ],
+                "macro_precision": 0.39383561643835613,
+                "macro_recall": 0.4694444444444444,
+                "macro_f1": 0.3910515934807433,
+                "weighted_f1": 0.685920749119816,
+                "macro_roc_auc": 0.8202331226309214,
+                "macro_pr_auc": 0.4904619706531663
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.41221370941505625,
+              "regime_accuracy": 0.4272727370262146,
+              "regime_loss": 1.019977376677773,
+              "regression_rmse_log_rv": 0.3861235846251395,
+              "regression_mae_log_rv": 0.29247302126181735,
+              "regression_loss": 0.14909142260376726,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    25,
+                    25,
+                    28
+                  ],
+                  [
+                    2,
+                    4,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.22857142857142856,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.3404255319148936,
+                    "support": 12,
+                    "roc_auc": 0.7542517006802721,
+                    "pr_auc": 0.3154477296790048
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8064516129032258,
+                    "recall": 0.32051282051282054,
+                    "f1": 0.45871559633027525,
+                    "support": 78,
+                    "roc_auc": 0.5817307692307693,
+                    "pr_auc": 0.7998801119406447
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 20,
+                    "roc_auc": 0.7394444444444445,
+                    "pr_auc": 0.35761945685505786
+                  }
+                ],
+                "macro_precision": 0.4510682865521575,
+                "macro_recall": 0.5623931623931624,
+                "macro_f1": 0.41221370941505625,
+                "weighted_f1": 0.4419538445158199,
+                "macro_roc_auc": 0.6918089714518286,
+                "macro_pr_auc": 0.49098243282490245
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.30854676489269656,
+              "regime_accuracy": 0.315315306186676,
+              "regime_loss": 1.118956965707632,
+              "regression_rmse_log_rv": 0.8444497673256942,
+              "regression_mae_log_rv": 0.6800824285627486,
+              "regression_loss": 0.713095409536419,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    18,
+                    11,
+                    15
+                  ],
+                  [
+                    17,
+                    8,
+                    23
+                  ],
+                  [
+                    4,
+                    6,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.4090909090909091,
+                    "f1": 0.4337349397590362,
+                    "support": 44,
+                    "roc_auc": 0.5654681139755766,
+                    "pr_auc": 0.4129272793102779
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.32,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.2191780821917808,
+                    "support": 48,
+                    "roc_auc": 0.5671296296296297,
+                    "pr_auc": 0.42557512423567406
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19148936170212766,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.2727272727272727,
+                    "support": 19,
+                    "roc_auc": 0.5715102974828375,
+                    "pr_auc": 0.3069017224813037
+                  }
+                ],
+                "macro_precision": 0.3243426077468631,
+                "macro_recall": 0.3498139287612972,
+                "macro_f1": 0.30854676489269656,
+                "weighted_f1": 0.31339372501280405,
+                "macro_roc_auc": 0.5680360136960146,
+                "macro_pr_auc": 0.38180137534241854
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3599033816425121,
+              "regime_accuracy": 0.4038461446762085,
+              "regime_loss": 1.0740910676809459,
+              "regression_rmse_log_rv": 0.7971977854233677,
+              "regression_mae_log_rv": 0.6314986216602847,
+              "regression_loss": 0.6355243090839218,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    15,
+                    8
+                  ],
+                  [
+                    7,
+                    19,
+                    26
+                  ],
+                  [
+                    0,
+                    6,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.16666666666666669,
+                    "support": 26,
+                    "roc_auc": 0.6661735700197239,
+                    "pr_auc": 0.38000457672866234
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.475,
+                    "recall": 0.36538461538461536,
+                    "f1": 0.4130434782608696,
+                    "support": 52,
+                    "roc_auc": 0.5943047337278107,
+                    "pr_auc": 0.5235207915662597
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37037037037037035,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5,
+                    "support": 26,
+                    "roc_auc": 0.8007889546351085,
+                    "pr_auc": 0.6714082957362842
+                  }
+                ],
+                "macro_precision": 0.38179012345679014,
+                "macro_recall": 0.4166666666666667,
+                "macro_f1": 0.3599033816425121,
+                "weighted_f1": 0.3731884057971015,
+                "macro_roc_auc": 0.6870890861275477,
+                "macro_pr_auc": 0.5249778880104021
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "classification": {
+      "regime_f1_macro": {
+        "mean": 0.39487964372360856,
+        "std": 0.09196177358561897,
+        "min": 0.23036223036223036,
+        "max": 0.5312716880996121,
+        "n": 25
+      },
+      "regression_rmse_log_rv": null
+    },
+    "regression": {
+      "regime_f1_macro": {
+        "mean": 0.19250931856343667,
+        "std": 0.08755529297414194,
+        "min": 0.042328042328042326,
+        "max": 0.34502923976608185,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7058088323153197,
+        "std": 0.15583505863805522,
+        "min": 0.406091532607048,
+        "max": 0.9592428943159441,
+        "n": 25
+      }
+    },
+    "dual": {
+      "regime_f1_macro": {
+        "mean": 0.4321664109315001,
+        "std": 0.10763234441976764,
+        "min": 0.2564484126984127,
+        "max": 0.7309941520467836,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.720563874462042,
+        "std": 0.1759300489355509,
+        "min": 0.3861235846251395,
+        "max": 0.9610065991537114,
+        "n": 25
+      }
+    }
+  }
+}

--- a/backend/artifacts/experiments/runpod_20260530/runpod_statement_delta_20260530T134347Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/runpod_statement_delta_20260530T134347Z.json
@@ -1,0 +1,5153 @@
+{
+  "head_modes": [
+    "classification",
+    "regression",
+    "dual"
+  ],
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "regression_alpha": 0.5,
+  "training_package_id": "canonical",
+  "rates_target_mode": "raw",
+  "rates_heads": [],
+  "use_retrieval_analogs": false,
+  "use_regime_conditioning": false,
+  "use_statement_delta": true,
+  "use_vote_features": false,
+  "use_press_conf": false,
+  "trials": {
+    "classification": [
+      {
+        "head_mode": "classification",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.41153202225995095,
+              "regime_accuracy": 0.44999998807907104,
+              "regime_loss": 1.2052595863254156,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    6,
+                    9
+                  ],
+                  [
+                    14,
+                    7,
+                    24
+                  ],
+                  [
+                    7,
+                    6,
+                    34
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.38235294117647056,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.41935483870967744,
+                    "support": 28,
+                    "roc_auc": 0.6599378881987578,
+                    "pr_auc": 0.30184916762658354
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3684210526315789,
+                    "recall": 0.15555555555555556,
+                    "f1": 0.21875,
+                    "support": 45,
+                    "roc_auc": 0.6,
+                    "pr_auc": 0.44632080965109183
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5074626865671642,
+                    "recall": 0.723404255319149,
+                    "f1": 0.5964912280701754,
+                    "support": 47,
+                    "roc_auc": 0.6420868551442728,
+                    "pr_auc": 0.4971985068240816
+                  }
+                ],
+                "macro_precision": 0.4194122267917379,
+                "macro_recall": 0.44774850838680624,
+                "macro_f1": 0.41153202225995095,
+                "weighted_f1": 0.4135064433597434,
+                "macro_roc_auc": 0.6340082477810102,
+                "macro_pr_auc": 0.415122828033919
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3881237524950099,
+              "regime_accuracy": 0.6355932354927063,
+              "regime_loss": 0.699605428566367,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    14,
+                    14,
+                    68
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23333333333333334,
+                    "recall": 0.7,
+                    "f1": 0.35,
+                    "support": 10,
+                    "roc_auc": 0.8537037037037037,
+                    "pr_auc": 0.2423074239367489
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.5636792452830188,
+                    "pr_auc": 0.10697425344199267
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9577464788732394,
+                    "recall": 0.7083333333333334,
+                    "f1": 0.8143712574850299,
+                    "support": 96,
+                    "roc_auc": 0.8948863636363636,
+                    "pr_auc": 0.9751748879325575
+                  }
+                ],
+                "macro_precision": 0.39702660406885754,
+                "macro_recall": 0.4694444444444444,
+                "macro_f1": 0.3881237524950099,
+                "weighted_f1": 0.6922003450725667,
+                "macro_roc_auc": 0.7707564375410287,
+                "macro_pr_auc": 0.441485521770433
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2690270170146331,
+              "regime_accuracy": 0.2545454502105713,
+              "regime_loss": 1.1753299994902178,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    47,
+                    7,
+                    24
+                  ],
+                  [
+                    9,
+                    0,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.15151515151515152,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.25641025641025644,
+                    "support": 12,
+                    "roc_auc": 0.7083333333333334,
+                    "pr_auc": 0.20684070250687328
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.08974358974358974,
+                    "f1": 0.1647058823529412,
+                    "support": 78,
+                    "roc_auc": 0.3782051282051282,
+                    "pr_auc": 0.6632001870124263
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2972972972972973,
+                    "recall": 0.55,
+                    "f1": 0.38596491228070173,
+                    "support": 20,
+                    "roc_auc": 0.7394444444444445,
+                    "pr_auc": 0.3146693422038457
+                  }
+                ],
+                "macro_precision": 0.4829374829374829,
+                "macro_recall": 0.49102564102564106,
+                "macro_f1": 0.2690270170146331,
+                "weighted_f1": 0.2149389104187866,
+                "macro_roc_auc": 0.6086609686609686,
+                "macro_pr_auc": 0.3949034105743818
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4776417233560091,
+              "regime_accuracy": 0.5045045018196106,
+              "regime_loss": 1.0204883134323797,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    30,
+                    7,
+                    7
+                  ],
+                  [
+                    17,
+                    17,
+                    14
+                  ],
+                  [
+                    7,
+                    3,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.6818181818181818,
+                    "f1": 0.6122448979591836,
+                    "support": 44,
+                    "roc_auc": 0.6729986431478969,
+                    "pr_auc": 0.5410162299577809
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6296296296296297,
+                    "recall": 0.3541666666666667,
+                    "f1": 0.45333333333333337,
+                    "support": 48,
+                    "roc_auc": 0.6233465608465608,
+                    "pr_auc": 0.55474802588212
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.3673469387755102,
+                    "support": 19,
+                    "roc_auc": 0.6636155606407322,
+                    "pr_auc": 0.3027612881175796
+                  }
+                ],
+                "macro_precision": 0.49506172839506174,
+                "macro_recall": 0.5032230196703881,
+                "macro_f1": 0.4776417233560091,
+                "weighted_f1": 0.5016069130354844,
+                "macro_roc_auc": 0.6533202548783966,
+                "macro_pr_auc": 0.46617518131916014
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.41130268199233716,
+              "regime_accuracy": 0.5288461446762085,
+              "regime_loss": 1.2403416083409236,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    18,
+                    7
+                  ],
+                  [
+                    3,
+                    39,
+                    10
+                  ],
+                  [
+                    0,
+                    11,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.06666666666666668,
+                    "support": 26,
+                    "roc_auc": 0.6010848126232742,
+                    "pr_auc": 0.3318247430800994
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5735294117647058,
+                    "recall": 0.75,
+                    "f1": 0.65,
+                    "support": 52,
+                    "roc_auc": 0.6745562130177515,
+                    "pr_auc": 0.6957408389602755
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.46875,
+                    "recall": 0.5769230769230769,
+                    "f1": 0.5172413793103449,
+                    "support": 26,
+                    "roc_auc": 0.7357001972386588,
+                    "pr_auc": 0.6033729092011766
+                  }
+                ],
+                "macro_precision": 0.4307598039215686,
+                "macro_recall": 0.4551282051282051,
+                "macro_f1": 0.41130268199233716,
+                "weighted_f1": 0.470977011494253,
+                "macro_roc_auc": 0.6704470742932281,
+                "macro_pr_auc": 0.5436461637471838
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.34331002331002325,
+              "regime_accuracy": 0.38333332538604736,
+              "regime_loss": 1.2034429020084383,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    20,
+                    3,
+                    5
+                  ],
+                  [
+                    17,
+                    3,
+                    25
+                  ],
+                  [
+                    23,
+                    1,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.7142857142857143,
+                    "f1": 0.4545454545454545,
+                    "support": 28,
+                    "roc_auc": 0.7092391304347826,
+                    "pr_auc": 0.3706252660085106
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.06666666666666667,
+                    "f1": 0.11538461538461539,
+                    "support": 45,
+                    "roc_auc": 0.41274074074074074,
+                    "pr_auc": 0.32594058066560894
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4339622641509434,
+                    "recall": 0.48936170212765956,
+                    "f1": 0.45999999999999996,
+                    "support": 47,
+                    "roc_auc": 0.5444476828912853,
+                    "pr_auc": 0.4112665608520477
+                  }
+                ],
+                "macro_precision": 0.39862234201856844,
+                "macro_recall": 0.4234380276933469,
+                "macro_f1": 0.34331002331002325,
+                "weighted_f1": 0.3294965034965035,
+                "macro_roc_auc": 0.5554758513556028,
+                "macro_pr_auc": 0.36927746917538906
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.42401021711366543,
+              "regime_accuracy": 0.6779661178588867,
+              "regime_loss": 0.6288408480458341,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    0
+                  ],
+                  [
+                    6,
+                    0,
+                    6
+                  ],
+                  [
+                    12,
+                    12,
+                    72
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.8,
+                    "f1": 0.4444444444444444,
+                    "support": 10,
+                    "roc_auc": 0.9222222222222223,
+                    "pr_auc": 0.37490875799319
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6871069182389937,
+                    "pr_auc": 0.14205317804792728
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9230769230769231,
+                    "recall": 0.75,
+                    "f1": 0.8275862068965517,
+                    "support": 96,
+                    "roc_auc": 0.8958333333333334,
+                    "pr_auc": 0.9768545851770128
+                  }
+                ],
+                "macro_precision": 0.4102564102564103,
+                "macro_recall": 0.5166666666666667,
+                "macro_f1": 0.42401021711366543,
+                "weighted_f1": 0.7109552568348594,
+                "macro_roc_auc": 0.8350541579315164,
+                "macro_pr_auc": 0.4979388404060434
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3563118811881188,
+              "regime_accuracy": 0.3545454442501068,
+              "regime_loss": 1.1527254191311922,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    1,
+                    1
+                  ],
+                  [
+                    37,
+                    18,
+                    23
+                  ],
+                  [
+                    5,
+                    4,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.19230769230769232,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.3125,
+                    "support": 12,
+                    "roc_auc": 0.7312925170068028,
+                    "pr_auc": 0.19333581090795104
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.782608695652174,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.3564356435643565,
+                    "support": 78,
+                    "roc_auc": 0.3922275641025641,
+                    "pr_auc": 0.6621739317526252
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3142857142857143,
+                    "recall": 0.55,
+                    "f1": 0.4,
+                    "support": 20,
+                    "roc_auc": 0.6961111111111111,
+                    "pr_auc": 0.255236494735363
+                  }
+                ],
+                "macro_precision": 0.42973403408186023,
+                "macro_recall": 0.538034188034188,
+                "macro_f1": 0.3563118811881188,
+                "weighted_f1": 0.3595634563456346,
+                "macro_roc_auc": 0.6065437307401593,
+                "macro_pr_auc": 0.37024874579864636
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.38621509209744503,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.0893660207037648,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    22,
+                    11,
+                    11
+                  ],
+                  [
+                    16,
+                    9,
+                    23
+                  ],
+                  [
+                    6,
+                    0,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.5,
+                    "f1": 0.5,
+                    "support": 44,
+                    "roc_auc": 0.6492537313432836,
+                    "pr_auc": 0.4874241190196043
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.45,
+                    "recall": 0.1875,
+                    "f1": 0.26470588235294124,
+                    "support": 48,
+                    "roc_auc": 0.6170634920634921,
+                    "pr_auc": 0.4998878661786004
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2765957446808511,
+                    "recall": 0.6842105263157895,
+                    "f1": 0.393939393939394,
+                    "support": 19,
+                    "roc_auc": 0.6195652173913043,
+                    "pr_auc": 0.4112993705346619
+                  }
+                ],
+                "macro_precision": 0.40886524822695036,
+                "macro_recall": 0.4572368421052631,
+                "macro_f1": 0.38621509209744503,
+                "weighted_f1": 0.3800966742143213,
+                "macro_roc_auc": 0.6286274802660267,
+                "macro_pr_auc": 0.46620378524428885
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5225819714256347,
+              "regime_accuracy": 0.5480769276618958,
+              "regime_loss": 1.0954904556274414,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    9,
+                    8
+                  ],
+                  [
+                    7,
+                    29,
+                    16
+                  ],
+                  [
+                    3,
+                    4,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.47368421052631576,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.39999999999999997,
+                    "support": 26,
+                    "roc_auc": 0.6390532544378699,
+                    "pr_auc": 0.37383733003955
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6904761904761905,
+                    "recall": 0.5576923076923077,
+                    "f1": 0.6170212765957447,
+                    "support": 52,
+                    "roc_auc": 0.6113165680473372,
+                    "pr_auc": 0.6104474268209463
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4418604651162791,
+                    "recall": 0.7307692307692307,
+                    "f1": 0.5507246376811594,
+                    "support": 26,
+                    "roc_auc": 0.7273175542406312,
+                    "pr_auc": 0.5679175887632819
+                  }
+                ],
+                "macro_precision": 0.5353402887062618,
+                "macro_recall": 0.5448717948717948,
+                "macro_f1": 0.5225819714256347,
+                "weighted_f1": 0.5461917977181622,
+                "macro_roc_auc": 0.6592291255752795,
+                "macro_pr_auc": 0.5174007818745928
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4083939111525318,
+              "regime_accuracy": 0.4333333373069763,
+              "regime_loss": 1.122418345716685,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    11,
+                    11,
+                    6
+                  ],
+                  [
+                    7,
+                    8,
+                    30
+                  ],
+                  [
+                    4,
+                    10,
+                    33
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.39285714285714285,
+                    "f1": 0.44,
+                    "support": 28,
+                    "roc_auc": 0.7391304347826086,
+                    "pr_auc": 0.3946364249981406
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.27586206896551724,
+                    "recall": 0.17777777777777778,
+                    "f1": 0.2162162162162162,
+                    "support": 45,
+                    "roc_auc": 0.424,
+                    "pr_auc": 0.32877873601030355
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4782608695652174,
+                    "recall": 0.7021276595744681,
+                    "f1": 0.5689655172413792,
+                    "support": 47,
+                    "roc_auc": 0.5948703002040221,
+                    "pr_auc": 0.4481622528982795
+                  }
+                ],
+                "macro_precision": 0.4180409795102449,
+                "macro_recall": 0.4242541934031296,
+                "macro_f1": 0.4083939111525318,
+                "weighted_f1": 0.4065925753339546,
+                "macro_roc_auc": 0.5860002449955436,
+                "macro_pr_auc": 0.39052580463557457
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4556372549019608,
+              "regime_accuracy": 0.6610169410705566,
+              "regime_loss": 0.6869304821652881,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    5,
+                    2,
+                    5
+                  ],
+                  [
+                    10,
+                    17,
+                    69
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 10,
+                    "roc_auc": 0.8777777777777778,
+                    "pr_auc": 0.3210350523460279
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.09090909090909091,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.11764705882352942,
+                    "support": 12,
+                    "roc_auc": 0.6218553459119497,
+                    "pr_auc": 0.11767609875168411
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9324324324324325,
+                    "recall": 0.71875,
+                    "f1": 0.8117647058823529,
+                    "support": 96,
+                    "roc_auc": 0.8783143939393939,
+                    "pr_auc": 0.972211999546906
+                  }
+                ],
+                "macro_precision": 0.4471744471744472,
+                "macro_recall": 0.5284722222222222,
+                "macro_f1": 0.4556372549019608,
+                "weighted_f1": 0.7094591226321038,
+                "macro_roc_auc": 0.7926491725430406,
+                "macro_pr_auc": 0.47030771688153933
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.30793682418358664,
+              "regime_accuracy": 0.40909090638160706,
+              "regime_loss": 1.2511692003770307,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    10,
+                    0
+                  ],
+                  [
+                    17,
+                    36,
+                    25
+                  ],
+                  [
+                    0,
+                    13,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.10526315789473684,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.12903225806451615,
+                    "support": 12,
+                    "roc_auc": 0.66921768707483,
+                    "pr_auc": 0.1574014858432109
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6101694915254238,
+                    "recall": 0.46153846153846156,
+                    "f1": 0.5255474452554745,
+                    "support": 78,
+                    "roc_auc": 0.3261217948717949,
+                    "pr_auc": 0.6394521309335758
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21875,
+                    "recall": 0.35,
+                    "f1": 0.2692307692307692,
+                    "support": 20,
+                    "roc_auc": 0.645,
+                    "pr_auc": 0.22020989104200364
+                  }
+                ],
+                "macro_precision": 0.3113942164733869,
+                "macro_recall": 0.3260683760683761,
+                "macro_f1": 0.30793682418358664,
+                "weighted_f1": 0.435688211011969,
+                "macro_roc_auc": 0.5467798273155416,
+                "macro_pr_auc": 0.33902116927293013
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.36521342771342774,
+              "regime_accuracy": 0.36936935782432556,
+              "regime_loss": 1.1673248796944424,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    10,
+                    17
+                  ],
+                  [
+                    16,
+                    14,
+                    18
+                  ],
+                  [
+                    7,
+                    2,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.425,
+                    "recall": 0.38636363636363635,
+                    "f1": 0.40476190476190477,
+                    "support": 44,
+                    "roc_auc": 0.5773405698778833,
+                    "pr_auc": 0.43596911518855186
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5384615384615384,
+                    "recall": 0.2916666666666667,
+                    "f1": 0.3783783783783784,
+                    "support": 48,
+                    "roc_auc": 0.6193783068783069,
+                    "pr_auc": 0.5199048372408798
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.3125,
+                    "support": 19,
+                    "roc_auc": 0.5509153318077803,
+                    "pr_auc": 0.20122607715891982
+                  }
+                ],
+                "macro_precision": 0.39522792022792025,
+                "macro_recall": 0.4014486975013291,
+                "macro_f1": 0.36521342771342774,
+                "weighted_f1": 0.3775602339791529,
+                "macro_roc_auc": 0.5825447361879902,
+                "macro_pr_auc": 0.38570000986278385
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.49463559008509067,
+              "regime_accuracy": 0.557692289352417,
+              "regime_loss": 1.079124166415288,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    12,
+                    9
+                  ],
+                  [
+                    2,
+                    35,
+                    15
+                  ],
+                  [
+                    1,
+                    7,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.625,
+                    "recall": 0.19230769230769232,
+                    "f1": 0.29411764705882354,
+                    "support": 26,
+                    "roc_auc": 0.611439842209073,
+                    "pr_auc": 0.41587707089760995
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6481481481481481,
+                    "recall": 0.6730769230769231,
+                    "f1": 0.6603773584905661,
+                    "support": 52,
+                    "roc_auc": 0.6312869822485208,
+                    "pr_auc": 0.5672251639754563
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.6923076923076923,
+                    "f1": 0.5294117647058824,
+                    "support": 26,
+                    "roc_auc": 0.754930966469428,
+                    "pr_auc": 0.6481110570535179
+                  }
+                ],
+                "macro_precision": 0.5672398589065256,
+                "macro_recall": 0.5192307692307693,
+                "macro_f1": 0.49463559008509067,
+                "weighted_f1": 0.5360710321864596,
+                "macro_roc_auc": 0.6658859303090073,
+                "macro_pr_auc": 0.543737763975528
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4205115005115005,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.0974779124813816,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    10,
+                    2
+                  ],
+                  [
+                    12,
+                    13,
+                    20
+                  ],
+                  [
+                    19,
+                    6,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3404255319148936,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.4266666666666666,
+                    "support": 28,
+                    "roc_auc": 0.7255434782608695,
+                    "pr_auc": 0.43602147387235834
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4482758620689655,
+                    "recall": 0.28888888888888886,
+                    "f1": 0.35135135135135137,
+                    "support": 45,
+                    "roc_auc": 0.5288888888888889,
+                    "pr_auc": 0.44316439696128845
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.46808510638297873,
+                    "f1": 0.4835164835164835,
+                    "support": 47,
+                    "roc_auc": 0.5651413582046051,
+                    "pr_auc": 0.42544465976709356
+                  }
+                ],
+                "macro_precision": 0.42956713132795304,
+                "macro_recall": 0.44280085556681303,
+                "macro_f1": 0.4205115005115005,
+                "weighted_f1": 0.4206896016896017,
+                "macro_roc_auc": 0.6065245751181211,
+                "macro_pr_auc": 0.43487684353358014
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.47340090779004806,
+              "regime_accuracy": 0.6779661178588867,
+              "regime_loss": 0.662644978802083,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    0
+                  ],
+                  [
+                    7,
+                    2,
+                    3
+                  ],
+                  [
+                    9,
+                    17,
+                    70
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.8,
+                    "f1": 0.47058823529411764,
+                    "support": 10,
+                    "roc_auc": 0.9231481481481482,
+                    "pr_auc": 0.42240559277323986
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.09523809523809523,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.12121212121212123,
+                    "support": 12,
+                    "roc_auc": 0.5731132075471698,
+                    "pr_auc": 0.10596436779462584
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.958904109589041,
+                    "recall": 0.7291666666666666,
+                    "f1": 0.8284023668639053,
+                    "support": 96,
+                    "roc_auc": 0.9019886363636364,
+                    "pr_auc": 0.9775676630539
+                  }
+                ],
+                "macro_precision": 0.46249184605348986,
+                "macro_recall": 0.5652777777777778,
+                "macro_f1": 0.47340090779004806,
+                "weighted_f1": 0.7261614832747588,
+                "macro_roc_auc": 0.7994166640196515,
+                "macro_pr_auc": 0.5019792078739219
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4048986598006206,
+              "regime_accuracy": 0.41818180680274963,
+              "regime_loss": 1.1115274450995705,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    2
+                  ],
+                  [
+                    25,
+                    23,
+                    30
+                  ],
+                  [
+                    0,
+                    4,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.21875,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.31818181818181823,
+                    "support": 12,
+                    "roc_auc": 0.6539115646258503,
+                    "pr_auc": 0.16845242515413147
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7666666666666667,
+                    "recall": 0.2948717948717949,
+                    "f1": 0.425925925925926,
+                    "support": 78,
+                    "roc_auc": 0.4551282051282051,
+                    "pr_auc": 0.7214761560045678
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.8,
+                    "f1": 0.47058823529411764,
+                    "support": 20,
+                    "roc_auc": 0.78,
+                    "pr_auc": 0.34565750775336407
+                  }
+                ],
+                "macro_precision": 0.4395833333333334,
+                "macro_recall": 0.5594017094017094,
+                "macro_f1": 0.4048986598006206,
+                "weighted_f1": 0.4222924431480582,
+                "macro_roc_auc": 0.6296799232513518,
+                "macro_pr_auc": 0.41186202963735447
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.38661297852474324,
+              "regime_accuracy": 0.4054054021835327,
+              "regime_loss": 1.054618985691698,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    25,
+                    5,
+                    14
+                  ],
+                  [
+                    25,
+                    10,
+                    13
+                  ],
+                  [
+                    8,
+                    1,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.43103448275862066,
+                    "recall": 0.5681818181818182,
+                    "f1": 0.4901960784313726,
+                    "support": 44,
+                    "roc_auc": 0.5841248303934871,
+                    "pr_auc": 0.43224025309455066
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.625,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.3125,
+                    "support": 48,
+                    "roc_auc": 0.6021825396825397,
+                    "pr_auc": 0.5283692832315763
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2702702702702703,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.35714285714285715,
+                    "support": 19,
+                    "roc_auc": 0.5955377574370709,
+                    "pr_auc": 0.3214678305994631
+                  }
+                ],
+                "macro_precision": 0.44210158434296365,
+                "macro_recall": 0.4342769803296119,
+                "macro_f1": 0.38661297852474324,
+                "weighted_f1": 0.3905796552855376,
+                "macro_roc_auc": 0.5939483758376992,
+                "macro_pr_auc": 0.42735912230853
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.380536398467433,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.0274375585409312,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    5,
+                    6
+                  ],
+                  [
+                    28,
+                    11,
+                    13
+                  ],
+                  [
+                    6,
+                    7,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.30612244897959184,
+                    "recall": 0.5769230769230769,
+                    "f1": 0.4,
+                    "support": 26,
+                    "roc_auc": 0.6301775147928994,
+                    "pr_auc": 0.38457147568474653
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4782608695652174,
+                    "recall": 0.21153846153846154,
+                    "f1": 0.29333333333333333,
+                    "support": 52,
+                    "roc_auc": 0.5240384615384616,
+                    "pr_auc": 0.5052055136344965
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.40625,
+                    "recall": 0.5,
+                    "f1": 0.4482758620689655,
+                    "support": 26,
+                    "roc_auc": 0.7016765285996055,
+                    "pr_auc": 0.46038483239550193
+                  }
+                ],
+                "macro_precision": 0.39687777284826975,
+                "macro_recall": 0.42948717948717946,
+                "macro_f1": 0.380536398467433,
+                "weighted_f1": 0.3587356321839081,
+                "macro_roc_auc": 0.6186308349769888,
+                "macro_pr_auc": 0.4500539405715817
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.37816709514516655,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.0748210111109278,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    14,
+                    7
+                  ],
+                  [
+                    5,
+                    11,
+                    29
+                  ],
+                  [
+                    3,
+                    13,
+                    31
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4666666666666667,
+                    "recall": 0.25,
+                    "f1": 0.32558139534883723,
+                    "support": 28,
+                    "roc_auc": 0.7274844720496895,
+                    "pr_auc": 0.3536804959952101
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2894736842105263,
+                    "recall": 0.24444444444444444,
+                    "f1": 0.26506024096385544,
+                    "support": 45,
+                    "roc_auc": 0.4740740740740741,
+                    "pr_auc": 0.35229126339491745
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4626865671641791,
+                    "recall": 0.6595744680851063,
+                    "f1": 0.5438596491228069,
+                    "support": 47,
+                    "roc_auc": 0.6164383561643836,
+                    "pr_auc": 0.4723758893150604
+                  }
+                ],
+                "macro_precision": 0.4062756393471241,
+                "macro_recall": 0.3846729708431836,
+                "macro_f1": 0.37816709514516655,
+                "weighted_f1": 0.38837827851594053,
+                "macro_roc_auc": 0.6059989674293824,
+                "macro_pr_auc": 0.39278254956839603
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.42929082412424724,
+              "regime_accuracy": 0.6355932354927063,
+              "regime_loss": 0.7711304981829756,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    5,
+                    2,
+                    5
+                  ],
+                  [
+                    16,
+                    14,
+                    66
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.7,
+                    "f1": 0.3684210526315789,
+                    "support": 10,
+                    "roc_auc": 0.8462962962962963,
+                    "pr_auc": 0.2104537866744498
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.10526315789473684,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.12903225806451615,
+                    "support": 12,
+                    "roc_auc": 0.6501572327044025,
+                    "pr_auc": 0.13074128296920817
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9295774647887324,
+                    "recall": 0.6875,
+                    "f1": 0.7904191616766466,
+                    "support": 96,
+                    "roc_auc": 0.8404356060606061,
+                    "pr_auc": 0.9638021539653522
+                  }
+                ],
+                "macro_precision": 0.4282802075611564,
+                "macro_recall": 0.5180555555555556,
+                "macro_f1": 0.42929082412424724,
+                "weighted_f1": 0.6873969249495598,
+                "macro_roc_auc": 0.778963045020435,
+                "macro_pr_auc": 0.43499907453633674
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2710063598952488,
+              "regime_accuracy": 0.26363635063171387,
+              "regime_loss": 1.1821536714380438,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    23,
+                    2,
+                    53
+                  ],
+                  [
+                    1,
+                    0,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.36363636363636365,
+                    "support": 12,
+                    "roc_auc": 0.7372448979591837,
+                    "pr_auc": 0.2481815819001383
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.02564102564102564,
+                    "f1": 0.04938271604938271,
+                    "support": 78,
+                    "roc_auc": 0.44511217948717946,
+                    "pr_auc": 0.7259476745448071
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.25333333333333335,
+                    "recall": 0.95,
+                    "f1": 0.39999999999999997,
+                    "support": 20,
+                    "roc_auc": 0.7611111111111111,
+                    "pr_auc": 0.30664642175283263
+                  }
+                ],
+                "macro_precision": 0.38999999999999996,
+                "macro_recall": 0.5474358974358974,
+                "macro_f1": 0.2710063598952488,
+                "weighted_f1": 0.14741352923171105,
+                "macro_roc_auc": 0.6478227295191581,
+                "macro_pr_auc": 0.42692522606592603
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.37923046603602156,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.2932038053518526,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    15,
+                    12
+                  ],
+                  [
+                    16,
+                    12,
+                    20
+                  ],
+                  [
+                    4,
+                    2,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4594594594594595,
+                    "recall": 0.38636363636363635,
+                    "f1": 0.41975308641975306,
+                    "support": 44,
+                    "roc_auc": 0.6146540027137042,
+                    "pr_auc": 0.45033780135003804
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.41379310344827586,
+                    "recall": 0.25,
+                    "f1": 0.31168831168831174,
+                    "support": 48,
+                    "roc_auc": 0.4947089947089947,
+                    "pr_auc": 0.44886420365991253
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.28888888888888886,
+                    "recall": 0.6842105263157895,
+                    "f1": 0.40625,
+                    "support": 19,
+                    "roc_auc": 0.6430205949656751,
+                    "pr_auc": 0.2437967127248971
+                  }
+                ],
+                "macro_precision": 0.3873804839322081,
+                "macro_recall": 0.44019138755980863,
+                "macro_f1": 0.37923046603602156,
+                "weighted_f1": 0.3707110339054784,
+                "macro_roc_auc": 0.5841278641294579,
+                "macro_pr_auc": 0.3809995725782826
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.46885622970714746,
+              "regime_accuracy": 0.48076921701431274,
+              "regime_loss": 1.075956445473891,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    8,
+                    8
+                  ],
+                  [
+                    13,
+                    23,
+                    16
+                  ],
+                  [
+                    5,
+                    4,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35714285714285715,
+                    "recall": 0.38461538461538464,
+                    "f1": 0.3703703703703704,
+                    "support": 26,
+                    "roc_auc": 0.611439842209073,
+                    "pr_auc": 0.3599669067078949
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6571428571428571,
+                    "recall": 0.4423076923076923,
+                    "f1": 0.528735632183908,
+                    "support": 52,
+                    "roc_auc": 0.6335059171597633,
+                    "pr_auc": 0.6250758484758844
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4146341463414634,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.5074626865671641,
+                    "support": 26,
+                    "roc_auc": 0.7287968441814595,
+                    "pr_auc": 0.5741794187430664
+                  }
+                ],
+                "macro_precision": 0.4763066202090592,
+                "macro_recall": 0.4935897435897436,
+                "macro_f1": 0.46885622970714746,
+                "weighted_f1": 0.48382608032633756,
+                "macro_roc_auc": 0.6579142011834319,
+                "macro_pr_auc": 0.5197407246422819
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "regression": [
+      {
+        "head_mode": "regression",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.23921586922859886,
+              "regime_accuracy": 0.36666667461395264,
+              "regime_loss": 1.0821080800891392,
+              "regression_rmse_log_rv": 0.9118455125988518,
+              "regression_mae_log_rv": 0.7651652749686036,
+              "regression_loss": 0.8314622388466628,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    2,
+                    24
+                  ],
+                  [
+                    5,
+                    2,
+                    38
+                  ],
+                  [
+                    3,
+                    4,
+                    40
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2,
+                    "recall": 0.07142857142857142,
+                    "f1": 0.10526315789473682,
+                    "support": 28,
+                    "roc_auc": 0.610248447204969,
+                    "pr_auc": 0.264533804199863
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.044444444444444446,
+                    "f1": 0.07547169811320754,
+                    "support": 45,
+                    "roc_auc": 0.49807407407407406,
+                    "pr_auc": 0.41088444659861967
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.39215686274509803,
+                    "recall": 0.851063829787234,
+                    "f1": 0.5369127516778522,
+                    "support": 47,
+                    "roc_auc": 0.6791023025357039,
+                    "pr_auc": 0.5435947522550403
+                  }
+                ],
+                "macro_precision": 0.280718954248366,
+                "macro_recall": 0.32231228188675,
+                "macro_f1": 0.23921586922859886,
+                "weighted_f1": 0.26315411804171684,
+                "macro_roc_auc": 0.5958082746049157,
+                "macro_pr_auc": 0.40633766768450763
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4114948683623383,
+              "regime_accuracy": 0.6610169410705566,
+              "regime_loss": 0.9642943073127229,
+              "regression_rmse_log_rv": 0.7947455218814758,
+              "regression_mae_log_rv": 0.610162807273347,
+              "regression_loss": 0.6316204445506595,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    11,
+                    1,
+                    0
+                  ],
+                  [
+                    17,
+                    9,
+                    70
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2,
+                    "recall": 0.7,
+                    "f1": 0.3111111111111111,
+                    "support": 10,
+                    "roc_auc": 0.6638888888888889,
+                    "pr_auc": 0.17176279289722982
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.07692307692307693,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.08,
+                    "support": 12,
+                    "roc_auc": 0.7161949685534591,
+                    "pr_auc": 0.14875444636630844
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.7291666666666666,
+                    "f1": 0.8433734939759037,
+                    "support": 96,
+                    "roc_auc": 0.8991477272727273,
+                    "pr_auc": 0.9783648121710947
+                  }
+                ],
+                "macro_precision": 0.4256410256410256,
+                "macro_recall": 0.5041666666666667,
+                "macro_f1": 0.4114948683623383,
+                "weighted_f1": 0.7206353095999819,
+                "macro_roc_auc": 0.7597438615716917,
+                "macro_pr_auc": 0.4329606838115443
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.20463361496360064,
+              "regime_accuracy": 0.20909090340137482,
+              "regime_loss": 1.1633926499973644,
+              "regression_rmse_log_rv": 0.5553702630216608,
+              "regression_mae_log_rv": 0.4333778104554354,
+              "regression_loss": 0.3084361290487487,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    4,
+                    0,
+                    8
+                  ],
+                  [
+                    15,
+                    4,
+                    59
+                  ],
+                  [
+                    5,
+                    0,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.2222222222222222,
+                    "support": 12,
+                    "roc_auc": 0.5620748299319728,
+                    "pr_auc": 0.11063102055280578
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.05128205128205128,
+                    "f1": 0.09756097560975609,
+                    "support": 78,
+                    "roc_auc": 0.6354166666666666,
+                    "pr_auc": 0.8291954338471345
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.18292682926829268,
+                    "recall": 0.75,
+                    "f1": 0.2941176470588236,
+                    "support": 20,
+                    "roc_auc": 0.5083333333333333,
+                    "pr_auc": 0.16814489446146236
+                  }
+                ],
+                "macro_precision": 0.44986449864498645,
+                "macro_recall": 0.3782051282051282,
+                "macro_f1": 0.20463361496360064,
+                "weighted_f1": 0.14689796095821922,
+                "macro_roc_auc": 0.5686082766439909,
+                "macro_pr_auc": 0.3693237829538009
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3655538302277433,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.0981363126952872,
+              "regression_rmse_log_rv": 0.7941614161862232,
+              "regression_mae_log_rv": 0.6261634605827632,
+              "regression_loss": 0.6306923549589076,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    29,
+                    9,
+                    6
+                  ],
+                  [
+                    30,
+                    6,
+                    12
+                  ],
+                  [
+                    9,
+                    1,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4264705882352941,
+                    "recall": 0.6590909090909091,
+                    "f1": 0.5178571428571429,
+                    "support": 44,
+                    "roc_auc": 0.5074626865671642,
+                    "pr_auc": 0.3820144034022563
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.375,
+                    "recall": 0.125,
+                    "f1": 0.1875,
+                    "support": 48,
+                    "roc_auc": 0.435515873015873,
+                    "pr_auc": 0.38427500563743167
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.391304347826087,
+                    "support": 19,
+                    "roc_auc": 0.522883295194508,
+                    "pr_auc": 0.2051776734510127
+                  }
+                ],
+                "macro_precision": 0.37826797385620914,
+                "macro_recall": 0.4192583732057416,
+                "macro_f1": 0.3655538302277433,
+                "weighted_f1": 0.353337809859549,
+                "macro_roc_auc": 0.48862061825918174,
+                "macro_pr_auc": 0.3238223608302336
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.35705705705705704,
+              "regime_accuracy": 0.36538460850715637,
+              "regime_loss": 1.1010444531073937,
+              "regression_rmse_log_rv": 0.8050657560693467,
+              "regression_mae_log_rv": 0.6410062341109062,
+              "regression_loss": 0.6481308715955089,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    1,
+                    11
+                  ],
+                  [
+                    25,
+                    7,
+                    20
+                  ],
+                  [
+                    9,
+                    0,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2916666666666667,
+                    "recall": 0.5384615384615384,
+                    "f1": 0.3783783783783784,
+                    "support": 26,
+                    "roc_auc": 0.571992110453649,
+                    "pr_auc": 0.347558278122487
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.875,
+                    "recall": 0.1346153846153846,
+                    "f1": 0.23333333333333334,
+                    "support": 52,
+                    "roc_auc": 0.6168639053254438,
+                    "pr_auc": 0.6283426401079218
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3541666666666667,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.4594594594594595,
+                    "support": 26,
+                    "roc_auc": 0.6568047337278107,
+                    "pr_auc": 0.4408289974180565
+                  }
+                ],
+                "macro_precision": 0.5069444444444445,
+                "macro_recall": 0.4423076923076923,
+                "macro_f1": 0.35705705705705704,
+                "weighted_f1": 0.3261261261261261,
+                "macro_roc_auc": 0.6152202498356344,
+                "macro_pr_auc": 0.47224330521615515
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.27205571971295905,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.13877626184835,
+              "regression_rmse_log_rv": 0.9201486759998011,
+              "regression_mae_log_rv": 0.7806412715523038,
+              "regression_loss": 0.846673585944187,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    0,
+                    11
+                  ],
+                  [
+                    23,
+                    0,
+                    22
+                  ],
+                  [
+                    24,
+                    0,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.265625,
+                    "recall": 0.6071428571428571,
+                    "f1": 0.3695652173913044,
+                    "support": 28,
+                    "roc_auc": 0.6366459627329193,
+                    "pr_auc": 0.27790876403114795
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 45,
+                    "roc_auc": 0.5934814814814815,
+                    "pr_auc": 0.4623362009638759
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4107142857142857,
+                    "recall": 0.48936170212765956,
+                    "f1": 0.4466019417475728,
+                    "support": 47,
+                    "roc_auc": 0.4660448848732148,
+                    "pr_auc": 0.3520879614858659
+                  }
+                ],
+                "macro_precision": 0.22544642857142858,
+                "macro_recall": 0.3655015197568389,
+                "macro_f1": 0.27205571971295905,
+                "weighted_f1": 0.2611509779091037,
+                "macro_roc_auc": 0.5653907763625385,
+                "macro_pr_auc": 0.36411097549362986
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.37501659365458656,
+              "regime_accuracy": 0.6355932354927063,
+              "regime_loss": 1.0202776658332955,
+              "regression_rmse_log_rv": 0.7765235865524552,
+              "regression_mae_log_rv": 0.6104141428308972,
+              "regression_loss": 0.6029888804722885,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    11,
+                    0,
+                    1
+                  ],
+                  [
+                    31,
+                    0,
+                    65
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.19230769230769232,
+                    "recall": 1.0,
+                    "f1": 0.32258064516129037,
+                    "support": 10,
+                    "roc_auc": 0.9453703703703704,
+                    "pr_auc": 0.4702424188714512
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.2586477987421384,
+                    "pr_auc": 0.06412278257502832
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9848484848484849,
+                    "recall": 0.6770833333333334,
+                    "f1": 0.8024691358024691,
+                    "support": 96,
+                    "roc_auc": 0.7154356060606061,
+                    "pr_auc": 0.8961922256717394
+                  }
+                ],
+                "macro_precision": 0.3923853923853924,
+                "macro_recall": 0.5590277777777778,
+                "macro_f1": 0.37501659365458656,
+                "weighted_f1": 0.6801935888868639,
+                "macro_roc_auc": 0.639817925057705,
+                "macro_pr_auc": 0.476852475706073
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.14489724834552423,
+              "regime_accuracy": 0.145454540848732,
+              "regime_loss": 1.3012215354225851,
+              "regression_rmse_log_rv": 0.4938513804182131,
+              "regression_mae_log_rv": 0.4118068482155319,
+              "regression_loss": 0.24388918594097464,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    11,
+                    0,
+                    1
+                  ],
+                  [
+                    49,
+                    0,
+                    29
+                  ],
+                  [
+                    15,
+                    0,
+                    5
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.14666666666666667,
+                    "recall": 0.9166666666666666,
+                    "f1": 0.25287356321839083,
+                    "support": 12,
+                    "roc_auc": 0.7687074829931972,
+                    "pr_auc": 0.2560266931135707
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.5276442307692307,
+                    "pr_auc": 0.7559126967837413
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.14285714285714285,
+                    "recall": 0.25,
+                    "f1": 0.18181818181818182,
+                    "support": 20,
+                    "roc_auc": 0.34555555555555556,
+                    "pr_auc": 0.1309215051350848
+                  }
+                ],
+                "macro_precision": 0.0965079365079365,
+                "macro_recall": 0.38888888888888884,
+                "macro_f1": 0.14489724834552423,
+                "weighted_f1": 0.06064405813622115,
+                "macro_roc_auc": 0.5473024231059945,
+                "macro_pr_auc": 0.3809536316774656
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.22549019607843138,
+              "regime_accuracy": 0.342342346906662,
+              "regime_loss": 1.1811379903008385,
+              "regression_rmse_log_rv": 0.7892380945715978,
+              "regression_mae_log_rv": 0.628512033068382,
+              "regression_loss": 0.6228967699230062,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    35,
+                    0,
+                    9
+                  ],
+                  [
+                    45,
+                    0,
+                    3
+                  ],
+                  [
+                    16,
+                    0,
+                    3
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3645833333333333,
+                    "recall": 0.7954545454545454,
+                    "f1": 0.5,
+                    "support": 44,
+                    "roc_auc": 0.4833785617367707,
+                    "pr_auc": 0.3809954076111993
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.48148148148148145,
+                    "pr_auc": 0.4359754123587847
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2,
+                    "recall": 0.15789473684210525,
+                    "f1": 0.17647058823529413,
+                    "support": 19,
+                    "roc_auc": 0.5812356979405034,
+                    "pr_auc": 0.22497843361852027
+                  }
+                ],
+                "macro_precision": 0.18819444444444444,
+                "macro_recall": 0.31778309409888356,
+                "macro_f1": 0.22549019607843138,
+                "weighted_f1": 0.22840487546369898,
+                "macro_roc_auc": 0.5153652470529185,
+                "macro_pr_auc": 0.34731641786283474
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.32427672955974846,
+              "regime_accuracy": 0.35576921701431274,
+              "regime_loss": 1.2440704015585093,
+              "regression_rmse_log_rv": 0.8493911237378291,
+              "regression_mae_log_rv": 0.6849189973346745,
+              "regression_loss": 0.721465281084612,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    24,
+                    0,
+                    2
+                  ],
+                  [
+                    43,
+                    0,
+                    9
+                  ],
+                  [
+                    13,
+                    0,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3,
+                    "recall": 0.9230769230769231,
+                    "f1": 0.4528301886792453,
+                    "support": 26,
+                    "roc_auc": 0.6143984220907298,
+                    "pr_auc": 0.36043861261800103
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.3768491124260355,
+                    "pr_auc": 0.40439067582724714
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5416666666666666,
+                    "recall": 0.5,
+                    "f1": 0.52,
+                    "support": 26,
+                    "roc_auc": 0.6868836291913215,
+                    "pr_auc": 0.3747110683118856
+                  }
+                ],
+                "macro_precision": 0.2805555555555555,
+                "macro_recall": 0.4743589743589744,
+                "macro_f1": 0.32427672955974846,
+                "weighted_f1": 0.24320754716981133,
+                "macro_roc_auc": 0.5593770545693623,
+                "macro_pr_auc": 0.3798467855857113
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.20088075880758804,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.1051832156266266,
+              "regression_rmse_log_rv": 0.9945336278188166,
+              "regression_mae_log_rv": 0.8241495193350905,
+              "regression_loss": 0.9890971368624564,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    1,
+                    27
+                  ],
+                  [
+                    0,
+                    1,
+                    44
+                  ],
+                  [
+                    0,
+                    1,
+                    46
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 28,
+                    "roc_auc": 0.32104037267080743,
+                    "pr_auc": 0.1633479563691464
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.022222222222222223,
+                    "f1": 0.04166666666666667,
+                    "support": 45,
+                    "roc_auc": 0.5105185185185185,
+                    "pr_auc": 0.38580526311029983
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.39316239316239315,
+                    "recall": 0.9787234042553191,
+                    "f1": 0.5609756097560975,
+                    "support": 47,
+                    "roc_auc": 0.5048090935587293,
+                    "pr_auc": 0.3807955221370434
+                  }
+                ],
+                "macro_precision": 0.24216524216524216,
+                "macro_recall": 0.33364854215918044,
+                "macro_f1": 0.20088075880758804,
+                "weighted_f1": 0.23534044715447153,
+                "macro_roc_auc": 0.4454559949160184,
+                "macro_pr_auc": 0.3099829138721632
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4589460784313726,
+              "regime_accuracy": 0.805084764957428,
+              "regime_loss": 0.9666728619801797,
+              "regression_rmse_log_rv": 0.75776564130949,
+              "regression_mae_log_rv": 0.5942790184043727,
+              "regression_loss": 0.5742087671491826,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    5,
+                    5
+                  ],
+                  [
+                    0,
+                    8,
+                    4
+                  ],
+                  [
+                    0,
+                    9,
+                    87
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 10,
+                    "roc_auc": 0.6231481481481481,
+                    "pr_auc": 0.16282487186297623
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.36363636363636365,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.4705882352941177,
+                    "support": 12,
+                    "roc_auc": 0.6871069182389937,
+                    "pr_auc": 0.17599368998936624
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.90625,
+                    "recall": 0.90625,
+                    "f1": 0.90625,
+                    "support": 96,
+                    "roc_auc": 0.743844696969697,
+                    "pr_auc": 0.8579551668861052
+                  }
+                ],
+                "macro_precision": 0.4232954545454546,
+                "macro_recall": 0.5243055555555555,
+                "macro_f1": 0.4589460784313726,
+                "weighted_f1": 0.7851445663010966,
+                "macro_roc_auc": 0.6846999211189463,
+                "macro_pr_auc": 0.39892457624614924
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.10256410256410257,
+              "regime_accuracy": 0.1818181872367859,
+              "regime_loss": 1.0914857864379883,
+              "regression_rmse_log_rv": 0.3918154019753048,
+              "regression_mae_log_rv": 0.3045116290894591,
+              "regression_loss": 0.15351930922506968,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    12
+                  ],
+                  [
+                    0,
+                    0,
+                    78
+                  ],
+                  [
+                    0,
+                    0,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.2950680272108844,
+                    "pr_auc": 0.07201838485797361
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.49198717948717946,
+                    "pr_auc": 0.7123393089034797
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.18181818181818182,
+                    "recall": 1.0,
+                    "f1": 0.3076923076923077,
+                    "support": 20,
+                    "roc_auc": 0.7105555555555556,
+                    "pr_auc": 0.32523359043140365
+                  }
+                ],
+                "macro_precision": 0.06060606060606061,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.10256410256410257,
+                "weighted_f1": 0.055944055944055944,
+                "macro_roc_auc": 0.49920358741787313,
+                "macro_pr_auc": 0.369863761397619
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.22665796912372257,
+              "regime_accuracy": 0.2702702581882477,
+              "regime_loss": 1.1485329592015316,
+              "regression_rmse_log_rv": 0.8016780295442142,
+              "regression_mae_log_rv": 0.6350417647947062,
+              "regression_loss": 0.6426876630538939,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    10,
+                    34
+                  ],
+                  [
+                    0,
+                    13,
+                    35
+                  ],
+                  [
+                    0,
+                    2,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.45725915875169604,
+                    "pr_auc": 0.3943342347382423
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.52,
+                    "recall": 0.2708333333333333,
+                    "f1": 0.35616438356164387,
+                    "support": 48,
+                    "roc_auc": 0.48644179894179895,
+                    "pr_auc": 0.48450869450437417
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19767441860465115,
+                    "recall": 0.8947368421052632,
+                    "f1": 0.32380952380952377,
+                    "support": 19,
+                    "roc_auc": 0.4839816933638444,
+                    "pr_auc": 0.15393243021571928
+                  }
+                ],
+                "macro_precision": 0.2392248062015504,
+                "macro_recall": 0.3885233918128655,
+                "macro_f1": 0.22665796912372257,
+                "weighted_f1": 0.20944388615621493,
+                "macro_roc_auc": 0.47589421701911316,
+                "macro_pr_auc": 0.3442584531527786
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.13333333333333333,
+              "regime_accuracy": 0.25,
+              "regime_loss": 1.1187673715444713,
+              "regression_rmse_log_rv": 0.7990200445171354,
+              "regression_mae_log_rv": 0.6394113830666845,
+              "regression_loss": 0.638433031540165,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    26
+                  ],
+                  [
+                    0,
+                    0,
+                    52
+                  ],
+                  [
+                    0,
+                    0,
+                    26
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5177514792899408,
+                    "pr_auc": 0.2795591542759995
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.5695266272189349,
+                    "pr_auc": 0.6121361925328235
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.25,
+                    "recall": 1.0,
+                    "f1": 0.4,
+                    "support": 26,
+                    "roc_auc": 0.5014792899408284,
+                    "pr_auc": 0.22970881329187925
+                  }
+                ],
+                "macro_precision": 0.08333333333333333,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.13333333333333333,
+                "weighted_f1": 0.1,
+                "macro_roc_auc": 0.529585798816568,
+                "macro_pr_auc": 0.37380138670023405
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.21128579023315866,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.131356551862783,
+              "regression_rmse_log_rv": 0.9228105824724431,
+              "regression_mae_log_rv": 0.7779760270748132,
+              "regression_loss": 0.8515793711231296,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    28,
+                    0
+                  ],
+                  [
+                    1,
+                    38,
+                    6
+                  ],
+                  [
+                    0,
+                    43,
+                    4
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 28,
+                    "roc_auc": 0.24145962732919254,
+                    "pr_auc": 0.15324510227349714
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3486238532110092,
+                    "recall": 0.8444444444444444,
+                    "f1": 0.49350649350649356,
+                    "support": 45,
+                    "roc_auc": 0.41125925925925927,
+                    "pr_auc": 0.3230890677953051
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4,
+                    "recall": 0.0851063829787234,
+                    "f1": 0.14035087719298245,
+                    "support": 47,
+                    "roc_auc": 0.3398426114835325,
+                    "pr_auc": 0.32945094947481285
+                  }
+                ],
+                "macro_precision": 0.24954128440366974,
+                "macro_recall": 0.3098502758077226,
+                "macro_f1": 0.21128579023315866,
+                "weighted_f1": 0.2400356952988532,
+                "macro_roc_auc": 0.33085383269066143,
+                "macro_pr_auc": 0.2685950398478717
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.2623275746618455,
+              "regime_accuracy": 0.39830508828163147,
+              "regime_loss": 1.100512557110544,
+              "regression_rmse_log_rv": 0.801841058930371,
+              "regression_mae_log_rv": 0.6365151244957569,
+              "regression_loss": 0.6429490837865788,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    10,
+                    0
+                  ],
+                  [
+                    0,
+                    12,
+                    0
+                  ],
+                  [
+                    0,
+                    61,
+                    35
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 10,
+                    "roc_auc": 0.25092592592592594,
+                    "pr_auc": 0.05307525281543644
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.14457831325301204,
+                    "recall": 1.0,
+                    "f1": 0.25263157894736843,
+                    "support": 12,
+                    "roc_auc": 0.8238993710691824,
+                    "pr_auc": 0.3208062169127178
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.3645833333333333,
+                    "f1": 0.5343511450381679,
+                    "support": 96,
+                    "roc_auc": 0.7921401515151515,
+                    "pr_auc": 0.953776777843177
+                  }
+                ],
+                "macro_precision": 0.3815261044176707,
+                "macro_recall": 0.4548611111111111,
+                "macro_f1": 0.2623275746618455,
+                "weighted_f1": 0.460417702296886,
+                "macro_roc_auc": 0.6223218161700866,
+                "macro_pr_auc": 0.44255274919044374
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.27027027027027023,
+              "regime_accuracy": 0.6818181872367859,
+              "regime_loss": 1.0369742870330811,
+              "regression_rmse_log_rv": 0.6298629193672407,
+              "regression_mae_log_rv": 0.4649931574896486,
+              "regression_loss": 0.39672729719382316,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    12,
+                    0
+                  ],
+                  [
+                    0,
+                    75,
+                    3
+                  ],
+                  [
+                    0,
+                    20,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.24319727891156462,
+                    "pr_auc": 0.06753773152959944
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7009345794392523,
+                    "recall": 0.9615384615384616,
+                    "f1": 0.8108108108108106,
+                    "support": 78,
+                    "roc_auc": 0.6209935897435898,
+                    "pr_auc": 0.8208326510964475
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.3438888888888889,
+                    "pr_auc": 0.13196737093259361
+                  }
+                ],
+                "macro_precision": 0.2336448598130841,
+                "macro_recall": 0.32051282051282054,
+                "macro_f1": 0.27027027027027023,
+                "weighted_f1": 0.5749385749385748,
+                "macro_roc_auc": 0.4026932525146811,
+                "macro_pr_auc": 0.3401125845195469
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2012578616352201,
+              "regime_accuracy": 0.4324324429035187,
+              "regime_loss": 1.0799826951171,
+              "regression_rmse_log_rv": 0.8147001153381339,
+              "regression_mae_log_rv": 0.6487172436942389,
+              "regression_loss": 0.6637362779319687,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    44,
+                    0
+                  ],
+                  [
+                    0,
+                    48,
+                    0
+                  ],
+                  [
+                    0,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.4596336499321574,
+                    "pr_auc": 0.3994773265537042
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.43243243243243246,
+                    "recall": 1.0,
+                    "f1": 0.6037735849056604,
+                    "support": 48,
+                    "roc_auc": 0.4861111111111111,
+                    "pr_auc": 0.4721724239344162
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.6189931350114416,
+                    "pr_auc": 0.2627117618224163
+                  }
+                ],
+                "macro_precision": 0.14414414414414414,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.2012578616352201,
+                "weighted_f1": 0.2610912799592045,
+                "macro_roc_auc": 0.5215792986849034,
+                "macro_pr_auc": 0.3781205041035123
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2830349531116794,
+              "regime_accuracy": 0.4423076808452606,
+              "regime_loss": 1.0679694505838246,
+              "regression_rmse_log_rv": 0.8071767488674603,
+              "regression_mae_log_rv": 0.6625240515075768,
+              "regression_loss": 0.651534303912243,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    24,
+                    2
+                  ],
+                  [
+                    0,
+                    40,
+                    12
+                  ],
+                  [
+                    0,
+                    20,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5414201183431953,
+                    "pr_auc": 0.3300390665257315
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.47619047619047616,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.588235294117647,
+                    "support": 52,
+                    "roc_auc": 0.5355029585798816,
+                    "pr_auc": 0.5427054017553616
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.2608695652173913,
+                    "support": 26,
+                    "roc_auc": 0.5488165680473372,
+                    "pr_auc": 0.2678860531738126
+                  }
+                ],
+                "macro_precision": 0.2587301587301587,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.2830349531116794,
+                "weighted_f1": 0.3593350383631713,
+                "macro_roc_auc": 0.5419132149901381,
+                "macro_pr_auc": 0.3802101738183019
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.28715075773899307,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.1398225487206097,
+              "regression_rmse_log_rv": 0.9523164924295839,
+              "regression_mae_log_rv": 0.7923175160520866,
+              "regression_loss": 0.9069067017533858,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    12,
+                    0
+                  ],
+                  [
+                    19,
+                    26,
+                    0
+                  ],
+                  [
+                    28,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25396825396825395,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.3516483516483516,
+                    "support": 28,
+                    "roc_auc": 0.4343944099378882,
+                    "pr_auc": 0.2071187585003888
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.45614035087719296,
+                    "recall": 0.5777777777777777,
+                    "f1": 0.5098039215686275,
+                    "support": 45,
+                    "roc_auc": 0.530962962962963,
+                    "pr_auc": 0.42357711676137644
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.35966190614981053,
+                    "pr_auc": 0.33735212458835984
+                  }
+                ],
+                "macro_precision": 0.23670286828181564,
+                "macro_recall": 0.38306878306878306,
+                "macro_f1": 0.28715075773899307,
+                "weighted_f1": 0.2732277526395174,
+                "macro_roc_auc": 0.44167309301688723,
+                "macro_pr_auc": 0.32268266661670836
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.12179487179487179,
+              "regime_accuracy": 0.11864406615495682,
+              "regime_loss": 1.2433766510527013,
+              "regression_rmse_log_rv": 0.7306937882847327,
+              "regression_mae_log_rv": 0.5722390525674416,
+              "regression_loss": 0.5339134122378938,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    7,
+                    0
+                  ],
+                  [
+                    1,
+                    11,
+                    0
+                  ],
+                  [
+                    38,
+                    58,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.07142857142857142,
+                    "recall": 0.3,
+                    "f1": 0.11538461538461536,
+                    "support": 10,
+                    "roc_auc": 0.3851851851851852,
+                    "pr_auc": 0.07292374005283907
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.14473684210526316,
+                    "recall": 0.9166666666666666,
+                    "f1": 0.25,
+                    "support": 12,
+                    "roc_auc": 0.7507861635220126,
+                    "pr_auc": 0.21319786790740414
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 96,
+                    "roc_auc": 0.4133522727272727,
+                    "pr_auc": 0.7941379313368787
+                  }
+                ],
+                "macro_precision": 0.07205513784461152,
+                "macro_recall": 0.4055555555555555,
+                "macro_f1": 0.12179487179487179,
+                "weighted_f1": 0.035202086049543675,
+                "macro_roc_auc": 0.5164412071448234,
+                "macro_pr_auc": 0.36008651309904066
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2528735632183908,
+              "regime_accuracy": 0.6000000238418579,
+              "regime_loss": 1.0579484614458952,
+              "regression_rmse_log_rv": 0.5283367199787778,
+              "regression_mae_log_rv": 0.40083823702933097,
+              "regression_loss": 0.2791396896779335,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    12,
+                    0
+                  ],
+                  [
+                    12,
+                    66,
+                    0
+                  ],
+                  [
+                    2,
+                    18,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.3358843537414966,
+                    "pr_auc": 0.0794879536570557
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6875,
+                    "recall": 0.8461538461538461,
+                    "f1": 0.7586206896551724,
+                    "support": 78,
+                    "roc_auc": 0.49599358974358976,
+                    "pr_auc": 0.7073027701776448
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.45555555555555555,
+                    "pr_auc": 0.1520493747343093
+                  }
+                ],
+                "macro_precision": 0.22916666666666666,
+                "macro_recall": 0.28205128205128205,
+                "macro_f1": 0.2528735632183908,
+                "weighted_f1": 0.5379310344827586,
+                "macro_roc_auc": 0.429144499680214,
+                "macro_pr_auc": 0.31294669952300325
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.27053028553836683,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.053202510368458,
+              "regression_rmse_log_rv": 0.8594919452289376,
+              "regression_mae_log_rv": 0.6956124466147509,
+              "regression_loss": 0.738726403913423,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    36,
+                    0
+                  ],
+                  [
+                    9,
+                    39,
+                    0
+                  ],
+                  [
+                    0,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.47058823529411764,
+                    "recall": 0.18181818181818182,
+                    "f1": 0.26229508196721313,
+                    "support": 44,
+                    "roc_auc": 0.4755766621438263,
+                    "pr_auc": 0.3799077928353632
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4148936170212766,
+                    "recall": 0.8125,
+                    "f1": 0.5492957746478874,
+                    "support": 48,
+                    "roc_auc": 0.4728835978835979,
+                    "pr_auc": 0.40841565284143677
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.3426773455377574,
+                    "pr_auc": 0.22294664907199324
+                  }
+                ],
+                "macro_precision": 0.2951606174384647,
+                "macro_recall": 0.331439393939394,
+                "macro_f1": 0.27053028553836683,
+                "weighted_f1": 0.34150613324014384,
+                "macro_roc_auc": 0.4303792018550605,
+                "macro_pr_auc": 0.33709003158293105
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3022222222222222,
+              "regime_accuracy": 0.48076921701431274,
+              "regime_loss": 1.069875955581665,
+              "regression_rmse_log_rv": 0.8515843615702717,
+              "regression_mae_log_rv": 0.6790887384872454,
+              "regression_loss": 0.7251959248710472,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    20,
+                    0
+                  ],
+                  [
+                    8,
+                    44,
+                    0
+                  ],
+                  [
+                    10,
+                    16,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.24000000000000002,
+                    "support": 26,
+                    "roc_auc": 0.47287968441814593,
+                    "pr_auc": 0.26912520973534904
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.55,
+                    "recall": 0.8461538461538461,
+                    "f1": 0.6666666666666667,
+                    "support": 52,
+                    "roc_auc": 0.5750739644970414,
+                    "pr_auc": 0.5559358296237772
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5310650887573964,
+                    "pr_auc": 0.29318498335989746
+                  }
+                ],
+                "macro_precision": 0.26666666666666666,
+                "macro_recall": 0.358974358974359,
+                "macro_f1": 0.3022222222222222,
+                "weighted_f1": 0.3933333333333334,
+                "macro_roc_auc": 0.5263395792241946,
+                "macro_pr_auc": 0.37274867423967456
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "dual": [
+      {
+        "head_mode": "dual",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.40375899988028663,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.1209476943495127,
+              "regression_rmse_log_rv": 0.8901292625525159,
+              "regression_mae_log_rv": 0.7472532614464096,
+              "regression_loss": 0.7923301040522859,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    12,
+                    2
+                  ],
+                  [
+                    14,
+                    13,
+                    18
+                  ],
+                  [
+                    17,
+                    8,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3111111111111111,
+                    "recall": 0.5,
+                    "f1": 0.3835616438356164,
+                    "support": 28,
+                    "roc_auc": 0.6843944099378882,
+                    "pr_auc": 0.33475697355679346
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3939393939393939,
+                    "recall": 0.28888888888888886,
+                    "f1": 0.3333333333333333,
+                    "support": 45,
+                    "roc_auc": 0.5484444444444444,
+                    "pr_auc": 0.39897170388611625
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5238095238095238,
+                    "recall": 0.46808510638297873,
+                    "f1": 0.49438202247191015,
+                    "support": 47,
+                    "roc_auc": 0.6164383561643836,
+                    "pr_auc": 0.49506627887311094
+                  }
+                ],
+                "macro_precision": 0.4096200096200096,
+                "macro_recall": 0.41899133175728914,
+                "macro_f1": 0.40375899988028663,
+                "weighted_f1": 0.4081306756964753,
+                "macro_roc_auc": 0.6164257368489054,
+                "macro_pr_auc": 0.4095983187720069
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4449498860067966,
+              "regime_accuracy": 0.6779661178588867,
+              "regime_loss": 0.6460890537601406,
+              "regression_rmse_log_rv": 0.8425339650478226,
+              "regression_mae_log_rv": 0.6638701994414047,
+              "regression_loss": 0.7098634822592056,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    2,
+                    1
+                  ],
+                  [
+                    15,
+                    10,
+                    71
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.22580645161290322,
+                    "recall": 0.7,
+                    "f1": 0.3414634146341463,
+                    "support": 10,
+                    "roc_auc": 0.8685185185185185,
+                    "pr_auc": 0.2604336674247665
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.13333333333333333,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.14814814814814814,
+                    "support": 12,
+                    "roc_auc": 0.7114779874213837,
+                    "pr_auc": 0.15358722823194523
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9861111111111112,
+                    "recall": 0.7395833333333334,
+                    "f1": 0.8452380952380952,
+                    "support": 96,
+                    "roc_auc": 0.9171401515151515,
+                    "pr_auc": 0.9815789521761502
+                  }
+                ],
+                "macro_precision": 0.44841696535244924,
+                "macro_recall": 0.5354166666666667,
+                "macro_f1": 0.4449498860067966,
+                "weighted_f1": 0.7316548226014947,
+                "macro_roc_auc": 0.8323788858183513,
+                "macro_pr_auc": 0.46519994927762065
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.25953949147226457,
+              "regime_accuracy": 0.23636363446712494,
+              "regime_loss": 1.5783777410333806,
+              "regression_rmse_log_rv": 0.750796827296302,
+              "regression_mae_log_rv": 0.5821023331425915,
+              "regression_loss": 0.5636958758781933,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    16,
+                    4,
+                    58
+                  ],
+                  [
+                    2,
+                    3,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.28,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.3783783783783784,
+                    "support": 12,
+                    "roc_auc": 0.7312925170068028,
+                    "pr_auc": 0.25462358694851
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5714285714285714,
+                    "recall": 0.05128205128205128,
+                    "f1": 0.09411764705882351,
+                    "support": 78,
+                    "roc_auc": 0.3802083333333333,
+                    "pr_auc": 0.6438518484384773
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19230769230769232,
+                    "recall": 0.75,
+                    "f1": 0.3061224489795919,
+                    "support": 20,
+                    "roc_auc": 0.5455555555555556,
+                    "pr_auc": 0.1912734071424792
+                  }
+                ],
+                "macro_precision": 0.3479120879120879,
+                "macro_recall": 0.4615384615384615,
+                "macro_f1": 0.25953949147226457,
+                "weighted_f1": 0.1636742362792783,
+                "macro_roc_auc": 0.5523521352985639,
+                "macro_pr_auc": 0.3632496141764889
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.39248784137673026,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.2070082038027825,
+              "regression_rmse_log_rv": 0.8681531691689126,
+              "regression_mae_log_rv": 0.7269016493590096,
+              "regression_loss": 0.7536899251380267,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    20,
+                    12,
+                    12
+                  ],
+                  [
+                    13,
+                    12,
+                    23
+                  ],
+                  [
+                    4,
+                    3,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5405405405405406,
+                    "recall": 0.45454545454545453,
+                    "f1": 0.49382716049382713,
+                    "support": 44,
+                    "roc_auc": 0.6974219810040706,
+                    "pr_auc": 0.5507898765456971
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4444444444444444,
+                    "recall": 0.25,
+                    "f1": 0.32,
+                    "support": 48,
+                    "roc_auc": 0.4937169312169312,
+                    "pr_auc": 0.4584487178976394
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2553191489361702,
+                    "recall": 0.631578947368421,
+                    "f1": 0.3636363636363636,
+                    "support": 19,
+                    "roc_auc": 0.6647597254004577,
+                    "pr_auc": 0.24765372838685398
+                  }
+                ],
+                "macro_precision": 0.4134347113070517,
+                "macro_recall": 0.44537480063795853,
+                "macro_f1": 0.39248784137673026,
+                "weighted_f1": 0.39637374748485854,
+                "macro_roc_auc": 0.6186328792071532,
+                "macro_pr_auc": 0.4189641076100635
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4024771524771525,
+              "regime_accuracy": 0.4326923191547394,
+              "regime_loss": 1.10788055566641,
+              "regression_rmse_log_rv": 0.8048071749523463,
+              "regression_mae_log_rv": 0.6565172921176642,
+              "regression_loss": 0.6477145888547766,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    10,
+                    11
+                  ],
+                  [
+                    3,
+                    21,
+                    28
+                  ],
+                  [
+                    2,
+                    5,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.19230769230769232,
+                    "f1": 0.2777777777777778,
+                    "support": 26,
+                    "roc_auc": 0.6168639053254438,
+                    "pr_auc": 0.34381304632728243
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5833333333333334,
+                    "recall": 0.40384615384615385,
+                    "f1": 0.4772727272727273,
+                    "support": 52,
+                    "roc_auc": 0.6157544378698225,
+                    "pr_auc": 0.5801974135044057
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3275862068965517,
+                    "recall": 0.7307692307692307,
+                    "f1": 0.4523809523809524,
+                    "support": 26,
+                    "roc_auc": 0.7509861932938856,
+                    "pr_auc": 0.6511043087641545
+                  }
+                ],
+                "macro_precision": 0.4703065134099617,
+                "macro_recall": 0.4423076923076923,
+                "macro_f1": 0.4024771524771525,
+                "weighted_f1": 0.4211760461760462,
+                "macro_roc_auc": 0.6612015121630507,
+                "macro_pr_auc": 0.5250382561986142
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.35808353808353804,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.1423450364602177,
+              "regression_rmse_log_rv": 0.8942898143902652,
+              "regression_mae_log_rv": 0.751144212303916,
+              "regression_loss": 0.7997542721221751,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    7,
+                    5
+                  ],
+                  [
+                    14,
+                    6,
+                    25
+                  ],
+                  [
+                    16,
+                    8,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.34782608695652173,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.4324324324324324,
+                    "support": 28,
+                    "roc_auc": 0.718167701863354,
+                    "pr_auc": 0.35046343164290167
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.13333333333333333,
+                    "f1": 0.18181818181818182,
+                    "support": 45,
+                    "roc_auc": 0.4666666666666667,
+                    "pr_auc": 0.34446517871878274
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4339622641509434,
+                    "recall": 0.48936170212765956,
+                    "f1": 0.45999999999999996,
+                    "support": 47,
+                    "roc_auc": 0.6071116292626056,
+                    "pr_auc": 0.4738981369675429
+                  }
+                ],
+                "macro_precision": 0.35583421227391693,
+                "macro_recall": 0.3980412022965214,
+                "macro_f1": 0.35808353808353804,
+                "weighted_f1": 0.34924938574938574,
+                "macro_roc_auc": 0.5973153325975421,
+                "macro_pr_auc": 0.3896089157764091
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5481481481481482,
+              "regime_accuracy": 0.7796609997749329,
+              "regime_loss": 0.5684018912961928,
+              "regression_rmse_log_rv": 0.7185552022419813,
+              "regression_mae_log_rv": 0.5577489207735506,
+              "regression_loss": 0.5163215786690146,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    0
+                  ],
+                  [
+                    6,
+                    3,
+                    3
+                  ],
+                  [
+                    12,
+                    3,
+                    81
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.8,
+                    "f1": 0.4444444444444444,
+                    "support": 10,
+                    "roc_auc": 0.9518518518518518,
+                    "pr_auc": 0.6007158196980179
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.375,
+                    "recall": 0.25,
+                    "f1": 0.3,
+                    "support": 12,
+                    "roc_auc": 0.8183962264150944,
+                    "pr_auc": 0.2553270588862258
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9642857142857143,
+                    "recall": 0.84375,
+                    "f1": 0.8999999999999999,
+                    "support": 96,
+                    "roc_auc": 0.9043560606060606,
+                    "pr_auc": 0.9785536347200202
+                  }
+                ],
+                "macro_precision": 0.5489926739926739,
+                "macro_recall": 0.63125,
+                "macro_f1": 0.5481481481481482,
+                "weighted_f1": 0.8003766478342749,
+                "macro_roc_auc": 0.891534712957669,
+                "macro_pr_auc": 0.6115321711014213
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3049095607235142,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.2871513475071301,
+              "regression_rmse_log_rv": 0.6630584732192755,
+              "regression_mae_log_rv": 0.48380625869189814,
+              "regression_loss": 0.43964653890787664,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    26,
+                    7,
+                    45
+                  ],
+                  [
+                    2,
+                    0,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.3333333333333333,
+                    "support": 12,
+                    "roc_auc": 0.7772108843537415,
+                    "pr_auc": 0.2550482761264478
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.875,
+                    "recall": 0.08974358974358974,
+                    "f1": 0.1627906976744186,
+                    "support": 78,
+                    "roc_auc": 0.40384615384615385,
+                    "pr_auc": 0.6829565156254881
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2727272727272727,
+                    "recall": 0.9,
+                    "f1": 0.41860465116279066,
+                    "support": 20,
+                    "roc_auc": 0.7227777777777777,
+                    "pr_auc": 0.2749052292859333
+                  }
+                ],
+                "macro_precision": 0.4566498316498316,
+                "macro_recall": 0.5521367521367521,
+                "macro_f1": 0.3049095607235142,
+                "weighted_f1": 0.22790697674418603,
+                "macro_roc_auc": 0.6346116053258911,
+                "macro_pr_auc": 0.4043033403459564
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4008031714091617,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.115851665798591,
+              "regression_rmse_log_rv": 0.812930785118049,
+              "regression_mae_log_rv": 0.6706082805454194,
+              "regression_loss": 0.6608564613926474,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    25,
+                    12,
+                    7
+                  ],
+                  [
+                    16,
+                    10,
+                    22
+                  ],
+                  [
+                    5,
+                    3,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5434782608695652,
+                    "recall": 0.5681818181818182,
+                    "f1": 0.5555555555555556,
+                    "support": 44,
+                    "roc_auc": 0.648236092265943,
+                    "pr_auc": 0.5211182066262685
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.273972602739726,
+                    "support": 48,
+                    "roc_auc": 0.5671296296296297,
+                    "pr_auc": 0.453690643799723
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.275,
+                    "recall": 0.5789473684210527,
+                    "f1": 0.37288135593220345,
+                    "support": 19,
+                    "roc_auc": 0.618421052631579,
+                    "pr_auc": 0.2408938751860665
+                  }
+                ],
+                "macro_precision": 0.4061594202898551,
+                "macro_recall": 0.45182083997873473,
+                "macro_f1": 0.4008031714091617,
+                "weighted_f1": 0.40252139764561407,
+                "macro_roc_auc": 0.6112622581757172,
+                "macro_pr_auc": 0.405234241870686
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.35998939505250865,
+              "regime_accuracy": 0.36538460850715637,
+              "regime_loss": 1.0652436293088472,
+              "regression_rmse_log_rv": 0.800281642899362,
+              "regression_mae_log_rv": 0.649739215678822,
+              "regression_loss": 0.640450707961702,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    5,
+                    11
+                  ],
+                  [
+                    20,
+                    10,
+                    22
+                  ],
+                  [
+                    6,
+                    2,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2777777777777778,
+                    "recall": 0.38461538461538464,
+                    "f1": 0.3225806451612903,
+                    "support": 26,
+                    "roc_auc": 0.6232741617357002,
+                    "pr_auc": 0.3228651067031544
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5882352941176471,
+                    "recall": 0.19230769230769232,
+                    "f1": 0.2898550724637681,
+                    "support": 52,
+                    "roc_auc": 0.507396449704142,
+                    "pr_auc": 0.4722716505713066
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.35294117647058826,
+                    "recall": 0.6923076923076923,
+                    "f1": 0.4675324675324675,
+                    "support": 26,
+                    "roc_auc": 0.7169625246548323,
+                    "pr_auc": 0.5566683295595208
+                  }
+                ],
+                "macro_precision": 0.40631808278867104,
+                "macro_recall": 0.4230769230769231,
+                "macro_f1": 0.35998939505250865,
+                "weighted_f1": 0.3424558144053235,
+                "macro_roc_auc": 0.6158777120315582,
+                "macro_pr_auc": 0.4506016956113273
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3904204956836536,
+              "regime_accuracy": 0.4333333373069763,
+              "regime_loss": 1.1816007885155035,
+              "regression_rmse_log_rv": 0.9233851277645446,
+              "regression_mae_log_rv": 0.7778225196583662,
+              "regression_loss": 0.8526400941767444,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    2,
+                    12
+                  ],
+                  [
+                    8,
+                    4,
+                    33
+                  ],
+                  [
+                    7,
+                    6,
+                    34
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4827586206896552,
+                    "recall": 0.5,
+                    "f1": 0.49122807017543857,
+                    "support": 28,
+                    "roc_auc": 0.6824534161490683,
+                    "pr_auc": 0.3551579193942668
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.08888888888888889,
+                    "f1": 0.14035087719298245,
+                    "support": 45,
+                    "roc_auc": 0.43644444444444447,
+                    "pr_auc": 0.3720071187788904
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.43037974683544306,
+                    "recall": 0.723404255319149,
+                    "f1": 0.5396825396825398,
+                    "support": 47,
+                    "roc_auc": 0.5502768872048965,
+                    "pr_auc": 0.4067036385263067
+                  }
+                ],
+                "macro_precision": 0.41549056695281056,
+                "macro_recall": 0.43743104806934596,
+                "macro_f1": 0.3904204956836536,
+                "weighted_f1": 0.3786271233639655,
+                "macro_roc_auc": 0.5563915825994697,
+                "macro_pr_auc": 0.37795622556648795
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.40507873142603684,
+              "regime_accuracy": 0.6440678238868713,
+              "regime_loss": 0.6854057650444871,
+              "regression_rmse_log_rv": 0.8100118346887232,
+              "regression_mae_log_rv": 0.6378626964860044,
+              "regression_loss": 0.6561191723357913,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    9,
+                    18,
+                    69
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2692307692307692,
+                    "recall": 0.7,
+                    "f1": 0.3888888888888889,
+                    "support": 10,
+                    "roc_auc": 0.9203703703703704,
+                    "pr_auc": 0.7404656680266436
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.5031446540880503,
+                    "pr_auc": 0.09231663290636329
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.971830985915493,
+                    "recall": 0.71875,
+                    "f1": 0.8263473053892216,
+                    "support": 96,
+                    "roc_auc": 0.9232954545454546,
+                    "pr_auc": 0.9805021096887453
+                  }
+                ],
+                "macro_precision": 0.4136872517154207,
+                "macro_recall": 0.47291666666666665,
+                "macro_f1": 0.40507873142603684,
+                "weighted_f1": 0.7052392390360522,
+                "macro_roc_auc": 0.7822701596679584,
+                "macro_pr_auc": 0.6044281368739174
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3658842239185751,
+              "regime_accuracy": 0.48181816935539246,
+              "regime_loss": 1.030522708459334,
+              "regression_rmse_log_rv": 0.4005221266135396,
+              "regression_mae_log_rv": 0.30571052761621437,
+              "regression_loss": 0.16041797390703225,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    9,
+                    2
+                  ],
+                  [
+                    12,
+                    38,
+                    28
+                  ],
+                  [
+                    0,
+                    6,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.07692307692307693,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.08,
+                    "support": 12,
+                    "roc_auc": 0.701530612244898,
+                    "pr_auc": 0.19393338627753473
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7169811320754716,
+                    "recall": 0.48717948717948717,
+                    "f1": 0.5801526717557253,
+                    "support": 78,
+                    "roc_auc": 0.5060096153846154,
+                    "pr_auc": 0.7114186401026309
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 20,
+                    "roc_auc": 0.7744444444444445,
+                    "pr_auc": 0.35558709067221034
+                  }
+                ],
+                "macro_precision": 0.3706953423934556,
+                "macro_recall": 0.4235042735042735,
+                "macro_f1": 0.3658842239185751,
+                "weighted_f1": 0.49965371269951425,
+                "macro_roc_auc": 0.660661557357986,
+                "macro_pr_auc": 0.4203130390174587
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3639098861825711,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.179526080975713,
+              "regression_rmse_log_rv": 0.878750868825478,
+              "regression_mae_log_rv": 0.7261684474510115,
+              "regression_loss": 0.7722030894615326,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    11,
+                    17,
+                    16
+                  ],
+                  [
+                    9,
+                    22,
+                    17
+                  ],
+                  [
+                    4,
+                    6,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4583333333333333,
+                    "recall": 0.25,
+                    "f1": 0.3235294117647059,
+                    "support": 44,
+                    "roc_auc": 0.5919267299864315,
+                    "pr_auc": 0.43438955924374917
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4888888888888889,
+                    "recall": 0.4583333333333333,
+                    "f1": 0.4731182795698925,
+                    "support": 48,
+                    "roc_auc": 0.5317460317460317,
+                    "pr_auc": 0.42754469381151344
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21428571428571427,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.29508196721311475,
+                    "support": 19,
+                    "roc_auc": 0.566933638443936,
+                    "pr_auc": 0.25190843492358184
+                  }
+                ],
+                "macro_precision": 0.3871693121693121,
+                "macro_recall": 0.3940058479532163,
+                "macro_f1": 0.3639098861825711,
+                "weighted_f1": 0.38334710733379346,
+                "macro_roc_auc": 0.5635354667254664,
+                "macro_pr_auc": 0.37128089599294817
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4470032894943739,
+              "regime_accuracy": 0.567307710647583,
+              "regime_loss": 1.008954529578869,
+              "regression_rmse_log_rv": 0.7540553880337307,
+              "regression_mae_log_rv": 0.5933847648288625,
+              "regression_loss": 0.5685995282227002,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    17,
+                    8
+                  ],
+                  [
+                    1,
+                    38,
+                    13
+                  ],
+                  [
+                    0,
+                    6,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.07142857142857144,
+                    "support": 26,
+                    "roc_auc": 0.6489151873767258,
+                    "pr_auc": 0.4634749194144555
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6229508196721312,
+                    "recall": 0.7307692307692307,
+                    "f1": 0.672566371681416,
+                    "support": 52,
+                    "roc_auc": 0.6782544378698225,
+                    "pr_auc": 0.6534473384287834
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4878048780487805,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5970149253731344,
+                    "support": 26,
+                    "roc_auc": 0.7776134122287969,
+                    "pr_auc": 0.6753256515552692
+                  }
+                ],
+                "macro_precision": 0.5369185659069705,
+                "macro_recall": 0.5128205128205129,
+                "macro_f1": 0.4470032894943739,
+                "weighted_f1": 0.5033940600411344,
+                "macro_roc_auc": 0.7015943458251152,
+                "macro_pr_auc": 0.5974159697995027
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4382842992685409,
+              "regime_accuracy": 0.4416666626930237,
+              "regime_loss": 1.1505330520444779,
+              "regression_rmse_log_rv": 0.8980487860614884,
+              "regression_mae_log_rv": 0.7452545770812624,
+              "regression_loss": 0.806491622146513,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    7,
+                    4
+                  ],
+                  [
+                    11,
+                    14,
+                    20
+                  ],
+                  [
+                    20,
+                    5,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3541666666666667,
+                    "recall": 0.6071428571428571,
+                    "f1": 0.4473684210526316,
+                    "support": 28,
+                    "roc_auc": 0.7107919254658385,
+                    "pr_auc": 0.39416109174682373
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5384615384615384,
+                    "recall": 0.3111111111111111,
+                    "f1": 0.39436619718309857,
+                    "support": 45,
+                    "roc_auc": 0.5084444444444445,
+                    "pr_auc": 0.3945428493593871
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4782608695652174,
+                    "recall": 0.46808510638297873,
+                    "f1": 0.47311827956989244,
+                    "support": 47,
+                    "roc_auc": 0.5686388807927718,
+                    "pr_auc": 0.4468795853408847
+                  }
+                ],
+                "macro_precision": 0.45696302489780755,
+                "macro_recall": 0.46211302487898226,
+                "macro_f1": 0.4382842992685409,
+                "weighted_f1": 0.4375779483541506,
+                "macro_roc_auc": 0.5959584169010183,
+                "macro_pr_auc": 0.41186117548236517
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5423775560942259,
+              "regime_accuracy": 0.7372881174087524,
+              "regime_loss": 0.6501606419935064,
+              "regression_rmse_log_rv": 0.7480869612866198,
+              "regression_mae_log_rv": 0.6114687923720833,
+              "regression_loss": 0.5596341016470486,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    5,
+                    5,
+                    2
+                  ],
+                  [
+                    10,
+                    11,
+                    75
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 10,
+                    "roc_auc": 0.9342592592592592,
+                    "pr_auc": 0.5686987214394479
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2631578947368421,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.3225806451612903,
+                    "support": 12,
+                    "roc_auc": 0.7672955974842768,
+                    "pr_auc": 0.17731535338271548
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.974025974025974,
+                    "recall": 0.78125,
+                    "f1": 0.8670520231213873,
+                    "support": 96,
+                    "roc_auc": 0.9384469696969697,
+                    "pr_auc": 0.986173151250606
+                  }
+                ],
+                "macro_precision": 0.5184552289815447,
+                "macro_recall": 0.6326388888888889,
+                "macro_f1": 0.5423775560942259,
+                "weighted_f1": 0.7752793386575311,
+                "macro_roc_auc": 0.8800006088135018,
+                "macro_pr_auc": 0.5773957420242565
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2886192754613807,
+              "regime_accuracy": 0.2818181812763214,
+              "regime_loss": 1.248958613655784,
+              "regression_rmse_log_rv": 0.5462928620082075,
+              "regression_mae_log_rv": 0.4261783587132496,
+              "regression_loss": 0.2984358910811184,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    34,
+                    7,
+                    37
+                  ],
+                  [
+                    2,
+                    2,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18181818181818182,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.28571428571428575,
+                    "support": 12,
+                    "roc_auc": 0.717687074829932,
+                    "pr_auc": 0.20299575690892868
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7,
+                    "recall": 0.08974358974358974,
+                    "f1": 0.1590909090909091,
+                    "support": 78,
+                    "roc_auc": 0.405849358974359,
+                    "pr_auc": 0.6717468218836603
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.8,
+                    "f1": 0.4210526315789473,
+                    "support": 20,
+                    "roc_auc": 0.7127777777777777,
+                    "pr_auc": 0.27475877543070887
+                  }
+                ],
+                "macro_precision": 0.3891774891774891,
+                "macro_recall": 0.5188034188034188,
+                "macro_f1": 0.2886192754613807,
+                "weighted_f1": 0.22053377244764802,
+                "macro_roc_auc": 0.6121047371940229,
+                "macro_pr_auc": 0.38316711807443266
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3370131250332111,
+              "regime_accuracy": 0.342342346906662,
+              "regime_loss": 1.1962378331890777,
+              "regression_rmse_log_rv": 0.9604745229881944,
+              "regression_mae_log_rv": 0.7938679405362219,
+              "regression_loss": 0.9225113093093994,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    11,
+                    16
+                  ],
+                  [
+                    16,
+                    8,
+                    24
+                  ],
+                  [
+                    5,
+                    1,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4473684210526316,
+                    "recall": 0.38636363636363635,
+                    "f1": 0.41463414634146345,
+                    "support": 44,
+                    "roc_auc": 0.6309362279511533,
+                    "pr_auc": 0.4523738410083445
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.23529411764705882,
+                    "support": 48,
+                    "roc_auc": 0.5287698412698413,
+                    "pr_auc": 0.509998249158308
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.24528301886792453,
+                    "recall": 0.6842105263157895,
+                    "f1": 0.36111111111111105,
+                    "support": 19,
+                    "roc_auc": 0.6086956521739131,
+                    "pr_auc": 0.23557557894528253
+                  }
+                ],
+                "macro_precision": 0.36421714664018534,
+                "macro_recall": 0.41241360978203084,
+                "macro_f1": 0.3370131250332111,
+                "weighted_f1": 0.3279201008756245,
+                "macro_roc_auc": 0.5894672404649692,
+                "macro_pr_auc": 0.39931588970397836
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4259578544061304,
+              "regime_accuracy": 0.5096153616905212,
+              "regime_loss": 0.9943281274575454,
+              "regression_rmse_log_rv": 0.751555027556304,
+              "regression_mae_log_rv": 0.5907139982222221,
+              "regression_loss": 0.5648349594451568,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    21,
+                    3
+                  ],
+                  [
+                    4,
+                    34,
+                    14
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.125,
+                    "support": 26,
+                    "roc_auc": 0.6429980276134122,
+                    "pr_auc": 0.35272620656508796
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.53125,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.5862068965517242,
+                    "support": 52,
+                    "roc_auc": 0.5724852071005917,
+                    "pr_auc": 0.5090915538281857
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.5666666666666668,
+                    "support": 26,
+                    "roc_auc": 0.7924063116370809,
+                    "pr_auc": 0.6687141818742123
+                  }
+                ],
+                "macro_precision": 0.4548611111111111,
+                "macro_recall": 0.4615384615384615,
+                "macro_f1": 0.4259578544061304,
+                "weighted_f1": 0.46602011494252876,
+                "macro_roc_auc": 0.6692965154503616,
+                "macro_pr_auc": 0.510177314089162
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3638341543513957,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.106051041415725,
+              "regression_rmse_log_rv": 0.9000263507988472,
+              "regression_mae_log_rv": 0.7678275174829954,
+              "regression_loss": 0.8100474321322896,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    6,
+                    8
+                  ],
+                  [
+                    15,
+                    4,
+                    26
+                  ],
+                  [
+                    13,
+                    3,
+                    31
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.5,
+                    "f1": 0.4,
+                    "support": 28,
+                    "roc_auc": 0.7259316770186336,
+                    "pr_auc": 0.3805446114381795
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.08888888888888889,
+                    "f1": 0.13793103448275862,
+                    "support": 45,
+                    "roc_auc": 0.4613333333333333,
+                    "pr_auc": 0.3698803287993491
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.47692307692307695,
+                    "recall": 0.6595744680851063,
+                    "f1": 0.5535714285714286,
+                    "support": 47,
+                    "roc_auc": 0.5767997668318274,
+                    "pr_auc": 0.43947193013807767
+                  }
+                ],
+                "macro_precision": 0.37264957264957266,
+                "macro_recall": 0.416154452324665,
+                "macro_f1": 0.3638341543513957,
+                "weighted_f1": 0.36187294745484405,
+                "macro_roc_auc": 0.5880215923945981,
+                "macro_pr_auc": 0.3966322901252021
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.36394927536231886,
+              "regime_accuracy": 0.5932203531265259,
+              "regime_loss": 0.6964645714072858,
+              "regression_rmse_log_rv": 0.7570778728048381,
+              "regression_mae_log_rv": 0.6071755758534043,
+              "regression_loss": 0.5731669054906986,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    11,
+                    0,
+                    1
+                  ],
+                  [
+                    18,
+                    15,
+                    63
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.19444444444444445,
+                    "recall": 0.7,
+                    "f1": 0.30434782608695654,
+                    "support": 10,
+                    "roc_auc": 0.8944444444444445,
+                    "pr_auc": 0.41935272211587993
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6957547169811321,
+                    "pr_auc": 0.1442461022963905
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.984375,
+                    "recall": 0.65625,
+                    "f1": 0.7875,
+                    "support": 96,
+                    "roc_auc": 0.9109848484848485,
+                    "pr_auc": 0.9801620277556883
+                  }
+                ],
+                "macro_precision": 0.3929398148148148,
+                "macro_recall": 0.45208333333333334,
+                "macro_f1": 0.36394927536231886,
+                "weighted_f1": 0.6664701547531319,
+                "macro_roc_auc": 0.8337280033034751,
+                "macro_pr_auc": 0.5145869507226529
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.38898350363988515,
+              "regime_accuracy": 0.40909090638160706,
+              "regime_loss": 1.234303227337924,
+              "regression_rmse_log_rv": 0.6712191556438326,
+              "regression_mae_log_rv": 0.4932159064655108,
+              "regression_loss": 0.45053515490321966,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    23,
+                    26,
+                    29
+                  ],
+                  [
+                    3,
+                    6,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23529411764705882,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.3478260869565218,
+                    "support": 12,
+                    "roc_auc": 0.6998299319727891,
+                    "pr_auc": 0.18206513881740827
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7647058823529411,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.4642857142857143,
+                    "support": 78,
+                    "roc_auc": 0.421875,
+                    "pr_auc": 0.6541605613971738
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2619047619047619,
+                    "recall": 0.55,
+                    "f1": 0.3548387096774194,
+                    "support": 20,
+                    "roc_auc": 0.68,
+                    "pr_auc": 0.25697189432609685
+                  }
+                ],
+                "macro_precision": 0.42063492063492064,
+                "macro_recall": 0.5166666666666667,
+                "macro_f1": 0.38898350363988515,
+                "weighted_f1": 0.43168157228465787,
+                "macro_roc_auc": 0.6005683106575964,
+                "macro_pr_auc": 0.3643991981802263
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4021620142309797,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.2613065495182436,
+              "regression_rmse_log_rv": 0.9689394278892921,
+              "regression_mae_log_rv": 0.7775869524559459,
+              "regression_loss": 0.9388436149184286,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    24,
+                    9,
+                    11
+                  ],
+                  [
+                    15,
+                    11,
+                    22
+                  ],
+                  [
+                    4,
+                    4,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5581395348837209,
+                    "recall": 0.5454545454545454,
+                    "f1": 0.5517241379310344,
+                    "support": 44,
+                    "roc_auc": 0.6407734056987788,
+                    "pr_auc": 0.4689944150323333
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4583333333333333,
+                    "recall": 0.22916666666666666,
+                    "f1": 0.3055555555555555,
+                    "support": 48,
+                    "roc_auc": 0.4973544973544973,
+                    "pr_auc": 0.44896136698903155
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.25,
+                    "recall": 0.5789473684210527,
+                    "f1": 0.3492063492063492,
+                    "support": 19,
+                    "roc_auc": 0.6138443935926774,
+                    "pr_auc": 0.22844475062050215
+                  }
+                ],
+                "macro_precision": 0.4221576227390181,
+                "macro_recall": 0.4511895268474216,
+                "macro_f1": 0.4021620142309797,
+                "weighted_f1": 0.41060765198696225,
+                "macro_roc_auc": 0.5839907655486511,
+                "macro_pr_auc": 0.3821335108806223
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4076946872215374,
+              "regime_accuracy": 0.4326923191547394,
+              "regime_loss": 1.0580558226658747,
+              "regression_rmse_log_rv": 0.7812050823096796,
+              "regression_mae_log_rv": 0.6362697912935311,
+              "regression_loss": 0.6102813806264732,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    13,
+                    7
+                  ],
+                  [
+                    7,
+                    22,
+                    23
+                  ],
+                  [
+                    4,
+                    5,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35294117647058826,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.2790697674418605,
+                    "support": 26,
+                    "roc_auc": 0.645956607495069,
+                    "pr_auc": 0.41451839153100417
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.55,
+                    "recall": 0.4230769230769231,
+                    "f1": 0.47826086956521735,
+                    "support": 52,
+                    "roc_auc": 0.6353550295857988,
+                    "pr_auc": 0.5511021891964044
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3617021276595745,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.4657534246575342,
+                    "support": 26,
+                    "roc_auc": 0.7519723865877712,
+                    "pr_auc": 0.6481331040491836
+                  }
+                ],
+                "macro_precision": 0.4215477680433876,
+                "macro_recall": 0.4358974358974359,
+                "macro_f1": 0.4076946872215374,
+                "weighted_f1": 0.42533623280745736,
+                "macro_roc_auc": 0.6777613412228797,
+                "macro_pr_auc": 0.5379178949255307
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "classification": {
+      "regime_f1_macro": {
+        "mean": 0.4005753924116641,
+        "std": 0.06191462281488251,
+        "min": 0.2690270170146331,
+        "max": 0.5225819714256347,
+        "n": 25
+      },
+      "regression_rmse_log_rv": null
+    },
+    "regression": {
+      "regime_f1_macro": {
+        "mean": 0.260192884795029,
+        "std": 0.08768542471558168,
+        "min": 0.10256410256410257,
+        "max": 0.4589460784313726,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7733587523468146,
+        "std": 0.14484697039457914,
+        "min": 0.3918154019753048,
+        "max": 0.9945336278188166,
+        "n": 25
+      }
+    },
+    "dual": {
+      "regime_f1_macro": {
+        "mean": 0.3922527822561967,
+        "std": 0.0635749665499232,
+        "min": 0.25953949147226457,
+        "max": 0.5481481481481482,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7918075084864061,
+        "std": 0.12571515463997154,
+        "min": 0.4005221266135396,
+        "max": 0.9689394278892921,
+        "n": 25
+      }
+    }
+  }
+}

--- a/backend/artifacts/experiments/runpod_20260530/runpod_surprise_20260530T143043Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/runpod_surprise_20260530T143043Z.json
@@ -1,0 +1,5157 @@
+{
+  "head_modes": [
+    "classification",
+    "regression",
+    "dual"
+  ],
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "regression_alpha": 0.5,
+  "training_package_id": "canonical",
+  "rates_target_mode": "fomc_attributable",
+  "rates_heads": [
+    "2y",
+    "5y",
+    "terminal"
+  ],
+  "use_retrieval_analogs": false,
+  "use_regime_conditioning": false,
+  "use_statement_delta": false,
+  "use_vote_features": false,
+  "use_press_conf": false,
+  "trials": {
+    "classification": [
+      {
+        "head_mode": "classification",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.38293566898218057,
+              "regime_accuracy": 0.44999998807907104,
+              "regime_loss": 1.185710631106935,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    5,
+                    10
+                  ],
+                  [
+                    10,
+                    2,
+                    33
+                  ],
+                  [
+                    4,
+                    4,
+                    39
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.48148148148148145,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.4727272727272727,
+                    "support": 28,
+                    "roc_auc": 0.6746894409937888,
+                    "pr_auc": 0.3636443862299921
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.18181818181818182,
+                    "recall": 0.044444444444444446,
+                    "f1": 0.07142857142857142,
+                    "support": 45,
+                    "roc_auc": 0.49748148148148147,
+                    "pr_auc": 0.3791276280007117
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.47560975609756095,
+                    "recall": 0.8297872340425532,
+                    "f1": 0.6046511627906976,
+                    "support": 47,
+                    "roc_auc": 0.5948703002040221,
+                    "pr_auc": 0.45738587045467993
+                  }
+                ],
+                "macro_precision": 0.37963647313240806,
+                "macro_recall": 0.4461724642575706,
+                "macro_f1": 0.38293566898218057,
+                "weighted_f1": 0.37391045001510115,
+                "macro_roc_auc": 0.5890137408930974,
+                "macro_pr_auc": 0.40005262822846127
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.48578042328042326,
+              "regime_accuracy": 0.6610169410705566,
+              "regime_loss": 0.6592556743298547,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    3,
+                    4,
+                    5
+                  ],
+                  [
+                    12,
+                    17,
+                    67
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 10,
+                    "roc_auc": 0.862037037037037,
+                    "pr_auc": 0.27929868371315936
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.2222222222222222,
+                    "support": 12,
+                    "roc_auc": 0.72562893081761,
+                    "pr_auc": 0.15365747408753794
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9305555555555556,
+                    "recall": 0.6979166666666666,
+                    "f1": 0.7976190476190476,
+                    "support": 96,
+                    "roc_auc": 0.8712121212121212,
+                    "pr_auc": 0.9699363160627303
+                  }
+                ],
+                "macro_precision": 0.47180134680134683,
+                "macro_recall": 0.5770833333333333,
+                "macro_f1": 0.48578042328042326,
+                "weighted_f1": 0.7085855528652139,
+                "macro_roc_auc": 0.8196260296889228,
+                "macro_pr_auc": 0.4676308246211425
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2717139165226597,
+              "regime_accuracy": 0.2545454502105713,
+              "regime_loss": 1.261507300897078,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    11,
+                    0,
+                    1
+                  ],
+                  [
+                    49,
+                    3,
+                    26
+                  ],
+                  [
+                    6,
+                    0,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.9166666666666666,
+                    "f1": 0.28205128205128205,
+                    "support": 12,
+                    "roc_auc": 0.7457482993197279,
+                    "pr_auc": 0.2022945536117145
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.07407407407407407,
+                    "support": 78,
+                    "roc_auc": 0.3489583333333333,
+                    "pr_auc": 0.6275269015182404
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.34146341463414637,
+                    "recall": 0.7,
+                    "f1": 0.4590163934426229,
+                    "support": 20,
+                    "roc_auc": 0.7011111111111111,
+                    "pr_auc": 0.27514695032651876
+                  }
+                ],
+                "macro_precision": 0.502710027100271,
+                "macro_recall": 0.5517094017094016,
+                "macro_f1": 0.2717139165226597,
+                "weighted_f1": 0.16675200937496018,
+                "macro_roc_auc": 0.5986059145880575,
+                "macro_pr_auc": 0.36832280181882454
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4462777366003173,
+              "regime_accuracy": 0.46846845746040344,
+              "regime_loss": 1.0783315931074122,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    25,
+                    6,
+                    13
+                  ],
+                  [
+                    17,
+                    19,
+                    12
+                  ],
+                  [
+                    7,
+                    4,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5102040816326531,
+                    "recall": 0.5681818181818182,
+                    "f1": 0.5376344086021506,
+                    "support": 44,
+                    "roc_auc": 0.5390094979647219,
+                    "pr_auc": 0.40772318259769186
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6551724137931034,
+                    "recall": 0.3958333333333333,
+                    "f1": 0.49350649350649356,
+                    "support": 48,
+                    "roc_auc": 0.5830026455026455,
+                    "pr_auc": 0.5425788573982961
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.24242424242424243,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.3076923076923077,
+                    "support": 19,
+                    "roc_auc": 0.5680778032036613,
+                    "pr_auc": 0.28106583132291696
+                  }
+                ],
+                "macro_precision": 0.46926691261666625,
+                "macro_recall": 0.4616892610313663,
+                "macro_f1": 0.4462777366003173,
+                "weighted_f1": 0.4791926082248663,
+                "macro_roc_auc": 0.5633633155570096,
+                "macro_pr_auc": 0.4104559571063016
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4023560910307898,
+              "regime_accuracy": 0.42307692766189575,
+              "regime_loss": 1.0812072799755976,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    13,
+                    7
+                  ],
+                  [
+                    12,
+                    18,
+                    22
+                  ],
+                  [
+                    6,
+                    0,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.24000000000000002,
+                    "support": 26,
+                    "roc_auc": 0.5848126232741617,
+                    "pr_auc": 0.37032567951991924
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5806451612903226,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.43373493975903615,
+                    "support": 52,
+                    "roc_auc": 0.6120562130177515,
+                    "pr_auc": 0.6303790974355433
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.40816326530612246,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5333333333333333,
+                    "support": 26,
+                    "roc_auc": 0.7026627218934911,
+                    "pr_auc": 0.5418150141618066
+                  }
+                ],
+                "macro_precision": 0.41293614219881497,
+                "macro_recall": 0.44871794871794873,
+                "macro_f1": 0.4023560910307898,
+                "weighted_f1": 0.4102008032128514,
+                "macro_roc_auc": 0.6331771860618014,
+                "macro_pr_auc": 0.5141732637057563
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3510457516339869,
+              "regime_accuracy": 0.36666667461395264,
+              "regime_loss": 1.1706159057097676,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    8,
+                    5
+                  ],
+                  [
+                    14,
+                    6,
+                    25
+                  ],
+                  [
+                    15,
+                    9,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3409090909090909,
+                    "recall": 0.5357142857142857,
+                    "f1": 0.41666666666666663,
+                    "support": 28,
+                    "roc_auc": 0.6921583850931677,
+                    "pr_auc": 0.3643695462331965
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2608695652173913,
+                    "recall": 0.13333333333333333,
+                    "f1": 0.1764705882352941,
+                    "support": 45,
+                    "roc_auc": 0.4311111111111111,
+                    "pr_auc": 0.3374727901312254
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4339622641509434,
+                    "recall": 0.48936170212765956,
+                    "f1": 0.45999999999999996,
+                    "support": 47,
+                    "roc_auc": 0.5607694549693967,
+                    "pr_auc": 0.4290905391489158
+                  }
+                ],
+                "macro_precision": 0.3452469734258085,
+                "macro_recall": 0.38613644039175954,
+                "macro_f1": 0.3510457516339869,
+                "weighted_f1": 0.3435653594771242,
+                "macro_roc_auc": 0.5613463170578918,
+                "macro_pr_auc": 0.37697762517111255
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5677587675003466,
+              "regime_accuracy": 0.7542372941970825,
+              "regime_loss": 0.6097758654820717,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    1,
+                    4,
+                    7
+                  ],
+                  [
+                    6,
+                    12,
+                    78
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.7,
+                    "f1": 0.5833333333333334,
+                    "support": 10,
+                    "roc_auc": 0.887962962962963,
+                    "pr_auc": 0.3074885335914747
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.21052631578947367,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.2580645161290323,
+                    "support": 12,
+                    "roc_auc": 0.7012578616352201,
+                    "pr_auc": 0.15450494376410595
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9176470588235294,
+                    "recall": 0.8125,
+                    "f1": 0.8618784530386742,
+                    "support": 96,
+                    "roc_auc": 0.8626893939393939,
+                    "pr_auc": 0.968555741471517
+                  }
+                ],
+                "macro_precision": 0.5427244582043343,
+                "macro_recall": 0.6152777777777777,
+                "macro_f1": 0.5677587675003466,
+                "weighted_f1": 0.7768681272762241,
+                "macro_roc_auc": 0.8173034061791924,
+                "macro_pr_auc": 0.47684973960903254
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.26296296296296295,
+              "regime_accuracy": 0.2545454502105713,
+              "regime_loss": 1.6291886307976462,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    3,
+                    3
+                  ],
+                  [
+                    21,
+                    6,
+                    51
+                  ],
+                  [
+                    1,
+                    3,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.21428571428571427,
+                    "recall": 0.5,
+                    "f1": 0.3,
+                    "support": 12,
+                    "roc_auc": 0.6318027210884354,
+                    "pr_auc": 0.1389738486094826
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.13333333333333336,
+                    "support": 78,
+                    "roc_auc": 0.3838141025641026,
+                    "pr_auc": 0.6212177769528913
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.22857142857142856,
+                    "recall": 0.8,
+                    "f1": 0.3555555555555555,
+                    "support": 20,
+                    "roc_auc": 0.6977777777777778,
+                    "pr_auc": 0.27866111462002724
+                  }
+                ],
+                "macro_precision": 0.3142857142857143,
+                "macro_recall": 0.45897435897435895,
+                "macro_f1": 0.26296296296296295,
+                "weighted_f1": 0.19191919191919196,
+                "macro_roc_auc": 0.5711315338101053,
+                "macro_pr_auc": 0.346284246727467
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.36311196868178897,
+              "regime_accuracy": 0.36936935782432556,
+              "regime_loss": 1.1083286770932774,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    10,
+                    17
+                  ],
+                  [
+                    17,
+                    15,
+                    16
+                  ],
+                  [
+                    5,
+                    5,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4358974358974359,
+                    "recall": 0.38636363636363635,
+                    "f1": 0.40963855421686746,
+                    "support": 44,
+                    "roc_auc": 0.5939620081411127,
+                    "pr_auc": 0.4302590706507658
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.3125,
+                    "f1": 0.38461538461538464,
+                    "support": 48,
+                    "roc_auc": 0.5496031746031746,
+                    "pr_auc": 0.464217357332157
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21428571428571427,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.29508196721311475,
+                    "support": 19,
+                    "roc_auc": 0.5480549199084668,
+                    "pr_auc": 0.22793677006670623
+                  }
+                ],
+                "macro_precision": 0.38339438339438336,
+                "macro_recall": 0.3908492822966507,
+                "macro_f1": 0.36311196868178897,
+                "weighted_f1": 0.3792089389561244,
+                "macro_roc_auc": 0.5638733675509181,
+                "macro_pr_auc": 0.37413773268320966
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4728009211775099,
+              "regime_accuracy": 0.5288461446762085,
+              "regime_loss": 1.0357175194300139,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    13,
+                    8
+                  ],
+                  [
+                    3,
+                    33,
+                    16
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.625,
+                    "recall": 0.19230769230769232,
+                    "f1": 0.29411764705882354,
+                    "support": 26,
+                    "roc_auc": 0.6863905325443787,
+                    "pr_auc": 0.5124468476755428
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6,
+                    "recall": 0.6346153846153846,
+                    "f1": 0.616822429906542,
+                    "support": 52,
+                    "roc_auc": 0.6475591715976331,
+                    "pr_auc": 0.6316111621804253
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4146341463414634,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.5074626865671641,
+                    "support": 26,
+                    "roc_auc": 0.7657790927021696,
+                    "pr_auc": 0.6523041929418659
+                  }
+                ],
+                "macro_precision": 0.5465447154471544,
+                "macro_recall": 0.4935897435897436,
+                "macro_f1": 0.4728009211775099,
+                "weighted_f1": 0.508806298359768,
+                "macro_roc_auc": 0.6999095989480605,
+                "macro_pr_auc": 0.5987874009326114
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3674150708049013,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.1817551760101215,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    5,
+                    8
+                  ],
+                  [
+                    14,
+                    2,
+                    29
+                  ],
+                  [
+                    9,
+                    4,
+                    34
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.39473684210526316,
+                    "recall": 0.5357142857142857,
+                    "f1": 0.45454545454545453,
+                    "support": 28,
+                    "roc_auc": 0.6937111801242236,
+                    "pr_auc": 0.35176276785295624
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.18181818181818182,
+                    "recall": 0.044444444444444446,
+                    "f1": 0.07142857142857142,
+                    "support": 45,
+                    "roc_auc": 0.5499259259259259,
+                    "pr_auc": 0.4035371499920552
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4788732394366197,
+                    "recall": 0.723404255319149,
+                    "f1": 0.576271186440678,
+                    "support": 47,
+                    "roc_auc": 0.6313028271640921,
+                    "pr_auc": 0.49188264055391445
+                  }
+                ],
+                "macro_precision": 0.35180942112002156,
+                "macro_recall": 0.43452099515929304,
+                "macro_f1": 0.3674150708049013,
+                "weighted_f1": 0.3585525350355859,
+                "macro_roc_auc": 0.6249799777380806,
+                "macro_pr_auc": 0.4157275194663086
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4007575757575757,
+              "regime_accuracy": 0.694915235042572,
+              "regime_loss": 0.6398951901217639,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    16,
+                    5,
+                    75
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23333333333333334,
+                    "recall": 0.7,
+                    "f1": 0.35,
+                    "support": 10,
+                    "roc_auc": 0.8925925925925926,
+                    "pr_auc": 0.307702126763543
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7279874213836478,
+                    "pr_auc": 0.15545421724413327
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9375,
+                    "recall": 0.78125,
+                    "f1": 0.8522727272727273,
+                    "support": 96,
+                    "roc_auc": 0.8797348484848485,
+                    "pr_auc": 0.9733302444835138
+                  }
+                ],
+                "macro_precision": 0.3902777777777778,
+                "macro_recall": 0.49374999999999997,
+                "macro_f1": 0.4007575757575757,
+                "weighted_f1": 0.723035439137134,
+                "macro_roc_auc": 0.8334382874870295,
+                "macro_pr_auc": 0.4788288628303967
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2737443347612839,
+              "regime_accuracy": 0.26363635063171387,
+              "regime_loss": 1.1522683035243642,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    42,
+                    10,
+                    26
+                  ],
+                  [
+                    8,
+                    1,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.13793103448275862,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.2285714285714286,
+                    "support": 12,
+                    "roc_auc": 0.6675170068027211,
+                    "pr_auc": 0.16563927402562928
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7692307692307693,
+                    "recall": 0.1282051282051282,
+                    "f1": 0.21978021978021975,
+                    "support": 78,
+                    "roc_auc": 0.4082532051282051,
+                    "pr_auc": 0.6885286346819532
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.28205128205128205,
+                    "recall": 0.55,
+                    "f1": 0.3728813559322034,
+                    "support": 20,
+                    "roc_auc": 0.7205555555555555,
+                    "pr_auc": 0.2807614011590121
+                  }
+                ],
+                "macro_precision": 0.39640436192160333,
+                "macro_recall": 0.4482905982905983,
+                "macro_f1": 0.2737443347612839,
+                "weighted_f1": 0.24857583094871225,
+                "macro_roc_auc": 0.5987752558288272,
+                "macro_pr_auc": 0.37830976995553156
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3970151857308358,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.0337208938306799,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    28,
+                    4,
+                    12
+                  ],
+                  [
+                    27,
+                    9,
+                    12
+                  ],
+                  [
+                    8,
+                    1,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4444444444444444,
+                    "recall": 0.6363636363636364,
+                    "f1": 0.5233644859813084,
+                    "support": 44,
+                    "roc_auc": 0.6231343283582089,
+                    "pr_auc": 0.4502038670767634
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6428571428571429,
+                    "recall": 0.1875,
+                    "f1": 0.2903225806451613,
+                    "support": 48,
+                    "roc_auc": 0.6081349206349206,
+                    "pr_auc": 0.6031784878376554
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.29411764705882354,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.3773584905660377,
+                    "support": 19,
+                    "roc_auc": 0.602974828375286,
+                    "pr_auc": 0.2926025303583631
+                  }
+                ],
+                "macro_precision": 0.46047307812013694,
+                "macro_recall": 0.45005980861244016,
+                "macro_f1": 0.3970151857308358,
+                "weighted_f1": 0.3975975907648651,
+                "macro_roc_auc": 0.6114146924561386,
+                "macro_pr_auc": 0.4486616284242606
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2949141281333925,
+              "regime_accuracy": 0.29807692766189575,
+              "regime_loss": 1.2175235564892108,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    11,
+                    7
+                  ],
+                  [
+                    29,
+                    4,
+                    19
+                  ],
+                  [
+                    6,
+                    1,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18604651162790697,
+                    "recall": 0.3076923076923077,
+                    "f1": 0.2318840579710145,
+                    "support": 26,
+                    "roc_auc": 0.5670611439842209,
+                    "pr_auc": 0.33148430198091
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.11764705882352941,
+                    "support": 52,
+                    "roc_auc": 0.5521449704142012,
+                    "pr_auc": 0.49702242775505395
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4222222222222222,
+                    "recall": 0.7307692307692307,
+                    "f1": 0.5352112676056338,
+                    "support": 26,
+                    "roc_auc": 0.6711045364891519,
+                    "pr_auc": 0.42154866866083274
+                  }
+                ],
+                "macro_precision": 0.28608957795004303,
+                "macro_recall": 0.3717948717948718,
+                "macro_f1": 0.2949141281333925,
+                "weighted_f1": 0.25059736080592676,
+                "macro_roc_auc": 0.5967702169625246,
+                "macro_pr_auc": 0.4166851327989322
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3610123352619736,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.1671556015423712,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    5,
+                    11
+                  ],
+                  [
+                    8,
+                    2,
+                    35
+                  ],
+                  [
+                    3,
+                    9,
+                    35
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5217391304347826,
+                    "recall": 0.42857142857142855,
+                    "f1": 0.47058823529411764,
+                    "support": 28,
+                    "roc_auc": 0.7313664596273292,
+                    "pr_auc": 0.3798909301200632
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.125,
+                    "recall": 0.044444444444444446,
+                    "f1": 0.06557377049180328,
+                    "support": 45,
+                    "roc_auc": 0.42814814814814817,
+                    "pr_auc": 0.3375934929396689
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.43209876543209874,
+                    "recall": 0.7446808510638298,
+                    "f1": 0.546875,
+                    "support": 47,
+                    "roc_auc": 0.5884581754590499,
+                    "pr_auc": 0.4336186310103841
+                  }
+                ],
+                "macro_precision": 0.35961263195562715,
+                "macro_recall": 0.4058989080265676,
+                "macro_f1": 0.3610123352619736,
+                "weighted_f1": 0.348586793836387,
+                "macro_roc_auc": 0.5826575944115091,
+                "macro_pr_auc": 0.38370101802337203
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4356413294960781,
+              "regime_accuracy": 0.7288135886192322,
+              "regime_loss": 0.6316007229231172,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    8,
+                    0,
+                    4
+                  ],
+                  [
+                    8,
+                    9,
+                    79
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.30434782608695654,
+                    "recall": 0.7,
+                    "f1": 0.42424242424242425,
+                    "support": 10,
+                    "roc_auc": 0.924074074074074,
+                    "pr_auc": 0.384120770533814
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7405660377358491,
+                    "pr_auc": 0.16175347156779832
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9518072289156626,
+                    "recall": 0.8229166666666666,
+                    "f1": 0.88268156424581,
+                    "support": 96,
+                    "roc_auc": 0.8939393939393939,
+                    "pr_auc": 0.976057054281879
+                  }
+                ],
+                "macro_precision": 0.4187183516675397,
+                "macro_recall": 0.5076388888888889,
+                "macro_f1": 0.4356413294960781,
+                "weighted_f1": 0.7540665627967966,
+                "macro_roc_auc": 0.8528598352497724,
+                "macro_pr_auc": 0.5073104321278304
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3539443082889328,
+              "regime_accuracy": 0.3545454442501068,
+              "regime_loss": 1.1325002258474177,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    25,
+                    16,
+                    37
+                  ],
+                  [
+                    4,
+                    1,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.21621621621621623,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.326530612244898,
+                    "support": 12,
+                    "roc_auc": 0.6972789115646258,
+                    "pr_auc": 0.1844022583256485
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8421052631578947,
+                    "recall": 0.20512820512820512,
+                    "f1": 0.32989690721649484,
+                    "support": 78,
+                    "roc_auc": 0.4150641025641026,
+                    "pr_auc": 0.7155890398562886
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2777777777777778,
+                    "recall": 0.75,
+                    "f1": 0.4054054054054055,
+                    "support": 20,
+                    "roc_auc": 0.7211111111111111,
+                    "pr_auc": 0.2800035598831617
+                  }
+                ],
+                "macro_precision": 0.4453664190506295,
+                "macro_recall": 0.5405982905982906,
+                "macro_f1": 0.3539443082889328,
+                "weighted_f1": 0.3432584928903044,
+                "macro_roc_auc": 0.6111513750799465,
+                "macro_pr_auc": 0.3933316193550329
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2948717948717949,
+              "regime_accuracy": 0.36036035418510437,
+              "regime_loss": 1.0366808840202102,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    30,
+                    1,
+                    13
+                  ],
+                  [
+                    38,
+                    0,
+                    10
+                  ],
+                  [
+                    8,
+                    1,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.39473684210526316,
+                    "recall": 0.6818181818181818,
+                    "f1": 0.5,
+                    "support": 44,
+                    "roc_auc": 0.594640434192673,
+                    "pr_auc": 0.4981080019239007
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.6669973544973545,
+                    "pr_auc": 0.5957397004880643
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.30303030303030304,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.38461538461538464,
+                    "support": 19,
+                    "roc_auc": 0.6350114416475973,
+                    "pr_auc": 0.4355441861812598
+                  }
+                ],
+                "macro_precision": 0.2325890483785221,
+                "macro_recall": 0.4027113237639553,
+                "macro_f1": 0.2948717948717949,
+                "weighted_f1": 0.26403326403326405,
+                "macro_roc_auc": 0.6322164101125416,
+                "macro_pr_auc": 0.5097972961977416
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3972435569209763,
+              "regime_accuracy": 0.48076921701431274,
+              "regime_loss": 1.132226852270273,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    13,
+                    11
+                  ],
+                  [
+                    3,
+                    31,
+                    18
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.12903225806451613,
+                    "support": 26,
+                    "roc_auc": 0.5769230769230769,
+                    "pr_auc": 0.3835529939058035
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5849056603773585,
+                    "recall": 0.5961538461538461,
+                    "f1": 0.5904761904761905,
+                    "support": 52,
+                    "roc_auc": 0.6349852071005917,
+                    "pr_auc": 0.5653854243247469
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3695652173913043,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.4722222222222222,
+                    "support": 26,
+                    "roc_auc": 0.6824457593688363,
+                    "pr_auc": 0.5891443503568673
+                  }
+                ],
+                "macro_precision": 0.45149029258955425,
+                "macro_recall": 0.4423076923076923,
+                "macro_f1": 0.3972435569209763,
+                "weighted_f1": 0.4455517153097798,
+                "macro_roc_auc": 0.6314513477975017,
+                "macro_pr_auc": 0.5126942561958059
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.40989908247046963,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.1277269525711606,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    9,
+                    5
+                  ],
+                  [
+                    11,
+                    13,
+                    21
+                  ],
+                  [
+                    18,
+                    6,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.32558139534883723,
+                    "recall": 0.5,
+                    "f1": 0.3943661971830986,
+                    "support": 28,
+                    "roc_auc": 0.7317546583850931,
+                    "pr_auc": 0.42440667243146835
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4642857142857143,
+                    "recall": 0.28888888888888886,
+                    "f1": 0.3561643835616438,
+                    "support": 45,
+                    "roc_auc": 0.4699259259259259,
+                    "pr_auc": 0.36819554505492214
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.46938775510204084,
+                    "recall": 0.48936170212765956,
+                    "f1": 0.47916666666666663,
+                    "support": 47,
+                    "roc_auc": 0.5610609151850773,
+                    "pr_auc": 0.41983441548961903
+                  }
+                ],
+                "macro_precision": 0.41975162157886414,
+                "macro_recall": 0.4260835303388495,
+                "macro_f1": 0.40989908247046963,
+                "weighted_f1": 0.41325403428945057,
+                "macro_roc_auc": 0.5875804998320321,
+                "macro_pr_auc": 0.4041455443253365
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3862800714360752,
+              "regime_accuracy": 0.6186440587043762,
+              "regime_loss": 0.8255355428841155,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    14,
+                    16,
+                    66
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.7,
+                    "f1": 0.3684210526315789,
+                    "support": 10,
+                    "roc_auc": 0.8787037037037037,
+                    "pr_auc": 0.49620310149961916
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6045597484276729,
+                    "pr_auc": 0.11356193386354826
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9295774647887324,
+                    "recall": 0.6875,
+                    "f1": 0.7904191616766466,
+                    "support": 96,
+                    "roc_auc": 0.853219696969697,
+                    "pr_auc": 0.9657073113091558
+                  }
+                ],
+                "macro_precision": 0.3931924882629108,
+                "macro_recall": 0.46249999999999997,
+                "macro_f1": 0.3862800714360752,
+                "weighted_f1": 0.6742750004006259,
+                "macro_roc_auc": 0.7788277163670245,
+                "macro_pr_auc": 0.5251574488907744
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.35934053175432484,
+              "regime_accuracy": 0.3545454442501068,
+              "regime_loss": 1.027407962625677,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    1,
+                    2
+                  ],
+                  [
+                    35,
+                    16,
+                    27
+                  ],
+                  [
+                    2,
+                    4,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1956521739130435,
+                    "recall": 0.75,
+                    "f1": 0.3103448275862069,
+                    "support": 12,
+                    "roc_auc": 0.7508503401360545,
+                    "pr_auc": 0.2998284756755424
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7619047619047619,
+                    "recall": 0.20512820512820512,
+                    "f1": 0.3232323232323232,
+                    "support": 78,
+                    "roc_auc": 0.5184294871794872,
+                    "pr_auc": 0.777338837564907
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.32558139534883723,
+                    "recall": 0.7,
+                    "f1": 0.44444444444444453,
+                    "support": 20,
+                    "roc_auc": 0.7611111111111111,
+                    "pr_auc": 0.36261593374021434
+                  }
+                ],
+                "macro_precision": 0.42771277705554755,
+                "macro_recall": 0.5517094017094016,
+                "macro_f1": 0.35934053175432484,
+                "weighted_f1": 0.34386498210949623,
+                "macro_roc_auc": 0.6767969794755508,
+                "macro_pr_auc": 0.47992774899355456
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.35391280252495555,
+              "regime_accuracy": 0.36036035418510437,
+              "regime_loss": 1.290343229134592,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    19,
+                    13,
+                    12
+                  ],
+                  [
+                    16,
+                    11,
+                    21
+                  ],
+                  [
+                    7,
+                    2,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4523809523809524,
+                    "recall": 0.4318181818181818,
+                    "f1": 0.4418604651162791,
+                    "support": 44,
+                    "roc_auc": 0.5888738127544098,
+                    "pr_auc": 0.4345449048585654
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4230769230769231,
+                    "recall": 0.22916666666666666,
+                    "f1": 0.29729729729729726,
+                    "support": 48,
+                    "roc_auc": 0.533068783068783,
+                    "pr_auc": 0.47786676268109946
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.23255813953488372,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.3225806451612903,
+                    "support": 19,
+                    "roc_auc": 0.61441647597254,
+                    "pr_auc": 0.21321294058653162
+                  }
+                ],
+                "macro_precision": 0.36933867166425305,
+                "macro_recall": 0.3957668793195109,
+                "macro_f1": 0.35391280252495555,
+                "weighted_f1": 0.35892939633739696,
+                "macro_roc_auc": 0.5787863572652442,
+                "macro_pr_auc": 0.3752082027087322
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.41941867010195616,
+              "regime_accuracy": 0.5192307829856873,
+              "regime_loss": 1.0145510939451365,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    18,
+                    7
+                  ],
+                  [
+                    4,
+                    33,
+                    15
+                  ],
+                  [
+                    0,
+                    6,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.06451612903225806,
+                    "support": 26,
+                    "roc_auc": 0.6760355029585798,
+                    "pr_auc": 0.3870284257592975
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5789473684210527,
+                    "recall": 0.6346153846153846,
+                    "f1": 0.6055045871559633,
+                    "support": 52,
+                    "roc_auc": 0.6094674556213018,
+                    "pr_auc": 0.5265099690038941
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.47619047619047616,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.588235294117647,
+                    "support": 26,
+                    "roc_auc": 0.8264299802761341,
+                    "pr_auc": 0.6973629823937969
+                  }
+                ],
+                "macro_precision": 0.4183792815371763,
+                "macro_recall": 0.4807692307692308,
+                "macro_f1": 0.41941867010195616,
+                "weighted_f1": 0.4659401493654579,
+                "macro_roc_auc": 0.7039776462853385,
+                "macro_pr_auc": 0.5369671257189962
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "regression": [
+      {
+        "head_mode": "regression",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.38912239494802775,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.4405186262708312,
+              "regression_rmse_log_rv": 0.9579329297337458,
+              "regression_mae_log_rv": 0.7747503152240824,
+              "regression_loss": 0.9176354978682775,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    3,
+                    16
+                  ],
+                  [
+                    11,
+                    6,
+                    28
+                  ],
+                  [
+                    4,
+                    3,
+                    40
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.375,
+                    "recall": 0.32142857142857145,
+                    "f1": 0.3461538461538462,
+                    "support": 28,
+                    "roc_auc": 0.6502329192546584,
+                    "pr_auc": 0.3148917793867064
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.13333333333333333,
+                    "f1": 0.2105263157894737,
+                    "support": 45,
+                    "roc_auc": 0.5128888888888888,
+                    "pr_auc": 0.399493581052556
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.47619047619047616,
+                    "recall": 0.851063829787234,
+                    "f1": 0.6106870229007634,
+                    "support": 47,
+                    "roc_auc": 0.6589915476537452,
+                    "pr_auc": 0.5361295917955471
+                  }
+                ],
+                "macro_precision": 0.4503968253968254,
+                "macro_recall": 0.435275244849713,
+                "macro_f1": 0.38912239494802775,
+                "weighted_f1": 0.3989023498264157,
+                "macro_roc_auc": 0.6073711185990974,
+                "macro_pr_auc": 0.4168383174116032
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4279942818074461,
+              "regime_accuracy": 0.6694915294647217,
+              "regime_loss": 0.6617657936225503,
+              "regression_rmse_log_rv": 1.1322378841568543,
+              "regression_mae_log_rv": 1.0213071051475708,
+              "regression_loss": 1.2819626263199904,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    7,
+                    17,
+                    72
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.7,
+                    "f1": 0.45161290322580644,
+                    "support": 10,
+                    "roc_auc": 0.9083333333333333,
+                    "pr_auc": 0.4106542313895255
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6580188679245284,
+                    "pr_auc": 0.13112552027434024
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.935064935064935,
+                    "recall": 0.75,
+                    "f1": 0.8323699421965318,
+                    "support": 96,
+                    "roc_auc": 0.8650568181818182,
+                    "pr_auc": 0.9697082898301653
+                  }
+                ],
+                "macro_precision": 0.4227994227994228,
+                "macro_recall": 0.48333333333333334,
+                "macro_f1": 0.4279942818074461,
+                "weighted_f1": 0.715454605789196,
+                "macro_roc_auc": 0.81046967314656,
+                "macro_pr_auc": 0.503829347164677
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.24536431856693294,
+              "regime_accuracy": 0.23636363446712494,
+              "regime_loss": 1.439949649030512,
+              "regression_rmse_log_rv": 0.49548956629005825,
+              "regression_mae_log_rv": 0.3964701968325244,
+              "regression_loss": 0.24550991030231004,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    0,
+                    4
+                  ],
+                  [
+                    31,
+                    4,
+                    43
+                  ],
+                  [
+                    3,
+                    3,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.19047619047619047,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.2962962962962963,
+                    "support": 12,
+                    "roc_auc": 0.7508503401360545,
+                    "pr_auc": 0.28891706905622355
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5714285714285714,
+                    "recall": 0.05128205128205128,
+                    "f1": 0.09411764705882351,
+                    "support": 78,
+                    "roc_auc": 0.3733974358974359,
+                    "pr_auc": 0.6419088727941246
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.22950819672131148,
+                    "recall": 0.7,
+                    "f1": 0.345679012345679,
+                    "support": 20,
+                    "roc_auc": 0.5677777777777778,
+                    "pr_auc": 0.20733911420773177
+                  }
+                ],
+                "macro_precision": 0.33047098620869114,
+                "macro_recall": 0.4726495726495726,
+                "macro_f1": 0.24536431856693294,
+                "weighted_f1": 0.161911929755067,
+                "macro_roc_auc": 0.5640085179370894,
+                "macro_pr_auc": 0.37938835201935994
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3584879496352997,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.2539401174423837,
+              "regression_rmse_log_rv": 0.7186538937968692,
+              "regression_mae_log_rv": 0.6041937636910006,
+              "regression_loss": 0.5164634190694017,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    28,
+                    4,
+                    12
+                  ],
+                  [
+                    24,
+                    10,
+                    14
+                  ],
+                  [
+                    5,
+                    8,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.49122807017543857,
+                    "recall": 0.6363636363636364,
+                    "f1": 0.5544554455445544,
+                    "support": 44,
+                    "roc_auc": 0.6282225237449118,
+                    "pr_auc": 0.4718093689918449
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.28571428571428575,
+                    "support": 48,
+                    "roc_auc": 0.5201719576719577,
+                    "pr_auc": 0.4431868170538124
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1875,
+                    "recall": 0.3157894736842105,
+                    "f1": 0.23529411764705882,
+                    "support": 19,
+                    "roc_auc": 0.5583524027459954,
+                    "pr_auc": 0.22785025047907465
+                  }
+                ],
+                "macro_precision": 0.37775784157363107,
+                "macro_recall": 0.38682881446039336,
+                "macro_f1": 0.3584879496352997,
+                "weighted_f1": 0.3836118338156777,
+                "macro_roc_auc": 0.5689156280542883,
+                "macro_pr_auc": 0.38094881217491067
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.38448326421180506,
+              "regime_accuracy": 0.5096153616905212,
+              "regime_loss": 1.0437347063651452,
+              "regression_rmse_log_rv": 1.0410761296340836,
+              "regression_mae_log_rv": 0.7987431586589082,
+              "regression_loss": 1.0838395076938832,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    18,
+                    8
+                  ],
+                  [
+                    0,
+                    33,
+                    19
+                  ],
+                  [
+                    0,
+                    6,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6691321499013807,
+                    "pr_auc": 0.4009707763010826
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5789473684210527,
+                    "recall": 0.6346153846153846,
+                    "f1": 0.6055045871559633,
+                    "support": 52,
+                    "roc_auc": 0.5872781065088757,
+                    "pr_auc": 0.5120394968458043
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.425531914893617,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.547945205479452,
+                    "support": 26,
+                    "roc_auc": 0.789447731755424,
+                    "pr_auc": 0.6539620973704017
+                  }
+                ],
+                "macro_precision": 0.3348264277715565,
+                "macro_recall": 0.4679487179487179,
+                "macro_f1": 0.38448326421180506,
+                "weighted_f1": 0.4397385949478447,
+                "macro_roc_auc": 0.6819526627218936,
+                "macro_pr_auc": 0.5223241235057628
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.32578214722919846,
+              "regime_accuracy": 0.3583333194255829,
+              "regime_loss": 1.1772382806746302,
+              "regression_rmse_log_rv": 0.798331761683961,
+              "regression_mae_log_rv": 0.6594316325026739,
+              "regression_loss": 0.6373336017134167,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    6,
+                    6
+                  ],
+                  [
+                    17,
+                    3,
+                    25
+                  ],
+                  [
+                    18,
+                    5,
+                    24
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3137254901960784,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.40506329113924044,
+                    "support": 28,
+                    "roc_auc": 0.6944875776397516,
+                    "pr_auc": 0.3833682885773513
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.21428571428571427,
+                    "recall": 0.06666666666666667,
+                    "f1": 0.10169491525423728,
+                    "support": 45,
+                    "roc_auc": 0.4308148148148148,
+                    "pr_auc": 0.359244595291635
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.43636363636363634,
+                    "recall": 0.5106382978723404,
+                    "f1": 0.4705882352941176,
+                    "support": 47,
+                    "roc_auc": 0.5467793646167298,
+                    "pr_auc": 0.4084439802766325
+                  }
+                ],
+                "macro_precision": 0.32145828028180967,
+                "macro_recall": 0.3829111786558595,
+                "macro_f1": 0.32578214722919846,
+                "weighted_f1": 0.3169640866430245,
+                "macro_roc_auc": 0.5573605856904321,
+                "macro_pr_auc": 0.3836856213818729
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5560114781596129,
+              "regime_accuracy": 0.7542372941970825,
+              "regime_loss": 0.5964921167341329,
+              "regression_rmse_log_rv": 0.9140240768326888,
+              "regression_mae_log_rv": 0.7812817194499075,
+              "regression_loss": 0.835440013029849,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    3,
+                    4,
+                    5
+                  ],
+                  [
+                    6,
+                    12,
+                    78
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4375,
+                    "recall": 0.7,
+                    "f1": 0.5384615384615384,
+                    "support": 10,
+                    "roc_auc": 0.8787037037037037,
+                    "pr_auc": 0.2942321835742888
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.21052631578947367,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.2580645161290323,
+                    "support": 12,
+                    "roc_auc": 0.7138364779874213,
+                    "pr_auc": 0.16816321530312525
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9397590361445783,
+                    "recall": 0.8125,
+                    "f1": 0.8715083798882681,
+                    "support": 96,
+                    "roc_auc": 0.890625,
+                    "pr_auc": 0.975780235044616
+                  }
+                ],
+                "macro_precision": 0.5292617839780173,
+                "macro_recall": 0.6152777777777777,
+                "macro_f1": 0.5560114781596129,
+                "weighted_f1": 0.7808999495545552,
+                "macro_roc_auc": 0.827721727230375,
+                "macro_pr_auc": 0.47939187797401
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.25022640195053986,
+              "regime_accuracy": 0.2545454502105713,
+              "regime_loss": 1.15146493694999,
+              "regression_rmse_log_rv": 0.3860455025931112,
+              "regression_mae_log_rv": 0.3204606041581428,
+              "regression_loss": 0.14903113007236785,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    0,
+                    4
+                  ],
+                  [
+                    35,
+                    0,
+                    43
+                  ],
+                  [
+                    0,
+                    0,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18604651162790697,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.2909090909090909,
+                    "support": 12,
+                    "roc_auc": 0.6794217687074829,
+                    "pr_auc": 0.1824957276397682
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.5296474358974359,
+                    "pr_auc": 0.6960926294503497
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.29850746268656714,
+                    "recall": 1.0,
+                    "f1": 0.45977011494252873,
+                    "support": 20,
+                    "roc_auc": 0.8255555555555556,
+                    "pr_auc": 0.6086458855956715
+                  }
+                ],
+                "macro_precision": 0.16151799143815804,
+                "macro_recall": 0.5555555555555555,
+                "macro_f1": 0.25022640195053986,
+                "weighted_f1": 0.11533010354326968,
+                "macro_roc_auc": 0.6782082533868249,
+                "macro_pr_auc": 0.4957447475619298
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.261008958038661,
+              "regime_accuracy": 0.3243243098258972,
+              "regime_loss": 1.130104849953034,
+              "regression_rmse_log_rv": 0.7691855254079922,
+              "regression_mae_log_rv": 0.6569431233219802,
+              "regression_loss": 0.591646372497169,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    28,
+                    0,
+                    16
+                  ],
+                  [
+                    21,
+                    0,
+                    27
+                  ],
+                  [
+                    8,
+                    3,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.49122807017543857,
+                    "recall": 0.6363636363636364,
+                    "f1": 0.5544554455445544,
+                    "support": 44,
+                    "roc_auc": 0.5753052917232022,
+                    "pr_auc": 0.42037405412147105
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.45337301587301587,
+                    "pr_auc": 0.38678516070372176
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1568627450980392,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.22857142857142856,
+                    "support": 19,
+                    "roc_auc": 0.545766590389016,
+                    "pr_auc": 0.3915698093667565
+                  }
+                ],
+                "macro_precision": 0.21603027175782594,
+                "macro_recall": 0.35247208931419455,
+                "macro_f1": 0.261008958038661,
+                "weighted_f1": 0.25890897970105886,
+                "macro_roc_auc": 0.524814965995078,
+                "macro_pr_auc": 0.3995763413973164
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5087685373871395,
+              "regime_accuracy": 0.557692289352417,
+              "regime_loss": 1.0962121486663818,
+              "regression_rmse_log_rv": 0.9578650958630179,
+              "regression_mae_log_rv": 0.7386272199219093,
+              "regression_loss": 0.9175055418726685,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    3,
+                    17
+                  ],
+                  [
+                    4,
+                    32,
+                    16
+                  ],
+                  [
+                    1,
+                    5,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5454545454545454,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.3243243243243243,
+                    "support": 26,
+                    "roc_auc": 0.5769230769230769,
+                    "pr_auc": 0.3074573242265291
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8,
+                    "recall": 0.6153846153846154,
+                    "f1": 0.6956521739130435,
+                    "support": 52,
+                    "roc_auc": 0.6642011834319527,
+                    "pr_auc": 0.6925790546136578
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37735849056603776,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5063291139240507,
+                    "support": 26,
+                    "roc_auc": 0.6711045364891519,
+                    "pr_auc": 0.46329020863952963
+                  }
+                ],
+                "macro_precision": 0.5742710120068611,
+                "macro_recall": 0.5384615384615384,
+                "macro_f1": 0.5087685373871395,
+                "weighted_f1": 0.5554894465186154,
+                "macro_roc_auc": 0.6374095989480605,
+                "macro_pr_auc": 0.4877755291599055
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3399931693989071,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.3108348406314765,
+              "regression_rmse_log_rv": 0.9269977748944365,
+              "regression_mae_log_rv": 0.7689029049834062,
+              "regression_loss": 0.8593248746592363,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    3,
+                    12
+                  ],
+                  [
+                    14,
+                    0,
+                    31
+                  ],
+                  [
+                    6,
+                    3,
+                    38
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3939393939393939,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.4262295081967213,
+                    "support": 28,
+                    "roc_auc": 0.6777950310559007,
+                    "pr_auc": 0.32096793304013566
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 45,
+                    "roc_auc": 0.5845925925925926,
+                    "pr_auc": 0.44257410139833964
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4691358024691358,
+                    "recall": 0.8085106382978723,
+                    "f1": 0.59375,
+                    "support": 47,
+                    "roc_auc": 0.6368405712620228,
+                    "pr_auc": 0.48293214194157474
+                  }
+                ],
+                "macro_precision": 0.28769173213617655,
+                "macro_recall": 0.42426545086119555,
+                "macro_f1": 0.3399931693989071,
+                "weighted_f1": 0.33200563524590165,
+                "macro_roc_auc": 0.633076064970172,
+                "macro_pr_auc": 0.41549139212668335
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4229102265341386,
+              "regime_accuracy": 0.6355932354927063,
+              "regime_loss": 0.6795263608633462,
+              "regression_rmse_log_rv": 1.0126105678225206,
+              "regression_mae_log_rv": 0.9052687327493913,
+              "regression_loss": 1.0253801620658476,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    2,
+                    1
+                  ],
+                  [
+                    17,
+                    13,
+                    66
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.21212121212121213,
+                    "recall": 0.7,
+                    "f1": 0.3255813953488372,
+                    "support": 10,
+                    "roc_auc": 0.875,
+                    "pr_auc": 0.2456410326593571
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.1111111111111111,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.13333333333333333,
+                    "support": 12,
+                    "roc_auc": 0.6957547169811321,
+                    "pr_auc": 0.14672088192276256
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9850746268656716,
+                    "recall": 0.6875,
+                    "f1": 0.8098159509202454,
+                    "support": 96,
+                    "roc_auc": 0.9024621212121212,
+                    "pr_auc": 0.9783948495202122
+                  }
+                ],
+                "macro_precision": 0.43610231669933164,
+                "macro_recall": 0.5180555555555556,
+                "macro_f1": 0.4229102265341386,
+                "weighted_f1": 0.69998428171044,
+                "macro_roc_auc": 0.8244056127310845,
+                "macro_pr_auc": 0.4569189213674439
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.24861297445357486,
+              "regime_accuracy": 0.23636363446712494,
+              "regime_loss": 1.4346996155652132,
+              "regression_rmse_log_rv": 0.452433336998939,
+              "regression_mae_log_rv": 0.36439207163857645,
+              "regression_loss": 0.2046959244279955,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    1,
+                    1
+                  ],
+                  [
+                    39,
+                    6,
+                    33
+                  ],
+                  [
+                    6,
+                    4,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18181818181818182,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.2985074626865672,
+                    "support": 12,
+                    "roc_auc": 0.7159863945578231,
+                    "pr_auc": 0.1941576234229977
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5454545454545454,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.13483146067415733,
+                    "support": 78,
+                    "roc_auc": 0.344150641025641,
+                    "pr_auc": 0.6099414030923563
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.22727272727272727,
+                    "recall": 0.5,
+                    "f1": 0.3125,
+                    "support": 20,
+                    "roc_auc": 0.6127777777777778,
+                    "pr_auc": 0.2016980638441411
+                  }
+                ],
+                "macro_precision": 0.3181818181818182,
+                "macro_recall": 0.47008547008547014,
+                "macro_f1": 0.24861297445357486,
+                "weighted_f1": 0.18499039531657344,
+                "macro_roc_auc": 0.557638271120414,
+                "macro_pr_auc": 0.33526569678649837
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.36288858800244617,
+              "regime_accuracy": 0.4324324429035187,
+              "regime_loss": 1.1681313619493643,
+              "regression_rmse_log_rv": 0.8353260364471153,
+              "regression_mae_log_rv": 0.7034143857308663,
+              "regression_loss": 0.6977695871664475,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    35,
+                    0,
+                    9
+                  ],
+                  [
+                    25,
+                    3,
+                    20
+                  ],
+                  [
+                    7,
+                    2,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5223880597014925,
+                    "recall": 0.7954545454545454,
+                    "f1": 0.6306306306306306,
+                    "support": 44,
+                    "roc_auc": 0.6438263229308006,
+                    "pr_auc": 0.4663766876611259
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6,
+                    "recall": 0.0625,
+                    "f1": 0.11320754716981132,
+                    "support": 48,
+                    "roc_auc": 0.5720899470899471,
+                    "pr_auc": 0.517862630290445
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2564102564102564,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.3448275862068965,
+                    "support": 19,
+                    "roc_auc": 0.6161327231121282,
+                    "pr_auc": 0.21800171439716018
+                  }
+                ],
+                "macro_precision": 0.45959943870391634,
+                "macro_recall": 0.4614234449760765,
+                "macro_f1": 0.36288858800244617,
+                "weighted_f1": 0.3579588662146822,
+                "macro_roc_auc": 0.6106829977109586,
+                "macro_pr_auc": 0.40074701078291036
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4848431579358568,
+              "regime_accuracy": 0.5,
+              "regime_loss": 1.0013729150478656,
+              "regression_rmse_log_rv": 1.0017788445835063,
+              "regression_mae_log_rv": 0.771439251548145,
+              "regression_loss": 1.0035608534550648,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    11,
+                    6
+                  ],
+                  [
+                    14,
+                    25,
+                    13
+                  ],
+                  [
+                    4,
+                    4,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.33962264150943394,
+                    "support": 26,
+                    "roc_auc": 0.6602564102564102,
+                    "pr_auc": 0.4191301577558934
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.625,
+                    "recall": 0.4807692307692308,
+                    "f1": 0.5434782608695652,
+                    "support": 52,
+                    "roc_auc": 0.6523668639053254,
+                    "pr_auc": 0.6047412147850623
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4864864864864865,
+                    "recall": 0.6923076923076923,
+                    "f1": 0.5714285714285714,
+                    "support": 26,
+                    "roc_auc": 0.7416173570019724,
+                    "pr_auc": 0.6052807407686954
+                  }
+                ],
+                "macro_precision": 0.48160660660660665,
+                "macro_recall": 0.5064102564102564,
+                "macro_f1": 0.4848431579358568,
+                "weighted_f1": 0.4995019336692839,
+                "macro_roc_auc": 0.6847468770545694,
+                "macro_pr_auc": 0.5430507044365503
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.35314096971207776,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.3722050431431878,
+              "regression_rmse_log_rv": 0.865203649956138,
+              "regression_mae_log_rv": 0.7359975249164563,
+              "regression_loss": 0.7485773558974234,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    12,
+                    9
+                  ],
+                  [
+                    13,
+                    8,
+                    24
+                  ],
+                  [
+                    8,
+                    6,
+                    33
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.25,
+                    "f1": 0.25,
+                    "support": 28,
+                    "roc_auc": 0.6187888198757764,
+                    "pr_auc": 0.2677701560188796
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.17777777777777778,
+                    "f1": 0.22535211267605634,
+                    "support": 45,
+                    "roc_auc": 0.5597037037037037,
+                    "pr_auc": 0.41618851622553465
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.7021276595744681,
+                    "f1": 0.584070796460177,
+                    "support": 47,
+                    "roc_auc": 0.6021568055960361,
+                    "pr_auc": 0.4517962815993959
+                  }
+                ],
+                "macro_precision": 0.3525641025641026,
+                "macro_recall": 0.37663514578408197,
+                "macro_f1": 0.35314096971207776,
+                "weighted_f1": 0.3716014375337571,
+                "macro_roc_auc": 0.5935497763918387,
+                "macro_pr_auc": 0.3785849846146034
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.42280701754385963,
+              "regime_accuracy": 0.7457627058029175,
+              "regime_loss": 0.592416506197493,
+              "regression_rmse_log_rv": 1.0206999066994487,
+              "regression_mae_log_rv": 0.9019525303738192,
+              "regression_loss": 1.041828299536263,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    12,
+                    3,
+                    81
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.7,
+                    "f1": 0.3684210526315789,
+                    "support": 10,
+                    "roc_auc": 0.9138888888888889,
+                    "pr_auc": 0.43508141858141847
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.8883647798742138,
+                    "pr_auc": 0.3097383932207154
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9642857142857143,
+                    "recall": 0.84375,
+                    "f1": 0.8999999999999999,
+                    "support": 96,
+                    "roc_auc": 0.9152462121212122,
+                    "pr_auc": 0.9819734148163852
+                  }
+                ],
+                "macro_precision": 0.4047619047619048,
+                "macro_recall": 0.5145833333333333,
+                "macro_f1": 0.42280701754385963,
+                "weighted_f1": 0.7634255129348796,
+                "macro_roc_auc": 0.9058332936281049,
+                "macro_pr_auc": 0.575597742206173
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.42823102823102827,
+              "regime_accuracy": 0.44545453786849976,
+              "regime_loss": 1.0468734567815607,
+              "regression_rmse_log_rv": 0.45990211456205976,
+              "regression_mae_log_rv": 0.3647739453044778,
+              "regression_loss": 0.21150995497865394,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    4,
+                    0
+                  ],
+                  [
+                    28,
+                    28,
+                    22
+                  ],
+                  [
+                    0,
+                    7,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.3333333333333333,
+                    "support": 12,
+                    "roc_auc": 0.6913265306122449,
+                    "pr_auc": 0.1712589928711713
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.717948717948718,
+                    "recall": 0.358974358974359,
+                    "f1": 0.47863247863247865,
+                    "support": 78,
+                    "roc_auc": 0.42427884615384615,
+                    "pr_auc": 0.6996321699667609
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37142857142857144,
+                    "recall": 0.65,
+                    "f1": 0.4727272727272728,
+                    "support": 20,
+                    "roc_auc": 0.7427777777777778,
+                    "pr_auc": 0.2854023104915732
+                  }
+                ],
+                "macro_precision": 0.4371998371998372,
+                "macro_recall": 0.5585470085470086,
+                "macro_f1": 0.42823102823102827,
+                "weighted_f1": 0.46170798898071624,
+                "macro_roc_auc": 0.6194610515146229,
+                "macro_pr_auc": 0.3854311577765018
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3351929124334785,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.2575107842116728,
+              "regression_rmse_log_rv": 0.774778081403097,
+              "regression_mae_log_rv": 0.6466583091532812,
+              "regression_loss": 0.6002810754226641,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    31,
+                    0,
+                    13
+                  ],
+                  [
+                    25,
+                    2,
+                    21
+                  ],
+                  [
+                    6,
+                    2,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.7045454545454546,
+                    "f1": 0.5849056603773585,
+                    "support": 44,
+                    "roc_auc": 0.6441655359565808,
+                    "pr_auc": 0.5435745031896588
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.041666666666666664,
+                    "f1": 0.07692307692307693,
+                    "support": 48,
+                    "roc_auc": 0.5694444444444444,
+                    "pr_auc": 0.5434290954589929
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.24444444444444444,
+                    "recall": 0.5789473684210527,
+                    "f1": 0.34375,
+                    "support": 19,
+                    "roc_auc": 0.6664759725400458,
+                    "pr_auc": 0.23035935945406402
+                  }
+                ],
+                "macro_precision": 0.4148148148148148,
+                "macro_recall": 0.4417198298777247,
+                "macro_f1": 0.3351929124334785,
+                "weighted_f1": 0.3239586193595627,
+                "macro_roc_auc": 0.6266953176470237,
+                "macro_pr_auc": 0.4391209860342386
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4160744595527204,
+              "regime_accuracy": 0.5096153616905212,
+              "regime_loss": 1.070913470708407,
+              "regression_rmse_log_rv": 1.0123899377361405,
+              "regression_mae_log_rv": 0.79068361769896,
+              "regression_loss": 1.0249333860293863,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    16,
+                    8
+                  ],
+                  [
+                    0,
+                    34,
+                    18
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 1.0,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.14285714285714288,
+                    "support": 26,
+                    "roc_auc": 0.6272189349112426,
+                    "pr_auc": 0.44036939141056985
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.576271186440678,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.6126126126126126,
+                    "support": 52,
+                    "roc_auc": 0.5887573964497042,
+                    "pr_auc": 0.5172687432102573
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3953488372093023,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.49275362318840576,
+                    "support": 26,
+                    "roc_auc": 0.7001972386587771,
+                    "pr_auc": 0.5962914283968559
+                  }
+                ],
+                "macro_precision": 0.6572066745499935,
+                "macro_recall": 0.4615384615384615,
+                "macro_f1": 0.4160744595527204,
+                "weighted_f1": 0.4652089978176935,
+                "macro_roc_auc": 0.638724523339908,
+                "macro_pr_auc": 0.5179765210058943
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3614113383100725,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.1322597445234748,
+              "regression_rmse_log_rv": 0.8317279809974955,
+              "regression_mae_log_rv": 0.6927530310458678,
+              "regression_loss": 0.6917714343741701,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    8,
+                    5
+                  ],
+                  [
+                    15,
+                    8,
+                    22
+                  ],
+                  [
+                    21,
+                    4,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.29411764705882354,
+                    "recall": 0.5357142857142857,
+                    "f1": 0.379746835443038,
+                    "support": 28,
+                    "roc_auc": 0.7329192546583851,
+                    "pr_auc": 0.4159766622438197
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.17777777777777778,
+                    "f1": 0.24615384615384614,
+                    "support": 45,
+                    "roc_auc": 0.4731851851851852,
+                    "pr_auc": 0.4285104429588043
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4489795918367347,
+                    "recall": 0.46808510638297873,
+                    "f1": 0.4583333333333333,
+                    "support": 47,
+                    "roc_auc": 0.5756339259691052,
+                    "pr_auc": 0.4255577175738764
+                  }
+                ],
+                "macro_precision": 0.3810324129651861,
+                "macro_recall": 0.393859056625014,
+                "macro_f1": 0.3614113383100725,
+                "weighted_f1": 0.36042917613329,
+                "macro_roc_auc": 0.5939127886042251,
+                "macro_pr_auc": 0.4233482742588335
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.39430993722996655,
+              "regime_accuracy": 0.7118644118309021,
+              "regime_loss": 0.6549154924134076,
+              "regression_rmse_log_rv": 0.9991705356338146,
+              "regression_mae_log_rv": 0.8862053675111383,
+              "regression_loss": 0.9983417592787641,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    11,
+                    0,
+                    1
+                  ],
+                  [
+                    19,
+                    0,
+                    77
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1891891891891892,
+                    "recall": 0.7,
+                    "f1": 0.2978723404255319,
+                    "support": 10,
+                    "roc_auc": 0.8805555555555555,
+                    "pr_auc": 0.47028323340629846
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7539308176100629,
+                    "pr_auc": 0.16971828309726303
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9871794871794872,
+                    "recall": 0.8020833333333334,
+                    "f1": 0.8850574712643677,
+                    "support": 96,
+                    "roc_auc": 0.8887310606060606,
+                    "pr_auc": 0.9762843136392316
+                  }
+                ],
+                "macro_precision": 0.39212289212289214,
+                "macro_recall": 0.5006944444444444,
+                "macro_f1": 0.39430993722996655,
+                "weighted_f1": 0.7452901749630053,
+                "macro_roc_auc": 0.841072477923893,
+                "macro_pr_auc": 0.5387619433809311
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.29533499446290146,
+              "regime_accuracy": 0.2818181812763214,
+              "regime_loss": 1.1973517526279795,
+              "regression_rmse_log_rv": 0.4468035101457813,
+              "regression_mae_log_rv": 0.36765519401888014,
+              "regression_loss": 0.19963337667859127,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    43,
+                    7,
+                    28
+                  ],
+                  [
+                    5,
+                    1,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1724137931034483,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.28571428571428575,
+                    "support": 12,
+                    "roc_auc": 0.7653061224489796,
+                    "pr_auc": 0.30228534255590855
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.875,
+                    "recall": 0.08974358974358974,
+                    "f1": 0.1627906976744186,
+                    "support": 78,
+                    "roc_auc": 0.3942307692307692,
+                    "pr_auc": 0.6751768340432934
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 20,
+                    "roc_auc": 0.7544444444444445,
+                    "pr_auc": 0.344698149996076
+                  }
+                ],
+                "macro_precision": 0.45519853709508884,
+                "macro_recall": 0.541025641025641,
+                "macro_f1": 0.29533499446290146,
+                "weighted_f1": 0.22614768951978254,
+                "macro_roc_auc": 0.6379937787080644,
+                "macro_pr_auc": 0.44072010886509266
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2943567782277459,
+              "regime_accuracy": 0.315315306186676,
+              "regime_loss": 1.1172605743787574,
+              "regression_rmse_log_rv": 0.7596868966512933,
+              "regression_mae_log_rv": 0.6488056139787659,
+              "regression_loss": 0.5771241809436728,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    21,
+                    8,
+                    15
+                  ],
+                  [
+                    20,
+                    5,
+                    23
+                  ],
+                  [
+                    8,
+                    2,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.4772727272727273,
+                    "f1": 0.4516129032258064,
+                    "support": 44,
+                    "roc_auc": 0.5613975576662144,
+                    "pr_auc": 0.41593467145433677
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.10416666666666667,
+                    "f1": 0.15873015873015875,
+                    "support": 48,
+                    "roc_auc": 0.6038359788359788,
+                    "pr_auc": 0.4442291812201615
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19148936170212766,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.2727272727272727,
+                    "support": 19,
+                    "roc_auc": 0.5955377574370709,
+                    "pr_auc": 0.31951162609640565
+                  }
+                ],
+                "macro_precision": 0.3177980412022965,
+                "macro_recall": 0.3517078681552366,
+                "macro_f1": 0.2943567782277459,
+                "weighted_f1": 0.2943408427279395,
+                "macro_roc_auc": 0.5869237646464214,
+                "macro_pr_auc": 0.3932251595903013
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4834399431414356,
+              "regime_accuracy": 0.5288461446762085,
+              "regime_loss": 1.0674258745633638,
+              "regression_rmse_log_rv": 1.013634465458641,
+              "regression_mae_log_rv": 0.7711695627076551,
+              "regression_loss": 1.027454829565625,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    12,
+                    8
+                  ],
+                  [
+                    4,
+                    32,
+                    16
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.33333333333333337,
+                    "support": 26,
+                    "roc_auc": 0.6622287968441815,
+                    "pr_auc": 0.41752316425273356
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6037735849056604,
+                    "recall": 0.6153846153846154,
+                    "f1": 0.6095238095238096,
+                    "support": 52,
+                    "roc_auc": 0.6161242603550295,
+                    "pr_auc": 0.5586486652106569
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4146341463414634,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.5074626865671641,
+                    "support": 26,
+                    "roc_auc": 0.7840236686390533,
+                    "pr_auc": 0.6480653400525351
+                  }
+                ],
+                "macro_precision": 0.5394692437490413,
+                "macro_recall": 0.5,
+                "macro_f1": 0.4834399431414356,
+                "weighted_f1": 0.5149609097370291,
+                "macro_roc_auc": 0.6874589086127547,
+                "macro_pr_auc": 0.5414123898386419
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "dual": [
+      {
+        "head_mode": "dual",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3672580143168378,
+              "regime_accuracy": 0.4416666626930237,
+              "regime_loss": 1.1965009310655177,
+              "regression_rmse_log_rv": 0.965609417690508,
+              "regression_mae_log_rv": 0.7691902191036206,
+              "regression_loss": 0.932401547532602,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    3,
+                    13
+                  ],
+                  [
+                    14,
+                    3,
+                    28
+                  ],
+                  [
+                    9,
+                    0,
+                    38
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.34285714285714286,
+                    "recall": 0.42857142857142855,
+                    "f1": 0.38095238095238093,
+                    "support": 28,
+                    "roc_auc": 0.6708074534161491,
+                    "pr_auc": 0.3011273937245214
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.06666666666666667,
+                    "f1": 0.11764705882352941,
+                    "support": 45,
+                    "roc_auc": 0.48474074074074075,
+                    "pr_auc": 0.3826320458202025
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4810126582278481,
+                    "recall": 0.8085106382978723,
+                    "f1": 0.6031746031746031,
+                    "support": 47,
+                    "roc_auc": 0.6196444185368697,
+                    "pr_auc": 0.4740452135067532
+                  }
+                ],
+                "macro_precision": 0.44128993369499697,
+                "macro_recall": 0.43458291117865583,
+                "macro_f1": 0.3672580143168378,
+                "weighted_f1": 0.36924992219109865,
+                "macro_roc_auc": 0.5917308708979199,
+                "macro_pr_auc": 0.3859348843504924
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.43244239631336406,
+              "regime_accuracy": 0.6864407062530518,
+              "regime_loss": 0.6522664210553897,
+              "regression_rmse_log_rv": 1.1422135186732751,
+              "regression_mae_log_rv": 1.0311254215848749,
+              "regression_loss": 1.3046517222399845,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    7,
+                    15,
+                    74
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.7,
+                    "f1": 0.45161290322580644,
+                    "support": 10,
+                    "roc_auc": 0.9055555555555556,
+                    "pr_auc": 0.4085803584332996
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6595911949685535,
+                    "pr_auc": 0.13153975189554495
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9367088607594937,
+                    "recall": 0.7708333333333334,
+                    "f1": 0.8457142857142858,
+                    "support": 96,
+                    "roc_auc": 0.8697916666666666,
+                    "pr_auc": 0.9711601062607702
+                  }
+                ],
+                "macro_precision": 0.42334739803094235,
+                "macro_recall": 0.49027777777777776,
+                "macro_f1": 0.43244239631336406,
+                "weighted_f1": 0.7263110208544873,
+                "macro_roc_auc": 0.8116461390635918,
+                "macro_pr_auc": 0.5037600721965383
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.25231729055258467,
+              "regime_accuracy": 0.22727273404598236,
+              "regime_loss": 1.2083116466348822,
+              "regression_rmse_log_rv": 0.5078124791346584,
+              "regression_mae_log_rv": 0.4164059166178049,
+              "regression_loss": 0.2578735139648879,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    2,
+                    0
+                  ],
+                  [
+                    52,
+                    3,
+                    23
+                  ],
+                  [
+                    6,
+                    2,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.14705882352941177,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.25,
+                    "support": 12,
+                    "roc_auc": 0.7457482993197279,
+                    "pr_auc": 0.21121508672336897
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.07058823529411765,
+                    "support": 78,
+                    "roc_auc": 0.3401442307692308,
+                    "pr_auc": 0.5955346986715067
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.34285714285714286,
+                    "recall": 0.6,
+                    "f1": 0.43636363636363634,
+                    "support": 20,
+                    "roc_auc": 0.7238888888888889,
+                    "pr_auc": 0.3023151547150914
+                  }
+                ],
+                "macro_precision": 0.30616246498599436,
+                "macro_recall": 0.49059829059829063,
+                "macro_f1": 0.25231729055258467,
+                "weighted_f1": 0.15666504618376279,
+                "macro_roc_auc": 0.6032604729926159,
+                "macro_pr_auc": 0.36968831336998903
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3840455840455841,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.075235256397348,
+              "regression_rmse_log_rv": 0.7550588029829038,
+              "regression_mae_log_rv": 0.6195619805366732,
+              "regression_loss": 0.5701137959619755,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    20,
+                    11,
+                    13
+                  ],
+                  [
+                    20,
+                    16,
+                    12
+                  ],
+                  [
+                    6,
+                    5,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.43478260869565216,
+                    "recall": 0.45454545454545453,
+                    "f1": 0.4444444444444445,
+                    "support": 44,
+                    "roc_auc": 0.5413839891451832,
+                    "pr_auc": 0.40825531018881356
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.4,
+                    "support": 48,
+                    "roc_auc": 0.5849867724867724,
+                    "pr_auc": 0.5391293772910675
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.24242424242424243,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.3076923076923077,
+                    "support": 19,
+                    "roc_auc": 0.5675057208237986,
+                    "pr_auc": 0.26274342860880745
+                  }
+                ],
+                "macro_precision": 0.3924022837066315,
+                "macro_recall": 0.40297713981924504,
+                "macro_f1": 0.3840455840455841,
+                "weighted_f1": 0.4018172018172019,
+                "macro_roc_auc": 0.5646254941519181,
+                "macro_pr_auc": 0.4033760386962295
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.45616605616605616,
+              "regime_accuracy": 0.49038460850715637,
+              "regime_loss": 1.0833305212167592,
+              "regression_rmse_log_rv": 1.0663875176806072,
+              "regression_mae_log_rv": 0.822206587799883,
+              "regression_loss": 1.1371823378650074,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    13,
+                    7
+                  ],
+                  [
+                    5,
+                    25,
+                    22
+                  ],
+                  [
+                    5,
+                    1,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.375,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.2857142857142857,
+                    "support": 26,
+                    "roc_auc": 0.5769230769230769,
+                    "pr_auc": 0.3784639318279155
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6410256410256411,
+                    "recall": 0.4807692307692308,
+                    "f1": 0.5494505494505495,
+                    "support": 52,
+                    "roc_auc": 0.5965236686390533,
+                    "pr_auc": 0.6101340364005423
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.40816326530612246,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5333333333333333,
+                    "support": 26,
+                    "roc_auc": 0.7066074950690335,
+                    "pr_auc": 0.5441893110019126
+                  }
+                ],
+                "macro_precision": 0.47472963544392116,
+                "macro_recall": 0.4935897435897436,
+                "macro_f1": 0.45616605616605616,
+                "weighted_f1": 0.4794871794871795,
+                "macro_roc_auc": 0.6266847468770546,
+                "macro_pr_auc": 0.5109290930767901
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3715419501133787,
+              "regime_accuracy": 0.38333332538604736,
+              "regime_loss": 1.1805555608121918,
+              "regression_rmse_log_rv": 0.7873441178866258,
+              "regression_mae_log_rv": 0.6438524070654239,
+              "regression_loss": 0.619910759970669,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    8,
+                    5
+                  ],
+                  [
+                    14,
+                    8,
+                    23
+                  ],
+                  [
+                    15,
+                    9,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3409090909090909,
+                    "recall": 0.5357142857142857,
+                    "f1": 0.41666666666666663,
+                    "support": 28,
+                    "roc_auc": 0.6777950310559007,
+                    "pr_auc": 0.3555746829848725
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.32,
+                    "recall": 0.17777777777777778,
+                    "f1": 0.2285714285714286,
+                    "support": 45,
+                    "roc_auc": 0.4725925925925926,
+                    "pr_auc": 0.3484772417010607
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.45098039215686275,
+                    "recall": 0.48936170212765956,
+                    "f1": 0.46938775510204084,
+                    "support": 47,
+                    "roc_auc": 0.5537744097930632,
+                    "pr_auc": 0.43786924733879107
+                  }
+                ],
+                "macro_precision": 0.3706298276886512,
+                "macro_recall": 0.4009512552065744,
+                "macro_f1": 0.3715419501133787,
+                "weighted_f1": 0.3667800453514739,
+                "macro_roc_auc": 0.5680540111471856,
+                "macro_pr_auc": 0.38064039067490807
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5560114781596129,
+              "regime_accuracy": 0.7542372941970825,
+              "regime_loss": 0.5949479962809611,
+              "regression_rmse_log_rv": 0.9135150626483245,
+              "regression_mae_log_rv": 0.7848910210304894,
+              "regression_loss": 0.8345097696853723,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    3,
+                    4,
+                    5
+                  ],
+                  [
+                    6,
+                    12,
+                    78
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4375,
+                    "recall": 0.7,
+                    "f1": 0.5384615384615384,
+                    "support": 10,
+                    "roc_auc": 0.8703703703703703,
+                    "pr_auc": 0.2722353976804441
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.21052631578947367,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.2580645161290323,
+                    "support": 12,
+                    "roc_auc": 0.7209119496855346,
+                    "pr_auc": 0.17062521805879394
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9397590361445783,
+                    "recall": 0.8125,
+                    "f1": 0.8715083798882681,
+                    "support": 96,
+                    "roc_auc": 0.8944128787878788,
+                    "pr_auc": 0.9766946315561407
+                  }
+                ],
+                "macro_precision": 0.5292617839780173,
+                "macro_recall": 0.6152777777777777,
+                "macro_f1": 0.5560114781596129,
+                "weighted_f1": 0.7808999495545552,
+                "macro_roc_auc": 0.8285650662812613,
+                "macro_pr_auc": 0.4731850824317929
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.43669503850463726,
+              "regime_accuracy": 0.4727272689342499,
+              "regime_loss": 1.0437329920855436,
+              "regression_rmse_log_rv": 0.40447782796311504,
+              "regression_mae_log_rv": 0.3401660736381018,
+              "regression_loss": 0.1636023133137593,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    5,
+                    0
+                  ],
+                  [
+                    22,
+                    33,
+                    23
+                  ],
+                  [
+                    0,
+                    8,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2413793103448276,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.34146341463414637,
+                    "support": 12,
+                    "roc_auc": 0.6828231292517006,
+                    "pr_auc": 0.17647330279530052
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.717391304347826,
+                    "recall": 0.4230769230769231,
+                    "f1": 0.532258064516129,
+                    "support": 78,
+                    "roc_auc": 0.4202724358974359,
+                    "pr_auc": 0.6920247507864967
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.34285714285714286,
+                    "recall": 0.6,
+                    "f1": 0.43636363636363634,
+                    "support": 20,
+                    "roc_auc": 0.7566666666666667,
+                    "pr_auc": 0.3174426548402621
+                  }
+                ],
+                "macro_precision": 0.4338759191832655,
+                "macro_recall": 0.5354700854700855,
+                "macro_f1": 0.43669503850463726,
+                "weighted_f1": 0.4940087521376414,
+                "macro_roc_auc": 0.6199207439386011,
+                "macro_pr_auc": 0.39531356947401974
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.33793820558526444,
+              "regime_accuracy": 0.3513513505458832,
+              "regime_loss": 1.346121158265322,
+              "regression_rmse_log_rv": 0.7727485124366194,
+              "regression_mae_log_rv": 0.6595893696649,
+              "regression_loss": 0.5971402634730081,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    21,
+                    8,
+                    15
+                  ],
+                  [
+                    16,
+                    8,
+                    24
+                  ],
+                  [
+                    7,
+                    2,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4772727272727273,
+                    "recall": 0.4772727272727273,
+                    "f1": 0.4772727272727273,
+                    "support": 44,
+                    "roc_auc": 0.6339891451831751,
+                    "pr_auc": 0.457957522735171
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4444444444444444,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.24242424242424243,
+                    "support": 48,
+                    "roc_auc": 0.4798280423280423,
+                    "pr_auc": 0.4591476219965114
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.20408163265306123,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.29411764705882354,
+                    "support": 19,
+                    "roc_auc": 0.5806636155606407,
+                    "pr_auc": 0.19380578684015246
+                  }
+                ],
+                "macro_precision": 0.37526626812341096,
+                "macro_recall": 0.3900850611376927,
+                "macro_f1": 0.33793820558526444,
+                "weighted_f1": 0.34436575613046205,
+                "macro_roc_auc": 0.564826934357286,
+                "macro_pr_auc": 0.37030364385727826
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.44584239411825616,
+              "regime_accuracy": 0.5288461446762085,
+              "regime_loss": 1.0173881879219642,
+              "regression_rmse_log_rv": 0.9619568920823343,
+              "regression_mae_log_rv": 0.7420135741122067,
+              "regression_loss": 0.9253610622247037,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    15,
+                    8
+                  ],
+                  [
+                    0,
+                    35,
+                    17
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 1.0,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.20689655172413793,
+                    "support": 26,
+                    "roc_auc": 0.7071005917159763,
+                    "pr_auc": 0.5711317450306856
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5932203389830508,
+                    "recall": 0.6730769230769231,
+                    "f1": 0.6306306306306306,
+                    "support": 52,
+                    "roc_auc": 0.6712278106508875,
+                    "pr_auc": 0.6723709146834259
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.40476190476190477,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.5,
+                    "support": 26,
+                    "roc_auc": 0.7564102564102564,
+                    "pr_auc": 0.6466036288898442
+                  }
+                ],
+                "macro_precision": 0.6659940812483186,
+                "macro_recall": 0.4807692307692308,
+                "macro_f1": 0.44584239411825616,
+                "weighted_f1": 0.49203945324634984,
+                "macro_roc_auc": 0.7115795529257068,
+                "macro_pr_auc": 0.6300354295346519
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3819974314421697,
+              "regime_accuracy": 0.44999998807907104,
+              "regime_loss": 1.1504160552477471,
+              "regression_rmse_log_rv": 0.8912091570668921,
+              "regression_mae_log_rv": 0.7455189390784653,
+              "regression_loss": 0.7942537616398804,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    6,
+                    8
+                  ],
+                  [
+                    14,
+                    2,
+                    29
+                  ],
+                  [
+                    6,
+                    3,
+                    38
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4117647058823529,
+                    "recall": 0.5,
+                    "f1": 0.45161290322580644,
+                    "support": 28,
+                    "roc_auc": 0.6906055900621118,
+                    "pr_auc": 0.31487600343583366
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.18181818181818182,
+                    "recall": 0.044444444444444446,
+                    "f1": 0.07142857142857142,
+                    "support": 45,
+                    "roc_auc": 0.549037037037037,
+                    "pr_auc": 0.4020531069198978
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5066666666666667,
+                    "recall": 0.8085106382978723,
+                    "f1": 0.6229508196721312,
+                    "support": 47,
+                    "roc_auc": 0.6423783153599534,
+                    "pr_auc": 0.499318841684693
+                  }
+                ],
+                "macro_precision": 0.36674985145573386,
+                "macro_recall": 0.45098502758077225,
+                "macro_f1": 0.3819974314421697,
+                "weighted_f1": 0.37615112940998713,
+                "macro_roc_auc": 0.627340314153034,
+                "macro_pr_auc": 0.4054159840134748
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.44354368186703513,
+              "regime_accuracy": 0.6694915294647217,
+              "regime_loss": 0.6319974433567564,
+              "regression_rmse_log_rv": 1.0176645863764222,
+              "regression_mae_log_rv": 0.9131430742272642,
+              "regression_loss": 1.0356412103646944,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    2,
+                    1
+                  ],
+                  [
+                    13,
+                    13,
+                    70
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2413793103448276,
+                    "recall": 0.7,
+                    "f1": 0.358974358974359,
+                    "support": 10,
+                    "roc_auc": 0.9185185185185185,
+                    "pr_auc": 0.3539876882376882
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.1111111111111111,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.13333333333333333,
+                    "support": 12,
+                    "roc_auc": 0.6768867924528302,
+                    "pr_auc": 0.14102063594997016
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9859154929577465,
+                    "recall": 0.7291666666666666,
+                    "f1": 0.8383233532934132,
+                    "support": 96,
+                    "roc_auc": 0.9081439393939394,
+                    "pr_auc": 0.9794568897534893
+                  }
+                ],
+                "macro_precision": 0.44613530480456176,
+                "macro_recall": 0.5319444444444444,
+                "macro_f1": 0.44354368186703513,
+                "weighted_f1": 0.7260066568297564,
+                "macro_roc_auc": 0.8345164167884294,
+                "macro_pr_auc": 0.4914884046470493
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.24961149961149964,
+              "regime_accuracy": 0.23636363446712494,
+              "regime_loss": 1.1467752153223212,
+              "regression_rmse_log_rv": 0.4671234588758051,
+              "regression_mae_log_rv": 0.38735532326609246,
+              "regression_loss": 0.21820432583209598,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    48,
+                    7,
+                    23
+                  ],
+                  [
+                    8,
+                    3,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.15151515151515152,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.25641025641025644,
+                    "support": 12,
+                    "roc_auc": 0.6658163265306123,
+                    "pr_auc": 0.16535905899863856
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7,
+                    "recall": 0.08974358974358974,
+                    "f1": 0.1590909090909091,
+                    "support": 78,
+                    "roc_auc": 0.3581730769230769,
+                    "pr_auc": 0.6361505216829906
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2647058823529412,
+                    "recall": 0.45,
+                    "f1": 0.33333333333333337,
+                    "support": 20,
+                    "roc_auc": 0.6922222222222222,
+                    "pr_auc": 0.25600494141539654
+                  }
+                ],
+                "macro_precision": 0.3720736779560309,
+                "macro_recall": 0.4576923076923077,
+                "macro_f1": 0.24961149961149964,
+                "weighted_f1": 0.20138800593346048,
+                "macro_roc_auc": 0.5720705418919705,
+                "macro_pr_auc": 0.35250484069900856
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.42936148818501757,
+              "regime_accuracy": 0.45945945382118225,
+              "regime_loss": 1.044073295417799,
+              "regression_rmse_log_rv": 0.8230710027680226,
+              "regression_mae_log_rv": 0.6894933677685913,
+              "regression_loss": 0.6774458755975583,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    29,
+                    3,
+                    12
+                  ],
+                  [
+                    21,
+                    14,
+                    13
+                  ],
+                  [
+                    8,
+                    3,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.6590909090909091,
+                    "f1": 0.5686274509803921,
+                    "support": 44,
+                    "roc_auc": 0.6180461329715061,
+                    "pr_auc": 0.45178392531888617
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7,
+                    "recall": 0.2916666666666667,
+                    "f1": 0.4117647058823529,
+                    "support": 48,
+                    "roc_auc": 0.6127645502645502,
+                    "pr_auc": 0.518013903455595
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.24242424242424243,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.3076923076923077,
+                    "support": 19,
+                    "roc_auc": 0.6086956521739131,
+                    "pr_auc": 0.27945361862589346
+                  }
+                ],
+                "macro_precision": 0.4808080808080808,
+                "macro_recall": 0.4572700691121743,
+                "macro_f1": 0.42936148818501757,
+                "weighted_f1": 0.4561303384832797,
+                "macro_roc_auc": 0.6131687784699899,
+                "macro_pr_auc": 0.41641714913345823
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2855699855699856,
+              "regime_accuracy": 0.2884615361690521,
+              "regime_loss": 1.1934688091278076,
+              "regression_rmse_log_rv": 1.0137296999010066,
+              "regression_mae_log_rv": 0.7801216221123468,
+              "regression_loss": 1.0276479044613849,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    12,
+                    6
+                  ],
+                  [
+                    26,
+                    4,
+                    22
+                  ],
+                  [
+                    6,
+                    2,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2,
+                    "recall": 0.3076923076923077,
+                    "f1": 0.24242424242424246,
+                    "support": 26,
+                    "roc_auc": 0.5655818540433925,
+                    "pr_auc": 0.31285529382939964
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.1142857142857143,
+                    "support": 52,
+                    "roc_auc": 0.5580621301775148,
+                    "pr_auc": 0.49810374729969126
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.391304347826087,
+                    "recall": 0.6923076923076923,
+                    "f1": 0.5,
+                    "support": 26,
+                    "roc_auc": 0.6735700197238659,
+                    "pr_auc": 0.43221207720266697
+                  }
+                ],
+                "macro_precision": 0.2711755233494364,
+                "macro_recall": 0.358974358974359,
+                "macro_f1": 0.2855699855699856,
+                "weighted_f1": 0.24274891774891777,
+                "macro_roc_auc": 0.5990713346482578,
+                "macro_pr_auc": 0.41439037277725266
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.37510533285181175,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.2720130320764416,
+              "regression_rmse_log_rv": 0.8654831323291557,
+              "regression_mae_log_rv": 0.7314351928544056,
+              "regression_loss": 0.749061052346287,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    10,
+                    10
+                  ],
+                  [
+                    9,
+                    9,
+                    27
+                  ],
+                  [
+                    7,
+                    7,
+                    33
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.2857142857142857,
+                    "f1": 0.30769230769230765,
+                    "support": 28,
+                    "roc_auc": 0.6510093167701864,
+                    "pr_auc": 0.2894287075446323
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.34615384615384615,
+                    "recall": 0.2,
+                    "f1": 0.2535211267605634,
+                    "support": 45,
+                    "roc_auc": 0.5096296296296297,
+                    "pr_auc": 0.4005454712417427
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4714285714285714,
+                    "recall": 0.7021276595744681,
+                    "f1": 0.5641025641025642,
+                    "support": 47,
+                    "roc_auc": 0.6146895948703002,
+                    "pr_auc": 0.4717502471188861
+                  }
+                ],
+                "macro_precision": 0.3836385836385836,
+                "macro_recall": 0.3959473150962513,
+                "macro_f1": 0.37510533285181175,
+                "weighted_f1": 0.387805465270254,
+                "macro_roc_auc": 0.5917761804233721,
+                "macro_pr_auc": 0.3872414753017537
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4694444444444445,
+              "regime_accuracy": 0.7203390002250671,
+              "regime_loss": 0.5774317904044006,
+              "regression_rmse_log_rv": 1.0470122167620641,
+              "regression_mae_log_rv": 0.9347364347195253,
+              "regression_loss": 1.0962345820490114,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    5,
+                    14,
+                    77
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35,
+                    "recall": 0.7,
+                    "f1": 0.4666666666666667,
+                    "support": 10,
+                    "roc_auc": 0.9277777777777778,
+                    "pr_auc": 0.41414513264513264
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.05555555555555555,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.06666666666666667,
+                    "support": 12,
+                    "roc_auc": 0.6933962264150944,
+                    "pr_auc": 0.1425850306654319
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9625,
+                    "recall": 0.8020833333333334,
+                    "f1": 0.8750000000000001,
+                    "support": 96,
+                    "roc_auc": 0.8863636363636364,
+                    "pr_auc": 0.9722794953551399
+                  }
+                ],
+                "macro_precision": 0.45601851851851855,
+                "macro_recall": 0.5284722222222222,
+                "macro_f1": 0.4694444444444445,
+                "weighted_f1": 0.7581920903954804,
+                "macro_roc_auc": 0.8358458801855028,
+                "macro_pr_auc": 0.5096698862219015
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.42823102823102827,
+              "regime_accuracy": 0.44545453786849976,
+              "regime_loss": 1.0468734567815607,
+              "regression_rmse_log_rv": 0.45990211456205976,
+              "regression_mae_log_rv": 0.3647739453044778,
+              "regression_loss": 0.21150995497865394,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    4,
+                    0
+                  ],
+                  [
+                    28,
+                    28,
+                    22
+                  ],
+                  [
+                    0,
+                    7,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.3333333333333333,
+                    "support": 12,
+                    "roc_auc": 0.6913265306122449,
+                    "pr_auc": 0.1712589928711713
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.717948717948718,
+                    "recall": 0.358974358974359,
+                    "f1": 0.47863247863247865,
+                    "support": 78,
+                    "roc_auc": 0.42427884615384615,
+                    "pr_auc": 0.6996321699667609
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37142857142857144,
+                    "recall": 0.65,
+                    "f1": 0.4727272727272728,
+                    "support": 20,
+                    "roc_auc": 0.7427777777777778,
+                    "pr_auc": 0.2854023104915732
+                  }
+                ],
+                "macro_precision": 0.4371998371998372,
+                "macro_recall": 0.5585470085470086,
+                "macro_f1": 0.42823102823102827,
+                "weighted_f1": 0.46170798898071624,
+                "macro_roc_auc": 0.6194610515146229,
+                "macro_pr_auc": 0.3854311577765018
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.354232876573593,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.0384356459559485,
+              "regression_rmse_log_rv": 0.8660870250813195,
+              "regression_mae_log_rv": 0.7239483892917633,
+              "regression_loss": 0.7501067350142101,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    29,
+                    1,
+                    14
+                  ],
+                  [
+                    34,
+                    4,
+                    10
+                  ],
+                  [
+                    8,
+                    0,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4084507042253521,
+                    "recall": 0.6590909090909091,
+                    "f1": 0.5043478260869565,
+                    "support": 44,
+                    "roc_auc": 0.6041383989145184,
+                    "pr_auc": 0.4721972927720239
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.1509433962264151,
+                    "support": 48,
+                    "roc_auc": 0.6570767195767195,
+                    "pr_auc": 0.5713810416299704
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3142857142857143,
+                    "recall": 0.5789473684210527,
+                    "f1": 0.40740740740740744,
+                    "support": 19,
+                    "roc_auc": 0.6344393592677345,
+                    "pr_auc": 0.4411037887434483
+                  }
+                ],
+                "macro_precision": 0.5075788061703554,
+                "macro_recall": 0.4404572036150984,
+                "macro_f1": 0.354232876573593,
+                "weighted_f1": 0.3349308838507635,
+                "macro_roc_auc": 0.6318848259196574,
+                "macro_pr_auc": 0.49489404104848084
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4160744595527204,
+              "regime_accuracy": 0.5096153616905212,
+              "regime_loss": 1.070913470708407,
+              "regression_rmse_log_rv": 1.0123899377361405,
+              "regression_mae_log_rv": 0.79068361769896,
+              "regression_loss": 1.0249333860293863,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    16,
+                    8
+                  ],
+                  [
+                    0,
+                    34,
+                    18
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 1.0,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.14285714285714288,
+                    "support": 26,
+                    "roc_auc": 0.6272189349112426,
+                    "pr_auc": 0.44036939141056985
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.576271186440678,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.6126126126126126,
+                    "support": 52,
+                    "roc_auc": 0.5887573964497042,
+                    "pr_auc": 0.5172687432102573
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3953488372093023,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.49275362318840576,
+                    "support": 26,
+                    "roc_auc": 0.7001972386587771,
+                    "pr_auc": 0.5962914283968559
+                  }
+                ],
+                "macro_precision": 0.6572066745499935,
+                "macro_recall": 0.4615384615384615,
+                "macro_f1": 0.4160744595527204,
+                "weighted_f1": 0.4652089978176935,
+                "macro_roc_auc": 0.638724523339908,
+                "macro_pr_auc": 0.5179765210058943
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3614113383100725,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.1322597445234748,
+              "regression_rmse_log_rv": 0.8317279809974955,
+              "regression_mae_log_rv": 0.6927530310458678,
+              "regression_loss": 0.6917714343741701,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    8,
+                    5
+                  ],
+                  [
+                    15,
+                    8,
+                    22
+                  ],
+                  [
+                    21,
+                    4,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.29411764705882354,
+                    "recall": 0.5357142857142857,
+                    "f1": 0.379746835443038,
+                    "support": 28,
+                    "roc_auc": 0.7329192546583851,
+                    "pr_auc": 0.4159766622438197
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.17777777777777778,
+                    "f1": 0.24615384615384614,
+                    "support": 45,
+                    "roc_auc": 0.4731851851851852,
+                    "pr_auc": 0.4285104429588043
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4489795918367347,
+                    "recall": 0.46808510638297873,
+                    "f1": 0.4583333333333333,
+                    "support": 47,
+                    "roc_auc": 0.5756339259691052,
+                    "pr_auc": 0.4255577175738764
+                  }
+                ],
+                "macro_precision": 0.3810324129651861,
+                "macro_recall": 0.393859056625014,
+                "macro_f1": 0.3614113383100725,
+                "weighted_f1": 0.36042917613329,
+                "macro_roc_auc": 0.5939127886042251,
+                "macro_pr_auc": 0.4233482742588335
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3833333333333333,
+              "regime_accuracy": 0.6186440587043762,
+              "regime_loss": 0.7831084950495575,
+              "regression_rmse_log_rv": 1.0357364801170181,
+              "regression_mae_log_rv": 0.9200018239207566,
+              "regression_loss": 1.0727500562451902,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    14,
+                    16,
+                    66
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23333333333333334,
+                    "recall": 0.7,
+                    "f1": 0.35,
+                    "support": 10,
+                    "roc_auc": 0.8898148148148148,
+                    "pr_auc": 0.5114874550794671
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6155660377358491,
+                    "pr_auc": 0.1165929756467135
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9565217391304348,
+                    "recall": 0.6875,
+                    "f1": 0.8,
+                    "support": 96,
+                    "roc_auc": 0.8589015151515151,
+                    "pr_auc": 0.967124136294448
+                  }
+                ],
+                "macro_precision": 0.39661835748792273,
+                "macro_recall": 0.46249999999999997,
+                "macro_f1": 0.3833333333333333,
+                "weighted_f1": 0.6805084745762713,
+                "macro_roc_auc": 0.7880941225673931,
+                "macro_pr_auc": 0.531734855673543
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2978959286691513,
+              "regime_accuracy": 0.290909081697464,
+              "regime_loss": 1.18057616407221,
+              "regression_rmse_log_rv": 0.463013551111826,
+              "regression_mae_log_rv": 0.3784954016991833,
+              "regression_loss": 0.21438154851318353,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    2,
+                    3
+                  ],
+                  [
+                    22,
+                    11,
+                    45
+                  ],
+                  [
+                    3,
+                    3,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.21875,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.31818181818181823,
+                    "support": 12,
+                    "roc_auc": 0.7032312925170068,
+                    "pr_auc": 0.30102087230897495
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6875,
+                    "recall": 0.14102564102564102,
+                    "f1": 0.2340425531914894,
+                    "support": 78,
+                    "roc_auc": 0.4154647435897436,
+                    "pr_auc": 0.6800548239195652
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.22580645161290322,
+                    "recall": 0.7,
+                    "f1": 0.3414634146341463,
+                    "support": 20,
+                    "roc_auc": 0.6788888888888889,
+                    "pr_auc": 0.27057976484040275
+                  }
+                ],
+                "macro_precision": 0.37735215053763443,
+                "macro_recall": 0.4747863247863248,
+                "macro_f1": 0.2978959286691513,
+                "weighted_f1": 0.26275244781637197,
+                "macro_roc_auc": 0.5991949749985465,
+                "macro_pr_auc": 0.417218487022981
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4141816877410098,
+              "regime_accuracy": 0.45045045018196106,
+              "regime_loss": 1.2274478548605314,
+              "regression_rmse_log_rv": 0.7768792534647916,
+              "regression_mae_log_rv": 0.6591125021222979,
+              "regression_loss": 0.6035413744640119,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    31,
+                    3,
+                    10
+                  ],
+                  [
+                    17,
+                    10,
+                    21
+                  ],
+                  [
+                    8,
+                    2,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5535714285714286,
+                    "recall": 0.7045454545454546,
+                    "f1": 0.62,
+                    "support": 44,
+                    "roc_auc": 0.6241519674355496,
+                    "pr_auc": 0.4662978992875726
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.3174603174603175,
+                    "support": 48,
+                    "roc_auc": 0.5846560846560847,
+                    "pr_auc": 0.5069061773742295
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.225,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.30508474576271183,
+                    "support": 19,
+                    "roc_auc": 0.6601830663615561,
+                    "pr_auc": 0.27541333914467575
+                  }
+                ],
+                "macro_precision": 0.48174603174603176,
+                "macro_recall": 0.4621876661350346,
+                "macro_f1": 0.4141816877410098,
+                "weighted_f1": 0.43526761628456545,
+                "macro_roc_auc": 0.6229970394843968,
+                "macro_pr_auc": 0.41620580526882595
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5016317016317017,
+              "regime_accuracy": 0.5096153616905212,
+              "regime_loss": 1.0742857272808368,
+              "regression_rmse_log_rv": 0.9873348607025932,
+              "regression_mae_log_rv": 0.749478192650713,
+              "regression_loss": 0.9748301271586092,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    8,
+                    6
+                  ],
+                  [
+                    12,
+                    24,
+                    16
+                  ],
+                  [
+                    5,
+                    4,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.41379310344827586,
+                    "recall": 0.46153846153846156,
+                    "f1": 0.43636363636363634,
+                    "support": 26,
+                    "roc_auc": 0.6711045364891519,
+                    "pr_auc": 0.4083477286868653
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.46153846153846156,
+                    "f1": 0.5454545454545455,
+                    "support": 52,
+                    "roc_auc": 0.6272189349112426,
+                    "pr_auc": 0.6460042665920808
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4358974358974359,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.523076923076923,
+                    "support": 26,
+                    "roc_auc": 0.7026627218934911,
+                    "pr_auc": 0.5074343583724399
+                  }
+                ],
+                "macro_precision": 0.5054524020041261,
+                "macro_recall": 0.5256410256410257,
+                "macro_f1": 0.5016317016317017,
+                "weighted_f1": 0.5125874125874126,
+                "macro_roc_auc": 0.6669953977646285,
+                "macro_pr_auc": 0.5205954512171287
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "classification": {
+      "regime_f1_macro": {
+        "mean": 0.38048619946753964,
+        "std": 0.06962182712062351,
+        "min": 0.26296296296296295,
+        "max": 0.5677587675003466,
+        "n": 25
+      },
+      "regression_rmse_log_rv": null
+    },
+    "regression": {
+      "regime_f1_macro": {
+        "mean": 0.37403188908419494,
+        "std": 0.08186288684420041,
+        "min": 0.24536431856693294,
+        "max": 0.5560114781596129,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.8233594402393123,
+        "std": 0.21359171136907856,
+        "min": 0.3860455025931112,
+        "max": 1.1322378841568543,
+        "n": 25
+      }
+    },
+    "dual": {
+      "regime_f1_macro": {
+        "mean": 0.39327538503560605,
+        "std": 0.07176913786092598,
+        "min": 0.24961149961149964,
+        "max": 0.5560114781596129,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.8334195442812634,
+        "std": 0.21169383510632325,
+        "min": 0.40447782796311504,
+        "max": 1.1422135186732751,
+        "n": 25
+      }
+    }
+  }
+}

--- a/backend/artifacts/experiments/runpod_20260530/runpod_vote_tally_20260530T135114Z.json
+++ b/backend/artifacts/experiments/runpod_20260530/runpod_vote_tally_20260530T135114Z.json
@@ -1,0 +1,5153 @@
+{
+  "head_modes": [
+    "classification",
+    "regression",
+    "dual"
+  ],
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "regression_alpha": 0.5,
+  "training_package_id": "canonical",
+  "rates_target_mode": "raw",
+  "rates_heads": [],
+  "use_retrieval_analogs": false,
+  "use_regime_conditioning": false,
+  "use_statement_delta": false,
+  "use_vote_features": true,
+  "use_press_conf": false,
+  "trials": {
+    "classification": [
+      {
+        "head_mode": "classification",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3664010049312929,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.149705136524092,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    2,
+                    13
+                  ],
+                  [
+                    8,
+                    2,
+                    35
+                  ],
+                  [
+                    4,
+                    8,
+                    35
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.52,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.49056603773584906,
+                    "support": 28,
+                    "roc_auc": 0.7313664596273292,
+                    "pr_auc": 0.4558092296912585
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.044444444444444446,
+                    "f1": 0.07017543859649122,
+                    "support": 45,
+                    "roc_auc": 0.416,
+                    "pr_auc": 0.3843370926034193
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.42168674698795183,
+                    "recall": 0.7446808510638298,
+                    "f1": 0.5384615384615385,
+                    "support": 47,
+                    "roc_auc": 0.5540658700087439,
+                    "pr_auc": 0.4085613528294106
+                  }
+                ],
+                "macro_precision": 0.3694511378848728,
+                "macro_recall": 0.4178036699313295,
+                "macro_f1": 0.3664010049312929,
+                "weighted_f1": 0.3516786341761516,
+                "macro_roc_auc": 0.567144109878691,
+                "macro_pr_auc": 0.4162358917080295
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4993668034060538,
+              "regime_accuracy": 0.7203390002250671,
+              "regime_loss": 0.5960507089808836,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    3,
+                    2
+                  ],
+                  [
+                    8,
+                    13,
+                    75
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 10,
+                    "roc_auc": 0.8944444444444445,
+                    "pr_auc": 0.31676623009343596
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.15789473684210525,
+                    "recall": 0.25,
+                    "f1": 0.1935483870967742,
+                    "support": 12,
+                    "roc_auc": 0.7555031446540881,
+                    "pr_auc": 0.17212476884572064
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.974025974025974,
+                    "recall": 0.78125,
+                    "f1": 0.8670520231213873,
+                    "support": 96,
+                    "roc_auc": 0.9034090909090909,
+                    "pr_auc": 0.9794715892900854
+                  }
+                ],
+                "macro_precision": 0.48336750968329917,
+                "macro_recall": 0.5770833333333333,
+                "macro_f1": 0.4993668034060538,
+                "weighted_f1": 0.7621574141085973,
+                "macro_roc_auc": 0.8511188933358745,
+                "macro_pr_auc": 0.489454196076414
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3863883999664739,
+              "regime_accuracy": 0.38181817531585693,
+              "regime_loss": 1.0809314619411121,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    21,
+                    16,
+                    41
+                  ],
+                  [
+                    0,
+                    2,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.27586206896551724,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.3902439024390244,
+                    "support": 12,
+                    "roc_auc": 0.7100340136054422,
+                    "pr_auc": 0.2205562996565669
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8421052631578947,
+                    "recall": 0.20512820512820512,
+                    "f1": 0.32989690721649484,
+                    "support": 78,
+                    "roc_auc": 0.48197115384615385,
+                    "pr_auc": 0.709800045402132
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2903225806451613,
+                    "recall": 0.9,
+                    "f1": 0.4390243902439024,
+                    "support": 20,
+                    "roc_auc": 0.7766666666666666,
+                    "pr_auc": 0.37665010306237046
+                  }
+                ],
+                "macro_precision": 0.46942997092285776,
+                "macro_recall": 0.5905982905982906,
+                "macro_f1": 0.3863883999664739,
+                "weighted_f1": 0.35632157633666306,
+                "macro_roc_auc": 0.6562239447060875,
+                "macro_pr_auc": 0.4356688160403565
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.44078435561252194,
+              "regime_accuracy": 0.45945945382118225,
+              "regime_loss": 1.063007951209367,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    27,
+                    9,
+                    8
+                  ],
+                  [
+                    17,
+                    14,
+                    17
+                  ],
+                  [
+                    7,
+                    2,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5294117647058824,
+                    "recall": 0.6136363636363636,
+                    "f1": 0.5684210526315789,
+                    "support": 44,
+                    "roc_auc": 0.673337856173677,
+                    "pr_auc": 0.4819003761359372
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.56,
+                    "recall": 0.2916666666666667,
+                    "f1": 0.3835616438356164,
+                    "support": 48,
+                    "roc_auc": 0.5717592592592593,
+                    "pr_auc": 0.49768414852842136
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.37037037037037035,
+                    "support": 19,
+                    "roc_auc": 0.6533180778032036,
+                    "pr_auc": 0.26154635581922986
+                  }
+                ],
+                "macro_precision": 0.45837535014005604,
+                "macro_recall": 0.47720627325890486,
+                "macro_f1": 0.44078435561252194,
+                "weighted_f1": 0.4545812815940189,
+                "macro_roc_auc": 0.6328050644120466,
+                "macro_pr_auc": 0.4137102934945294
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4027362936413115,
+              "regime_accuracy": 0.4615384638309479,
+              "regime_loss": 1.0810143489104052,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    14,
+                    9
+                  ],
+                  [
+                    1,
+                    25,
+                    26
+                  ],
+                  [
+                    1,
+                    5,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.1935483870967742,
+                    "support": 26,
+                    "roc_auc": 0.6849112426035503,
+                    "pr_auc": 0.4666942221063537
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5681818181818182,
+                    "recall": 0.4807692307692308,
+                    "f1": 0.5208333333333334,
+                    "support": 52,
+                    "roc_auc": 0.6024408284023669,
+                    "pr_auc": 0.5153747186742587
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.36363636363636365,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.4938271604938272,
+                    "support": 26,
+                    "roc_auc": 0.8318540433925049,
+                    "pr_auc": 0.7065488549847735
+                  }
+                ],
+                "macro_precision": 0.5106060606060606,
+                "macro_recall": 0.4551282051282051,
+                "macro_f1": 0.4027362936413115,
+                "weighted_f1": 0.43226055356431703,
+                "macro_roc_auc": 0.7064020381328073,
+                "macro_pr_auc": 0.562872598588462
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.404305493425231,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.118303478665025,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    10,
+                    5
+                  ],
+                  [
+                    7,
+                    16,
+                    22
+                  ],
+                  [
+                    11,
+                    17,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.41935483870967744,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.44067796610169496,
+                    "support": 28,
+                    "roc_auc": 0.7282608695652174,
+                    "pr_auc": 0.46941097861007347
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.37209302325581395,
+                    "recall": 0.35555555555555557,
+                    "f1": 0.36363636363636365,
+                    "support": 45,
+                    "roc_auc": 0.4077037037037037,
+                    "pr_auc": 0.35249327387876694
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.41304347826086957,
+                    "recall": 0.40425531914893614,
+                    "f1": 0.4086021505376344,
+                    "support": 47,
+                    "roc_auc": 0.5461964441853687,
+                    "pr_auc": 0.40127973638185066
+                  }
+                ],
+                "macro_precision": 0.40149711340878697,
+                "macro_recall": 0.40803219633006865,
+                "macro_f1": 0.404305493425231,
+                "weighted_f1": 0.3992243374146053,
+                "macro_roc_auc": 0.5607203391514299,
+                "macro_pr_auc": 0.4077279962902303
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5655162738496072,
+              "regime_accuracy": 0.7542372941970825,
+              "regime_loss": 0.5554335582054267,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    4,
+                    5,
+                    3
+                  ],
+                  [
+                    6,
+                    13,
+                    77
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4117647058823529,
+                    "recall": 0.7,
+                    "f1": 0.5185185185185185,
+                    "support": 10,
+                    "roc_auc": 0.8916666666666667,
+                    "pr_auc": 0.44022704762031134
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.23809523809523808,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.30303030303030304,
+                    "support": 12,
+                    "roc_auc": 0.7444968553459119,
+                    "pr_auc": 0.16543432105271166
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9625,
+                    "recall": 0.8020833333333334,
+                    "f1": 0.8750000000000001,
+                    "support": 96,
+                    "roc_auc": 0.9247159090909091,
+                    "pr_auc": 0.9831943279245067
+                  }
+                ],
+                "macro_precision": 0.537453314659197,
+                "macro_recall": 0.6395833333333333,
+                "macro_f1": 0.5655162738496072,
+                "weighted_f1": 0.7866232950978714,
+                "macro_roc_auc": 0.853626477034496,
+                "macro_pr_auc": 0.5296185655325099
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.38303968930567395,
+              "regime_accuracy": 0.3909091055393219,
+              "regime_loss": 1.0904598647897894,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    2
+                  ],
+                  [
+                    26,
+                    19,
+                    33
+                  ],
+                  [
+                    1,
+                    2,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.20588235294117646,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.3043478260869565,
+                    "support": 12,
+                    "roc_auc": 0.6445578231292517,
+                    "pr_auc": 0.15928260056342647
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7916666666666666,
+                    "recall": 0.24358974358974358,
+                    "f1": 0.37254901960784315,
+                    "support": 78,
+                    "roc_auc": 0.3994391025641026,
+                    "pr_auc": 0.6780360172750043
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3269230769230769,
+                    "recall": 0.85,
+                    "f1": 0.4722222222222222,
+                    "support": 20,
+                    "roc_auc": 0.7588888888888888,
+                    "pr_auc": 0.3366873278857096
+                  }
+                ],
+                "macro_precision": 0.44149069884364,
+                "macro_recall": 0.558974358974359,
+                "macro_f1": 0.38303968930567395,
+                "weighted_f1": 0.38323128988090627,
+                "macro_roc_auc": 0.6009619381940811,
+                "macro_pr_auc": 0.3913353152413801
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.34800569800569797,
+              "regime_accuracy": 0.3513513505458832,
+              "regime_loss": 1.0855397828779507,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    12,
+                    15
+                  ],
+                  [
+                    17,
+                    11,
+                    20
+                  ],
+                  [
+                    7,
+                    1,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4146341463414634,
+                    "recall": 0.38636363636363635,
+                    "f1": 0.39999999999999997,
+                    "support": 44,
+                    "roc_auc": 0.6075305291723202,
+                    "pr_auc": 0.43479214178986425
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4583333333333333,
+                    "recall": 0.22916666666666666,
+                    "f1": 0.3055555555555555,
+                    "support": 48,
+                    "roc_auc": 0.582010582010582,
+                    "pr_auc": 0.5175430993945149
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2391304347826087,
+                    "recall": 0.5789473684210527,
+                    "f1": 0.3384615384615385,
+                    "support": 19,
+                    "roc_auc": 0.5909610983981693,
+                    "pr_auc": 0.36158998764699185
+                  }
+                ],
+                "macro_precision": 0.37069930481913516,
+                "macro_recall": 0.39815922381711855,
+                "macro_f1": 0.34800569800569797,
+                "weighted_f1": 0.3486255486255486,
+                "macro_roc_auc": 0.5935007365270238,
+                "macro_pr_auc": 0.4379750762771237
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4225085739020411,
+              "regime_accuracy": 0.45192307233810425,
+              "regime_loss": 1.1598319090329683,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    9,
+                    11
+                  ],
+                  [
+                    11,
+                    24,
+                    17
+                  ],
+                  [
+                    4,
+                    5,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.25531914893617025,
+                    "support": 26,
+                    "roc_auc": 0.5626232741617357,
+                    "pr_auc": 0.28069945379502853
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.631578947368421,
+                    "recall": 0.46153846153846156,
+                    "f1": 0.5333333333333333,
+                    "support": 52,
+                    "roc_auc": 0.5839497041420119,
+                    "pr_auc": 0.5264175684194933
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37777777777777777,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.4788732394366198,
+                    "support": 26,
+                    "roc_auc": 0.6730769230769231,
+                    "pr_auc": 0.43330204871611744
+                  }
+                ],
+                "macro_precision": 0.43169033695349485,
+                "macro_recall": 0.44871794871794873,
+                "macro_f1": 0.4225085739020411,
+                "weighted_f1": 0.4502147637598642,
+                "macro_roc_auc": 0.6065499671268902,
+                "macro_pr_auc": 0.41347302364354643
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3144853071811818,
+              "regime_accuracy": 0.34166666865348816,
+              "regime_loss": 1.0987300241796734,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    16,
+                    5,
+                    7
+                  ],
+                  [
+                    12,
+                    3,
+                    30
+                  ],
+                  [
+                    19,
+                    6,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3404255319148936,
+                    "recall": 0.5714285714285714,
+                    "f1": 0.4266666666666666,
+                    "support": 28,
+                    "roc_auc": 0.7216614906832298,
+                    "pr_auc": 0.46432957247286666
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.21428571428571427,
+                    "recall": 0.06666666666666667,
+                    "f1": 0.10169491525423728,
+                    "support": 45,
+                    "roc_auc": 0.47703703703703704,
+                    "pr_auc": 0.40435417549009744
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3728813559322034,
+                    "recall": 0.46808510638297873,
+                    "f1": 0.41509433962264153,
+                    "support": 47,
+                    "roc_auc": 0.4986884290294375,
+                    "pr_auc": 0.3656603301327265
+                  }
+                ],
+                "macro_precision": 0.3091975340442704,
+                "macro_recall": 0.3687267814927389,
+                "macro_f1": 0.3144853071811818,
+                "weighted_f1": 0.3002697651280958,
+                "macro_roc_auc": 0.5657956522499015,
+                "macro_pr_auc": 0.41144802603189684
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3735503179947624,
+              "regime_accuracy": 0.6101694703102112,
+              "regime_loss": 0.7568321581614219,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    11,
+                    0,
+                    1
+                  ],
+                  [
+                    16,
+                    15,
+                    65
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.20588235294117646,
+                    "recall": 0.7,
+                    "f1": 0.3181818181818182,
+                    "support": 10,
+                    "roc_auc": 0.8527777777777777,
+                    "pr_auc": 0.2609240642219587
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7099056603773585,
+                    "pr_auc": 0.15234361013939657
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9848484848484849,
+                    "recall": 0.6770833333333334,
+                    "f1": 0.8024691358024691,
+                    "support": 96,
+                    "roc_auc": 0.8726325757575758,
+                    "pr_auc": 0.9728526649841742
+                  }
+                ],
+                "macro_precision": 0.3969102792632204,
+                "macro_recall": 0.45902777777777776,
+                "macro_f1": 0.3735503179947624,
+                "weighted_f1": 0.679820806939451,
+                "macro_roc_auc": 0.8117720046375707,
+                "macro_pr_auc": 0.4620401131151765
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.26457610396679593,
+              "regime_accuracy": 0.2545454502105713,
+              "regime_loss": 1.2563584934581409,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    45,
+                    1,
+                    32
+                  ],
+                  [
+                    2,
+                    1,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.17543859649122806,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.28985507246376807,
+                    "support": 12,
+                    "roc_auc": 0.7117346938775511,
+                    "pr_auc": 0.19680595677621823
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.01282051282051282,
+                    "f1": 0.025,
+                    "support": 78,
+                    "roc_auc": 0.38982371794871795,
+                    "pr_auc": 0.6700400139128002
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.85,
+                    "f1": 0.4788732394366197,
+                    "support": 20,
+                    "roc_auc": 0.7605555555555555,
+                    "pr_auc": 0.31182744428777115
+                  }
+                ],
+                "macro_precision": 0.3362573099415205,
+                "macro_recall": 0.5653846153846154,
+                "macro_f1": 0.26457610396679593,
+                "weighted_f1": 0.13641568780270555,
+                "macro_roc_auc": 0.6207046557939415,
+                "macro_pr_auc": 0.3928911383255966
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.39176432851038484,
+              "regime_accuracy": 0.44144144654273987,
+              "regime_loss": 1.0574331134003443,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    33,
+                    1,
+                    10
+                  ],
+                  [
+                    24,
+                    8,
+                    16
+                  ],
+                  [
+                    7,
+                    4,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.515625,
+                    "recall": 0.75,
+                    "f1": 0.6111111111111112,
+                    "support": 44,
+                    "roc_auc": 0.6675712347354138,
+                    "pr_auc": 0.48780659949072713
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6153846153846154,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.26229508196721313,
+                    "support": 48,
+                    "roc_auc": 0.5952380952380952,
+                    "pr_auc": 0.5194875315706684
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.23529411764705882,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.3018867924528302,
+                    "support": 19,
+                    "roc_auc": 0.6435926773455377,
+                    "pr_auc": 0.24217960587130752
+                  }
+                ],
+                "macro_precision": 0.4554345776772248,
+                "macro_recall": 0.44590643274853803,
+                "macro_f1": 0.39176432851038484,
+                "weighted_f1": 0.40734145837764774,
+                "macro_roc_auc": 0.6354673357730155,
+                "macro_pr_auc": 0.4164912456442344
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4828062126107979,
+              "regime_accuracy": 0.5096153616905212,
+              "regime_loss": 1.0366716476587148,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    11,
+                    7
+                  ],
+                  [
+                    7,
+                    28,
+                    17
+                  ],
+                  [
+                    3,
+                    6,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4444444444444444,
+                    "recall": 0.3076923076923077,
+                    "f1": 0.3636363636363637,
+                    "support": 26,
+                    "roc_auc": 0.6632149901380671,
+                    "pr_auc": 0.40618528044216473
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6222222222222222,
+                    "recall": 0.5384615384615384,
+                    "f1": 0.577319587628866,
+                    "support": 52,
+                    "roc_auc": 0.5902366863905325,
+                    "pr_auc": 0.5280819842686055
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4146341463414634,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.5074626865671641,
+                    "support": 26,
+                    "roc_auc": 0.7169625246548323,
+                    "pr_auc": 0.5309718001618609
+                  }
+                ],
+                "macro_precision": 0.4937669376693767,
+                "macro_recall": 0.5,
+                "macro_f1": 0.4828062126107979,
+                "weighted_f1": 0.506434556365315,
+                "macro_roc_auc": 0.6568047337278107,
+                "macro_pr_auc": 0.4884130216242104
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.40234697695015154,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.146399541531717,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    12,
+                    6
+                  ],
+                  [
+                    6,
+                    11,
+                    28
+                  ],
+                  [
+                    5,
+                    13,
+                    29
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.47619047619047616,
+                    "recall": 0.35714285714285715,
+                    "f1": 0.40816326530612246,
+                    "support": 28,
+                    "roc_auc": 0.7278726708074534,
+                    "pr_auc": 0.4069619393664712
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3055555555555556,
+                    "recall": 0.24444444444444444,
+                    "f1": 0.2716049382716049,
+                    "support": 45,
+                    "roc_auc": 0.42014814814814816,
+                    "pr_auc": 0.33204992894092183
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4603174603174603,
+                    "recall": 0.6170212765957447,
+                    "f1": 0.5272727272727272,
+                    "support": 47,
+                    "roc_auc": 0.5581463130282717,
+                    "pr_auc": 0.41620963988599236
+                  }
+                ],
+                "macro_precision": 0.414021164021164,
+                "macro_recall": 0.40620285939434875,
+                "macro_f1": 0.40234697695015154,
+                "weighted_f1": 0.40360509860509863,
+                "macro_roc_auc": 0.5687223773279578,
+                "macro_pr_auc": 0.3850738360644618
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5285714285714286,
+              "regime_accuracy": 0.7711864113807678,
+              "regime_loss": 0.5708344705024008,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    6,
+                    3,
+                    3
+                  ],
+                  [
+                    12,
+                    3,
+                    81
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.28,
+                    "recall": 0.7,
+                    "f1": 0.4,
+                    "support": 10,
+                    "roc_auc": 0.9166666666666666,
+                    "pr_auc": 0.45518960300069733
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.25,
+                    "f1": 0.28571428571428575,
+                    "support": 12,
+                    "roc_auc": 0.789308176100629,
+                    "pr_auc": 0.1941022135301292
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9642857142857143,
+                    "recall": 0.84375,
+                    "f1": 0.8999999999999999,
+                    "support": 96,
+                    "roc_auc": 0.9038825757575758,
+                    "pr_auc": 0.9796083821891829
+                  }
+                ],
+                "macro_precision": 0.5258730158730159,
+                "macro_recall": 0.5979166666666667,
+                "macro_f1": 0.5285714285714286,
+                "weighted_f1": 0.7951573849878935,
+                "macro_roc_auc": 0.8699524728416238,
+                "macro_pr_auc": 0.5429667329066697
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2663442668909448,
+              "regime_accuracy": 0.26363635063171387,
+              "regime_loss": 1.22381517236883,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    36,
+                    3,
+                    39
+                  ],
+                  [
+                    2,
+                    0,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.17391304347826086,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.27586206896551724,
+                    "support": 12,
+                    "roc_auc": 0.70578231292517,
+                    "pr_auc": 0.19412318616649404
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.75,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.07317073170731708,
+                    "support": 78,
+                    "roc_auc": 0.40064102564102566,
+                    "pr_auc": 0.6896774462343901
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3,
+                    "recall": 0.9,
+                    "f1": 0.45000000000000007,
+                    "support": 20,
+                    "roc_auc": 0.7472222222222222,
+                    "pr_auc": 0.2998198624714563
+                  }
+                ],
+                "macro_precision": 0.4079710144927536,
+                "macro_recall": 0.535042735042735,
+                "macro_f1": 0.2663442668909448,
+                "weighted_f1": 0.16379692637051765,
+                "macro_roc_auc": 0.6178818535961393,
+                "macro_pr_auc": 0.39454016495744676
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.32372440226624155,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.3011016845100114,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    19,
+                    7,
+                    18
+                  ],
+                  [
+                    17,
+                    10,
+                    21
+                  ],
+                  [
+                    5,
+                    6,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4634146341463415,
+                    "recall": 0.4318181818181818,
+                    "f1": 0.4470588235294118,
+                    "support": 44,
+                    "roc_auc": 0.5430800542740841,
+                    "pr_auc": 0.39860099452660347
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.43478260869565216,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.28169014084507044,
+                    "support": 48,
+                    "roc_auc": 0.5201719576719577,
+                    "pr_auc": 0.45317987584740926
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1702127659574468,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.24242424242424243,
+                    "support": 19,
+                    "roc_auc": 0.5640732265446224,
+                    "pr_auc": 0.19072810980025542
+                  }
+                ],
+                "macro_precision": 0.35613666959981344,
+                "macro_recall": 0.35373471557682085,
+                "macro_f1": 0.32372440226624155,
+                "weighted_f1": 0.34052050091818115,
+                "macro_roc_auc": 0.5424417461635548,
+                "macro_pr_auc": 0.3475029933914227
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3973063973063973,
+              "regime_accuracy": 0.5288461446762085,
+              "regime_loss": 1.4081443960850055,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    17,
+                    9
+                  ],
+                  [
+                    0,
+                    35,
+                    17
+                  ],
+                  [
+                    0,
+                    6,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5473372781065089,
+                    "pr_auc": 0.3066386865822584
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.603448275862069,
+                    "recall": 0.6730769230769231,
+                    "f1": 0.6363636363636364,
+                    "support": 52,
+                    "roc_auc": 0.669008875739645,
+                    "pr_auc": 0.6788549716657593
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.43478260869565216,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5555555555555555,
+                    "support": 26,
+                    "roc_auc": 0.7657790927021696,
+                    "pr_auc": 0.6186378006356795
+                  }
+                ],
+                "macro_precision": 0.34607696151924033,
+                "macro_recall": 0.48076923076923084,
+                "macro_f1": 0.3973063973063973,
+                "weighted_f1": 0.45707070707070707,
+                "macro_roc_auc": 0.6607084155161078,
+                "macro_pr_auc": 0.5347104862945657
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.37884566488685484,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.1419529936495447,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    3,
+                    10
+                  ],
+                  [
+                    10,
+                    6,
+                    29
+                  ],
+                  [
+                    16,
+                    3,
+                    28
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.36585365853658536,
+                    "recall": 0.5357142857142857,
+                    "f1": 0.43478260869565216,
+                    "support": 28,
+                    "roc_auc": 0.7111801242236024,
+                    "pr_auc": 0.45992893481075403
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.13333333333333333,
+                    "f1": 0.2105263157894737,
+                    "support": 45,
+                    "roc_auc": 0.4231111111111111,
+                    "pr_auc": 0.3372832261180832
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.417910447761194,
+                    "recall": 0.5957446808510638,
+                    "f1": 0.4912280701754387,
+                    "support": 47,
+                    "roc_auc": 0.5415330807344797,
+                    "pr_auc": 0.39474174640326043
+                  }
+                ],
+                "macro_precision": 0.42792136876592646,
+                "macro_recall": 0.42159743329956095,
+                "macro_f1": 0.37884566488685484,
+                "weighted_f1": 0.37279430460208496,
+                "macro_roc_auc": 0.5586081053563977,
+                "macro_pr_auc": 0.3973179691106992
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4084790673025967,
+              "regime_accuracy": 0.6694915294647217,
+              "regime_loss": 0.7107713530629368,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    10,
+                    0,
+                    2
+                  ],
+                  [
+                    10,
+                    14,
+                    72
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25925925925925924,
+                    "recall": 0.7,
+                    "f1": 0.37837837837837834,
+                    "support": 10,
+                    "roc_auc": 0.8953703703703704,
+                    "pr_auc": 0.3217253958760043
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6595911949685535,
+                    "pr_auc": 0.1305494037846376
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.972972972972973,
+                    "recall": 0.75,
+                    "f1": 0.8470588235294119,
+                    "support": 96,
+                    "roc_auc": 0.9005681818181818,
+                    "pr_auc": 0.9786599075684931
+                  }
+                ],
+                "macro_precision": 0.4107440774107441,
+                "macro_recall": 0.48333333333333334,
+                "macro_f1": 0.4084790673025967,
+                "weighted_f1": 0.7211985664627739,
+                "macro_roc_auc": 0.8185099157190351,
+                "macro_pr_auc": 0.476978235743045
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3198350506652992,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.247757235440341,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    41,
+                    12,
+                    25
+                  ],
+                  [
+                    5,
+                    1,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.14814814814814814,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.24242424242424243,
+                    "support": 12,
+                    "roc_auc": 0.6479591836734694,
+                    "pr_auc": 0.15272748390041688
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8,
+                    "recall": 0.15384615384615385,
+                    "f1": 0.25806451612903225,
+                    "support": 78,
+                    "roc_auc": 0.36177884615384615,
+                    "pr_auc": 0.6657701631308063
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.34146341463414637,
+                    "recall": 0.7,
+                    "f1": 0.4590163934426229,
+                    "support": 20,
+                    "roc_auc": 0.7316666666666667,
+                    "pr_auc": 0.31047602062493007
+                  }
+                ],
+                "macro_precision": 0.42987052092743155,
+                "macro_recall": 0.5068376068376068,
+                "macro_f1": 0.3198350506652992,
+                "weighted_f1": 0.29289500941825347,
+                "macro_roc_auc": 0.5804682321646607,
+                "macro_pr_auc": 0.37632455588538444
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.40212825776206057,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.4126373683392346,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    23,
+                    3,
+                    18
+                  ],
+                  [
+                    17,
+                    10,
+                    21
+                  ],
+                  [
+                    4,
+                    2,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5227272727272727,
+                    "recall": 0.5227272727272727,
+                    "f1": 0.5227272727272727,
+                    "support": 44,
+                    "roc_auc": 0.5881953867028494,
+                    "pr_auc": 0.43403124114896874
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.3174603174603175,
+                    "support": 48,
+                    "roc_auc": 0.44675925925925924,
+                    "pr_auc": 0.4286297258724242
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.25,
+                    "recall": 0.6842105263157895,
+                    "f1": 0.36619718309859156,
+                    "support": 19,
+                    "roc_auc": 0.5903890160183066,
+                    "pr_auc": 0.19205018203510527
+                  }
+                ],
+                "macro_precision": 0.47979797979797983,
+                "macro_recall": 0.4717570441254652,
+                "macro_f1": 0.40212825776206057,
+                "weighted_f1": 0.40716974519791427,
+                "macro_roc_auc": 0.5417812206601385,
+                "macro_pr_auc": 0.35157038301883275
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3867907316183179,
+              "regime_accuracy": 0.5096153616905212,
+              "regime_loss": 1.0100711767490094,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    19,
+                    7
+                  ],
+                  [
+                    3,
+                    36,
+                    13
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6489151873767258,
+                    "pr_auc": 0.34231081325180274
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5625,
+                    "recall": 0.6923076923076923,
+                    "f1": 0.6206896551724138,
+                    "support": 52,
+                    "roc_auc": 0.5713757396449705,
+                    "pr_auc": 0.49494368954739315
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4594594594594595,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.5396825396825398,
+                    "support": 26,
+                    "roc_auc": 0.7785996055226825,
+                    "pr_auc": 0.648694679229155
+                  }
+                ],
+                "macro_precision": 0.34065315315315314,
+                "macro_recall": 0.44871794871794873,
+                "macro_f1": 0.3867907316183179,
+                "weighted_f1": 0.4452654625068418,
+                "macro_roc_auc": 0.6662968441814595,
+                "macro_pr_auc": 0.49531639400945027
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "regression": [
+      {
+        "head_mode": "regression",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.19526980874316943,
+              "regime_accuracy": 0.2666666805744171,
+              "regime_loss": 1.1268073314964602,
+              "regression_rmse_log_rv": 0.9198174545685829,
+              "regression_mae_log_rv": 0.7730519801746899,
+              "regression_loss": 0.8460641497290271,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    23,
+                    0
+                  ],
+                  [
+                    14,
+                    27,
+                    4
+                  ],
+                  [
+                    14,
+                    33,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.15151515151515152,
+                    "recall": 0.17857142857142858,
+                    "f1": 0.16393442622950818,
+                    "support": 28,
+                    "roc_auc": 0.3765527950310559,
+                    "pr_auc": 0.17524875876897195
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3253012048192771,
+                    "recall": 0.6,
+                    "f1": 0.42187500000000006,
+                    "support": 45,
+                    "roc_auc": 0.44562962962962965,
+                    "pr_auc": 0.3426519635207799
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.40658700087438066,
+                    "pr_auc": 0.3286268463128325
+                  }
+                ],
+                "macro_precision": 0.15893878544480955,
+                "macro_recall": 0.25952380952380955,
+                "macro_f1": 0.19526980874316943,
+                "weighted_f1": 0.1964544911202186,
+                "macro_roc_auc": 0.4095898085116887,
+                "macro_pr_auc": 0.28217585620086144
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.10379658655520724,
+              "regime_accuracy": 0.11864406615495682,
+              "regime_loss": 1.2024490954512257,
+              "regression_rmse_log_rv": 0.766196412758846,
+              "regression_mae_log_rv": 0.5917573722110967,
+              "regression_loss": 0.5870569429245238,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    7,
+                    2
+                  ],
+                  [
+                    0,
+                    12,
+                    0
+                  ],
+                  [
+                    18,
+                    77,
+                    1
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.05263157894736842,
+                    "recall": 0.1,
+                    "f1": 0.06896551724137931,
+                    "support": 10,
+                    "roc_auc": 0.6268518518518519,
+                    "pr_auc": 0.10446044997709354
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.125,
+                    "recall": 1.0,
+                    "f1": 0.2222222222222222,
+                    "support": 12,
+                    "roc_auc": 0.6422955974842768,
+                    "pr_auc": 0.42526015250726645
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.010416666666666666,
+                    "f1": 0.0202020202020202,
+                    "support": 96,
+                    "roc_auc": 0.4616477272727273,
+                    "pr_auc": 0.7869361205670263
+                  }
+                ],
+                "macro_precision": 0.17032163742690057,
+                "macro_recall": 0.37013888888888885,
+                "macro_f1": 0.10379658655520724,
+                "weighted_f1": 0.04487894727520677,
+                "macro_roc_auc": 0.5769317255362854,
+                "macro_pr_auc": 0.4388855743504621
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.1810897435897436,
+              "regime_accuracy": 0.2454545497894287,
+              "regime_loss": 1.0916349107568915,
+              "regression_rmse_log_rv": 0.7216803691067217,
+              "regression_mae_log_rv": 0.558175395206887,
+              "regression_loss": 0.5208225551540141,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    63,
+                    15,
+                    0
+                  ],
+                  [
+                    17,
+                    3,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.13043478260869565,
+                    "recall": 1.0,
+                    "f1": 0.23076923076923078,
+                    "support": 12,
+                    "roc_auc": 0.47278911564625853,
+                    "pr_auc": 0.11393484207320999
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8333333333333334,
+                    "recall": 0.19230769230769232,
+                    "f1": 0.3125,
+                    "support": 78,
+                    "roc_auc": 0.546073717948718,
+                    "pr_auc": 0.742407460836606
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.42,
+                    "pr_auc": 0.19066721774857728
+                  }
+                ],
+                "macro_precision": 0.32125603864734303,
+                "macro_recall": 0.3974358974358974,
+                "macro_f1": 0.1810897435897436,
+                "weighted_f1": 0.24676573426573428,
+                "macro_roc_auc": 0.4796209445316588,
+                "macro_pr_auc": 0.3490031735527978
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.25976230899830216,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.0649040726390453,
+              "regression_rmse_log_rv": 0.8203433506101376,
+              "regression_mae_log_rv": 0.6667429434622193,
+              "regression_loss": 0.6729632128902673,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    32,
+                    12,
+                    0
+                  ],
+                  [
+                    35,
+                    10,
+                    3
+                  ],
+                  [
+                    13,
+                    6,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4,
+                    "recall": 0.7272727272727273,
+                    "f1": 0.5161290322580645,
+                    "support": 44,
+                    "roc_auc": 0.5074626865671642,
+                    "pr_auc": 0.42410065950570824
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.35714285714285715,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.2631578947368421,
+                    "support": 48,
+                    "roc_auc": 0.43617724867724866,
+                    "pr_auc": 0.39771574782554353
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.5829519450800915,
+                    "pr_auc": 0.1820774659759109
+                  }
+                ],
+                "macro_precision": 0.2523809523809524,
+                "macro_recall": 0.3118686868686869,
+                "macro_f1": 0.25976230899830216,
+                "weighted_f1": 0.3183896969975068,
+                "macro_roc_auc": 0.5088639601081681,
+                "macro_pr_auc": 0.3346312911023876
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3512622499209683,
+              "regime_accuracy": 0.4711538553237915,
+              "regime_loss": 1.0707891170795147,
+              "regression_rmse_log_rv": 0.8064228743220889,
+              "regression_mae_log_rv": 0.6520588632690936,
+              "regression_loss": 0.6503178522298997,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    11,
+                    0
+                  ],
+                  [
+                    18,
+                    34,
+                    0
+                  ],
+                  [
+                    2,
+                    24,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.5769230769230769,
+                    "f1": 0.4918032786885245,
+                    "support": 26,
+                    "roc_auc": 0.6977317554240631,
+                    "pr_auc": 0.4686851948780666
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4927536231884058,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.5619834710743802,
+                    "support": 52,
+                    "roc_auc": 0.5133136094674556,
+                    "pr_auc": 0.4963513031297906
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5857988165680473,
+                    "pr_auc": 0.2994128945269549
+                  }
+                ],
+                "macro_precision": 0.30710835058661146,
+                "macro_recall": 0.4102564102564103,
+                "macro_f1": 0.3512622499209683,
+                "weighted_f1": 0.40394255520932126,
+                "macro_roc_auc": 0.598948060486522,
+                "macro_pr_auc": 0.4214831308449374
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.1847041847041847,
+              "regime_accuracy": 0.25,
+              "regime_loss": 1.1324077846543321,
+              "regression_rmse_log_rv": 0.886695642310407,
+              "regression_mae_log_rv": 0.7614400436539047,
+              "regression_loss": 0.7862291620922651,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    24,
+                    0,
+                    4
+                  ],
+                  [
+                    39,
+                    0,
+                    6
+                  ],
+                  [
+                    41,
+                    0,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23076923076923078,
+                    "recall": 0.8571428571428571,
+                    "f1": 0.36363636363636365,
+                    "support": 28,
+                    "roc_auc": 0.48641304347826086,
+                    "pr_auc": 0.21980893985485747
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 45,
+                    "roc_auc": 0.506962962962963,
+                    "pr_auc": 0.4315735321224542
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.375,
+                    "recall": 0.1276595744680851,
+                    "f1": 0.1904761904761905,
+                    "support": 47,
+                    "roc_auc": 0.42436607403089477,
+                    "pr_auc": 0.35715842962276384
+                  }
+                ],
+                "macro_precision": 0.20192307692307696,
+                "macro_recall": 0.3282674772036474,
+                "macro_f1": 0.1847041847041847,
+                "weighted_f1": 0.15945165945165946,
+                "macro_roc_auc": 0.4725806934907062,
+                "macro_pr_auc": 0.3361803005333585
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.20368776008035586,
+              "regime_accuracy": 0.24576270580291748,
+              "regime_loss": 1.073409569465508,
+              "regression_rmse_log_rv": 0.7228534691537359,
+              "regression_mae_log_rv": 0.568373238951978,
+              "regression_loss": 0.5225171378675911,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    10,
+                    1,
+                    1
+                  ],
+                  [
+                    71,
+                    7,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.10989010989010989,
+                    "recall": 1.0,
+                    "f1": 0.198019801980198,
+                    "support": 10,
+                    "roc_auc": 0.8231481481481482,
+                    "pr_auc": 0.19470319695773994
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.125,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.1,
+                    "support": 12,
+                    "roc_auc": 0.5110062893081762,
+                    "pr_auc": 0.19715425082892038
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9473684210526315,
+                    "recall": 0.1875,
+                    "f1": 0.3130434782608696,
+                    "support": 96,
+                    "roc_auc": 0.7855113636363636,
+                    "pr_auc": 0.9322917509346421
+                  }
+                ],
+                "macro_precision": 0.3940861769809138,
+                "macro_recall": 0.4236111111111111,
+                "macro_f1": 0.20368776008035586,
+                "weighted_f1": 0.2816302706173344,
+                "macro_roc_auc": 0.706555267030896,
+                "macro_pr_auc": 0.4413830662404341
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.22909842845326714,
+              "regime_accuracy": 0.22727273404598236,
+              "regime_loss": 1.2476105603304777,
+              "regression_rmse_log_rv": 0.7130360112904778,
+              "regression_mae_log_rv": 0.565821498952044,
+              "regression_loss": 0.5084203533970343,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    22,
+                    12,
+                    44
+                  ],
+                  [
+                    11,
+                    3,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.175,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.2692307692307692,
+                    "support": 12,
+                    "roc_auc": 0.6649659863945578,
+                    "pr_auc": 0.1548876270798633
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8,
+                    "recall": 0.15384615384615385,
+                    "f1": 0.25806451612903225,
+                    "support": 78,
+                    "roc_auc": 0.452724358974359,
+                    "pr_auc": 0.7128435143816024
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.10909090909090909,
+                    "recall": 0.3,
+                    "f1": 0.16,
+                    "support": 20,
+                    "roc_auc": 0.41333333333333333,
+                    "pr_auc": 0.1442351038692356
+                  }
+                ],
+                "macro_precision": 0.3613636363636364,
+                "macro_recall": 0.3457264957264958,
+                "macro_f1": 0.22909842845326714,
+                "weighted_f1": 0.24145274080757953,
+                "macro_roc_auc": 0.5103412262340834,
+                "macro_pr_auc": 0.33732208177690043
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.16431924882629106,
+              "regime_accuracy": 0.315315306186676,
+              "regime_loss": 1.1348488169944997,
+              "regression_rmse_log_rv": 0.8240329626213524,
+              "regression_mae_log_rv": 0.6818016227166932,
+              "regression_loss": 0.6790303234865231,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    35,
+                    0,
+                    9
+                  ],
+                  [
+                    44,
+                    0,
+                    4
+                  ],
+                  [
+                    19,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35714285714285715,
+                    "recall": 0.7954545454545454,
+                    "f1": 0.4929577464788732,
+                    "support": 44,
+                    "roc_auc": 0.4426729986431479,
+                    "pr_auc": 0.35981239806427645
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.5016534391534392,
+                    "pr_auc": 0.40356811326237957
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.43077803203661325,
+                    "pr_auc": 0.14962677856464754
+                  }
+                ],
+                "macro_precision": 0.11904761904761905,
+                "macro_recall": 0.26515151515151514,
+                "macro_f1": 0.16431924882629106,
+                "weighted_f1": 0.1954066742799137,
+                "macro_roc_auc": 0.4583681566110667,
+                "macro_pr_auc": 0.30433576329710116
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.20000000000000004,
+              "regime_accuracy": 0.2788461446762085,
+              "regime_loss": 1.1723501682281494,
+              "regression_rmse_log_rv": 0.8136977228761098,
+              "regression_mae_log_rv": 0.6398648915794463,
+              "regression_loss": 0.6621039842137664,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    0,
+                    0
+                  ],
+                  [
+                    45,
+                    0,
+                    7
+                  ],
+                  [
+                    23,
+                    0,
+                    3
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2765957446808511,
+                    "recall": 1.0,
+                    "f1": 0.43333333333333335,
+                    "support": 26,
+                    "roc_auc": 0.52465483234714,
+                    "pr_auc": 0.261586879932506
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.3701923076923077,
+                    "pr_auc": 0.40055336061592595
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.16666666666666669,
+                    "support": 26,
+                    "roc_auc": 0.527120315581854,
+                    "pr_auc": 0.2714106410423568
+                  }
+                ],
+                "macro_precision": 0.1921985815602837,
+                "macro_recall": 0.3717948717948718,
+                "macro_f1": 0.20000000000000004,
+                "weighted_f1": 0.15000000000000002,
+                "macro_roc_auc": 0.4739891518737673,
+                "macro_pr_auc": 0.31118362719692955
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.24378798771322138,
+              "regime_accuracy": 0.2666666805744171,
+              "regime_loss": 1.1210658567924865,
+              "regression_rmse_log_rv": 0.9298586978155136,
+              "regression_mae_log_rv": 0.7887946606671903,
+              "regression_loss": 0.8646371979031625,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    19,
+                    0,
+                    9
+                  ],
+                  [
+                    28,
+                    4,
+                    13
+                  ],
+                  [
+                    32,
+                    6,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.24050632911392406,
+                    "recall": 0.6785714285714286,
+                    "f1": 0.3551401869158879,
+                    "support": 28,
+                    "roc_auc": 0.546972049689441,
+                    "pr_auc": 0.2767477046882117
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.08888888888888889,
+                    "f1": 0.14545454545454545,
+                    "support": 45,
+                    "roc_auc": 0.5623703703703704,
+                    "pr_auc": 0.39277244074328266
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2903225806451613,
+                    "recall": 0.19148936170212766,
+                    "f1": 0.23076923076923078,
+                    "support": 47,
+                    "roc_auc": 0.27368114252404546,
+                    "pr_auc": 0.30993663236985647
+                  }
+                ],
+                "macro_precision": 0.31027630325302846,
+                "macro_recall": 0.31964989305414837,
+                "macro_f1": 0.24378798771322138,
+                "weighted_f1": 0.22779611354377713,
+                "macro_roc_auc": 0.461007854194619,
+                "macro_pr_auc": 0.32648559260045024
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.18803418803418803,
+              "regime_accuracy": 0.37288135290145874,
+              "regime_loss": 1.0887476872589628,
+              "regression_rmse_log_rv": 0.8107237685649006,
+              "regression_mae_log_rv": 0.6155773431883526,
+              "regression_loss": 0.6572730289160744,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    10
+                  ],
+                  [
+                    6,
+                    0,
+                    6
+                  ],
+                  [
+                    52,
+                    0,
+                    44
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 10,
+                    "roc_auc": 0.2537037037037037,
+                    "pr_auc": 0.053148561190369786
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.27044025157232704,
+                    "pr_auc": 0.06529580707956632
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.7333333333333333,
+                    "recall": 0.4583333333333333,
+                    "f1": 0.5641025641025641,
+                    "support": 96,
+                    "roc_auc": 0.2821969696969697,
+                    "pr_auc": 0.7401503103493277
+                  }
+                ],
+                "macro_precision": 0.24444444444444444,
+                "macro_recall": 0.15277777777777776,
+                "macro_f1": 0.18803418803418803,
+                "weighted_f1": 0.4589308996088657,
+                "macro_roc_auc": 0.2687803083243335,
+                "macro_pr_auc": 0.28619822620642127
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.12024756852343059,
+              "regime_accuracy": 0.12727272510528564,
+              "regime_loss": 1.1888298273086548,
+              "regression_rmse_log_rv": 0.5480820443898735,
+              "regression_mae_log_rv": 0.42512259523765267,
+              "regression_loss": 0.3003939273825833,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    74,
+                    0,
+                    4
+                  ],
+                  [
+                    18,
+                    0,
+                    2
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.11538461538461539,
+                    "recall": 1.0,
+                    "f1": 0.20689655172413793,
+                    "support": 12,
+                    "roc_auc": 0.6777210884353742,
+                    "pr_auc": 0.1485090830099449
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.5056089743589743,
+                    "pr_auc": 0.7273527187878315
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.1,
+                    "f1": 0.15384615384615383,
+                    "support": 20,
+                    "roc_auc": 0.5238888888888888,
+                    "pr_auc": 0.2119653342800578
+                  }
+                ],
+                "macro_precision": 0.14957264957264957,
+                "macro_recall": 0.3666666666666667,
+                "macro_f1": 0.12024756852343059,
+                "weighted_f1": 0.05054256088738847,
+                "macro_roc_auc": 0.5690729838944124,
+                "macro_pr_auc": 0.36260904535927807
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3438212494300046,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.1068436940401074,
+              "regression_rmse_log_rv": 0.8222302674955444,
+              "regression_mae_log_rv": 0.6782283229870839,
+              "regression_loss": 0.6760626127857945,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    25,
+                    0,
+                    19
+                  ],
+                  [
+                    11,
+                    3,
+                    34
+                  ],
+                  [
+                    5,
+                    0,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6097560975609756,
+                    "recall": 0.5681818181818182,
+                    "f1": 0.5882352941176471,
+                    "support": 44,
+                    "roc_auc": 0.7004748982360922,
+                    "pr_auc": 0.6333052260316798
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.0625,
+                    "f1": 0.11764705882352941,
+                    "support": 48,
+                    "roc_auc": 0.6650132275132276,
+                    "pr_auc": 0.64822290426773
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.208955223880597,
+                    "recall": 0.7368421052631579,
+                    "f1": 0.3255813953488372,
+                    "support": 19,
+                    "roc_auc": 0.5549199084668193,
+                    "pr_auc": 0.3366406853511723
+                  }
+                ],
+                "macro_precision": 0.6062371071471909,
+                "macro_recall": 0.45584130781499205,
+                "macro_f1": 0.3438212494300046,
+                "weighted_f1": 0.3397789033903945,
+                "macro_roc_auc": 0.6401360114053797,
+                "macro_pr_auc": 0.5393896052168606
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.13217592592592595,
+              "regime_accuracy": 0.14423076808452606,
+              "regime_loss": 1.154600794498737,
+              "regression_rmse_log_rv": 0.7771542782435822,
+              "regression_mae_log_rv": 0.6286982707589721,
+              "regression_loss": 0.6039687721923032,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    2,
+                    17
+                  ],
+                  [
+                    13,
+                    0,
+                    39
+                  ],
+                  [
+                    18,
+                    0,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.18421052631578946,
+                    "recall": 0.2692307692307692,
+                    "f1": 0.21875,
+                    "support": 26,
+                    "roc_auc": 0.4383629191321499,
+                    "pr_auc": 0.20828257765276048
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.39829881656804733,
+                    "pr_auc": 0.40575222684870565
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.125,
+                    "recall": 0.3076923076923077,
+                    "f1": 0.17777777777777778,
+                    "support": 26,
+                    "roc_auc": 0.15532544378698224,
+                    "pr_auc": 0.1479921756622492
+                  }
+                ],
+                "macro_precision": 0.10307017543859649,
+                "macro_recall": 0.1923076923076923,
+                "macro_f1": 0.13217592592592595,
+                "weighted_f1": 0.09913194444444445,
+                "macro_roc_auc": 0.33066239316239315,
+                "macro_pr_auc": 0.2540089933879051
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2839655172413793,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.104576673003134,
+              "regression_rmse_log_rv": 0.885604969302432,
+              "regression_mae_log_rv": 0.7579759479558561,
+              "regression_loss": 0.7842961616531616,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    25,
+                    1
+                  ],
+                  [
+                    2,
+                    39,
+                    4
+                  ],
+                  [
+                    0,
+                    41,
+                    6
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.07142857142857142,
+                    "f1": 0.125,
+                    "support": 28,
+                    "roc_auc": 0.5768633540372671,
+                    "pr_auc": 0.3712039397807159
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.37142857142857144,
+                    "recall": 0.8666666666666667,
+                    "f1": 0.52,
+                    "support": 45,
+                    "roc_auc": 0.40503703703703703,
+                    "pr_auc": 0.3243171029239396
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5454545454545454,
+                    "recall": 0.1276595744680851,
+                    "f1": 0.2068965517241379,
+                    "support": 47,
+                    "roc_auc": 0.4264062955406587,
+                    "pr_auc": 0.3498432618642183
+                  }
+                ],
+                "macro_precision": 0.47229437229437227,
+                "macro_recall": 0.3552516041877744,
+                "macro_f1": 0.2839655172413793,
+                "weighted_f1": 0.30520114942528737,
+                "macro_roc_auc": 0.46943556220498756,
+                "macro_pr_auc": 0.3484547681896246
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.13226985709538053,
+              "regime_accuracy": 0.18644067645072937,
+              "regime_loss": 1.1435082160820396,
+              "regression_rmse_log_rv": 0.8188735115218186,
+              "regression_mae_log_rv": 0.6319932911103054,
+              "regression_loss": 0.6705538278720741,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    4,
+                    6
+                  ],
+                  [
+                    0,
+                    9,
+                    3
+                  ],
+                  [
+                    6,
+                    77,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 10,
+                    "roc_auc": 0.26944444444444443,
+                    "pr_auc": 0.05421556447516013
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.1,
+                    "recall": 0.75,
+                    "f1": 0.17647058823529416,
+                    "support": 12,
+                    "roc_auc": 0.4968553459119497,
+                    "pr_auc": 0.10260637693088781
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5909090909090909,
+                    "recall": 0.13541666666666666,
+                    "f1": 0.22033898305084745,
+                    "support": 96,
+                    "roc_auc": 0.2689393939393939,
+                    "pr_auc": 0.6849224439582715
+                  }
+                ],
+                "macro_precision": 0.23030303030303031,
+                "macro_recall": 0.2951388888888889,
+                "macro_f1": 0.13226985709538053,
+                "weighted_f1": 0.19720499518393972,
+                "macro_roc_auc": 0.345079728098596,
+                "macro_pr_auc": 0.28058146178810645
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2569832402234637,
+              "regime_accuracy": 0.6272727251052856,
+              "regime_loss": 0.9905646681785584,
+              "regression_rmse_log_rv": 0.5587291022700744,
+              "regression_mae_log_rv": 0.4492293187268925,
+              "regression_loss": 0.3121782097235233,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    12,
+                    0
+                  ],
+                  [
+                    6,
+                    69,
+                    3
+                  ],
+                  [
+                    0,
+                    20,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.3392857142857143,
+                    "pr_auc": 0.07641543922920242
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6831683168316832,
+                    "recall": 0.8846153846153846,
+                    "f1": 0.7709497206703911,
+                    "support": 78,
+                    "roc_auc": 0.6213942307692307,
+                    "pr_auc": 0.8057443143293015
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.44333333333333336,
+                    "pr_auc": 0.14918068783962202
+                  }
+                ],
+                "macro_precision": 0.22772277227722773,
+                "macro_recall": 0.2948717948717949,
+                "macro_f1": 0.2569832402234637,
+                "weighted_f1": 0.5466734382935501,
+                "macro_roc_auc": 0.4680044261294261,
+                "macro_pr_auc": 0.34378014713270866
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2012578616352201,
+              "regime_accuracy": 0.4324324429035187,
+              "regime_loss": 1.1034772212307637,
+              "regression_rmse_log_rv": 0.8518652075828163,
+              "regression_mae_log_rv": 0.7182915361077936,
+              "regression_loss": 0.7256743318901147,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    44,
+                    0
+                  ],
+                  [
+                    0,
+                    48,
+                    0
+                  ],
+                  [
+                    0,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.35888738127544095,
+                    "pr_auc": 0.30358163547174905
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.43243243243243246,
+                    "recall": 1.0,
+                    "f1": 0.6037735849056604,
+                    "support": 48,
+                    "roc_auc": 0.39715608465608465,
+                    "pr_auc": 0.4167624836805787
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.3718535469107552,
+                    "pr_auc": 0.15090185726828706
+                  }
+                ],
+                "macro_precision": 0.14414414414414414,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.2012578616352201,
+                "weighted_f1": 0.2610912799592045,
+                "macro_roc_auc": 0.3759656709474269,
+                "macro_pr_auc": 0.29041532547353827
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.22534001431639228,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.0781359122349665,
+              "regression_rmse_log_rv": 0.8765441647665245,
+              "regression_mae_log_rv": 0.6909048165678262,
+              "regression_loss": 0.7683296727862441,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    16,
+                    10
+                  ],
+                  [
+                    0,
+                    36,
+                    16
+                  ],
+                  [
+                    0,
+                    23,
+                    3
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5202169625246549,
+                    "pr_auc": 0.4249320929452875
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.48,
+                    "recall": 0.6923076923076923,
+                    "f1": 0.5669291338582677,
+                    "support": 52,
+                    "roc_auc": 0.47596153846153844,
+                    "pr_auc": 0.566450475372727
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.10344827586206896,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.10909090909090909,
+                    "support": 26,
+                    "roc_auc": 0.3071992110453649,
+                    "pr_auc": 0.17353570115407999
+                  }
+                ],
+                "macro_precision": 0.19448275862068964,
+                "macro_recall": 0.2692307692307692,
+                "macro_f1": 0.22534001431639228,
+                "weighted_f1": 0.3107372942018612,
+                "macro_roc_auc": 0.4344592373438527,
+                "macro_pr_auc": 0.38830608982403153
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.23895582329317266,
+              "regime_accuracy": 0.34166666865348816,
+              "regime_loss": 1.093405778438501,
+              "regression_rmse_log_rv": 0.9347847961237291,
+              "regression_mae_log_rv": 0.8024245059369908,
+              "regression_loss": 0.8738226150640818,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    14,
+                    14
+                  ],
+                  [
+                    1,
+                    9,
+                    35
+                  ],
+                  [
+                    0,
+                    15,
+                    32
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 28,
+                    "roc_auc": 0.38004658385093165,
+                    "pr_auc": 0.18178445380346525
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.23684210526315788,
+                    "recall": 0.2,
+                    "f1": 0.21686746987951808,
+                    "support": 45,
+                    "roc_auc": 0.4402962962962963,
+                    "pr_auc": 0.34648438298036954
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3950617283950617,
+                    "recall": 0.6808510638297872,
+                    "f1": 0.4999999999999999,
+                    "support": 47,
+                    "roc_auc": 0.542698921597202,
+                    "pr_auc": 0.4464399504173044
+                  }
+                ],
+                "macro_precision": 0.21063461121940652,
+                "macro_recall": 0.2936170212765958,
+                "macro_f1": 0.23895582329317266,
+                "weighted_f1": 0.2771586345381526,
+                "macro_roc_auc": 0.4543472672481433,
+                "macro_pr_auc": 0.3249029290670464
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3962628865979381,
+              "regime_accuracy": 0.7627118825912476,
+              "regime_loss": 1.0084261853816145,
+              "regression_rmse_log_rv": 0.7567886953611432,
+              "regression_mae_log_rv": 0.5759555937651292,
+              "regression_loss": 0.5727291294264213,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    4,
+                    6
+                  ],
+                  [
+                    0,
+                    5,
+                    7
+                  ],
+                  [
+                    0,
+                    11,
+                    85
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 10,
+                    "roc_auc": 0.13703703703703704,
+                    "pr_auc": 0.049467880041396475
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.3125,
+                    "support": 12,
+                    "roc_auc": 0.7885220125786163,
+                    "pr_auc": 0.19621652595755046
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.8673469387755102,
+                    "recall": 0.8854166666666666,
+                    "f1": 0.8762886597938144,
+                    "support": 96,
+                    "roc_auc": 0.712594696969697,
+                    "pr_auc": 0.9250961119117297
+                  }
+                ],
+                "macro_precision": 0.3724489795918367,
+                "macro_recall": 0.43402777777777773,
+                "macro_f1": 0.3962628865979381,
+                "weighted_f1": 0.7446924689847981,
+                "macro_roc_auc": 0.5460512488617835,
+                "macro_pr_auc": 0.3902601726368922
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.25027028696753467,
+              "regime_accuracy": 0.3545454442501068,
+              "regime_loss": 1.0834062099456787,
+              "regression_rmse_log_rv": 0.5810582785358872,
+              "regression_mae_log_rv": 0.44733430049170486,
+              "regression_loss": 0.3376287230550886,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    2,
+                    10
+                  ],
+                  [
+                    0,
+                    19,
+                    59
+                  ],
+                  [
+                    0,
+                    0,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.3715986394557823,
+                    "pr_auc": 0.08286300942391789
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.9047619047619048,
+                    "recall": 0.24358974358974358,
+                    "f1": 0.38383838383838387,
+                    "support": 78,
+                    "roc_auc": 0.5885416666666666,
+                    "pr_auc": 0.7958675442756986
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2247191011235955,
+                    "recall": 1.0,
+                    "f1": 0.36697247706422015,
+                    "support": 20,
+                    "roc_auc": 0.6011111111111112,
+                    "pr_auc": 0.19712891441309555
+                  }
+                ],
+                "macro_precision": 0.3764936686285001,
+                "macro_recall": 0.41452991452991456,
+                "macro_f1": 0.25027028696753467,
+                "weighted_f1": 0.3388985770970759,
+                "macro_roc_auc": 0.5204171390778534,
+                "macro_pr_auc": 0.35861982270423737
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.09743589743589744,
+              "regime_accuracy": 0.171171173453331,
+              "regime_loss": 1.1476893608631196,
+              "regression_rmse_log_rv": 0.8321287431431857,
+              "regression_mae_log_rv": 0.667411881771677,
+              "regression_loss": 0.692438245165058,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    44
+                  ],
+                  [
+                    0,
+                    0,
+                    48
+                  ],
+                  [
+                    0,
+                    0,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.41485753052917235,
+                    "pr_auc": 0.35554477065081885
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.48908730158730157,
+                    "pr_auc": 0.4269199892729933
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.17117117117117117,
+                    "recall": 1.0,
+                    "f1": 0.2923076923076923,
+                    "support": 19,
+                    "roc_auc": 0.5743707093821511,
+                    "pr_auc": 0.22550645394580032
+                  }
+                ],
+                "macro_precision": 0.057057057057057055,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.09743589743589744,
+                "weighted_f1": 0.05003465003465004,
+                "macro_roc_auc": 0.4927718471662083,
+                "macro_pr_auc": 0.3359904046232041
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.13541666666666666,
+              "regime_accuracy": 0.25,
+              "regime_loss": 1.110346766618582,
+              "regression_rmse_log_rv": 0.7823077549700262,
+              "regression_mae_log_rv": 0.6183737272378773,
+              "regression_loss": 0.6120054234862427,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    2,
+                    24
+                  ],
+                  [
+                    0,
+                    0,
+                    52
+                  ],
+                  [
+                    0,
+                    0,
+                    26
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.3821499013806706,
+                    "pr_auc": 0.19280867382824973
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.5599112426035503,
+                    "pr_auc": 0.49420104773482787
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2549019607843137,
+                    "recall": 1.0,
+                    "f1": 0.40625,
+                    "support": 26,
+                    "roc_auc": 0.6227810650887574,
+                    "pr_auc": 0.5211624757592074
+                  }
+                ],
+                "macro_precision": 0.0849673202614379,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.13541666666666666,
+                "weighted_f1": 0.1015625,
+                "macro_roc_auc": 0.5216140696909928,
+                "macro_pr_auc": 0.402724065774095
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "dual": [
+      {
+        "head_mode": "dual",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.38158486894119076,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.239689065178794,
+              "regression_rmse_log_rv": 0.9086979539684036,
+              "regression_mae_log_rv": 0.767141741613159,
+              "regression_loss": 0.8257319715463629,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    6,
+                    12
+                  ],
+                  [
+                    9,
+                    9,
+                    27
+                  ],
+                  [
+                    7,
+                    10,
+                    30
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.38461538461538464,
+                    "recall": 0.35714285714285715,
+                    "f1": 0.3703703703703704,
+                    "support": 28,
+                    "roc_auc": 0.6774068322981367,
+                    "pr_auc": 0.3184037457844893
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.36,
+                    "recall": 0.2,
+                    "f1": 0.2571428571428571,
+                    "support": 45,
+                    "roc_auc": 0.5081481481481481,
+                    "pr_auc": 0.39009089040392675
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.43478260869565216,
+                    "recall": 0.6382978723404256,
+                    "f1": 0.5172413793103449,
+                    "support": 47,
+                    "roc_auc": 0.5861264937336054,
+                    "pr_auc": 0.4481225265554677
+                  }
+                ],
+                "macro_precision": 0.3931326644370123,
+                "macro_recall": 0.39848024316109426,
+                "macro_f1": 0.38158486894119076,
+                "weighted_f1": 0.38543453141154294,
+                "macro_roc_auc": 0.5905604913932967,
+                "macro_pr_auc": 0.38553905424796125
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5078144078144079,
+              "regime_accuracy": 0.7627118825912476,
+              "regime_loss": 0.5584165625653025,
+              "regression_rmse_log_rv": 0.6976849829543437,
+              "regression_mae_log_rv": 0.5517636068733567,
+              "regression_loss": 0.48676433544000286,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    5,
+                    2,
+                    5
+                  ],
+                  [
+                    8,
+                    7,
+                    81
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35,
+                    "recall": 0.7,
+                    "f1": 0.4666666666666667,
+                    "support": 10,
+                    "roc_auc": 0.9166666666666666,
+                    "pr_auc": 0.4543792973186744
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.16666666666666666,
+                    "support": 12,
+                    "roc_auc": 0.7224842767295597,
+                    "pr_auc": 0.16105390403273062
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9418604651162791,
+                    "recall": 0.84375,
+                    "f1": 0.8901098901098902,
+                    "support": 96,
+                    "roc_auc": 0.8910984848484849,
+                    "pr_auc": 0.973284785816408
+                  }
+                ],
+                "macro_precision": 0.48617571059431525,
+                "macro_recall": 0.5701388888888889,
+                "macro_f1": 0.5078144078144079,
+                "weighted_f1": 0.7806543738747129,
+                "macro_roc_auc": 0.8434164760815704,
+                "macro_pr_auc": 0.529572662389271
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.25148335276590233,
+              "regime_accuracy": 0.2454545497894287,
+              "regime_loss": 1.171109752221541,
+              "regression_rmse_log_rv": 0.5594701238128528,
+              "regression_mae_log_rv": 0.4213613751196218,
+              "regression_loss": 0.31300681943916875,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    37,
+                    4,
+                    37
+                  ],
+                  [
+                    5,
+                    0,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.25806451612903225,
+                    "support": 12,
+                    "roc_auc": 0.7236394557823129,
+                    "pr_auc": 0.19928093436045607
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8,
+                    "recall": 0.05128205128205128,
+                    "f1": 0.09638554216867469,
+                    "support": 78,
+                    "roc_auc": 0.4310897435897436,
+                    "pr_auc": 0.6757475304730775
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2727272727272727,
+                    "recall": 0.75,
+                    "f1": 0.39999999999999997,
+                    "support": 20,
+                    "roc_auc": 0.7361111111111112,
+                    "pr_auc": 0.34484350111347967
+                  }
+                ],
+                "macro_precision": 0.4109090909090909,
+                "macro_recall": 0.4893162393162393,
+                "macro_f1": 0.25148335276590233,
+                "weighted_f1": 0.1692258771155001,
+                "macro_roc_auc": 0.6302801034943892,
+                "macro_pr_auc": 0.4066239886490044
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.427169321906164,
+              "regime_accuracy": 0.44144144654273987,
+              "regime_loss": 1.1126625342440037,
+              "regression_rmse_log_rv": 0.8496124831155046,
+              "regression_mae_log_rv": 0.6866782765063617,
+              "regression_loss": 0.7218413714656937,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    25,
+                    11,
+                    8
+                  ],
+                  [
+                    16,
+                    14,
+                    18
+                  ],
+                  [
+                    6,
+                    3,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5319148936170213,
+                    "recall": 0.5681818181818182,
+                    "f1": 0.5494505494505494,
+                    "support": 44,
+                    "roc_auc": 0.6424694708276798,
+                    "pr_auc": 0.4732886404718673
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.2916666666666667,
+                    "f1": 0.3684210526315789,
+                    "support": 48,
+                    "roc_auc": 0.5459656084656085,
+                    "pr_auc": 0.46714845417676804
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2777777777777778,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.36363636363636365,
+                    "support": 19,
+                    "roc_auc": 0.647025171624714,
+                    "pr_auc": 0.2726684820614264
+                  }
+                ],
+                "macro_precision": 0.4365642237982663,
+                "macro_recall": 0.4620547581073897,
+                "macro_f1": 0.427169321906164,
+                "weighted_f1": 0.4393614919930709,
+                "macro_roc_auc": 0.611820083639334,
+                "macro_pr_auc": 0.4043685255700206
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3125,
+              "regime_accuracy": 0.4038461446762085,
+              "regime_loss": 1.1176449748185964,
+              "regression_rmse_log_rv": 0.7969474293389338,
+              "regression_mae_log_rv": 0.6334432234826426,
+              "regression_loss": 0.6351252051299349,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    18,
+                    8
+                  ],
+                  [
+                    2,
+                    21,
+                    29
+                  ],
+                  [
+                    0,
+                    5,
+                    21
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6720907297830375,
+                    "pr_auc": 0.39749405837257396
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4772727272727273,
+                    "recall": 0.40384615384615385,
+                    "f1": 0.4375,
+                    "support": 52,
+                    "roc_auc": 0.5869082840236687,
+                    "pr_auc": 0.5145424703696606
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3620689655172414,
+                    "recall": 0.8076923076923077,
+                    "f1": 0.5,
+                    "support": 26,
+                    "roc_auc": 0.8476331360946746,
+                    "pr_auc": 0.7316872122798375
+                  }
+                ],
+                "macro_precision": 0.2797805642633229,
+                "macro_recall": 0.4038461538461539,
+                "macro_f1": 0.3125,
+                "weighted_f1": 0.34375,
+                "macro_roc_auc": 0.7022107166337936,
+                "macro_pr_auc": 0.547907913674024
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3610092647348709,
+              "regime_accuracy": 0.3583333194255829,
+              "regime_loss": 1.0827149872230788,
+              "regression_rmse_log_rv": 0.9291818213906925,
+              "regression_mae_log_rv": 0.7708833478449378,
+              "regression_loss": 0.8633788572029248,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    7,
+                    6
+                  ],
+                  [
+                    9,
+                    14,
+                    22
+                  ],
+                  [
+                    23,
+                    10,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3191489361702128,
+                    "recall": 0.5357142857142857,
+                    "f1": 0.4,
+                    "support": 28,
+                    "roc_auc": 0.6917701863354038,
+                    "pr_auc": 0.3965126148889323
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.45161290322580644,
+                    "recall": 0.3111111111111111,
+                    "f1": 0.3684210526315789,
+                    "support": 45,
+                    "roc_auc": 0.4743703703703704,
+                    "pr_auc": 0.3729494635119503
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.2978723404255319,
+                    "f1": 0.3146067415730337,
+                    "support": 47,
+                    "roc_auc": 0.5514427280676187,
+                    "pr_auc": 0.4052958933272174
+                  }
+                ],
+                "macro_precision": 0.36803172424311753,
+                "macro_recall": 0.3815659124169762,
+                "macro_f1": 0.3610092647348709,
+                "weighted_f1": 0.354712201852947,
+                "macro_roc_auc": 0.572527761591131,
+                "macro_pr_auc": 0.3915859905760333
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4569739952718676,
+              "regime_accuracy": 0.7796609997749329,
+              "regime_loss": 0.5118942321357081,
+              "regression_rmse_log_rv": 0.7058825567785733,
+              "regression_mae_log_rv": 0.5493203415456465,
+              "regression_loss": 0.49827018396425576,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    5,
+                    0,
+                    7
+                  ],
+                  [
+                    8,
+                    3,
+                    85
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35,
+                    "recall": 0.7,
+                    "f1": 0.4666666666666667,
+                    "support": 10,
+                    "roc_auc": 0.9435185185185185,
+                    "pr_auc": 0.49283455674760024
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.8058176100628931,
+                    "pr_auc": 0.21410844099406937
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9239130434782609,
+                    "recall": 0.8854166666666666,
+                    "f1": 0.9042553191489361,
+                    "support": 96,
+                    "roc_auc": 0.946969696969697,
+                    "pr_auc": 0.987616624157617
+                  }
+                ],
+                "macro_precision": 0.4246376811594203,
+                "macro_recall": 0.5284722222222222,
+                "macro_f1": 0.4569739952718676,
+                "weighted_f1": 0.7752133669912249,
+                "macro_roc_auc": 0.8987686085170362,
+                "macro_pr_auc": 0.5648532072997622
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3579852230747371,
+              "regime_accuracy": 0.3636363744735718,
+              "regime_loss": 1.0980037515813654,
+              "regression_rmse_log_rv": 0.4407107712621893,
+              "regression_mae_log_rv": 0.32883102560034866,
+              "regression_loss": 0.19422598390651377,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    2,
+                    3
+                  ],
+                  [
+                    26,
+                    18,
+                    34
+                  ],
+                  [
+                    1,
+                    4,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.20588235294117646,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.3043478260869565,
+                    "support": 12,
+                    "roc_auc": 0.66921768707483,
+                    "pr_auc": 0.18592324110641673
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.75,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.3529411764705882,
+                    "support": 78,
+                    "roc_auc": 0.4463141025641026,
+                    "pr_auc": 0.6707688484440796
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.28846153846153844,
+                    "recall": 0.75,
+                    "f1": 0.4166666666666667,
+                    "support": 20,
+                    "roc_auc": 0.7211111111111111,
+                    "pr_auc": 0.3401943230834126
+                  }
+                ],
+                "macro_precision": 0.41478129713423834,
+                "macro_recall": 0.5213675213675214,
+                "macro_f1": 0.3579852230747371,
+                "weighted_f1": 0.35922653646438807,
+                "macro_roc_auc": 0.6122143002500146,
+                "macro_pr_auc": 0.39896213754463633
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3795255930087391,
+              "regime_accuracy": 0.38738739490509033,
+              "regime_loss": 1.0905643486539907,
+              "regression_rmse_log_rv": 0.813863524404822,
+              "regression_mae_log_rv": 0.6823546624666935,
+              "regression_loss": 0.6623738363566384,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    21,
+                    12,
+                    11
+                  ],
+                  [
+                    17,
+                    10,
+                    21
+                  ],
+                  [
+                    7,
+                    0,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4666666666666667,
+                    "recall": 0.4772727272727273,
+                    "f1": 0.4719101123595506,
+                    "support": 44,
+                    "roc_auc": 0.6309362279511533,
+                    "pr_auc": 0.4673900583539253
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.28571428571428575,
+                    "support": 48,
+                    "roc_auc": 0.5912698412698413,
+                    "pr_auc": 0.5080282102560127
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2727272727272727,
+                    "recall": 0.631578947368421,
+                    "f1": 0.38095238095238093,
+                    "support": 19,
+                    "roc_auc": 0.5983981693363845,
+                    "pr_auc": 0.3107850249694395
+                  }
+                ],
+                "macro_precision": 0.39797979797979793,
+                "macro_recall": 0.4390616693248272,
+                "macro_f1": 0.3795255930087391,
+                "weighted_f1": 0.37582365672253315,
+                "macro_roc_auc": 0.6068680795191264,
+                "macro_pr_auc": 0.4287344311931258
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3778602350030922,
+              "regime_accuracy": 0.4326923191547394,
+              "regime_loss": 1.0965369939804077,
+              "regression_rmse_log_rv": 0.8279960176767743,
+              "regression_mae_log_rv": 0.6425863372144074,
+              "regression_loss": 0.6855774052885972,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    12,
+                    11
+                  ],
+                  [
+                    4,
+                    25,
+                    23
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.18181818181818182,
+                    "support": 26,
+                    "roc_auc": 0.5576923076923077,
+                    "pr_auc": 0.30358834654086203
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5434782608695652,
+                    "recall": 0.4807692307692308,
+                    "f1": 0.5102040816326531,
+                    "support": 52,
+                    "roc_auc": 0.6235207100591716,
+                    "pr_auc": 0.6032788064070134
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.44155844155844154,
+                    "support": 26,
+                    "roc_auc": 0.7490138067061144,
+                    "pr_auc": 0.6005965822620373
+                  }
+                ],
+                "macro_precision": 0.435127674258109,
+                "macro_recall": 0.4166666666666667,
+                "macro_f1": 0.3778602350030922,
+                "weighted_f1": 0.4109461966604824,
+                "macro_roc_auc": 0.6434089414858646,
+                "macro_pr_auc": 0.5024879117366375
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3671083818142642,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.1591045730682834,
+              "regression_rmse_log_rv": 0.9601077074603722,
+              "regression_mae_log_rv": 0.8303361398458946,
+              "regression_loss": 0.9218068099248117,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    11,
+                    9,
+                    8
+                  ],
+                  [
+                    9,
+                    5,
+                    31
+                  ],
+                  [
+                    8,
+                    6,
+                    33
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.39285714285714285,
+                    "recall": 0.39285714285714285,
+                    "f1": 0.39285714285714285,
+                    "support": 28,
+                    "roc_auc": 0.6979813664596274,
+                    "pr_auc": 0.32438807606554376
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.1111111111111111,
+                    "f1": 0.15384615384615383,
+                    "support": 45,
+                    "roc_auc": 0.4148148148148148,
+                    "pr_auc": 0.3280272847482942
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4583333333333333,
+                    "recall": 0.7021276595744681,
+                    "f1": 0.5546218487394958,
+                    "support": 47,
+                    "roc_auc": 0.5491110463421743,
+                    "pr_auc": 0.4186658970262361
+                  }
+                ],
+                "macro_precision": 0.3670634920634921,
+                "macro_recall": 0.40203197118090733,
+                "macro_f1": 0.3671083818142642,
+                "weighted_f1": 0.36658586511527685,
+                "macro_roc_auc": 0.5539690758722055,
+                "macro_pr_auc": 0.35702708594669136
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.39008427469965934,
+              "regime_accuracy": 0.6694915294647217,
+              "regime_loss": 0.7255340466054819,
+              "regression_rmse_log_rv": 0.7970703986443889,
+              "regression_mae_log_rv": 0.6278560341067486,
+              "regression_loss": 0.635321220395125,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    11,
+                    0,
+                    1
+                  ],
+                  [
+                    16,
+                    8,
+                    72
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.20588235294117646,
+                    "recall": 0.7,
+                    "f1": 0.3181818181818182,
+                    "support": 10,
+                    "roc_auc": 0.8518518518518519,
+                    "pr_auc": 0.23148849767270818
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7051886792452831,
+                    "pr_auc": 0.14878852069651
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9863013698630136,
+                    "recall": 0.75,
+                    "f1": 0.8520710059171598,
+                    "support": 96,
+                    "roc_auc": 0.884469696969697,
+                    "pr_auc": 0.974362018349677
+                  }
+                ],
+                "macro_precision": 0.39739457426806335,
+                "macro_recall": 0.48333333333333334,
+                "macro_f1": 0.39008427469965934,
+                "weighted_f1": 0.7201748707615723,
+                "macro_roc_auc": 0.813836742688944,
+                "macro_pr_auc": 0.4515463455729651
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.26744013089394614,
+              "regime_accuracy": 0.26363635063171387,
+              "regime_loss": 1.2192915352908047,
+              "regression_rmse_log_rv": 0.5642718907862664,
+              "regression_mae_log_rv": 0.42351211618886075,
+              "regression_loss": 0.3184027667315082,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    33,
+                    3,
+                    42
+                  ],
+                  [
+                    1,
+                    1,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.19047619047619047,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.2962962962962963,
+                    "support": 12,
+                    "roc_auc": 0.6947278911564626,
+                    "pr_auc": 0.169729345829969
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.07228915662650603,
+                    "support": 78,
+                    "roc_auc": 0.42467948717948717,
+                    "pr_auc": 0.6614654231986102
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.9,
+                    "f1": 0.4337349397590361,
+                    "support": 20,
+                    "roc_auc": 0.7783333333333333,
+                    "pr_auc": 0.34554414615513723
+                  }
+                ],
+                "macro_precision": 0.35873015873015873,
+                "macro_recall": 0.535042735042735,
+                "macro_f1": 0.26744013089394614,
+                "weighted_f1": 0.16244371425094317,
+                "macro_roc_auc": 0.6325802372230943,
+                "macro_pr_auc": 0.3922463050612388
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4044375263549709,
+              "regime_accuracy": 0.4324324429035187,
+              "regime_loss": 1.187854668825332,
+              "regression_rmse_log_rv": 0.8962072925878448,
+              "regression_mae_log_rv": 0.7539670627127897,
+              "regression_loss": 0.8031875112876349,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    28,
+                    5,
+                    11
+                  ],
+                  [
+                    17,
+                    7,
+                    24
+                  ],
+                  [
+                    5,
+                    1,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.56,
+                    "recall": 0.6363636363636364,
+                    "f1": 0.5957446808510639,
+                    "support": 44,
+                    "roc_auc": 0.675033921302578,
+                    "pr_auc": 0.5006582921288253
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5384615384615384,
+                    "recall": 0.14583333333333334,
+                    "f1": 0.22950819672131148,
+                    "support": 48,
+                    "roc_auc": 0.5300925925925926,
+                    "pr_auc": 0.4570646970913366
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2708333333333333,
+                    "recall": 0.6842105263157895,
+                    "f1": 0.38805970149253727,
+                    "support": 19,
+                    "roc_auc": 0.6332951945080092,
+                    "pr_auc": 0.23228972615176227
+                  }
+                ],
+                "macro_precision": 0.45643162393162395,
+                "macro_recall": 0.4888024986709197,
+                "macro_f1": 0.4044375263549709,
+                "weighted_f1": 0.40182246602187366,
+                "macro_roc_auc": 0.6128072361343933,
+                "macro_pr_auc": 0.39667090512397474
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3822591061741152,
+              "regime_accuracy": 0.38461539149284363,
+              "regime_loss": 1.0758078556794386,
+              "regression_rmse_log_rv": 0.7702160163358573,
+              "regression_mae_log_rv": 0.6293018931934896,
+              "regression_loss": 0.5932327118202777,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    7,
+                    10
+                  ],
+                  [
+                    11,
+                    14,
+                    27
+                  ],
+                  [
+                    3,
+                    6,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.391304347826087,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.36734693877551017,
+                    "support": 26,
+                    "roc_auc": 0.6646942800788954,
+                    "pr_auc": 0.4427324913866672
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5185185185185185,
+                    "recall": 0.2692307692307692,
+                    "f1": 0.35443037974683544,
+                    "support": 52,
+                    "roc_auc": 0.5913461538461539,
+                    "pr_auc": 0.5208893467603758
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3148148148148148,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.42500000000000004,
+                    "support": 26,
+                    "roc_auc": 0.7011834319526628,
+                    "pr_auc": 0.5790287245328324
+                  }
+                ],
+                "macro_precision": 0.40821256038647347,
+                "macro_recall": 0.4230769230769231,
+                "macro_f1": 0.3822591061741152,
+                "weighted_f1": 0.3753019245672953,
+                "macro_roc_auc": 0.6524079552925707,
+                "macro_pr_auc": 0.5142168542266251
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.41583401583401586,
+              "regime_accuracy": 0.42500001192092896,
+              "regime_loss": 1.1473230162771697,
+              "regression_rmse_log_rv": 0.9025467999593695,
+              "regression_mae_log_rv": 0.7678273531976932,
+              "regression_loss": 0.8145907261168982,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    6,
+                    9
+                  ],
+                  [
+                    8,
+                    10,
+                    27
+                  ],
+                  [
+                    6,
+                    13,
+                    28
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.48148148148148145,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.4727272727272727,
+                    "support": 28,
+                    "roc_auc": 0.6948757763975155,
+                    "pr_auc": 0.42538549383430646
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3448275862068966,
+                    "recall": 0.2222222222222222,
+                    "f1": 0.27027027027027023,
+                    "support": 45,
+                    "roc_auc": 0.4085925925925926,
+                    "pr_auc": 0.34339772164609045
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4375,
+                    "recall": 0.5957446808510638,
+                    "f1": 0.5045045045045045,
+                    "support": 47,
+                    "roc_auc": 0.5368697172835908,
+                    "pr_auc": 0.40043272160376453
+                  }
+                ],
+                "macro_precision": 0.42126968922945934,
+                "macro_recall": 0.4274175391196668,
+                "macro_f1": 0.41583401583401586,
+                "weighted_f1": 0.40925197925197926,
+                "macro_roc_auc": 0.546779362091233,
+                "macro_pr_auc": 0.3897386456947205
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5222886716099385,
+              "regime_accuracy": 0.7118644118309021,
+              "regime_loss": 0.6535728260622187,
+              "regression_rmse_log_rv": 0.8011409982681238,
+              "regression_mae_log_rv": 0.6190974032032793,
+              "regression_loss": 0.6418268991060458,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    6,
+                    5,
+                    1
+                  ],
+                  [
+                    11,
+                    13,
+                    72
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2916666666666667,
+                    "recall": 0.7,
+                    "f1": 0.4117647058823529,
+                    "support": 10,
+                    "roc_auc": 0.9074074074074074,
+                    "pr_auc": 0.325800729334934
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.23809523809523808,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.30303030303030304,
+                    "support": 12,
+                    "roc_auc": 0.7161949685534591,
+                    "pr_auc": 0.15182963311780678
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9863013698630136,
+                    "recall": 0.75,
+                    "f1": 0.8520710059171598,
+                    "support": 96,
+                    "roc_auc": 0.9024621212121212,
+                    "pr_auc": 0.9787434622216166
+                  }
+                ],
+                "macro_precision": 0.5053544248749727,
+                "macro_recall": 0.6222222222222222,
+                "macro_f1": 0.5222886716099385,
+                "weighted_f1": 0.7589222649426653,
+                "macro_roc_auc": 0.8420214990576627,
+                "macro_pr_auc": 0.4854579415581191
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3034170425431777,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.0958101511001588,
+              "regression_rmse_log_rv": 0.4467277177522813,
+              "regression_mae_log_rv": 0.33892348802606154,
+              "regression_loss": 0.1995656538081619,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    29,
+                    7,
+                    42
+                  ],
+                  [
+                    2,
+                    0,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.20512820512820512,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.31372549019607837,
+                    "support": 12,
+                    "roc_auc": 0.7270408163265306,
+                    "pr_auc": 0.2077994081419774
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.875,
+                    "recall": 0.08974358974358974,
+                    "f1": 0.1627906976744186,
+                    "support": 78,
+                    "roc_auc": 0.4987980769230769,
+                    "pr_auc": 0.7417044432379571
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.9,
+                    "f1": 0.4337349397590361,
+                    "support": 20,
+                    "roc_auc": 0.7538888888888889,
+                    "pr_auc": 0.3251175606740102
+                  }
+                ],
+                "macro_precision": 0.4552808302808303,
+                "macro_recall": 0.5521367521367521,
+                "macro_f1": 0.3034170425431777,
+                "weighted_f1": 0.2285189008739847,
+                "macro_roc_auc": 0.6599092607128322,
+                "macro_pr_auc": 0.4248738040179816
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.305183801915828,
+              "regime_accuracy": 0.3243243098258972,
+              "regime_loss": 1.3483689293187695,
+              "regression_rmse_log_rv": 0.9856481759131384,
+              "regression_mae_log_rv": 0.833862222831797,
+              "regression_loss": 0.9715023266808969,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    4,
+                    23
+                  ],
+                  [
+                    16,
+                    4,
+                    28
+                  ],
+                  [
+                    4,
+                    0,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4594594594594595,
+                    "recall": 0.38636363636363635,
+                    "f1": 0.41975308641975306,
+                    "support": 44,
+                    "roc_auc": 0.5966757123473542,
+                    "pr_auc": 0.439432921087682
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.14285714285714285,
+                    "support": 48,
+                    "roc_auc": 0.5095899470899471,
+                    "pr_auc": 0.44481925736633926
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.22727272727272727,
+                    "recall": 0.7894736842105263,
+                    "f1": 0.3529411764705882,
+                    "support": 19,
+                    "roc_auc": 0.6138443935926774,
+                    "pr_auc": 0.2346014943163591
+                  }
+                ],
+                "macro_precision": 0.3955773955773956,
+                "macro_recall": 0.41972355130249867,
+                "macro_f1": 0.305183801915828,
+                "weighted_f1": 0.28857802714011865,
+                "macro_roc_auc": 0.5733700176766595,
+                "macro_pr_auc": 0.37295122425679345
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3395424836601308,
+              "regime_accuracy": 0.45192307233810425,
+              "regime_loss": 1.1954919420755827,
+              "regression_rmse_log_rv": 0.8967880189878193,
+              "regression_mae_log_rv": 0.7083026342935717,
+              "regression_loss": 0.8042287510000974,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    13,
+                    13
+                  ],
+                  [
+                    0,
+                    29,
+                    23
+                  ],
+                  [
+                    0,
+                    8,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5621301775147929,
+                    "pr_auc": 0.3767544544880216
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.58,
+                    "recall": 0.5576923076923077,
+                    "f1": 0.5686274509803922,
+                    "support": 52,
+                    "roc_auc": 0.6693786982248521,
+                    "pr_auc": 0.6896428351314449
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.6923076923076923,
+                    "f1": 0.45,
+                    "support": 26,
+                    "roc_auc": 0.7805719921104537,
+                    "pr_auc": 0.6635642397536022
+                  }
+                ],
+                "macro_precision": 0.30444444444444446,
+                "macro_recall": 0.4166666666666667,
+                "macro_f1": 0.3395424836601308,
+                "weighted_f1": 0.3968137254901961,
+                "macro_roc_auc": 0.6706936226166995,
+                "macro_pr_auc": 0.5766538431243563
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.339629260367047,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.2225367606215463,
+              "regression_rmse_log_rv": 0.9315401494648476,
+              "regression_mae_log_rv": 0.7945904633476554,
+              "regression_loss": 0.8677670500649908,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    3,
+                    12
+                  ],
+                  [
+                    14,
+                    3,
+                    28
+                  ],
+                  [
+                    13,
+                    3,
+                    31
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.325,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.3823529411764706,
+                    "support": 28,
+                    "roc_auc": 0.6704192546583851,
+                    "pr_auc": 0.29414506852927774
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.06666666666666667,
+                    "f1": 0.1111111111111111,
+                    "support": 45,
+                    "roc_auc": 0.522962962962963,
+                    "pr_auc": 0.39506010532019376
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.43661971830985913,
+                    "recall": 0.6595744680851063,
+                    "f1": 0.5254237288135594,
+                    "support": 47,
+                    "roc_auc": 0.6050714077528417,
+                    "pr_auc": 0.46943705549490894
+                  }
+                ],
+                "macro_precision": 0.3649843505477308,
+                "macro_recall": 0.3968422830124958,
+                "macro_f1": 0.339629260367047,
+                "weighted_f1": 0.33667331339315393,
+                "macro_roc_auc": 0.5994845417913967,
+                "macro_pr_auc": 0.3862140764481268
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4776340996168582,
+              "regime_accuracy": 0.7118644118309021,
+              "regime_loss": 0.6129034318156161,
+              "regression_rmse_log_rv": 0.6944616558044389,
+              "regression_mae_log_rv": 0.532249995886143,
+              "regression_loss": 0.48227699138264296,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    2,
+                    3
+                  ],
+                  [
+                    8,
+                    13,
+                    75
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 10,
+                    "roc_auc": 0.9018518518518519,
+                    "pr_auc": 0.46052616233296584
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.1111111111111111,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.13333333333333333,
+                    "support": 12,
+                    "roc_auc": 0.7216981132075472,
+                    "pr_auc": 0.15447429923455924
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9615384615384616,
+                    "recall": 0.78125,
+                    "f1": 0.8620689655172413,
+                    "support": 96,
+                    "roc_auc": 0.8958333333333334,
+                    "pr_auc": 0.9772228532150338
+                  }
+                ],
+                "macro_precision": 0.4636104636104636,
+                "macro_recall": 0.5493055555555556,
+                "macro_f1": 0.4776340996168582,
+                "weighted_f1": 0.7519798363530099,
+                "macro_roc_auc": 0.8397944327975774,
+                "macro_pr_auc": 0.5307411049275196
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3155555555555556,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.486100417917425,
+              "regression_rmse_log_rv": 0.6859372437388463,
+              "regression_mae_log_rv": 0.5199199343333021,
+              "regression_loss": 0.4705099023480455,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    26,
+                    14,
+                    38
+                  ],
+                  [
+                    2,
+                    6,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.3333333333333333,
+                    "support": 12,
+                    "roc_auc": 0.7108843537414966,
+                    "pr_auc": 0.18375951885256767
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6363636363636364,
+                    "recall": 0.1794871794871795,
+                    "f1": 0.28,
+                    "support": 78,
+                    "roc_auc": 0.36899038461538464,
+                    "pr_auc": 0.646799571997507
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.23076923076923078,
+                    "recall": 0.6,
+                    "f1": 0.33333333333333337,
+                    "support": 20,
+                    "roc_auc": 0.5911111111111111,
+                    "pr_auc": 0.21603910606538249
+                  }
+                ],
+                "macro_precision": 0.36311836311836315,
+                "macro_recall": 0.48205128205128206,
+                "macro_f1": 0.3155555555555556,
+                "weighted_f1": 0.29551515151515156,
+                "macro_roc_auc": 0.5569952831559974,
+                "macro_pr_auc": 0.3488660656384857
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4207173098843837,
+              "regime_accuracy": 0.4324324429035187,
+              "regime_loss": 1.1135752565891284,
+              "regression_rmse_log_rv": 0.8305030411956628,
+              "regression_mae_log_rv": 0.6797343633821452,
+              "regression_loss": 0.6897353014352448,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    24,
+                    7,
+                    13
+                  ],
+                  [
+                    16,
+                    12,
+                    20
+                  ],
+                  [
+                    5,
+                    2,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5333333333333333,
+                    "recall": 0.5454545454545454,
+                    "f1": 0.5393258426966293,
+                    "support": 44,
+                    "roc_auc": 0.6719810040705563,
+                    "pr_auc": 0.505760832565354
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5714285714285714,
+                    "recall": 0.25,
+                    "f1": 0.34782608695652173,
+                    "support": 48,
+                    "roc_auc": 0.576058201058201,
+                    "pr_auc": 0.5010736502195212
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.26666666666666666,
+                    "recall": 0.631578947368421,
+                    "f1": 0.37500000000000006,
+                    "support": 19,
+                    "roc_auc": 0.7013729977116705,
+                    "pr_auc": 0.3013547903302175
+                  }
+                ],
+                "macro_precision": 0.45714285714285713,
+                "macro_recall": 0.4756778309409888,
+                "macro_f1": 0.4207173098843837,
+                "weighted_f1": 0.4283872905636462,
+                "macro_roc_auc": 0.6498040676134759,
+                "macro_pr_auc": 0.43606309103836427
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.47089314194577353,
+              "regime_accuracy": 0.48076921701431274,
+              "regime_loss": 0.9988537889260513,
+              "regression_rmse_log_rv": 0.7784718272173362,
+              "regression_mae_log_rv": 0.6233966427926834,
+              "regression_loss": 0.6060183857710982,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    10,
+                    7
+                  ],
+                  [
+                    8,
+                    21,
+                    23
+                  ],
+                  [
+                    1,
+                    5,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.40909090909090906,
+                    "support": 26,
+                    "roc_auc": 0.6952662721893491,
+                    "pr_auc": 0.389867459984256
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5833333333333334,
+                    "recall": 0.40384615384615385,
+                    "f1": 0.4772727272727273,
+                    "support": 52,
+                    "roc_auc": 0.6534763313609467,
+                    "pr_auc": 0.5622008057069346
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5263157894736842,
+                    "support": 26,
+                    "roc_auc": 0.834319526627219,
+                    "pr_auc": 0.7147991119992161
+                  }
+                ],
+                "macro_precision": 0.49444444444444446,
+                "macro_recall": 0.5064102564102564,
+                "macro_f1": 0.47089314194577353,
+                "weighted_f1": 0.472488038277512,
+                "macro_roc_auc": 0.7276873767258382,
+                "macro_pr_auc": 0.5556224592301356
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "classification": {
+      "regime_f1_macro": {
+        "mean": 0.39442428402120483,
+        "std": 0.0703193122669556,
+        "min": 0.26457610396679593,
+        "max": 0.5655162738496072,
+        "n": 25
+      },
+      "regression_rmse_log_rv": null
+    },
+    "regression": {
+      "regime_f1_macro": {
+        "mean": 0.21276861163885222,
+        "std": 0.07506438728582615,
+        "min": 0.09743589743589744,
+        "max": 0.3962628865979381,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7904604219882205,
+        "std": 0.10331032572631849,
+        "min": 0.5480820443898735,
+        "max": 0.9347847961237291,
+        "n": 25
+      }
+    },
+    "dual": {
+      "regime_f1_macro": {
+        "mean": 0.38143724261562545,
+        "std": 0.06921394387210386,
+        "min": 0.25148335276590233,
+        "max": 0.5222886716099385,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7788674639527874,
+        "std": 0.14702459896322248,
+        "min": 0.4407107712621893,
+        "max": 0.9856481759131384,
+        "n": 25
+      }
+    }
+  }
+}

--- a/scripts/analyze_runpod_batch.py
+++ b/scripts/analyze_runpod_batch.py
@@ -1,0 +1,260 @@
+"""Cross-arm paired analysis on the runpod batch artefacts.
+
+For every opt-in arm vs canonical (matched by seed × fold), reports the
+paired Wilcoxon signed-rank statistic + Holm-Bonferroni-corrected
+p-value on the dual head_mode regime_f1_macro deltas. Also emits the
+arm × head_mode mean F1 table consumed by wiki §6.
+
+The cross-arm comparison sits outside :mod:`app.eval.paired_comparisons`
+because that helper compares head_modes within one sweep file; this
+script joins across sweep files.
+
+CLI::
+
+    python scripts/analyze_runpod_batch.py \\
+        --artefact-dir backend/artifacts/experiments/runpod_20260530 \\
+        --output backend/artifacts/experiments/runpod_20260530/cross_arm_paired.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from scipy.stats import wilcoxon
+
+_DEFAULT_DIR = Path("backend/artifacts/experiments/runpod_20260530")
+
+ARMS: dict[str, str] = {
+    "canonical": "runpod_canonical_20260530T120517Z.json",
+    "statement_delta": "runpod_statement_delta_20260530T134347Z.json",
+    "vote_tally": "runpod_vote_tally_20260530T135114Z.json",
+    "press_conf": "runpod_press_conf_20260530T141754Z.json",
+    "surprise": "runpod_surprise_20260530T143043Z.json",
+    "retrieval": "runpod_retrieval_20260530T124410Z.json",
+    "regime": "runpod_regime_20260530T124847Z.json",
+}
+
+
+def _extract_cells(
+    path: Path, head_mode: str, metric: str = "regime_f1_macro"
+) -> dict[tuple[int, str], float]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    trials = payload.get("trials") or {}
+    cells: dict[tuple[int, str], float] = {}
+    for trial in trials.get(head_mode, []) or []:
+        seed = int(trial.get("seed", -1))
+        for fold in trial.get("folds", []) or []:
+            fid = str(fold.get("fold_id", ""))
+            v = (fold.get("metrics") or {}).get(metric)
+            if v is not None and seed >= 0:
+                cells[(seed, fid)] = float(v)
+    return cells
+
+
+def _holm_bonferroni(p_values: list[float]) -> list[float]:
+    n = len(p_values)
+    if n == 0:
+        return []
+    indexed = sorted(
+        enumerate(p_values), key=lambda kv: (math.isnan(kv[1]), kv[1])
+    )
+    out = [0.0] * n
+    running = 0.0
+    for rank, (idx, p) in enumerate(indexed):
+        adj = 1.0 if math.isnan(p) else min(1.0, p * (n - rank))
+        adj = max(adj, running)
+        running = adj
+        out[idx] = adj
+    return out
+
+
+@dataclass(frozen=True)
+class PairedResult:
+    arm: str
+    head_mode: str
+    n_pairs: int
+    mean_delta: float
+    std_delta: float
+    wilcoxon_stat: float
+    p_value: float
+    p_value_holm: float
+
+
+def cross_arm_paired(
+    artefact_dir: Path,
+    head_mode: str = "dual",
+    reference_arm: str = "canonical",
+    arms: dict[str, str] | None = None,
+) -> list[PairedResult]:
+    arms = arms or ARMS
+    ref_cells = _extract_cells(artefact_dir / arms[reference_arm], head_mode)
+    raw: list[PairedResult] = []
+    for name, fname in arms.items():
+        if name == reference_arm:
+            continue
+        arm_cells = _extract_cells(artefact_dir / fname, head_mode)
+        shared = sorted(
+            set(ref_cells) & set(arm_cells), key=lambda k: (k[1], k[0])
+        )
+        deltas = [arm_cells[k] - ref_cells[k] for k in shared]
+        n = len(deltas)
+        if n == 0:
+            raw.append(PairedResult(
+                arm=name, head_mode=head_mode, n_pairs=0,
+                mean_delta=float("nan"), std_delta=float("nan"),
+                wilcoxon_stat=float("nan"), p_value=float("nan"),
+                p_value_holm=float("nan"),
+            ))
+            continue
+        mu = statistics.fmean(deltas)
+        sd = statistics.pstdev(deltas) if n > 1 else 0.0
+        nonzero = [d for d in deltas if d != 0.0]
+        if len(nonzero) >= 2:
+            stat, pval = wilcoxon(nonzero, alternative="two-sided")
+        else:
+            stat, pval = float("nan"), float("nan")
+        raw.append(PairedResult(
+            arm=name, head_mode=head_mode, n_pairs=n,
+            mean_delta=mu, std_delta=sd,
+            wilcoxon_stat=float(stat), p_value=float(pval),
+            p_value_holm=float("nan"),
+        ))
+    holm = _holm_bonferroni([r.p_value for r in raw])
+    return [
+        PairedResult(
+            arm=r.arm, head_mode=r.head_mode, n_pairs=r.n_pairs,
+            mean_delta=r.mean_delta, std_delta=r.std_delta,
+            wilcoxon_stat=r.wilcoxon_stat, p_value=r.p_value,
+            p_value_holm=h,
+        )
+        for r, h in zip(raw, holm, strict=False)
+    ]
+
+
+def headline_means(
+    artefact_dir: Path,
+    arms: dict[str, str] | None = None,
+    metric: str = "regime_f1_macro",
+) -> list[dict[str, Any]]:
+    arms = arms or ARMS
+    rows: list[dict[str, Any]] = []
+    for name, fname in arms.items():
+        d = json.loads((artefact_dir / fname).read_text(encoding="utf-8"))
+        row: dict[str, Any] = {"arm": name}
+        for mode in ("classification", "dual", "regression"):
+            vals = []
+            for trial in (d.get("trials") or {}).get(mode, []) or []:
+                for fold in trial.get("folds", []) or []:
+                    v = (fold.get("metrics") or {}).get(metric)
+                    if v is not None:
+                        vals.append(float(v))
+            row[mode] = {
+                "n": len(vals),
+                "mean": statistics.fmean(vals) if vals else None,
+                "std": statistics.pstdev(vals) if len(vals) > 1 else (0.0 if vals else None),
+            }
+        rows.append(row)
+    return rows
+
+
+def render_markdown(
+    headline: list[dict[str, Any]],
+    paired_dual: list[PairedResult],
+    paired_class: list[PairedResult],
+    *,
+    reference_arm: str = "canonical",
+) -> str:
+    lines = [
+        "### Headline table: per-arm × head_mode mean F1 (n=25 unless noted)",
+        "",
+        "| Arm | class | dual | regression |",
+        "|---|---:|---:|---:|",
+    ]
+    for row in headline:
+        cls = row["classification"]
+        dl = row["dual"]
+        rg = row["regression"]
+        def _f(b: dict[str, Any]) -> str:
+            return "—" if b["mean"] is None else f"{b['mean']:.4f} ± {b['std']:.4f}"
+        lines.append(f"| {row['arm']} | {_f(cls)} | {_f(dl)} | {_f(rg)} |")
+    lines.extend([
+        "",
+        f"### Dual-head paired Wilcoxon vs {reference_arm} (Holm-corrected)",
+        "",
+        "| Arm | n | mean Δ | W | p | p (Holm) | verdict |",
+        "|---|---:|---:|---:|---:|---:|---|",
+    ])
+    for r in paired_dual:
+        verdict = (
+            "—" if math.isnan(r.p_value_holm)
+            else "significant ↓" if r.p_value_holm < 0.05 and r.mean_delta < 0
+            else "significant ↑" if r.p_value_holm < 0.05 and r.mean_delta > 0
+            else "null"
+        )
+        lines.append(
+            f"| {r.arm} | {r.n_pairs} | {r.mean_delta:+.4f}"
+            f" | {r.wilcoxon_stat:.1f} | {r.p_value:.4f}"
+            f" | {r.p_value_holm:.4f} | {verdict} |"
+        )
+    lines.extend([
+        "",
+        f"### Classification-only paired Wilcoxon vs {reference_arm} (Holm-corrected)",
+        "",
+        "| Arm | n | mean Δ | W | p | p (Holm) | verdict |",
+        "|---|---:|---:|---:|---:|---:|---|",
+    ])
+    for r in paired_class:
+        verdict = (
+            "—" if math.isnan(r.p_value_holm)
+            else "significant ↓" if r.p_value_holm < 0.05 and r.mean_delta < 0
+            else "significant ↑" if r.p_value_holm < 0.05 and r.mean_delta > 0
+            else "null"
+        )
+        lines.append(
+            f"| {r.arm} | {r.n_pairs} | {r.mean_delta:+.4f}"
+            f" | {r.wilcoxon_stat:.1f} | {r.p_value:.4f}"
+            f" | {r.p_value_holm:.4f} | {verdict} |"
+        )
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--artefact-dir", default=str(_DEFAULT_DIR))
+    p.add_argument(
+        "--output",
+        default=str(_DEFAULT_DIR / "cross_arm_paired.json"),
+    )
+    p.add_argument("--reference-arm", default="canonical")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    art = Path(args.artefact_dir)
+    paired_dual = cross_arm_paired(art, head_mode="dual", reference_arm=args.reference_arm)
+    paired_class = cross_arm_paired(art, head_mode="classification", reference_arm=args.reference_arm)
+    headline = headline_means(art)
+    md = render_markdown(headline, paired_dual, paired_class, reference_arm=args.reference_arm)
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps({
+        "reference_arm": args.reference_arm,
+        "headline": headline,
+        "paired_dual": [asdict(r) for r in paired_dual],
+        "paired_classification": [asdict(r) for r in paired_class],
+        "markdown": md,
+    }, indent=2), encoding="utf-8")
+    print(f"Wrote {out}\n")
+    print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- All 13 runpod sweep artefacts + per-arm logs landed under `backend/artifacts/experiments/runpod_20260530/`.
- `scripts/analyze_runpod_batch.py`: cross-arm paired Wilcoxon + Holm correction (sits outside `app.eval.paired_comparisons` which is within-file by design).
- Wiki §6.29: per-arm headline table, paired Wilcoxon table, per-fold baselines, ordinal confusion decomposition, three open anomalies.

## Headline (dual head, n=25)
- canonical: 0.4498 ± 0.1113 (winner)
- retrieval: 0.4322 ± 0.1076 (null vs canonical, p=0.13)
- statement_delta / vote_tally / press_conf / surprise / regime: all significantly worse on Holm-corrected p<0.05

## Test plan
- [ ] `docker compose run --rm backend python -m scripts.analyze_runpod_batch` reproduces §6.29
- [ ] `docker compose run --rm backend python -m app.eval.per_fold_baselines --sweep-artefact artifacts/experiments/runpod_20260530/runpod_canonical_*.json` reproduces the per-fold table