### PR TITLE
per-asset target follow-ups: --force-refresh flag + cache-name docs (#486)

### DIFF
--- a/backend/app/data/event_dataset_builder.py
+++ b/backend/app/data/event_dataset_builder.py
@@ -2173,6 +2173,7 @@ def build_event_rows(
     delta_encoder: Any | None = None,
     per_asset_target_series: dict[str, _CloseSeries] | None = None,
     per_asset_target_cache_dir: Path | None = None,
+    per_asset_target_force_refresh: bool = False,
     prior_window_days: int = PRIOR_WINDOW_DAYS,
 ) -> pd.DataFrame:
     """Build the events DataFrame for one training package.
@@ -2300,7 +2301,11 @@ def build_event_rows(
                 continue
             try:
                 per_asset_target_series[sym] = _fetch_close_series(
-                    sym, start=earliest, end=latest, cache_dir=target_cache_dir
+                    sym,
+                    start=earliest,
+                    end=latest,
+                    cache_dir=target_cache_dir,
+                    force_refresh=per_asset_target_force_refresh,
                 )
             except Exception as exc:
                 # Broadened from RuntimeError to Exception (#481 review): yfinance
@@ -2530,7 +2535,24 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "Where to cache the per-asset forward-vol target price series "
             "(#481). Defaults to <DATA_DIR>/external/yfinance. One parquet "
             "per symbol; a missing/failing symbol collapses its column to "
-            "None across all rows."
+            "None across all rows. The parquet filename uses yfinance's "
+            "raw symbol (e.g. ``DX-Y.NYB.parquet``, ``EURUSD=X.parquet``), "
+            "not the column slug on events.parquet (``dxy``, ``eurusd``) -- "
+            "the slug normalisation lives downstream on the column write, "
+            "not on the cache write, so the cache stays interoperable with "
+            "any yfinance consumer that addresses by raw symbol."
+        ),
+    )
+    parser.add_argument(
+        "--per-asset-target-force-refresh",
+        action="store_true",
+        help=(
+            "Bypass the cache for the per-asset forward-vol target "
+            "series and force a fresh yfinance fetch on every symbol. "
+            "Default off keeps the existing cache-once-pinned-forever "
+            "behaviour. Use when the upstream series has been revised "
+            "or when the cache parquet for one symbol is suspected "
+            "corrupted (delete-the-parquet is the alternative)."
         ),
     )
     parser.add_argument(
@@ -2689,6 +2711,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         rates_horizon=int(args.rates_horizon),
         delta_encoder=delta_encoder,
         per_asset_target_cache_dir=per_asset_target_cache_dir,
+        per_asset_target_force_refresh=bool(args.per_asset_target_force_refresh),
         prior_window_days=int(args.prior_window),
     )
     output_path = Path(args.output)
@@ -2731,6 +2754,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             rates_horizon=int(args.rates_horizon),
             delta_encoder=delta_encoder,
             per_asset_target_cache_dir=per_asset_target_cache_dir,
+        per_asset_target_force_refresh=bool(args.per_asset_target_force_refresh),
             prior_window_days=int(args.prior_window),
         )
         full_output_path = Path(full_output_arg)

--- a/tests/unit/test_per_asset_vol_columns.py
+++ b/tests/unit/test_per_asset_vol_columns.py
@@ -249,3 +249,31 @@ def test_supported_symbols_is_a_subset_of_per_asset_target_symbols() -> None:
         "the per-asset target columns exist for every symbol the embedding head "
         "can id."
     )
+
+
+def test_build_event_rows_threads_per_asset_force_refresh() -> None:
+    """#486 follow-up: ``--per-asset-target-force-refresh`` reaches the fetch.
+
+    Pre-fix the per-asset fetch hard-coded ``force_refresh=False`` so the
+    operator had to delete the parquet under ``data/external/yfinance/``
+    to invalidate a corrupted or stale cache. The CLI flag now threads
+    ``per_asset_target_force_refresh`` through ``build_event_rows`` to
+    every per-asset ``_fetch_close_series`` call.
+
+    Pinned via inspect.signature so a future refactor that drops the
+    kwarg or flips the default fails at test time.
+    """
+
+    import inspect
+
+    sig = inspect.signature(edb.build_event_rows)
+    assert "per_asset_target_force_refresh" in sig.parameters, (
+        "build_event_rows must accept the per_asset_target_force_refresh "
+        "kwarg so the CLI flag can reach the per-asset fetch path."
+    )
+    default = sig.parameters["per_asset_target_force_refresh"].default
+    assert default is False, (
+        "per_asset_target_force_refresh must default to False so the "
+        "post-#486 path stays byte-identical to the pre-#486 cache-once-"
+        "pinned-forever behaviour for callers that don't set it."
+    )


### PR DESCRIPTION
## Summary

- New \`--per-asset-target-force-refresh\` CLI flag on \`event_dataset_builder\`; threads through \`build_event_rows\` to every per-asset fetch.
- Cache filename convention documented inline on the cache-dir help text (raw yfinance symbol vs events-column slug — kept separate by design).
- Default-off keeps existing cache-once-pinned-forever behaviour byte-identical.
- One inspect.signature contract test pins the kwarg name + default.
- Closes the three remaining #486 items (tautological assertion + symbol-set constants landed in #552).

## Test plan

- \`docker compose run --rm backend pytest tests/unit/test_per_asset_vol_columns.py -q\`