### PR TITLE
runner: --vol-target-mode and --target-horizon on dual-head sweep

### DIFF
--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -130,6 +130,15 @@ RICH_EXTRA_FEATURE_SIZE = (
 )
 RICH_FEATURE_SIZE = FEATURE_SIZE + RICH_EXTRA_FEATURE_SIZE
 
+# Supported supervised forward-vol horizons in trading days. The events
+# parquet ships ``forward_realized_vol_<H>d`` columns for every value
+# here (the data-builder writes them per
+# ``event_dataset_builder._FORWARD_VOL_MULTI_HORIZON_COLUMNS``); ``10``
+# remains the canonical y axis. The loader validates
+# ``ModelConfig.vol_target_horizon`` against this tuple at entry.
+SUPPORTED_VOL_TARGET_HORIZONS: tuple[int, ...] = (1, 3, 5, 10, 20, 30)
+DEFAULT_VOL_TARGET_HORIZON: int = 10
+
 # Slice offsets inside the rich vector. Used by the per-family
 # ablation path on the loader to zero an individual family without
 # changing the per-bar feature size; a downstream sweep can then
@@ -604,6 +613,20 @@ class ModelConfig:
     # convergence failure) fall back to the raw target so row alignment
     # with ``y`` is preserved. See #434 for the data side and ADR 0034.
     vol_target_mode: str = "raw"
+    # Supervised forward-vol horizon (in trading days). ``10`` (default,
+    # byte-identical to the pre-flag path) reads
+    # ``forward_realized_vol_10d`` off the events parquet as the y axis
+    # for both the classification quantile-fit and the dual-head MSE
+    # branch. Setting a different value routes the loader to populate
+    # the per-row ``forward_realized_vol_10d`` slot from
+    # ``forward_realized_vol_<H>d`` so downstream consumers
+    # (``vol_regime_class_for``, ``_build_partition_log_rv_target``,
+    # the dual-head finite guard) keep reading the same attribute. The
+    # value is validated against ``SUPPORTED_VOL_TARGET_HORIZONS`` at
+    # loader entry rather than ``__post_init__`` so checkpoint round-trip
+    # via ``_coerce_model_config`` does not fail on legacy payloads
+    # without the field.
+    vol_target_horizon: int = 10
     # #307 macro-regime conditioning toggle. ``False`` (default) keeps
     # the pre-#307 path byte-identical: the loader leaves
     # ``FeatureVector.macro_regime_features`` at ``None`` and
@@ -705,6 +728,10 @@ class ModelConfig:
             ),
             vol_target_mode=str(
                 getattr(model, "vol_target_mode", "raw") or "raw"
+            ),
+            vol_target_horizon=int(
+                getattr(model, "vol_target_horizon", DEFAULT_VOL_TARGET_HORIZON)
+                or DEFAULT_VOL_TARGET_HORIZON
             ),
             use_regime_conditioning=bool(
                 getattr(model, "use_regime_conditioning", False)

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -160,6 +160,7 @@ def build_forecaster(
             "rates_alpha",
             "rates_target_mode",
             "vol_target_mode",
+            "vol_target_horizon",
             "use_regime_conditioning",
             "use_sep",
             "use_press_conf",
@@ -211,6 +212,11 @@ def build_forecaster(
         # the regression / dual head trained against.
         flat.vol_target_mode = str(
             getattr(resolved, "vol_target_mode", "raw") or "raw"
+        )  # type: ignore[assignment]
+        # Round-trip the supervised forward-vol horizon so
+        # ``ModelConfig.from_model`` recovers it on resume.
+        flat.vol_target_horizon = int(
+            getattr(resolved, "vol_target_horizon", 10) or 10
         )  # type: ignore[assignment]
         return flat
 
@@ -268,6 +274,14 @@ def build_forecaster(
     # does not see the unrecognised kwarg.
     vol_target_mode_value = str(
         kwargs.pop("vol_target_mode", "raw") or "raw"
+    )
+    # Supervised forward-vol horizon. Loader-side knob (the loader
+    # routes the per-row ``forward_realized_vol_10d`` slot to the
+    # chosen column); the model ctor does not consume it. Stash it back
+    # on the built module so ``ModelConfig.from_model`` round-trips it
+    # onto the persisted run summary.
+    vol_target_horizon_value = int(
+        kwargs.pop("vol_target_horizon", 10) or 10
     )
     # #317 finding #8: fail fast at the factory rather than silently
     # zeroing rates_heads when output_mode='regression'. The operator
@@ -408,6 +422,7 @@ def build_forecaster(
     # #435 round-trip the forward-vol target derivation onto the built
     # module so ``ModelConfig.from_model`` recovers it on resume.
     model.vol_target_mode = vol_target_mode_value  # type: ignore[assignment]
+    model.vol_target_horizon = vol_target_horizon_value  # type: ignore[assignment]
     # #443/#444 round-trip the two new opt-in flags. Default-off path
     # behaves byte-identically; flag-on a future sweep that resumes off
     # this checkpoint rebuilds with the same loader-tail widths. The

--- a/backend/app/training/checkpoint.py
+++ b/backend/app/training/checkpoint.py
@@ -168,6 +168,10 @@ def _coerce_payload_config(payload: dict[str, Any] | None) -> ModelConfig:
             # checkpoints leave the key absent and the default collapses
             # to the raw column.
             vol_target_mode=str(raw.get("vol_target_mode", "raw") or "raw"),
+            # Round-trip the supervised forward-vol horizon so a checkpoint
+            # trained under ``--target-horizon`` rehydrates against the
+            # same events-parquet column on eval / calibration paths.
+            vol_target_horizon=int(raw.get("vol_target_horizon", 10) or 10),
             # #304 dual-head: forward head_mode + regression_alpha so a
             # dual-head checkpoint rehydrates the same head config the
             # run trained against. Pre-#304 checkpoints leave the keys

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -19,6 +19,7 @@ from app.models.config import (
     DEFAULT_DATA_DIR,
     DEFAULT_TEXT_ADAPTER_DIM,
     DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS,
+    DEFAULT_VOL_TARGET_HORIZON,
     FEATURE_SIZE,
     MULTI_TASK_CERTAINTY_LABELS,
     MULTI_TASK_STANCE_LABELS,
@@ -27,6 +28,7 @@ from app.models.config import (
     RICH_PRESS_CONF_DIM,
     RICH_STATEMENT_DELTA_DIM,
     RICH_VOTE_FEATURES_DIM,
+    SUPPORTED_VOL_TARGET_HORIZONS,
     RichFeatureScalerParams,
     SEQUENCE_LENGTH,
     FeatureVector,
@@ -160,6 +162,27 @@ def _extract_required_float(record: dict[str, Any], keys: Sequence[str]) -> floa
         if key in record and record[key] not in {None, ""}:
             return float(record[key])
     raise ValueError(f"Missing required numeric field from keys: {', '.join(keys)}")
+
+
+def _resolve_forward_vol_column(horizon: int) -> str:
+    """Validate ``horizon`` and return the matching events-parquet column.
+
+    Centralises the column-name lookup so the two loader entry points
+    (:func:`_load_package_sequences_with_metadata` and the legacy
+    :func:`load_training_sequences_from_package`) share one validation
+    contract. Non-supported horizons raise ``ValueError`` with the
+    canonical horizon list so an operator-supplied
+    ``--target-horizon`` typo surfaces at loader entry rather than
+    after the package read.
+    """
+
+    horizon_int = int(horizon)
+    if horizon_int not in SUPPORTED_VOL_TARGET_HORIZONS:
+        raise ValueError(
+            f"unsupported vol_target_horizon={horizon!r}; expected one of "
+            f"{SUPPORTED_VOL_TARGET_HORIZONS}"
+        )
+    return f"forward_realized_vol_{horizon_int}d"
 
 
 def build_feature_vectors(
@@ -1772,6 +1795,7 @@ def _load_package_sequences_with_metadata(
     use_text_embeddings: bool = True,
     text_embedding_cache_dir: Path | str | None = None,
     encoder_lora: bool = False,
+    vol_target_horizon: int = DEFAULT_VOL_TARGET_HORIZON,
 ) -> list[tuple[list[FeatureVector], str, str]]:
     """Materialise every event in a training package as a sequence triple.
 
@@ -1793,6 +1817,7 @@ def _load_package_sequences_with_metadata(
             f"Unsupported target_mode: {target_mode!r}. "
             f"Choose one of {sorted(_VALID_TARGET_MODES)}."
         )
+    forward_vol_column = _resolve_forward_vol_column(vol_target_horizon)
 
     package_dir = _resolve_training_package_dir(training_package_id)
     frame = _read_events_frame(package_dir)
@@ -1979,14 +2004,23 @@ def _load_package_sequences_with_metadata(
         # axis, not an input feature. Tier 1 (Market-Only) needs it just
         # like tier 3 (Market+Rich+NLP); a missing target would crash the
         # per-fold quantile fit with "0 valid rows for n_classes=3".
-        forward_vol_value = _coerce_finite_float(
-            row.get("forward_realized_vol_10d")
-        )
+        # The ``forward_vol_column`` selector (default
+        # ``forward_realized_vol_10d``) routes the canonical y axis to
+        # the operator-chosen horizon; the per-row slot stays named
+        # ``forward_realized_vol_10d`` on the FeatureVector so downstream
+        # consumers (``vol_regime_class_for``, the dual-head MSE
+        # builder) keep reading the same attribute regardless of which
+        # horizon column was sourced.
+        forward_vol_value = _coerce_finite_float(row.get(forward_vol_column))
         # #236 GARCH(1,1) baseline + residual. Frozen into the events
         # parquet at build time (see ``app.data.garch_residual``);
         # the loader only reads them off the row and broadcasts onto
         # the target slot. Older events.parquet files without these
-        # columns degrade cleanly to ``None`` here.
+        # columns degrade cleanly to ``None`` here. The baseline/residual
+        # pair is currently only computed against the 10d horizon so
+        # the column names stay hard-coded here; non-10d horizons emit
+        # ``None`` on both and the GARCH-residual mode falls back to
+        # the raw target per ADR 0034.
         garch_baseline_value = _coerce_finite_float(
             row.get("forward_realized_vol_10d_garch_baseline")
         )
@@ -2282,6 +2316,7 @@ def load_walk_forward_split(
     text_embedding_cache_dir: Path | str | None = None,
     embargo_days: int = 0,
     encoder_lora: bool = False,
+    vol_target_horizon: int = DEFAULT_VOL_TARGET_HORIZON,
 ) -> WalkForwardSplit:
     """Return the (train, val, test) sequence partitions for one fold.
 
@@ -2362,6 +2397,7 @@ def load_walk_forward_split(
         use_text_embeddings=use_text_embeddings,
         text_embedding_cache_dir=text_embedding_cache_dir,
         encoder_lora=encoder_lora,
+        vol_target_horizon=vol_target_horizon,
     )
 
     train: list[list[FeatureVector]] = []
@@ -2485,6 +2521,7 @@ def load_training_sequences_from_package(
     text_pool_lambda_inv_days: float = DEFAULT_TEXT_POOL_LAMBDA_INV_DAYS,
     use_text_embeddings: bool = True,
     text_embedding_cache_dir: Path | str | None = None,
+    vol_target_horizon: int = DEFAULT_VOL_TARGET_HORIZON,
 ) -> list[list[FeatureVector]]:
     """Load one prior-window sequence per FOMC event in a training package.
 
@@ -2825,7 +2862,7 @@ def load_training_sequences_from_package(
         # like tier 3 (Market+Rich+NLP); a missing target would crash the
         # per-fold quantile fit with "0 valid rows for n_classes=3".
         forward_vol_value = _coerce_finite_float(
-            row.get("forward_realized_vol_10d")
+            row.get(_resolve_forward_vol_column(vol_target_horizon))
         )
         # #236 GARCH(1,1) baseline + residual (see matched walk-forward
         # site above for the contract).

--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -120,6 +120,39 @@ def _parse_args() -> argparse.Namespace:
             "strict-prior policy-surprise direction. See ADR 0027."
         ),
     )
+    # #435 dual-head MSE-branch target derivation. ``raw`` (default,
+    # byte-identical) feeds ``log(forward_realized_vol_10d)``;
+    # ``garch_residual`` swaps in the GARCH(1,1) residual column with
+    # fallback to raw on rows lacking a residual (ADR 0034).
+    parser.add_argument(
+        "--vol-target-mode",
+        type=str,
+        choices=("raw", "garch_residual"),
+        default="raw",
+        help=(
+            "Forward-vol regression-target derivation. ``raw`` (default) "
+            "feeds the standardised ``log(forward_realized_vol_10d)``; "
+            "``garch_residual`` swaps in "
+            "``forward_realized_vol_10d_garch_residual`` (signed, no "
+            "log). See ADR 0034."
+        ),
+    )
+    # Supervised forward-vol horizon (trading days). ``10`` keeps the
+    # canonical y axis; the loader switches to
+    # ``forward_realized_vol_<H>d`` for any other supported choice.
+    parser.add_argument(
+        "--target-horizon",
+        type=int,
+        choices=(1, 3, 5, 10, 20, 30),
+        default=10,
+        help=(
+            "Supervised forward-vol horizon in trading days. ``10`` "
+            "(default) reads the canonical "
+            "``forward_realized_vol_10d`` column; other choices read "
+            "``forward_realized_vol_<H>d`` from the same events "
+            "parquet (populated by the multi-horizon data builder)."
+        ),
+    )
     # #306 retrieval-augmented input features. Off by default so the
     # canonical sweep stays byte-identical.
     parser.add_argument(
@@ -298,7 +331,7 @@ def _resolve_auto_rates_heads(
     return ()
 
 
-def _run_one_cell(
+def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
     head_mode: str,
     seed: int,
     *,
@@ -308,6 +341,8 @@ def _run_one_cell(
     regression_alpha: float,
     hidden_size: int,
     rates_target_mode: str = "raw",
+    vol_target_mode: str = "raw",
+    vol_target_horizon: int = 10,
     use_retrieval_analogs: bool = False,
     use_regime_conditioning: bool = False,
     use_statement_delta: bool = False,
@@ -330,6 +365,8 @@ def _run_one_cell(
         hidden_size=hidden_size,
         rates_heads=rates_heads,
         rates_target_mode=rates_target_mode,
+        vol_target_mode=vol_target_mode,
+        vol_target_horizon=vol_target_horizon,
         use_regime_conditioning=use_regime_conditioning,
         use_press_conf=use_press_conf,
         use_statement_delta=use_statement_delta,
@@ -347,6 +384,7 @@ def _run_one_cell(
             use_statement_delta=use_statement_delta,
             use_vote_features=use_vote_features,
             use_press_conf=use_press_conf,
+            vol_target_horizon=vol_target_horizon,
         )
         result = train_model(
             model_config=config,
@@ -407,6 +445,8 @@ def main() -> int:
                     regression_alpha=args.regression_alpha,
                     hidden_size=args.hidden_size,
                     rates_target_mode=str(args.rates_target_mode),
+                    vol_target_mode=str(args.vol_target_mode),
+                    vol_target_horizon=int(args.target_horizon),
                     use_retrieval_analogs=bool(args.use_retrieval_analogs),
                     use_regime_conditioning=bool(args.use_regime_conditioning),
                     use_statement_delta=bool(args.use_statement_delta),
@@ -444,6 +484,8 @@ def main() -> int:
         "rates_heads": list(
             _resolve_auto_rates_heads(str(args.rates_target_mode), rates_heads=None)
         ),
+        "vol_target_mode": str(args.vol_target_mode),
+        "vol_target_horizon": int(args.target_horizon),
         "use_retrieval_analogs": bool(args.use_retrieval_analogs),
         "use_regime_conditioning": bool(args.use_regime_conditioning),
         "use_statement_delta": bool(args.use_statement_delta),

--- a/tests/unit/test_run_dual_head_comparison.py
+++ b/tests/unit/test_run_dual_head_comparison.py
@@ -44,6 +44,8 @@ def test_dual_head_runner_exposes_new_flags(monkeypatch):
     )
     args = _parse_args()
     assert args.rates_target_mode == "raw"
+    assert args.vol_target_mode == "raw"
+    assert args.target_horizon == 10
     assert args.use_retrieval_analogs is False
     assert args.use_regime_conditioning is False
     assert args.use_statement_delta is False
@@ -63,6 +65,10 @@ def test_dual_head_runner_accepts_opt_in_flags(monkeypatch):
             "tp_dummy",
             "--rates-target-mode",
             "fomc_attributable",
+            "--vol-target-mode",
+            "garch_residual",
+            "--target-horizon",
+            "5",
             "--use-retrieval-analogs",
             "--use-regime-conditioning",
             "--use-statement-delta",
@@ -72,11 +78,49 @@ def test_dual_head_runner_accepts_opt_in_flags(monkeypatch):
     )
     args = _parse_args()
     assert args.rates_target_mode == "fomc_attributable"
+    assert args.vol_target_mode == "garch_residual"
+    assert args.target_horizon == 5
     assert args.use_retrieval_analogs is True
     assert args.use_regime_conditioning is True
     assert args.use_statement_delta is True
     assert args.use_vote_features is True
     assert args.use_press_conf is True
+
+
+def test_dual_head_runner_rejects_unknown_vol_target_mode(monkeypatch):
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+            "--vol-target-mode",
+            "definitely_not_a_mode",
+        ],
+    )
+    with pytest.raises(SystemExit):
+        _parse_args()
+
+
+def test_dual_head_runner_rejects_unsupported_target_horizon(monkeypatch):
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+            "--target-horizon",
+            "7",
+        ],
+    )
+    with pytest.raises(SystemExit):
+        _parse_args()
 
 
 def test_dual_head_runner_rejects_unknown_rates_target_mode(monkeypatch):
@@ -226,10 +270,13 @@ def test_dual_head_runner_default_off_byte_identity(monkeypatch):
     assert loader_kwargs["use_vote_features"] is False
     assert loader_kwargs["use_press_conf"] is False
     assert loader_kwargs["rich_features"] is True
+    assert loader_kwargs["vol_target_horizon"] == 10
 
     train_kwargs = captured["train_calls"][0]
     model_config = train_kwargs["model_config"]
     assert model_config.rates_target_mode == "raw"
+    assert model_config.vol_target_mode == "raw"
+    assert model_config.vol_target_horizon == 10
     assert model_config.use_regime_conditioning is False
 
 
@@ -248,6 +295,8 @@ def test_dual_head_runner_opt_in_threads_through(monkeypatch):
         regression_alpha=0.5,
         hidden_size=64,
         rates_target_mode="fomc_attributable",
+        vol_target_mode="garch_residual",
+        vol_target_horizon=5,
         use_retrieval_analogs=True,
         use_regime_conditioning=True,
         use_statement_delta=True,
@@ -261,10 +310,13 @@ def test_dual_head_runner_opt_in_threads_through(monkeypatch):
     assert loader_kwargs["use_statement_delta"] is True
     assert loader_kwargs["use_vote_features"] is True
     assert loader_kwargs["use_press_conf"] is True
+    assert loader_kwargs["vol_target_horizon"] == 5
 
     train_kwargs = captured["train_calls"][0]
     model_config = train_kwargs["model_config"]
     assert model_config.rates_target_mode == "fomc_attributable"
+    assert model_config.vol_target_mode == "garch_residual"
+    assert model_config.vol_target_horizon == 5
     assert model_config.use_regime_conditioning is True
 
 

--- a/tests/unit/test_vol_target_mode.py
+++ b/tests/unit/test_vol_target_mode.py
@@ -377,3 +377,155 @@ def test_train_model_smoke_vol_target_mode_raw_default() -> None:
     assert result.summary.epochs_completed == 1
     persisted_config = ModelConfig.from_model(result.model)
     assert persisted_config.vol_target_mode == "raw"
+
+
+# ---------------------------------------------------------------------------
+# vol_target_horizon: ModelConfig field + loader column resolver
+# ---------------------------------------------------------------------------
+
+
+def test_model_config_default_vol_target_horizon_is_ten() -> None:
+    """Pre-flag default persists; explicit opt-in only flips the field."""
+
+    from app.models.config import DEFAULT_VOL_TARGET_HORIZON
+
+    config = ModelConfig()
+    assert config.vol_target_horizon == 10
+    assert DEFAULT_VOL_TARGET_HORIZON == 10
+
+
+def test_model_config_vol_target_horizon_round_trip_through_coerce() -> None:
+    from app.training.loop import _coerce_model_config
+
+    rebuilt = _coerce_model_config(
+        {
+            "vol_target_horizon": 5,
+            "output_mode": "classification",
+            "head_mode": "dual",
+        }
+    )
+    assert rebuilt.vol_target_horizon == 5
+
+
+def test_supported_vol_target_horizons_cover_events_parquet_columns() -> None:
+    from app.models.config import SUPPORTED_VOL_TARGET_HORIZONS
+
+    assert SUPPORTED_VOL_TARGET_HORIZONS == (1, 3, 5, 10, 20, 30)
+
+
+def test_resolve_forward_vol_column_returns_canonical_for_default() -> None:
+    from app.training.loaders import _resolve_forward_vol_column
+
+    assert _resolve_forward_vol_column(10) == "forward_realized_vol_10d"
+
+
+def test_resolve_forward_vol_column_returns_per_horizon_column() -> None:
+    from app.training.loaders import _resolve_forward_vol_column
+
+    assert _resolve_forward_vol_column(5) == "forward_realized_vol_5d"
+    assert _resolve_forward_vol_column(30) == "forward_realized_vol_30d"
+
+
+def test_resolve_forward_vol_column_rejects_unsupported_horizon() -> None:
+    from app.training.loaders import _resolve_forward_vol_column
+
+    with pytest.raises(ValueError, match="vol_target_horizon"):
+        _resolve_forward_vol_column(7)
+
+
+# --------------------------------------------------------------------------- #
+# Loader integration: vol_target_horizon routes to the per-horizon column
+# --------------------------------------------------------------------------- #
+
+
+def test_load_training_sequences_routes_per_horizon_column(
+    tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Confirm horizon=5 reads forward_realized_vol_5d, not 10d.
+
+    Builds a one-row events.parquet where the 5d and 10d columns hold
+    DIFFERENT values, then asserts the loader writes the chosen
+    horizon's value into ``FeatureVector.forward_realized_vol_10d``
+    (the canonical slot every downstream consumer reads).
+    """
+    import json
+    from pathlib import Path
+
+    import pandas as pd
+
+    from app.training import loaders
+
+    pkg_id = "horizon_route_pkg"
+    pkg_dir = tmp_path / "processed" / pkg_id  # type: ignore[operator]
+    pkg_dir.mkdir(parents=True)
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+
+    prior_bars = json.dumps(
+        [
+            {
+                "date": f"2024-01-{i + 1:02d}",
+                "close": 4500.0 + i,
+                "vol_5d": 0.012,
+            }
+            for i in range(loaders.SEQUENCE_LENGTH + 1)
+        ]
+    )
+    row = {
+        "event_date": "2024-02-15",
+        "event_kind": "statement",
+        "document_id": "doc_a",
+        "text_hash": "hash_a",
+        "source": "scraped_fed",
+        "source_record_id": "src:hash_a",
+        "as_of_ts": "2024-02-15T19:00:00Z",
+        "text": "FOMC body",
+        "token_count": 2,
+        "axis_stance": "hawkish",
+        "axis_time": None,
+        "axis_certainty": None,
+        "axis_factor": None,
+        "axis_time_label": None,
+        "axis_certain_label": None,
+        "credibility_drift_score": 0.0,
+        "credibility_realized_vs_stated_gap": 0.0,
+        "credibility_market_implied_gap": 0.0,
+        "credibility_months_since_reversal": 0,
+        "prior_window_sha256": "0" * 64,
+        "prior_bars_json": prior_bars,
+        "asset_symbol": "^GSPC",
+        "horizon": 1,
+        "realized_return": 0.01,
+        "abnormal_return": 0.01,
+        "alpha": 0.0,
+        "beta": 1.0,
+        "direction_t1d": 1,
+        "volatility_shift": 0.0,
+        "concurrent_macro_release": False,
+        "intra_meeting_stance_shift": 0.0,
+        "intra_meeting_certainty_shift": 0.0,
+        "intra_meeting_factor_shift": 0.0,
+        "realized_date": "2024-02-16",
+        "forward_realized_vol_5d": 0.0075,
+        "forward_realized_vol_10d": 0.0150,
+        "forward_realized_vol_20d": 0.0250,
+    }
+    pd.DataFrame([row]).to_parquet(pkg_dir / "events.parquet", index=False)
+    pd.DataFrame(
+        [{"text_hash": "hash_a", "split_tag": "train"}]
+    ).to_parquet(pkg_dir / "splits_train_val_test.parquet", index=False)
+
+    sequences_10d = loaders.load_training_sequences_from_package(pkg_id)
+    sequences_5d = loaders.load_training_sequences_from_package(
+        pkg_id, vol_target_horizon=5
+    )
+    sequences_20d = loaders.load_training_sequences_from_package(
+        pkg_id, vol_target_horizon=20
+    )
+
+    def _target_vol(seqs: list[list]) -> float:
+        # Target row is the last bar of the sequence
+        return seqs[0][-1].forward_realized_vol_10d
+
+    assert _target_vol(sequences_10d) == pytest.approx(0.0150)
+    assert _target_vol(sequences_5d) == pytest.approx(0.0075)
+    assert _target_vol(sequences_20d) == pytest.approx(0.0250)


### PR DESCRIPTION
## Summary
- `--vol-target-mode {raw,garch_residual}` (existing infrastructure surfaced)
- `--target-horizon {1,3,5,10,20,30}` (new — loader routes per-row vol target to chosen `forward_realized_vol_<H>d`)
- `ModelConfig.vol_target_horizon` + checkpoint round-trip + factory stash
- Loader routing applied to BOTH walk-forward and legacy entry points (reviewer-flagged latent hole)
- Loader-level integration test confirms 5d/10d/20d horizons read different columns
- Default-off byte-identity preserved

Unblocks `garch_residual`, `horizon_5d`, `horizon_20d` arms in the next runpod batch.

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit/test_vol_target_mode.py tests/unit/test_run_dual_head_comparison.py -q`
- [ ] `docker compose run --rm backend bash -c "cd /app && mypy --strict --ignore-missing-imports --follow-imports=silent app/training app/models app/eval"`