### PR TITLE
loaders: thread sequence_length kwarg through load_walk_forward_split (#476 foundation)

### DIFF
--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -1796,6 +1796,7 @@ def _load_package_sequences_with_metadata(
     text_embedding_cache_dir: Path | str | None = None,
     encoder_lora: bool = False,
     vol_target_horizon: int = DEFAULT_VOL_TARGET_HORIZON,
+    sequence_length: int = SEQUENCE_LENGTH,
 ) -> list[tuple[list[FeatureVector], str, str]]:
     """Materialise every event in a training package as a sequence triple.
 
@@ -1966,7 +1967,7 @@ def _load_package_sequences_with_metadata(
         except ValueError:
             continue
         bars = _parse_prior_bars(row.get("prior_bars_json"))
-        if len(bars) < SEQUENCE_LENGTH:
+        if len(bars) < sequence_length:
             continue
         row_text_hash = str(row.get("text_hash", ""))
         sentiment_score = _stance_to_sentiment(row.get("axis_stance"))
@@ -1975,7 +1976,7 @@ def _load_package_sequences_with_metadata(
             event_date=event_date,
             sentiment_score=sentiment_score,
         )
-        if len(vectors) < SEQUENCE_LENGTH:
+        if len(vectors) < sequence_length:
             continue
         realized_return = _coerce_finite_float(row.get("realized_return"))
         abnormal_return = _coerce_finite_float(row.get("abnormal_return"))
@@ -2317,6 +2318,7 @@ def load_walk_forward_split(
     embargo_days: int = 0,
     encoder_lora: bool = False,
     vol_target_horizon: int = DEFAULT_VOL_TARGET_HORIZON,
+    sequence_length: int = SEQUENCE_LENGTH,
 ) -> WalkForwardSplit:
     """Return the (train, val, test) sequence partitions for one fold.
 
@@ -2360,6 +2362,14 @@ def load_walk_forward_split(
     are split-tag-driven and have no manifest dates to anchor the
     embargo against).
 
+    ``sequence_length`` gates the minimum prior-bar count an event must
+    carry to survive the loader. Defaults to the module-level
+    ``SEQUENCE_LENGTH`` (20) so existing callers get byte-identical
+    behaviour; override (e.g. 60) to drive the longer-window arm
+    against a TP whose ``prior_bars_json`` carries the matching wider
+    window. Rows whose prior-bar list is shorter than ``sequence_length``
+    are dropped from every partition.
+
     Raises ``ValueError`` when the chosen partition produces an empty
     test list: a sweep that silently runs on no held-out events is the
     research-quality footgun this refactor was written to remove.
@@ -2398,6 +2408,7 @@ def load_walk_forward_split(
         text_embedding_cache_dir=text_embedding_cache_dir,
         encoder_lora=encoder_lora,
         vol_target_horizon=vol_target_horizon,
+        sequence_length=sequence_length,
     )
 
     train: list[list[FeatureVector]] = []

--- a/tests/unit/test_loaders_sequence_length.py
+++ b/tests/unit/test_loaders_sequence_length.py
@@ -1,0 +1,256 @@
+"""Sequence-length plumbing on ``load_walk_forward_split`` (#476).
+
+Pins three contracts:
+
+- the new ``sequence_length`` kwarg defaults to the module-level
+  ``SEQUENCE_LENGTH`` so existing callers stay byte-identical;
+- passing ``sequence_length=60`` against a TP whose ``prior_bars_json``
+  carries 60 bars yields 60-bar prior windows on every supervised
+  sequence;
+- the same 60-bar TP run with the default 20 kwarg drops every row
+  that lacks 60 bars only when the override raises the gate above the
+  TP width — at the default 20-bar gate the loader still admits the
+  rows (it only checks ``len(bars) >= sequence_length``).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+pd = pytest.importorskip("pandas")
+pytest.importorskip("pyarrow")
+pytest.importorskip("torch")
+
+from app.models.config import SEQUENCE_LENGTH  # noqa: E402
+from app.training import loaders  # noqa: E402
+
+
+_TRAINING_PACKAGE_ID_60 = "tp_seq_len_60_v1"
+_TRAINING_PACKAGE_ID_20 = "tp_seq_len_20_v1"
+
+
+def _synth_prior_bars(*, event_date: _dt.date, base_close: float, n_bars: int) -> str:
+    payload = []
+    for offset in range(n_bars, 0, -1):
+        bar_date = _dt.date.fromordinal(event_date.toordinal() - offset)
+        payload.append(
+            {
+                "date": bar_date.isoformat(),
+                "close": round(base_close + (n_bars - offset) * 1.5, 10),
+                "volume": 1_000_000.0,
+                "vol_5d": 0.012,
+                "vol_20d": 0.018,
+                "vol_60d": 0.022,
+                "cum_return_20d": 0.0,
+                "vix_close": 15.0,
+                "dxy_close": 103.0,
+                "tnx_close": 4.20,
+                "gold_close": 2050.0,
+                "vix3m_close": 17.0,
+                "irx_close": 5.10,
+                "vix_term_slope": 0.0,
+                "yield_curve_slope_10y_3m": -0.90,
+            }
+        )
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+def _make_event_row(
+    *,
+    event_date: str,
+    text: str,
+    axis_stance: str | None,
+    base_close: float,
+    n_bars: int,
+) -> dict:
+    ed = _dt.date.fromisoformat(event_date)
+    text_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    return {
+        "event_date": event_date,
+        "event_kind": "statement",
+        "document_id": text_hash[:16],
+        "text_hash": text_hash,
+        "source": "scraped_fed",
+        "source_record_id": f"src:{text_hash[:8]}",
+        "as_of_ts": f"{event_date}T19:00:00Z",
+        "text": text,
+        "token_count": len(text.split()),
+        "axis_stance": axis_stance,
+        "axis_time": None,
+        "axis_certainty": None,
+        "axis_factor": None,
+        "axis_time_label": None,
+        "axis_certain_label": None,
+        "credibility_drift_score": 0.0,
+        "credibility_realized_vs_stated_gap": 0.0,
+        "credibility_market_implied_gap": 0.0,
+        "credibility_months_since_reversal": 0,
+        "prior_window_sha256": "0" * 64,
+        "prior_bars_json": _synth_prior_bars(
+            event_date=ed, base_close=base_close, n_bars=n_bars
+        ),
+        "asset_symbol": "^GSPC",
+        "horizon": 1,
+        "realized_return": 0.001,
+        "abnormal_return": 0.001,
+        "alpha": 0.0,
+        "beta": 1.0,
+        "direction_t1d": 1,
+        "volatility_shift": 0.0,
+        "concurrent_macro_release": False,
+        "intra_meeting_stance_shift": 0.0,
+        "intra_meeting_certainty_shift": 0.0,
+        "intra_meeting_factor_shift": 0.0,
+        "realized_date": (ed + _dt.timedelta(days=1)).isoformat(),
+        "forward_realized_vol_10d": 0.015,
+        "yield_2y_change_5d": 1.0,
+        "yield_5y_change_5d": 0.5,
+        "terminal_rate_change_5d": 0.0,
+    }
+
+
+def _materialise_package(
+    *,
+    root: Path,
+    package_id: str,
+    n_bars: int,
+) -> Path:
+    package_dir = root / "processed" / package_id
+    package_dir.mkdir(parents=True)
+    rows = [
+        _make_event_row(
+            event_date="2023-09-20",
+            text=f"Event A ({n_bars} bars).",
+            axis_stance="hawkish",
+            base_close=4400.0,
+            n_bars=n_bars,
+        ),
+        _make_event_row(
+            event_date="2023-12-13",
+            text=f"Event B ({n_bars} bars).",
+            axis_stance="neutral",
+            base_close=4500.0,
+            n_bars=n_bars,
+        ),
+        _make_event_row(
+            event_date="2024-03-20",
+            text=f"Event C ({n_bars} bars).",
+            axis_stance="neutral",
+            base_close=4600.0,
+            n_bars=n_bars,
+        ),
+    ]
+    pd.DataFrame(rows).to_parquet(package_dir / "events.parquet", index=False)
+
+    split_rows = [
+        {"text_hash": row["text_hash"], "split_tag": "train" if i < 2 else "test"}
+        for i, row in enumerate(rows)
+    ]
+    pd.DataFrame(split_rows).to_parquet(
+        package_dir / "splits_train_val_test.parquet", index=False
+    )
+    return package_dir
+
+
+@pytest.fixture
+def package_60bar(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+    return _materialise_package(
+        root=tmp_path, package_id=_TRAINING_PACKAGE_ID_60, n_bars=60
+    )
+
+
+@pytest.fixture
+def package_20bar(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setattr(loaders, "DATA_DIR", tmp_path)
+    return _materialise_package(
+        root=tmp_path, package_id=_TRAINING_PACKAGE_ID_20, n_bars=20
+    )
+
+
+def test_default_kwarg_matches_module_constant(package_20bar: Path) -> None:
+    """``load_walk_forward_split(...)`` w/o ``sequence_length`` -> 20-bar windows.
+
+    Default-path byte-identity: every supervised sequence carries
+    ``SEQUENCE_LENGTH`` lookback bars + 1 appended target frame.
+    """
+
+    split = loaders.load_walk_forward_split(
+        _TRAINING_PACKAGE_ID_20,
+        rich_features=False,
+        text_encoder=None,
+    )
+    assert split.train, "20-bar fixture must produce at least one train sequence"
+    for partition in (split.train, split.val, split.test):
+        for sequence in partition:
+            assert len(sequence) == SEQUENCE_LENGTH + 1
+
+
+def test_explicit_default_matches_implicit_default(package_20bar: Path) -> None:
+    """Passing ``sequence_length=SEQUENCE_LENGTH`` matches the kwarg-elided call.
+
+    Same fixture, same per-sequence lengths, same partition counts.
+    """
+
+    elided = loaders.load_walk_forward_split(
+        _TRAINING_PACKAGE_ID_20,
+        rich_features=False,
+        text_encoder=None,
+    )
+    explicit = loaders.load_walk_forward_split(
+        _TRAINING_PACKAGE_ID_20,
+        rich_features=False,
+        text_encoder=None,
+        sequence_length=SEQUENCE_LENGTH,
+    )
+    assert len(elided.train) == len(explicit.train)
+    assert len(elided.val) == len(explicit.val)
+    assert len(elided.test) == len(explicit.test)
+    for partition_a, partition_b in zip(
+        (elided.train, elided.val, elided.test),
+        (explicit.train, explicit.val, explicit.test),
+    ):
+        for seq_a, seq_b in zip(partition_a, partition_b):
+            assert len(seq_a) == len(seq_b) == SEQUENCE_LENGTH + 1
+
+
+def test_sequence_length_60_yields_60_bar_windows(package_60bar: Path) -> None:
+    """``sequence_length=60`` against a 60-bar TP -> 60-bar lookback windows."""
+
+    split = loaders.load_walk_forward_split(
+        _TRAINING_PACKAGE_ID_60,
+        rich_features=False,
+        text_encoder=None,
+        sequence_length=60,
+    )
+    assert split.train, "60-bar fixture must produce at least one train sequence"
+    for partition in (split.train, split.val, split.test):
+        for sequence in partition:
+            # 60 prior bars + 1 appended event-day target frame.
+            assert len(sequence) == 60 + 1
+
+
+def test_sequence_length_60_against_20bar_tp_drops_every_event(
+    package_20bar: Path,
+) -> None:
+    """``sequence_length=60`` against a 20-bar TP -> empty test (every row dropped).
+
+    The gate ``len(bars) >= sequence_length`` short-circuits each event
+    before the target frame appends. With no event surviving the
+    walk-forward split the loader raises rather than silently training
+    on no held-out rows.
+    """
+
+    with pytest.raises(ValueError, match="empty test partition"):
+        loaders.load_walk_forward_split(
+            _TRAINING_PACKAGE_ID_20,
+            rich_features=False,
+            text_encoder=None,
+            sequence_length=60,
+        )


### PR DESCRIPTION
## Summary
- Adds `sequence_length: int = SEQUENCE_LENGTH` kwarg to `load_walk_forward_split` and `_load_package_sequences_with_metadata` (end of signature).
- Gates the two internal `len(...) < SEQUENCE_LENGTH` checks on the parameter.
- Default keeps every existing caller byte-identical.
- **Does NOT expose the `--sequence-length` runner flag** — downstream tensor builders (`_build_training_tensors`, etc.) still hardcode `SEQUENCE_LENGTH` in their window slicing. Exposing the runner flag now would produce a silent no-op (loader emits 61-vector sequences, builder slices the last 20). The tensor-builder threading is a follow-up PR; this one ships the foundation.

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit/test_loaders_sequence_length.py tests/unit/test_run_dual_head_comparison.py -q`
- [ ] `docker compose run --rm backend bash -c "cd /app && mypy --strict --ignore-missing-imports --follow-imports=silent app/training app/models"`