### PR TITLE
methodology: absolute regime cutoffs as alternative target label (#472)

### DIFF
--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
@@ -138,6 +139,30 @@ RICH_FEATURE_SIZE = FEATURE_SIZE + RICH_EXTRA_FEATURE_SIZE
 # ``ModelConfig.vol_target_horizon`` against this tuple at entry.
 SUPPORTED_VOL_TARGET_HORIZONS: tuple[int, ...] = (1, 3, 5, 10, 20, 30)
 DEFAULT_VOL_TARGET_HORIZON: int = 10
+
+# #472 vol-regime labelling modes. ``per_fold_quantile`` (default,
+# byte-identical) fits per-fold (q33, q67) cutoffs on the train slice;
+# ``absolute`` uses a fixed pair of cutoffs so every fold's
+# calm / normal / high cells refer to the same vol level (no per-fold
+# bin drift). The literal vocabulary is pinned here so the CLI
+# ``choices=`` tuple and the loop dispatch agree.
+VOL_REGIME_LABEL_MODES: tuple[str, ...] = ("per_fold_quantile", "absolute")
+DEFAULT_VOL_REGIME_LABEL_MODE: str = "per_fold_quantile"
+# Annualized-to-per-period conversion for ``forward_realized_vol_10d``
+# (per-period standard deviation of log returns over 10 trading days):
+# ``vol_annualized = vol_per_period * sqrt(252 / 10)``. The defaults
+# below pin ``calm_max`` at 12% annualized and ``high_min`` at 22%
+# annualized -- the economic boundaries documented in the issue --
+# expressed in the SAME per-period unit as
+# ``forward_realized_vol_10d`` so the loader can compare without
+# rescaling. ``vol_regime_absolute_class_for`` consumes this tuple.
+ANNUALIZATION_SQRT_10D: float = math.sqrt(252.0 / 10.0)
+DEFAULT_ABSOLUTE_VOL_CALM_MAX_ANNUALIZED: float = 0.12
+DEFAULT_ABSOLUTE_VOL_HIGH_MIN_ANNUALIZED: float = 0.22
+DEFAULT_ABSOLUTE_VOL_THRESHOLDS: tuple[float, float] = (
+    DEFAULT_ABSOLUTE_VOL_CALM_MAX_ANNUALIZED / ANNUALIZATION_SQRT_10D,
+    DEFAULT_ABSOLUTE_VOL_HIGH_MIN_ANNUALIZED / ANNUALIZATION_SQRT_10D,
+)
 
 # Slice offsets inside the rich vector. Used by the per-family
 # ablation path on the loader to zero an individual family without
@@ -423,6 +448,24 @@ SYMBOL_ID_LOOKUP: dict[str, int] = {sym: idx for idx, sym in enumerate(SUPPORTED
 N_SUPPORTED_SYMBOLS: int = len(SUPPORTED_SYMBOLS)
 
 
+def _coerce_absolute_vol_thresholds(value: Any) -> tuple[float, float]:
+    """Round-trip helper for :attr:`ModelConfig.absolute_vol_thresholds`.
+
+    Accepts ``None`` (legacy checkpoint without the field), a length-2
+    sequence, or already-typed tuple and returns the canonical
+    ``(calm_max, high_min)`` float pair. Falls back to
+    :data:`DEFAULT_ABSOLUTE_VOL_THRESHOLDS` when the payload is missing
+    so pre-#472 checkpoints deserialise into the byte-identical default.
+    """
+
+    if value is None:
+        return DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+    seq = tuple(value)
+    if len(seq) != 2:
+        return DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+    return float(seq[0]), float(seq[1])
+
+
 @dataclass(frozen=True)
 class ModelConfig:
     input_size: int = FEATURE_SIZE
@@ -456,6 +499,25 @@ class ModelConfig:
     n_classes: int = 3
     vol_regime_quantiles: tuple[float, ...] = ()
     vol_regime_target: str = "forward_realized_vol_10d"
+    # #472 vol-regime labelling mode. ``per_fold_quantile`` (default,
+    # byte-identical) fits per-fold (q33, q67) cutoffs on the train
+    # slice each fold; ``absolute`` uses the fixed
+    # ``absolute_vol_thresholds`` pair so every fold's calm / normal /
+    # high cells refer to the same economic vol level. On the
+    # ``absolute`` path the per-fold quantile fit is skipped and the
+    # absolute thresholds flow through every downstream consumer
+    # (``vol_regime_class_for`` / ``_build_partition_log_rv_target`` /
+    # the multi-task target builder) so row alignment with ``y`` is
+    # preserved.
+    vol_regime_label_mode: str = DEFAULT_VOL_REGIME_LABEL_MODE
+    # Per-period (calm_max, high_min) cutoffs the absolute labelling
+    # path bins ``forward_realized_vol_10d`` into. The defaults convert
+    # 12% / 22% annualized -- the economic boundaries documented in
+    # the issue -- via ``vol_per_period = vol_annualized /
+    # sqrt(252 / 10)`` so the cutoffs share the same per-period unit as
+    # the target column. Setting custom values is expected via the
+    # canonical-sweep CLI (annualized percent in, per-period out).
+    absolute_vol_thresholds: tuple[float, float] = DEFAULT_ABSOLUTE_VOL_THRESHOLDS
     # Phase B (#227) LR-schedule selector. ``plateau`` is the legacy
     # ReduceLROnPlateau path (locked by the determinism regression).
     # ``cosine_warmup`` builds a OneCycleLR over the configured epoch
@@ -699,6 +761,13 @@ class ModelConfig:
             vol_regime_target=str(
                 getattr(model, "vol_regime_target", "forward_realized_vol_10d")
                 or "forward_realized_vol_10d"
+            ),
+            vol_regime_label_mode=str(
+                getattr(model, "vol_regime_label_mode", DEFAULT_VOL_REGIME_LABEL_MODE)
+                or DEFAULT_VOL_REGIME_LABEL_MODE
+            ),
+            absolute_vol_thresholds=_coerce_absolute_vol_thresholds(
+                getattr(model, "absolute_vol_thresholds", DEFAULT_ABSOLUTE_VOL_THRESHOLDS)
             ),
             lr_schedule=str(getattr(model, "lr_schedule", "plateau") or "plateau"),
             sequence_length=int(getattr(model, "sequence_length", 0) or 0),

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -162,6 +162,11 @@ def build_forecaster(
             "rates_target_mode",
             "vol_target_mode",
             "vol_target_horizon",
+            # #472 vol-regime labelling mode + absolute thresholds are
+            # loop / loader-side knobs; the flat_mlp ctor does not
+            # consume them.
+            "vol_regime_label_mode",
+            "absolute_vol_thresholds",
             "use_regime_conditioning",
             "use_sep",
             "use_press_conf",
@@ -220,6 +225,32 @@ def build_forecaster(
         flat.vol_target_horizon = int(
             getattr(resolved, "vol_target_horizon", 10) or 10
         )  # type: ignore[assignment]
+        # #472 round-trip the vol-regime labelling knobs onto the flat_mlp
+        # module so the persisted run summary records which contract the
+        # classification target trained under.
+        from app.models.config import (
+            DEFAULT_ABSOLUTE_VOL_THRESHOLDS,
+            DEFAULT_VOL_REGIME_LABEL_MODE,
+        )
+
+        flat.vol_regime_label_mode = str(
+            getattr(resolved, "vol_regime_label_mode", DEFAULT_VOL_REGIME_LABEL_MODE)
+            or DEFAULT_VOL_REGIME_LABEL_MODE
+        )  # type: ignore[assignment]
+        _flat_thresholds_raw = getattr(
+            resolved, "absolute_vol_thresholds", DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+        )
+        if _flat_thresholds_raw is None:
+            flat.absolute_vol_thresholds = DEFAULT_ABSOLUTE_VOL_THRESHOLDS  # type: ignore[assignment]
+        else:
+            _flat_seq = tuple(_flat_thresholds_raw)
+            if len(_flat_seq) != 2:
+                flat.absolute_vol_thresholds = DEFAULT_ABSOLUTE_VOL_THRESHOLDS  # type: ignore[assignment]
+            else:
+                flat.absolute_vol_thresholds = (  # type: ignore[assignment]
+                    float(_flat_seq[0]),
+                    float(_flat_seq[1]),
+                )
         return flat
 
     kwargs = resolved.to_dict()
@@ -282,6 +313,34 @@ def build_forecaster(
     vol_target_mode_value = str(
         kwargs.pop("vol_target_mode", "raw") or "raw"
     )
+    # #472 vol-regime labelling mode + absolute thresholds. Both are
+    # loop / loader-side knobs (the trainer selects between
+    # ``fit_vol_regime_quantiles`` and the fixed thresholds; the loader
+    # uses the resulting cutoffs in ``vol_regime_class_for``). Pop here
+    # so the ForecasterModel ctor never sees the unrecognised kwargs.
+    # Stash back on the built module so ``ModelConfig.from_model``
+    # round-trips both onto the persisted run summary regardless of
+    # whether the run also wires the absolute branch.
+    from app.models.config import (
+        DEFAULT_ABSOLUTE_VOL_THRESHOLDS,
+        DEFAULT_VOL_REGIME_LABEL_MODE,
+    )
+
+    vol_regime_label_mode_value = str(
+        kwargs.pop("vol_regime_label_mode", DEFAULT_VOL_REGIME_LABEL_MODE)
+        or DEFAULT_VOL_REGIME_LABEL_MODE
+    )
+    _absolute_thresholds_raw = kwargs.pop(
+        "absolute_vol_thresholds", DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+    )
+    if _absolute_thresholds_raw is None:
+        absolute_vol_thresholds_value: tuple[float, float] = DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+    else:
+        _seq = tuple(_absolute_thresholds_raw)
+        if len(_seq) != 2:
+            absolute_vol_thresholds_value = DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+        else:
+            absolute_vol_thresholds_value = (float(_seq[0]), float(_seq[1]))
     # Supervised forward-vol horizon. Loader-side knob (the loader
     # routes the per-row ``forward_realized_vol_10d`` slot to the
     # chosen column); the model ctor does not consume it. Stash it back
@@ -431,6 +490,11 @@ def build_forecaster(
     # module so ``ModelConfig.from_model`` recovers it on resume.
     model.vol_target_mode = vol_target_mode_value  # type: ignore[assignment]
     model.vol_target_horizon = vol_target_horizon_value  # type: ignore[assignment]
+    # #472 round-trip the vol-regime labelling knobs so a resumed
+    # checkpoint reuses the same calm / normal / high contract the
+    # original run trained under.
+    model.vol_regime_label_mode = vol_regime_label_mode_value  # type: ignore[assignment]
+    model.absolute_vol_thresholds = absolute_vol_thresholds_value  # type: ignore[assignment]
     # #443/#444 round-trip the two new opt-in flags. Default-off path
     # behaves byte-identically; flag-on a future sweep that resumes off
     # this checkpoint rebuilds with the same loader-tail widths. The

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -3300,6 +3300,52 @@ def vol_regime_class_for(value: float | None, quantiles: Sequence[float]) -> int
     return len(quantiles)
 
 
+def vol_regime_absolute_class_for(
+    value: float | None, thresholds: tuple[float, float]
+) -> int:
+    """Map a forward-vol value to a 3-class regime index using absolute cutoffs.
+
+    Alternative to :func:`vol_regime_class_for` (#472): replaces the
+    per-fold quantile bins -- whose cutoffs drift between folds and
+    carry no economic meaning -- with a fixed pair of thresholds
+    ``(calm_max, high_min)`` so every fold's "calm" / "normal" / "high"
+    cell refers to the same vol level. Returns ``0`` (calm) when
+    ``value < calm_max``, ``1`` (normal) when ``calm_max <= value <
+    high_min``, ``2`` (high) when ``value >= high_min``. Returns ``-1``
+    for missing (``None`` / NaN) values so the caller drops the row
+    from the classification training set -- matches the contract of
+    :func:`vol_regime_class_for`.
+
+    The thresholds are expressed in the SAME per-period unit as
+    ``forward_realized_vol_10d`` (per-period standard deviation of log
+    returns over 10 trading days; NOT annualized). Convert from a
+    human-readable annualized vol via
+    ``vol_per_period = vol_annualized / sqrt(252 / 10)`` (equivalently
+    ``vol_annualized = vol_per_period * sqrt(25.2)``). The
+    :class:`app.models.config.ModelConfig` defaults derive
+    ``calm_max`` from 12% annualized and ``high_min`` from 22%
+    annualized; the caller in :mod:`scripts.run_dual_head_comparison`
+    converts user-supplied annualized percentages before passing them
+    through.
+
+    Caveat: when a fold's test slice has zero rows above ``high_min``
+    (e.g. early-2010s windows where realised vol never crossed 22%
+    annualised), the test partition's class-2 cell is empty and
+    macro-F1 reflects that. This is intentional: "calm" / "normal" /
+    "high" become a stable economic definition rather than a per-fold
+    artefact.
+    """
+
+    if value is None or value != value:
+        return -1
+    calm_max, high_min = thresholds
+    if value < calm_max:
+        return 0
+    if value < high_min:
+        return 1
+    return 2
+
+
 def collect_forward_vols(
     sequence_groups: Sequence[Sequence[FeatureVector]],
     *,

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -18,6 +18,7 @@ from app.determinism import enable_deterministic_mode, make_generator, seed_work
 from app.evaluation.metrics import EvaluationMetrics, TrainingResult, TrainingRunSummary
 from app.models.config import (
     BEST_MODEL_PATH,
+    DEFAULT_ABSOLUTE_VOL_THRESHOLDS,
     DEFAULT_BATCH_SIZE,
     DEFAULT_DROPOUT,
     DEFAULT_EARLY_STOPPING_PATIENCE,
@@ -28,6 +29,7 @@ from app.models.config import (
     DEFAULT_LEARNING_RATE,
     DEFAULT_NUM_LAYERS,
     DEFAULT_VALIDATION_SPLIT,
+    DEFAULT_VOL_REGIME_LABEL_MODE,
     FEATURE_SIZE,
     SEQUENCE_LENGTH,
     FeatureVector,
@@ -254,6 +256,10 @@ def _coerce_model_config(model_config: ModelConfig | dict[str, Any] | None = Non
         tuple_fields = {
             "rates_heads",
             "vol_regime_quantiles",
+            # JSON round-trips tuples as lists; #472 absolute thresholds
+            # must coerce back so downstream equality + tuple-typed slots
+            # stay correct on resume.
+            "absolute_vol_thresholds",
         }
         kwargs: dict[str, Any] = {}
         for key, value in model_config.items():
@@ -2676,19 +2682,46 @@ def train_model(
             train_forward_vols = collect_forward_vols(
                 train_groups, sequence_length=active_sequence_length
             )
-            fitted_quantiles = fit_vol_regime_quantiles(
-                train_forward_vols, n_classes=n_classes_active
+            # #472 vol-regime labelling mode. ``per_fold_quantile``
+            # (default, byte-identical) fits per-fold (q33, q67) cutoffs
+            # on the train slice; ``absolute`` skips the fit and feeds
+            # the fixed ``(calm_max, high_min)`` pair through every
+            # downstream consumer (``vol_regime_class_for`` /
+            # ``_build_partition_log_rv_target`` / multi-task target
+            # builder) so the same bin contract holds across folds. The
+            # absolute thresholds flow through the ``vol_regime_quantiles``
+            # slot deliberately: ``vol_regime_class_for`` already maps a
+            # value to a class index by less-than comparison against an
+            # ordered tuple of cutoffs, so reusing the slot keeps the
+            # row-alignment / class-weight / log_rv-target paths
+            # byte-identical to the quantile branch.
+            _active_label_mode = str(
+                getattr(active_model_config, "vol_regime_label_mode", DEFAULT_VOL_REGIME_LABEL_MODE)
+                or DEFAULT_VOL_REGIME_LABEL_MODE
             )
-            if not fitted_quantiles:
-                raise ValueError(
-                    "vol-regime classification requires >= n_classes valid "
-                    "forward_realized_vol_10d targets on the train slice; "
-                    f"got {len(train_forward_vols)} valid rows for "
-                    f"n_classes={n_classes_active}."
+            if _active_label_mode == "absolute":
+                fitted_quantiles = tuple(
+                    float(v) for v in getattr(
+                        active_model_config, "absolute_vol_thresholds", DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+                    )
                 )
-            active_model_config = dataclasses.replace(
-                active_model_config, vol_regime_quantiles=fitted_quantiles
-            )
+                active_model_config = dataclasses.replace(
+                    active_model_config, vol_regime_quantiles=fitted_quantiles
+                )
+            else:
+                fitted_quantiles = fit_vol_regime_quantiles(
+                    train_forward_vols, n_classes=n_classes_active
+                )
+                if not fitted_quantiles:
+                    raise ValueError(
+                        "vol-regime classification requires >= n_classes valid "
+                        "forward_realized_vol_10d targets on the train slice; "
+                        f"got {len(train_forward_vols)} valid rows for "
+                        f"n_classes={n_classes_active}."
+                    )
+                active_model_config = dataclasses.replace(
+                    active_model_config, vol_regime_quantiles=fitted_quantiles
+                )
             # A1 (#206) per-fold class weighting. Counts each class in
             # the train slice under the just-fitted quantile cutoffs,
             # then builds inverse-frequency weights so the loss path
@@ -2997,19 +3030,34 @@ def train_model(
         legacy_fitted_quantiles: tuple[float, ...] = ()
         if active_output_mode == "classification":
             n_classes_active = int(getattr(active_model_config, "n_classes", 3) or 3)
-            legacy_forward_vols = collect_forward_vols(
-                active_sequence_groups, sequence_length=active_sequence_length
+            # #472 absolute labelling mirrors the walk-forward branch: skip
+            # the per-fold quantile fit and route the fixed thresholds
+            # through ``vol_regime_quantiles`` so the existing class-index
+            # mapping path stays byte-identical on the absolute branch.
+            _active_label_mode_legacy = str(
+                getattr(active_model_config, "vol_regime_label_mode", DEFAULT_VOL_REGIME_LABEL_MODE)
+                or DEFAULT_VOL_REGIME_LABEL_MODE
             )
-            legacy_fitted_quantiles = fit_vol_regime_quantiles(
-                legacy_forward_vols, n_classes=n_classes_active
-            )
-            if not legacy_fitted_quantiles:
-                raise ValueError(
-                    "vol-regime classification requires >= n_classes valid "
-                    "forward_realized_vol_10d targets on the legacy single-list "
-                    f"path; got {len(legacy_forward_vols)} valid rows for "
-                    f"n_classes={n_classes_active}."
+            if _active_label_mode_legacy == "absolute":
+                legacy_fitted_quantiles = tuple(
+                    float(v) for v in getattr(
+                        active_model_config, "absolute_vol_thresholds", DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+                    )
                 )
+            else:
+                legacy_forward_vols = collect_forward_vols(
+                    active_sequence_groups, sequence_length=active_sequence_length
+                )
+                legacy_fitted_quantiles = fit_vol_regime_quantiles(
+                    legacy_forward_vols, n_classes=n_classes_active
+                )
+                if not legacy_fitted_quantiles:
+                    raise ValueError(
+                        "vol-regime classification requires >= n_classes valid "
+                        "forward_realized_vol_10d targets on the legacy single-list "
+                        f"path; got {len(legacy_forward_vols)} valid rows for "
+                        f"n_classes={n_classes_active}."
+                    )
             active_model_config = dataclasses.replace(
                 active_model_config, vol_regime_quantiles=legacy_fitted_quantiles
             )

--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -294,6 +294,51 @@ def _parse_args() -> argparse.Namespace:
             "model input shape constant."
         ),
     )
+    # #472 vol-regime labelling mode. ``per_fold_quantile`` (default,
+    # byte-identical) keeps the per-fold (q33, q67) cutoffs the canonical
+    # sweep fits each fold; ``absolute`` swaps in the fixed
+    # ``(calm_max, high_min)`` pair so every fold's calm / normal / high
+    # cells refer to the same economic vol level.
+    parser.add_argument(
+        "--vol-regime-label-mode",
+        dest="vol_regime_label_mode",
+        type=str,
+        choices=("per_fold_quantile", "absolute"),
+        default="per_fold_quantile",
+        help=(
+            "Vol-regime labelling mode. ``per_fold_quantile`` (default) "
+            "fits per-fold quantile cutoffs on the train slice each fold; "
+            "``absolute`` uses a fixed (calm_max, high_min) pair so every "
+            "fold's calm / normal / high cells refer to the same vol "
+            "level."
+        ),
+    )
+    parser.add_argument(
+        "--absolute-calm-max",
+        dest="absolute_calm_max",
+        type=float,
+        default=None,
+        help=(
+            "calm_max boundary in ANNUALIZED vol units (e.g. 12.0 for "
+            "12%%); converted to per-period via "
+            "vol_per_period = vol_annualized / sqrt(252 / 10) before "
+            "passing to ModelConfig. Only consumed when "
+            "--vol-regime-label-mode=absolute. Default: 12%%."
+        ),
+    )
+    parser.add_argument(
+        "--absolute-high-min",
+        dest="absolute_high_min",
+        type=float,
+        default=None,
+        help=(
+            "high_min boundary in ANNUALIZED vol units (e.g. 22.0 for "
+            "22%%); converted to per-period via "
+            "vol_per_period = vol_annualized / sqrt(252 / 10) before "
+            "passing to ModelConfig. Only consumed when "
+            "--vol-regime-label-mode=absolute. Default: 22%%."
+        ),
+    )
     parser.set_defaults(
         use_retrieval_analogs=False,
         use_regime_conditioning=False,
@@ -424,15 +469,27 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
     regime_loss: str = "ce",
     text_encoder: str | None = None,
     use_text_embeddings: bool = True,
+    vol_regime_label_mode: str = "per_fold_quantile",
+    absolute_vol_thresholds: tuple[float, float] | None = None,
 ) -> dict[str, Any]:
     # Imports happen here so the script is importable without a torch
     # install (useful for doc-only environments).
-    from app.models.config import RICH_FEATURE_SIZE, SEQUENCE_LENGTH, ModelConfig
+    from app.models.config import (
+        DEFAULT_ABSOLUTE_VOL_THRESHOLDS,
+        RICH_FEATURE_SIZE,
+        SEQUENCE_LENGTH,
+        ModelConfig,
+    )
     from app.training.loaders import load_walk_forward_split
     from app.training.loop import train_model
 
     active_sequence_length = int(sequence_length) if sequence_length else SEQUENCE_LENGTH
     rates_heads = _resolve_auto_rates_heads(rates_target_mode, rates_heads=None)
+    resolved_absolute_thresholds: tuple[float, float] = (
+        absolute_vol_thresholds
+        if absolute_vol_thresholds is not None
+        else DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+    )
     config = ModelConfig(
         input_size=RICH_FEATURE_SIZE,
         output_mode="classification",
@@ -450,6 +507,8 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
         use_statement_delta=use_statement_delta,
         use_vote_features=use_vote_features,
         regime_loss_mode=regime_loss,
+        vol_regime_label_mode=vol_regime_label_mode,
+        absolute_vol_thresholds=resolved_absolute_thresholds,
     )
 
     per_fold: list[dict[str, Any]] = []
@@ -495,6 +554,41 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
     }
 
 
+def _resolve_absolute_thresholds(
+    label_mode: str,
+    calm_max_annualized: float | None,
+    high_min_annualized: float | None,
+) -> tuple[float, float] | None:
+    """Convert CLI annualized vol percentages to per-period thresholds.
+
+    Returns ``None`` when ``label_mode != 'absolute'`` so the default
+    ModelConfig threshold pair is used; when ``absolute`` is requested
+    but the operator did not supply explicit values, returns ``None``
+    too so the canonical defaults (12% / 22% annualized) flow through.
+    The CLI accepts percentages either as a fraction (``0.12``) or as
+    a percent (``12.0``); values >= 1.0 are treated as percent so the
+    operator can type the integer they read in the docstring.
+    """
+
+    from app.models.config import ANNUALIZATION_SQRT_10D
+
+    if label_mode != "absolute":
+        return None
+    if calm_max_annualized is None and high_min_annualized is None:
+        return None
+
+    def _normalize(v: float | None, fallback: float) -> float:
+        if v is None:
+            return fallback
+        if v >= 1.0:
+            return float(v) / 100.0
+        return float(v)
+
+    calm_max = _normalize(calm_max_annualized, 0.12)
+    high_min = _normalize(high_min_annualized, 0.22)
+    return calm_max / ANNUALIZATION_SQRT_10D, high_min / ANNUALIZATION_SQRT_10D
+
+
 def main() -> int:
     ensure_compile_safe()
     args = _parse_args()
@@ -508,6 +602,13 @@ def main() -> int:
             "[dual_head_comparison] auto-activating rates heads for "
             f"rates_target_mode={args.rates_target_mode}"
         )
+    from app.models.config import DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+
+    absolute_thresholds = _resolve_absolute_thresholds(
+        str(args.vol_regime_label_mode),
+        args.absolute_calm_max,
+        args.absolute_high_min,
+    )
 
     trials: dict[str, list[dict[str, Any]]] = {mode: [] for mode in args.head_modes}
     for head_mode in args.head_modes:
@@ -540,6 +641,8 @@ def main() -> int:
                         str(args.text_encoder) if args.text_encoder else None
                     ),
                     use_text_embeddings=bool(args.use_text_embeddings),
+                    vol_regime_label_mode=str(args.vol_regime_label_mode),
+                    absolute_vol_thresholds=absolute_thresholds,
                 )
             )
 
@@ -585,6 +688,23 @@ def main() -> int:
             str(args.text_encoder) if args.text_encoder else None
         ),
         "use_text_embeddings": bool(args.use_text_embeddings),
+        "vol_regime_label_mode": str(args.vol_regime_label_mode),
+        # When absolute mode is on, persist the EFFECTIVE thresholds
+        # (CLI values when set, defaults otherwise) so the artefact
+        # unambiguously records what trained -- avoids the "did
+        # absolute mode use defaults or quantile mode" ambiguity that
+        # would otherwise need source-code reading to resolve.
+        "absolute_vol_thresholds": (
+            list(absolute_thresholds)
+            if absolute_thresholds is not None
+            else (
+                list(DEFAULT_ABSOLUTE_VOL_THRESHOLDS)
+                if str(args.vol_regime_label_mode) == "absolute"
+                else None
+            )
+        ),
+        "absolute_calm_max_annualized": args.absolute_calm_max,
+        "absolute_high_min_annualized": args.absolute_high_min,
         "trials": trials,
         "summary": summary,
     }

--- a/tests/unit/test_absolute_regime_cutoffs.py
+++ b/tests/unit/test_absolute_regime_cutoffs.py
@@ -1,0 +1,222 @@
+"""Unit tests for the #472 absolute vol-regime labelling path.
+
+Covers the alternative-target row that swaps the per-fold quantile
+cutoffs for fixed (calm_max, high_min) thresholds expressed in the
+same per-period unit as ``forward_realized_vol_10d``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# vol_regime_absolute_class_for: math
+# ---------------------------------------------------------------------------
+
+
+def test_absolute_class_for_below_calm_max() -> None:
+    """Values strictly below ``calm_max`` map to class 0 (calm)."""
+
+    from app.training.loaders import vol_regime_absolute_class_for
+
+    thresholds = (0.02, 0.04)
+    assert vol_regime_absolute_class_for(0.0, thresholds) == 0
+    assert vol_regime_absolute_class_for(0.005, thresholds) == 0
+    assert vol_regime_absolute_class_for(0.019999, thresholds) == 0
+
+
+def test_absolute_class_for_between_thresholds() -> None:
+    """Values in ``[calm_max, high_min)`` map to class 1 (normal)."""
+
+    from app.training.loaders import vol_regime_absolute_class_for
+
+    thresholds = (0.02, 0.04)
+    assert vol_regime_absolute_class_for(0.02, thresholds) == 1
+    assert vol_regime_absolute_class_for(0.03, thresholds) == 1
+    assert vol_regime_absolute_class_for(0.039999, thresholds) == 1
+
+
+def test_absolute_class_for_at_or_above_high_min() -> None:
+    """Values >= ``high_min`` map to class 2 (high)."""
+
+    from app.training.loaders import vol_regime_absolute_class_for
+
+    thresholds = (0.02, 0.04)
+    assert vol_regime_absolute_class_for(0.04, thresholds) == 2
+    assert vol_regime_absolute_class_for(0.1, thresholds) == 2
+    assert vol_regime_absolute_class_for(1.0, thresholds) == 2
+
+
+def test_absolute_class_for_missing_returns_minus_one() -> None:
+    """Missing (None / NaN) targets return -1, matching the quantile contract."""
+
+    from app.training.loaders import (
+        vol_regime_absolute_class_for,
+        vol_regime_class_for,
+    )
+
+    thresholds = (0.02, 0.04)
+    assert vol_regime_absolute_class_for(None, thresholds) == -1
+    assert vol_regime_absolute_class_for(float("nan"), thresholds) == -1
+    # Same -1 contract as the per-fold quantile path so the
+    # row-drop predicate is identical on both branches.
+    assert vol_regime_class_for(None, thresholds) == -1
+    assert vol_regime_class_for(float("nan"), thresholds) == -1
+
+
+def test_absolute_class_for_matches_quantile_class_for_on_shared_inputs() -> None:
+    """Absolute + quantile paths agree on every cell for the same ordered cutoffs.
+
+    Both helpers implement the same less-than-cutoffs algorithm; the
+    only difference is the alternative function fixes the tuple length
+    at 2 and documents the economic semantics. The cell-by-cell match
+    is what lets the loop dispatch route the absolute thresholds
+    through the existing ``vol_regime_quantiles`` slot without any
+    downstream codepath changes.
+    """
+
+    from app.training.loaders import (
+        vol_regime_absolute_class_for,
+        vol_regime_class_for,
+    )
+
+    thresholds = (0.025, 0.05)
+    for value in [0.0, 0.01, 0.025, 0.03, 0.05, 0.07]:
+        assert vol_regime_absolute_class_for(
+            value, thresholds
+        ) == vol_regime_class_for(value, thresholds)
+
+
+# ---------------------------------------------------------------------------
+# Annualized -> per-period conversion: ModelConfig defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_absolute_thresholds_match_12_and_22_pct_annualized() -> None:
+    """ModelConfig defaults reflect the documented 12% / 22% annualized cutoffs.
+
+    The conversion formula is
+    ``vol_per_period = vol_annualized / sqrt(252 / 10)``; the test
+    re-derives the cutoffs and asserts the dataclass default is within
+    float tolerance of the recomputed pair. Guards against a future
+    edit that touches the constants without recomputing the per-period
+    values.
+    """
+
+    from app.models.config import (
+        DEFAULT_ABSOLUTE_VOL_CALM_MAX_ANNUALIZED,
+        DEFAULT_ABSOLUTE_VOL_HIGH_MIN_ANNUALIZED,
+        DEFAULT_ABSOLUTE_VOL_THRESHOLDS,
+    )
+
+    expected_calm = DEFAULT_ABSOLUTE_VOL_CALM_MAX_ANNUALIZED / math.sqrt(25.2)
+    expected_high = DEFAULT_ABSOLUTE_VOL_HIGH_MIN_ANNUALIZED / math.sqrt(25.2)
+    assert DEFAULT_ABSOLUTE_VOL_CALM_MAX_ANNUALIZED == pytest.approx(0.12)
+    assert DEFAULT_ABSOLUTE_VOL_HIGH_MIN_ANNUALIZED == pytest.approx(0.22)
+    assert DEFAULT_ABSOLUTE_VOL_THRESHOLDS[0] == pytest.approx(expected_calm)
+    assert DEFAULT_ABSOLUTE_VOL_THRESHOLDS[1] == pytest.approx(expected_high)
+    # Sanity check: round-trip per-period -> annualized -> per-period.
+    calm_back = DEFAULT_ABSOLUTE_VOL_THRESHOLDS[0] * math.sqrt(25.2)
+    high_back = DEFAULT_ABSOLUTE_VOL_THRESHOLDS[1] * math.sqrt(25.2)
+    assert calm_back == pytest.approx(0.12)
+    assert high_back == pytest.approx(0.22)
+
+
+def test_modelconfig_carries_default_label_mode_and_thresholds() -> None:
+    """Default ModelConfig opts into the byte-identical quantile path."""
+
+    from app.models.config import (
+        DEFAULT_ABSOLUTE_VOL_THRESHOLDS,
+        DEFAULT_VOL_REGIME_LABEL_MODE,
+        ModelConfig,
+    )
+
+    cfg = ModelConfig()
+    assert cfg.vol_regime_label_mode == DEFAULT_VOL_REGIME_LABEL_MODE
+    assert cfg.vol_regime_label_mode == "per_fold_quantile"
+    assert cfg.absolute_vol_thresholds == DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+
+
+# ---------------------------------------------------------------------------
+# ModelConfig round-trip via from_model
+# ---------------------------------------------------------------------------
+
+
+class _StubModel:
+    """Minimal stand-in for the model object ``ModelConfig.from_model`` reads.
+
+    Carries only the attributes the round-trip needs to assert the new
+    fields survive checkpoint serialise / deserialise. All other slots
+    fall back to ``ModelConfig`` defaults via ``getattr(default)``.
+    """
+
+    def __init__(
+        self,
+        *,
+        vol_regime_label_mode: str,
+        absolute_vol_thresholds: tuple[float, float],
+    ) -> None:
+        self.model_type = "lstm"
+        self.input_size = 6
+        self.hidden_size = 64
+        self.num_layers = 1
+        self.dropout = 0.1
+        self.head_hidden_size = 32
+        self.initial_decay_rate = 0.0
+        self.vol_regime_label_mode = vol_regime_label_mode
+        self.absolute_vol_thresholds = absolute_vol_thresholds
+
+
+def test_modelconfig_round_trips_absolute_label_mode() -> None:
+    """``vol_regime_label_mode='absolute'`` survives ``from_model``."""
+
+    from app.models.config import ModelConfig
+
+    thresholds = (0.03, 0.05)
+    stub = _StubModel(
+        vol_regime_label_mode="absolute",
+        absolute_vol_thresholds=thresholds,
+    )
+    cfg = ModelConfig.from_model(stub)
+    assert cfg.vol_regime_label_mode == "absolute"
+    assert cfg.absolute_vol_thresholds == thresholds
+
+
+def test_modelconfig_round_trips_per_fold_label_mode() -> None:
+    """Default ``per_fold_quantile`` survives ``from_model`` unchanged."""
+
+    from app.models.config import DEFAULT_ABSOLUTE_VOL_THRESHOLDS, ModelConfig
+
+    stub = _StubModel(
+        vol_regime_label_mode="per_fold_quantile",
+        absolute_vol_thresholds=DEFAULT_ABSOLUTE_VOL_THRESHOLDS,
+    )
+    cfg = ModelConfig.from_model(stub)
+    assert cfg.vol_regime_label_mode == "per_fold_quantile"
+    assert cfg.absolute_vol_thresholds == DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+
+
+def test_legacy_model_without_label_mode_falls_back_to_default() -> None:
+    """Pre-#472 checkpoints (no field) restore the default labelling mode."""
+
+    from app.models.config import (
+        DEFAULT_ABSOLUTE_VOL_THRESHOLDS,
+        DEFAULT_VOL_REGIME_LABEL_MODE,
+        ModelConfig,
+    )
+
+    class _LegacyModel:
+        model_type = "lstm"
+        input_size = 6
+        hidden_size = 64
+        num_layers = 1
+        dropout = 0.1
+        head_hidden_size = 32
+        initial_decay_rate = 0.0
+
+    cfg = ModelConfig.from_model(_LegacyModel())
+    assert cfg.vol_regime_label_mode == DEFAULT_VOL_REGIME_LABEL_MODE
+    assert cfg.absolute_vol_thresholds == DEFAULT_ABSOLUTE_VOL_THRESHOLDS

--- a/tests/unit/test_run_dual_head_comparison.py
+++ b/tests/unit/test_run_dual_head_comparison.py
@@ -170,6 +170,153 @@ def test_dual_head_runner_rejects_unknown_rates_target_mode(monkeypatch):
         _parse_args()
 
 
+# ---------------------------------------------------------------------------
+# #472 vol-regime label mode: parser surface + ModelConfig wiring
+# ---------------------------------------------------------------------------
+
+
+def test_dual_head_runner_vol_regime_label_mode_defaults_off(monkeypatch):
+    """Default invocation keeps the byte-identical per-fold quantile path."""
+
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+        ],
+    )
+    args = _parse_args()
+    assert args.vol_regime_label_mode == "per_fold_quantile"
+    assert args.absolute_calm_max is None
+    assert args.absolute_high_min is None
+
+
+def test_dual_head_runner_accepts_absolute_label_mode_with_overrides(monkeypatch):
+    """Operator can opt into absolute labelling and override the cutoffs."""
+
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+            "--vol-regime-label-mode",
+            "absolute",
+            "--absolute-calm-max",
+            "10.0",
+            "--absolute-high-min",
+            "25.0",
+        ],
+    )
+    args = _parse_args()
+    assert args.vol_regime_label_mode == "absolute"
+    assert args.absolute_calm_max == pytest.approx(10.0)
+    assert args.absolute_high_min == pytest.approx(25.0)
+
+
+def test_dual_head_runner_rejects_unknown_vol_regime_label_mode(monkeypatch):
+    """argparse rejects any value outside the allowed enum."""
+
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+            "--vol-regime-label-mode",
+            "definitely_not_a_mode",
+        ],
+    )
+    with pytest.raises(SystemExit):
+        _parse_args()
+
+
+def test_dual_head_runner_default_label_mode_threads_per_fold_quantile(monkeypatch):
+    """Default invocation builds a ModelConfig with the quantile path on."""
+
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from app.models.config import DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+    from scripts import run_dual_head_comparison as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    runner._run_one_cell(
+        "dual",
+        seed=11,
+        training_package_id="tp_dummy",
+        fold_ids=["fold_001"],
+        epochs=1,
+        regression_alpha=0.5,
+        hidden_size=64,
+    )
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.vol_regime_label_mode == "per_fold_quantile"
+    assert model_config.absolute_vol_thresholds == DEFAULT_ABSOLUTE_VOL_THRESHOLDS
+
+
+def test_dual_head_runner_absolute_label_mode_threads_through(monkeypatch):
+    """``absolute`` opts the trainer into the fixed-threshold branch."""
+
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from scripts import run_dual_head_comparison as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    thresholds = (0.03, 0.05)
+    runner._run_one_cell(
+        "dual",
+        seed=11,
+        training_package_id="tp_dummy",
+        fold_ids=["fold_001"],
+        epochs=1,
+        regression_alpha=0.5,
+        hidden_size=64,
+        vol_regime_label_mode="absolute",
+        absolute_vol_thresholds=thresholds,
+    )
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.vol_regime_label_mode == "absolute"
+    assert model_config.absolute_vol_thresholds == thresholds
+
+
+def test_resolve_absolute_thresholds_converts_annualized_percent(monkeypatch):
+    """Annualized percent inputs convert to per-period units via sqrt(25.2)."""
+
+    import math
+
+    from scripts.run_dual_head_comparison import _resolve_absolute_thresholds
+
+    out = _resolve_absolute_thresholds("absolute", 12.0, 22.0)
+    assert out is not None
+    calm, high = out
+    assert calm == pytest.approx(0.12 / math.sqrt(25.2))
+    assert high == pytest.approx(0.22 / math.sqrt(25.2))
+
+
+def test_resolve_absolute_thresholds_returns_none_on_quantile_mode():
+    """Quantile mode never converts cutoffs even if values are supplied."""
+
+    from scripts.run_dual_head_comparison import _resolve_absolute_thresholds
+
+    assert (
+        _resolve_absolute_thresholds("per_fold_quantile", 12.0, 22.0) is None
+    )
+
+
 def test_per_family_runner_exposes_new_flags(monkeypatch):
     from scripts.run_per_family_ablation import _parse_args
 


### PR DESCRIPTION
## Summary
- New `--vol-regime-label-mode {per_fold_quantile, absolute}` flag (default `per_fold_quantile`, byte-identical).
- Absolute cutoffs: calm < 12% annualised, normal 12-22%, high >= 22%. Runner converts annualised inputs to per-period before passing to ModelConfig.
- Per-fold quantile manifests untouched on the absolute path.
- Reviewer fixes applied: `absolute_vol_thresholds` added to `_coerce_model_config` tuple_fields (JSON resume safety); run-summary now records effective thresholds (defaults on or CLI on) so the artefact is unambiguous.
- 32 tests pass; determinism regression stays green.

Unlocks the `absolute_regime` Wave 3 arm.

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit/test_absolute_regime_cutoffs.py tests/unit/test_run_dual_head_comparison.py -q`
- [ ] CI green