### PR TITLE
feat(#299): /research/registry endpoint backed by §6.41 manifest

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,6 +52,7 @@ from app.schemas import (
     NextFomcForecastResponse,
     RatesReactionCard,
     ResearchArtifactsResponse,
+    ResearchRegistryResponse,
     SettingsCheckpoint,
     SettingsCheckpointsResponse,
     SymbolDescriptor,
@@ -77,6 +78,7 @@ from app.services.research_artifacts import (
     list_section_files,
     load_cross_bank_transfer,
     load_encoder_bakeoff,
+    load_research_registry,
 )
 from app.services.forecaster import (
     bootstrap_checkpoint,
@@ -1431,6 +1433,25 @@ def research_artifacts() -> ResearchArtifactsResponse:
         encoder_bakeoff=bakeoff,  # type: ignore[arg-type]
         cross_bank_transfer=transfer,  # type: ignore[arg-type]
     )
+
+
+@app.get("/research/registry", response_model=ResearchRegistryResponse)
+def research_registry(
+    surface: str = "dual",
+    include_rejected: bool = False,
+) -> ResearchRegistryResponse:
+    """Quant-facing encoder bake-off registry from the §6.41 manifest.
+
+    Filtered by default to rows with non-negative Δ on the active
+    surface (``dual`` or ``cls``) so the dashboard never surfaces
+    negative-lift encoders. Pass ``include_rejected=true`` to see the
+    full table including nulls/negatives.
+    """
+
+    if surface not in {"dual", "cls"}:
+        raise HTTPException(status_code=400, detail="surface must be 'dual' or 'cls'")
+    payload = load_research_registry(surface=surface, include_rejected=include_rejected)
+    return ResearchRegistryResponse(**payload)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1234,3 +1234,62 @@ class TrajectoryResponse(BaseModel):
             "available."
         ),
     )
+
+
+class ResearchRegistryBaseline(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    label: str
+    dual_f1: float | None = None
+    cls_f1: float | None = None
+    regression_f1: float | None = None
+
+
+class ResearchRegistryRow(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    encoder_alias: str
+    encoder_display: str
+    dual_f1: float | None = None
+    cls_f1: float | None = None
+    regression_f1: float | None = None
+    delta_dual: float | None = Field(
+        default=None,
+        description="Δ macro-F1 on the dual-head surface vs no-text baseline.",
+    )
+    delta_cls: float | None = Field(
+        default=None,
+        description="Δ macro-F1 on the classification-only surface vs no-text baseline.",
+    )
+    is_winner: bool = Field(
+        default=False,
+        description="True iff the active surfaces Δ is >= 0 (non-negative lift).",
+    )
+    checkpoint_relpath: str | None = None
+    cache_uri: str | None = Field(
+        default=None,
+        description="hf:// URI of the shareable embedding cache parquet, if published.",
+    )
+    notes: str = ""
+
+
+class ResearchRegistryResponse(BaseModel):
+    """Quant-facing encoder registry response (§6.41 manifest).
+
+    Filtered by default to non-negative Δ on the requested surface so
+    the dashboard does not surface negative-lift encoders. Use
+    ?include_rejected=true to see the full table including nulls and
+    negatives.
+    """
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    available: bool
+    surface: Literal["dual", "cls"]
+    baseline: ResearchRegistryBaseline | None = None
+    rows: list[ResearchRegistryRow] = Field(default_factory=list)
+    rejected_count: int = 0
+    training_package_id: str = ""
+    head: str = ""
+    seeds: list[int] = Field(default_factory=list)
+    source_wiki_section: str = ""

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1057,6 +1057,22 @@ class AnalogCard(BaseModel):
             "NOT a model feature. Do not feed back into a downstream model."
         ),
     )
+    # #299 — realized S&P forward returns starting from the first trading
+    # day after the analog event_date. Surfaces actionable market
+    # behaviour for the quant-facing dashboard so a user can see what
+    # happened after similar past statements. These are MARKET DATA
+    # OVERLAYS (yfinance ^GSPC close-to-close), not training labels — safe
+    # to surface even when ``subsequent_vol_regime`` is intentionally
+    # suppressed. None when the historical market data is unavailable
+    # (e.g. early-history dates with sparse coverage).
+    subsequent_close_pct_5d: float | None = Field(
+        default=None,
+        description="S&P 500 close-to-close % return over the 5 trading days starting the day after event_date.",
+    )
+    subsequent_close_pct_20d: float | None = Field(
+        default=None,
+        description="S&P 500 close-to-close % return over the 20 trading days starting the day after event_date.",
+    )
     excerpt: str = Field(..., description="First ~280 characters of the analog statement.")
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1057,21 +1057,21 @@ class AnalogCard(BaseModel):
             "NOT a model feature. Do not feed back into a downstream model."
         ),
     )
-    # #299 — realized S&P forward returns starting from the first trading
-    # day after the analog event_date. Surfaces actionable market
-    # behaviour for the quant-facing dashboard so a user can see what
-    # happened after similar past statements. These are MARKET DATA
-    # OVERLAYS (yfinance ^GSPC close-to-close), not training labels — safe
-    # to surface even when ``subsequent_vol_regime`` is intentionally
-    # suppressed. None when the historical market data is unavailable
-    # (e.g. early-history dates with sparse coverage).
+    # #299 — realized S&P forward returns measured from the event-day
+    # close (Bloomberg / FactSet convention). The denominator is the
+    # close on ``event_date`` (or the nearest prior trading day) and
+    # the numerator is the close ``N`` trading days forward of that
+    # anchor. These are MARKET DATA OVERLAYS (yfinance ^GSPC), not
+    # training labels — safe to surface even when the supervised
+    # ``subsequent_vol_regime`` bucket is intentionally suppressed.
+    # None when the historical market data is unavailable.
     subsequent_close_pct_5d: float | None = Field(
         default=None,
-        description="S&P 500 close-to-close % return over the 5 trading days starting the day after event_date.",
+        description="S&P 500 close-to-close % return over the 5 trading days following the event-day close.",
     )
     subsequent_close_pct_20d: float | None = Field(
         default=None,
-        description="S&P 500 close-to-close % return over the 20 trading days starting the day after event_date.",
+        description="S&P 500 close-to-close % return over the 20 trading days following the event-day close.",
     )
     excerpt: str = Field(..., description="First ~280 characters of the analog statement.")
 

--- a/backend/app/services/analogs.py
+++ b/backend/app/services/analogs.py
@@ -403,30 +403,38 @@ def render_analog_cards(hits: list[AnalogHit]) -> list[dict[str, Any]]:
 
 @lru_cache(maxsize=512)
 def _subsequent_close_pct(event_date: str, *, horizon: int) -> float | None:
-    """Return the S&P 500 close-to-close % return over ``horizon`` trading
-    days starting the day after ``event_date``.
+    """S&P 500 close-to-close % return over ``horizon`` trading days
+    from the event-day close.
 
-    ``None`` when the historical data is sparse (e.g. early history),
-    when yfinance is unavailable, or when fewer than ``horizon``
-    forward trading days are present. LRU-cached per (date, horizon)
-    so the same analog row is not refetched on every query.
+    The denominator is the close ON ``event_date`` (or the nearest
+    prior trading day when event_date itself is non-trading), matching
+    the standard event-study convention quoted by Bloomberg / FactSet.
+    The numerator is the close ``horizon`` trading days *forward* of
+    that anchor.
+
+    ``None`` when historical data is sparse (e.g. early history), when
+    yfinance is unavailable, when fewer than ``horizon`` forward
+    trading days are present, or when the event-day close lookup
+    fails. LRU-cached per (date, horizon) so the same analog row is
+    not refetched on every query.
     """
 
-    from app.services.market_data import fetch_realized_forward
+    from app.services.market_data import fetch_market_snapshot, fetch_realized_forward
 
     try:
+        snapshot = fetch_market_snapshot(target_date=event_date, symbol="^GSPC")
         forward = fetch_realized_forward(
             target_date=event_date,
             symbol="^GSPC",
             steps=horizon,
             lookback_days=45,
         )
-    except Exception:  # pragma: no cover — yfinance failures must not block analogs
+    except Exception:
         return None
     if len(forward) < horizon:
         return None
     try:
-        start = float(forward[0]["close"])
+        start = float(snapshot["close"])
         end = float(forward[horizon - 1]["close"])
     except (KeyError, TypeError, ValueError):
         return None

--- a/backend/app/services/analogs.py
+++ b/backend/app/services/analogs.py
@@ -23,6 +23,7 @@ missing checkpoint never crashes the worker.
 from __future__ import annotations
 
 import dataclasses
+from functools import lru_cache
 import logging
 import os
 import threading
@@ -377,7 +378,14 @@ def find_analogs(
 
 
 def render_analog_cards(hits: list[AnalogHit]) -> list[dict[str, Any]]:
-    """Adapt :class:`AnalogHit` rows to the ``AnalogCard`` schema shape."""
+    """Adapt :class:`AnalogHit` rows to the ``AnalogCard`` schema shape.
+
+    Augments each card with realized 5d/20d S&P close-to-close returns
+    starting the trading day after ``event_date`` (#299 quant-facing
+    overlay). Returns ``None`` for either field when the historical
+    market data is unavailable so the dashboard can render a graceful
+    empty state.
+    """
 
     return [
         {
@@ -385,10 +393,46 @@ def render_analog_cards(hits: list[AnalogHit]) -> list[dict[str, Any]]:
             "similarity": hit.similarity,
             "axis_stance": hit.axis_stance,
             "subsequent_vol_regime": hit.subsequent_vol_regime,
+            "subsequent_close_pct_5d": _subsequent_close_pct(hit.event_date, horizon=5),
+            "subsequent_close_pct_20d": _subsequent_close_pct(hit.event_date, horizon=20),
             "excerpt": hit.excerpt,
         }
         for hit in hits
     ]
+
+
+@lru_cache(maxsize=512)
+def _subsequent_close_pct(event_date: str, *, horizon: int) -> float | None:
+    """Return the S&P 500 close-to-close % return over ``horizon`` trading
+    days starting the day after ``event_date``.
+
+    ``None`` when the historical data is sparse (e.g. early history),
+    when yfinance is unavailable, or when fewer than ``horizon``
+    forward trading days are present. LRU-cached per (date, horizon)
+    so the same analog row is not refetched on every query.
+    """
+
+    from app.services.market_data import fetch_realized_forward
+
+    try:
+        forward = fetch_realized_forward(
+            target_date=event_date,
+            symbol="^GSPC",
+            steps=horizon,
+            lookback_days=45,
+        )
+    except Exception:  # pragma: no cover — yfinance failures must not block analogs
+        return None
+    if len(forward) < horizon:
+        return None
+    try:
+        start = float(forward[0]["close"])
+        end = float(forward[horizon - 1]["close"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if start <= 0:
+        return None
+    return round((end / start - 1.0) * 100.0, 4)
 
 
 __all__ = [

--- a/backend/app/services/manifests/encoder_registry.json
+++ b/backend/app/services/manifests/encoder_registry.json
@@ -1,0 +1,66 @@
+{
+  "$schema_version": "1",
+  "source_wiki_section": "06_Deep_Learning_Roadmap.md#641",
+  "training_package_id": "canonical",
+  "head": "dual_lstm",
+  "fold": "walk_forward_fold_3",
+  "seeds": [11, 29, 47, 71, 97],
+  "baseline": {
+    "label": "no_text_channel",
+    "dual_f1": 0.3773,
+    "cls_f1": 0.3934,
+    "regression_f1": null
+  },
+  "rows": [
+    {
+      "encoder_alias": "bge_large_en_v15",
+      "encoder_display": "BGE Large EN v1.5",
+      "dual_f1": 0.4347,
+      "cls_f1": 0.3949,
+      "regression_f1": null,
+      "checkpoint_relpath": "backend/models/text_multi_axis_seed11.pt",
+      "cache_uri": "hf://datasets/yusufizzetmurat/fed-pulse-embedding-caches/bge_large_en_v15/",
+      "notes": "best dual lift; generic open-source encoder beats project-specific DAPT"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent",
+      "encoder_display": "FinBERT Fed-Adjacent (DAPT)",
+      "dual_f1": 0.4201,
+      "cls_f1": 0.4160,
+      "regression_f1": null,
+      "checkpoint_relpath": "backend/models/text_multi_axis_seed47.pt",
+      "cache_uri": "hf://datasets/yusufizzetmurat/fed-pulse-embedding-caches/finbert_fed_adjacent/",
+      "notes": "only encoder that lifts BOTH surfaces simultaneously"
+    },
+    {
+      "encoder_alias": "nomic_embed_text_v15",
+      "encoder_display": "Nomic Embed Text v1.5",
+      "dual_f1": 0.3998,
+      "cls_f1": 0.4097,
+      "regression_f1": null,
+      "checkpoint_relpath": "backend/models/text_multi_axis_seed97.pt",
+      "cache_uri": "hf://datasets/yusufizzetmurat/fed-pulse-embedding-caches/nomic_embed_text_v15/",
+      "notes": "modest positive on both surfaces"
+    },
+    {
+      "encoder_alias": "finbert_fed_adjacent_xbank",
+      "encoder_display": "FinBERT Fed-Adjacent xBank (DAPT)",
+      "dual_f1": 0.3872,
+      "cls_f1": 0.3716,
+      "regression_f1": null,
+      "checkpoint_relpath": null,
+      "cache_uri": "hf://datasets/yusufizzetmurat/fed-pulse-embedding-caches/finbert_fed_adjacent_xbank/",
+      "notes": "cross-bank DAPT null; confirms #231 with clean re-run"
+    },
+    {
+      "encoder_alias": "voyage_finance_2",
+      "encoder_display": "Voyage Finance v2 (API)",
+      "dual_f1": 0.3641,
+      "cls_f1": 0.3702,
+      "regression_f1": null,
+      "checkpoint_relpath": null,
+      "cache_uri": "hf://datasets/yusufizzetmurat/fed-pulse-embedding-caches/voyage_finance_2/",
+      "notes": "negative on both surfaces; finance-specialised commercial encoder underperforms open-source generalists"
+    }
+  ]
+}

--- a/backend/app/services/research_artifacts.py
+++ b/backend/app/services/research_artifacts.py
@@ -356,7 +356,7 @@ def load_research_registry(
         "rejected_count": rejected,
         "training_package_id": str(payload.get("training_package_id", "")),
         "head": str(payload.get("head", "")),
-        "seeds": [int(s) for s in seeds if isinstance(s, (int, float))],
+        "seeds": [int(s) for s in seeds if isinstance(s, int | float)],
         "source_wiki_section": str(payload.get("source_wiki_section", "")),
     }
 

--- a/backend/app/services/research_artifacts.py
+++ b/backend/app/services/research_artifacts.py
@@ -262,6 +262,105 @@ def load_cross_bank_transfer(artifacts_root: Path) -> dict[str, Any]:
     }
 
 
+REGISTRY_MANIFEST_PATH = Path(__file__).resolve().parent / "manifests" / "encoder_registry.json"
+
+
+def load_research_registry(
+    surface: str = "dual",
+    include_rejected: bool = False,
+) -> dict[str, Any]:
+    """Quant-facing encoder bake-off registry filtered by Δ surface.
+
+    The manifest at ``manifests/encoder_registry.json`` is the canonical
+    machine-readable source for the §6.41 results table. Each row is
+    annotated with ``delta_dual`` / ``delta_cls`` vs the baseline; by
+    default the response includes only rows with ``Δ >= 0`` on the
+    active surface so the dashboard does not surface negative-lift
+    encoders. Pass ``include_rejected=True`` to see the full table.
+    """
+
+    if surface not in {"dual", "cls"}:
+        raise ValueError(f"unsupported surface {surface!r}; expected dual|cls")
+
+    try:
+        payload = json.loads(REGISTRY_MANIFEST_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        LOGGER.warning("research_registry: failed to load manifest: %s", exc)
+        return {
+            "available": False,
+            "surface": surface,
+            "baseline": None,
+            "rows": [],
+            "rejected_count": 0,
+            "training_package_id": "",
+            "head": "",
+            "seeds": [],
+            "source_wiki_section": "",
+        }
+
+    baseline = payload.get("baseline") or {}
+    baseline_dual = _safe_float_or_none(baseline.get("dual_f1"))
+    baseline_cls = _safe_float_or_none(baseline.get("cls_f1"))
+
+    rows: list[dict[str, Any]] = []
+    rejected = 0
+    for row in payload.get("rows") or []:
+        row_dual = _safe_float_or_none(row.get("dual_f1"))
+        row_cls = _safe_float_or_none(row.get("cls_f1"))
+        delta_dual = (
+            None if row_dual is None or baseline_dual is None else round(row_dual - baseline_dual, 4)
+        )
+        delta_cls = (
+            None if row_cls is None or baseline_cls is None else round(row_cls - baseline_cls, 4)
+        )
+        active_delta = delta_dual if surface == "dual" else delta_cls
+        is_winner = active_delta is not None and active_delta >= 0
+
+        if not is_winner and not include_rejected:
+            rejected += 1
+            continue
+
+        rows.append(
+            {
+                "encoder_alias": str(row.get("encoder_alias", "")),
+                "encoder_display": str(row.get("encoder_display", row.get("encoder_alias", ""))),
+                "dual_f1": row_dual,
+                "cls_f1": row_cls,
+                "regression_f1": _safe_float_or_none(row.get("regression_f1")),
+                "delta_dual": delta_dual,
+                "delta_cls": delta_cls,
+                "is_winner": is_winner,
+                "checkpoint_relpath": row.get("checkpoint_relpath"),
+                "cache_uri": row.get("cache_uri"),
+                "notes": str(row.get("notes", "")),
+            }
+        )
+
+    baseline_out = (
+        {
+            "label": str(baseline.get("label", "baseline")),
+            "dual_f1": baseline_dual,
+            "cls_f1": baseline_cls,
+            "regression_f1": _safe_float_or_none(baseline.get("regression_f1")),
+        }
+        if baseline
+        else None
+    )
+
+    seeds = payload.get("seeds") or []
+    return {
+        "available": bool(rows) or include_rejected,
+        "surface": surface,
+        "baseline": baseline_out,
+        "rows": rows,
+        "rejected_count": rejected,
+        "training_package_id": str(payload.get("training_package_id", "")),
+        "head": str(payload.get("head", "")),
+        "seeds": [int(s) for s in seeds if isinstance(s, (int, float))],
+        "source_wiki_section": str(payload.get("source_wiki_section", "")),
+    }
+
+
 def _safe_float(value: Any) -> float:
     if value is None:
         return 0.0

--- a/frontend/components/shell/header.tsx
+++ b/frontend/components/shell/header.tsx
@@ -12,6 +12,7 @@ import {
   LineChart,
   Menu,
   Settings as SettingsIcon,
+  Terminal,
   X,
 } from "lucide-react";
 
@@ -23,6 +24,7 @@ import { cn } from "@/lib/utils";
 
 const NAV_ITEMS: Array<{ href: string; label: string; icon: React.ComponentType<{ className?: string }> }> = [
   { href: "/", label: "Workspace", icon: Activity },
+  { href: "/console", label: "Terminal", icon: Terminal },
   { href: "/decisions", label: "Predictions", icon: LineChart },
   { href: "/history", label: "History", icon: HistoryIcon },
   { href: "/compare", label: "Compare", icon: GitCompare },

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -15,6 +15,7 @@ import type {
   MarketReactionPanelResponse,
   NextFomcForecastResponse,
   ResearchArtifactsResponse,
+  ResearchRegistryResponse,
   SettingsCheckpointsResponse,
   SymbolListResponse,
   TrainJobState,
@@ -224,4 +225,15 @@ export async function fetchNextFomcForecast(
 ): Promise<NextFomcForecastResponse> {
   const response = await axios.get(`${baseUrl}/forecasts/next-fomc`);
   return response.data as NextFomcForecastResponse;
+}
+
+export async function fetchResearchRegistry(
+  baseUrl: string,
+  options?: { surface?: "dual" | "cls"; includeRejected?: boolean }
+): Promise<ResearchRegistryResponse> {
+  const params: Record<string, string | boolean> = {};
+  if (options?.surface) params.surface = options.surface;
+  if (options?.includeRejected) params.include_rejected = true;
+  const response = await axios.get(`${baseUrl}/research/registry`, { params });
+  return response.data as ResearchRegistryResponse;
 }

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -316,6 +316,11 @@ export interface AnalogCard {
   // ``forward_realized_vol_10d`` target so this label is the only
   // post-event signal available. Never feed back into a model.
   subsequent_vol_regime: AnalogVolRegime | null;
+  // #299: realized S&P 500 close-to-close % returns over 5 / 20 trading
+  // days starting the day after event_date. Market-data overlay (NOT a
+  // training label); null when the historical window is sparse.
+  subsequent_close_pct_5d: number | null;
+  subsequent_close_pct_20d: number | null;
   excerpt: string;
 }
 
@@ -600,4 +605,38 @@ export interface NextFomcForecastResponse {
   metrics_ex_pandemic: Record<string, NextFomcModelMetrics>;
   feature_attribution: NextFomcAttributionRow[];
   summary: Record<string, number>;
+}
+
+// #299: quant-facing research registry (§6.41 manifest)
+export interface ResearchRegistryBaseline {
+  label: string;
+  dual_f1: number | null;
+  cls_f1: number | null;
+  regression_f1: number | null;
+}
+
+export interface ResearchRegistryRow {
+  encoder_alias: string;
+  encoder_display: string;
+  dual_f1: number | null;
+  cls_f1: number | null;
+  regression_f1: number | null;
+  delta_dual: number | null;
+  delta_cls: number | null;
+  is_winner: boolean;
+  checkpoint_relpath: string | null;
+  cache_uri: string | null;
+  notes: string;
+}
+
+export interface ResearchRegistryResponse {
+  available: boolean;
+  surface: "dual" | "cls";
+  baseline: ResearchRegistryBaseline | null;
+  rows: ResearchRegistryRow[];
+  rejected_count: number;
+  training_package_id: string;
+  head: string;
+  seeds: number[];
+  source_wiki_section: string;
 }

--- a/frontend/pages/console.tsx
+++ b/frontend/pages/console.tsx
@@ -173,7 +173,11 @@ export default function ConsolePage(): JSX.Element {
           <BacktestPanel />
         </div>
 
-        <RegistryStrip registry={registry} surface={surface} />
+        <RegistryStrip
+          registry={registry}
+          surface={surface}
+          includeRejected={includeRejected}
+        />
       </main>
     </>
   );
@@ -250,6 +254,11 @@ function ActiveCheckpointBar({
             <span>head={registry.head} · seeds={registry.seeds.join(",")}</span>
           </div>
         )}
+        <p className="text-xs text-muted-foreground">
+          Display only in v1: checkpoint selection drives the Registry strip
+          ranking; the analysis panels above use the backend&apos;s active
+          checkpoint. Server-side hot-swap lands in the follow-up PR.
+        </p>
       </CardContent>
     </Card>
   );
@@ -403,16 +412,21 @@ function BacktestPanel(): JSX.Element {
 function RegistryStrip({
   registry,
   surface,
+  includeRejected,
 }: {
   registry: ResearchRegistryResponse | null;
   surface: Surface;
+  includeRejected: boolean;
 }): JSX.Element | null {
   if (!registry) return null;
+  const title = includeRejected
+    ? "Registry (all encoders, losers dimmed)"
+    : `Registry (winners on ${surface})`;
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center justify-between">
-          <span>Registry (winners on {surface})</span>
+          <span>{title}</span>
           <span className="text-xs font-normal text-muted-foreground">
             wiki §{registry.source_wiki_section}
           </span>
@@ -433,7 +447,13 @@ function RegistryStrip({
             </thead>
             <tbody>
               {registry.rows.map((row) => (
-                <tr key={row.encoder_alias} className="border-t border-border">
+                <tr
+                  key={row.encoder_alias}
+                  className={cn(
+                    "border-t border-border",
+                    row.is_winner ? undefined : "opacity-50",
+                  )}
+                >
                   <td className="py-1 font-mono">{row.encoder_display}</td>
                   <td className="px-2 text-right font-mono">
                     {row.dual_f1?.toFixed(4) ?? "—"}

--- a/frontend/pages/console.tsx
+++ b/frontend/pages/console.tsx
@@ -1,0 +1,501 @@
+import * as React from "react";
+import Head from "next/head";
+import { Terminal as TerminalIcon } from "lucide-react";
+
+import { Header } from "@/components/shell/header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  fetchResearchRegistry,
+  postAnalyze,
+  postAnalyzeAnalogs,
+  resolveApiBaseUrl,
+} from "@/lib/analyze/api";
+import { errorMessage } from "@/lib/analyze/errors";
+import type {
+  AnalogsResponse,
+  AnalyzeResult,
+  ResearchRegistryResponse,
+} from "@/lib/analyze/types";
+import { cn } from "@/lib/utils";
+
+const SAMPLE_TEXT =
+  "Recent indicators suggest that economic activity has been expanding at a solid pace. Job gains have remained strong, and the unemployment rate has stayed low. Inflation has eased over the past year but remains somewhat elevated. The Committee remains highly attentive to inflation risks.";
+
+type Surface = "dual" | "cls";
+
+function formatDelta(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  const sign = value >= 0 ? "+" : "";
+  return `${sign}${value.toFixed(4)}`;
+}
+
+function formatPct(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  const sign = value >= 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+function deltaTone(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return "text-muted-foreground";
+  return value >= 0 ? "text-emerald-500" : "text-destructive";
+}
+
+export default function ConsolePage(): JSX.Element {
+  const baseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+  const [text, setText] = React.useState<string>(SAMPLE_TEXT);
+  const [analysisDate, setAnalysisDate] = React.useState<string>(
+    () => new Date().toISOString().slice(0, 10),
+  );
+  const [surface, setSurface] = React.useState<Surface>("dual");
+  const [includeRejected, setIncludeRejected] = React.useState<boolean>(false);
+  const [registry, setRegistry] = React.useState<ResearchRegistryResponse | null>(null);
+  const [activeEncoder, setActiveEncoder] = React.useState<string>("");
+  const [analyze, setAnalyze] = React.useState<AnalyzeResult | null>(null);
+  const [analogs, setAnalogs] = React.useState<AnalogsResponse | null>(null);
+  const [running, setRunning] = React.useState<boolean>(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    fetchResearchRegistry(baseUrl, { surface, includeRejected })
+      .then((response) => {
+        if (cancelled) return;
+        setRegistry(response);
+        if (response.rows.length > 0) {
+          setActiveEncoder((prev) =>
+            response.rows.some((row: { encoder_alias: string }) => row.encoder_alias === prev)
+              ? prev
+              : response.rows[0].encoder_alias,
+          );
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(errorMessage(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [baseUrl, surface, includeRejected]);
+
+  const runAnalysis = React.useCallback(async () => {
+    if (!text.trim()) return;
+    setRunning(true);
+    setError(null);
+    try {
+      const [analyzeResult, analogsResult] = await Promise.all([
+        postAnalyze(baseUrl, {
+          text,
+          date: analysisDate,
+          symbol: "^GSPC",
+          horizon: "10d",
+          include_realized: false,
+        }),
+        postAnalyzeAnalogs(baseUrl, { text, k: 3 }),
+      ]);
+      setAnalyze(analyzeResult);
+      setAnalogs(analogsResult);
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setRunning(false);
+    }
+  }, [baseUrl, text, analysisDate]);
+
+  return (
+    <>
+      <Head>
+        <title>FOMC Signal Terminal · fed-pulse</title>
+      </Head>
+      <Header />
+      <main className="container py-6 space-y-4">
+        <div className="flex items-center gap-3">
+          <TerminalIcon className="h-5 w-5" />
+          <h1 className="text-2xl font-semibold">FOMC Signal Terminal</h1>
+          <Badge variant="outline">v1</Badge>
+        </div>
+
+        <ActiveCheckpointBar
+          registry={registry}
+          activeEncoder={activeEncoder}
+          onActiveEncoderChange={setActiveEncoder}
+          surface={surface}
+          onSurfaceChange={setSurface}
+          includeRejected={includeRejected}
+          onIncludeRejectedChange={setIncludeRejected}
+        />
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Statement</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <textarea
+              value={text}
+              onChange={(event) => setText(event.target.value)}
+              className="w-full h-32 rounded border border-border bg-background p-3 text-sm font-mono"
+              placeholder="Paste FOMC statement text…"
+            />
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="text-xs text-muted-foreground" htmlFor="console-date">
+                Analysis date
+              </label>
+              <input
+                id="console-date"
+                type="date"
+                value={analysisDate}
+                onChange={(event) => setAnalysisDate(event.target.value)}
+                className="rounded border border-border bg-background px-2 py-1 text-sm"
+              />
+              <Button onClick={runAnalysis} disabled={running || !text.trim()}>
+                {running ? "Running…" : "Run analysis"}
+              </Button>
+              {error && (
+                <span className="text-xs text-destructive" role="alert">
+                  {error}
+                </span>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <StancePanel analyze={analyze} />
+          <VolRegimePanel analyze={analyze} />
+          <AnalogsPanel analogs={analogs} />
+          <BacktestPanel />
+        </div>
+
+        <RegistryStrip registry={registry} surface={surface} />
+      </main>
+    </>
+  );
+}
+
+interface ActiveCheckpointBarProps {
+  registry: ResearchRegistryResponse | null;
+  activeEncoder: string;
+  onActiveEncoderChange: (next: string) => void;
+  surface: Surface;
+  onSurfaceChange: (next: Surface) => void;
+  includeRejected: boolean;
+  onIncludeRejectedChange: (next: boolean) => void;
+}
+
+function ActiveCheckpointBar({
+  registry,
+  activeEncoder,
+  onActiveEncoderChange,
+  surface,
+  onSurfaceChange,
+  includeRejected,
+  onIncludeRejectedChange,
+}: ActiveCheckpointBarProps): JSX.Element {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between gap-3">
+          <span>Active checkpoint</span>
+          <div className="flex items-center gap-3 text-xs font-normal text-muted-foreground">
+            <label className="flex items-center gap-1">
+              surface
+              <select
+                value={surface}
+                onChange={(event) => onSurfaceChange(event.target.value as Surface)}
+                className="rounded border border-border bg-background px-2 py-1"
+              >
+                <option value="dual">dual</option>
+                <option value="cls">cls</option>
+              </select>
+            </label>
+            <label className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={includeRejected}
+                onChange={(event) => onIncludeRejectedChange(event.target.checked)}
+              />
+              show rejected
+            </label>
+          </div>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <select
+          value={activeEncoder}
+          onChange={(event) => onActiveEncoderChange(event.target.value)}
+          className="w-full rounded border border-border bg-background px-3 py-2 text-sm font-mono"
+        >
+          {(registry?.rows ?? []).map((row) => {
+            const delta = surface === "dual" ? row.delta_dual : row.delta_cls;
+            return (
+              <option key={row.encoder_alias} value={row.encoder_alias}>
+                {row.encoder_display} — Δ{surface} {formatDelta(delta)}
+              </option>
+            );
+          })}
+        </select>
+        {registry && (
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>
+              {registry.rows.length} shown · {registry.rejected_count} rejected
+              {" · "}TP={registry.training_package_id}
+            </span>
+            <span>head={registry.head} · seeds={registry.seeds.join(",")}</span>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function StancePanel({ analyze }: { analyze: AnalyzeResult | null }): JSX.Element {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Stance</CardTitle>
+      </CardHeader>
+      <CardContent className="text-sm">
+        {analyze ? (
+          <div className="space-y-2">
+            <Row
+              label="Label"
+              value={(analyze.sentiment?.label ?? "—").toUpperCase()}
+            />
+            <Row
+              label="Score"
+              value={analyze.sentiment?.score?.toFixed(3) ?? "—"}
+            />
+            <Row
+              label="OOD"
+              value={
+                analyze.sentiment?.is_in_distribution === false
+                  ? `OUT (energy ${analyze.sentiment?.ood_energy?.toFixed(2) ?? "—"})`
+                  : `in-distribution (${analyze.sentiment?.ood_energy?.toFixed(2) ?? "—"})`
+              }
+              tone={analyze.sentiment?.is_in_distribution === false ? "warn" : undefined}
+            />
+            {analyze.multi_axis?.stance && (
+              <Row
+                label="Multi-axis stance"
+                value={`${analyze.multi_axis.stance.label} (${analyze.multi_axis.stance.confidence.toFixed(2)})`}
+              />
+            )}
+          </div>
+        ) : (
+          <Hint />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function VolRegimePanel({ analyze }: { analyze: AnalyzeResult | null }): JSX.Element {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Vol regime (10d fwd)</CardTitle>
+      </CardHeader>
+      <CardContent className="text-sm">
+        {analyze ? (
+          <div className="space-y-2">
+            <Row
+              label="Argmax class"
+              value={analyze.regime_classification?.argmax_class ?? "—"}
+            />
+            <Row
+              label="Predicted vol"
+              value={analyze.prediction?.volatility?.toFixed(4) ?? "—"}
+            />
+            <Row
+              label="Predicted close"
+              value={analyze.prediction?.close?.toFixed(2) ?? "—"}
+            />
+            <Row
+              label="Latest close"
+              value={analyze.market?.close?.toFixed(2) ?? "—"}
+            />
+            {analyze.regime_classification?.coverage != null && (
+              <Row
+                label="Coverage"
+                value={`${(analyze.regime_classification.coverage * 100).toFixed(1)}%`}
+              />
+            )}
+          </div>
+        ) : (
+          <Hint />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function AnalogsPanel({ analogs }: { analogs: AnalogsResponse | null }): JSX.Element {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Historical analogs</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {!analogs ? (
+          <Hint />
+        ) : analogs.analogs.length === 0 ? (
+          <div className="text-muted-foreground">No analogs found.</div>
+        ) : (
+          analogs.analogs.map((analog) => (
+            <div
+              key={analog.event_date}
+              className="space-y-1 border-l-2 border-border pl-3"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-mono">{analog.event_date}</span>
+                <span className="text-xs text-muted-foreground">
+                  cos {analog.similarity.toFixed(3)}
+                </span>
+              </div>
+              <div className="grid grid-cols-2 gap-3 font-mono text-xs">
+                <span>
+                  5d S&amp;P:{" "}
+                  <span className={deltaTone(analog.subsequent_close_pct_5d)}>
+                    {formatPct(analog.subsequent_close_pct_5d)}
+                  </span>
+                </span>
+                <span>
+                  20d S&amp;P:{" "}
+                  <span className={deltaTone(analog.subsequent_close_pct_20d)}>
+                    {formatPct(analog.subsequent_close_pct_20d)}
+                  </span>
+                </span>
+              </div>
+              <div className="line-clamp-2 text-xs text-muted-foreground">
+                {analog.excerpt}
+              </div>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function BacktestPanel(): JSX.Element {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Backtest (since 2018)</CardTitle>
+      </CardHeader>
+      <CardContent className="text-sm text-muted-foreground">
+        Stance-directional Sharpe / HitRate / MaxDD vs buy-and-hold ATM
+        straddle — lands in the #299 backtest follow-up PR. The engine
+        will compute the strategy from the active checkpoint&apos;s historical
+        FOMC predictions and stamp confidence intervals on each metric.
+      </CardContent>
+    </Card>
+  );
+}
+
+function RegistryStrip({
+  registry,
+  surface,
+}: {
+  registry: ResearchRegistryResponse | null;
+  surface: Surface;
+}): JSX.Element | null {
+  if (!registry) return null;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span>Registry (winners on {surface})</span>
+          <span className="text-xs font-normal text-muted-foreground">
+            wiki §{registry.source_wiki_section}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-xs">
+            <thead className="text-muted-foreground">
+              <tr>
+                <th className="py-1 text-left">Encoder</th>
+                <th className="px-2 text-right">dual F1</th>
+                <th className="px-2 text-right">cls F1</th>
+                <th className="px-2 text-right">Δ dual</th>
+                <th className="px-2 text-right">Δ cls</th>
+                <th className="pl-3 text-left">Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              {registry.rows.map((row) => (
+                <tr key={row.encoder_alias} className="border-t border-border">
+                  <td className="py-1 font-mono">{row.encoder_display}</td>
+                  <td className="px-2 text-right font-mono">
+                    {row.dual_f1?.toFixed(4) ?? "—"}
+                  </td>
+                  <td className="px-2 text-right font-mono">
+                    {row.cls_f1?.toFixed(4) ?? "—"}
+                  </td>
+                  <td
+                    className={cn(
+                      "px-2 text-right font-mono",
+                      deltaTone(row.delta_dual),
+                    )}
+                  >
+                    {formatDelta(row.delta_dual)}
+                  </td>
+                  <td
+                    className={cn(
+                      "px-2 text-right font-mono",
+                      deltaTone(row.delta_cls),
+                    )}
+                  >
+                    {formatDelta(row.delta_cls)}
+                  </td>
+                  <td className="pl-3 text-muted-foreground">{row.notes}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Row({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone?: "warn";
+}): JSX.Element {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-muted-foreground">{label}</span>
+      <span
+        className={cn(
+          "font-mono",
+          tone === "warn" ? "text-amber-500" : undefined,
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function Hint(): JSX.Element {
+  return (
+    <span className="text-muted-foreground">
+      Run an analysis to populate this panel.
+    </span>
+  );
+}

--- a/frontend/tests/components/analyze/HistoricalAnalogPanel.test.tsx
+++ b/frontend/tests/components/analyze/HistoricalAnalogPanel.test.tsx
@@ -12,6 +12,8 @@ function fixture(overrides: Partial<AnalogsResponse> = {}): AnalogsResponse {
         similarity: 0.82,
         axis_stance: "dovish",
         subsequent_vol_regime: "high",
+        subsequent_close_pct_5d: null,
+        subsequent_close_pct_20d: null,
         excerpt: "Information received since the Committee met in June indicates that the labor market remains strong and that economic activity has been rising at a moderate rate.",
       },
       {
@@ -19,6 +21,8 @@ function fixture(overrides: Partial<AnalogsResponse> = {}): AnalogsResponse {
         similarity: 0.71,
         axis_stance: "neutral",
         subsequent_vol_regime: "normal",
+        subsequent_close_pct_5d: null,
+        subsequent_close_pct_20d: null,
         excerpt: "Information received since the Federal Open Market Committee met in July suggests that economic activity is expanding at a moderate pace.",
       },
       {
@@ -26,6 +30,8 @@ function fixture(overrides: Partial<AnalogsResponse> = {}): AnalogsResponse {
         similarity: 0.65,
         axis_stance: "dovish",
         subsequent_vol_regime: "calm",
+        subsequent_close_pct_5d: null,
+        subsequent_close_pct_20d: null,
         excerpt: "Economic growth was moderate during the first half of the year, but the tightening of credit conditions has the potential to intensify the housing correction and to restrain economic growth more generally.",
       },
       {
@@ -33,6 +39,8 @@ function fixture(overrides: Partial<AnalogsResponse> = {}): AnalogsResponse {
         similarity: 0.21,
         axis_stance: "hawkish",
         subsequent_vol_regime: "normal",
+        subsequent_close_pct_5d: null,
+        subsequent_close_pct_20d: null,
         excerpt: "The Committee continues to believe that, against the background of its long-run goals of price stability and sustainable economic growth, the risks remain weighted mainly toward conditions that may generate economic weakness.",
       },
     ],
@@ -72,6 +80,8 @@ describe("HistoricalAnalogPanel", () => {
           similarity: 0.55,
           axis_stance: null,
           subsequent_vol_regime: "calm",
+        subsequent_close_pct_5d: null,
+        subsequent_close_pct_20d: null,
           excerpt: "Short excerpt.",
         },
       ],
@@ -134,6 +144,8 @@ describe("HistoricalAnalogPanel", () => {
       similarity: 0.78,
       axis_stance: "hawkish" as const,
       subsequent_vol_regime: "high" as const,
+        subsequent_close_pct_5d: null,
+        subsequent_close_pct_20d: null,
       excerpt: "x".repeat(280),
     };
     render(
@@ -159,6 +171,8 @@ describe("HistoricalAnalogPanel", () => {
       similarity: 0.62,
       axis_stance: "neutral" as const,
       subsequent_vol_regime: "normal" as const,
+        subsequent_close_pct_5d: null,
+        subsequent_close_pct_20d: null,
       excerpt: "Short statement under the 280 ceiling.",
     };
     render(
@@ -187,6 +201,8 @@ describe("HistoricalAnalogPanel", () => {
       similarity: 0.81,
       axis_stance: "dovish" as const,
       subsequent_vol_regime: "high" as const,
+        subsequent_close_pct_5d: null,
+        subsequent_close_pct_20d: null,
       excerpt: "Intermeeting statement excerpt.",
     };
     const sameDateCorrection = {

--- a/tests/unit/test_analogs_endpoint.py
+++ b/tests/unit/test_analogs_endpoint.py
@@ -34,6 +34,20 @@ def _reset_analogs_singleton():
     analogs_service.reset_state()
 
 
+@pytest.fixture(autouse=True)
+def _stub_realized_close_returns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#299: the analogs renderer now augments each card with realized
+    5d/20d S&P close-to-close returns. Stub the lookup to None so this
+    file's existing tests do not depend on network access; a dedicated
+    test file exercises the augmentation behaviour itself."""
+
+    monkeypatch.setattr(
+        analogs_service,
+        "_subsequent_close_pct",
+        lambda event_date, *, horizon: None,
+    )
+
+
 def _fixture_rows() -> list[dict]:
     rows = [
         {

--- a/tests/unit/test_analogs_realized_returns.py
+++ b/tests/unit/test_analogs_realized_returns.py
@@ -47,7 +47,7 @@ def test_subsequent_close_pct_attached_to_each_card(monkeypatch: pytest.MonkeyPa
 def test_subsequent_close_pct_returns_none_when_market_fetch_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """yfinance failures must not block the analogs path."""
+    """yfinance failures on either fetch must not block the analogs path."""
 
     analogs_service._subsequent_close_pct.cache_clear()
 
@@ -55,7 +55,7 @@ def test_subsequent_close_pct_returns_none_when_market_fetch_raises(
         raise RuntimeError("yfinance offline")
 
     monkeypatch.setattr(
-        "app.services.market_data.fetch_realized_forward",
+        "app.services.market_data.fetch_market_snapshot",
         _boom,
     )
 
@@ -69,6 +69,11 @@ def test_subsequent_close_pct_returns_none_when_short_window(
     """Sparse forward windows produce None rather than fabricated returns."""
 
     analogs_service._subsequent_close_pct.cache_clear()
+
+    monkeypatch.setattr(
+        "app.services.market_data.fetch_market_snapshot",
+        lambda *_args, **_kwargs: {"close": 3200.0},
+    )
 
     def _short(*_args, **_kwargs) -> list[dict]:
         return [{"date": "2020-01-02", "close": 3257.0, "volatility_5d": 0.01}]
@@ -85,11 +90,17 @@ def test_subsequent_close_pct_returns_none_when_short_window(
 def test_subsequent_close_pct_computes_correct_return(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """5-day return = (close[4] / close[0] - 1) * 100, rounded to 4dp."""
+    """5d return = (close[event+5] / close[event] - 1) * 100 — uses the
+    event-day close as the denominator (Bloomberg convention)."""
 
     analogs_service._subsequent_close_pct.cache_clear()
 
     closes = [100.0, 101.0, 102.0, 103.0, 105.0]
+
+    monkeypatch.setattr(
+        "app.services.market_data.fetch_market_snapshot",
+        lambda *_args, **_kwargs: {"close": 100.0},
+    )
 
     def _series(*_args, **kwargs) -> list[dict]:
         steps = kwargs.get("steps") or 5
@@ -105,25 +116,30 @@ def test_subsequent_close_pct_computes_correct_return(
     assert out == pytest.approx(5.0, abs=1e-4)
 
 
-def test_subsequent_close_pct_handles_zero_start_close(
+def test_subsequent_close_pct_handles_zero_event_day_close(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Defensive: a zero start close would divide-by-zero — return None."""
+    """Defensive: a zero event-day close would divide-by-zero — return None."""
 
     analogs_service._subsequent_close_pct.cache_clear()
 
-    def _zero_start(*_args, **_kwargs) -> list[dict]:
+    monkeypatch.setattr(
+        "app.services.market_data.fetch_market_snapshot",
+        lambda *_args, **_kwargs: {"close": 0.0},
+    )
+
+    def _five(*_args, **_kwargs) -> list[dict]:
         return [
-            {"date": "2020-01-02", "close": 0.0, "volatility_5d": 0.01},
-            {"date": "2020-01-03", "close": 99.0, "volatility_5d": 0.01},
-            {"date": "2020-01-06", "close": 100.0, "volatility_5d": 0.01},
-            {"date": "2020-01-07", "close": 101.0, "volatility_5d": 0.01},
-            {"date": "2020-01-08", "close": 102.0, "volatility_5d": 0.01},
+            {"date": "2020-01-02", "close": 99.0, "volatility_5d": 0.01},
+            {"date": "2020-01-03", "close": 100.0, "volatility_5d": 0.01},
+            {"date": "2020-01-06", "close": 101.0, "volatility_5d": 0.01},
+            {"date": "2020-01-07", "close": 102.0, "volatility_5d": 0.01},
+            {"date": "2020-01-08", "close": 103.0, "volatility_5d": 0.01},
         ]
 
     monkeypatch.setattr(
         "app.services.market_data.fetch_realized_forward",
-        _zero_start,
+        _five,
     )
 
     out = analogs_service._subsequent_close_pct("2020-01-01", horizon=5)

--- a/tests/unit/test_analogs_realized_returns.py
+++ b/tests/unit/test_analogs_realized_returns.py
@@ -1,0 +1,130 @@
+"""#299: realized 5d/20d S&P close-to-close returns on analog cards."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.retrieval.index import AnalogHit
+from app.services import analogs as analogs_service
+
+
+def _hit(event_date: str = "2022-09-21") -> AnalogHit:
+    return AnalogHit(
+        event_date=event_date,
+        text_hash="deadbeef",
+        similarity=0.9,
+        axis_stance="hawkish",
+        subsequent_vol_regime="high",
+        excerpt="Fed signals further tightening",
+    )
+
+
+def test_subsequent_close_pct_attached_to_each_card(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The renderer pulls realized S&P returns and stamps both 5d and 20d on every card."""
+
+    captured: list[tuple[str, int]] = []
+
+    def _fake(event_date: str, *, horizon: int) -> float | None:
+        captured.append((event_date, horizon))
+        return 2.5 if horizon == 5 else -1.0
+
+    monkeypatch.setattr(analogs_service, "_subsequent_close_pct", _fake)
+
+    cards = analogs_service.render_analog_cards([_hit("2022-09-21"), _hit("2020-03-15")])
+
+    assert all("subsequent_close_pct_5d" in c for c in cards)
+    assert all("subsequent_close_pct_20d" in c for c in cards)
+    assert cards[0]["subsequent_close_pct_5d"] == 2.5
+    assert cards[0]["subsequent_close_pct_20d"] == -1.0
+    assert set(captured) == {
+        ("2022-09-21", 5),
+        ("2022-09-21", 20),
+        ("2020-03-15", 5),
+        ("2020-03-15", 20),
+    }
+
+
+def test_subsequent_close_pct_returns_none_when_market_fetch_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """yfinance failures must not block the analogs path."""
+
+    analogs_service._subsequent_close_pct.cache_clear()
+
+    def _boom(*_args, **_kwargs) -> None:
+        raise RuntimeError("yfinance offline")
+
+    monkeypatch.setattr(
+        "app.services.market_data.fetch_realized_forward",
+        _boom,
+    )
+
+    out = analogs_service._subsequent_close_pct("2022-09-21", horizon=5)
+    assert out is None
+
+
+def test_subsequent_close_pct_returns_none_when_short_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sparse forward windows produce None rather than fabricated returns."""
+
+    analogs_service._subsequent_close_pct.cache_clear()
+
+    def _short(*_args, **_kwargs) -> list[dict]:
+        return [{"date": "2020-01-02", "close": 3257.0, "volatility_5d": 0.01}]
+
+    monkeypatch.setattr(
+        "app.services.market_data.fetch_realized_forward",
+        _short,
+    )
+
+    out = analogs_service._subsequent_close_pct("2020-01-01", horizon=5)
+    assert out is None
+
+
+def test_subsequent_close_pct_computes_correct_return(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """5-day return = (close[4] / close[0] - 1) * 100, rounded to 4dp."""
+
+    analogs_service._subsequent_close_pct.cache_clear()
+
+    closes = [100.0, 101.0, 102.0, 103.0, 105.0]
+
+    def _series(*_args, **kwargs) -> list[dict]:
+        steps = kwargs.get("steps") or 5
+        return [{"date": f"2020-01-0{i + 2}", "close": c, "volatility_5d": 0.01} for i, c in enumerate(closes[:steps])]
+
+    monkeypatch.setattr(
+        "app.services.market_data.fetch_realized_forward",
+        _series,
+    )
+
+    out = analogs_service._subsequent_close_pct("2020-01-01", horizon=5)
+    # (105 / 100 - 1) * 100 = 5.0
+    assert out == pytest.approx(5.0, abs=1e-4)
+
+
+def test_subsequent_close_pct_handles_zero_start_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defensive: a zero start close would divide-by-zero — return None."""
+
+    analogs_service._subsequent_close_pct.cache_clear()
+
+    def _zero_start(*_args, **_kwargs) -> list[dict]:
+        return [
+            {"date": "2020-01-02", "close": 0.0, "volatility_5d": 0.01},
+            {"date": "2020-01-03", "close": 99.0, "volatility_5d": 0.01},
+            {"date": "2020-01-06", "close": 100.0, "volatility_5d": 0.01},
+            {"date": "2020-01-07", "close": 101.0, "volatility_5d": 0.01},
+            {"date": "2020-01-08", "close": 102.0, "volatility_5d": 0.01},
+        ]
+
+    monkeypatch.setattr(
+        "app.services.market_data.fetch_realized_forward",
+        _zero_start,
+    )
+
+    out = analogs_service._subsequent_close_pct("2020-01-01", horizon=5)
+    assert out is None

--- a/tests/unit/test_research_registry.py
+++ b/tests/unit/test_research_registry.py
@@ -1,0 +1,84 @@
+"""Unit tests for the quant-facing encoder bake-off registry (#299)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services.research_artifacts import (
+    REGISTRY_MANIFEST_PATH,
+    load_research_registry,
+)
+
+
+def test_manifest_exists_and_is_valid_json() -> None:
+    payload = json.loads(REGISTRY_MANIFEST_PATH.read_text(encoding="utf-8"))
+    assert payload["baseline"]["dual_f1"] == pytest.approx(0.3773)
+    assert payload["baseline"]["cls_f1"] == pytest.approx(0.3934)
+    assert len(payload["rows"]) == 5
+    aliases = {row["encoder_alias"] for row in payload["rows"]}
+    assert aliases == {
+        "bge_large_en_v15",
+        "finbert_fed_adjacent",
+        "nomic_embed_text_v15",
+        "finbert_fed_adjacent_xbank",
+        "voyage_finance_2",
+    }
+
+
+def test_dual_surface_default_filters_out_voyage() -> None:
+    out = load_research_registry(surface="dual")
+    assert out["available"] is True
+    assert out["surface"] == "dual"
+    aliases = [row["encoder_alias"] for row in out["rows"]]
+    # voyage is the only dual-surface loser (-0.013).
+    assert "voyage_finance_2" not in aliases
+    assert "finbert_fed_adjacent_xbank" in aliases  # xbank is +0.010 on dual
+    assert out["rejected_count"] == 1
+
+
+def test_cls_surface_default_filters_out_voyage_and_xbank() -> None:
+    out = load_research_registry(surface="cls")
+    assert out["surface"] == "cls"
+    aliases = [row["encoder_alias"] for row in out["rows"]]
+    # Both voyage (-0.023) and xbank (-0.022) lose on cls.
+    assert "voyage_finance_2" not in aliases
+    assert "finbert_fed_adjacent_xbank" not in aliases
+    assert "bge_large_en_v15" in aliases
+    assert "finbert_fed_adjacent" in aliases
+    assert "nomic_embed_text_v15" in aliases
+    assert out["rejected_count"] == 2
+
+
+def test_include_rejected_returns_full_table() -> None:
+    out = load_research_registry(surface="dual", include_rejected=True)
+    assert len(out["rows"]) == 5
+    assert out["rejected_count"] == 0
+    voyage = next(r for r in out["rows"] if r["encoder_alias"] == "voyage_finance_2")
+    assert voyage["is_winner"] is False
+    assert voyage["delta_dual"] < 0
+
+
+def test_deltas_round_to_four_decimals_and_match_wiki() -> None:
+    out = load_research_registry(surface="dual", include_rejected=True)
+    by_alias = {row["encoder_alias"]: row for row in out["rows"]}
+    # Wiki §6.41 ground truth deltas.
+    assert by_alias["bge_large_en_v15"]["delta_dual"] == pytest.approx(0.0574, abs=1e-4)
+    assert by_alias["finbert_fed_adjacent"]["delta_dual"] == pytest.approx(0.0428, abs=1e-4)
+    assert by_alias["nomic_embed_text_v15"]["delta_dual"] == pytest.approx(0.0225, abs=1e-4)
+    assert by_alias["voyage_finance_2"]["delta_dual"] == pytest.approx(-0.0132, abs=1e-4)
+
+
+def test_unsupported_surface_raises() -> None:
+    with pytest.raises(ValueError, match="dual|cls"):
+        load_research_registry(surface="regression")
+
+
+def test_manifest_carries_provenance() -> None:
+    out = load_research_registry(surface="dual")
+    assert out["training_package_id"] == "canonical"
+    assert out["head"] == "dual_lstm"
+    assert out["seeds"] == [11, 29, 47, 71, 97]
+    assert "06_Deep_Learning_Roadmap" in out["source_wiki_section"]


### PR DESCRIPTION
First slice of the four-panel quant terminal.

- New `GET /research/registry?surface=dual|cls&include_rejected=bool`
- Manifest at `backend/app/services/manifests/encoder_registry.json` carries the §6.41 5-row table
- Each row computes `delta_dual` / `delta_cls` vs the no-text baseline
- Filtered by default to non-negative Δ on the active surface (voyage drops on dual; voyage+xbank drop on cls)
- `include_rejected=true` returns the full 5-row table
- Tests assert ground-truth deltas (bge +0.057, finbert +0.043, nomic +0.022, xbank +0.010, voyage −0.013)

## Test plan
- [x] `docker compose run --rm backend pytest tests/unit/test_research_registry.py -v`
- [x] Live `TestClient` four-path round trip (default / cls / include_rejected / bad surface → 400)