### PR TITLE
fix: thread text channel into ModelConfig from _run_one_cell (#546)

### DIFF
--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -635,6 +635,48 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
     # tail (regime / sep / press_conf / statement_delta / vote / vix) is
     # widened inside ``ForecasterBase.__init__`` via the per-tail
     # ``*_tail_dim`` accumulators; widening here would double-count.
+    # Text-channel resolution. The loader already loads the encoder
+    # and emits per-event pooled embeddings when both ``text_encoder``
+    # and ``use_text_embeddings`` are truthy, but the model only
+    # consumes the channel when BOTH ``text_embedding_dim`` and
+    # ``text_adapter_dim`` are positive on ModelConfig. Before #546
+    # this runner threaded neither, so every text-encoder arm trained
+    # against a 0-width text channel (i.e. the no-text baseline). The
+    # block below resolves the encoder's native hidden_size off the
+    # registry-pinned config and sets both dims so the model actually
+    # consumes the embeddings. The 128-dim adapter target mirrors the
+    # forecaster_credibility default.
+    resolved_text_embedding_dim = 0
+    resolved_text_adapter_dim = 0
+    resolved_text_channel = "scalar"
+    if text_encoder and use_text_embeddings:
+        from app.models.registry import encoder_ref
+
+        ref = encoder_ref(text_encoder)
+        if ref is None:
+            raise ValueError(
+                f"text_encoder={text_encoder!r} did not resolve via "
+                "app.models.registry.encoder_ref. Add it to "
+                "backend/app/models/registry.yaml or pass a valid alias."
+            )
+        from transformers import AutoConfig
+
+        encoder_config = AutoConfig.from_pretrained(
+            ref.repo, revision=ref.revision or None
+        )
+        resolved_text_embedding_dim = int(
+            getattr(encoder_config, "hidden_size", 0) or 0
+        )
+        if resolved_text_embedding_dim <= 0:
+            raise ValueError(
+                f"text_encoder={text_encoder!r} resolved a config but "
+                f"hidden_size was {resolved_text_embedding_dim!r}. The "
+                "encoder cannot drive the text channel without a positive "
+                "hidden_size on its transformer config."
+            )
+        resolved_text_adapter_dim = 128
+        resolved_text_channel = "embeddings"
+
     config = ModelConfig(
         input_size=RICH_FEATURE_SIZE,
         output_mode="classification",
@@ -659,6 +701,9 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
         absolute_vol_thresholds=resolved_absolute_thresholds,
         aux_horizons=tuple(aux_horizons),
         aux_horizon_alpha=float(aux_horizon_alpha),
+        text_channel=resolved_text_channel,
+        text_embedding_dim=resolved_text_embedding_dim,
+        text_adapter_dim=resolved_text_adapter_dim,
     )
 
     per_fold: list[dict[str, Any]] = []

--- a/tests/unit/test_run_dual_head_comparison.py
+++ b/tests/unit/test_run_dual_head_comparison.py
@@ -732,6 +732,72 @@ def test_dual_head_runner_text_encoder_threads_into_loader(monkeypatch):
     assert loader_kwargs["use_text_embeddings"] is False
 
 
+def test_dual_head_runner_text_encoder_activates_model_text_channel(monkeypatch):
+    """``text_encoder`` + ``use_text_embeddings`` activate the model text channel.
+
+    Pre-#546 runner threaded the loader-side toggle but left ModelConfig at
+    text_embedding_dim=0 / text_adapter_dim=0, so the model silently
+    ignored the embeddings the loader emitted (the encoder bake-off
+    no-op surfaced in §6.38). This pins the regression: when the text
+    encoder is set, the model's text channel must be non-zero on both
+    dims AND the channel mode must be ``embeddings``.
+    """
+
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    pytest.importorskip("transformers", reason="encoder hidden_size resolution")
+    from scripts import run_dual_head_comparison as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    runner._run_one_cell(
+        "dual",
+        seed=11,
+        training_package_id="tp_dummy",
+        fold_ids=["fold_001"],
+        epochs=1,
+        regression_alpha=0.5,
+        hidden_size=64,
+        text_encoder="finbert_fed_adjacent",
+        use_text_embeddings=True,
+    )
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.text_embedding_dim > 0, (
+        "text_encoder set with use_text_embeddings=True must resolve a "
+        "positive hidden_size onto ModelConfig.text_embedding_dim; "
+        "otherwise ForecasterBase ignores the loader-emitted embeddings."
+    )
+    assert model_config.text_adapter_dim > 0
+    assert model_config.text_channel == "embeddings"
+
+
+def test_dual_head_runner_text_encoder_unset_keeps_text_channel_off(monkeypatch):
+    """Default invocation must keep the text channel at the byte-identical
+    no-text path (both dims 0, channel='scalar')."""
+
+    pytest.importorskip("torch", reason="train_model import path needs torch")
+    from scripts import run_dual_head_comparison as runner
+
+    captured = _capture_calls(monkeypatch, runner)
+
+    runner._run_one_cell(
+        "dual",
+        seed=11,
+        training_package_id="tp_dummy",
+        fold_ids=["fold_001"],
+        epochs=1,
+        regression_alpha=0.5,
+        hidden_size=64,
+    )
+
+    train_kwargs = captured["train_calls"][0]
+    model_config = train_kwargs["model_config"]
+    assert model_config.text_embedding_dim == 0
+    assert model_config.text_adapter_dim == 0
+    assert model_config.text_channel == "scalar"
+
+
 # ---------------------------------------------------------------------------
 # #401 follow-up: auto-activate rates heads when rates_target_mode != raw.
 # Without rates heads mounted, --rates-target-mode is a no-op and the


### PR DESCRIPTION
## Summary

- The dual-head runner stripped the text channel from every text-encoder cell — text_embedding_dim defaulted to 0, so ForecasterBase ignored the loader-emitted embeddings.
- Surfaced by the wave-4 bake-off: 4 disparate encoders all returned byte-identical results to the no-text baseline (see §6.38, addendum forthcoming).
- Fix: resolve the encoder's hidden_size via \`transformers.AutoConfig\` (config-only, no weights), thread into ModelConfig as \`text_embedding_dim\` + \`text_adapter_dim=128\` + \`text_channel='embeddings'\`.
- Default no-text path stays byte-identical.
- Invalidates every prior text-encoder result (cross_bank_revisited Wave-3 included). Wiki retraction in follow-up.
- Two parser tests pin the regression both ways.

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_run_dual_head_comparison.py -q\`