### PR TITLE
calibration: temperature scaling + per-class Platt on regime softmax (#477)

### DIFF
--- a/backend/app/evaluation/calibration_temperature.py
+++ b/backend/app/evaluation/calibration_temperature.py
@@ -171,8 +171,14 @@ def fit_platt_per_class(
         b = torch.tensor(0.0, requires_grad=True)
         optimiser = torch.optim.LBFGS([a, b], lr=lr, max_iter=max_iter)
 
-        def _closure(a: torch.Tensor = a, b: torch.Tensor = b, z: torch.Tensor = z, y: torch.Tensor = y) -> torch.Tensor:
-            optimiser.zero_grad()
+        def _closure(
+            a: torch.Tensor = a,
+            b: torch.Tensor = b,
+            z: torch.Tensor = z,
+            y: torch.Tensor = y,
+            opt: torch.optim.LBFGS = optimiser,
+        ) -> torch.Tensor:
+            opt.zero_grad()
             logit = a * z + b
             loss = F.binary_cross_entropy_with_logits(logit, y)
             loss.backward()  # type: ignore[no-untyped-call]

--- a/backend/app/evaluation/calibration_temperature.py
+++ b/backend/app/evaluation/calibration_temperature.py
@@ -114,6 +114,187 @@ def apply_temperature(logits: torch.Tensor, T: float) -> torch.Tensor:
 
 
 # ---------------------------------------------------------------------------
+# Per-class Platt scaling (one-vs-rest sigmoid)
+# ---------------------------------------------------------------------------
+
+
+def fit_platt_per_class(
+    val_logits: torch.Tensor,
+    val_targets: torch.Tensor,
+    *,
+    n_classes: int = 3,
+    max_iter: int = 200,
+    lr: float = 0.05,
+) -> list[tuple[float, float]]:
+    """Fit a per-class sigmoid Platt calibrator on softmax scores.
+
+    For each class ``c`` the calibrator is ``p_c = sigmoid(a_c * z_c + b_c)``
+    where ``z_c`` is the per-class softmax score from ``val_logits``. The
+    parameters minimise binary cross-entropy against the one-vs-rest
+    indicator ``1[target == c]`` and are fit with LBFGS, mirroring the
+    reference implementation in Platt (1999).
+
+    Returns a list of ``(a, b)`` tuples of length ``n_classes``. When a
+    class is absent from the val targets the calibrator falls back to
+    the identity ``(1.0, 0.0)`` so the inference path is byte-identical
+    to the uncalibrated softmax for that class.
+    """
+
+    if val_logits.shape[0] != val_targets.shape[0]:
+        raise ValueError(
+            f"val_logits ({val_logits.shape[0]} rows) and val_targets "
+            f"({val_targets.shape[0]} rows) must have the same length"
+        )
+    if val_logits.dim() != 2:
+        raise ValueError(f"val_logits must be 2-D; got shape {tuple(val_logits.shape)}")
+    if val_targets.dim() != 1:
+        raise ValueError(f"val_targets must be 1-D; got shape {tuple(val_targets.shape)}")
+    if n_classes <= 0:
+        raise ValueError(f"n_classes must be positive; got {n_classes}")
+    if val_logits.shape[0] == 0:
+        return [(1.0, 0.0)] * n_classes
+
+    logits = val_logits.detach().float()
+    targets = val_targets.long()
+    softmax_scores = F.softmax(logits, dim=-1)
+
+    params: list[tuple[float, float]] = []
+    for c in range(n_classes):
+        z = softmax_scores[:, c].detach()
+        y = (targets == c).float()
+        if y.sum().item() == 0 or y.sum().item() == y.numel():
+            # All zeros or all ones -- BCE is degenerate; keep identity.
+            params.append((1.0, 0.0))
+            continue
+
+        a = torch.tensor(1.0, requires_grad=True)
+        b = torch.tensor(0.0, requires_grad=True)
+        optimiser = torch.optim.LBFGS([a, b], lr=lr, max_iter=max_iter)
+
+        def _closure(a: torch.Tensor = a, b: torch.Tensor = b, z: torch.Tensor = z, y: torch.Tensor = y) -> torch.Tensor:
+            optimiser.zero_grad()
+            logit = a * z + b
+            loss = F.binary_cross_entropy_with_logits(logit, y)
+            loss.backward()  # type: ignore[no-untyped-call]
+            return loss
+
+        optimiser.step(_closure)  # type: ignore[no-untyped-call]
+        params.append((float(a.detach().item()), float(b.detach().item())))
+    return params
+
+
+def apply_platt_per_class(
+    logits: torch.Tensor,
+    params: Sequence[tuple[float, float]],
+    *,
+    renormalise: bool = True,
+) -> torch.Tensor:
+    """Apply per-class Platt sigmoids to the softmax of ``logits``.
+
+    Returns the per-row vector ``sigmoid(a_c * softmax(logits)_c + b_c)``
+    over each class; when ``renormalise=True`` the resulting vector is
+    rescaled to sum to 1 so the downstream conformal / argmax surface
+    can keep treating it as a probability distribution. The sigmoid
+    outputs are not naturally normalised across classes (one-vs-rest by
+    construction), so renormalising is the standard recovery step when
+    the consumer expects a categorical distribution.
+    """
+
+    if logits.dim() != 2:
+        raise ValueError(f"logits must be 2-D; got shape {tuple(logits.shape)}")
+    if logits.shape[-1] != len(params):
+        raise ValueError(
+            f"params length {len(params)} does not match logits classes "
+            f"{logits.shape[-1]}"
+        )
+
+    softmax_scores = F.softmax(logits, dim=-1)
+    a_vec = torch.tensor([p[0] for p in params], dtype=softmax_scores.dtype)
+    b_vec = torch.tensor([p[1] for p in params], dtype=softmax_scores.dtype)
+    calibrated = torch.sigmoid(softmax_scores * a_vec + b_vec)
+    if renormalise:
+        denom = calibrated.sum(dim=-1, keepdim=True).clamp(min=1e-12)
+        calibrated = calibrated / denom
+    return calibrated
+
+
+# ---------------------------------------------------------------------------
+# Multi-class Brier + NLL
+# ---------------------------------------------------------------------------
+
+
+def brier_score(
+    probs: Sequence[Sequence[float]],
+    targets: Sequence[int],
+    *,
+    n_classes: int | None = None,
+) -> float:
+    """Multi-class Brier score: mean of ``||p - one_hot(target)||^2``.
+
+    The lower the better; equals 0 for a perfect deterministic predictor
+    and ``2`` in the worst case for a 3-class problem (probability mass
+    entirely on the wrong class). Matches the
+    ``next_fomc_decision._classification_metrics`` definition so the two
+    pipelines agree on the metric.
+    """
+
+    if len(probs) != len(targets):
+        raise ValueError("probs and targets must have the same length")
+    if not probs:
+        return 0.0
+    width = n_classes if n_classes is not None else len(probs[0])
+    if width <= 0:
+        raise ValueError(f"n_classes must be positive; got {width}")
+
+    total = 0.0
+    for row, target in zip(probs, targets):
+        row_list = list(row)
+        if len(row_list) != width:
+            raise ValueError(
+                f"row width {len(row_list)} does not match expected {width}"
+            )
+        target_idx = int(target)
+        row_sum = 0.0
+        for i, p in enumerate(row_list):
+            indicator = 1.0 if i == target_idx else 0.0
+            diff = float(p) - indicator
+            row_sum += diff * diff
+        total += row_sum
+    return total / len(probs)
+
+
+def negative_log_likelihood(
+    probs: Sequence[Sequence[float]],
+    targets: Sequence[int],
+    *,
+    eps: float = 1e-12,
+) -> float:
+    """Mean NLL = ``-mean(log p[target])`` over the rows.
+
+    ``eps`` floors the per-row probability so an unlucky 0 does not blow
+    up to infinity; matches the convention used by sklearn's log_loss.
+    """
+
+    if len(probs) != len(targets):
+        raise ValueError("probs and targets must have the same length")
+    if not probs:
+        return 0.0
+    import math as _math
+
+    total = 0.0
+    for row, target in zip(probs, targets):
+        row_list = list(row)
+        target_idx = int(target)
+        if target_idx < 0 or target_idx >= len(row_list):
+            raise ValueError(
+                f"target index {target_idx} out of bounds for {len(row_list)} classes"
+            )
+        p = max(float(row_list[target_idx]), eps)
+        total += -_math.log(p)
+    return total / len(probs)
+
+
+# ---------------------------------------------------------------------------
 # Reliability curve + ECE
 # ---------------------------------------------------------------------------
 
@@ -377,6 +558,10 @@ def render_reliability_diagram_png(
 __all__ = [
     "fit_temperature",
     "apply_temperature",
+    "fit_platt_per_class",
+    "apply_platt_per_class",
+    "brier_score",
+    "negative_log_likelihood",
     "ReliabilityBin",
     "ReliabilityCurve",
     "reliability_curve",

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -1141,6 +1141,7 @@ def build_regime_classification_card(
     if str(getattr(model, "output_mode", "regression")) != "classification":
         return None
     manifest = _conformal_manifest_for(BEST_MODEL_PATH)
+    calibration_sidecar = _calibration_sidecar_for(BEST_MODEL_PATH)
 
     from app.evaluation.conformal import (
         format_class_set_label,
@@ -1248,7 +1249,9 @@ def build_regime_classification_card(
             ):
                 logits = model(x, **kwargs)
                 if logits.dim() == 2:
-                    probs_tensor = torch.softmax(logits, dim=-1).squeeze(0)
+                    probs_tensor = _apply_calibration_to_softmax(
+                        logits, calibration_sidecar
+                    ).squeeze(0)
                     probs = [float(p) for p in probs_tensor.tolist()]
                     n_classes = len(probs)
                     labels_local: tuple[str, ...] = VOL_REGIME_CLASS_LABELS
@@ -1299,7 +1302,7 @@ def build_regime_classification_card(
     logits = model(x, **kwargs)
     if logits.dim() != 2:
         return None
-    probs_tensor = torch.softmax(logits, dim=-1).squeeze(0)
+    probs_tensor = _apply_calibration_to_softmax(logits, calibration_sidecar).squeeze(0)
     probs = [float(p) for p in probs_tensor.tolist()]
     n_classes = len(probs)
     labels: tuple[str, ...] = VOL_REGIME_CLASS_LABELS
@@ -1411,6 +1414,80 @@ def _conformal_manifest_for(checkpoint_path: Path | None) -> Any:
         return load_manifest(manifest_path)
     except Exception:
         return None
+
+
+def _calibration_sidecar_for(checkpoint_path: Path | None) -> dict[str, Any] | None:
+    """Load the regime-head post-hoc calibration sidecar, when present.
+
+    Written by ``scripts/calibrate_regime_classifier.py`` next to the
+    checkpoint as ``{stem}.calibration.json``. Carries any of:
+    ``temperature`` (scalar), ``platt_a`` / ``platt_b`` (per-class
+    sigmoid params). Absent file -> ``None`` so the inference path
+    keeps the raw softmax (byte-identical to the pre-calibration
+    contract).
+    """
+
+    if checkpoint_path is None:
+        return None
+    sidecar_path = checkpoint_path.with_name(checkpoint_path.stem + ".calibration.json")
+    if not sidecar_path.exists():
+        return None
+    try:
+        import json as _json
+
+        payload = _json.loads(sidecar_path.read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _apply_calibration_to_softmax(
+    logits: torch.Tensor,
+    sidecar: dict[str, Any] | None,
+) -> torch.Tensor:
+    """Apply temperature scaling + per-class Platt to a logits batch.
+
+    ``logits`` shape: ``(B, n_classes)`` -- already-batched stance logits
+    off the regime head. Returns a per-row probability tensor of the
+    same shape. When the sidecar is missing or carries neither
+    parameter set the function falls back to the raw softmax.
+
+    Composition order matches the calibration script: temperature
+    first, Platt second, so a "both" sidecar reproduces the
+    val-partition fit exactly.
+    """
+
+    from app.evaluation.calibration_temperature import (
+        apply_platt_per_class,
+        apply_temperature,
+    )
+
+    if sidecar is None:
+        return torch.softmax(logits, dim=-1)
+
+    working = logits
+    temperature_value: float | None = None
+
+    temperature_raw = sidecar.get("temperature")
+    if isinstance(temperature_raw, (int, float)) and float(temperature_raw) > 0.0:
+        temperature_value = float(temperature_raw)
+        working = working / temperature_value
+
+    a_raw = sidecar.get("platt_a")
+    b_raw = sidecar.get("platt_b")
+    if (
+        isinstance(a_raw, list)
+        and isinstance(b_raw, list)
+        and len(a_raw) == len(b_raw) == int(working.shape[-1])
+    ):
+        params = [(float(a), float(b)) for a, b in zip(a_raw, b_raw)]
+        return apply_platt_per_class(working, params)
+
+    if temperature_value is not None:
+        return apply_temperature(logits, temperature_value)
+    return torch.softmax(logits, dim=-1)
 
 
 def _build_confidence_bands(

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -1471,7 +1471,7 @@ def _apply_calibration_to_softmax(
     temperature_value: float | None = None
 
     temperature_raw = sidecar.get("temperature")
-    if isinstance(temperature_raw, (int, float)) and float(temperature_raw) > 0.0:
+    if isinstance(temperature_raw, int | float) and float(temperature_raw) > 0.0:
         temperature_value = float(temperature_raw)
         working = working / temperature_value
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -140,6 +140,10 @@ ignore = [
 # Tests are intentionally not a package (no __init__.py) so pytest can
 # autodiscover, and test fixtures naturally pile up positional arguments.
 "tests/**/*.py" = ["C901", "PLR0913", "INP001"]
+# Scripts are top-level entrypoints, not a package; CLI builders accept a
+# fan-out of keyword arguments by design. Mirrors the root-level ruff.toml
+# rule so root- and backend-rooted invocations agree.
+"scripts/**/*.py" = ["C901", "PLR0913", "INP001"]
 # Existing files that already exceed the C901 / PLR0913 thresholds. The
 # rules are wired in to catch *new* violations during review; refactoring
 # the entries below into per-file ignores is intentional — they map the

--- a/scripts/calibrate_regime_classifier.py
+++ b/scripts/calibrate_regime_classifier.py
@@ -38,14 +38,20 @@ from typing import Any
 import torch
 
 from app.evaluation.calibration_temperature import (
+    apply_platt_per_class,
     apply_temperature,
+    brier_score,
     expected_calibration_error,
+    fit_platt_per_class,
     fit_temperature,
+    negative_log_likelihood,
     reliability_curve,
     render_reliability_diagram_png,
 )
 from app.training.checkpoint import _coerce_payload_config
 from app.training.loaders import load_walk_forward_split
+
+CALIBRATION_METHODS = ("temperature", "platt", "both")
 
 
 def _resolve_package_dir(training_package_id: str) -> Path:
@@ -142,6 +148,277 @@ def _build_model_from_payload(payload: dict[str, Any], device: torch.device):
     return model
 
 
+def _metric_block(
+    probs: list[list[float]],
+    targets: list[int],
+    *,
+    n_classes: int,
+) -> dict[str, float]:
+    """Pack ECE + Brier + NLL into a serialisable block."""
+
+    return {
+        "ece": float(expected_calibration_error(probs, targets, n_bins=10)),
+        "brier": float(brier_score(probs, targets, n_classes=n_classes)),
+        "nll": float(negative_log_likelihood(probs, targets)),
+    }
+
+
+def _fit_method(
+    method: str,
+    val_logits: torch.Tensor,
+    val_targets: torch.Tensor,
+    targets_list: list[int],
+    n_classes: int,
+) -> dict[str, Any]:
+    """Run the requested calibrator(s) on val logits.
+
+    Returns a dict with optional ``temperature`` / ``platt_params`` and
+    per-method ``post_probs`` / ``post_metrics`` / ``post_curve``.
+    When fitting ``both``, Platt sees the temperature-scaled logits so
+    the two layers compose at inference (temperature first, Platt
+    second) and reproduce the val-partition fit exactly.
+    """
+
+    result: dict[str, Any] = {}
+    if method in ("temperature", "both"):
+        T = fit_temperature(val_logits, val_targets)
+        post_probs = apply_temperature(val_logits, T).tolist()
+        result["temperature"] = float(T)
+        result["post_probs_T"] = post_probs
+        result["post_curve_T"] = reliability_curve(post_probs, targets_list, n_bins=10)
+        result["post_metrics_T"] = _metric_block(post_probs, targets_list, n_classes=n_classes)
+
+    if method in ("platt", "both"):
+        T_existing = result.get("temperature")
+        logits_for_platt = (
+            val_logits / float(T_existing)
+            if (method == "both" and T_existing is not None)
+            else val_logits
+        )
+        params = fit_platt_per_class(logits_for_platt, val_targets, n_classes=n_classes)
+        post_probs_p = apply_platt_per_class(logits_for_platt, params).tolist()
+        result["platt_params"] = params
+        result["post_probs_platt"] = post_probs_p
+        result["post_curve_platt"] = reliability_curve(post_probs_p, targets_list, n_bins=10)
+        result["post_metrics_platt"] = _metric_block(post_probs_p, targets_list, n_classes=n_classes)
+
+    return result
+
+
+def _build_manifest(
+    fold_id: str,
+    method: str,
+    n_val_rows: int,
+    n_classes: int,
+    pre_metrics: dict[str, float],
+    pre_curve_dict: dict[str, object],
+    fit: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the per-fold calibration_manifest.json payload."""
+
+    payload: dict[str, Any] = {
+        "fold_id": fold_id,
+        "method": method,
+        "n_val_rows": n_val_rows,
+        "n_classes": n_classes,
+        "pre_metrics": pre_metrics,
+        "pre_curve": pre_curve_dict,
+    }
+    if "temperature" in fit:
+        payload["temperature"] = float(fit["temperature"])
+        payload["post_metrics_temperature"] = fit["post_metrics_T"]
+        payload["post_curve_temperature"] = fit["post_curve_T"].to_dict()
+        # Back-compat: keep the legacy flat keys consumed by older
+        # operator scripts and dashboards.
+        payload["pre_ece"] = float(pre_metrics["ece"])
+        payload["post_ece"] = float(fit["post_metrics_T"]["ece"])
+        payload["post_curve"] = fit["post_curve_T"].to_dict()
+    if "platt_params" in fit:
+        payload["platt_a"] = [float(a) for a, _ in fit["platt_params"]]
+        payload["platt_b"] = [float(b) for _, b in fit["platt_params"]]
+        payload["post_metrics_platt"] = fit["post_metrics_platt"]
+        payload["post_curve_platt"] = fit["post_curve_platt"].to_dict()
+    return payload
+
+
+def _build_summary_entry(
+    n_val_rows: int,
+    pre_metrics: dict[str, float],
+    fit: dict[str, Any],
+) -> dict[str, float]:
+    """Flat per-fold metrics block for the global calibration_summary.json."""
+
+    entry: dict[str, float] = {
+        "n_val_rows": float(n_val_rows),
+        "pre_ece": float(pre_metrics["ece"]),
+        "pre_brier": float(pre_metrics["brier"]),
+        "pre_nll": float(pre_metrics["nll"]),
+    }
+    if "temperature" in fit:
+        entry["temperature"] = float(fit["temperature"])
+        entry["post_ece"] = float(fit["post_metrics_T"]["ece"])
+        entry["post_brier_temperature"] = float(fit["post_metrics_T"]["brier"])
+        entry["post_nll_temperature"] = float(fit["post_metrics_T"]["nll"])
+    if "platt_params" in fit:
+        entry["post_ece_platt"] = float(fit["post_metrics_platt"]["ece"])
+        entry["post_brier_platt"] = float(fit["post_metrics_platt"]["brier"])
+        entry["post_nll_platt"] = float(fit["post_metrics_platt"]["nll"])
+    return entry
+
+
+def _build_sidecar(
+    fold_id: str,
+    method: str,
+    n_val_rows: int,
+    n_classes: int,
+    pre_metrics: dict[str, float],
+    fit: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the ``{checkpoint}.calibration.json`` payload."""
+
+    payload: dict[str, Any] = {
+        "fold_id": fold_id,
+        "method": method,
+        "n_val_rows": n_val_rows,
+        "n_classes": n_classes,
+        "pre_metrics": pre_metrics,
+    }
+    if "temperature" in fit:
+        payload["temperature"] = float(fit["temperature"])
+        payload["post_metrics_temperature"] = fit["post_metrics_T"]
+    if "platt_params" in fit:
+        payload["platt_a"] = [float(a) for a, _ in fit["platt_params"]]
+        payload["platt_b"] = [float(b) for _, b in fit["platt_params"]]
+        payload["post_metrics_platt"] = fit["post_metrics_platt"]
+    return payload
+
+
+def _render_fold_diagrams(
+    fold_id: str,
+    fold_dir: Path,
+    pre_curve: Any,
+    pre_metrics: dict[str, float],
+    fit: dict[str, Any],
+) -> None:
+    """Write the uncalibrated + calibrated reliability PNGs for one fold."""
+
+    render_reliability_diagram_png(
+        pre_curve,
+        fold_dir / "reliability_pre.png",
+        title=f"{fold_id} · uncalibrated · ECE={pre_metrics['ece']:.4f}",
+    )
+    if "post_curve_T" in fit:
+        T = fit.get("temperature")
+        ece_post = fit["post_metrics_T"]["ece"]
+        title = (
+            f"{fold_id} · T={float(T):.3f} · ECE={ece_post:.4f}"
+            if T is not None
+            else f"{fold_id} · ECE={ece_post:.4f}"
+        )
+        render_reliability_diagram_png(
+            fit["post_curve_T"], fold_dir / "reliability_post.png", title=title
+        )
+    if "post_curve_platt" in fit:
+        ece_p = fit["post_metrics_platt"]["ece"]
+        render_reliability_diagram_png(
+            fit["post_curve_platt"],
+            fold_dir / "reliability_post_platt.png",
+            title=f"{fold_id} · platt · ECE={ece_p:.4f}",
+        )
+
+
+def _log_fold(fold_id: str, pre_metrics: dict[str, float], fit: dict[str, Any], n_val: int) -> None:
+    """One-line operator log for the fold's calibration result."""
+
+    if "temperature" in fit:
+        T = float(fit["temperature"])
+        direction = "softened" if T > 1.0 else "sharpened"
+        t_msg = f"T={T:.3f} ({direction}); "
+        post_ece = fit["post_metrics_T"]["ece"]
+    elif "post_metrics_platt" in fit:
+        t_msg = ""
+        post_ece = fit["post_metrics_platt"]["ece"]
+    else:
+        t_msg = ""
+        post_ece = pre_metrics["ece"]
+    print(
+        f"[calibrate] {fold_id}: {t_msg}ECE {pre_metrics['ece']:.4f} -> {post_ece:.4f}; "
+        f"n_val={n_val}",
+        flush=True,
+    )
+
+
+def _process_fold(
+    fold_id: str,
+    args: argparse.Namespace,
+    *,
+    model: torch.nn.Module,
+    device: torch.device,
+    close_scale: float,
+    rich_feature_scaler: Any,
+    output_root: Path,
+) -> tuple[dict[str, float], dict[str, Any]] | None:
+    """Run one fold end-to-end. Returns ``(summary_entry, sidecar_payload)``
+    or ``None`` when the fold is skipped (load failure or empty val
+    partition)."""
+
+    try:
+        split = load_walk_forward_split(args.training_package_id, fold_id=fold_id)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"[calibrate] {fold_id}: load failed ({exc}); skipping", flush=True)
+        return None
+
+    val_logits, val_targets = _collect_logits_and_targets(
+        model,
+        split.val,
+        device=device,
+        close_scale=close_scale,
+        rich_feature_scaler=rich_feature_scaler,
+    )
+    if val_logits.numel() == 0:
+        print(f"[calibrate] {fold_id}: empty val partition; skipping", flush=True)
+        return None
+
+    n_classes = int(val_logits.shape[-1])
+    targets_list = val_targets.tolist()
+    pre_probs = torch.softmax(val_logits, dim=-1).tolist()
+    pre_curve = reliability_curve(pre_probs, targets_list, n_bins=10)
+    pre_metrics = _metric_block(pre_probs, targets_list, n_classes=n_classes)
+    n_val = int(val_logits.shape[0])
+
+    fold_dir = output_root / fold_id
+    fold_dir.mkdir(parents=True, exist_ok=True)
+
+    fit = _fit_method(args.method, val_logits, val_targets, targets_list, n_classes)
+    _render_fold_diagrams(fold_id, fold_dir, pre_curve, pre_metrics, fit)
+
+    manifest_payload = _build_manifest(
+        fold_id, args.method, n_val, n_classes, pre_metrics, pre_curve.to_dict(), fit
+    )
+    (fold_dir / "calibration_manifest.json").write_text(
+        json.dumps(manifest_payload, indent=2)
+    )
+
+    summary_entry = _build_summary_entry(n_val, pre_metrics, fit)
+    sidecar_payload = _build_sidecar(
+        fold_id, args.method, n_val, n_classes, pre_metrics, fit
+    )
+    _log_fold(fold_id, pre_metrics, fit, n_val)
+    return summary_entry, sidecar_payload
+
+
+def _calibration_sidecar_path(checkpoint_path: Path) -> Path:
+    """Return the canonical sidecar path next to a checkpoint.
+
+    Mirrors :func:`forecaster._conformal_manifest_for` -- the regime
+    classifier inference path reads ``{stem}.calibration.json`` next to
+    the checkpoint via :func:`with_name`, which works on Python 3.11 and
+    3.12+ alike (``with_suffix`` rejects multi-dot suffixes on 3.11).
+    """
+
+    return checkpoint_path.with_name(checkpoint_path.stem + ".calibration.json")
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--training-package-id", required=True)
@@ -164,6 +441,26 @@ def main(argv: list[str] | None = None) -> int:
         "--output-dir",
         type=Path,
         default=Path("/data/artifacts/calibration"),
+    )
+    p.add_argument(
+        "--method",
+        choices=CALIBRATION_METHODS,
+        default="temperature",
+        help=(
+            "Calibrator to fit: 'temperature' (single scalar; preserves "
+            "argmax), 'platt' (per-class one-vs-rest sigmoid; tighter "
+            "per-class fit), or 'both' (fit both and record both in the "
+            "sidecar; inference path applies temperature -> platt when "
+            "both are present)."
+        ),
+    )
+    p.add_argument(
+        "--no-sidecar",
+        action="store_true",
+        help=(
+            "Skip writing the {checkpoint}.calibration.json sidecar that "
+            "the inference path reads at serving time."
+        ),
     )
     p.add_argument("--device", default=None)
     args = p.parse_args(argv)
@@ -198,80 +495,30 @@ def main(argv: list[str] | None = None) -> int:
         folds_to_run = [args.fold]
 
     per_fold_summary: dict[str, dict[str, float]] = {}
+    last_sidecar_payload: dict[str, Any] | None = None
 
     for fold_id in folds_to_run:
-        try:
-            split = load_walk_forward_split(
-                args.training_package_id,
-                fold_id=fold_id,
-            )
-        except (FileNotFoundError, ValueError) as exc:
-            print(f"[calibrate] {fold_id}: load failed ({exc}); skipping", flush=True)
-            continue
-
-        val_logits, val_targets = _collect_logits_and_targets(
-            model,
-            split.val,
+        result = _process_fold(
+            fold_id,
+            args,
+            model=model,
             device=device,
             close_scale=close_scale,
             rich_feature_scaler=rich_feature_scaler,
+            output_root=output_root,
         )
-        if val_logits.numel() == 0:
-            print(f"[calibrate] {fold_id}: empty val partition; skipping", flush=True)
+        if result is None:
             continue
+        summary_entry, sidecar_payload = result
+        per_fold_summary[fold_id] = summary_entry
+        # All-folds overwrites on each iteration so the sidecar reflects
+        # the chronologically-latest fold; single-fold writes once.
+        last_sidecar_payload = sidecar_payload
 
-        T = fit_temperature(val_logits, val_targets)
-
-        pre_probs = torch.softmax(val_logits, dim=-1).tolist()
-        post_probs = apply_temperature(val_logits, T).tolist()
-        targets_list = val_targets.tolist()
-
-        pre_curve = reliability_curve(pre_probs, targets_list, n_bins=10)
-        post_curve = reliability_curve(post_probs, targets_list, n_bins=10)
-        pre_ece = expected_calibration_error(pre_probs, targets_list)
-        post_ece = expected_calibration_error(post_probs, targets_list)
-
-        fold_dir = output_root / fold_id
-        fold_dir.mkdir(parents=True, exist_ok=True)
-        render_reliability_diagram_png(
-            pre_curve,
-            fold_dir / "reliability_pre.png",
-            title=f"{fold_id} · uncalibrated · ECE={pre_ece:.4f}",
-        )
-        render_reliability_diagram_png(
-            post_curve,
-            fold_dir / "reliability_post.png",
-            title=f"{fold_id} · T={T:.3f} · ECE={post_ece:.4f}",
-        )
-
-        manifest_payload: dict[str, Any] = {
-            "fold_id": fold_id,
-            "temperature": float(T),
-            "n_val_rows": int(val_logits.shape[0]),
-            "pre_ece": float(pre_ece),
-            "post_ece": float(post_ece),
-            "pre_curve": pre_curve.to_dict(),
-            "post_curve": post_curve.to_dict(),
-        }
-        (fold_dir / "calibration_manifest.json").write_text(
-            json.dumps(manifest_payload, indent=2)
-        )
-
-        per_fold_summary[fold_id] = {
-            "temperature": float(T),
-            "pre_ece": float(pre_ece),
-            "post_ece": float(post_ece),
-            "n_val_rows": int(val_logits.shape[0]),
-        }
-
-        improvement = pre_ece - post_ece
-        direction = "softened" if T > 1.0 else "sharpened"
-        print(
-            f"[calibrate] {fold_id}: T={T:.3f} ({direction}); "
-            f"ECE {pre_ece:.4f} -> {post_ece:.4f} (Δ = {improvement:+.4f}); "
-            f"n_val={int(val_logits.shape[0])}",
-            flush=True,
-        )
+    if last_sidecar_payload is not None and not args.no_sidecar:
+        sidecar_path = _calibration_sidecar_path(args.checkpoint_path)
+        sidecar_path.write_text(json.dumps(last_sidecar_payload, indent=2))
+        print(f"[calibrate] sidecar -> {sidecar_path}", flush=True)
 
     summary_path = output_root / "calibration_summary.json"
     summary_path.write_text(json.dumps(per_fold_summary, indent=2))

--- a/tests/unit/test_calibrate_regime_classifier.py
+++ b/tests/unit/test_calibrate_regime_classifier.py
@@ -1,0 +1,279 @@
+"""Unit tests for the regime-classifier post-hoc calibrators.
+
+Covers ``fit_temperature``, ``fit_platt_per_class``, the ECE / Brier /
+NLL math helpers, and the end-to-end NLL-improvement property that the
+calibrator is meant to deliver. The CLI / checkpoint-IO surface of the
+driver script is exercised by the existing
+``test_calibration_temperature`` module and by manual operator runs;
+this file targets the parts the issue scopes as net-new.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.evaluation.calibration_temperature import (  # noqa: E402
+    apply_platt_per_class,
+    apply_temperature,
+    brier_score,
+    expected_calibration_error,
+    fit_platt_per_class,
+    fit_temperature,
+    negative_log_likelihood,
+)
+
+
+# ---------------------------------------------------------------------------
+# fit_temperature
+# ---------------------------------------------------------------------------
+
+
+def test_fit_temperature_overconfident_logits_yields_T_gt_one() -> None:
+    """Known-overconfident fixture: half the rows predict the wrong class
+    with a huge logit gap. Fitter should push T > 1 to soften."""
+
+    torch.manual_seed(29)
+    n = 400
+    targets = torch.randint(0, 3, (n,))
+    logits = torch.full((n, 3), -3.0)
+    for i, t in enumerate(targets):
+        if i % 2 == 0:
+            logits[i, int(t)] = 5.0  # correct, high confidence
+        else:
+            wrong = (int(t) + 1) % 3
+            logits[i, wrong] = 5.0  # wrong, high confidence
+
+    T = fit_temperature(logits, targets)
+    assert T > 1.0, f"overconfident logits should push T > 1; got {T}"
+
+
+# ---------------------------------------------------------------------------
+# fit_platt_per_class
+# ---------------------------------------------------------------------------
+
+
+def test_fit_platt_per_class_returns_one_param_pair_per_class() -> None:
+    torch.manual_seed(11)
+    logits = torch.randn(120, 3)
+    targets = torch.randint(0, 3, (120,))
+    params = fit_platt_per_class(logits, targets, n_classes=3)
+    assert len(params) == 3
+    for a, b in params:
+        assert isinstance(a, float) and isinstance(b, float)
+
+
+def test_fit_platt_per_class_corrects_known_per_class_shift() -> None:
+    """Construct a fixture where class 0 is systematically under-scored:
+    the true class-0 rows carry low softmax mass for class 0 (~0.4) but
+    most are correct. Platt should recover a positive slope ``a`` for
+    class 0 (or at least improve the BCE on the held-out logits)."""
+
+    torch.manual_seed(47)
+    n = 300
+    targets = torch.zeros(n, dtype=torch.long)
+
+    # Build logits where class 0 wins by a slim margin on most rows but
+    # the absolute softmax score for class 0 hovers ~0.4 (underconfident).
+    logits = torch.zeros(n, 3)
+    for i in range(n):
+        logits[i, 0] = 0.6
+        logits[i, 1] = 0.3
+        logits[i, 2] = 0.0
+
+    params = fit_platt_per_class(logits, targets, n_classes=3)
+    a0, b0 = params[0]
+
+    # The class-0 BCE under raw softmax vs Platt: Platt should not be
+    # worse, and on this fixture the slope+offset combo should push
+    # class-0 probabilities up (a*z + b should yield p > z for z near
+    # the cluster mean).
+    z_cluster_mean = torch.softmax(logits[0], dim=-1)[0].item()
+    raw_p = z_cluster_mean
+    platt_p = 1.0 / (1.0 + math.exp(-(a0 * z_cluster_mean + b0)))
+    assert platt_p > raw_p, (
+        f"platt should lift the under-confident class-0 score: "
+        f"raw={raw_p:.3f}, platt={platt_p:.3f}, a0={a0}, b0={b0}"
+    )
+
+
+def test_fit_platt_per_class_handles_empty_input() -> None:
+    params = fit_platt_per_class(
+        torch.empty(0, 3), torch.empty(0, dtype=torch.long), n_classes=3
+    )
+    assert params == [(1.0, 0.0)] * 3
+
+
+def test_fit_platt_per_class_handles_absent_class() -> None:
+    """If a class is never represented in val targets, identity (1, 0)
+    should be returned for that class."""
+
+    torch.manual_seed(71)
+    n = 100
+    targets = torch.zeros(n, dtype=torch.long)  # only class 0 seen
+    logits = torch.randn(n, 3)
+    params = fit_platt_per_class(logits, targets, n_classes=3)
+    # Class 0 has both positive and negative examples? No -- all rows
+    # are class 0, so for class 1 and 2 every target is 0 -> identity.
+    assert params[1] == (1.0, 0.0)
+    assert params[2] == (1.0, 0.0)
+
+
+def test_apply_platt_per_class_yields_distribution() -> None:
+    torch.manual_seed(97)
+    logits = torch.randn(20, 3) * 2
+    params = [(1.5, -0.2), (1.0, 0.0), (0.8, 0.1)]
+    out = apply_platt_per_class(logits, params)
+    assert out.shape == logits.shape
+    row_sums = out.sum(dim=-1)
+    for s in row_sums.tolist():
+        assert abs(s - 1.0) < 1e-6
+
+
+def test_apply_platt_per_class_rejects_param_length_mismatch() -> None:
+    with pytest.raises(ValueError, match="params length"):
+        apply_platt_per_class(torch.randn(5, 3), [(1.0, 0.0), (1.0, 0.0)])
+
+
+# ---------------------------------------------------------------------------
+# ECE hand-computed
+# ---------------------------------------------------------------------------
+
+
+def test_expected_calibration_error_matches_hand_computed_ten_bins() -> None:
+    """Hand-built 10-row, 10-bin case.
+
+    The fixture places one row in each of the top 5 bins (so the
+    argmax-class probability lands in a distinct bin per row); the
+    bottom 5 bins are empty. Half the rows are correct (alternating).
+    Per-bin gap is ``|confidence - accuracy|``; mass-weighted sum is
+    the ECE.
+
+    Constraint: the max-prob row form ``[c, (1 - c) / 2, (1 - c) / 2]``
+    keeps class 0 as argmax only when ``c > (1 - c) / 2`` i.e.
+    ``c > 1/3``; that is why the fixture only populates the top half.
+    """
+
+    midpoints = [0.55, 0.65, 0.75, 0.85, 0.95]
+    probs = [[c, (1.0 - c) / 2, (1.0 - c) / 2] for c in midpoints]
+    targets = [0, 1, 0, 1, 0]  # alternating correct (class 0) / wrong (class 1)
+    n_rows = len(probs)
+
+    expected = sum(
+        (1 / n_rows) * abs(c - (1.0 if t == 0 else 0.0))
+        for c, t in zip(midpoints, targets)
+    )
+    actual = expected_calibration_error(probs, targets, n_bins=10)
+    assert actual == pytest.approx(expected, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Brier
+# ---------------------------------------------------------------------------
+
+
+def test_brier_score_perfect_prediction_is_zero() -> None:
+    probs = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    targets = [0, 1, 2]
+    assert brier_score(probs, targets, n_classes=3) == pytest.approx(0.0)
+
+
+def test_brier_score_matches_manual_computation() -> None:
+    # Row 0: target=0, ||p - [1,0,0]||^2 = (0.2)^2 + (0.5)^2 + (0.3)^2 = 0.38
+    # Row 1: target=1, ||p - [0,1,0]||^2 = (0.6)^2 + (0.7)^2 + (0.3)^2 = 0.94
+    probs = [[0.8, 0.5, 0.3], [0.6, 0.3, 0.3]]
+    targets = [0, 1]
+    expected = (0.38 + 0.94) / 2
+    assert brier_score(probs, targets, n_classes=3) == pytest.approx(expected, abs=1e-9)
+
+
+def test_brier_score_rejects_length_mismatch() -> None:
+    with pytest.raises(ValueError, match="same length"):
+        brier_score([[1.0, 0.0, 0.0]], [0, 1])
+
+
+def test_brier_score_rejects_row_width_mismatch() -> None:
+    with pytest.raises(ValueError, match="row width"):
+        brier_score([[1.0, 0.0]], [0], n_classes=3)
+
+
+# ---------------------------------------------------------------------------
+# NLL helper
+# ---------------------------------------------------------------------------
+
+
+def test_negative_log_likelihood_matches_manual() -> None:
+    probs = [[0.8, 0.1, 0.1], [0.3, 0.6, 0.1]]
+    targets = [0, 1]
+    expected = (-math.log(0.8) + -math.log(0.6)) / 2
+    assert negative_log_likelihood(probs, targets) == pytest.approx(expected, abs=1e-9)
+
+
+def test_negative_log_likelihood_floors_zero_probability() -> None:
+    probs = [[0.0, 1.0, 0.0]]
+    targets = [0]
+    # Floored at eps=1e-12 -> log(1e-12) ~ -27.6
+    assert negative_log_likelihood(probs, targets) > 20.0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: synthetic overconfident logits -> NLL drops after fit
+# ---------------------------------------------------------------------------
+
+
+def test_temperature_fit_reduces_nll_on_overconfident_synthetic() -> None:
+    """End-to-end property: on a known-overconfident synthetic fixture
+    the fitted T should produce strictly lower NLL than the raw
+    softmax."""
+
+    torch.manual_seed(11)
+    n = 500
+    targets = torch.randint(0, 3, (n,))
+    logits = torch.full((n, 3), -3.0)
+    for i, t in enumerate(targets):
+        if i % 2 == 0:
+            logits[i, int(t)] = 5.0
+        else:
+            wrong = (int(t) + 1) % 3
+            logits[i, wrong] = 5.0
+
+    pre_probs = torch.softmax(logits, dim=-1).tolist()
+    pre_nll = negative_log_likelihood(pre_probs, targets.tolist())
+
+    T = fit_temperature(logits, targets)
+    post_probs = apply_temperature(logits, T).tolist()
+    post_nll = negative_log_likelihood(post_probs, targets.tolist())
+
+    assert post_nll < pre_nll, (
+        f"temperature fit should lower NLL; pre={pre_nll:.4f}, post={post_nll:.4f}, T={T:.3f}"
+    )
+
+
+def test_platt_fit_does_not_worsen_brier_on_overconfident_synthetic() -> None:
+    """Companion property for Platt: on the same overconfident fixture,
+    Platt should not regress the Brier score relative to raw softmax."""
+
+    torch.manual_seed(11)
+    n = 500
+    targets = torch.randint(0, 3, (n,))
+    logits = torch.full((n, 3), -3.0)
+    for i, t in enumerate(targets):
+        if i % 2 == 0:
+            logits[i, int(t)] = 5.0
+        else:
+            wrong = (int(t) + 1) % 3
+            logits[i, wrong] = 5.0
+
+    pre_probs = torch.softmax(logits, dim=-1).tolist()
+    pre_brier = brier_score(pre_probs, targets.tolist(), n_classes=3)
+
+    params = fit_platt_per_class(logits, targets, n_classes=3)
+    post_probs = apply_platt_per_class(logits, params).tolist()
+    post_brier = brier_score(post_probs, targets.tolist(), n_classes=3)
+
+    assert post_brier <= pre_brier + 1e-6, (
+        f"platt fit should not regress brier; pre={pre_brier:.4f}, post={post_brier:.4f}"
+    )


### PR DESCRIPTION
## Summary
- `fit_platt_per_class` + `apply_platt_per_class` + `brier_score` + `negative_log_likelihood` added alongside the existing temperature-scaling helpers.
- `scripts/calibrate_regime_classifier.py` extended with `--method {temperature, platt, both}`; writes `{checkpoint}.calibration.json` sidecar with per-fold NLL / Brier / ECE before & after.
- `app/services/forecaster.py` reads the sidecar at serving time and composes `temperature → per-class Platt → renormalise` before conformal set construction.
- Default (no sidecar present) is byte-identical to today; calibration tightens conformal sets without changing argmax / macro-F1 ranking.

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit/test_calibrate_regime_classifier.py -q`
- [ ] CI green