### PR TITLE
embedding_cache: default to CUDA when available (#553)

### DIFF
--- a/backend/app/data/embedding_cache.py
+++ b/backend/app/data/embedding_cache.py
@@ -122,8 +122,33 @@ def _file_sha256(path: Path) -> str:
     return hasher.hexdigest()
 
 
+def _resolve_cache_device() -> str:
+    """Pick the device the cache builder should load the encoder onto.
+
+    Priority: ``FED_PULSE_EMBEDDING_CACHE_DEVICE`` env override (operator
+    knob to force CPU on a GPU pod when the card is busy with a training
+    run) → ``cuda`` when ``torch.cuda.is_available()`` → ``cpu`` fallback.
+    Default-on CUDA closes #553 -- the pre-fix path loaded on CPU even on
+    a pod with an idle 97 GB card, ~10x slower than the GPU pass that the
+    same encoder pays at /analyze time.
+    """
+
+    import torch  # type: ignore[import-not-found]
+
+    override = (os.environ.get("FED_PULSE_EMBEDDING_CACHE_DEVICE") or "").strip().lower()
+    if override:
+        return override
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
 def _load_encoder(ref: EncoderRef):
-    """Lazy-import AutoModel/AutoTokenizer so test code can monkeypatch."""
+    """Lazy-import AutoModel/AutoTokenizer so test code can monkeypatch.
+
+    The encoder is sent to the device returned by :func:`_resolve_cache_device`
+    (CUDA when available, else CPU). The encode loop downstream reads
+    ``next(model.parameters()).device`` to route input tensors, so a single
+    ``.to(device)`` here is enough to flip the whole hot path from CPU to GPU.
+    """
 
     from transformers import AutoModel, AutoTokenizer  # type: ignore[import-not-found]
 
@@ -135,6 +160,9 @@ def _load_encoder(ref: EncoderRef):
     model = AutoModel.from_pretrained(
         ref.repo, revision=revision, trust_remote_code=trust
     )
+    device = _resolve_cache_device()
+    model = model.to(device)
+    model.eval()
     return tokenizer, model
 
 

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -1964,6 +1964,24 @@ def _load_package_sequences_with_metadata(
             cache_dir=cache_dir,
             registry_path=registry_for_lookup,
         )
+        # #554: fail loud when an encoder is configured but the lookup
+        # came back empty. Pre-fix the loader logged a per-batch WARNING
+        # on cache miss + then proceeded with empty embeddings, so the
+        # arm produced byte-identical output to the no-text baseline
+        # silently -- which is exactly how the wave-4 bake-off cells
+        # all looked the same (see §6.39 retraction). A single ERROR-
+        # level log at the load boundary surfaces the gap in run logs
+        # without raising (the empty-fallback path stays alive for the
+        # existing test surface that relies on it).
+        if not embedding_lookup:
+            _logger.error(
+                "text_encoder=%r is configured but the embedding cache "
+                "lookup returned empty -- every row will hit the no-text "
+                "fallback and the arm's output will be byte-identical to "
+                "the use_text_embeddings=False path. See PR #546 / §6.39 "
+                "for the methodology context.",
+                text_encoder,
+            )
     # ``embedding_event_dates`` is captured for symmetry with the
     # ``_read_chunk_embedding_lookup`` contract; the prior-4 pooler
     # consumes statement dates off ``prior_chronology`` further down,
@@ -2882,6 +2900,18 @@ def load_training_sequences_from_package(
             cache_dir=cache_dir,
             registry_path=registry_for_lookup,
         )
+        # #554 mirror site to the walk-forward loader. Same ERROR-level
+        # fail-loud signal when the cache lookup returns empty so a
+        # silent-fallback bake-off cannot recur on the legacy load path.
+        if not embedding_lookup:
+            _logger.error(
+                "text_encoder=%r is configured but the embedding cache "
+                "lookup returned empty -- every row will hit the no-text "
+                "fallback and the arm's output will be byte-identical to "
+                "the use_text_embeddings=False path. See PR #546 / §6.39 "
+                "for the methodology context.",
+                text_encoder,
+            )
     # Captured for symmetry; the prior-4 pooler reads dates off
     # ``prior_chronology`` so the dict is not consumed here.
     _ = embedding_event_dates

--- a/tests/unit/test_embedding_cache.py
+++ b/tests/unit/test_embedding_cache.py
@@ -236,3 +236,47 @@ def test_build_cache_reuses_existing_parquet_without_network(tmp_path: Path, mon
         allow_network=False,
     )
     assert result.row_count == 1
+
+
+def test_resolve_cache_device_prefers_cuda_when_available(monkeypatch) -> None:
+    """#553: default to CUDA when ``torch.cuda.is_available()`` returns True.
+
+    Pre-#553 ``_load_encoder`` never moved the model off CPU even on a pod
+    with an idle GPU; rebuilding the wave-4 bake-off caches ran ~10× slower
+    than necessary. The default-on CUDA selection is the operational fix.
+    """
+
+    import torch
+
+    monkeypatch.delenv("FED_PULSE_EMBEDDING_CACHE_DEVICE", raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    assert ec._resolve_cache_device() == "cuda"
+
+
+def test_resolve_cache_device_falls_back_to_cpu_without_cuda(monkeypatch) -> None:
+    """CPU fallback keeps the laptop / CI builds byte-identical to pre-#553."""
+
+    import torch
+
+    monkeypatch.delenv("FED_PULSE_EMBEDDING_CACHE_DEVICE", raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    assert ec._resolve_cache_device() == "cpu"
+
+
+def test_resolve_cache_device_env_override_wins(monkeypatch) -> None:
+    """``FED_PULSE_EMBEDDING_CACHE_DEVICE`` forces a specific device.
+
+    Useful when the GPU is occupied by a training run and the operator
+    wants to share rather than queue. The override beats the
+    is_available probe in both directions.
+    """
+
+    import torch
+
+    monkeypatch.setenv("FED_PULSE_EMBEDDING_CACHE_DEVICE", "cpu")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    assert ec._resolve_cache_device() == "cpu"
+
+    monkeypatch.setenv("FED_PULSE_EMBEDDING_CACHE_DEVICE", "cuda")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    assert ec._resolve_cache_device() == "cuda"


### PR DESCRIPTION
## Summary

- New \`_resolve_cache_device\` helper: env override → \`cuda\` if available → \`cpu\` fallback.
- \`_load_encoder\` calls \`.to(device).eval()\` after loading the AutoModel.
- Downstream encode loop already follows \`model.device\`, no other change needed.
- Three unit tests cover the device-resolution priority order.
- Surfaced by the wave-4 bake-off salvage (pod CPU build hit timeout on finbert alone, ~10× slower than a GPU pass).

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_embedding_cache.py -q\`