### PR TITLE
runner: expose --text-encoder + --use-text-embeddings on dual-head sweep

### DIFF
--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -256,12 +256,51 @@ def _parse_args() -> argparse.Namespace:
             "``1 + |true - argmax|`` so far-bin confusions pay more."
         ),
     )
+    # Pooled-text path. Default ``None`` keeps the text path off so the
+    # canonical sweep stays byte-identical; set to an encoder alias
+    # (resolved through ``app.models.registry.encoder_ref``) or a HF
+    # repo id to consume that encoder's pooled embeddings as a feature
+    # family. The companion ``--no-text-embeddings`` toggle zeros the
+    # slot while keeping input shape constant; together they match the
+    # loader predicate ``bool(text_encoder) and bool(use_text_embeddings)``.
+    parser.add_argument(
+        "--text-encoder",
+        dest="text_encoder",
+        type=str,
+        default=None,
+        help=(
+            "Encoder alias or HF repo id whose pooled FOMC statement "
+            "embeddings the loader attaches as a per-event feature "
+            "family. Default ``None`` keeps the text path off so the "
+            "canonical sweep stays byte-identical."
+        ),
+    )
+    parser.add_argument(
+        "--use-text-embeddings",
+        dest="use_text_embeddings",
+        action="store_true",
+        help=(
+            "Enable the pooled-text embedding slot when "
+            "``--text-encoder`` is set (default). No-op when "
+            "``--text-encoder`` is unset."
+        ),
+    )
+    parser.add_argument(
+        "--no-text-embeddings",
+        dest="use_text_embeddings",
+        action="store_false",
+        help=(
+            "Zero the pooled-text embedding slot while keeping the "
+            "model input shape constant."
+        ),
+    )
     parser.set_defaults(
         use_retrieval_analogs=False,
         use_regime_conditioning=False,
         use_statement_delta=False,
         use_vote_features=False,
         use_press_conf=False,
+        use_text_embeddings=True,
     )
     return parser.parse_args()
 
@@ -383,6 +422,8 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
     use_vote_features: bool = False,
     use_press_conf: bool = False,
     regime_loss: str = "ce",
+    text_encoder: str | None = None,
+    use_text_embeddings: bool = True,
 ) -> dict[str, Any]:
     # Imports happen here so the script is importable without a torch
     # install (useful for doc-only environments).
@@ -422,6 +463,8 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
             use_statement_delta=use_statement_delta,
             use_vote_features=use_vote_features,
             use_press_conf=use_press_conf,
+            text_encoder=text_encoder,
+            use_text_embeddings=use_text_embeddings,
             vol_target_horizon=vol_target_horizon,
             sequence_length=active_sequence_length,
         )
@@ -493,6 +536,10 @@ def main() -> int:
                     use_vote_features=bool(args.use_vote_features),
                     use_press_conf=bool(args.use_press_conf),
                     regime_loss=str(args.regime_loss),
+                    text_encoder=(
+                        str(args.text_encoder) if args.text_encoder else None
+                    ),
+                    use_text_embeddings=bool(args.use_text_embeddings),
                 )
             )
 
@@ -534,6 +581,10 @@ def main() -> int:
         "use_vote_features": bool(args.use_vote_features),
         "use_press_conf": bool(args.use_press_conf),
         "regime_loss": str(args.regime_loss),
+        "text_encoder": (
+            str(args.text_encoder) if args.text_encoder else None
+        ),
+        "use_text_embeddings": bool(args.use_text_embeddings),
         "trials": trials,
         "summary": summary,
     }

--- a/tests/unit/test_run_dual_head_comparison.py
+++ b/tests/unit/test_run_dual_head_comparison.py
@@ -53,6 +53,30 @@ def test_dual_head_runner_exposes_new_flags(monkeypatch):
     assert args.use_statement_delta is False
     assert args.use_vote_features is False
     assert args.use_press_conf is False
+    assert args.text_encoder is None
+    assert args.use_text_embeddings is True
+
+
+def test_dual_head_runner_text_encoder_opt_in(monkeypatch):
+    """``--text-encoder <alias>`` parses; ``--no-text-embeddings`` flips."""
+
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+            "--text-encoder",
+            "finbert_fed_adjacent_xbank",
+            "--no-text-embeddings",
+        ],
+    )
+    args = _parse_args()
+    assert args.text_encoder == "finbert_fed_adjacent_xbank"
+    assert args.use_text_embeddings is False
 
 
 def test_dual_head_runner_accepts_opt_in_flags(monkeypatch):
@@ -278,6 +302,10 @@ def test_dual_head_runner_default_off_byte_identity(monkeypatch):
     assert loader_kwargs["rich_features"] is True
     assert loader_kwargs["vol_target_horizon"] == 10
     assert loader_kwargs["sequence_length"] == SEQUENCE_LENGTH
+    # Default-off: text path stays disabled (text_encoder=None gates the
+    # loader's ``use_text_path`` predicate regardless of the toggle).
+    assert loader_kwargs["text_encoder"] is None
+    assert loader_kwargs["use_text_embeddings"] is True
 
     train_kwargs = captured["train_calls"][0]
     model_config = train_kwargs["model_config"]
@@ -329,6 +357,31 @@ def test_dual_head_runner_opt_in_threads_through(monkeypatch):
     assert model_config.vol_target_horizon == 5
     assert model_config.sequence_length == 60
     assert model_config.use_regime_conditioning is True
+
+
+def test_dual_head_runner_text_encoder_threads_into_loader(monkeypatch):
+    """Setting ``text_encoder`` forwards the alias + toggle to the loader."""
+
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from scripts import run_dual_head_comparison as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    runner._run_one_cell(
+        "dual",
+        seed=11,
+        training_package_id="tp_dummy",
+        fold_ids=["fold_001"],
+        epochs=1,
+        regression_alpha=0.5,
+        hidden_size=64,
+        text_encoder="finbert_fed_adjacent_xbank",
+        use_text_embeddings=False,
+    )
+
+    loader_kwargs = captured["loader_calls"][0]
+    assert loader_kwargs["text_encoder"] == "finbert_fed_adjacent_xbank"
+    assert loader_kwargs["use_text_embeddings"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New `--text-encoder` (default `None`) + `--use-text-embeddings`/`--no-text-embeddings` (paired bool, default `True`) on `run_dual_head_comparison.py`.
- Both thread into `load_walk_forward_split` and are persisted on the run-summary payload.
- Default-off byte-identity preserved.
- Unblocks the **cross_bank_revisited** Wave 3 arm: re-run canonical with `finbert_fed_adjacent_xbank` (cross-bank-supervised encoder, embedding cache already exists) against the post-strict-forward + dual-head methodology. Tests whether PR #231's null was a methodology artefact.

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit/test_run_dual_head_comparison.py -q`
- [ ] CI green