### PR TITLE
registry: per-encoder trust_remote_code opt-in (#548)

### DIFF
--- a/backend/app/data/embedding_cache.py
+++ b/backend/app/data/embedding_cache.py
@@ -128,8 +128,13 @@ def _load_encoder(ref: EncoderRef):
     from transformers import AutoModel, AutoTokenizer  # type: ignore[import-not-found]
 
     revision = ref.revision or None
-    tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=revision)
-    model = AutoModel.from_pretrained(ref.repo, revision=revision)
+    trust = bool(getattr(ref, "trust_remote_code", False))
+    tokenizer = AutoTokenizer.from_pretrained(
+        ref.repo, revision=revision, trust_remote_code=trust
+    )
+    model = AutoModel.from_pretrained(
+        ref.repo, revision=revision, trust_remote_code=trust
+    )
     return tokenizer, model
 
 

--- a/backend/app/models/registry.py
+++ b/backend/app/models/registry.py
@@ -62,6 +62,13 @@ class EncoderRef:
     # that drops a feature mid-flight refuses to bind a checkpoint
     # trained against the old declaration.
     inference_features: tuple[str, ...] = ()
+    # #548 opt-in for HF encoders that ship custom modeling code
+    # (e.g. nomic-ai/nomic-bert-2048). Default False so every existing
+    # AutoConfig / AutoModel load stays in the standard transformers
+    # path. Flip to True at the registry row only after a security
+    # review of the repo — the flag tells transformers it is OK to
+    # download and execute Python from the HF repo at load time.
+    trust_remote_code: bool = False
 
 
 @lru_cache(maxsize=1)
@@ -84,6 +91,7 @@ def load_registry(path: Path | None = None) -> dict[str, EncoderRef]:
             description=str(fields.get("description", "")),
             role=str(raw_role) if raw_role is not None else None,
             inference_features=tuple(str(v) for v in raw_features),
+            trust_remote_code=bool(fields.get("trust_remote_code", False)),
         )
         by_repo[ref.repo] = ref
         by_repo[ref.alias] = ref

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -107,7 +107,14 @@ encoders:
     revision: b0753ae76394dd36bcfb912a46018088bca48be0
     gated: false
     task: sentence_embedding
-    description: Nomic embed text v1.5. Sentence-embedding encoder; second bake-off entry alongside BGE.
+    description: |
+      Nomic embed text v1.5. Sentence-embedding encoder; second bake-off
+      entry alongside BGE. Ships custom modeling code (``nomic-bert-2048``)
+      so ``trust_remote_code: true`` is required for ``AutoModel`` /
+      ``AutoConfig`` to consume the repo. Security envelope: only this
+      alias opts in; the registry default keeps every other encoder on
+      the standard transformers path.
+    trust_remote_code: true
     inference_features: []
 
   voyage_finance_2:

--- a/scripts/run_dual_head_comparison.py
+++ b/scripts/run_dual_head_comparison.py
@@ -687,7 +687,9 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
         from transformers import AutoConfig
 
         encoder_config = AutoConfig.from_pretrained(
-            ref.repo, revision=ref.revision or None
+            ref.repo,
+            revision=ref.revision or None,
+            trust_remote_code=bool(getattr(ref, "trust_remote_code", False)),
         )
         resolved_text_embedding_dim = int(
             getattr(encoder_config, "hidden_size", 0) or 0

--- a/tests/unit/test_registry_role_resolution.py
+++ b/tests/unit/test_registry_role_resolution.py
@@ -164,3 +164,34 @@ def test_resolve_by_role_dedups_alias_fanout() -> None:
     # contract is what keeps role-uniqueness debuggable when a future
     # registry edit introduces an accidental second tagged row.
     assert resolve_by_role("classifier") != resolve_by_role("retrieval")
+
+
+def test_registry_propagates_trust_remote_code_field() -> None:
+    """``trust_remote_code: true`` round-trips off the YAML row.
+
+    Default False keeps every existing alias on the standard transformers
+    load path; the opt-in is per-row only after a security review.
+    Pins the #548 contract: a registry edit that drops the field on the
+    nomic row would silently flip its load back to the failing path.
+    """
+
+    _reset_registry_cache()
+    from app.models.registry import load_registry
+
+    registry = load_registry()
+    # nomic opts in (custom modeling code).
+    nomic = registry.get("nomic_embed_text_v15")
+    assert nomic is not None
+    assert nomic.trust_remote_code is True
+    # Every other alias defaults to False.
+    for alias, ref in registry.items():
+        if alias == "nomic_embed_text_v15":
+            continue
+        if alias != ref.alias:
+            # Skip repo / repo_alias keys — same ref, already checked.
+            continue
+        assert ref.trust_remote_code is False, (
+            f"alias {alias!r} unexpectedly opts into trust_remote_code; "
+            "only registry rows that ship custom modeling code should "
+            "flip this — review the entry before landing it."
+        )


### PR DESCRIPTION
## Summary

- New \`EncoderRef.trust_remote_code\` field, default False.
- \`embedding_cache._load_encoder\` + \`run_dual_head_comparison\` AutoConfig honor the flag.
- \`nomic_embed_text_v15\` registry row opts in (custom modeling code).
- Pins the security envelope: per-row opt-in only after review, not a global default.
- Unblocks nomic in the post-#546 wave-4 bake-off re-run.

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_registry_role_resolution.py -q\`