### PR TITLE
runner: expose focal + class_balanced regime-loss kernels (#502 follow-up)

### DIFF
--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -603,6 +603,17 @@ class ModelConfig:
     # contract. The training loop reads this off the stashed module
     # attribute when constructing the CE / MultiTaskLoss instance.
     regime_loss_mode: str = "ce"
+    # ``focal`` mode only. Lin et al. 2017's (1 - p_true) ** gamma modulating
+    # factor on the regime-axis CE. Default 2.0 matches the paper. The training
+    # loop reads this off the stashed module attribute when constructing the
+    # focal CE branch (``app.training.loss.focal_cross_entropy``); ignored under
+    # any other ``regime_loss_mode`` so default-on runs stay byte-identical.
+    focal_gamma: float = 2.0
+    # ``class_balanced`` mode only. Cui et al. 2019's effective-number
+    # reweighting hyperparameter. ``beta -> 1`` mimics inverse-frequency
+    # weights; ``beta = 0`` collapses to uniform. Default 0.999 mirrors the
+    # paper's CIFAR-LT recipe. Ignored under any other ``regime_loss_mode``.
+    class_balanced_beta: float = 0.999
     # Steepens inverse-frequency class weights via ``raw[c] = 1 / (n_c + 1) ** power``.
     # ``1.0`` (default) is the legacy formula and preserves byte-identity with
     # pre-2026-05-25 sweep numbers; higher values force the gradient onto the

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -827,6 +827,8 @@ class ModelConfig:
             multi_task_lambda_certainty=float(getattr(model, "multi_task_lambda_certainty", 0.3)),
             regime_loss_mode=str(getattr(model, "regime_loss_mode", "ce") or "ce"),
             class_weight_power=float(getattr(model, "class_weight_power", 1.0)),
+            focal_gamma=float(getattr(model, "focal_gamma", 2.0)),
+            class_balanced_beta=float(getattr(model, "class_balanced_beta", 0.999)),
             head_mode=str(getattr(model, "head_mode", "dual") or "dual"),
             regression_alpha=float(getattr(model, "regression_alpha", 0.5)),
             use_derived_text_features=bool(

--- a/backend/app/models/factory.py
+++ b/backend/app/models/factory.py
@@ -154,6 +154,12 @@ def build_forecaster(
             "multi_task_lambda_certainty",
             "regime_loss_mode",
             "class_weight_power",
+            # #502 focal + class_balanced loss-side hyperparameters.
+            # The flat_mlp ctor does not consume them; the trainer reads
+            # them off the stashed module attribute when constructing
+            # the loss kernel.
+            "focal_gamma",
+            "class_balanced_beta",
             "regression_alpha",
             "use_derived_text_features",
             "rates_head_mode",
@@ -210,6 +216,8 @@ def build_forecaster(
         flat.multi_task_lambda_certainty = float(resolved.multi_task_lambda_certainty)  # type: ignore[assignment]
         flat.regime_loss_mode = str(resolved.regime_loss_mode or "ce")  # type: ignore[assignment]
         flat.class_weight_power = float(resolved.class_weight_power)  # type: ignore[assignment]
+        flat.focal_gamma = float(resolved.focal_gamma)  # type: ignore[assignment]
+        flat.class_balanced_beta = float(resolved.class_balanced_beta)  # type: ignore[assignment]
         flat.regression_alpha = float(resolved.regression_alpha)  # type: ignore[assignment]
         flat.use_derived_text_features = bool(resolved.use_derived_text_features)  # type: ignore[assignment]
         flat.rates_heads = flat_rates_heads  # type: ignore[assignment]
@@ -284,6 +292,12 @@ def build_forecaster(
     # unrecognised kwarg.
     regime_loss_mode_value = str(kwargs.pop("regime_loss_mode", "ce") or "ce")
     class_weight_power = float(kwargs.pop("class_weight_power", 1.0))
+    # #502 focal + class_balanced regime-loss hyperparameters. Pure
+    # loss-side knobs the trainer reads off the stashed module
+    # attribute when constructing the loss kernel; pop here so the
+    # ForecasterModel ctor does not see the unrecognised kwargs.
+    focal_gamma_value = float(kwargs.pop("focal_gamma", 2.0))
+    class_balanced_beta_value = float(kwargs.pop("class_balanced_beta", 0.999))
     # #304 dual-head methodology. ``regression_alpha`` is a loss-side
     # knob (the training loop reads it from the model attribute);
     # ``head_mode`` is forwarded to the ForecasterModel constructor so
@@ -519,6 +533,8 @@ def build_forecaster(
     model.multi_task_lambda_certainty = multi_task_lambda_certainty  # type: ignore[assignment]
     model.regime_loss_mode = regime_loss_mode_value  # type: ignore[assignment]
     model.class_weight_power = class_weight_power  # type: ignore[assignment]
+    model.focal_gamma = focal_gamma_value  # type: ignore[assignment]
+    model.class_balanced_beta = class_balanced_beta_value  # type: ignore[assignment]
     # #304 / #309 -- stash the loss + loader flags so
     # ``ModelConfig.from_model`` round-trips them onto the persisted
     # checkpoint payload. ``head_mode`` itself was already passed to

--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -288,13 +288,43 @@ def _parse_args() -> argparse.Namespace:
         "--regime-loss",
         dest="regime_loss",
         type=str,
-        choices=("ce", "ordinal_ce"),
+        choices=("ce", "ordinal_ce", "focal", "class_balanced"),
         default="ce",
         help=(
             "Regime-axis loss kernel. ``ce`` (default) keeps the standard "
             "cross-entropy byte-identical to the pre-#470 canonical "
             "sweep; ``ordinal_ce`` weights each row's CE by "
-            "``1 + |true - argmax|`` so far-bin confusions pay more."
+            "``1 + |true - argmax|`` so far-bin confusions pay more; "
+            "``focal`` applies Lin et al. 2017's (1-p)**gamma modulator; "
+            "``class_balanced`` uses Cui et al. 2019 effective-number "
+            "reweighting on the existing inverse-frequency path."
+        ),
+    )
+    # #502 focal-loss hyperparameter. Only consulted when
+    # ``--regime-loss focal`` is set; ignored under every other mode.
+    parser.add_argument(
+        "--focal-gamma",
+        dest="focal_gamma",
+        type=float,
+        default=2.0,
+        help=(
+            "Focusing parameter for ``--regime-loss focal``. Default 2.0 "
+            "matches Lin et al. 2017. Higher values down-weight easy "
+            "examples more aggressively. Ignored under other loss modes."
+        ),
+    )
+    # #502 class-balanced hyperparameter. Only consulted when
+    # ``--regime-loss class_balanced`` is set; ignored under every other
+    # mode.
+    parser.add_argument(
+        "--class-balanced-beta",
+        dest="class_balanced_beta",
+        type=float,
+        default=0.999,
+        help=(
+            "Effective-number reweighting hyperparameter for "
+            "``--regime-loss class_balanced``. Default 0.999 mirrors Cui "
+            "et al. 2019's CIFAR-LT recipe. Ignored under other loss modes."
         ),
     )
     # #471 multi-horizon auxiliary regression heads. Empty default
@@ -573,6 +603,8 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
     use_press_conf: bool = False,
     use_vix_features: bool = False,
     regime_loss: str = "ce",
+    focal_gamma: float = 2.0,
+    class_balanced_beta: float = 0.999,
     text_encoder: str | None = None,
     use_text_embeddings: bool = True,
     vol_regime_label_mode: str = "per_fold_quantile",
@@ -621,6 +653,8 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
         use_vote_features=use_vote_features,
         use_vix_features=use_vix_features,
         regime_loss_mode=regime_loss,
+        focal_gamma=float(focal_gamma),
+        class_balanced_beta=float(class_balanced_beta),
         vol_regime_label_mode=vol_regime_label_mode,
         absolute_vol_thresholds=resolved_absolute_thresholds,
         aux_horizons=tuple(aux_horizons),
@@ -756,6 +790,8 @@ def main() -> int:
                     use_press_conf=bool(args.use_press_conf),
                     use_vix_features=bool(args.use_vix_features),
                     regime_loss=str(args.regime_loss),
+                    focal_gamma=float(args.focal_gamma),
+                    class_balanced_beta=float(args.class_balanced_beta),
                     text_encoder=(
                         str(args.text_encoder) if args.text_encoder else None
                     ),
@@ -807,6 +843,8 @@ def main() -> int:
         "use_press_conf": bool(args.use_press_conf),
         "use_vix_features": bool(args.use_vix_features),
         "regime_loss": str(args.regime_loss),
+        "focal_gamma": float(args.focal_gamma),
+        "class_balanced_beta": float(args.class_balanced_beta),
         "text_encoder": (
             str(args.text_encoder) if args.text_encoder else None
         ),

--- a/tests/unit/test_run_dual_head_comparison.py
+++ b/tests/unit/test_run_dual_head_comparison.py
@@ -77,6 +77,54 @@ def test_dual_head_runner_no_mp_surprise_flag(monkeypatch):
     assert args.use_mp_surprise is False
 
 
+def test_dual_head_runner_regime_loss_focal_choice_accepted(monkeypatch):
+    """``--regime-loss focal`` parses + ``--focal-gamma`` overrides default."""
+
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+            "--regime-loss",
+            "focal",
+            "--focal-gamma",
+            "1.5",
+        ],
+    )
+    args = _parse_args()
+    assert args.regime_loss == "focal"
+    assert args.focal_gamma == 1.5
+    assert args.class_balanced_beta == 0.999
+
+
+def test_dual_head_runner_regime_loss_class_balanced_choice_accepted(monkeypatch):
+    """``--regime-loss class_balanced`` parses + ``--class-balanced-beta``."""
+
+    from scripts.run_dual_head_comparison import _parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_dual_head_comparison",
+            "--training-package-id",
+            "tp_dummy",
+            "--regime-loss",
+            "class_balanced",
+            "--class-balanced-beta",
+            "0.99",
+        ],
+    )
+    args = _parse_args()
+    assert args.regime_loss == "class_balanced"
+    assert args.class_balanced_beta == 0.99
+    assert args.focal_gamma == 2.0
+
+
 def test_dual_head_runner_text_encoder_opt_in(monkeypatch):
     """``--text-encoder <alias>`` parses; ``--no-text-embeddings`` flips."""
 


### PR DESCRIPTION
## Summary

- ``--regime-loss`` choices extended from ``{ce, ordinal_ce}`` to ``{ce, ordinal_ce, focal, class_balanced}``.
- New ``--focal-gamma`` (default 2.0) + ``--class-balanced-beta`` (default 0.999) flags; threaded through the runner.
- ``ModelConfig`` grows ``focal_gamma`` and ``class_balanced_beta`` as first-class fields.
- Default ``ce`` path byte-identical; existing runs do not move.
- Closes the runner-side gap left by #532; unblocks the Wave-3 focal/class_balanced arms.

## Test plan

- ``docker compose run --rm backend pytest tests/unit/test_run_dual_head_comparison.py -q``