### PR TITLE
frontend: clarify Asset + Horizon picker scope (#474/#475)

### DIFF
--- a/frontend/components/analyze/AnalyzeForm.tsx
+++ b/frontend/components/analyze/AnalyzeForm.tsx
@@ -13,6 +13,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { HORIZON_OPTIONS } from "@/lib/analyze/constants";
 import { SAMPLE_STATEMENTS } from "@/lib/analyze/sample-statements";
 import type { AnalyzeRequest, Horizon } from "@/lib/analyze/types";
@@ -62,7 +67,27 @@ export function AnalyzeForm({ value, onChange, onSubmit, loading }: AnalyzeFormP
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="symbol">Asset</Label>
+              <div className="flex items-center gap-1">
+                <Label htmlFor="symbol">Asset</Label>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label="What does the asset picker affect?"
+                      className="text-muted-foreground hover:text-foreground text-xs leading-none"
+                    >
+                      ⓘ
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    Drives the market-data panel and the autoregressive price /
+                    volatility forecast curve. Statement-level analysis (regime
+                    classification, multi-axis sentiment, policy action,
+                    credibility) is asset-independent and does not change with
+                    this selection.
+                  </TooltipContent>
+                </Tooltip>
+              </div>
               <AssetPicker
                 id="symbol"
                 value={value.symbol}
@@ -71,7 +96,26 @@ export function AnalyzeForm({ value, onChange, onSubmit, loading }: AnalyzeFormP
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="horizon">Horizon</Label>
+              <div className="flex items-center gap-1">
+                <Label htmlFor="horizon">Horizon</Label>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label="What does the horizon picker affect?"
+                      className="text-muted-foreground hover:text-foreground text-xs leading-none"
+                    >
+                      ⓘ
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    Drives the price / volatility forecast curve (the
+                    autoregressive prediction block). The regime classification
+                    always reports the next 10 trading days, independent of
+                    this selection.
+                  </TooltipContent>
+                </Tooltip>
+              </div>
               <Select
                 value={value.horizon}
                 onValueChange={(next) => patch({ horizon: next as Horizon })}

--- a/frontend/tests/components/analyze/AnalyzeForm.test.tsx
+++ b/frontend/tests/components/analyze/AnalyzeForm.test.tsx
@@ -1,8 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render as rtlRender, screen, fireEvent } from "@testing-library/react";
 
 import { AnalyzeForm } from "@/components/analyze/AnalyzeForm";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import type { AnalyzeRequest } from "@/lib/analyze/types";
+
+// AnalyzeForm uses Tooltip primitives for the picker-scope info icons
+// (#474/#475). Radix tooltips require a TooltipProvider ancestor; the
+// production app mounts one at the page root (see pages/_app.js).
+function render(ui: React.ReactElement) {
+  return rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
+}
 
 function baseRequest(): AnalyzeRequest {
   return {
@@ -52,5 +60,17 @@ describe("AnalyzeForm", () => {
       />
     );
     expect(screen.getByRole("button", { name: /running analysis/i })).toBeDisabled();
+  });
+
+  it("exposes picker-scope info icons next to the Asset and Horizon labels (#474/#475)", () => {
+    render(
+      <AnalyzeForm value={baseRequest()} onChange={vi.fn()} onSubmit={vi.fn()} loading={false} />
+    );
+    expect(
+      screen.getByLabelText("What does the asset picker affect?")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("What does the horizon picker affect?")
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/analyze/AnalyzeForm.test.tsx
+++ b/frontend/tests/components/analyze/AnalyzeForm.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { render as rtlRender, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { AnalyzeForm } from "@/components/analyze/AnalyzeForm";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -71,6 +72,32 @@ describe("AnalyzeForm", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByLabelText("What does the horizon picker affect?")
+    ).toBeInTheDocument();
+  });
+
+  it("asset tooltip reveals the scope-clarification text on hover (#475)", async () => {
+    const user = userEvent.setup();
+    render(
+      <AnalyzeForm value={baseRequest()} onChange={vi.fn()} onSubmit={vi.fn()} loading={false} />
+    );
+    await user.hover(
+      screen.getByLabelText("What does the asset picker affect?")
+    );
+    expect(
+      await screen.findByText(/asset-independent/i)
+    ).toBeInTheDocument();
+  });
+
+  it("horizon tooltip reveals the scope-clarification text on hover (#474)", async () => {
+    const user = userEvent.setup();
+    render(
+      <AnalyzeForm value={baseRequest()} onChange={vi.fn()} onSubmit={vi.fn()} loading={false} />
+    );
+    await user.hover(
+      screen.getByLabelText("What does the horizon picker affect?")
+    );
+    expect(
+      await screen.findByText(/autoregressive prediction block/i)
     ).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/analyze/AnalyzeForm.test.tsx
+++ b/frontend/tests/components/analyze/AnalyzeForm.test.tsx
@@ -83,9 +83,14 @@ describe("AnalyzeForm", () => {
     await user.hover(
       screen.getByLabelText("What does the asset picker affect?")
     );
-    expect(
-      await screen.findByText(/asset-independent/i)
-    ).toBeInTheDocument();
+    // Radix renders the tooltip content in a portal AND in an
+    // aria-describedby region for screen readers, so findByText matches
+    // multiple nodes by design. findAllByText asserts at least one of
+    // them surfaces the scope-clarification copy — that's the contract
+    // the user actually experiences (the substring is unique to this
+    // tooltip, so >=1 match is the right invariant).
+    const matches = await screen.findAllByText(/asset-independent/i);
+    expect(matches.length).toBeGreaterThan(0);
   });
 
   it("horizon tooltip reveals the scope-clarification text on hover (#474)", async () => {
@@ -96,8 +101,7 @@ describe("AnalyzeForm", () => {
     await user.hover(
       screen.getByLabelText("What does the horizon picker affect?")
     );
-    expect(
-      await screen.findByText(/autoregressive prediction block/i)
-    ).toBeInTheDocument();
+    const matches = await screen.findAllByText(/autoregressive prediction block/i);
+    expect(matches.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

- Adds an ⓘ tooltip next to each picker label on the AnalyzeForm card.
- Asset tooltip: explains the picker drives market data + AR forecast only; statement-level analysis is asset-independent.
- Horizon tooltip: explains the picker drives the AR forecast curve; regime classification always reports the next 10 trading days.
- One regression test pins the two info icons by accessible name.
- Short-term UX fix per both issues; medium-term fix gates on #471 + per-asset target work.

## Test plan

- \`docker compose run --rm frontend npm test -- --run AnalyzeForm\`