### PR TITLE
linguistic: structured LDA misc-bucket warning + hawk/dove jackknife runner (#506)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ JUDGE_REQUEST_INTERVAL ?= 0.0
 PSEUDO_SERVICE ?= backend-gpu
 PSEUDO_PROFILE_FLAG ?= --profile gpu
 
-.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package pre-sweep-column-audit build-events-parquet pull-op-fed pull-swanson-three-factor pull-beige-book pull-press-conferences pull-speeches pull-testimonies pull-regional-research train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build per-fold-baselines paired-stats ordinal-confusion
+.PHONY: help dev dev-cpu dev-gpu down logs lock verify openapi-snapshot data-prep audit-training-package pre-sweep-column-audit build-events-parquet pull-op-fed pull-swanson-three-factor pull-beige-book pull-press-conferences pull-speeches pull-testimonies pull-regional-research train-smoke train-batch changelog audit-python audit-npm pseudo-labels pseudo-labels-audit-sample pseudo-labels-audit-metrics pseudo-labels-judge-pass pseudo-labels-audit-metrics-judge macro-state build-macro-state build-mp-surprises build-rates-panel rebuild-linguistic-features cache-voyage-embeddings next-fomc cross-asset forecaster-sweep forecaster-sweep-exhaustive forecaster-sweep-baseline forecaster-sweep-aggregate forecaster-sweep-shuffled-control forecaster-credibility-train regime-baseline-tiers regime-arch-sweep regime-pooled-aggregate regime-ensemble-aggregate regime-capacity-push train-text-multi-axis-classifier dual-head-comparison derived-features-ablation rates-heads-sweep canonical-comparison canonical-comparison-fomc-attributable canonical-comparison-retrieval-analogs canonical-comparison-regime-conditioning text-path-ab per-family-ablation hawk-dove-jackknife finetune-pilot-b2 finetune-pilot-b2-phrasebank cross-source-transfer reproduce-all reproduce-smoke push-artefacts deploy-prod-build per-fold-baselines paired-stats ordinal-confusion
 
 help:
 	@echo "Targets:"
@@ -84,6 +84,8 @@ help:
 	@echo "                         - Canonical dual-head comparison (5 seeds x 40 epochs, regression-alpha=0.5, canonical output JSON)"
 	@echo "  make per-family-ablation TRAINING_PACKAGE_ID=<id>"
 	@echo "                         - Per-family rich-feature ablation (#334; backs the §6 substitution-finding table)"
+	@echo "  make hawk-dove-jackknife TRAINING_PACKAGE_ID=<id> [SMOKE=1]"
+	@echo "                         - Leave-one-out per token on the in-house hawk/dove lexicon (#506; ~3-4 GPU-hours full, ~30 min smoke)"
 	@echo "  make finetune-pilot-b2 TRAINING_PACKAGE_ID=<id> [ENCODER_ALIAS=<alias>]"
 	@echo "                         - B2 end-to-end fine-tune on vol-regime (#213; AutoModelForSequenceClassification, 5 seeds x 4 folds x 5 epochs)"
 	@echo "  make finetune-pilot-b2-phrasebank TRAINING_PACKAGE_ID=<id> [PHRASEBANK_AUX_LAMBDA=0.3] [PHRASEBANK_SUBSET=sentences_allagree]"
@@ -963,6 +965,22 @@ per-family-ablation:
 		--epochs 40 \
 		--head-mode dual \
 		--regression-alpha 0.5
+
+# #506 hawk/dove lexicon jackknife. Leave-one-out per single-token entry
+# in HAWK_TOKENS / DOVE_TOKENS, rebuilds the per-document linguistic
+# features parquet under the patched lexicon, and runs a baseline-only
+# per-family ablation smoke per cell to read off macro-F1. Writes the
+# artefact to ``backend/artifacts/experiments/hawk_dove_jackknife.json``
+# with a fragile-tokens list keyed off ``|delta| > 0.005``. GPU-bound:
+# ~3-4 hours for the full sweep at the default epochs=40; ``SMOKE=1``
+# drops the per-cell budget to 5 epochs (~30 min total).
+hawk-dove-jackknife:
+	@if [ -z "$$TRAINING_PACKAGE_ID" ]; then echo "TRAINING_PACKAGE_ID required" >&2; exit 1; fi
+	docker compose run --rm backend python -m scripts.run_hawk_dove_jackknife \
+		--training-package-id $$TRAINING_PACKAGE_ID \
+		--output artifacts/experiments/hawk_dove_jackknife.json \
+		--seeds 11 \
+		$(if $(SMOKE),--smoke,)
 
 # #213 B2 end-to-end fine-tune harness. Fine-tunes
 # AutoModelForSequenceClassification directly on FOMC document text

--- a/backend/app/features/linguistic.py
+++ b/backend/app/features/linguistic.py
@@ -73,6 +73,7 @@ import math
 import pickle
 import re
 import sys
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Sequence
@@ -505,6 +506,16 @@ def _build_vectorizer(
     )
 
 
+class LinguisticLdaSlotWarning(UserWarning):
+    """Emitted when a named LDA slot falls into the misc bucket.
+
+    Downstream consumers that need to filter the misc-bucket signal out
+    of their pytest warning capture (or surface it explicitly in a CI
+    log) can target this category directly rather than parsing the
+    message string.
+    """
+
+
 #: Minimum number of slot seed words that must appear in the winning
 #: topic's top-N vocabulary for the slot to be assigned. If a slot's
 #: best topic clears posterior mass but only via incidental seed hits
@@ -518,10 +529,45 @@ MIN_SEED_OVERLAP: int = 2
 SEED_OVERLAP_TOP_N: int = 10
 
 
+@dataclass(frozen=True)
+class _NamedSlotDiagnostic:
+    """Per-slot trace from the named-topic assignment pass.
+
+    ``status`` is one of ``"assigned"``, ``"unassigned_below_floor"`` (a
+    candidate topic exists but its top-N vocabulary contains fewer than
+    ``MIN_SEED_OVERLAP`` seed words), ``"unassigned_no_seed_in_vocab"``
+    (none of the slot's seeds appear in the fitted vectoriser's
+    vocabulary), or ``"unassigned_no_candidate"`` (every topic is
+    already used by a higher-priority slot).
+    """
+
+    slot: str
+    status: str
+    best_topic: int | None
+    overlap_count: int
+    overlap_threshold: int
+    overlap_top_n: int
+
+
 def _assign_named_topics(
     lda: LatentDirichletAllocation, vocab: Sequence[str]
 ) -> tuple[dict[str, int], tuple[int, ...]]:
     """Pin each named topic slot to its best-matching LDA topic.
+
+    Thin wrapper over :func:`_assign_named_topics_with_diagnostics` that
+    discards the per-slot trace, preserving the original two-tuple
+    return shape that the public surface and the existing unit tests
+    consume.
+    """
+
+    assignments, misc, _ = _assign_named_topics_with_diagnostics(lda, vocab)
+    return assignments, misc
+
+
+def _assign_named_topics_with_diagnostics(
+    lda: LatentDirichletAllocation, vocab: Sequence[str]
+) -> tuple[dict[str, int], tuple[int, ...], list[_NamedSlotDiagnostic]]:
+    """Same as :func:`_assign_named_topics` plus a per-slot trace.
 
     Iterate the named slots in declaration order; for each slot pick
     the unassigned topic whose seed words receive the most cumulative
@@ -535,12 +581,15 @@ def _assign_named_topics(
     (``SEED_OVERLAP_TOP_N``) vocabulary, otherwise the slot is left
     unassigned. Downstream callers emit ``0.0`` for the slot and the
     topic that would have been pinned falls through to the misc pool.
-    This blocks the silent-mislabel failure mode observed on the
-    Sprint 1 fit where ``employment`` inherited a QE / balance-sheet
-    topic with zero labor vocabulary.
+    This blocks the silent-mislabel failure mode observed on an
+    early training-package fit where ``employment`` inherited a
+    QE / balance-sheet topic with zero labor vocabulary.
 
-    Returns the slot->index map plus the remaining topic indices in
-    ascending order.
+    Returns the slot->index map, the remaining topic indices in
+    ascending order, and a list of :class:`_NamedSlotDiagnostic` rows
+    (one per slot in declaration order) carrying the structured outcome
+    so callers can surface the misc-bucket drop reason without parsing
+    the human-readable coherence note.
     """
 
     word_to_idx = {w: i for i, w in enumerate(vocab)}
@@ -560,11 +609,22 @@ def _assign_named_topics(
 
     assignments: dict[str, int] = {}
     used: set[int] = set()
+    diagnostics: list[_NamedSlotDiagnostic] = []
     for slot in NAMED_TOPIC_KEYS:
         seeds = TOPIC_SEED_WORDS[slot]
         seed_set = set(seeds)
         seed_indices = [word_to_idx[w] for w in seeds if w in word_to_idx]
         if not seed_indices:
+            diagnostics.append(
+                _NamedSlotDiagnostic(
+                    slot=slot,
+                    status="unassigned_no_seed_in_vocab",
+                    best_topic=None,
+                    overlap_count=0,
+                    overlap_threshold=MIN_SEED_OVERLAP,
+                    overlap_top_n=SEED_OVERLAP_TOP_N,
+                )
+            )
             continue
         # Walk topic indices in ascending order with a strict ``>``
         # comparison so ties go to the lower index (deterministic and
@@ -579,6 +639,16 @@ def _assign_named_topics(
                 best_score = score
                 best_topic = topic_idx
         if best_topic < 0:
+            diagnostics.append(
+                _NamedSlotDiagnostic(
+                    slot=slot,
+                    status="unassigned_no_candidate",
+                    best_topic=None,
+                    overlap_count=0,
+                    overlap_threshold=MIN_SEED_OVERLAP,
+                    overlap_top_n=SEED_OVERLAP_TOP_N,
+                )
+            )
             continue
         # Seed-overlap floor: reject the assignment if the winning
         # topic's top-N vocabulary does not contain at least
@@ -587,12 +657,32 @@ def _assign_named_topics(
         # (if any) and otherwise falls to the misc pool.
         overlap = top_n_per_topic[best_topic] & seed_set
         if len(overlap) < MIN_SEED_OVERLAP:
+            diagnostics.append(
+                _NamedSlotDiagnostic(
+                    slot=slot,
+                    status="unassigned_below_floor",
+                    best_topic=best_topic,
+                    overlap_count=len(overlap),
+                    overlap_threshold=MIN_SEED_OVERLAP,
+                    overlap_top_n=SEED_OVERLAP_TOP_N,
+                )
+            )
             continue
         assignments[slot] = best_topic
         used.add(best_topic)
+        diagnostics.append(
+            _NamedSlotDiagnostic(
+                slot=slot,
+                status="assigned",
+                best_topic=best_topic,
+                overlap_count=len(overlap),
+                overlap_threshold=MIN_SEED_OVERLAP,
+                overlap_top_n=SEED_OVERLAP_TOP_N,
+            )
+        )
 
     misc = tuple(sorted(i for i in range(normalised.shape[0]) if i not in used))
-    return assignments, misc
+    return assignments, misc, diagnostics
 
 
 def _top_words_for_topic(
@@ -642,7 +732,7 @@ def fit_lda(
         evaluate_every=-1,
     )
     lda.fit(dtm)
-    assignments, misc = _assign_named_topics(lda, vocab)
+    assignments, misc, diagnostics = _assign_named_topics_with_diagnostics(lda, vocab)
     top_words = [
         _top_words_for_topic(lda, vocab, t, TOP_WORDS_PER_TOPIC) for t in range(num_topics)
     ]
@@ -664,6 +754,41 @@ def fit_lda(
             f"seed-overlap floor (MIN_SEED_OVERLAP={MIN_SEED_OVERLAP} of top-"
             f"{SEED_OVERLAP_TOP_N}); slot emitted as 0.0 and the topic falls "
             "to misc"
+        )
+    # One ``LinguisticLdaSlotWarning`` per dropped slot. Downstream
+    # consumers (per-fold training-package builds, the official seed
+    # sweep) see the misc-bucket drop in CI logs instead of having to
+    # diff the LDA audit JSON against a clean reference run. The
+    # ``[linguistic.lda]`` category prefix is also written into the
+    # message body so log scrapers without warning-class metadata can
+    # still filter for the event.
+    for diag in diagnostics:
+        if diag.status == "assigned":
+            continue
+        if diag.status == "unassigned_below_floor":
+            reason = (
+                f"best candidate topic {diag.best_topic} cleared posterior "
+                f"weight but only contained {diag.overlap_count} of the "
+                f"slot's seed words in its top-{diag.overlap_top_n} "
+                f"vocabulary (threshold {diag.overlap_threshold})"
+            )
+        elif diag.status == "unassigned_no_seed_in_vocab":
+            reason = (
+                "no slot seed word survived the vectoriser's vocabulary "
+                "cutoffs"
+            )
+        else:
+            reason = (
+                "every fitted topic was already claimed by a "
+                "higher-priority slot"
+            )
+        warnings.warn(
+            f"[linguistic.lda] named slot {diag.slot!r} fell into the misc "
+            f"bucket -- {reason}. The slot emits 0.0 for every document in "
+            "this fit; the LDA topic that would have been pinned falls "
+            "through into the next misc_* slot.",
+            LinguisticLdaSlotWarning,
+            stacklevel=2,
         )
     return LdaArtifact(
         vectorizer=vectorizer,

--- a/scripts/run_hawk_dove_jackknife.py
+++ b/scripts/run_hawk_dove_jackknife.py
@@ -1,0 +1,505 @@
+"""Jackknife-by-token robustness probe on the hawk / dove lexicons (#506).
+
+The 15-dim ``RICH_LINGUISTIC_SLICE`` block carries one in-house feature,
+``hawk_dove_asymmetry``, that is computed against two hand-curated
+lexicons in :mod:`app.features.linguistic`:
+
+- ``HAWK_TOKENS`` -- 7 single-token hawkish markers
+- ``HAWK_PHRASES`` -- 1 multi-token phrase
+- ``DOVE_TOKENS`` -- 9 single-token dovish markers
+- ``DOVE_PHRASES`` -- 1 multi-token phrase
+
+This runner leaves each single-token entry out in turn, recomputes the
+``hawk_dove_asymmetry`` column on every event in a training package
+under the patched lexicon, swaps the patched ``linguistic_features``
+parquet into the package directory for the duration of one cell, and
+calls :mod:`scripts.run_per_family_ablation` with a single-seed, single-
+fold ``baseline`` smoke. The result is a per-token (with-F1, without-F1,
+delta) triple plus a ``fragile_tokens`` list of every token whose
+``|delta|`` exceeds :data:`FRAGILE_DELTA_THRESHOLD` (0.005 macro-F1).
+
+Why this matters: the asymmetry feature is the only place in the rich-
+feature block where a hand-curated 16-token lexicon picks up signal. A
+single fragile token (one whose removal flips the family lift) would
+warrant rephrasing the wiki claim from "the in-house hawk-dove block
+carries X macro-F1" to "the block carries X macro-F1 contingent on a
+small handful of tokens." The jackknife exposes the dependency cleanly.
+
+Execution cost
+--------------
+
+The runner is GPU-bound. At the default canonical-comparison settings
+(1 seed x 1 fold x baseline cell x 40 epochs) one cell takes roughly
+8-12 minutes on a single Runpod A100 against the post-#350 training
+package. The union of the four lexicon collections holds 18 entries
+(7 hawk tokens + 1 hawk phrase + 9 dove tokens + 1 dove phrase) so a
+full sweep is ~3-4 GPU-hours. A faster smoke (``--epochs 5``,
+``--smoke``) reduces the cost to ~30 minutes total but trades CI
+fidelity for sweep budget.
+
+This script ships in the repo as a runner; the JSON artefact populates
+after a separate GPU pass. The Makefile target ``hawk-dove-jackknife``
+invokes it without arguments other than ``TRAINING_PACKAGE_ID``.
+
+Output
+------
+
+JSON artefact at ``backend/artifacts/experiments/hawk_dove_jackknife.json``::
+
+    {
+      "training_package_id": "...",
+      "baseline_f1": 0.4538,
+      "fragile_delta_threshold": 0.005,
+      "tokens": [
+        {
+          "token": "tightening",
+          "kind": "hawk",
+          "without_f1": 0.4502,
+          "delta": -0.0036
+        },
+        ...
+      ],
+      "fragile_tokens": ["restrictive"]
+    }
+
+The ``with_f1`` is omitted from each per-token row because it is the
+same baseline number every cell shares; the top-level ``baseline_f1``
+carries it once.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+from app.config import BACKEND_ROOT
+
+
+#: |delta| floor above which a token is considered fragile. 0.005 is the
+#: tightest band the per-family ablation table treats as a real lift; a
+#: token whose removal moves macro-F1 by more than that warrants a
+#: separate caveat in the wiki write-up.
+FRAGILE_DELTA_THRESHOLD: float = 0.005
+
+
+@dataclass(frozen=True)
+class TokenJackknifeResult:
+    """Per-token smoke result.
+
+    ``without_f1`` is the macro-F1 the per-family ablation runner
+    reported with the token leave-one-out applied; ``delta`` is the
+    signed difference vs the baseline (negative = removing the token
+    hurt the model).
+    """
+
+    token: str
+    kind: str
+    without_f1: float
+    delta: float
+
+
+def fragile_tokens_from_results(
+    results: Iterable[TokenJackknifeResult],
+    *,
+    threshold: float = FRAGILE_DELTA_THRESHOLD,
+) -> list[str]:
+    """Return the tokens whose ``|delta|`` exceeds ``threshold``.
+
+    Sorted lexicographically so re-runs against the same delta vector
+    hit the same JSON bytes.
+    """
+
+    fragile = [r.token for r in results if abs(r.delta) > threshold]
+    return sorted(fragile)
+
+
+def patched_lexicons(
+    leave_out_token: str,
+    *,
+    base_hawk: frozenset[str],
+    base_dove: frozenset[str],
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Return ``(hawk, dove)`` lexicons with ``leave_out_token`` removed.
+
+    The token is dropped from whichever collection contains it; if it
+    appears in neither, both inputs come back unchanged so the caller's
+    fixture round-trips losslessly. Symmetric removal (a token that
+    accidentally lives in both lists) drops from both.
+    """
+
+    return (base_hawk - {leave_out_token}, base_dove - {leave_out_token})
+
+
+def _build_token_inventory(
+    hawk_tokens: frozenset[str],
+    dove_tokens: frozenset[str],
+) -> list[tuple[str, str]]:
+    """Return ``(token, kind)`` pairs covering both single-token lists.
+
+    Output is sorted by ``(kind, token)`` so the runner walks the same
+    order every call and the JSON line-up matches the wiki citation
+    schedule.
+    """
+
+    items: list[tuple[str, str]] = []
+    for token in sorted(hawk_tokens):
+        items.append((token, "hawk"))
+    for token in sorted(dove_tokens):
+        items.append((token, "dove"))
+    return items
+
+
+def _rebuild_patched_parquet(
+    package_dir: Path,
+    *,
+    patched_hawk: frozenset[str],
+    patched_dove: frozenset[str],
+    output_parquet: Path,
+) -> None:
+    """Recompute ``hawk_dove_asymmetry`` on the patched lexicon and write
+    the resulting frame as parquet at ``output_parquet``.
+
+    Reads the canonical ``linguistic_features.parquet`` for every other
+    column (the LDA shares, the densities, the pivot distance) so we
+    only re-do the cheap per-document hawk/dove pass. Falls back to
+    rebuilding the whole frame via :func:`build_linguistic_feature_frame`
+    when the canonical parquet is absent.
+    """
+
+    import pandas as pd
+
+    from app.features import linguistic as linguistic_mod
+
+    canonical_parquet = package_dir / "linguistic_features.parquet"
+    if not canonical_parquet.exists():
+        # Cold rebuild: the runner has no cached frame to splice into,
+        # so we recompute the whole frame against the patched lexicon.
+        original_hawk = linguistic_mod.HAWK_TOKENS
+        original_dove = linguistic_mod.DOVE_TOKENS
+        try:
+            linguistic_mod.HAWK_TOKENS = patched_hawk
+            linguistic_mod.DOVE_TOKENS = patched_dove
+            frame, _ = linguistic_mod.build_linguistic_feature_frame(
+                package_dir=package_dir
+            )
+        finally:
+            linguistic_mod.HAWK_TOKENS = original_hawk
+            linguistic_mod.DOVE_TOKENS = original_dove
+        frame.to_parquet(output_parquet, engine="pyarrow", index=False)
+        return
+
+    registry = package_dir / "registry_normalized.jsonl"
+    if not registry.exists():
+        raise FileNotFoundError(
+            f"Cannot recompute hawk/dove asymmetry: {registry} missing"
+        )
+
+    # Walk the registry once and assemble ``text_hash -> patched
+    # asymmetry`` under the patched lexicon. The hash-keyed dict folds
+    # any sentence-level shards together by hash, mirroring the
+    # ``_aggregate_corpus`` join the canonical feature builder uses.
+    text_by_hash: dict[str, list[str]] = {}
+    for line in registry.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        payload = json.loads(line)
+        text_hash = str(payload.get("text_hash", "") or "").strip()
+        text = str(payload.get("text", "") or "")
+        if not text_hash or not text:
+            continue
+        text_by_hash.setdefault(text_hash, []).append(text)
+
+    original_hawk = linguistic_mod.HAWK_TOKENS
+    original_dove = linguistic_mod.DOVE_TOKENS
+    try:
+        linguistic_mod.HAWK_TOKENS = patched_hawk
+        linguistic_mod.DOVE_TOKENS = patched_dove
+        patched_asymmetry: dict[str, float] = {}
+        for text_hash, shards in text_by_hash.items():
+            joined = "\n".join(shards)
+            patched_asymmetry[text_hash] = linguistic_mod.hawk_dove_asymmetry(joined)
+    finally:
+        linguistic_mod.HAWK_TOKENS = original_hawk
+        linguistic_mod.DOVE_TOKENS = original_dove
+
+    frame = pd.read_parquet(canonical_parquet, engine="pyarrow")
+    frame["hawk_dove_asymmetry"] = frame["text_hash"].map(patched_asymmetry).astype(float)
+    output_parquet.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_parquet(output_parquet, engine="pyarrow", index=False)
+
+
+def _invoke_per_family_baseline(
+    *,
+    training_package_id: str,
+    seeds: list[int],
+    folds: list[str] | None,
+    epochs: int,
+    output_json: Path,
+) -> float:
+    """Run the per-family ablation runner under the ``baseline`` cell.
+
+    Shells out to :mod:`scripts.run_per_family_ablation` with
+    ``--cells baseline`` so the smoke covers exactly one cell. Parses
+    the resulting JSON and returns the cell's bootstrap mean macro-F1.
+    """
+
+    cmd: list[str] = [
+        sys.executable,
+        "-m",
+        "scripts.run_per_family_ablation",
+        "--training-package-id",
+        training_package_id,
+        "--cells",
+        "baseline",
+        "--epochs",
+        str(epochs),
+        "--seeds",
+        *[str(s) for s in seeds],
+        "--output",
+        str(output_json),
+    ]
+    if folds:
+        cmd.extend(["--folds", *folds])
+    subprocess.run(cmd, check=True)
+    payload = json.loads(output_json.read_text())
+    baseline_summary = payload["summary"]["baseline"]
+    return float(baseline_summary["regime_f1_macro"]["mean"])
+
+
+def _run_jackknife(
+    *,
+    training_package_id: str,
+    seeds: list[int],
+    folds: list[str] | None,
+    epochs: int,
+    package_dir: Path,
+    tmp_artefact_dir: Path,
+    macro_f1_for_lexicon: Callable[[frozenset[str], frozenset[str]], float],
+) -> tuple[float, list[TokenJackknifeResult]]:
+    """Walk every single-token entry in the union and collect deltas.
+
+    ``macro_f1_for_lexicon`` is the per-cell driver. The production path
+    swaps in :func:`_macro_f1_for_lexicon_real`; tests inject a stub
+    that returns a deterministic synthetic delta vector.
+    """
+
+    from app.features.linguistic import DOVE_TOKENS, HAWK_TOKENS
+
+    inventory = _build_token_inventory(HAWK_TOKENS, DOVE_TOKENS)
+
+    baseline_f1 = macro_f1_for_lexicon(HAWK_TOKENS, DOVE_TOKENS)
+    results: list[TokenJackknifeResult] = []
+    for token, kind in inventory:
+        patched_hawk, patched_dove = patched_lexicons(
+            token, base_hawk=HAWK_TOKENS, base_dove=DOVE_TOKENS
+        )
+        without_f1 = macro_f1_for_lexicon(patched_hawk, patched_dove)
+        results.append(
+            TokenJackknifeResult(
+                token=token,
+                kind=kind,
+                without_f1=without_f1,
+                delta=without_f1 - baseline_f1,
+            )
+        )
+    return baseline_f1, results
+
+
+def _macro_f1_for_lexicon_real(
+    *,
+    training_package_id: str,
+    seeds: list[int],
+    folds: list[str] | None,
+    epochs: int,
+    package_dir: Path,
+    tmp_artefact_dir: Path,
+) -> Callable[[frozenset[str], frozenset[str]], float]:
+    """Bind a per-cell driver that swaps the lexicon and shells out."""
+
+    canonical_parquet = package_dir / "linguistic_features.parquet"
+    backup_parquet = tmp_artefact_dir / "linguistic_features.canonical.parquet"
+    tmp_artefact_dir.mkdir(parents=True, exist_ok=True)
+    # Snapshot the start-state: either the canonical parquet exists (and
+    # the backup is its byte-identical copy), or it does not (and the
+    # restore step deletes the patched file rather than restoring from
+    # a non-existent backup). Without the start-not-exists branch a
+    # crash after the first swap would leave the canonical path holding
+    # a patched parquet permanently.
+    canonical_existed_at_startup = canonical_parquet.exists()
+    if canonical_existed_at_startup and not backup_parquet.exists():
+        backup_parquet.write_bytes(canonical_parquet.read_bytes())
+
+    cell_counter = {"n": 0}
+
+    def driver(patched_hawk: frozenset[str], patched_dove: frozenset[str]) -> float:
+        cell_counter["n"] += 1
+        patched_parquet = (
+            tmp_artefact_dir / f"linguistic_features.patched_cell_{cell_counter['n']:03d}.parquet"
+        )
+        _rebuild_patched_parquet(
+            package_dir,
+            patched_hawk=patched_hawk,
+            patched_dove=patched_dove,
+            output_parquet=patched_parquet,
+        )
+        canonical_parquet.write_bytes(patched_parquet.read_bytes())
+        try:
+            cell_output = (
+                tmp_artefact_dir / f"per_family_baseline_cell_{cell_counter['n']:03d}.json"
+            )
+            return _invoke_per_family_baseline(
+                training_package_id=training_package_id,
+                seeds=seeds,
+                folds=folds,
+                epochs=epochs,
+                output_json=cell_output,
+            )
+        finally:
+            if canonical_existed_at_startup and backup_parquet.exists():
+                canonical_parquet.write_bytes(backup_parquet.read_bytes())
+            elif canonical_parquet.exists():
+                canonical_parquet.unlink()
+
+    return driver
+
+
+def _serialise_payload(
+    *,
+    training_package_id: str,
+    baseline_f1: float,
+    results: list[TokenJackknifeResult],
+    threshold: float,
+) -> dict[str, object]:
+    return {
+        "training_package_id": training_package_id,
+        "baseline_f1": baseline_f1,
+        "fragile_delta_threshold": threshold,
+        "tokens": [
+            {
+                "token": r.token,
+                "kind": r.kind,
+                "without_f1": r.without_f1,
+                "delta": r.delta,
+            }
+            for r in results
+        ],
+        "fragile_tokens": fragile_tokens_from_results(
+            results, threshold=threshold
+        ),
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--training-package-id",
+        required=True,
+        help="Training-package ID (local id or ``hf://datasets/...`` URI).",
+    )
+    parser.add_argument(
+        "--seeds",
+        nargs="+",
+        type=int,
+        default=[11],
+        help="Seeds passed through to the per-family runner (default: 11).",
+    )
+    parser.add_argument(
+        "--folds",
+        nargs="+",
+        default=None,
+        help="Optional fold-id subset; defaults to every fold in the package.",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=40,
+        help="Epochs per cell (default 40; --smoke drops to 5).",
+    )
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Shortcut for a fast pass (epochs=5).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help=(
+            "Output JSON path. Defaults to "
+            "``backend/artifacts/experiments/hawk_dove_jackknife.json``."
+        ),
+    )
+    parser.add_argument(
+        "--tmp-artefact-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Scratch dir for per-cell parquet / JSON artefacts. Defaults "
+            "to ``backend/artifacts/experiments/hawk_dove_jackknife_cells/``."
+        ),
+    )
+    return parser.parse_args()
+
+
+def _resolve_output_path(arg: Path | None) -> Path:
+    if arg is not None:
+        return arg
+    return BACKEND_ROOT / "artifacts" / "experiments" / "hawk_dove_jackknife.json"
+
+
+def _resolve_tmp_dir(arg: Path | None) -> Path:
+    if arg is not None:
+        return arg
+    return BACKEND_ROOT / "artifacts" / "experiments" / "hawk_dove_jackknife_cells"
+
+
+def main() -> int:
+    from app.training.loaders import _resolve_training_package_dir
+
+    args = _parse_args()
+    epochs = 5 if args.smoke else int(args.epochs)
+    output_path = _resolve_output_path(args.output)
+    tmp_dir = _resolve_tmp_dir(args.tmp_artefact_dir)
+    package_dir = _resolve_training_package_dir(args.training_package_id)
+
+    driver = _macro_f1_for_lexicon_real(
+        training_package_id=args.training_package_id,
+        seeds=list(args.seeds),
+        folds=list(args.folds) if args.folds else None,
+        epochs=epochs,
+        package_dir=package_dir,
+        tmp_artefact_dir=tmp_dir,
+    )
+    baseline_f1, results = _run_jackknife(
+        training_package_id=args.training_package_id,
+        seeds=list(args.seeds),
+        folds=list(args.folds) if args.folds else None,
+        epochs=epochs,
+        package_dir=package_dir,
+        tmp_artefact_dir=tmp_dir,
+        macro_f1_for_lexicon=driver,
+    )
+    payload = _serialise_payload(
+        training_package_id=args.training_package_id,
+        baseline_f1=baseline_f1,
+        results=results,
+        threshold=FRAGILE_DELTA_THRESHOLD,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    print(f"[hawk_dove_jackknife] wrote {output_path}")
+    print(
+        f"[hawk_dove_jackknife] baseline_f1={baseline_f1:.4f} "
+        f"fragile_tokens={payload['fragile_tokens']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_hawk_dove_jackknife.py
+++ b/tests/unit/test_hawk_dove_jackknife.py
@@ -1,0 +1,207 @@
+"""Unit coverage for ``scripts.run_hawk_dove_jackknife`` (#506).
+
+The runner itself is GPU-bound and not invoked in CI; these tests cover
+the helper math that drives the JSON artefact:
+
+- ``patched_lexicons`` correctly drops a token from a small fixture
+  lexicon and leaves the other collection untouched.
+- ``_serialise_payload`` emits the documented schema.
+- ``fragile_tokens_from_results`` returns exactly the tokens whose
+  ``|delta|`` exceeds the threshold, against a synthetic delta vector.
+"""
+
+from __future__ import annotations
+
+from scripts.run_hawk_dove_jackknife import (
+    FRAGILE_DELTA_THRESHOLD,
+    TokenJackknifeResult,
+    _build_token_inventory,
+    _serialise_payload,
+    fragile_tokens_from_results,
+    patched_lexicons,
+)
+
+
+# ---------------------------------------------------------------------------
+# patched_lexicons
+# ---------------------------------------------------------------------------
+
+
+def test_patched_lexicons_drops_token_from_hawk_only():
+    """A hawk token is removed from HAWK only; DOVE comes back intact."""
+
+    hawk = frozenset({"tightening", "restrictive", "hike"})
+    dove = frozenset({"easing", "cut"})
+    patched_hawk, patched_dove = patched_lexicons(
+        "tightening", base_hawk=hawk, base_dove=dove
+    )
+    assert patched_hawk == frozenset({"restrictive", "hike"})
+    assert patched_dove == dove
+
+
+def test_patched_lexicons_drops_token_from_dove_only():
+    """A dove token is removed from DOVE only; HAWK comes back intact."""
+
+    hawk = frozenset({"hike"})
+    dove = frozenset({"easing", "cut", "accommodative"})
+    patched_hawk, patched_dove = patched_lexicons(
+        "accommodative", base_hawk=hawk, base_dove=dove
+    )
+    assert patched_dove == frozenset({"easing", "cut"})
+    assert patched_hawk == hawk
+
+
+def test_patched_lexicons_unknown_token_returns_inputs_unchanged():
+    """A token that lives in neither lexicon round-trips losslessly."""
+
+    hawk = frozenset({"hike"})
+    dove = frozenset({"cut"})
+    patched_hawk, patched_dove = patched_lexicons(
+        "neutral", base_hawk=hawk, base_dove=dove
+    )
+    assert patched_hawk == hawk
+    assert patched_dove == dove
+
+
+def test_patched_lexicons_token_in_both_lexicons_drops_from_both():
+    """A token accidentally listed in both lists is dropped symmetrically."""
+
+    hawk = frozenset({"firm", "hike"})
+    dove = frozenset({"firm", "cut"})
+    patched_hawk, patched_dove = patched_lexicons(
+        "firm", base_hawk=hawk, base_dove=dove
+    )
+    assert "firm" not in patched_hawk
+    assert "firm" not in patched_dove
+
+
+# ---------------------------------------------------------------------------
+# _build_token_inventory
+# ---------------------------------------------------------------------------
+
+
+def test_build_token_inventory_sorts_and_tags_kind():
+    """Inventory walks hawk tokens (sorted) then dove tokens (sorted)."""
+
+    hawk = frozenset({"hike", "raise"})
+    dove = frozenset({"ease", "cut"})
+    inventory = _build_token_inventory(hawk, dove)
+    assert inventory == [
+        ("hike", "hawk"),
+        ("raise", "hawk"),
+        ("cut", "dove"),
+        ("ease", "dove"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# fragile_tokens_from_results
+# ---------------------------------------------------------------------------
+
+
+def test_fragile_tokens_threshold_math_is_strictly_above():
+    """``|delta| > threshold`` -- equality is not fragile."""
+
+    results = [
+        TokenJackknifeResult(
+            token="a", kind="hawk", without_f1=0.50, delta=0.0049
+        ),
+        TokenJackknifeResult(
+            token="b", kind="hawk", without_f1=0.50, delta=-0.0051
+        ),
+        TokenJackknifeResult(
+            token="c", kind="dove", without_f1=0.50, delta=0.005
+        ),
+        TokenJackknifeResult(
+            token="d", kind="dove", without_f1=0.50, delta=0.020
+        ),
+    ]
+    fragile = fragile_tokens_from_results(results, threshold=0.005)
+    assert fragile == ["b", "d"]
+
+
+def test_fragile_tokens_uses_absolute_delta():
+    """Negative deltas of equal magnitude trip the threshold."""
+
+    results = [
+        TokenJackknifeResult(
+            token="positive", kind="hawk", without_f1=0.50, delta=0.010
+        ),
+        TokenJackknifeResult(
+            token="negative", kind="hawk", without_f1=0.50, delta=-0.010
+        ),
+    ]
+    fragile = fragile_tokens_from_results(results, threshold=0.005)
+    assert fragile == ["negative", "positive"]
+
+
+def test_fragile_tokens_empty_when_all_inside_band():
+    results = [
+        TokenJackknifeResult(
+            token="x", kind="hawk", without_f1=0.50, delta=0.001
+        ),
+    ]
+    assert fragile_tokens_from_results(results, threshold=0.005) == []
+
+
+def test_fragile_tokens_default_threshold_matches_constant():
+    """The default threshold is the module-level FRAGILE_DELTA_THRESHOLD."""
+
+    results = [
+        TokenJackknifeResult(
+            token="bandwidth_check",
+            kind="hawk",
+            without_f1=0.50,
+            delta=FRAGILE_DELTA_THRESHOLD + 1e-6,
+        ),
+    ]
+    assert fragile_tokens_from_results(results) == ["bandwidth_check"]
+
+
+# ---------------------------------------------------------------------------
+# _serialise_payload
+# ---------------------------------------------------------------------------
+
+
+def test_serialise_payload_emits_documented_schema():
+    """The JSON shape matches the runner docstring."""
+
+    results = [
+        TokenJackknifeResult(
+            token="hike", kind="hawk", without_f1=0.451, delta=-0.003
+        ),
+        TokenJackknifeResult(
+            token="cut", kind="dove", without_f1=0.470, delta=0.016
+        ),
+    ]
+    payload = _serialise_payload(
+        training_package_id="tp_test",
+        baseline_f1=0.454,
+        results=results,
+        threshold=0.005,
+    )
+    assert payload["training_package_id"] == "tp_test"
+    assert payload["baseline_f1"] == 0.454
+    assert payload["fragile_delta_threshold"] == 0.005
+    assert payload["fragile_tokens"] == ["cut"]
+    assert isinstance(payload["tokens"], list)
+    assert payload["tokens"][0] == {
+        "token": "hike",
+        "kind": "hawk",
+        "without_f1": 0.451,
+        "delta": -0.003,
+    }
+
+
+def test_serialise_payload_empty_results_emits_empty_fragile_list():
+    """No per-token results -> no fragile tokens; baseline still surfaces."""
+
+    payload = _serialise_payload(
+        training_package_id="tp_empty",
+        baseline_f1=0.40,
+        results=[],
+        threshold=0.005,
+    )
+    assert payload["tokens"] == []
+    assert payload["fragile_tokens"] == []
+    assert payload["baseline_f1"] == 0.40

--- a/tests/unit/test_linguistic_features.py
+++ b/tests/unit/test_linguistic_features.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import math
 import random
+import warnings
 from pathlib import Path
 
 import pandas as pd
@@ -10,6 +11,7 @@ import pytest
 
 from app.features.linguistic import (
     HEDGE_TOKENS,
+    LinguisticLdaSlotWarning,
     LinguisticVector,
     MIN_SEED_OVERLAP,
     NAMED_TOPIC_KEYS,
@@ -445,8 +447,8 @@ def _seed_overlap_corpus() -> list[str]:
 def test_seed_overlap_floor_drops_employment_to_misc_when_no_labor_topic():
     """``employment`` falls to misc when no fitted topic contains labor seeds.
 
-    Mirrors the Sprint 1 mislabel: top-15 of the topic that would have
-    been pinned to ``employment`` is pure policy boilerplate
+    Mirrors the early-fit mislabel: top-15 of the topic that would
+    have been pinned to ``employment`` is pure policy boilerplate
     (``committee``, ``federal``, ``policy``, ``securities``, ``rate``,
     ...). The seed-overlap floor must reject the assignment and emit
     ``topic_share_employment == 0.0``.
@@ -949,3 +951,93 @@ def test_pivot_distance_prefer_source_default_is_off(tmp_path):
                 assert isinstance(vb, float) and math.isnan(vb)
             else:
                 assert va == vb
+
+
+# ---------------------------------------------------------------------------
+# Structured warning when an LDA named slot drops to the misc bucket
+# ---------------------------------------------------------------------------
+
+
+def test_fit_lda_emits_warning_when_named_slot_drops_to_misc():
+    """The Sprint-1 mislabel corpus drops ``employment`` to misc; the fit
+    must surface a ``LinguisticLdaSlotWarning`` naming the dropped slot
+    with the structured category prefix.
+    """
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", LinguisticLdaSlotWarning)
+        artifact = fit_lda(_seed_overlap_corpus(), min_df=2)
+    drop_warnings = [
+        w for w in captured if issubclass(w.category, LinguisticLdaSlotWarning)
+    ]
+    # ``employment`` drops on this corpus.
+    assert "employment" not in artifact.topic_assignments
+    matching = [w for w in drop_warnings if "'employment'" in str(w.message)]
+    assert matching, (
+        "expected a LinguisticLdaSlotWarning naming the unassigned "
+        f"'employment' slot; got: {[str(w.message) for w in drop_warnings]}"
+    )
+    message = str(matching[0].message)
+    assert "[linguistic.lda]" in message
+    assert "misc bucket" in message
+
+
+def test_fit_lda_silent_when_all_named_slots_assigned():
+    """The topic-pure toy corpus assigns every named slot cleanly; no
+    ``LinguisticLdaSlotWarning`` should fire.
+    """
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", LinguisticLdaSlotWarning)
+        artifact = fit_lda(_toy_corpus())
+    drop_warnings = [
+        w for w in captured if issubclass(w.category, LinguisticLdaSlotWarning)
+    ]
+    # Every named slot is assigned on this corpus.
+    assert set(artifact.topic_assignments.keys()) == set(NAMED_TOPIC_KEYS)
+    assert not drop_warnings, (
+        "expected no LinguisticLdaSlotWarning when every named slot "
+        f"resolves; got: {[str(w.message) for w in drop_warnings]}"
+    )
+
+
+def test_fit_lda_drop_warning_carries_seed_overlap_floor_reading(tmp_path):
+    """When the drop path is the seed-overlap floor, the warning must
+    cite the overlap count, threshold, and top-N window so the reader
+    can read off "score = N below threshold M of top-K".
+    """
+
+    # The default toy corpus path drops ``financial_stability`` via
+    # the below-floor branch on the byte-deterministic builder fit
+    # (observed empirically: best topic 2 only contained 0 of the
+    # slot's seed words). Re-running the builder reproduces the
+    # warning and lets us assert against the structured payload.
+    package = tmp_path / "tp_floor"
+    docs = [
+        ("hash_inf", _INFLATION_DOC),
+        ("hash_emp", _EMPLOYMENT_DOC),
+        ("hash_fin", _FINANCIAL_DOC),
+        ("hash_gro", _GROWTH_DOC),
+        ("hash_bal", _BALANCE_SHEET_DOC),
+        ("hash_inf2", _INFLATION_DOC),
+        ("hash_emp2", _EMPLOYMENT_DOC),
+        ("hash_fin2", _FINANCIAL_DOC),
+        ("hash_gro2", _GROWTH_DOC),
+        ("hash_bal2", _BALANCE_SHEET_DOC),
+    ]
+    _seed_training_package(package, docs)
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", LinguisticLdaSlotWarning)
+        build_linguistic_feature_frame(package_dir=package)
+    drop_warnings = [
+        w for w in captured if issubclass(w.category, LinguisticLdaSlotWarning)
+    ]
+    below_floor = [w for w in drop_warnings if "contained" in str(w.message)]
+    assert below_floor, (
+        "expected at least one below-floor LinguisticLdaSlotWarning; "
+        f"got: {[str(w.message) for w in drop_warnings]}"
+    )
+    message = str(below_floor[0].message)
+    assert "[linguistic.lda]" in message
+    assert f"threshold {MIN_SEED_OVERLAP}" in message
+    assert f"top-{SEED_OVERLAP_TOP_N}" in message


### PR DESCRIPTION
## Summary
- `fit_lda` emits one structured `[linguistic.lda]` warning per named slot that drops to misc, carrying the overlap count + threshold + top-N window.
- New `LinguisticLdaSlotWarning` category + `_NamedSlotDiagnostic` trace (`unassigned_below_floor` / `unassigned_no_seed_in_vocab` / `unassigned_no_candidate`) so downstream callers can filter.
- `scripts/run_hawk_dove_jackknife.py` + `make hawk-dove-jackknife`: leave-one-out per token (16 single tokens; phrases skipped by design), emits fragile-token list at `|delta| > 0.005`. Runner is GPU-bound; ships unexecuted.
- Mutation-safe restore: snapshots the canonical parquet's start-state; a crash mid-loop never leaves a patched file at the canonical path.
- Wiki §6.19 footnote distinguishes the L-M baseline arm from the in-house `RICH_LINGUISTIC_SLICE`.

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit/test_linguistic_features.py tests/unit/test_hawk_dove_jackknife.py -q`
- [ ] `docker compose run --rm -w /app backend bash -c "pip install ruff==0.5.0 -q 2>/dev/null; ruff check backend/app/features/linguistic.py scripts/run_hawk_dove_jackknife.py tests/unit/"`
- [ ] CI green