### PR TITLE
trust_remote_code audit across registry-aware encoder loads (#557)

### DIFF
--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -2580,9 +2580,14 @@ def _build_delta_encoder_callable(repo_or_alias: str):
     ref = encoder_ref(repo_or_alias)
     repo = ref.repo if ref is not None else repo_or_alias
     revision = ref.revision if ref is not None else None
+    trust = bool(getattr(ref, "trust_remote_code", False)) if ref is not None else False
 
-    tokenizer = AutoTokenizer.from_pretrained(repo, revision=revision)
-    model = AutoModel.from_pretrained(repo, revision=revision)
+    tokenizer = AutoTokenizer.from_pretrained(
+        repo, revision=revision, trust_remote_code=trust
+    )
+    model = AutoModel.from_pretrained(
+        repo, revision=revision, trust_remote_code=trust
+    )
     model.eval()
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = model.to(device)

--- a/backend/app/data/finetune_pilot_b2.py
+++ b/backend/app/data/finetune_pilot_b2.py
@@ -449,8 +449,13 @@ def _train_and_eval_one_cell(  # noqa: PLR0913 — per-cell knobs surface as nam
     tokenizer_kwargs: dict[str, Any] = {"token": hf_token} if hf_token else {}
     if revision:
         tokenizer_kwargs["revision"] = revision
+    if ref is not None and getattr(ref, "trust_remote_code", False):
+        tokenizer_kwargs["trust_remote_code"] = True
     tokenizer = AutoTokenizer.from_pretrained(encoder_repo, **tokenizer_kwargs)
 
+    model_kwargs: dict[str, Any] = {}
+    if ref is not None and getattr(ref, "trust_remote_code", False):
+        model_kwargs["trust_remote_code"] = True
     model = AutoModelForSequenceClassification.from_pretrained(
         encoder_repo,
         num_labels=N_CLASSES,
@@ -459,6 +464,7 @@ def _train_and_eval_one_cell(  # noqa: PLR0913 — per-cell knobs surface as nam
         ignore_mismatched_sizes=True,
         token=hf_token,
         revision=revision,
+        **model_kwargs,
     )
 
     # Auxiliary 3-class linear head over the encoder's pooled output.

--- a/backend/app/data/train_text_multi_axis_classifier.py
+++ b/backend/app/data/train_text_multi_axis_classifier.py
@@ -1134,7 +1134,11 @@ def main(argv: list[str] | None = None) -> int:
             f"Encoder alias {args.encoder_alias!r} is unpinned in registry.yaml; "
             "add a revision before training."
         )
-    tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)
+    tokenizer = AutoTokenizer.from_pretrained(
+        ref.repo,
+        revision=ref.revision,
+        trust_remote_code=bool(getattr(ref, "trust_remote_code", False)),
+    )
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = TextMultiAxisClassifier.from_encoder_alias(

--- a/backend/app/models/text_multi_axis_classifier.py
+++ b/backend/app/models/text_multi_axis_classifier.py
@@ -104,7 +104,11 @@ class TextMultiAxisClassifier(nn.Module):
                 "registry. Multi-axis classifier training refuses unpinned "
                 "encoders to keep checkpoint provenance unambiguous."
             )
-        encoder = AutoModel.from_pretrained(ref.repo, revision=ref.revision)
+        encoder = AutoModel.from_pretrained(
+            ref.repo,
+            revision=ref.revision,
+            trust_remote_code=bool(getattr(ref, "trust_remote_code", False)),
+        )
         hidden_size = int(getattr(encoder.config, "hidden_size", 0))
         if hidden_size <= 0:
             raise ValueError(

--- a/backend/app/services/multi_axis_classifier.py
+++ b/backend/app/services/multi_axis_classifier.py
@@ -263,7 +263,11 @@ def _load_state() -> "_ClassifierState | _LoadFailure":
             raise ValueError(
                 f"Encoder alias {encoder_alias!r} is unpinned in registry.yaml"
             )
-        tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)  # type: ignore[no-untyped-call]
+        tokenizer = AutoTokenizer.from_pretrained(  # type: ignore[no-untyped-call]
+            ref.repo,
+            revision=ref.revision,
+            trust_remote_code=bool(getattr(ref, "trust_remote_code", False)),
+        )
         model = TextMultiAxisClassifier.from_encoder_alias(
             encoder_alias=encoder_alias,
             head_hidden_size=head_hidden_size,

--- a/backend/app/training/encoder_lora.py
+++ b/backend/app/training/encoder_lora.py
@@ -122,8 +122,13 @@ def build_lora_encoder(
             "encoder build"
         )
 
-    tokenizer = AutoTokenizer.from_pretrained(ref.repo, revision=ref.revision)  # type: ignore[no-untyped-call]
-    base_encoder = AutoModel.from_pretrained(ref.repo, revision=ref.revision)
+    trust = bool(getattr(ref, "trust_remote_code", False))
+    tokenizer = AutoTokenizer.from_pretrained(  # type: ignore[no-untyped-call]
+        ref.repo, revision=ref.revision, trust_remote_code=trust
+    )
+    base_encoder = AutoModel.from_pretrained(
+        ref.repo, revision=ref.revision, trust_remote_code=trust
+    )
     base_encoder.requires_grad_(False)
 
     lora_config = LoraConfig(

--- a/tests/unit/test_text_multi_axis_classifier.py
+++ b/tests/unit/test_text_multi_axis_classifier.py
@@ -129,10 +129,16 @@ def test_from_encoder_alias_forwards_trust_remote_code(monkeypatch) -> None:
         revision = "deadbeef"
         trust_remote_code = True
 
-    import app.models.text_multi_axis_classifier as mod
+    # from_encoder_alias does an inline ``from transformers import
+    # AutoModel`` so the monkey-patch has to land on the transformers
+    # module symbol that import resolves to, not a non-existent module
+    # attribute on the classifier module itself.
+    import transformers
 
     monkeypatch.setattr(
-        mod, "AutoModel", type("FakeAutoModel", (), {"from_pretrained": staticmethod(_fake_from_pretrained)})
+        transformers,
+        "AutoModel",
+        type("FakeAutoModel", (), {"from_pretrained": staticmethod(_fake_from_pretrained)}),
     )
     import app.models.registry as registry
     monkeypatch.setattr(registry, "encoder_ref", lambda alias: _FakeRef())

--- a/tests/unit/test_text_multi_axis_classifier.py
+++ b/tests/unit/test_text_multi_axis_classifier.py
@@ -100,3 +100,58 @@ def test_factor_branch_stays_in_minus_one_to_one_range() -> None:
     out = model(input_ids=input_ids, attention_mask=torch.ones_like(input_ids))
     assert torch.all(out["factor"] >= -1.0)
     assert torch.all(out["factor"] <= 1.0)
+
+
+def test_from_encoder_alias_forwards_trust_remote_code(monkeypatch) -> None:
+    """#557: from_encoder_alias must thread the registry's trust_remote_code.
+
+    Pre-fix the call site loaded the encoder without honoring the
+    registry flag; nomic-style encoders that ship custom modeling
+    code would raise. Monkey-patches AutoModel + encoder_ref so the
+    test runs without hitting the HF Hub.
+    """
+
+    captured = {}
+
+    def _fake_from_pretrained(repo, **kwargs):
+        captured["repo"] = repo
+        captured["kwargs"] = kwargs
+        config = type("FakeConfig", (), {"hidden_size": 16})()
+        encoder = type(
+            "FakeEncoder",
+            (),
+            {"config": config, "__init__": lambda self: None},
+        )()
+        return encoder
+
+    class _FakeRef:
+        repo = "fake/nomic-style-encoder"
+        revision = "deadbeef"
+        trust_remote_code = True
+
+    import app.models.text_multi_axis_classifier as mod
+
+    monkeypatch.setattr(
+        mod, "AutoModel", type("FakeAutoModel", (), {"from_pretrained": staticmethod(_fake_from_pretrained)})
+    )
+    import app.models.registry as registry
+    monkeypatch.setattr(registry, "encoder_ref", lambda alias: _FakeRef())
+
+    try:
+        TextMultiAxisClassifier.from_encoder_alias(
+            encoder_alias="fake_nomic",
+            head_hidden_size=8,
+            dropout=0.0,
+        )
+    except Exception:
+        # Construction may fail downstream (the fake encoder doesn't
+        # have a real forward) -- we only care that the from_pretrained
+        # call received trust_remote_code=True from the registry flag.
+        pass
+
+    assert captured.get("kwargs", {}).get("trust_remote_code") is True, (
+        "TextMultiAxisClassifier.from_encoder_alias did not forward "
+        "trust_remote_code from the registry-pinned EncoderRef. The fix "
+        "is to pass trust_remote_code=ref.trust_remote_code on the "
+        "AutoModel.from_pretrained call."
+    )


### PR DESCRIPTION
## Summary

- Extends #549's trust_remote_code opt-in from runner + cache builder to every \`Auto*.from_pretrained\` site that resolves an encoder via \`encoder_ref\`.
- 6 sites updated: encoder_lora, text_multi_axis_classifier, multi_axis_classifier service, train_text_multi_axis_classifier, event_dataset_builder, finetune_pilot_b2.
- 2 sites deliberately left (analogs + trajectory train both load strictly offline with trust_remote_code=False for safety).
- CLI-checkpoint-only sites (llm_zero_shot, embedding_comparator, pseudo_labeling, continued_pretraining) deferred — not on nomic critical path.
- New unit test on text_multi_axis_classifier locks the contract via monkey-patched encoder_ref + AutoModel.
- Unblocks the §6.41 nomic row once a fresh nomic cache is built.

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_text_multi_axis_classifier.py -q\`