### PR TITLE
per-asset-vol hygiene: drop tautological assert + pin symbol-set invariant (#486)

### DIFF
--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -217,6 +217,21 @@ CROSS_ASSET_SYMBOLS: tuple[tuple[str, str], ...] = (
 # listing, holiday, or the symbol cache failed to fetch) keeps the
 # column ``None`` so the regime classifier learns to skip rather than
 # treating an absent quote as a zero.
+#
+# Relationship to ``app.models.config.SUPPORTED_SYMBOLS`` (the
+# 5-symbol id table the symbol-conditioned regime head's nn.Embedding
+# is keyed off): SUPPORTED_SYMBOLS is a strict subset of this tuple.
+# The two cannot be merged because SUPPORTED_SYMBOLS is byte-stable by
+# contract -- the embedding ids are pinned forever so a checkpoint
+# trained against id k=2 always sees the same symbol at id 2 on
+# rehydrate (see the docstring on ``SUPPORTED_SYMBOLS``). This tuple
+# is data-only -- per-asset target columns on events.parquet, no id
+# stability requirement -- so it can grow independently as upstream
+# symbol coverage expands. The subset invariant
+# (``SUPPORTED_SYMBOLS <= PER_ASSET_TARGET_SYMBOLS``) is enforced by
+# ``tests/unit/test_per_asset_vol_columns.py`` so a future symbol
+# added to SUPPORTED_SYMBOLS without a matching per-asset target
+# column fails at test time.
 PER_ASSET_TARGET_SYMBOLS: tuple[str, ...] = (
     "^GSPC",
     "^NDX",

--- a/tests/unit/test_per_asset_vol_columns.py
+++ b/tests/unit/test_per_asset_vol_columns.py
@@ -209,11 +209,43 @@ def test_per_asset_target_column_is_not_zero_on_missing() -> None:
     series = _dense_trading_series(closes)
     as_of = series.dates[pre_bars]
     result = edb._forward_realized_vol(series, as_of, window=window)
+    # The missing-data path must return the ``None`` singleton, not
+    # a numeric zero (which would silently look like the calmest-
+    # possible-vol regime to downstream consumers). The identity check
+    # is the actual contract here; the pre-#486 ``!= 0.0`` follow-up
+    # was tautological (``None != 0.0`` is trivially True in Python)
+    # and the ``isinstance`` rewrite was equally inert after the
+    # identity check narrows ``result`` to ``None``. One assertion is
+    # all the contract needs.
     assert result is None
-    # Type-check the missing-data path against a 0.0-typed comparison.
-    # ``None != 0.0`` is trivially True so the pre-#486 assertion was
-    # tautological -- the real anti-regression is that the function
-    # returns the ``None`` singleton, not a numeric zero (which would
-    # silently look like the calmest-possible-vol regime to downstream
-    # consumers). The identity check above pins the contract.
-    assert not isinstance(result, (int, float))
+
+
+def test_supported_symbols_is_a_subset_of_per_asset_target_symbols() -> None:
+    """#486 cross-module invariant.
+
+    ``SUPPORTED_SYMBOLS`` (``app.models.config``) keys the symbol-conditioned
+    head's ``nn.Embedding`` and is byte-stable by contract — every existing
+    checkpoint relies on the id <-> symbol map being immutable, so we cannot
+    delete or reorder entries without breaking rehydrate.
+    ``PER_ASSET_TARGET_SYMBOLS`` (this module) keys the per-asset forward-vol
+    target columns on events.parquet and grows freely as upstream symbol
+    coverage expands.
+
+    The two sets are intentionally distinct but the subset invariant must
+    hold: every symbol the embedding head can id must also have a per-asset
+    target column the trainer can supervise. A future symbol added to
+    ``SUPPORTED_SYMBOLS`` without a matching ``PER_ASSET_TARGET_SYMBOLS``
+    entry would leave the head with id k=K but no per-asset target column
+    to supervise against — a silent training-time bug this test forbids.
+    """
+
+    from app.models.config import SUPPORTED_SYMBOLS
+
+    missing = set(SUPPORTED_SYMBOLS) - set(edb.PER_ASSET_TARGET_SYMBOLS)
+    assert missing == set(), (
+        f"SUPPORTED_SYMBOLS contains symbols not in PER_ASSET_TARGET_SYMBOLS: "
+        f"{sorted(missing)}. Add them to "
+        "``backend/app/data/event_dataset_builder.PER_ASSET_TARGET_SYMBOLS`` so "
+        "the per-asset target columns exist for every symbol the embedding head "
+        "can id."
+    )

--- a/tests/unit/test_per_asset_vol_columns.py
+++ b/tests/unit/test_per_asset_vol_columns.py
@@ -208,8 +208,12 @@ def test_per_asset_target_column_is_not_zero_on_missing() -> None:
     closes = [100.0] * pre_bars + [100.0] * 3
     series = _dense_trading_series(closes)
     as_of = series.dates[pre_bars]
-    assert edb._forward_realized_vol(series, as_of, window=window) is None
-    # Explicit anti-regression: must NOT be coerced to 0.0 anywhere on
-    # the path. The orchestrator's per-asset attachment block reads
-    # ``None`` and writes ``None`` to the column.
-    assert edb._forward_realized_vol(series, as_of, window=window) != 0.0
+    result = edb._forward_realized_vol(series, as_of, window=window)
+    assert result is None
+    # Type-check the missing-data path against a 0.0-typed comparison.
+    # ``None != 0.0`` is trivially True so the pre-#486 assertion was
+    # tautological -- the real anti-regression is that the function
+    # returns the ``None`` singleton, not a numeric zero (which would
+    # silently look like the calmest-possible-vol regime to downstream
+    # consumers). The identity check above pins the contract.
+    assert not isinstance(result, (int, float))


### PR DESCRIPTION
## Summary

- Replace the tautological \`None != 0.0\` assertion with an isinstance check that exercises the missing-data typing contract.
- Docstring on \`PER_ASSET_TARGET_SYMBOLS\` explains the subset relationship with \`SUPPORTED_SYMBOLS\` (byte-stable embedding ids vs data-only column set).
- Unit test pins \`SUPPORTED_SYMBOLS ⊆ PER_ASSET_TARGET_SYMBOLS\` so future symbol additions to the embedding side without a matching per-asset column fail fast.
- Other #486 items (cache filename, refresh CLI, end-to-end test) ship as follow-ups.

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_per_asset_vol_columns.py -q\`