### PR TITLE
sequence_length: thread through tensor builders + re-add runner flag (#476)

### DIFF
--- a/backend/app/train_forecaster.py
+++ b/backend/app/train_forecaster.py
@@ -1361,7 +1361,15 @@ def _build_model_config(args: argparse.Namespace) -> ModelConfig:
         output_mode=output_mode,
         n_classes=n_classes,
         lr_schedule=str(getattr(args, "lr_schedule", "plateau") or "plateau"),
-        sequence_length=int(getattr(args, "sequence_length", 0) or 0),
+        # Persist the resolved length (post 0-sentinel coercion) so the
+        # run-summary value matches what actually trained and stays
+        # comparable across runners. ``run_dual_head_comparison`` stores
+        # the resolved int the same way.
+        sequence_length=(
+            int(getattr(args, "sequence_length", 0))
+            if int(getattr(args, "sequence_length", 0) or 0) > 0
+            else SEQUENCE_LENGTH
+        ),
         use_time_decay=bool(getattr(args, "use_time_decay", True)),
         encoder_lora=bool(getattr(args, "encoder_lora", False)),
         lora_curriculum_freeze_epoch=getattr(args, "lora_freeze_epoch", None),
@@ -2735,6 +2743,12 @@ def main() -> int:
 
     package_sequences: list[list[FeatureVector]] | None = None
     walk_forward_splits: dict[str, WalkForwardSplit] | None = None
+    # ``args.sequence_length=0`` is the "fall back to the module default"
+    # sentinel; resolve it once so the package + legacy branches and the
+    # window-count arithmetic in either branch see the same int.
+    resolved_sequence_length = (
+        int(args.sequence_length) if int(args.sequence_length) > 0 else SEQUENCE_LENGTH
+    )
     if use_package_path:
         print(f"Training-package id: {args.training_package_id}")
         print(f"Target mode: {args.target_mode}")
@@ -2810,6 +2824,7 @@ def main() -> int:
                         text_pool_lambda_inv_days=float(args.text_pool_lambda_inv_days),
                         use_text_embeddings=bool(args.use_text_embeddings),
                         embargo_days=int(args.embargo_days),
+                        sequence_length=resolved_sequence_length,
                     )
                     if multi_encoder_mode_main:
                         # Key by (encoder, fold) so the sweep can route
@@ -2834,7 +2849,7 @@ def main() -> int:
                 for s in walk_forward_splits.values()
             )
             window_count = sum(
-                sum(max(0, len(seq) - SEQUENCE_LENGTH) for seq in (s.train + s.val + s.test))
+                sum(max(0, len(seq) - resolved_sequence_length) for seq in (s.train + s.val + s.test))
                 for s in walk_forward_splits.values()
             )
         else:
@@ -2864,6 +2879,7 @@ def main() -> int:
                     # Single-fold uses split_tag, not manifest dates -- embargo
                     # passes through but the loader will no-op on this path.
                     embargo_days=int(args.embargo_days),
+                    sequence_length=resolved_sequence_length,
                 )
                 if multi_encoder_mode_main:
                     walk_forward_splits[(encoder_arg, "_single_fold")] = split
@@ -2884,7 +2900,7 @@ def main() -> int:
                 len(seq) for seq in (example_split.train + example_split.val + example_split.test)
             )
             window_count = sum(
-                max(0, len(seq) - SEQUENCE_LENGTH)
+                max(0, len(seq) - resolved_sequence_length)
                 for seq in (example_split.train + example_split.val + example_split.test)
             )
         print(f"Device: {device}")
@@ -2903,10 +2919,14 @@ def main() -> int:
             )
             return 1
     else:
-        sequences, summaries = inspect_training_data_sources(data_dir)
+        sequences, summaries = inspect_training_data_sources(
+            data_dir, sequence_length=resolved_sequence_length
+        )
         sequence_count = len(sequences)
         observation_count = sum(len(sequence) for sequence in sequences)
-        window_count = sum(max(0, len(sequence) - SEQUENCE_LENGTH) for sequence in sequences)
+        window_count = sum(
+            max(0, len(sequence) - resolved_sequence_length) for sequence in sequences
+        )
 
         _print_data_inventory(
             data_dir,

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -310,6 +310,8 @@ def _load_record_groups(path: Path) -> tuple[list[list[dict[str, Any]]], str]:
 
 def inspect_training_data_sources(
     data_dir: str | Path | None = None,
+    *,
+    sequence_length: int = SEQUENCE_LENGTH,
 ) -> tuple[list[list[FeatureVector]], list[TrainingDataSourceSummary]]:
     root = Path(data_dir) if data_dir is not None else DEFAULT_DATA_DIR
     if not root.exists():
@@ -340,7 +342,7 @@ def inspect_training_data_sources(
 
             record_count = sum(len(group) for group in groups)
             vectors_for_path = [build_feature_vectors(group) for group in groups]
-            usable = [vector_group for vector_group in vectors_for_path if len(vector_group) >= SEQUENCE_LENGTH + 1]
+            usable = [vector_group for vector_group in vectors_for_path if len(vector_group) >= sequence_length + 1]
             sequences.extend(usable)
             summaries.append(
                 TrainingDataSourceSummary(
@@ -504,8 +506,10 @@ def _append_event_day_target(
 
     The Phase 8 ``events.parquet`` carries 20 trading-day prior bars but
     no event-day bar; the downstream training-tensor builder needs a
-    ``SEQUENCE_LENGTH + 1`` row to compute one supervised (window,
-    target) pair per event.
+    ``sequence_length + 1`` row to compute one supervised (window,
+    target) pair per event. The default ``sequence_length`` is the
+    module-level ``SEQUENCE_LENGTH=20`` but the loader threads the
+    chosen value through end-to-end (#476).
 
     Two derivations are supported via ``target_mode``:
 
@@ -2533,6 +2537,7 @@ def load_training_sequences_from_package(
     use_text_embeddings: bool = True,
     text_embedding_cache_dir: Path | str | None = None,
     vol_target_horizon: int = DEFAULT_VOL_TARGET_HORIZON,
+    sequence_length: int = SEQUENCE_LENGTH,
 ) -> list[list[FeatureVector]]:
     """Load one prior-window sequence per FOMC event in a training package.
 
@@ -2834,7 +2839,7 @@ def load_training_sequences_from_package(
         except ValueError:
             continue
         bars = _parse_prior_bars(row.get("prior_bars_json"))
-        if len(bars) < SEQUENCE_LENGTH:
+        if len(bars) < sequence_length:
             continue
         row_text_hash = str(row.get("text_hash", ""))
         sentiment_score = _stance_to_sentiment(row.get("axis_stance"))
@@ -2843,7 +2848,7 @@ def load_training_sequences_from_package(
             event_date=event_date,
             sentiment_score=sentiment_score,
         )
-        if len(vectors) < SEQUENCE_LENGTH:
+        if len(vectors) < sequence_length:
             continue
         realized_return = _coerce_finite_float(row.get("realized_return"))
         abnormal_return = _coerce_finite_float(row.get("abnormal_return"))
@@ -3297,22 +3302,25 @@ def vol_regime_class_for(value: float | None, quantiles: Sequence[float]) -> int
 
 def collect_forward_vols(
     sequence_groups: Sequence[Sequence[FeatureVector]],
+    *,
+    sequence_length: int = SEQUENCE_LENGTH,
 ) -> list[float]:
     """Pull the forward-vol target off every supervised target row.
 
-    A "target" row is the bar at index ``SEQUENCE_LENGTH`` in a sequence
+    A "target" row is the bar at index ``sequence_length`` in a sequence
     group (the event-day bar appended by ``_append_event_day_target``).
     Non-target bars are skipped because their ``forward_realized_vol_10d``
     is irrelevant to the y axis. Rows whose target column is null /
     NaN are dropped so the caller (per-fold quantile fit) only sees
-    valid floats.
+    valid floats. ``sequence_length`` defaults to ``SEQUENCE_LENGTH`` so
+    pre-existing callers keep their byte-identical row counts.
     """
 
     out: list[float] = []
     for sequence_group in sequence_groups:
-        if len(sequence_group) < SEQUENCE_LENGTH + 1:
+        if len(sequence_group) < sequence_length + 1:
             continue
-        for idx in range(SEQUENCE_LENGTH, len(sequence_group)):
+        for idx in range(sequence_length, len(sequence_group)):
             value = getattr(sequence_group[idx], "forward_realized_vol_10d", None)
             if value is None:
                 continue
@@ -3322,7 +3330,11 @@ def collect_forward_vols(
     return out
 
 
-def fit_close_scale(sequence_groups: Sequence[Sequence[FeatureVector]]) -> float:
+def fit_close_scale(
+    sequence_groups: Sequence[Sequence[FeatureVector]],
+    *,
+    sequence_length: int = SEQUENCE_LENGTH,
+) -> float:
     """Compute the per-fold close-price normaliser from the training rows.
 
     The forecaster normalises the close target by dividing by a positive
@@ -3346,9 +3358,9 @@ def fit_close_scale(sequence_groups: Sequence[Sequence[FeatureVector]]) -> float
 
     target_closes: list[float] = []
     for group in sequence_groups:
-        if len(group) < SEQUENCE_LENGTH + 1:
+        if len(group) < sequence_length + 1:
             continue
-        for idx in range(SEQUENCE_LENGTH, len(group)):
+        for idx in range(sequence_length, len(group)):
             target = group[idx]
             value = float(target.market_close)
             if value > 0.0:
@@ -3364,6 +3376,7 @@ def _build_training_tensors(
     *,
     output_mode: str = "regression",
     vol_regime_quantiles: Sequence[float] = (),
+    sequence_length: int = SEQUENCE_LENGTH,
 ) -> tuple[torch.Tensor | None, torch.Tensor | None, float]:
     """Materialise the (x, y, close_scale) triple for the training path.
 
@@ -3385,7 +3398,11 @@ def _build_training_tensors(
     ``FeatureVector`` constructed without the rich-feature loader).
     """
 
-    fitted_scale = float(close_scale) if close_scale is not None else fit_close_scale(sequence_groups)
+    fitted_scale = (
+        float(close_scale)
+        if close_scale is not None
+        else fit_close_scale(sequence_groups, sequence_length=sequence_length)
+    )
 
     use_rich = False
     for sequence_group in sequence_groups:
@@ -3402,10 +3419,10 @@ def _build_training_tensors(
     is_classification = output_mode == "classification"
 
     for sequence_group in sequence_groups:
-        if len(sequence_group) < SEQUENCE_LENGTH + 1:
+        if len(sequence_group) < sequence_length + 1:
             continue
-        for idx in range(SEQUENCE_LENGTH, len(sequence_group)):
-            window = sequence_group[idx - SEQUENCE_LENGTH : idx]
+        for idx in range(sequence_length, len(sequence_group)):
+            window = sequence_group[idx - sequence_length : idx]
             target = sequence_group[idx]
             if is_classification:
                 cls_idx = vol_regime_class_for(
@@ -3447,6 +3464,7 @@ def _build_multi_task_target_tensors(
     sequence_groups: Sequence[Sequence[FeatureVector]],
     *,
     vol_regime_quantiles: Sequence[float],
+    sequence_length: int = SEQUENCE_LENGTH,
 ) -> dict[str, torch.Tensor] | None:
     """Materialise per-axis targets aligned with ``_build_training_tensors``.
 
@@ -3470,9 +3488,9 @@ def _build_multi_task_target_tensors(
     certainty_masks: list[bool] = []
 
     for sequence_group in sequence_groups:
-        if len(sequence_group) < SEQUENCE_LENGTH + 1:
+        if len(sequence_group) < sequence_length + 1:
             continue
-        for idx in range(SEQUENCE_LENGTH, len(sequence_group)):
+        for idx in range(sequence_length, len(sequence_group)):
             target_row = sequence_group[idx]
             cls_idx = vol_regime_class_for(
                 getattr(target_row, "forward_realized_vol_10d", None),
@@ -3513,12 +3531,13 @@ def _build_text_embedding_tensors(
     sequence_groups: Sequence[Sequence[FeatureVector]],
     *,
     fallback_in_dim: int = 0,
+    sequence_length: int = SEQUENCE_LENGTH,
 ) -> tuple[torch.Tensor | None, torch.Tensor | None, int]:
     """Materialise the (pooled, missing_flag, in_dim) triple per training window.
 
     For each window the per-event pooled embedding lives on every
     ``FeatureVector`` in the group; the helper reads the embedding
-    off the LAST prior bar (index ``SEQUENCE_LENGTH - 1``) so the
+    off the LAST prior bar (index ``sequence_length - 1``) so the
     chosen vector matches the supervised window the trainer sees.
     Missing rows materialise a zero ``in_dim``-vector + a ``1.0``
     missing flag so the model's adapter projects the same zero slot
@@ -3556,9 +3575,9 @@ def _build_text_embedding_tensors(
     pooled_rows: list[list[float]] = []
     missing_rows: list[list[float]] = []
     for sequence_group in sequence_groups:
-        if len(sequence_group) < SEQUENCE_LENGTH + 1:
+        if len(sequence_group) < sequence_length + 1:
             continue
-        for idx in range(SEQUENCE_LENGTH, len(sequence_group)):
+        for idx in range(sequence_length, len(sequence_group)):
             anchor = sequence_group[idx - 1]
             pooled_payload = list(getattr(anchor, "text_embedding_pooled", []) or [])
             missing_flag = float(getattr(anchor, "text_embedding_missing", 1.0))

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -1307,6 +1307,7 @@ def _build_partition_multi_task_tensors(
     sequence_groups: "Sequence[Sequence[FeatureVector]]",
     *,
     vol_regime_quantiles: "Sequence[float]",
+    sequence_length: int = SEQUENCE_LENGTH,
 ) -> dict[str, torch.Tensor] | None:
     """Materialise per-partition multi-task target + mask tensors (#273).
 
@@ -1327,7 +1328,9 @@ def _build_partition_multi_task_tensors(
     from app.training.loaders import _build_multi_task_target_tensors
 
     return _build_multi_task_target_tensors(
-        sequence_groups, vol_regime_quantiles=vol_regime_quantiles
+        sequence_groups,
+        vol_regime_quantiles=vol_regime_quantiles,
+        sequence_length=sequence_length,
     )
 
 
@@ -1711,6 +1714,7 @@ def _build_partition_log_rv_target(
     vol_regime_quantiles: "Sequence[float]",
     log_rv_scaler: "tuple[float, float] | None" = None,
     vol_target_mode: str = DEFAULT_VOL_TARGET_MODE,
+    sequence_length: int = SEQUENCE_LENGTH,
 ) -> tuple[torch.Tensor | None, "tuple[float, float] | None"]:
     """Materialise per-partition log(forward_realized_vol_10d) targets (#304).
 
@@ -1764,23 +1768,23 @@ def _build_partition_log_rv_target(
     rejected_non_finite = 0
     residual_fallback_count = 0
     for sequence_group in sequence_groups:
-        if len(sequence_group) < SEQUENCE_LENGTH + 1:
+        if len(sequence_group) < sequence_length + 1:
             continue
         # Group-level pre-filter mirrors ``_build_partition_tensors`` so
         # the row counts agree. The classification branch in
         # ``_build_partition_tensors`` drops a whole group when its
-        # leading target (idx == SEQUENCE_LENGTH) has a null
+        # leading target (idx == sequence_length) has a null
         # forward_realized_vol_10d; iterating per-row without that
         # group-level gate would emit log_rv values for downstream
         # rows whose x / y counterparts were dropped, breaking the
         # TensorDataset row-count invariant.
-        leading_target = sequence_group[SEQUENCE_LENGTH]
+        leading_target = sequence_group[sequence_length]
         leading_vol = getattr(leading_target, "forward_realized_vol_10d", None)
         if leading_vol is None or (
             isinstance(leading_vol, float) and leading_vol != leading_vol
         ):
             continue
-        for idx in range(SEQUENCE_LENGTH, len(sequence_group)):
+        for idx in range(sequence_length, len(sequence_group)):
             target_row = sequence_group[idx]
             cls_idx = vol_regime_class_for(
                 getattr(target_row, "forward_realized_vol_10d", None),
@@ -2363,6 +2367,7 @@ def _build_partition_tensors(
     vol_regime_quantiles: Sequence[float] = (),
     lora_bundle: Any = None,
     lora_max_tokens: int = 0,
+    sequence_length: int = SEQUENCE_LENGTH,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -2407,10 +2412,10 @@ def _build_partition_tensors(
         # row-aligned tensors.
         filtered: list[list[FeatureVector]] = []
         for group in sequence_groups:
-            if len(group) < SEQUENCE_LENGTH + 1:
+            if len(group) < sequence_length + 1:
                 continue
             target_value = getattr(
-                group[SEQUENCE_LENGTH], "forward_realized_vol_10d", None
+                group[sequence_length], "forward_realized_vol_10d", None
             )
             if target_value is None:
                 continue
@@ -2426,6 +2431,7 @@ def _build_partition_tensors(
         close_scale=close_scale,
         output_mode=output_mode,
         vol_regime_quantiles=vol_regime_quantiles,
+        sequence_length=sequence_length,
     )
     if x is None or y is None:
         # ``_build_training_tensors`` returns None tensors only when the
@@ -2454,7 +2460,9 @@ def _build_partition_tensors(
         )
         return x, y, scale, input_ids, attention_mask
     text_emb, text_missing, _ = _build_text_embedding_tensors(
-        active_groups, fallback_in_dim=fallback_text_in_dim
+        active_groups,
+        fallback_in_dim=fallback_text_in_dim,
+        sequence_length=sequence_length,
     )
     return x, y, scale, text_emb, text_missing
 
@@ -2606,6 +2614,11 @@ def train_model(
     test_rates_targets: RatesPartitionTensors | None = None
     rates_scalers: dict[str, Any] = {}
     rates_edges: dict[str, Any] = {}
+    # ``ModelConfig.sequence_length=0`` means "use module default" so
+    # checkpoints saved before #530 keep the byte-identical 20-bar window.
+    active_sequence_length = int(
+        getattr(active_model_config, "sequence_length", 0) or 0
+    ) or SEQUENCE_LENGTH
 
     if walk_forward_path:
         train_groups: list[list[FeatureVector]] = [list(group) for group in train_sequence_groups or []]
@@ -2623,7 +2636,9 @@ def train_model(
         )
         if active_output_mode == "classification":
             n_classes_active = int(getattr(active_model_config, "n_classes", 3) or 3)
-            train_forward_vols = collect_forward_vols(train_groups)
+            train_forward_vols = collect_forward_vols(
+                train_groups, sequence_length=active_sequence_length
+            )
             fitted_quantiles = fit_vol_regime_quantiles(
                 train_forward_vols, n_classes=n_classes_active
             )
@@ -2702,6 +2717,7 @@ def train_model(
             output_mode=active_output_mode,
             vol_regime_quantiles=fitted_quantiles,
             lora_bundle=encoder_lora_bundle,
+            sequence_length=active_sequence_length,
         )
         # Multi-task aux tensors (#273) — sibling call so the partition
         # tensorisation contract on _build_partition_tensors stays a
@@ -2711,13 +2727,16 @@ def train_model(
         # mode, so the row order aligns with train_x / train_y.
         if multi_task_loss_active:
             train_mt_aux = _build_partition_multi_task_tensors(
-                train_groups, vol_regime_quantiles=fitted_quantiles
+                train_groups,
+                vol_regime_quantiles=fitted_quantiles,
+                sequence_length=active_sequence_length,
             )
         if dual_head_active and active_output_mode == "classification":
             train_log_rv, log_rv_scaler = _build_partition_log_rv_target(
                 train_groups,
                 vol_regime_quantiles=fitted_quantiles,
                 vol_target_mode=active_vol_target_mode,
+                sequence_length=active_sequence_length,
             )
         # #292 rates heads -- per-partition targets fitted on train.
         if rates_heads_active and active_output_mode == "classification":
@@ -2769,10 +2788,13 @@ def train_model(
             output_mode=active_output_mode,
             vol_regime_quantiles=fitted_quantiles,
             lora_bundle=encoder_lora_bundle,
+            sequence_length=active_sequence_length,
         )
         if multi_task_loss_active:
             val_mt_aux = _build_partition_multi_task_tensors(
-                val_groups, vol_regime_quantiles=fitted_quantiles
+                val_groups,
+                vol_regime_quantiles=fitted_quantiles,
+                sequence_length=active_sequence_length,
             )
         if dual_head_active and active_output_mode == "classification":
             val_log_rv, _ = _build_partition_log_rv_target(
@@ -2780,6 +2802,7 @@ def train_model(
                 vol_regime_quantiles=fitted_quantiles,
                 log_rv_scaler=log_rv_scaler,
                 vol_target_mode=active_vol_target_mode,
+                sequence_length=active_sequence_length,
             )
         if rates_heads_active and active_output_mode == "classification":
             from app.training.rates_targets import build_partition_rates_targets
@@ -2819,10 +2842,13 @@ def train_model(
             output_mode=active_output_mode,
             vol_regime_quantiles=fitted_quantiles,
             lora_bundle=encoder_lora_bundle,
+            sequence_length=active_sequence_length,
         )
         if multi_task_loss_active:
             test_mt_aux = _build_partition_multi_task_tensors(
-                test_groups, vol_regime_quantiles=fitted_quantiles
+                test_groups,
+                vol_regime_quantiles=fitted_quantiles,
+                sequence_length=active_sequence_length,
             )
         if dual_head_active and active_output_mode == "classification":
             test_log_rv, _ = _build_partition_log_rv_target(
@@ -2830,6 +2856,7 @@ def train_model(
                 vol_regime_quantiles=fitted_quantiles,
                 log_rv_scaler=log_rv_scaler,
                 vol_target_mode=active_vol_target_mode,
+                sequence_length=active_sequence_length,
             )
         if rates_heads_active and active_output_mode == "classification":
             from app.training.rates_targets import build_partition_rates_targets
@@ -2907,7 +2934,9 @@ def train_model(
         legacy_fitted_quantiles: tuple[float, ...] = ()
         if active_output_mode == "classification":
             n_classes_active = int(getattr(active_model_config, "n_classes", 3) or 3)
-            legacy_forward_vols = collect_forward_vols(active_sequence_groups)
+            legacy_forward_vols = collect_forward_vols(
+                active_sequence_groups, sequence_length=active_sequence_length
+            )
             legacy_fitted_quantiles = fit_vol_regime_quantiles(
                 legacy_forward_vols, n_classes=n_classes_active
             )
@@ -2925,6 +2954,7 @@ def train_model(
             active_sequence_groups,
             output_mode=active_output_mode,
             vol_regime_quantiles=legacy_fitted_quantiles,
+            sequence_length=active_sequence_length,
         )
         # #304 dual-head on the legacy path. Build the log_rv target
         # tensor over the full active_sequence_groups list, then split
@@ -2935,10 +2965,12 @@ def train_model(
                 active_sequence_groups,
                 vol_regime_quantiles=legacy_fitted_quantiles,
                 vol_target_mode=active_vol_target_mode,
+                sequence_length=active_sequence_length,
             )
         text_emb_tensor, text_missing_tensor, _text_emb_dim = _build_text_embedding_tensors(
             active_sequence_groups,
             fallback_in_dim=fallback_text_in_dim,
+            sequence_length=active_sequence_length,
         )
         if x is None or y is None:
             model = (

--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -153,6 +153,23 @@ def _parse_args() -> argparse.Namespace:
             "parquet (populated by the multi-horizon data builder)."
         ),
     )
+    # Prior-bar window length. Default matches the canonical 20-bar
+    # window so the pre-existing sweep stays byte-identical; override
+    # for the longer-window arm (e.g. 60) against a TP whose
+    # ``prior_bars_json`` carries the matching wider window.
+    from app.models.config import SEQUENCE_LENGTH
+
+    parser.add_argument(
+        "--sequence-length",
+        type=int,
+        default=SEQUENCE_LENGTH,
+        help=(
+            "Prior-bar window length per supervised event. Default "
+            f"{SEQUENCE_LENGTH} matches the canonical lookback. Override "
+            "against a TP whose prior_bars_json carries the matching "
+            "wider window (e.g. 60)."
+        ),
+    )
     # #306 retrieval-augmented input features. Off by default so the
     # canonical sweep stays byte-identical.
     parser.add_argument(
@@ -359,6 +376,7 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
     rates_target_mode: str = "raw",
     vol_target_mode: str = "raw",
     vol_target_horizon: int = 10,
+    sequence_length: int | None = None,
     use_retrieval_analogs: bool = False,
     use_regime_conditioning: bool = False,
     use_statement_delta: bool = False,
@@ -368,10 +386,11 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
 ) -> dict[str, Any]:
     # Imports happen here so the script is importable without a torch
     # install (useful for doc-only environments).
-    from app.models.config import RICH_FEATURE_SIZE, ModelConfig
+    from app.models.config import RICH_FEATURE_SIZE, SEQUENCE_LENGTH, ModelConfig
     from app.training.loaders import load_walk_forward_split
     from app.training.loop import train_model
 
+    active_sequence_length = int(sequence_length) if sequence_length else SEQUENCE_LENGTH
     rates_heads = _resolve_auto_rates_heads(rates_target_mode, rates_heads=None)
     config = ModelConfig(
         input_size=RICH_FEATURE_SIZE,
@@ -384,6 +403,7 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
         rates_target_mode=rates_target_mode,
         vol_target_mode=vol_target_mode,
         vol_target_horizon=vol_target_horizon,
+        sequence_length=active_sequence_length,
         use_regime_conditioning=use_regime_conditioning,
         use_press_conf=use_press_conf,
         use_statement_delta=use_statement_delta,
@@ -403,6 +423,7 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
             use_vote_features=use_vote_features,
             use_press_conf=use_press_conf,
             vol_target_horizon=vol_target_horizon,
+            sequence_length=active_sequence_length,
         )
         result = train_model(
             model_config=config,
@@ -465,6 +486,7 @@ def main() -> int:
                     rates_target_mode=str(args.rates_target_mode),
                     vol_target_mode=str(args.vol_target_mode),
                     vol_target_horizon=int(args.target_horizon),
+                    sequence_length=int(args.sequence_length),
                     use_retrieval_analogs=bool(args.use_retrieval_analogs),
                     use_regime_conditioning=bool(args.use_regime_conditioning),
                     use_statement_delta=bool(args.use_statement_delta),
@@ -505,6 +527,7 @@ def main() -> int:
         ),
         "vol_target_mode": str(args.vol_target_mode),
         "vol_target_horizon": int(args.target_horizon),
+        "sequence_length": int(args.sequence_length),
         "use_retrieval_analogs": bool(args.use_retrieval_analogs),
         "use_regime_conditioning": bool(args.use_regime_conditioning),
         "use_statement_delta": bool(args.use_statement_delta),

--- a/tests/unit/test_loaders_sequence_length.py
+++ b/tests/unit/test_loaders_sequence_length.py
@@ -254,3 +254,55 @@ def test_sequence_length_60_against_20bar_tp_drops_every_event(
             text_encoder=None,
             sequence_length=60,
         )
+
+
+def test_build_training_tensors_emits_60bar_timestep_dim(package_60bar: Path) -> None:
+    """``_build_training_tensors(..., sequence_length=60)`` -> ``x.shape[1] == 60``.
+
+    Loader-side plumbing is necessary but not sufficient: the tensor
+    builder slices its own window off the sequence groups, so the
+    timestep dim of the x tensor must also pick up the override.
+    """
+
+    import torch
+
+    split = loaders.load_walk_forward_split(
+        _TRAINING_PACKAGE_ID_60,
+        rich_features=False,
+        text_encoder=None,
+        sequence_length=60,
+    )
+    x, y, _scale = loaders._build_training_tensors(
+        split.train, sequence_length=60
+    )
+    assert isinstance(x, torch.Tensor)
+    assert isinstance(y, torch.Tensor)
+    # Window count = sum(max(0, len(group) - sequence_length)) over groups;
+    # the 60-bar fixture emits one (sequence_length + 1)-row group per
+    # split partition so the per-group window count is exactly 1, and the
+    # batch dim must be `len(split.train) * 1`. The explicit product
+    # locks the multi-window contract in case a future fixture variant
+    # widens the per-group row count.
+    expected_windows = sum(
+        max(0, len(group) - 60) for group in split.train
+    )
+    assert x.shape[0] == expected_windows
+    assert x.shape[1] == 60
+    assert x.shape[0] == y.shape[0]
+
+
+def test_build_training_tensors_default_matches_module_constant(
+    package_20bar: Path,
+) -> None:
+    """Default kwarg drops to ``SEQUENCE_LENGTH`` -> ``x.shape[1] == 20``."""
+
+    import torch
+
+    split = loaders.load_walk_forward_split(
+        _TRAINING_PACKAGE_ID_20,
+        rich_features=False,
+        text_encoder=None,
+    )
+    x, _y, _scale = loaders._build_training_tensors(split.train)
+    assert isinstance(x, torch.Tensor)
+    assert x.shape[1] == SEQUENCE_LENGTH

--- a/tests/unit/test_run_dual_head_comparison.py
+++ b/tests/unit/test_run_dual_head_comparison.py
@@ -31,6 +31,7 @@ import pytest
 def test_dual_head_runner_exposes_new_flags(monkeypatch):
     """The three new flags ship on the canonical sweep runner."""
 
+    from app.models.config import SEQUENCE_LENGTH
     from scripts.run_dual_head_comparison import _parse_args
 
     monkeypatch.setattr(
@@ -46,6 +47,7 @@ def test_dual_head_runner_exposes_new_flags(monkeypatch):
     assert args.rates_target_mode == "raw"
     assert args.vol_target_mode == "raw"
     assert args.target_horizon == 10
+    assert args.sequence_length == SEQUENCE_LENGTH
     assert args.use_retrieval_analogs is False
     assert args.use_regime_conditioning is False
     assert args.use_statement_delta is False
@@ -69,6 +71,8 @@ def test_dual_head_runner_accepts_opt_in_flags(monkeypatch):
             "garch_residual",
             "--target-horizon",
             "5",
+            "--sequence-length",
+            "60",
             "--use-retrieval-analogs",
             "--use-regime-conditioning",
             "--use-statement-delta",
@@ -80,6 +84,7 @@ def test_dual_head_runner_accepts_opt_in_flags(monkeypatch):
     assert args.rates_target_mode == "fomc_attributable"
     assert args.vol_target_mode == "garch_residual"
     assert args.target_horizon == 5
+    assert args.sequence_length == 60
     assert args.use_retrieval_analogs is True
     assert args.use_regime_conditioning is True
     assert args.use_statement_delta is True
@@ -246,6 +251,7 @@ def test_dual_head_runner_default_off_byte_identity(monkeypatch):
     """Default invocation matches the pre-PR canonical loader kwargs."""
 
     pytest.importorskip("torch", reason="train_model import path needs torch")
+    from app.models.config import SEQUENCE_LENGTH
     from scripts import run_dual_head_comparison as runner
 
     captured = _capture_calls(monkeypatch, runner)
@@ -271,12 +277,14 @@ def test_dual_head_runner_default_off_byte_identity(monkeypatch):
     assert loader_kwargs["use_press_conf"] is False
     assert loader_kwargs["rich_features"] is True
     assert loader_kwargs["vol_target_horizon"] == 10
+    assert loader_kwargs["sequence_length"] == SEQUENCE_LENGTH
 
     train_kwargs = captured["train_calls"][0]
     model_config = train_kwargs["model_config"]
     assert model_config.rates_target_mode == "raw"
     assert model_config.vol_target_mode == "raw"
     assert model_config.vol_target_horizon == 10
+    assert model_config.sequence_length == SEQUENCE_LENGTH
     assert model_config.use_regime_conditioning is False
 
 
@@ -297,6 +305,7 @@ def test_dual_head_runner_opt_in_threads_through(monkeypatch):
         rates_target_mode="fomc_attributable",
         vol_target_mode="garch_residual",
         vol_target_horizon=5,
+        sequence_length=60,
         use_retrieval_analogs=True,
         use_regime_conditioning=True,
         use_statement_delta=True,
@@ -311,12 +320,14 @@ def test_dual_head_runner_opt_in_threads_through(monkeypatch):
     assert loader_kwargs["use_vote_features"] is True
     assert loader_kwargs["use_press_conf"] is True
     assert loader_kwargs["vol_target_horizon"] == 5
+    assert loader_kwargs["sequence_length"] == 60
 
     train_kwargs = captured["train_calls"][0]
     model_config = train_kwargs["model_config"]
     assert model_config.rates_target_mode == "fomc_attributable"
     assert model_config.vol_target_mode == "garch_residual"
     assert model_config.vol_target_horizon == 5
+    assert model_config.sequence_length == 60
     assert model_config.use_regime_conditioning is True
 
 


### PR DESCRIPTION
## Summary
- Threads `sequence_length` kwarg through every downstream tensor builder (`collect_forward_vols`, `fit_close_scale`, `_build_training_tensors`, `_build_multi_task_target_tensors`, `_build_text_embedding_tensors`, `_build_partition_log_rv_target`, `_build_partition_tensors`, `_build_partition_multi_task_tensors`, `inspect_training_data_sources`, `load_training_sequences_from_package`).
- `train_model` derives `active_sequence_length = model_config.sequence_length or SEQUENCE_LENGTH` once and threads through every call site.
- `scripts/run_dual_head_comparison.py` re-adds `--sequence-length` CLI flag; `train_forecaster.py` hoists the 0-sentinel resolver above the branch + aligns `ModelConfig.sequence_length` persistence between the two runners.
- Test asserts `x.shape[1] == 60` via the explicit window-count product (not fixture coincidence).
- Default-off byte-identity preserved.

Closes the gap in #530 that made `--sequence-length 60` a silent no-op past the loader filter. Unlocks the `seq_len_60` arm against the `canonical_60bar` TP (#528).

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit/test_loaders_sequence_length.py tests/unit/test_run_dual_head_comparison.py -q`
- [ ] CI green