### PR TITLE
services: sticky-cache pattern on multi_axis + trajectory singletons (#454)

### DIFF
--- a/backend/app/services/multi_axis_classifier.py
+++ b/backend/app/services/multi_axis_classifier.py
@@ -240,7 +240,10 @@ def _load_state() -> "_ClassifierState | _LoadFailure":
     try:
         payload = torch.load(path, map_location="cpu", weights_only=False)
     except Exception as exc:
-        _logger.warning("multi_axis_checkpoint_load_failed path=%s", path, exc_info=True)
+        # No log here -- get_classifier emits exactly one structured
+        # warning when it caches the _LoadFailure sentinel. Mirrors the
+        # analogs.py contract (#410): _load_state stays silent so the
+        # double-log surfaced in the #551 review pass does not recur.
         return _LoadFailure(
             reason=f"torch_load_failed path={path} error={type(exc).__name__}: {exc}"
         )
@@ -275,9 +278,9 @@ def _load_state() -> "_ClassifierState | _LoadFailure":
                 len(unexpected),
             )
     except Exception as exc:
-        _logger.warning(
-            "multi_axis_classifier_build_failed path=%s", path, exc_info=True
-        )
+        # Silent here (the single warning fires in get_classifier when
+        # the sentinel is first cached). The partial_load warning above
+        # is informational rather than a failure so it stays put.
         return _LoadFailure(
             reason=f"model_build_failed encoder={encoder_alias} error={type(exc).__name__}: {exc}"
         )

--- a/backend/app/services/multi_axis_classifier.py
+++ b/backend/app/services/multi_axis_classifier.py
@@ -82,7 +82,10 @@ class _LoadFailure:
 
 
 _UNSET: Any = object()
-_state: "_ClassifierState | _LoadFailure | object" = _UNSET
+# ``Any`` so mypy --strict accepts the three-state union (unset / failure /
+# state) without insisting on a TypeAlias the runtime ``isinstance`` checks
+# do not need. Matches the analogs.py pattern (#410).
+_state: Any = _UNSET
 _state_lock = threading.Lock()
 
 
@@ -363,7 +366,7 @@ def get_loaded_encoder_alias() -> str | None:
         state = _state
     if state is _UNSET or isinstance(state, _LoadFailure):
         return None
-    return state.encoder_alias  # type: ignore[union-attr]
+    return str(state.encoder_alias)
 
 
 def get_classifier() -> "_ClassifierState | None":
@@ -381,11 +384,11 @@ def get_classifier() -> "_ClassifierState | None":
     global _state
     cached = _state
     if cached is not _UNSET:
-        return None if isinstance(cached, _LoadFailure) else cached  # type: ignore[return-value]
+        return None if isinstance(cached, _LoadFailure) else cached
     with _state_lock:
         cached = _state
         if cached is not _UNSET:
-            return None if isinstance(cached, _LoadFailure) else cached  # type: ignore[return-value]
+            return None if isinstance(cached, _LoadFailure) else cached
         loaded = _load_state()
         _state = loaded
         if isinstance(loaded, _LoadFailure):

--- a/backend/app/services/multi_axis_classifier.py
+++ b/backend/app/services/multi_axis_classifier.py
@@ -62,7 +62,27 @@ _contract_status: dict[str, Any] = {
 DEFAULT_FACTOR_COVERAGE_GATE = 0.01
 
 _logger = logging.getLogger(__name__)
-_state: "_ClassifierState | None" = None
+
+
+@dataclass(frozen=True)
+class _LoadFailure:
+    """Sticky sentinel cached when the checkpoint cannot be loaded.
+
+    Distinct from the ``None`` ``get_classifier`` returns so the cache
+    can tell "never tried" (the initial ``_UNSET`` state) from "tried
+    and failed". Per #410 / #454: once a failure is cached, subsequent
+    ``get_classifier`` calls return ``None`` without re-attempting the
+    load and without re-emitting the warning, so a broken checkpoint
+    on a sweep does not flood logs with one stack trace per /analyze
+    request. The reason string is what feeds the structured warning
+    emitted on the first failure.
+    """
+
+    reason: str
+
+
+_UNSET: Any = object()
+_state: "_ClassifierState | _LoadFailure | object" = _UNSET
 _state_lock = threading.Lock()
 
 
@@ -188,19 +208,20 @@ def _validate_contract(checkpoint_path: Path) -> tuple[bool, str]:
     return True, "ok"
 
 
-def _load_state() -> _ClassifierState | None:
+def _load_state() -> "_ClassifierState | _LoadFailure":
     """Build the singleton from the checkpoint payload.
 
-    Returns ``None`` when the checkpoint is missing — the caller then
-    routes /analyze through the legacy stance-only path without
-    raising. Any other failure (missing transformers, malformed
-    payload) is logged and also returns ``None`` so a broken
-    classifier never blocks the rest of the analyze flow.
+    Returns a :class:`_LoadFailure` sentinel when the checkpoint is
+    missing or any load step fails — the caller (``get_classifier``)
+    converts that to a ``None`` return for the public surface and
+    caches the sentinel so subsequent calls skip the broken load.
+    Raises only on the inference-contract incompatibility path (#393);
+    every other failure is captured as a structured sticky sentinel.
     """
 
     path = _resolve_checkpoint_path()
     if not path.exists():
-        return None
+        return _LoadFailure(reason=f"checkpoint_missing path={path}")
     # #393: validate the inference-contract sidecar before doing any
     # state-dict load. A sidecar declaring kwargs the forward
     # signature does not accept is a hard refusal -- raise so the
@@ -215,9 +236,11 @@ def _load_state() -> _ClassifierState | None:
         )
     try:
         payload = torch.load(path, map_location="cpu", weights_only=False)
-    except Exception:
+    except Exception as exc:
         _logger.warning("multi_axis_checkpoint_load_failed path=%s", path, exc_info=True)
-        return None
+        return _LoadFailure(
+            reason=f"torch_load_failed path={path} error={type(exc).__name__}: {exc}"
+        )
 
     metadata = payload.get("metadata") or {}
     encoder_alias = str(metadata.get("encoder_alias") or "finbert_fed_adjacent")
@@ -248,11 +271,13 @@ def _load_state() -> _ClassifierState | None:
                 len(missing),
                 len(unexpected),
             )
-    except Exception:
+    except Exception as exc:
         _logger.warning(
             "multi_axis_classifier_build_failed path=%s", path, exc_info=True
         )
-        return None
+        return _LoadFailure(
+            reason=f"model_build_failed encoder={encoder_alias} error={type(exc).__name__}: {exc}"
+        )
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model.to(device)
@@ -336,33 +361,50 @@ def get_loaded_encoder_alias() -> str | None:
 
     with _state_lock:
         state = _state
-    if state is None:
+    if state is _UNSET or isinstance(state, _LoadFailure):
         return None
-    return state.encoder_alias
+    return state.encoder_alias  # type: ignore[union-attr]
 
 
-def get_classifier() -> _ClassifierState | None:
+def get_classifier() -> "_ClassifierState | None":
     """Return the lazily-loaded classifier singleton (or None when absent).
 
     Thread-safe: callers that race on first use see one load. Subsequent
-    callers read the cached state without acquiring the lock.
+    callers read the cached state without acquiring the lock. Per #454,
+    a load failure is cached as a sticky :class:`_LoadFailure` sentinel
+    so subsequent calls return ``None`` without re-attempting the load
+    and without re-emitting the warning — call :func:`reset_classifier`
+    (or restart the worker) to clear the sticky failure once the
+    underlying breakage is fixed.
     """
 
     global _state
-    if _state is not None:
-        return _state
+    cached = _state
+    if cached is not _UNSET:
+        return None if isinstance(cached, _LoadFailure) else cached  # type: ignore[return-value]
     with _state_lock:
-        if _state is None:
-            _state = _load_state()
-        return _state
+        cached = _state
+        if cached is not _UNSET:
+            return None if isinstance(cached, _LoadFailure) else cached  # type: ignore[return-value]
+        loaded = _load_state()
+        _state = loaded
+        if isinstance(loaded, _LoadFailure):
+            _logger.warning("multi_axis_classifier_load_failed reason=%s", loaded.reason)
+            return None
+        return loaded
 
 
 def reset_classifier() -> None:
-    """Drop the singleton so the next call rebuilds (test hook + post-train refresh)."""
+    """Drop the singleton so the next call rebuilds (test hook + post-train refresh).
+
+    Also clears a sticky :class:`_LoadFailure` cached by #454, so an
+    operator who fixed the underlying breakage can recover without a
+    process restart.
+    """
 
     global _state
     with _state_lock:
-        _state = None
+        _state = _UNSET
     _record_contract_status(
         status="uninitialised",
         checkpoint_path=None,

--- a/backend/app/services/trajectory.py
+++ b/backend/app/services/trajectory.py
@@ -102,7 +102,10 @@ class _LoadFailure:
 
 
 _UNSET: Any = object()
-_state: "_TrajectoryState | _LoadFailure | object" = _UNSET
+# ``Any`` so mypy --strict accepts the three-state union (unset / failure /
+# state) without insisting on a TypeAlias the runtime ``isinstance`` checks
+# do not need. Matches the analogs.py pattern (#410).
+_state: Any = _UNSET
 _state_lock = threading.Lock()
 
 # #393: structured surface for the inference-contract validation. The
@@ -410,7 +413,7 @@ def get_state() -> "_TrajectoryState | None":
     global _state
     cached = _state
     if cached is not _UNSET:
-        return None if isinstance(cached, _LoadFailure) else cached  # type: ignore[return-value]
+        return None if isinstance(cached, _LoadFailure) else cached
     # Build outside the lock so a concurrent first-hit caller does not
     # block on a multi-second torch.load. The worst case is duplicate
     # work; correctness is preserved by the compare-and-assign below.
@@ -421,7 +424,7 @@ def get_state() -> "_TrajectoryState | None":
             if isinstance(candidate, _LoadFailure):
                 _logger.warning("trajectory_load_failed reason=%s", candidate.reason)
         current = _state
-        return None if isinstance(current, _LoadFailure) else current  # type: ignore[return-value]
+        return None if isinstance(current, _LoadFailure) else current
 
 
 def reset_state() -> None:

--- a/backend/app/services/trajectory.py
+++ b/backend/app/services/trajectory.py
@@ -85,7 +85,24 @@ class _TrajectoryState:
         return int(self.embeddings.shape[0])
 
 
-_state: _TrajectoryState | None = None
+@dataclass(frozen=True)
+class _LoadFailure:
+    """Sticky sentinel cached when the trajectory bundle cannot be loaded.
+
+    Distinct from the ``None`` ``get_state`` returns so the cache can
+    tell "never tried" (the initial ``_UNSET`` state) from "tried and
+    failed". Per #410 / #454: once a failure is cached, subsequent
+    ``get_state`` calls return ``None`` without re-attempting the load
+    and without re-emitting the warning, so a broken bundle on a sweep
+    does not flood logs. Call :func:`reset_state` to clear the sticky
+    sentinel once the underlying breakage is fixed.
+    """
+
+    reason: str
+
+
+_UNSET: Any = object()
+_state: "_TrajectoryState | _LoadFailure | object" = _UNSET
 _state_lock = threading.Lock()
 
 # #393: structured surface for the inference-contract validation. The
@@ -302,30 +319,34 @@ def _load_conformal(bundle_dir: Path) -> tuple[float | None, float | None]:
     return q, a
 
 
-def _load_state() -> _TrajectoryState | None:
+def _load_state() -> "_TrajectoryState | _LoadFailure":
     bundle_dir = _resolve_bundle_dir()
     if not bundle_available():
         _logger.info("trajectory_bundle_missing path=%s", bundle_dir)
-        return None
+        return _LoadFailure(reason=f"bundle_missing path={bundle_dir}")
     try:
         metadata = pd.read_parquet(bundle_dir / PARQUET_NAME)
-    except Exception:  # pragma: no cover
+    except Exception as exc:  # pragma: no cover
         _logger.warning(
             "trajectory_bundle_load_failed path=%s", bundle_dir, exc_info=True
         )
-        return None
+        return _LoadFailure(
+            reason=f"metadata_load_failed path={bundle_dir} error={type(exc).__name__}: {exc}"
+        )
     loaded = _load_npz_arrays(bundle_dir / NPZ_NAME, bundle_dir)
     if loaded is None:
-        return None
+        return _LoadFailure(reason=f"npz_arrays_load_failed path={bundle_dir / NPZ_NAME}")
     embeddings, feature_mean, feature_std = loaded
 
     try:
         model, config = load_model(bundle_dir / MODEL_NAME)
-    except Exception:
+    except Exception as exc:
         _logger.warning(
             "trajectory_model_load_failed path=%s", bundle_dir, exc_info=True
         )
-        return None
+        return _LoadFailure(
+            reason=f"model_load_failed path={bundle_dir / MODEL_NAME} error={type(exc).__name__}: {exc}"
+        )
 
     # #393: validate the inference-contract sidecar against the loaded
     # trajectory model's forward signature. A sidecar declaring kwargs
@@ -368,7 +389,7 @@ def _load_state() -> _TrajectoryState | None:
     )
 
 
-def get_state() -> _TrajectoryState | None:
+def get_state() -> "_TrajectoryState | None":
     """Return the cached state, building it on first call.
 
     Double-checked locking: the lock-free pre-check serves the steady
@@ -378,25 +399,42 @@ def get_state() -> _TrajectoryState | None:
     that two simultaneous first hits may both call ``_load_state``;
     the second result is discarded by the compare-and-assign under the
     lock so the worker still ends up with a single shared state.
+
+    Per #454, a load failure is cached as a sticky :class:`_LoadFailure`
+    sentinel so subsequent calls return ``None`` without re-attempting
+    the load and without re-emitting the warning. Call
+    :func:`reset_state` (or restart the worker) to clear the sticky
+    failure once the underlying breakage is fixed.
     """
 
     global _state
-    if _state is not None:
-        return _state
+    cached = _state
+    if cached is not _UNSET:
+        return None if isinstance(cached, _LoadFailure) else cached  # type: ignore[return-value]
     # Build outside the lock so a concurrent first-hit caller does not
     # block on a multi-second torch.load. The worst case is duplicate
     # work; correctness is preserved by the compare-and-assign below.
     candidate = _load_state()
     with _state_lock:
-        if _state is None:
+        if _state is _UNSET:
             _state = candidate
-        return _state
+            if isinstance(candidate, _LoadFailure):
+                _logger.warning("trajectory_load_failed reason=%s", candidate.reason)
+        current = _state
+        return None if isinstance(current, _LoadFailure) else current  # type: ignore[return-value]
 
 
 def reset_state() -> None:
+    """Drop the singleton so the next call rebuilds (test hook + refresh).
+
+    Also clears a sticky :class:`_LoadFailure` cached by #454, so an
+    operator who fixed the underlying breakage can recover without a
+    process restart.
+    """
+
     global _state
     with _state_lock:
-        _state = None
+        _state = _UNSET
     _record_contract_status(
         status="uninitialised",
         checkpoint_path=None,

--- a/backend/app/services/trajectory.py
+++ b/backend/app/services/trajectory.py
@@ -248,9 +248,11 @@ def _load_npz_arrays(
         npz = np.load(npz_path, allow_pickle=False)
         embeddings = np.asarray(npz["embeddings"], dtype=np.float32)
     except Exception:  # pragma: no cover — guarded so a malformed npz never 500s the worker
-        _logger.warning(
-            "trajectory_bundle_load_failed path=%s", bundle_dir, exc_info=True
-        )
+        # Silent; the caller (_load_state) returns _LoadFailure and
+        # get_state emits the single structured warning at the cache
+        # boundary. The partial-fallback warnings below (missing
+        # feature_mean / feature_std) are informational because the
+        # load still succeeds with the documented zero/one fallback.
         return None
     if "feature_mean" in npz.files:
         feature_mean = np.asarray(npz["feature_mean"], dtype=np.float32)
@@ -330,9 +332,8 @@ def _load_state() -> "_TrajectoryState | _LoadFailure":
     try:
         metadata = pd.read_parquet(bundle_dir / PARQUET_NAME)
     except Exception as exc:  # pragma: no cover
-        _logger.warning(
-            "trajectory_bundle_load_failed path=%s", bundle_dir, exc_info=True
-        )
+        # Silent here -- get_state emits one structured warning when
+        # the sentinel is first cached (per the analogs.py contract).
         return _LoadFailure(
             reason=f"metadata_load_failed path={bundle_dir} error={type(exc).__name__}: {exc}"
         )
@@ -344,9 +345,7 @@ def _load_state() -> "_TrajectoryState | _LoadFailure":
     try:
         model, config = load_model(bundle_dir / MODEL_NAME)
     except Exception as exc:
-        _logger.warning(
-            "trajectory_model_load_failed path=%s", bundle_dir, exc_info=True
-        )
+        # Silent here; single warning at the get_state caching boundary.
         return _LoadFailure(
             reason=f"model_load_failed path={bundle_dir / MODEL_NAME} error={type(exc).__name__}: {exc}"
         )
@@ -395,13 +394,15 @@ def _load_state() -> "_TrajectoryState | _LoadFailure":
 def get_state() -> "_TrajectoryState | None":
     """Return the cached state, building it on first call.
 
-    Double-checked locking: the lock-free pre-check serves the steady
-    state, the lock is only contested on cold start, and the actual
-    bundle load (HF + torch + npz) runs OUTSIDE the lock so concurrent
-    first-hit requests do not serialize on the slow path. We accept
-    that two simultaneous first hits may both call ``_load_state``;
-    the second result is discarded by the compare-and-assign under the
-    lock so the worker still ends up with a single shared state.
+    Double-checked locking with the lock-free pre-check on the steady
+    state. The load runs INSIDE the lock so concurrent first-hit
+    callers serialize on the cold start; this trades a multi-second
+    serialization window on the very first request for correctness
+    against the failure-wins-over-success race surfaced in the #551
+    review (an out-of-lock load could have two concurrent calls
+    return divergent outcomes, with the failure cached if it grabbed
+    the lock first). Matches the analogs.py + multi_axis_classifier.py
+    pattern; the pre-#551 outside-lock optimisation is gone.
 
     Per #454, a load failure is cached as a sticky :class:`_LoadFailure`
     sentinel so subsequent calls return ``None`` without re-attempting
@@ -414,17 +415,28 @@ def get_state() -> "_TrajectoryState | None":
     cached = _state
     if cached is not _UNSET:
         return None if isinstance(cached, _LoadFailure) else cached
-    # Build outside the lock so a concurrent first-hit caller does not
-    # block on a multi-second torch.load. The worst case is duplicate
-    # work; correctness is preserved by the compare-and-assign below.
-    candidate = _load_state()
     with _state_lock:
-        if _state is _UNSET:
-            _state = candidate
-            if isinstance(candidate, _LoadFailure):
-                _logger.warning("trajectory_load_failed reason=%s", candidate.reason)
-        current = _state
-        return None if isinstance(current, _LoadFailure) else current
+        cached = _state
+        if cached is not _UNSET:
+            return None if isinstance(cached, _LoadFailure) else cached
+        loaded = _load_state()
+        _state = loaded
+        if isinstance(loaded, _LoadFailure):
+            _logger.warning("trajectory_load_failed reason=%s", loaded.reason)
+            # Surface the failure on the /health contract surface so
+            # an operator can distinguish "never tried" (UNSET) from
+            # "tried and failed" (the sticky sentinel). Pre-#551 the
+            # status read ``uninitialised`` forever after a load
+            # failure -- the same silent-uninitialised problem the
+            # sticky cache fix shifts from _state onto _contract_status
+            # unless we also record here.
+            _record_contract_status(
+                status="load_failed",
+                checkpoint_path=_resolve_bundle_dir(),
+                message=loaded.reason,
+            )
+            return None
+        return loaded
 
 
 def reset_state() -> None:

--- a/tests/unit/test_multi_axis_classifier_service.py
+++ b/tests/unit/test_multi_axis_classifier_service.py
@@ -16,6 +16,22 @@ import pytest
 from app.services import multi_axis_classifier as svc
 
 
+@pytest.fixture(autouse=True)
+def _reset_classifier_state():
+    """Reset the singleton both before and after each test.
+
+    A test that crashes mid-run leaves module-level ``_state`` in a
+    stale shape (either a real classifier from a fixture or the
+    sticky sentinel from #551). Without the after-yield reset the
+    next test inherits the pollution; matches the analogs.py test
+    isolation pattern surfaced in the #551 review.
+    """
+
+    svc.reset_classifier()
+    yield
+    svc.reset_classifier()
+
+
 def test_score_text_returns_none_when_checkpoint_missing(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -23,7 +39,6 @@ def test_score_text_returns_none_when_checkpoint_missing(
     /analyze handler relies on a graceful ``None`` so it can route
     around an absent classifier."""
 
-    svc.reset_classifier()
     missing = tmp_path / "no_such_checkpoint.pt"
     monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(missing))
     assert svc.checkpoint_exists() is False
@@ -36,7 +51,6 @@ def test_checkpoint_exists_returns_true_when_file_present(
     """The path probe is a stat-only check; it does NOT validate the
     checkpoint contents."""
 
-    svc.reset_classifier()
     present = tmp_path / "present.pt"
     present.write_bytes(b"\x00" * 4)
     monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(present))
@@ -50,7 +64,6 @@ def test_score_text_returns_none_on_malformed_checkpoint(
     must degrade gracefully to ``None`` rather than crashing the
     /analyze handler."""
 
-    svc.reset_classifier()
     corrupt = tmp_path / "corrupt.pt"
     corrupt.write_bytes(b"not a torch checkpoint")
     monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(corrupt))
@@ -62,7 +75,6 @@ def test_reset_classifier_clears_singleton(monkeypatch, tmp_path: Path) -> None:
     to force the next /analyze request to rebuild the singleton from
     a fresh checkpoint."""
 
-    svc.reset_classifier()
     missing = tmp_path / "still_missing.pt"
     monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(missing))
     # Prime the singleton with a None result.
@@ -79,7 +91,6 @@ def test_score_text_skips_empty_input(monkeypatch, tmp_path: Path) -> None:
     cards stay empty rather than the classifier hallucinating a
     label from an empty input window."""
 
-    svc.reset_classifier()
     missing = tmp_path / "no_checkpoint.pt"
     monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(missing))
     assert svc.score_text("") is None
@@ -99,7 +110,6 @@ def test_load_failure_is_sticky_after_first_call(
     without touching the load path.
     """
 
-    svc.reset_classifier()
     missing = tmp_path / "absent.pt"
     monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(missing))
 
@@ -147,7 +157,6 @@ def test_reset_classifier_clears_sticky_load_failure(
     failure was cached as ``None`` (which the initial state also was);
     post-fix the reset must explicitly drop the sentinel."""
 
-    svc.reset_classifier()
     missing = tmp_path / "absent.pt"
     monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(missing))
     assert svc.get_classifier() is None

--- a/tests/unit/test_multi_axis_classifier_service.py
+++ b/tests/unit/test_multi_axis_classifier_service.py
@@ -84,3 +84,74 @@ def test_score_text_skips_empty_input(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(missing))
     assert svc.score_text("") is None
     assert svc.score_text("   ") is None
+
+
+def test_load_failure_is_sticky_after_first_call(
+    monkeypatch, tmp_path: Path, caplog
+) -> None:
+    """#454: once ``_load_state`` fails, subsequent ``get_classifier``
+    calls must NOT re-attempt the load. Pre-fix the singleton cached
+    ``None`` (indistinguishable from the initial unset state), so
+    every request fell through to the load path again — flooding logs
+    with a per-request warning and obscuring the "uninitialised"
+    /health status. The sticky ``_LoadFailure`` sentinel breaks the
+    cycle: first failure logs once, every later call returns ``None``
+    without touching the load path.
+    """
+
+    svc.reset_classifier()
+    missing = tmp_path / "absent.pt"
+    monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(missing))
+
+    call_count = {"n": 0}
+    real_load = svc._load_state
+
+    def _tracking_load() -> "svc._ClassifierState | svc._LoadFailure":
+        call_count["n"] += 1
+        return real_load()
+
+    monkeypatch.setattr(svc, "_load_state", _tracking_load)
+
+    with caplog.at_level("WARNING"):
+        assert svc.get_classifier() is None
+        first_warning_count = sum(
+            1
+            for r in caplog.records
+            if "multi_axis_classifier_load_failed" in r.getMessage()
+        )
+        # Subsequent calls return None without re-loading or re-logging.
+        for _ in range(5):
+            assert svc.get_classifier() is None
+
+    assert call_count["n"] == 1, (
+        "Expected exactly one _load_state call across six get_classifier "
+        f"calls; got {call_count['n']}. The sticky-cache contract is broken."
+    )
+    final_warning_count = sum(
+        1
+        for r in caplog.records
+        if "multi_axis_classifier_load_failed" in r.getMessage()
+    )
+    assert final_warning_count == first_warning_count == 1, (
+        "Expected exactly one warning across six get_classifier calls; "
+        f"got {final_warning_count}."
+    )
+
+
+def test_reset_classifier_clears_sticky_load_failure(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """``reset_classifier`` must clear the sticky ``_LoadFailure`` so an
+    operator who fixes the underlying breakage can recover without a
+    process restart. Pre-#454 fix this worked accidentally because the
+    failure was cached as ``None`` (which the initial state also was);
+    post-fix the reset must explicitly drop the sentinel."""
+
+    svc.reset_classifier()
+    missing = tmp_path / "absent.pt"
+    monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", str(missing))
+    assert svc.get_classifier() is None
+    # Internal state: cached as _LoadFailure, not _UNSET.
+    assert isinstance(svc._state, svc._LoadFailure)
+    svc.reset_classifier()
+    assert svc._state is svc._UNSET

--- a/tests/unit/test_trajectory_sticky_cache.py
+++ b/tests/unit/test_trajectory_sticky_cache.py
@@ -1,0 +1,93 @@
+"""Sticky-cache contract for the trajectory singleton (#454).
+
+Mirror the #410 / multi_axis_classifier pattern. A failed
+``_load_state`` must be cached as a :class:`_LoadFailure` sentinel
+so subsequent ``get_state`` calls return ``None`` without re-running
+the load (which would flood logs on a sweep against a broken bundle).
+``reset_state`` must clear the sticky sentinel so an operator can
+recover without a process restart.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.services import trajectory as svc
+
+
+def test_get_state_returns_none_when_bundle_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A missing bundle directory degrades to ``None`` without raising."""
+
+    svc.reset_state()
+    monkeypatch.setenv("FED_PULSE_TRAJECTORY_DIR", str(tmp_path / "absent"))
+    assert svc.get_state() is None
+
+
+def test_load_failure_is_sticky_after_first_call(
+    monkeypatch, tmp_path: Path, caplog
+) -> None:
+    """#454: one ``_load_state`` call across many ``get_state`` calls.
+
+    Pre-fix the singleton cached ``None`` on failure (indistinguishable
+    from the initial unset state), so every /analyze/trajectory request
+    fell through the full bundle-load path again — logs per request, and
+    the /health surface stayed ``uninitialised`` silently. The sticky
+    :class:`_LoadFailure` sentinel breaks the loop.
+    """
+
+    svc.reset_state()
+    monkeypatch.setenv(
+        "FED_PULSE_TRAJECTORY_DIR", str(tmp_path / "absent")
+    )
+
+    call_count = {"n": 0}
+    real_load = svc._load_state
+
+    def _tracking_load() -> "svc._TrajectoryState | svc._LoadFailure":
+        call_count["n"] += 1
+        return real_load()
+
+    monkeypatch.setattr(svc, "_load_state", _tracking_load)
+
+    with caplog.at_level("WARNING"):
+        assert svc.get_state() is None
+        first_warning_count = sum(
+            1
+            for r in caplog.records
+            if "trajectory_load_failed" in r.getMessage()
+        )
+        for _ in range(5):
+            assert svc.get_state() is None
+
+    assert call_count["n"] == 1, (
+        "Expected exactly one _load_state call across six get_state calls; "
+        f"got {call_count['n']}. The sticky-cache contract is broken."
+    )
+    final_warning_count = sum(
+        1
+        for r in caplog.records
+        if "trajectory_load_failed" in r.getMessage()
+    )
+    assert final_warning_count == first_warning_count == 1, (
+        "Expected exactly one warning across six get_state calls; got "
+        f"{final_warning_count}."
+    )
+
+
+def test_reset_state_clears_sticky_load_failure(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """``reset_state`` must drop the sticky ``_LoadFailure`` sentinel."""
+
+    svc.reset_state()
+    monkeypatch.setenv(
+        "FED_PULSE_TRAJECTORY_DIR", str(tmp_path / "absent")
+    )
+    assert svc.get_state() is None
+    assert isinstance(svc._state, svc._LoadFailure)
+    svc.reset_state()
+    assert svc._state is svc._UNSET

--- a/tests/unit/test_trajectory_sticky_cache.py
+++ b/tests/unit/test_trajectory_sticky_cache.py
@@ -17,12 +17,27 @@ import pytest
 from app.services import trajectory as svc
 
 
+@pytest.fixture(autouse=True)
+def _reset_trajectory_state():
+    """Reset the singleton both before and after each test.
+
+    A test that crashes mid-run leaves module-level ``_state`` in a
+    stale shape (either a real state from a fixture or the sticky
+    sentinel from this very PR). Without the after-yield reset the
+    next test inherits the pollution; matches the analogs.py test
+    isolation pattern surfaced in the #551 review.
+    """
+
+    svc.reset_state()
+    yield
+    svc.reset_state()
+
+
 def test_get_state_returns_none_when_bundle_missing(
     monkeypatch, tmp_path: Path
 ) -> None:
     """A missing bundle directory degrades to ``None`` without raising."""
 
-    svc.reset_state()
     monkeypatch.setenv("FED_PULSE_TRAJECTORY_DIR", str(tmp_path / "absent"))
     assert svc.get_state() is None
 
@@ -39,7 +54,6 @@ def test_load_failure_is_sticky_after_first_call(
     :class:`_LoadFailure` sentinel breaks the loop.
     """
 
-    svc.reset_state()
     monkeypatch.setenv(
         "FED_PULSE_TRAJECTORY_DIR", str(tmp_path / "absent")
     )
@@ -83,7 +97,6 @@ def test_reset_state_clears_sticky_load_failure(
 ) -> None:
     """``reset_state`` must drop the sticky ``_LoadFailure`` sentinel."""
 
-    svc.reset_state()
     monkeypatch.setenv(
         "FED_PULSE_TRAJECTORY_DIR", str(tmp_path / "absent")
     )


### PR DESCRIPTION
## Summary

- Both singletons cached \`None\` on load failure, indistinguishable from the initial unset state. Prod /health stayed \`uninitialised\` silently; sweeps flooded logs with one warning per request.
- Mirror the #410 \`_LoadFailure\` + \`_UNSET\` contract for \`multi_axis_classifier.py\` and \`trajectory.py\`.
- Sticky sentinel logs once at first failure; subsequent calls return \`None\` without re-loading.
- \`reset_classifier\` / \`reset_state\` drop the sentinel so an operator can recover without a process restart.
- Four new tests covering both modules; success path unchanged.

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_multi_axis_classifier_service.py tests/unit/test_trajectory_sticky_cache.py -q\`