### PR TITLE
methodology: multi-horizon aux regression heads (#471)

### DIFF
--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -747,6 +747,21 @@ class ModelConfig:
     # to a follow-up because the response surface still emits one card
     # per statement (no per-symbol picker yet). See ADR + #480.
     symbol_embedding_dim: int = 0
+    # #471 multi-horizon auxiliary regression targets. Empty tuple
+    # (default) keeps the dual-head log-RV path byte-identical: no aux
+    # heads mount, no aux MSE term enters the joint loss, and the
+    # state_dict shape is unchanged. Each value in the tuple must be a
+    # supported forward-vol horizon other than 10 (the canonical primary
+    # target); the model factory mounts one parallel regression head per
+    # entry (same architecture as the canonical log-RV head) and the
+    # training loop adds an auxiliary
+    # ``aux_horizon_alpha * MSE(log(forward_realized_vol_<H>d_pred), target)``
+    # term to the joint loss for each mounted head. Applies to any
+    # ``head_mode`` whose forward emits the primary ``log_rv`` head
+    # (``regression`` and ``dual`` -- ``classification`` has no
+    # regression branch to mount aux heads against). See #471.
+    aux_horizons: tuple[int, ...] = ()
+    aux_horizon_alpha: float = 0.3
 
     @classmethod
     def from_model(cls, model: "Any") -> "ModelConfig":
@@ -842,6 +857,12 @@ class ModelConfig:
             ),
             symbol_embedding_dim=int(
                 getattr(model, "symbol_embedding_dim", 0) or 0
+            ),
+            aux_horizons=tuple(
+                int(v) for v in getattr(model, "aux_horizons", ()) or ()
+            ),
+            aux_horizon_alpha=float(
+                getattr(model, "aux_horizon_alpha", 0.3)
             ),
         )
 

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -176,6 +176,13 @@ def build_forecaster(
             # #480 symbol-conditioned regime head is research-only on the
             # recurrent class. The flat_mlp ctor does not consume it.
             "symbol_embedding_dim",
+            # #471 multi-horizon aux regression heads. The flat_mlp ctor
+            # does not mount the recurrent log-RV head's architecture,
+            # so the aux heads are not wired into it either. Drop both
+            # the head-list and the loss-side alpha so the kwargs
+            # dispatch stays a strict shape contract.
+            "aux_horizons",
+            "aux_horizon_alpha",
         ):
             flat_kwargs.pop(drop, None)
         flat_rates_heads = tuple(
@@ -431,6 +438,42 @@ def build_forecaster(
     # response-surface picker. Default 0 keeps the legacy path
     # byte-identical (no embedding module, no widening).
     symbol_embedding_dim_value = int(kwargs.pop("symbol_embedding_dim", 0) or 0)
+    # #471 multi-horizon aux regression heads. Pop here so the serving
+    # constructor (which does not accept the kwarg) does not receive
+    # it. The research class consumes ``aux_horizons`` directly to
+    # mount one parallel log-RV head per horizon; ``aux_horizon_alpha``
+    # is a loss-side knob the training loop reads off the stashed
+    # module attribute, so the model ctor never sees it.
+    aux_horizons_value: tuple[int, ...] = tuple(
+        int(v) for v in kwargs.pop("aux_horizons", ()) or ()
+    )
+    aux_horizon_alpha_value = float(kwargs.pop("aux_horizon_alpha", 0.3))
+    # Validate aux horizons are in the supported set and don't include
+    # the canonical primary (10). Reject early instead of mounting heads
+    # that the loss path cannot supervise. The empty-tuple default
+    # short-circuits cleanly.
+    if aux_horizons_value:
+        from app.models.config import SUPPORTED_VOL_TARGET_HORIZONS
+        invalid = [
+            h for h in aux_horizons_value
+            if h not in SUPPORTED_VOL_TARGET_HORIZONS or h == 10
+        ]
+        if invalid:
+            raise ValueError(
+                f"aux_horizons={aux_horizons_value} contains unsupported entries "
+                f"{invalid}. Allowed: any non-empty subset of "
+                f"{tuple(h for h in SUPPORTED_VOL_TARGET_HORIZONS if h != 10)}."
+            )
+        # Aux heads share the architecture of the primary log-RV head
+        # (head_mode in {regression, dual}). Reject classification mode
+        # so the misconfiguration surfaces before training fires.
+        head_mode_value = str(kwargs.get("head_mode", "dual") or "dual")
+        if head_mode_value == "classification":
+            raise ValueError(
+                f"aux_horizons={aux_horizons_value} requires head_mode in "
+                "{'regression', 'dual'} (the aux heads share the architecture "
+                f"of the primary log-RV head). Got head_mode={head_mode_value!r}."
+            )
     model: ForecasterResearchModel | ForecasterServingModel
     if role == "serving":
         # Serving construction trims the loss-side / sweep-side knobs the
@@ -462,6 +505,7 @@ def build_forecaster(
             use_vote_features=use_vote_features_flag,
             use_vix_features=use_vix_features_flag,
             symbol_embedding_dim=symbol_embedding_dim_value,
+            aux_horizons=aux_horizons_value,
             **kwargs,
         )
     # mypy reads ``nn.Module`` attribute writes as ``Tensor | Module``;
@@ -517,6 +561,14 @@ def build_forecaster(
     # which role built the module.
     if not hasattr(model, "symbol_embedding_dim"):
         model.symbol_embedding_dim = symbol_embedding_dim_value
+    # #471 round-trip the aux-horizons tuple + alpha so
+    # ``ModelConfig.from_model`` recovers them on resume. The research
+    # class set ``aux_horizons`` in its ctor; the serving class never
+    # mounts the heads, so the tuple stashes empty there. ``aux_horizon_alpha``
+    # is loss-side only -- the model ctor never sees it.
+    if not hasattr(model, "aux_horizons"):
+        model.aux_horizons = aux_horizons_value
+    model.aux_horizon_alpha = aux_horizon_alpha_value  # type: ignore[assignment]
     return model
 
 

--- a/backend/app/models/research_model.py
+++ b/backend/app/models/research_model.py
@@ -78,6 +78,7 @@ class ForecasterResearchModel(ForecasterBase):
         use_vix_features: bool = False,
         symbol_embedding_dim: int = 0,
         n_symbols: int = 0,
+        aux_horizons: tuple[int, ...] = (),
     ):
         if output_mode not in {"regression", "classification"}:
             raise ValueError(
@@ -178,6 +179,31 @@ class ForecasterResearchModel(ForecasterBase):
                 )
             else:
                 self.regression_head = None
+            # #471 multi-horizon auxiliary regression heads. Mount only
+            # when the primary log-RV regression head is also mounted --
+            # the aux heads share the encoder + recurrent core and only
+            # differ from the primary in their supervised target column
+            # (``forward_realized_vol_<H>d`` for each H). Aux heads stay
+            # empty when ``head_mode='classification'`` because the joint
+            # loss has no primary regression branch for them to compose
+            # with; the same head-mode + aux-horizons combination is
+            # rejected at the factory to surface the misconfiguration
+            # early. ``aux_horizons=()`` (default) leaves the ModuleDict
+            # empty so the state_dict shape is byte-identical to the
+            # pre-#471 path.
+            self.aux_horizons: tuple[int, ...] = tuple(
+                int(h) for h in aux_horizons or ()
+            )
+            self.aux_regression_heads: nn.ModuleDict = nn.ModuleDict()
+            if self.aux_horizons and self.regression_head is not None:
+                for horizon in self.aux_horizons:
+                    self.aux_regression_heads[f"h{int(horizon)}"] = nn.Sequential(
+                        nn.LayerNorm(head_input_size),
+                        nn.Linear(head_input_size, head_hidden_size),
+                        nn.GELU(),
+                        nn.Dropout(dropout),
+                        nn.Linear(head_hidden_size, 1),
+                    )
             self.rates_heads_active: tuple[str, ...] = tuple(
                 str(name).lower() for name in rates_heads or ()
             )
@@ -226,6 +252,8 @@ class ForecasterResearchModel(ForecasterBase):
             self.rates_aux_classification = bool(rates_aux_classification)
             self.rates_regression_heads = nn.ModuleDict()
             self.rates_classification_heads = nn.ModuleDict()
+            self.aux_horizons = ()
+            self.aux_regression_heads = nn.ModuleDict()
 
     def _pool_with_symbol(
         self,
@@ -289,6 +317,10 @@ class ForecasterResearchModel(ForecasterBase):
             ):
                 log_rv_pred = self.regression_head(head_input).squeeze(-1)
                 stashed["log_rv"] = log_rv_pred.detach()
+                for horizon in self.aux_horizons:
+                    key = f"h{int(horizon)}"
+                    aux_pred = self.aux_regression_heads[key](head_input).squeeze(-1)
+                    stashed[f"aux_log_rv_{int(horizon)}d"] = aux_pred.detach()
             for name in self.rates_heads_active:
                 bps_pred = self.rates_regression_heads[name](pooled_step).squeeze(-1)
                 stashed[f"rates_{name}_bps"] = bps_pred.detach()
@@ -346,6 +378,10 @@ class ForecasterResearchModel(ForecasterBase):
         ):
             log_rv_pred = self.regression_head(head_input).squeeze(-1)
             multi_task["log_rv"] = log_rv_pred
+            for horizon in self.aux_horizons:
+                key = f"h{int(horizon)}"
+                aux_pred = self.aux_regression_heads[key](head_input).squeeze(-1)
+                multi_task[f"aux_log_rv_{int(horizon)}d"] = aux_pred
         for name in self.rates_heads_active:
             bps_pred = self.rates_regression_heads[name](pooled_step).squeeze(-1)
             multi_task[f"rates_{name}_bps"] = bps_pred

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -2077,6 +2077,15 @@ def _load_package_sequences_with_metadata(
         garch_residual_value = _coerce_finite_float(
             row.get("forward_realized_vol_10d_garch_residual")
         )
+        # #471 multi-horizon auxiliary vol targets. Each value rides on
+        # the same event row alongside ``forward_realized_vol_10d``; the
+        # per-fold aux-target builder reads them off the target row of
+        # each supervised sequence. Pre-#480 parquets without the column
+        # degrade to ``None`` here and the aux head sees the row masked.
+        forward_vol_aux_values: dict[int, float | None] = {
+            h: _coerce_finite_float(row.get(f"forward_realized_vol_{h}d"))
+            for h in (1, 3, 5, 20, 30)
+        }
         # #292 rates-complex strict-forward 5d yield change targets.
         # Each value rides on the same event row alongside
         # forward_realized_vol_10d; the per-fold target builder
@@ -2201,6 +2210,11 @@ def _load_package_sequences_with_metadata(
             vix_features_list = None
         for vector in vectors:
             vector.forward_realized_vol_10d = forward_vol_value
+            vector.forward_realized_vol_1d = forward_vol_aux_values[1]
+            vector.forward_realized_vol_3d = forward_vol_aux_values[3]
+            vector.forward_realized_vol_5d = forward_vol_aux_values[5]
+            vector.forward_realized_vol_20d = forward_vol_aux_values[20]
+            vector.forward_realized_vol_30d = forward_vol_aux_values[30]
             vector.forward_realized_vol_10d_garch_baseline = garch_baseline_value
             vector.forward_realized_vol_10d_garch_residual = garch_residual_value
             vector.target_yield_2y_change_5d = rates_2y_value
@@ -2956,6 +2970,12 @@ def load_training_sequences_from_package(
         garch_residual_value = _coerce_finite_float(
             row.get("forward_realized_vol_10d_garch_residual")
         )
+        # #471 multi-horizon auxiliary vol targets (matched site to the
+        # walk-forward loader above). Pre-#480 parquets degrade to ``None``.
+        forward_vol_aux_values: dict[int, float | None] = {
+            h: _coerce_finite_float(row.get(f"forward_realized_vol_{h}d"))
+            for h in (1, 3, 5, 20, 30)
+        }
         # #292 rates-complex strict-forward 5d yield change targets.
         # Each value rides on the same event row alongside
         # forward_realized_vol_10d; the per-fold target builder
@@ -3058,6 +3078,11 @@ def load_training_sequences_from_package(
             vix_features_list = None
         for vector in vectors:
             vector.forward_realized_vol_10d = forward_vol_value
+            vector.forward_realized_vol_1d = forward_vol_aux_values[1]
+            vector.forward_realized_vol_3d = forward_vol_aux_values[3]
+            vector.forward_realized_vol_5d = forward_vol_aux_values[5]
+            vector.forward_realized_vol_20d = forward_vol_aux_values[20]
+            vector.forward_realized_vol_30d = forward_vol_aux_values[30]
             vector.forward_realized_vol_10d_garch_baseline = garch_baseline_value
             vector.forward_realized_vol_10d_garch_residual = garch_residual_value
             vector.target_yield_2y_change_5d = rates_2y_value

--- a/backend/app/training/loop.py
+++ b/backend/app/training/loop.py
@@ -260,6 +260,7 @@ def _coerce_model_config(model_config: ModelConfig | dict[str, Any] | None = Non
             # must coerce back so downstream equality + tuple-typed slots
             # stay correct on resume.
             "absolute_vol_thresholds",
+            "aux_horizons",
         }
         kwargs: dict[str, Any] = {}
         for key, value in model_config.items():
@@ -267,6 +268,8 @@ def _coerce_model_config(model_config: ModelConfig | dict[str, Any] | None = Non
                 continue
             if key == "rates_heads":
                 kwargs[key] = tuple(str(v).lower() for v in (value or ()))
+            elif key == "aux_horizons":
+                kwargs[key] = tuple(int(v) for v in (value or ()))
             elif key in tuple_fields:
                 kwargs[key] = tuple(float(v) for v in (value or ()))
             else:
@@ -815,6 +818,7 @@ def _make_partition_dataset(
     mt_aux: dict[str, torch.Tensor] | None,
     log_rv: torch.Tensor | None = None,
     rates_index: torch.Tensor | None = None,
+    aux_log_rv: torch.Tensor | None = None,
 ) -> TensorDataset:
     """Pack one partition's tensors into a TensorDataset using a fixed contract.
 
@@ -843,6 +847,15 @@ def _make_partition_dataset(
     is trained against under ``head_mode`` in ``{regression, dual}``.
     The tensor sits at the end of the tuple regardless of whether the
     multi-task aux block precedes it so the contract is composable.
+
+    The optional ``aux_log_rv`` tensor (#471) carries the per-horizon
+    standardised log-vol targets stacked column-wise; it is folded
+    INTO ``log_rv`` so the dataset arity stays unchanged. When ``log_rv``
+    is 1-D (no aux) the column count is 1 and the train step slices
+    ``[:, 0]`` (recovered via ``.unsqueeze(-1)`` for the rank-1 input
+    so the slice operates on a uniform 2-D tensor). When aux horizons
+    are mounted the column count is ``1 + len(aux_horizons)`` and the
+    aux columns ride alongside the primary.
     """
 
     tensors: list[torch.Tensor] = [x, y]
@@ -857,7 +870,16 @@ def _make_partition_dataset(
                 )
             tensors.append(mt_aux[key])
     if log_rv is not None:
-        tensors.append(log_rv)
+        if aux_log_rv is not None:
+            # Stack primary (1-D) into a (N, 1+H) tensor; col 0 stays
+            # the primary log_rv, col 1..H carry the aux horizons in
+            # the same column order ``aux_horizons`` was passed to the
+            # partition builder. Keeps the dataset arity contract
+            # byte-identical to pre-#471 when ``aux_log_rv`` is None.
+            stacked = torch.cat([log_rv.unsqueeze(-1), aux_log_rv], dim=-1)
+            tensors.append(stacked)
+        else:
+            tensors.append(log_rv)
     if rates_index is not None:
         tensors.append(rates_index)
     return TensorDataset(*tensors)
@@ -874,14 +896,19 @@ def _unpack_batch(
     torch.Tensor | None,
     torch.Tensor | None,
 ]:
-    """Decode a DataLoader batch into ``(x, y, text, text_missing, mt_aux, log_rv)``.
+    """Decode a DataLoader batch into ``(x, y, text, text_missing, mt_aux, log_rv, rates_index)``.
 
     Eight batch shapes are tolerated; see :func:`_make_partition_dataset`
     for the arity-to-contents map. ``mt_aux`` is a 4-key dict (factor,
     factor_mask, certainty, certainty_mask) when the multi-task path is
     active and ``None`` otherwise; the topic axis pair was retired in
-    ADR 0044. ``log_rv`` is the optional 1-D dual-head regression target
-    tensor (#304); ``None`` on classification-only runs.
+    ADR 0044. ``log_rv`` is the dual-head regression target tensor
+    (#304); ``None`` on classification-only runs. When ``aux_horizons``
+    (#471) is non-empty the partition builder folds the per-horizon
+    stacked targets into ``log_rv`` as a 2-D ``(N, 1+H)`` tensor with
+    the primary at column 0 and the aux horizons in columns 1..H; the
+    train step splits the columns at the loss-construction site so
+    the unpack tuple shape stays unchanged.
     """
 
     arity = len(batch)
@@ -1483,6 +1510,9 @@ def _combine_dual_head_loss(
     batch_log_rv: torch.Tensor | None,
     head_mode: str,
     regression_alpha: float,
+    batch_aux_log_rv: torch.Tensor | None = None,
+    aux_horizons: tuple[int, ...] = (),
+    aux_horizon_alpha: float = 0.0,
 ) -> torch.Tensor:
     """Combine the classification CE with the #304 log(RV) MSE term.
 
@@ -1529,11 +1559,93 @@ def _combine_dual_head_loss(
     log_rv_pred = logits_dict["log_rv"]
     mse_loss = F.mse_loss(log_rv_pred, batch_log_rv.to(log_rv_pred.dtype))
     _assert_dual_head_scales_balanced(ce_loss, mse_loss)
+    aux_term = _maybe_aux_horizon_mse(
+        logits_dict=logits_dict,
+        batch_aux_log_rv=batch_aux_log_rv,
+        aux_horizons=aux_horizons,
+        aux_horizon_alpha=aux_horizon_alpha,
+    )
     if head_mode == "regression":
-        return mse_loss
+        return mse_loss + aux_term
     if alpha >= 1.0:
-        return mse_loss
-    return (1.0 - alpha) * ce_loss + alpha * mse_loss
+        return mse_loss + aux_term
+    return (1.0 - alpha) * ce_loss + alpha * mse_loss + aux_term
+
+
+def _split_log_rv_into_primary_and_aux(
+    combined: torch.Tensor | None,
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    """Split the joint ``log_rv`` tensor into the primary + aux blocks (#471).
+
+    The partition builder folds the aux-horizon stack into ``log_rv`` as
+    a 2-D ``(N, 1+H)`` tensor so the dataset arity stays unchanged.
+    When ``combined`` is ``None`` or 1-D the byte-identical pre-#471
+    contract holds: ``(combined, None)``. When 2-D the primary
+    1-D tensor at column 0 + the 2-D aux tensor at columns 1..H are
+    returned; an ``H == 0`` (1-column) tensor degrades to no-aux so a
+    future caller that emits a wrapped primary still composes cleanly.
+    """
+
+    if combined is None:
+        return None, None
+    if combined.dim() == 1:
+        return combined, None
+    primary = combined[:, 0]
+    if combined.size(1) <= 1:
+        return primary, None
+    return primary, combined[:, 1:]
+
+
+def _maybe_aux_horizon_mse(
+    *,
+    logits_dict: dict[str, torch.Tensor],
+    batch_aux_log_rv: torch.Tensor | None,
+    aux_horizons: tuple[int, ...],
+    aux_horizon_alpha: float,
+) -> torch.Tensor:
+    """Aux MSE: ``alpha * mean_h MSE(pred_h, target_h)`` (#471).
+
+    Returns a graph-attached scalar zero when no aux heads are mounted
+    or the batch carries no aux targets (degenerate fixture). Otherwise
+    averages the per-horizon MSE before scaling by ``alpha`` so the
+    effective aux budget is the same regardless of how many horizons
+    are mounted -- doubling ``aux_horizons`` does not double the aux
+    gradient relative to the primary loss.
+    """
+
+    if not aux_horizons or batch_aux_log_rv is None:
+        # Graph-attached zero so backward stays defined when the caller
+        # adds the term unconditionally. Use the log_rv head's tensor
+        # when available so the zero rides the same device/dtype.
+        anchor = logits_dict.get("log_rv")
+        if anchor is None:
+            anchor = next(iter(logits_dict.values()))
+        return anchor.sum() * 0.0
+    alpha = float(aux_horizon_alpha)
+    if alpha <= 0.0:
+        anchor = logits_dict.get("log_rv")
+        if anchor is None:
+            anchor = next(iter(logits_dict.values()))
+        return anchor.sum() * 0.0
+    total: torch.Tensor | None = None
+    n_contributed = 0
+    for col, horizon in enumerate(aux_horizons):
+        key = f"aux_log_rv_{int(horizon)}d"
+        if key not in logits_dict:
+            continue
+        pred = logits_dict[key]
+        target = batch_aux_log_rv[:, col].to(pred.dtype)
+        mse = F.mse_loss(pred, target)
+        total = mse if total is None else total + mse
+        n_contributed += 1
+    if total is not None and n_contributed > 0:
+        total = alpha * total / float(n_contributed)
+    if total is None:
+        anchor = logits_dict.get("log_rv")
+        if anchor is None:
+            anchor = next(iter(logits_dict.values()))
+        return anchor.sum() * 0.0
+    return total
 
 
 def _maybe_add_dual_head_loss(
@@ -1543,6 +1655,9 @@ def _maybe_add_dual_head_loss(
     batch_log_rv: torch.Tensor | None,
     head_mode: str,
     regression_alpha: float,
+    batch_aux_log_rv: torch.Tensor | None = None,
+    aux_horizons: tuple[int, ...] = (),
+    aux_horizon_alpha: float = 0.0,
 ) -> torch.Tensor:
     """Augment an existing multi-task loss with the dual-head MSE.
 
@@ -1580,14 +1695,20 @@ def _maybe_add_dual_head_loss(
     log_rv_pred = logits_dict["log_rv"]
     mse_loss = F.mse_loss(log_rv_pred, batch_log_rv.to(log_rv_pred.dtype))
     _assert_dual_head_scales_balanced(loss, mse_loss)
+    aux_term = _maybe_aux_horizon_mse(
+        logits_dict=logits_dict,
+        batch_aux_log_rv=batch_aux_log_rv,
+        aux_horizons=aux_horizons,
+        aux_horizon_alpha=aux_horizon_alpha,
+    )
     if head_mode == "regression":
-        return loss + mse_loss
+        return loss + mse_loss + aux_term
     alpha = float(regression_alpha)
     if alpha <= 0.0:
-        return loss
+        return loss + aux_term
     if alpha >= 1.0:
-        return mse_loss
-    return (1.0 - alpha) * loss + alpha * mse_loss
+        return mse_loss + aux_term
+    return (1.0 - alpha) * loss + alpha * mse_loss + aux_term
 
 
 # One-shot diagnostic: warn (once per process) when the CE side and the
@@ -1905,6 +2026,112 @@ def _build_partition_log_rv_target(
     return standardised, scaler_out
 
 
+def _build_partition_aux_log_rv_targets(
+    sequence_groups: "Sequence[Sequence[FeatureVector]]",
+    *,
+    aux_horizons: "Sequence[int]",
+    vol_regime_quantiles: "Sequence[float]",
+    aux_log_rv_scalers: "dict[int, tuple[float, float]] | None" = None,
+    sequence_length: int = SEQUENCE_LENGTH,
+) -> "tuple[torch.Tensor | None, dict[int, tuple[float, float]] | None]":
+    """Materialise per-partition aux log-vol targets for #471.
+
+    Returns ``(stacked, scalers)`` where ``stacked`` is a 2D
+    ``torch.float32`` of shape ``(N, len(aux_horizons))`` (column order
+    matches ``aux_horizons``) and ``scalers`` is a per-horizon
+    standardiser dict (mean, std). The row count + ordering match the
+    classification ``y`` tensor :func:`_build_partition_tensors` emits
+    so the TensorDataset row invariant holds when both tensors are
+    packed alongside.
+
+    The per-row gate mirrors :func:`_build_partition_log_rv_target`:
+    same group-level pre-filter on ``forward_realized_vol_10d`` (so the
+    row counts agree across the primary + aux paths), then per-row
+    ``vol_regime_class_for`` gate against the same quantiles. Rows
+    whose aux horizon target is missing / non-finite / non-positive
+    fall back to the primary log_rv value so the column shape stays
+    rectangular (the alternative — masking — would force an aux mask
+    tensor pair per horizon and double the dataset payload). The
+    fallback rate is logged once per partition + horizon so the
+    operator can grep how often the data side dropped an aux row.
+
+    Standardisation is fitted per horizon on the train slice only (no
+    look-ahead) and echoed back on val / test so the partitions share
+    the train-fit transform.
+    """
+
+    from app.training.loaders import vol_regime_class_for
+
+    horizons = [int(h) for h in aux_horizons]
+    if not horizons:
+        return None, aux_log_rv_scalers
+
+    per_horizon_values: dict[int, list[float]] = {h: [] for h in horizons}
+    fallback_counts: dict[int, int] = {h: 0 for h in horizons}
+    for sequence_group in sequence_groups:
+        if len(sequence_group) < sequence_length + 1:
+            continue
+        leading_target = sequence_group[sequence_length]
+        leading_vol = getattr(leading_target, "forward_realized_vol_10d", None)
+        if leading_vol is None or (
+            isinstance(leading_vol, float) and leading_vol != leading_vol
+        ):
+            continue
+        for idx in range(sequence_length, len(sequence_group)):
+            target_row = sequence_group[idx]
+            cls_idx = vol_regime_class_for(
+                getattr(target_row, "forward_realized_vol_10d", None),
+                vol_regime_quantiles,
+            )
+            if cls_idx < 0:
+                continue
+            primary_vol = getattr(target_row, "forward_realized_vol_10d", None)
+            if not _is_finite_positive_forward_vol(primary_vol):
+                continue
+            # mypy: narrowed at runtime by the guard above
+            primary_log = math.log(float(primary_vol))  # type: ignore[arg-type]
+            for horizon in horizons:
+                attr = f"forward_realized_vol_{horizon}d"
+                aux_vol = getattr(target_row, attr, None)
+                if _is_finite_positive_forward_vol(aux_vol):
+                    per_horizon_values[horizon].append(
+                        math.log(float(aux_vol))  # type: ignore[arg-type]
+                    )
+                else:
+                    fallback_counts[horizon] += 1
+                    per_horizon_values[horizon].append(primary_log)
+
+    if not per_horizon_values[horizons[0]]:
+        return None, aux_log_rv_scalers
+
+    columns: list[torch.Tensor] = []
+    scalers_out: dict[int, tuple[float, float]] = (
+        dict(aux_log_rv_scalers) if aux_log_rv_scalers else {}
+    )
+    for horizon in horizons:
+        raw = torch.tensor(per_horizon_values[horizon], dtype=torch.float32)
+        if horizon in scalers_out:
+            mean_v, std_v = scalers_out[horizon]
+        else:
+            mean_v = float(raw.mean().item())
+            std_v = float(raw.std(unbiased=False).item())
+            if std_v < 1e-6:
+                std_v = 1.0
+            scalers_out[horizon] = (mean_v, std_v)
+        columns.append((raw - mean_v) / std_v)
+        if fallback_counts[horizon]:
+            _logger.warning(
+                "[aux-horizon] horizon=%dd: %d row(s) had missing or "
+                "non-positive forward_realized_vol_%dd; fell back to "
+                "log(forward_realized_vol_10d)",
+                horizon,
+                fallback_counts[horizon],
+                horizon,
+            )
+    stacked = torch.stack(columns, dim=1)
+    return stacked, scalers_out
+
+
 def _evaluate_model(
     model: nn.Module,
     loader: DataLoader[Any],
@@ -2052,9 +2279,15 @@ def _evaluate_model(
                 batch_text,
                 batch_text_missing,
                 batch_mt_aux,
-                batch_log_rv,
+                batch_log_rv_combined,
                 _batch_rates_index,
             ) = _unpack_batch(batch)
+            # Eval ignores the aux-horizon columns — the headline metrics
+            # only surface the primary log_rv MAE / RMSE / R². The
+            # aux-horizon eval surface is left as a follow-up.
+            batch_log_rv, _batch_aux_log_rv = _split_log_rv_into_primary_and_aux(
+                batch_log_rv_combined
+            )
             if multi_task_active and batch_mt_aux is None:
                 raise RuntimeError(
                     "multi_task_loss_fn is active but the DataLoader yielded "
@@ -2657,6 +2890,22 @@ def train_model(
     test_rates_targets: RatesPartitionTensors | None = None
     rates_scalers: dict[str, Any] = {}
     rates_edges: dict[str, Any] = {}
+    # #471 multi-horizon aux regression targets. Each entry maps a
+    # horizon int to its per-partition standardised log-vol target
+    # tensor (built from the same group/row filter the primary log_rv
+    # builder uses). Empty when ``aux_horizons=()`` so the partition
+    # tensor pack is byte-identical to the pre-#471 path.
+    active_aux_horizons: tuple[int, ...] = tuple(
+        int(h) for h in getattr(active_model_config, "aux_horizons", ()) or ()
+    )
+    active_aux_horizon_alpha = float(
+        getattr(active_model_config, "aux_horizon_alpha", 0.3)
+    )
+    aux_horizons_active = bool(active_aux_horizons)
+    train_aux_log_rv: torch.Tensor | None = None
+    val_aux_log_rv: torch.Tensor | None = None
+    test_aux_log_rv: torch.Tensor | None = None
+    aux_log_rv_scalers: dict[int, tuple[float, float]] | None = None
     # ``ModelConfig.sequence_length=0`` means "use module default" so
     # checkpoints saved before #530 keep the byte-identical 20-bar window.
     active_sequence_length = int(
@@ -2834,6 +3083,15 @@ def train_model(
                 vol_target_mode=active_vol_target_mode,
                 sequence_length=active_sequence_length,
             )
+            if aux_horizons_active:
+                train_aux_log_rv, aux_log_rv_scalers = (
+                    _build_partition_aux_log_rv_targets(
+                        train_groups,
+                        aux_horizons=active_aux_horizons,
+                        vol_regime_quantiles=fitted_quantiles,
+                        sequence_length=active_sequence_length,
+                    )
+                )
         # #292 rates heads -- per-partition targets fitted on train.
         if rates_heads_active and active_output_mode == "classification":
             from app.training.rates_targets import build_partition_rates_targets
@@ -2900,6 +3158,19 @@ def train_model(
                 vol_target_mode=active_vol_target_mode,
                 sequence_length=active_sequence_length,
             )
+            # Skip val/test aux build when the train call returned without
+            # fitting scalers (degenerate empty-train fixture). Without
+            # this guard ``_build_partition_aux_log_rv_targets`` would
+            # silently re-fit the per-horizon mean/std on the val slice,
+            # leaking the held-out distribution into the standardiser.
+            if aux_horizons_active and aux_log_rv_scalers:
+                val_aux_log_rv, _ = _build_partition_aux_log_rv_targets(
+                    val_groups,
+                    aux_horizons=active_aux_horizons,
+                    vol_regime_quantiles=fitted_quantiles,
+                    aux_log_rv_scalers=aux_log_rv_scalers,
+                    sequence_length=active_sequence_length,
+                )
         if rates_heads_active and active_output_mode == "classification":
             from app.training.rates_targets import build_partition_rates_targets
 
@@ -2954,6 +3225,15 @@ def train_model(
                 vol_target_mode=active_vol_target_mode,
                 sequence_length=active_sequence_length,
             )
+            # Same train-only-scaler guard as the val branch above.
+            if aux_horizons_active and aux_log_rv_scalers:
+                test_aux_log_rv, _ = _build_partition_aux_log_rv_targets(
+                    test_groups,
+                    aux_horizons=active_aux_horizons,
+                    vol_regime_quantiles=fitted_quantiles,
+                    aux_log_rv_scalers=aux_log_rv_scalers,
+                    sequence_length=active_sequence_length,
+                )
         if rates_heads_active and active_output_mode == "classification":
             from app.training.rates_targets import build_partition_rates_targets
 
@@ -3071,6 +3351,7 @@ def train_model(
         # tensor over the full active_sequence_groups list, then split
         # below alongside (x, y) so the row alignment invariant holds.
         legacy_full_log_rv: torch.Tensor | None = None
+        legacy_full_aux_log_rv: torch.Tensor | None = None
         if dual_head_active and active_output_mode == "classification":
             legacy_full_log_rv, log_rv_scaler = _build_partition_log_rv_target(
                 active_sequence_groups,
@@ -3078,6 +3359,15 @@ def train_model(
                 vol_target_mode=active_vol_target_mode,
                 sequence_length=active_sequence_length,
             )
+            if aux_horizons_active:
+                legacy_full_aux_log_rv, aux_log_rv_scalers = (
+                    _build_partition_aux_log_rv_targets(
+                        active_sequence_groups,
+                        aux_horizons=active_aux_horizons,
+                        vol_regime_quantiles=legacy_fitted_quantiles,
+                        sequence_length=active_sequence_length,
+                    )
+                )
         text_emb_tensor, text_missing_tensor, _text_emb_dim = _build_text_embedding_tensors(
             active_sequence_groups,
             fallback_in_dim=fallback_text_in_dim,
@@ -3167,6 +3457,9 @@ def train_model(
         if legacy_full_log_rv is not None:
             train_log_rv = legacy_full_log_rv[: len(train_x)]
             val_log_rv = legacy_full_log_rv[len(train_x) :]
+        if legacy_full_aux_log_rv is not None:
+            train_aux_log_rv = legacy_full_aux_log_rv[: len(train_x)]
+            val_aux_log_rv = legacy_full_aux_log_rv[len(train_x) :]
         # Legacy path has no real held-out test partition; the val
         # tensors serve as both early-stopping and final-report eval.
         test_x = val_x
@@ -3175,6 +3468,8 @@ def train_model(
         test_text_missing = val_text_missing
         if legacy_full_log_rv is not None:
             test_log_rv = val_log_rv
+        if legacy_full_aux_log_rv is not None:
+            test_aux_log_rv = val_aux_log_rv
 
     # Empty-tensor guard for the walk-forward branch. The legacy branch
     # already short-circuits above on (x, y) == (None, None).
@@ -3271,6 +3566,10 @@ def train_model(
     train_log_rv = _move_to_device(train_log_rv, device_obj)
     val_log_rv = _move_to_device(val_log_rv, device_obj)
     test_log_rv = _move_to_device(test_log_rv, device_obj)
+    # #471 aux-horizon targets ride alongside log_rv on the same device.
+    train_aux_log_rv = _move_to_device(train_aux_log_rv, device_obj)
+    val_aux_log_rv = _move_to_device(val_aux_log_rv, device_obj)
+    test_aux_log_rv = _move_to_device(test_aux_log_rv, device_obj)
     # Tensors now live on the target device, so DataLoader pinning is
     # neither needed nor supported (PyTorch raises on pinning a CUDA
     # tensor). The original pin-memory comment about deprecation
@@ -3294,6 +3593,7 @@ def train_model(
         train_mt_aux,
         train_log_rv,
         rates_index=train_rates_index,
+        aux_log_rv=train_aux_log_rv,
     )
 
     # Early-stopping val loader: when the walk-forward branch supplied
@@ -3315,6 +3615,7 @@ def train_model(
         val_mt_aux_used = train_mt_aux
         val_log_rv_used = train_log_rv
         val_rates_targets_used = train_rates_targets
+        val_aux_log_rv_used = train_aux_log_rv
     else:
         val_x_used = val_x
         val_y_used = val_y
@@ -3323,6 +3624,7 @@ def train_model(
         val_mt_aux_used = val_mt_aux
         val_log_rv_used = val_log_rv
         val_rates_targets_used = val_rates_targets
+        val_aux_log_rv_used = val_aux_log_rv
 
     val_rates_index = (
         torch.arange(int(val_x_used.size(0)), dtype=torch.int64, device=val_x_used.device)
@@ -3337,6 +3639,7 @@ def train_model(
         val_mt_aux_used,
         val_log_rv_used,
         rates_index=val_rates_index,
+        aux_log_rv=val_aux_log_rv_used,
     )
 
     if test_x is not None and test_y is not None and len(test_x) > 0:
@@ -3353,6 +3656,7 @@ def train_model(
             test_mt_aux,
             test_log_rv,
             rates_index=test_rates_index,
+            aux_log_rv=test_aux_log_rv,
         )
     else:
         test_dataset = None
@@ -3762,9 +4066,18 @@ def train_model(
                 batch_text,
                 batch_text_missing,
                 batch_mt_aux,
-                batch_log_rv,
+                batch_log_rv_combined,
                 batch_rates_index,
             ) = _unpack_batch(batch)
+            # #471 split the (N, 1+H) joint log_rv tensor into the
+            # primary 1-D ``batch_log_rv`` (column 0) and the per-horizon
+            # 2-D ``batch_aux_log_rv`` (columns 1..H). When aux horizons
+            # are inactive the partition builder emitted the legacy 1-D
+            # tensor; this branch leaves ``batch_aux_log_rv`` at ``None``
+            # and ``batch_log_rv`` byte-identical to the pre-#471 path.
+            batch_log_rv, batch_aux_log_rv = _split_log_rv_into_primary_and_aux(
+                batch_log_rv_combined
+            )
             # Tensors are already on the target device; the .to() calls
             # below were the hot kernel-launch source the perf rewrite
             # eliminates.
@@ -3840,6 +4153,9 @@ def train_model(
                         batch_log_rv=batch_log_rv,
                         head_mode=active_head_mode,
                         regression_alpha=regression_alpha,
+                        batch_aux_log_rv=batch_aux_log_rv,
+                        aux_horizons=active_aux_horizons,
+                        aux_horizon_alpha=active_aux_horizon_alpha,
                     )
                     rates_loss = _build_rates_batch_loss(
                         logits_dict=logits_dict,
@@ -3876,6 +4192,9 @@ def train_model(
                         batch_log_rv=batch_log_rv,
                         head_mode=active_head_mode,
                         regression_alpha=regression_alpha,
+                        batch_aux_log_rv=batch_aux_log_rv,
+                        aux_horizons=active_aux_horizons,
+                        aux_horizon_alpha=active_aux_horizon_alpha,
                     )
                     rates_loss = _build_rates_batch_loss(
                         logits_dict=logits_dict,

--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -297,6 +297,35 @@ def _parse_args() -> argparse.Namespace:
             "``1 + |true - argmax|`` so far-bin confusions pay more."
         ),
     )
+    # #471 multi-horizon auxiliary regression heads. Empty default
+    # (no aux heads mounted) keeps every existing canonical sweep
+    # byte-identical. ``--aux-horizons 5,20`` mounts one parallel
+    # regression head per listed horizon; each head shares the
+    # encoder + recurrent core with the primary log-RV head and is
+    # supervised against ``forward_realized_vol_<H>d``.
+    parser.add_argument(
+        "--aux-horizons",
+        dest="aux_horizons",
+        type=_parse_aux_horizons,
+        default=(),
+        help=(
+            "Comma-separated forward-vol horizons to mount as auxiliary "
+            "regression targets alongside the canonical 10d primary. "
+            "Example: '--aux-horizons 5,20'. Each entry must be a "
+            "supported horizon other than 10. Empty default leaves the "
+            "joint loss byte-identical to the pre-#471 path."
+        ),
+    )
+    parser.add_argument(
+        "--aux-horizon-alpha",
+        type=float,
+        default=0.3,
+        help=(
+            "Weight on each auxiliary horizon's MSE term in the joint "
+            "loss (single scalar shared across every aux horizon). "
+            "Default 0.3 mirrors the multi-task aux convention."
+        ),
+    )
     # Pooled-text path. Default ``None`` keeps the text path off so the
     # canonical sweep stays byte-identical; set to an encoder alias
     # (resolved through ``app.models.registry.encoder_ref``) or a HF
@@ -390,6 +419,40 @@ def _parse_args() -> argparse.Namespace:
         use_vix_features=False,
     )
     return parser.parse_args()
+
+
+def _parse_aux_horizons(value: str) -> tuple[int, ...]:
+    """Parse the ``--aux-horizons`` CLI value into a validated tuple.
+
+    Accepts a comma-separated list of integers (e.g. ``"5,20"``).
+    Rejects any entry not in the supported aux set
+    (``{1, 3, 5, 20, 30}``) so the misconfiguration surfaces at parse
+    time rather than after the loader read.
+    """
+
+    from app.models.config import SUPPORTED_VOL_TARGET_HORIZONS
+
+    if not value or not value.strip():
+        return ()
+    parts = [chunk.strip() for chunk in value.split(",") if chunk.strip()]
+    horizons: list[int] = []
+    allowed = tuple(h for h in SUPPORTED_VOL_TARGET_HORIZONS if h != 10)
+    for chunk in parts:
+        try:
+            horizon = int(chunk)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                f"--aux-horizons entry {chunk!r} is not an integer"
+            ) from exc
+        if horizon not in allowed:
+            raise argparse.ArgumentTypeError(
+                f"--aux-horizons entry {horizon} is not in the allowed "
+                f"set {allowed} (10 is the primary and excluded)"
+            )
+        horizons.append(horizon)
+    # Preserve operator-supplied ordering so the column order on the
+    # aux target tensor is reproducible across runs.
+    return tuple(horizons)
 
 
 def _resolve_fold_ids(training_package_id: str, override: list[str] | None) -> list[str]:
@@ -515,6 +578,8 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
     vol_regime_label_mode: str = "per_fold_quantile",
     absolute_vol_thresholds: tuple[float, float] | None = None,
     use_mp_surprise: bool = True,
+    aux_horizons: tuple[int, ...] = (),
+    aux_horizon_alpha: float = 0.3,
 ) -> dict[str, Any]:
     # Imports happen here so the script is importable without a torch
     # install (useful for doc-only environments).
@@ -558,6 +623,8 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
         regime_loss_mode=regime_loss,
         vol_regime_label_mode=vol_regime_label_mode,
         absolute_vol_thresholds=resolved_absolute_thresholds,
+        aux_horizons=tuple(aux_horizons),
+        aux_horizon_alpha=float(aux_horizon_alpha),
     )
 
     per_fold: list[dict[str, Any]] = []
@@ -696,6 +763,8 @@ def main() -> int:
                     vol_regime_label_mode=str(args.vol_regime_label_mode),
                     absolute_vol_thresholds=absolute_thresholds,
                     use_mp_surprise=bool(args.use_mp_surprise),
+                    aux_horizons=tuple(args.aux_horizons),
+                    aux_horizon_alpha=float(args.aux_horizon_alpha),
                 )
             )
 
@@ -760,6 +829,8 @@ def main() -> int:
         "absolute_calm_max_annualized": args.absolute_calm_max,
         "absolute_high_min_annualized": args.absolute_high_min,
         "use_mp_surprise": bool(args.use_mp_surprise),
+        "aux_horizons": list(args.aux_horizons),
+        "aux_horizon_alpha": float(args.aux_horizon_alpha),
         "trials": trials,
         "summary": summary,
     }

--- a/tests/unit/test_multi_horizon_aux.py
+++ b/tests/unit/test_multi_horizon_aux.py
@@ -1,0 +1,223 @@
+"""Multi-horizon auxiliary regression heads (#471).
+
+The regime classifier trains primarily against
+``forward_realized_vol_10d``. ``aux_horizons`` mounts parallel
+regression heads against other forward-vol horizons so the encoder
+sees more horizon-signal without changing the canonical headline.
+
+These tests pin the wiring at four layers:
+
+- ``ModelConfig.aux_horizons`` defaults empty and round-trips through
+  ``from_model`` when set.
+- ``build_forecaster`` mounts the correct number of aux regression heads
+  alongside the primary log-RV head.
+- The joint loss equals the hand-computed sum of the primary MSE +
+  ``alpha * MSE`` per aux horizon.
+- A model built with ``aux_horizons=()`` (default) has identical
+  state_dict shape to the pre-#471 dual-head construction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from app.models.config import ModelConfig
+from app.models.factory import build_forecaster
+from app.training.loop import _maybe_aux_horizon_mse
+
+
+# ---------------------------------------------------------------------------
+# ModelConfig round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_aux_horizons_default_empty() -> None:
+    """No aux horizons mounted by default keeps the pre-#471 path byte-identical."""
+
+    config = ModelConfig()
+    assert config.aux_horizons == ()
+    assert config.aux_horizon_alpha == pytest.approx(0.3)
+
+
+def test_aux_horizons_opt_in_roundtrip_via_from_model() -> None:
+    """``aux_horizons`` survives the ModelConfig.from_model round-trip."""
+
+    config = ModelConfig(
+        output_mode="classification",
+        head_mode="dual",
+        n_classes=3,
+        hidden_size=16,
+        head_hidden_size=8,
+        aux_horizons=(5, 20),
+        aux_horizon_alpha=0.4,
+    )
+    model = build_forecaster(config)
+    rebuilt = ModelConfig.from_model(model)
+    assert rebuilt.aux_horizons == (5, 20)
+    assert rebuilt.aux_horizon_alpha == pytest.approx(0.4)
+
+
+# ---------------------------------------------------------------------------
+# Factory + head mounting
+# ---------------------------------------------------------------------------
+
+
+def _build_dual_head(
+    aux_horizons: tuple[int, ...] = (), aux_horizon_alpha: float = 0.3
+) -> "torch.nn.Module":
+    config = ModelConfig(
+        output_mode="classification",
+        head_mode="dual",
+        n_classes=3,
+        hidden_size=16,
+        head_hidden_size=8,
+        aux_horizons=aux_horizons,
+        aux_horizon_alpha=aux_horizon_alpha,
+    )
+    return build_forecaster(config)
+
+
+def test_factory_mounts_one_aux_head_per_horizon() -> None:
+    """``aux_horizons=(5, 20)`` mounts two aux regression heads."""
+
+    model = _build_dual_head(aux_horizons=(5, 20))
+    assert hasattr(model, "aux_regression_heads")
+    aux_heads = model.aux_regression_heads
+    # ModuleDict keyed by ``h<H>`` so the state_dict carries
+    # ``aux_regression_heads.h5`` / ``.h20`` paths.
+    assert set(aux_heads.keys()) == {"h5", "h20"}
+
+
+def test_factory_rejects_aux_horizons_under_classification_only() -> None:
+    """Aux heads need a primary regression branch to compose with."""
+
+    with pytest.raises(ValueError, match="head_mode"):
+        build_forecaster(
+            ModelConfig(
+                output_mode="classification",
+                head_mode="classification",
+                n_classes=3,
+                hidden_size=16,
+                head_hidden_size=8,
+                aux_horizons=(5,),
+            )
+        )
+
+
+def test_factory_rejects_unsupported_aux_horizon() -> None:
+    with pytest.raises(ValueError, match="aux_horizons"):
+        build_forecaster(
+            ModelConfig(
+                output_mode="classification",
+                head_mode="dual",
+                n_classes=3,
+                hidden_size=16,
+                head_hidden_size=8,
+                aux_horizons=(7,),
+            )
+        )
+
+
+def test_factory_rejects_primary_horizon_in_aux() -> None:
+    """10d is the primary and cannot appear in the aux tuple."""
+
+    with pytest.raises(ValueError, match="aux_horizons"):
+        build_forecaster(
+            ModelConfig(
+                output_mode="classification",
+                head_mode="dual",
+                n_classes=3,
+                hidden_size=16,
+                head_hidden_size=8,
+                aux_horizons=(10,),
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Default-off byte-identity: aux heads do not perturb the state_dict shape
+# ---------------------------------------------------------------------------
+
+
+def test_aux_horizons_off_byte_identical_state_dict_shape() -> None:
+    """``aux_horizons=()`` must mount no aux head and leave the legacy
+    state_dict shape intact. A future regression here would surface as a
+    deserialisation failure on every pre-#471 checkpoint."""
+
+    legacy = _build_dual_head(aux_horizons=())
+    legacy_keys = set(legacy.state_dict().keys())
+    # No aux key may appear when aux_horizons=().
+    assert not any(key.startswith("aux_regression_heads.") for key in legacy_keys)
+    # Active path mounts at least one new key per aux head.
+    active = _build_dual_head(aux_horizons=(5,))
+    active_keys = set(active.state_dict().keys())
+    aux_keys = {k for k in active_keys if k.startswith("aux_regression_heads.")}
+    assert aux_keys  # at least one parameter per aux head
+    # Removing aux keys recovers exactly the legacy key set.
+    assert (active_keys - aux_keys) == legacy_keys
+
+
+# ---------------------------------------------------------------------------
+# Loss math
+# ---------------------------------------------------------------------------
+
+
+def test_aux_horizon_mse_hand_computed_three_rows() -> None:
+    """Verify the joint aux MSE equals the hand-computed sum for 3 rows.
+
+    Primary log_rv predictions: [0.0, 0.0, 0.0]
+    Aux 5d predictions:        [1.0, 1.0, 1.0]
+    Aux 20d predictions:       [2.0, 2.0, 2.0]
+    Targets aux 5d:            [0.0, 0.0, 0.0] -> MSE = 1.0
+    Targets aux 20d:           [0.0, 0.0, 0.0] -> MSE = 4.0
+    alpha = 0.3
+    Aux contribution is alpha * mean(per-horizon MSE):
+    Expected: 0.3 * (1.0 + 4.0) / 2 = 0.75
+    """
+
+    logits = {
+        "log_rv": torch.zeros(3),
+        "aux_log_rv_5d": torch.ones(3),
+        "aux_log_rv_20d": torch.full((3,), 2.0),
+    }
+    aux_target = torch.zeros((3, 2))
+    out = _maybe_aux_horizon_mse(
+        logits_dict=logits,
+        batch_aux_log_rv=aux_target,
+        aux_horizons=(5, 20),
+        aux_horizon_alpha=0.3,
+    )
+    expected = 0.3 * (1.0 + 4.0) / 2.0
+    assert out.item() == pytest.approx(expected, rel=1e-6)
+
+
+def test_aux_horizon_mse_empty_horizons_returns_zero() -> None:
+    """No aux heads mounted -> zero contribution to the joint loss."""
+
+    logits = {"log_rv": torch.zeros(3)}
+    out = _maybe_aux_horizon_mse(
+        logits_dict=logits,
+        batch_aux_log_rv=None,
+        aux_horizons=(),
+        aux_horizon_alpha=0.3,
+    )
+    assert out.item() == pytest.approx(0.0)
+
+
+def test_aux_horizon_mse_alpha_zero_zeroes_contribution() -> None:
+    """alpha=0 must collapse the aux contribution to a graph-attached zero."""
+
+    logits = {
+        "log_rv": torch.zeros(3),
+        "aux_log_rv_5d": torch.ones(3),
+    }
+    target = torch.zeros((3, 1))
+    out = _maybe_aux_horizon_mse(
+        logits_dict=logits,
+        batch_aux_log_rv=target,
+        aux_horizons=(5,),
+        aux_horizon_alpha=0.0,
+    )
+    assert out.item() == pytest.approx(0.0)

--- a/tests/unit/test_run_dual_head_comparison.py
+++ b/tests/unit/test_run_dual_head_comparison.py
@@ -172,6 +172,88 @@ def test_dual_head_runner_rejects_unsupported_target_horizon(monkeypatch):
         _parse_args()
 
 
+def test_dual_head_runner_aux_horizons_default_empty(monkeypatch):
+    """``--aux-horizons`` defaults to an empty tuple (#471 default-off)."""
+
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+        ],
+    )
+    args = _parse_args()
+    assert args.aux_horizons == ()
+    assert args.aux_horizon_alpha == 0.3
+
+
+def test_dual_head_runner_aux_horizons_accepts_csv(monkeypatch):
+    """``--aux-horizons 5,20`` parses into a 2-tuple of ints."""
+
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+            "--aux-horizons",
+            "5,20",
+            "--aux-horizon-alpha",
+            "0.5",
+        ],
+    )
+    args = _parse_args()
+    assert args.aux_horizons == (5, 20)
+    assert args.aux_horizon_alpha == 0.5
+
+
+def test_dual_head_runner_rejects_invalid_aux_horizon(monkeypatch):
+    """An aux horizon outside ``{1, 3, 5, 20, 30}`` fails parse."""
+
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+            "--aux-horizons",
+            "7",
+        ],
+    )
+    with pytest.raises(SystemExit):
+        _parse_args()
+
+
+def test_dual_head_runner_rejects_primary_horizon_in_aux(monkeypatch):
+    """10d is the primary and must be rejected from the aux tuple."""
+
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+            "--aux-horizons",
+            "10",
+        ],
+    )
+    with pytest.raises(SystemExit):
+        _parse_args()
+
+
 def test_dual_head_runner_rejects_unknown_rates_target_mode(monkeypatch):
     from scripts.run_dual_head_comparison import _parse_args
 
@@ -506,6 +588,32 @@ def test_dual_head_runner_no_mp_surprise_threads_into_loader(monkeypatch):
 
     loader_kwargs = captured["loader_calls"][0]
     assert loader_kwargs["use_mp_surprise"] is False
+
+
+def test_dual_head_runner_aux_horizons_threads_through(monkeypatch):
+    """``--aux-horizons`` lands on the ModelConfig the runner builds."""
+
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from scripts import run_dual_head_comparison as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    runner._run_one_cell(
+        "dual",
+        seed=11,
+        training_package_id="tp_dummy",
+        fold_ids=["fold_001"],
+        epochs=1,
+        regression_alpha=0.5,
+        hidden_size=64,
+        aux_horizons=(5, 20),
+        aux_horizon_alpha=0.4,
+    )
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.aux_horizons == (5, 20)
+    assert model_config.aux_horizon_alpha == 0.4
 
 
 def test_dual_head_runner_opt_in_threads_through(monkeypatch):


### PR DESCRIPTION
## Summary

- Mount auxiliary 5d/20d log-RV regression heads alongside canonical 10d.
- Encoder sees cross-horizon vol signal; primary target unchanged.
- ModelConfig adds `aux_horizons=()` + `aux_horizon_alpha=0.3` (default-off).
- Joint loss adds `alpha * mean(MSE_h)` so doubling H does not scale aux budget linearly.
- Val/test scaler build guarded so degenerate empty-train folds skip aux supervision.
- New CLI: `--aux-horizons 5,20 --aux-horizon-alpha 0.3` in `run_dual_head_comparison`.
- Aux columns folded into the existing `log_rv` slot as `(N, 1+H)`; batch arity unchanged.
- 12 new + 5 extended unit tests.

## Test plan

- `docker compose run --rm backend pytest tests/unit/test_multi_horizon_aux.py -q`
- `docker compose run --rm backend pytest tests/unit/test_run_dual_head_comparison.py -q`
- `docker compose run --rm backend pytest tests/ -q`