### PR TITLE
runner: --no-mp-surprise CLI toggle for mp_surprise ablation

### DIFF
--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -255,6 +255,32 @@ def _parse_args() -> argparse.Namespace:
             "+ missing=1.0."
         ),
     )
+    # mp_surprise rich-feature block toggle. Default True matches
+    # ``load_walk_forward_split`` so canonical runs stay byte-identical.
+    # ``--no-mp-surprise`` zeros the mp_surprise block (and its missing
+    # flags) end-to-end, isolating the feature's contribution to the
+    # joint loss at the loader boundary rather than the model.
+    parser.add_argument(
+        "--use-mp-surprise",
+        dest="use_mp_surprise",
+        action="store_true",
+        help=(
+            "Attach the mp_surprise (monetary-policy surprise) feature "
+            "block from data/external/fred/mp_surprises.parquet to each "
+            "statement event. On by default."
+        ),
+    )
+    parser.add_argument(
+        "--no-mp-surprise",
+        dest="use_mp_surprise",
+        action="store_false",
+        help=(
+            "Zero the mp_surprise feature block end-to-end so the "
+            "loader returns the same shape with zeros in the mp_surprise "
+            "slot. Use to isolate the block's contribution."
+        ),
+    )
+    parser.set_defaults(use_mp_surprise=True)
     # #470 regime-loss variant. ``ce`` keeps the standard CE on the
     # 3-class regime head; ``ordinal_ce`` swaps in bin-distance-weighted
     # CE so a calm->high miss costs 2x a calm->normal miss.
@@ -488,6 +514,7 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
     use_text_embeddings: bool = True,
     vol_regime_label_mode: str = "per_fold_quantile",
     absolute_vol_thresholds: tuple[float, float] | None = None,
+    use_mp_surprise: bool = True,
 ) -> dict[str, Any]:
     # Imports happen here so the script is importable without a torch
     # install (useful for doc-only environments).
@@ -549,6 +576,7 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
             use_vix_features=use_vix_features,
             vol_target_horizon=vol_target_horizon,
             sequence_length=active_sequence_length,
+            use_mp_surprise=use_mp_surprise,
         )
         result = train_model(
             model_config=config,
@@ -667,6 +695,7 @@ def main() -> int:
                     use_text_embeddings=bool(args.use_text_embeddings),
                     vol_regime_label_mode=str(args.vol_regime_label_mode),
                     absolute_vol_thresholds=absolute_thresholds,
+                    use_mp_surprise=bool(args.use_mp_surprise),
                 )
             )
 
@@ -730,6 +759,7 @@ def main() -> int:
         ),
         "absolute_calm_max_annualized": args.absolute_calm_max,
         "absolute_high_min_annualized": args.absolute_high_min,
+        "use_mp_surprise": bool(args.use_mp_surprise),
         "trials": trials,
         "summary": summary,
     }

--- a/tests/unit/test_run_dual_head_comparison.py
+++ b/tests/unit/test_run_dual_head_comparison.py
@@ -55,6 +55,26 @@ def test_dual_head_runner_exposes_new_flags(monkeypatch):
     assert args.use_press_conf is False
     assert args.text_encoder is None
     assert args.use_text_embeddings is True
+    assert args.use_mp_surprise is True
+
+
+def test_dual_head_runner_no_mp_surprise_flag(monkeypatch):
+    """``--no-mp-surprise`` flips the loader toggle to False."""
+
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+            "--no-mp-surprise",
+        ],
+    )
+    args = _parse_args()
+    assert args.use_mp_surprise is False
 
 
 def test_dual_head_runner_text_encoder_opt_in(monkeypatch):
@@ -453,6 +473,8 @@ def test_dual_head_runner_default_off_byte_identity(monkeypatch):
     # loader's ``use_text_path`` predicate regardless of the toggle).
     assert loader_kwargs["text_encoder"] is None
     assert loader_kwargs["use_text_embeddings"] is True
+    # mp_surprise defaults on to match the loader default.
+    assert loader_kwargs["use_mp_surprise"] is True
 
     train_kwargs = captured["train_calls"][0]
     model_config = train_kwargs["model_config"]
@@ -461,6 +483,29 @@ def test_dual_head_runner_default_off_byte_identity(monkeypatch):
     assert model_config.vol_target_horizon == 10
     assert model_config.sequence_length == SEQUENCE_LENGTH
     assert model_config.use_regime_conditioning is False
+
+
+def test_dual_head_runner_no_mp_surprise_threads_into_loader(monkeypatch):
+    """``use_mp_surprise=False`` reaches the loader as the kwarg."""
+
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from scripts import run_dual_head_comparison as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    runner._run_one_cell(
+        "dual",
+        seed=11,
+        training_package_id="tp_dummy",
+        fold_ids=["fold_001"],
+        epochs=1,
+        regression_alpha=0.5,
+        hidden_size=64,
+        use_mp_surprise=False,
+    )
+
+    loader_kwargs = captured["loader_calls"][0]
+    assert loader_kwargs["use_mp_surprise"] is False
 
 
 def test_dual_head_runner_opt_in_threads_through(monkeypatch):


### PR DESCRIPTION
## Summary

- New `--use-mp-surprise / --no-mp-surprise` flag pair on `run_dual_head_comparison`.
- Default True matches loader default; `--no-mp-surprise` zeros the block end-to-end.
- Threads through `_run_one_cell` to `load_walk_forward_split`; written into payload artefact.
- Enables one-flag mp_surprise ablation arm (recent bisect found −0.072 dual F1 from this block).
- Two new unit tests cover default-on parse, flag-flip, and loader kwarg propagation.

## Test plan

- `docker compose run --rm backend pytest tests/unit/test_run_dual_head_comparison.py -q`