### PR TITLE
feat(#299): /research/backtest engine + console panel (PR-B)

### DIFF
--- a/backend/app/evaluation/backtest.py
+++ b/backend/app/evaluation/backtest.py
@@ -155,15 +155,24 @@ def compute_backtest_metrics(
             "symbol": symbol,
         }
 
-    strategy_pcts = [t.strategy_return_pct for t in realized]
+    # ``realized`` is already filtered to entries where
+    # strategy_return_pct is not None; the inner check below is for
+    # mypy's benefit (it cannot narrow on attribute access alone).
+    strategy_pcts: list[float] = [
+        t.strategy_return_pct
+        for t in realized
+        if t.strategy_return_pct is not None
+    ]
     # #564 review F1: benchmark compounds over EVERY trade with valid
     # forward data (incl. neutral positions). Restricting to ``realized``
     # would silently exclude neutral-position dates from the buy-and-hold
     # comparison and make alpha look favorable when neutrals span moves
     # the strategy missed. Full-window buy-and-hold is the standard
     # baseline.
-    forward_pcts = [
-        t.forward_return_pct for t in trades if t.forward_return_pct is not None
+    forward_pcts: list[float] = [
+        t.forward_return_pct
+        for t in trades
+        if t.forward_return_pct is not None
     ]
 
     mean = sum(strategy_pcts) / n_trades

--- a/backend/app/evaluation/backtest.py
+++ b/backend/app/evaluation/backtest.py
@@ -1,0 +1,214 @@
+"""Stance-directional backtest engine for the quant-facing console (#299).
+
+Given a list of signal positions {date, position in [-1, 0, 1]} and a
+forward holding period, this module looks up the market data for each
+date, computes the per-trade return, and aggregates Sharpe, hit-rate,
+max-drawdown, and benchmark (buy-and-hold) deltas.
+
+This is the v1 engine: it assumes daily-resolution S&P (^GSPC) close
+data via :func:`app.services.market_data.fetch_realized_forward`. The
+position is treated as a simple multiplier on the forward holding
+return (no slippage, no fees, no overnight gap handling) — the goal
+is to surface the quant-relevant signal magnitude, not to model
+execution. Real execution-quality refinements are out of scope; if
+needed they belong in a follow-up.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+TRADING_DAYS_PER_YEAR = 252
+
+
+@dataclass(frozen=True)
+class BacktestTrade:
+    """One realized trade: signal at ``date``, held ``horizon_days``."""
+
+    date: str
+    position: int
+    forward_return_pct: float | None
+    strategy_return_pct: float | None
+
+
+def _validate_position(position: Any) -> int:
+    """Coerce + bound-check a position signal to {-1, 0, 1}."""
+
+    if isinstance(position, bool):
+        raise ValueError(f"position must be int in {{-1,0,1}}, got bool")
+    try:
+        as_int = int(position)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"position must be int in {{-1,0,1}}, got {position!r}") from exc
+    if as_int not in (-1, 0, 1):
+        raise ValueError(f"position must be in {{-1,0,1}}, got {as_int}")
+    return as_int
+
+
+def _lookup_forward_pct(date: str, horizon_days: int, symbol: str) -> float | None:
+    """Return the close-to-close % return over ``horizon_days`` trading
+    days from the close on ``date`` (or the nearest prior trading day).
+
+    None when the historical window is sparse (early-history dates) or
+    when yfinance / cache is unavailable. Same convention as
+    :func:`app.services.analogs._subsequent_close_pct` so the
+    backtest numbers line up with the historical-analog panel on the
+    console.
+    """
+
+    from app.services.market_data import fetch_market_snapshot, fetch_realized_forward
+
+    try:
+        snapshot = fetch_market_snapshot(target_date=date, symbol=symbol)
+        forward = fetch_realized_forward(
+            target_date=date,
+            symbol=symbol,
+            steps=horizon_days,
+            lookback_days=45,
+        )
+    except Exception:
+        return None
+    if len(forward) < horizon_days:
+        return None
+    try:
+        start = float(snapshot["close"])
+        end = float(forward[horizon_days - 1]["close"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if start <= 0:
+        return None
+    return (end / start - 1.0) * 100.0
+
+
+def compute_backtest_metrics(
+    positions: Iterable[dict[str, Any]],
+    *,
+    symbol: str = "^GSPC",
+    horizon_days: int = 5,
+) -> dict[str, Any]:
+    """Run the stance-directional backtest engine.
+
+    ``positions`` is an iterable of ``{"date": "YYYY-MM-DD", "position":
+    -1|0|1}`` dicts. The engine looks up the forward % return per
+    trade, multiplies by the position to get the strategy return, and
+    aggregates the metrics below.
+
+    Returns a dict with:
+    - ``trades``: per-trade ``BacktestTrade`` dicts in date order
+    - ``n_trades``: int, count of non-zero positions with valid forward returns
+    - ``sharpe``: float | None, mean(strategy) / std(strategy) * sqrt(holding-period scale)
+    - ``hit_rate``: float | None, share of trades where sign(strategy) > 0
+    - ``max_dd_pct``: float | None, max % drawdown of cumulative strategy PnL
+    - ``cum_return_pct``: float | None, cumulative compounded strategy return
+    - ``benchmark_cum_pct``: float | None, cumulative buy-and-hold return over the same windows
+    - ``alpha_cum_pct``: float | None, cum_return_pct − benchmark_cum_pct
+    - ``horizon_days``: int, echo of the input horizon
+    - ``symbol``: str, echo of the input symbol
+    """
+
+    trades: list[BacktestTrade] = []
+    for entry in positions:
+        date = str(entry.get("date", "")).strip()
+        if not date:
+            raise ValueError(f"position entry missing 'date': {entry!r}")
+        position = _validate_position(entry.get("position"))
+        forward_pct = _lookup_forward_pct(date, horizon_days, symbol)
+        strategy_pct = (
+            None
+            if forward_pct is None or position == 0
+            else round(position * forward_pct, 4)
+        )
+        trades.append(
+            BacktestTrade(
+                date=date,
+                position=position,
+                forward_return_pct=None if forward_pct is None else round(forward_pct, 4),
+                strategy_return_pct=strategy_pct,
+            )
+        )
+
+    realized = [t for t in trades if t.strategy_return_pct is not None]
+    n_trades = len(realized)
+
+    if n_trades == 0:
+        return {
+            "trades": [trade_to_dict(t) for t in trades],
+            "n_trades": 0,
+            "sharpe": None,
+            "hit_rate": None,
+            "max_dd_pct": None,
+            "cum_return_pct": None,
+            "benchmark_cum_pct": None,
+            "alpha_cum_pct": None,
+            "horizon_days": horizon_days,
+            "symbol": symbol,
+        }
+
+    strategy_pcts = [t.strategy_return_pct for t in realized]
+    forward_pcts = [t.forward_return_pct for t in realized if t.forward_return_pct is not None]
+
+    mean = sum(strategy_pcts) / n_trades
+    variance = (
+        sum((r - mean) ** 2 for r in strategy_pcts) / (n_trades - 1)
+        if n_trades > 1
+        else 0.0
+    )
+    std = math.sqrt(variance)
+    # Annualization: each trade is a discrete holding-period return.
+    # The standard convention is mean / std * sqrt(periods_per_year)
+    # where periods_per_year = trading_days / horizon_days.
+    periods_per_year = TRADING_DAYS_PER_YEAR / max(horizon_days, 1)
+    sharpe = (
+        round((mean / std) * math.sqrt(periods_per_year), 4)
+        if std > 0
+        else None
+    )
+
+    hits = sum(1 for r in strategy_pcts if r > 0)
+    hit_rate = round(hits / n_trades, 4)
+
+    cum_strategy = 1.0
+    peak = 1.0
+    max_dd = 0.0
+    for r in strategy_pcts:
+        cum_strategy *= 1.0 + r / 100.0
+        if cum_strategy > peak:
+            peak = cum_strategy
+        dd = (cum_strategy - peak) / peak * 100.0
+        if dd < max_dd:
+            max_dd = dd
+
+    cum_benchmark = 1.0
+    for r in forward_pcts:
+        cum_benchmark *= 1.0 + r / 100.0
+
+    cum_return_pct = round((cum_strategy - 1.0) * 100.0, 4)
+    benchmark_cum_pct = round((cum_benchmark - 1.0) * 100.0, 4)
+
+    return {
+        "trades": [trade_to_dict(t) for t in trades],
+        "n_trades": n_trades,
+        "sharpe": sharpe,
+        "hit_rate": hit_rate,
+        "max_dd_pct": round(max_dd, 4),
+        "cum_return_pct": cum_return_pct,
+        "benchmark_cum_pct": benchmark_cum_pct,
+        "alpha_cum_pct": round(cum_return_pct - benchmark_cum_pct, 4),
+        "horizon_days": horizon_days,
+        "symbol": symbol,
+    }
+
+
+def trade_to_dict(trade: BacktestTrade) -> dict[str, Any]:
+    return {
+        "date": trade.date,
+        "position": trade.position,
+        "forward_return_pct": trade.forward_return_pct,
+        "strategy_return_pct": trade.strategy_return_pct,
+    }
+
+
+__all__ = ["compute_backtest_metrics", "trade_to_dict", "BacktestTrade", "TRADING_DAYS_PER_YEAR"]

--- a/backend/app/evaluation/backtest.py
+++ b/backend/app/evaluation/backtest.py
@@ -35,7 +35,15 @@ class BacktestTrade:
 
 
 def _validate_position(position: Any) -> int:
-    """Coerce + bound-check a position signal to {-1, 0, 1}."""
+    """Coerce + bound-check a position signal to {-1, 0, 1}.
+
+    Bool check is the load-bearing guard for direct engine callers
+    (tests, internal callers that build positions by name). The
+    schema layer (``BacktestPositionEntry`` with strict=True) catches
+    bool first at the endpoint boundary, but the engine accepts raw
+    dicts that bypass the schema — this guard is what stops a True/
+    False from riding through as 1/0 in that path.
+    """
 
     if isinstance(position, bool):
         raise ValueError(f"position must be int in {{-1,0,1}}, got bool")
@@ -148,7 +156,15 @@ def compute_backtest_metrics(
         }
 
     strategy_pcts = [t.strategy_return_pct for t in realized]
-    forward_pcts = [t.forward_return_pct for t in realized if t.forward_return_pct is not None]
+    # #564 review F1: benchmark compounds over EVERY trade with valid
+    # forward data (incl. neutral positions). Restricting to ``realized``
+    # would silently exclude neutral-position dates from the buy-and-hold
+    # comparison and make alpha look favorable when neutrals span moves
+    # the strategy missed. Full-window buy-and-hold is the standard
+    # baseline.
+    forward_pcts = [
+        t.forward_return_pct for t in trades if t.forward_return_pct is not None
+    ]
 
     mean = sum(strategy_pcts) / n_trades
     variance = (

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,6 +52,8 @@ from app.schemas import (
     NextFomcForecastResponse,
     RatesReactionCard,
     ResearchArtifactsResponse,
+    BacktestRequest,
+    BacktestResponse,
     ResearchRegistryResponse,
     SettingsCheckpoint,
     SettingsCheckpointsResponse,
@@ -1452,6 +1454,29 @@ def research_registry(
         raise HTTPException(status_code=400, detail="surface must be 'dual' or 'cls'")
     payload = load_research_registry(surface=surface, include_rejected=include_rejected)
     return ResearchRegistryResponse(**payload)
+
+
+@app.post("/research/backtest", response_model=BacktestResponse)
+def research_backtest(request: BacktestRequest) -> BacktestResponse:
+    """Run the stance-directional backtest engine on a caller-supplied
+    {date, position} series.
+
+    Frontend (or any caller) supplies the positions; this endpoint
+    looks up the S&P forward returns per date and aggregates Sharpe,
+    hit-rate, max-drawdown, and benchmark deltas. Decouples the
+    engine from any specific signal source so the same harness can
+    serve oracle backtests, history-driven backtests, and live-
+    classifier backtests interchangeably.
+    """
+
+    from app.evaluation.backtest import compute_backtest_metrics
+
+    payload = compute_backtest_metrics(
+        positions=[entry.model_dump() for entry in request.positions],
+        symbol=request.symbol,
+        horizon_days=request.horizon_days,
+    )
+    return BacktestResponse(**payload)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1309,3 +1309,57 @@ class ResearchRegistryResponse(BaseModel):
     head: str = ""
     seeds: list[int] = Field(default_factory=list)
     source_wiki_section: str = ""
+
+
+# #299 PR-B — stance-directional backtest engine
+
+class BacktestPositionEntry(BaseModel):
+    """One {date, position} signal in the backtest request."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    date: str = Field(..., description="ISO date YYYY-MM-DD of the signal.")
+    position: int = Field(..., description="Position in {-1, 0, 1}. Hawkish=-1, neutral=0, dovish=+1.")
+
+
+class BacktestRequest(BaseModel):
+    """Request body for POST /research/backtest."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    positions: list[BacktestPositionEntry] = Field(
+        ..., min_length=1, description="At least one signal entry."
+    )
+    symbol: str = Field("^GSPC", description="Market ticker for the strategy backtest.")
+    horizon_days: int = Field(
+        5,
+        ge=1,
+        le=60,
+        description="Forward holding period in trading days.",
+    )
+
+
+class BacktestTradeRow(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    date: str
+    position: int
+    forward_return_pct: float | None = None
+    strategy_return_pct: float | None = None
+
+
+class BacktestResponse(BaseModel):
+    """Aggregate backtest metrics for the quant terminal."""
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    trades: list[BacktestTradeRow] = Field(default_factory=list)
+    n_trades: int
+    sharpe: float | None = None
+    hit_rate: float | None = None
+    max_dd_pct: float | None = None
+    cum_return_pct: float | None = None
+    benchmark_cum_pct: float | None = None
+    alpha_cum_pct: float | None = None
+    horizon_days: int
+    symbol: str

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -4,6 +4,8 @@ import type {
   AnalogsResponse,
   AnalyzeRequest,
   AnalyzeResult,
+  BacktestPositionEntry,
+  BacktestResponse,
   ClassificationBreakdownResponse,
   EvaluationCoverageResponse,
   FomcCalendarResponse,
@@ -236,4 +238,16 @@ export async function fetchResearchRegistry(
   if (options?.includeRejected) params.include_rejected = true;
   const response = await axios.get(`${baseUrl}/research/registry`, { params });
   return response.data as ResearchRegistryResponse;
+}
+
+export async function postResearchBacktest(
+  baseUrl: string,
+  body: {
+    positions: BacktestPositionEntry[];
+    symbol?: string;
+    horizon_days?: number;
+  }
+): Promise<BacktestResponse> {
+  const response = await axios.post(`${baseUrl}/research/backtest`, body);
+  return response.data as BacktestResponse;
 }

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -640,3 +640,31 @@ export interface ResearchRegistryResponse {
   seeds: number[];
   source_wiki_section: string;
 }
+
+// #299 PR-B — stance-directional backtest engine
+export type BacktestPosition = -1 | 0 | 1;
+
+export interface BacktestPositionEntry {
+  date: string;
+  position: BacktestPosition;
+}
+
+export interface BacktestTradeRow {
+  date: string;
+  position: number;
+  forward_return_pct: number | null;
+  strategy_return_pct: number | null;
+}
+
+export interface BacktestResponse {
+  trades: BacktestTradeRow[];
+  n_trades: number;
+  sharpe: number | null;
+  hit_rate: number | null;
+  max_dd_pct: number | null;
+  cum_return_pct: number | null;
+  benchmark_cum_pct: number | null;
+  alpha_cum_pct: number | null;
+  horizon_days: number;
+  symbol: string;
+}

--- a/frontend/pages/console.tsx
+++ b/frontend/pages/console.tsx
@@ -457,7 +457,12 @@ function BacktestPanel({ baseUrl }: { baseUrl: string }): JSX.Element {
             Demo series: 8 historical FOMC dates with proxied stances
             (hawkish=-1 short S&amp;P, dovish=+1 long). Computes Sharpe /
             HitRate / MaxDD vs buy-and-hold on real ^GSPC 5d forward
-            returns. Live predicted-stance backtest lands in v1.1.
+            returns. <strong>Note:</strong> the 2022&ndash;2024 window
+            covers the Fed hiking cycle&apos;s sharp equity sell-off, so
+            short-SPX bets dominate the sample. Hit-rate and Sharpe
+            reflect a directionally favorable period, not out-of-
+            sample model performance. Live predicted-stance backtest
+            lands in v1.1.
           </p>
         )}
         {result && (
@@ -491,8 +496,8 @@ function BacktestPanel({ baseUrl }: { baseUrl: string }): JSX.Element {
               />
             </div>
             <p className="text-xs text-muted-foreground">
-              {result.n_trades} realized trades · horizon {result.horizon_days}d ·{" "}
-              {result.symbol}
+              {result.n_trades} / {result.trades.length} dates realized ·
+              horizon {result.horizon_days}d · {result.symbol}
             </p>
           </>
         )}

--- a/frontend/pages/console.tsx
+++ b/frontend/pages/console.tsx
@@ -15,12 +15,15 @@ import {
   fetchResearchRegistry,
   postAnalyze,
   postAnalyzeAnalogs,
+  postResearchBacktest,
   resolveApiBaseUrl,
 } from "@/lib/analyze/api";
 import { errorMessage } from "@/lib/analyze/errors";
 import type {
   AnalogsResponse,
   AnalyzeResult,
+  BacktestPositionEntry,
+  BacktestResponse,
   ResearchRegistryResponse,
 } from "@/lib/analyze/types";
 import { cn } from "@/lib/utils";
@@ -170,7 +173,7 @@ export default function ConsolePage(): JSX.Element {
           <StancePanel analyze={analyze} />
           <VolRegimePanel analyze={analyze} />
           <AnalogsPanel analogs={analogs} />
-          <BacktestPanel />
+          <BacktestPanel baseUrl={baseUrl} />
         </div>
 
         <RegistryStrip
@@ -393,17 +396,106 @@ function AnalogsPanel({ analogs }: { analogs: AnalogsResponse | null }): JSX.Ele
   );
 }
 
-function BacktestPanel(): JSX.Element {
+// #299 PR-B demo series: 8 historical FOMC dates with hard-coded
+// stance proxies (hawkish=-1 short S&P, dovish=+1 long, neutral=0).
+// The stances are conservative reads of the published Fed direction
+// at each meeting; this lets the backtest panel render real Sharpe
+// / HitRate / MaxDD numbers from real S&P forward returns without
+// needing the full predicted-stance fan-out infra. A follow-up PR
+// can swap this for live /analyze predictions over the same dates.
+const DEMO_BACKTEST_POSITIONS: BacktestPositionEntry[] = [
+  { date: "2022-03-16", position: -1 }, // 25bp hike, start of cycle
+  { date: "2022-06-15", position: -1 }, // 75bp hike, surprise
+  { date: "2022-11-02", position: -1 }, // 75bp hike, sustained tightening
+  { date: "2023-02-01", position: -1 }, // 25bp hike, decelerating
+  { date: "2023-07-26", position: -1 }, // 25bp hike, last in cycle
+  { date: "2023-12-13", position: 0 }, // hold, neutral
+  { date: "2024-03-20", position: 0 }, // hold, neutral
+  { date: "2024-09-18", position: 1 }, // 50bp cut, dovish
+];
+
+function BacktestPanel({ baseUrl }: { baseUrl: string }): JSX.Element {
+  const [result, setResult] = React.useState<BacktestResponse | null>(null);
+  const [running, setRunning] = React.useState<boolean>(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const run = React.useCallback(async () => {
+    setRunning(true);
+    setError(null);
+    try {
+      const response = await postResearchBacktest(baseUrl, {
+        positions: DEMO_BACKTEST_POSITIONS,
+        symbol: "^GSPC",
+        horizon_days: 5,
+      });
+      setResult(response);
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setRunning(false);
+    }
+  }, [baseUrl]);
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Backtest (since 2018)</CardTitle>
+        <CardTitle className="flex items-center justify-between">
+          <span>Backtest (stance-directional, 5d)</span>
+          <Button size="sm" onClick={run} disabled={running}>
+            {running ? "Running…" : result ? "Re-run" : "Run backtest"}
+          </Button>
+        </CardTitle>
       </CardHeader>
-      <CardContent className="text-sm text-muted-foreground">
-        Stance-directional Sharpe / HitRate / MaxDD vs buy-and-hold ATM
-        straddle — lands in the #299 backtest follow-up PR. The engine
-        will compute the strategy from the active checkpoint&apos;s historical
-        FOMC predictions and stamp confidence intervals on each metric.
+      <CardContent className="space-y-2 text-sm">
+        {error && (
+          <span className="text-xs text-destructive" role="alert">
+            {error}
+          </span>
+        )}
+        {!result && !running && (
+          <p className="text-xs text-muted-foreground">
+            Demo series: 8 historical FOMC dates with proxied stances
+            (hawkish=-1 short S&amp;P, dovish=+1 long). Computes Sharpe /
+            HitRate / MaxDD vs buy-and-hold on real ^GSPC 5d forward
+            returns. Live predicted-stance backtest lands in v1.1.
+          </p>
+        )}
+        {result && (
+          <>
+            <div className="grid grid-cols-3 gap-3 text-sm">
+              <Row label="Sharpe" value={result.sharpe?.toFixed(2) ?? "—"} />
+              <Row
+                label="HitRate"
+                value={
+                  result.hit_rate != null
+                    ? `${(result.hit_rate * 100).toFixed(1)}%`
+                    : "—"
+                }
+              />
+              <Row
+                label="MaxDD"
+                value={
+                  result.max_dd_pct != null
+                    ? `${result.max_dd_pct.toFixed(2)}%`
+                    : "—"
+                }
+                tone={result.max_dd_pct != null && result.max_dd_pct < -5 ? "warn" : undefined}
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-3 text-xs text-muted-foreground">
+              <Row label="cum return" value={formatPct(result.cum_return_pct)} />
+              <Row label="buy-and-hold" value={formatPct(result.benchmark_cum_pct)} />
+              <Row
+                label="alpha"
+                value={formatPct(result.alpha_cum_pct)}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {result.n_trades} realized trades · horizon {result.horizon_days}d ·{" "}
+              {result.symbol}
+            </p>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -1,0 +1,134 @@
+"""Unit tests for the stance-directional backtest engine (#299 PR-B)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from app.evaluation import backtest
+
+
+@pytest.fixture(autouse=True)
+def _stub_market(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the per-date forward % return so the engine math is deterministic."""
+
+    pinned: dict[str, float] = {
+        "2024-01-15": 1.0,
+        "2024-02-15": -2.0,
+        "2024-03-15": 0.5,
+        "2024-04-15": -0.5,
+        "2024-05-15": 2.0,
+    }
+
+    def _fake(date: str, horizon_days: int, symbol: str) -> float | None:
+        return pinned.get(date)
+
+    monkeypatch.setattr(backtest, "_lookup_forward_pct", _fake)
+
+
+def _series(positions: list[tuple[str, int]]) -> list[dict]:
+    return [{"date": d, "position": p} for d, p in positions]
+
+
+def test_empty_realized_trades_returns_null_metrics() -> None:
+    """A date with no forward data still appears in trades but metrics are null."""
+
+    out = backtest.compute_backtest_metrics(
+        _series([("2099-01-01", 1)])  # not in the stub
+    )
+    assert out["n_trades"] == 0
+    assert out["sharpe"] is None
+    assert out["hit_rate"] is None
+    assert out["max_dd_pct"] is None
+    assert len(out["trades"]) == 1
+
+
+def test_long_only_hawkish_signal_short_sp_loses_when_market_up() -> None:
+    """position=-1 with a +1% forward return → strategy return is -1%."""
+
+    out = backtest.compute_backtest_metrics(_series([("2024-01-15", -1)]))
+    assert out["trades"][0]["strategy_return_pct"] == pytest.approx(-1.0)
+    assert out["n_trades"] == 1
+    assert out["hit_rate"] == 0.0
+
+
+def test_dovish_signal_long_sp_wins_when_market_up() -> None:
+    """position=+1 with a +1% forward return → strategy return is +1%."""
+
+    out = backtest.compute_backtest_metrics(_series([("2024-01-15", 1)]))
+    assert out["trades"][0]["strategy_return_pct"] == pytest.approx(1.0)
+    assert out["hit_rate"] == 1.0
+
+
+def test_neutral_signal_is_a_skip() -> None:
+    """position=0 → strategy_return is None (no exposure, no contribution)."""
+
+    out = backtest.compute_backtest_metrics(
+        _series([("2024-01-15", 0), ("2024-02-15", -1)])
+    )
+    assert out["trades"][0]["strategy_return_pct"] is None
+    assert out["n_trades"] == 1  # only the hawkish trade counts
+
+
+def test_sharpe_annualizes_with_holding_period_scale() -> None:
+    """For a 5-day horizon: sharpe = mean/std * sqrt(252/5) = mean/std * sqrt(50.4)."""
+
+    out = backtest.compute_backtest_metrics(
+        _series([("2024-01-15", 1), ("2024-02-15", -1), ("2024-05-15", 1)]),
+        horizon_days=5,
+    )
+    # Strategy returns: +1.0, +2.0, +2.0 → mean 1.6667, sample std 0.5774
+    expected_sharpe = (5.0 / 3.0) / math.sqrt(1.0 / 3.0) * math.sqrt(252 / 5)
+    assert out["sharpe"] == pytest.approx(expected_sharpe, abs=1e-2)
+
+
+def test_max_drawdown_tracks_compounded_strategy_pnl() -> None:
+    """A losing trade after gains produces a non-zero max DD."""
+
+    out = backtest.compute_backtest_metrics(
+        _series([("2024-01-15", 1), ("2024-02-15", 1), ("2024-04-15", 1)]),
+    )
+    # +1%, -2%, -0.5% → cum 1.01, 0.9898, 0.98487
+    # peaks: 1.0, 1.01, 1.01, 1.01 → max DD = (0.98487 / 1.01 - 1) * 100 ≈ -2.49%
+    assert out["max_dd_pct"] is not None
+    assert out["max_dd_pct"] < 0
+    assert out["max_dd_pct"] == pytest.approx(-2.488, abs=0.05)
+
+
+def test_benchmark_and_alpha_signs() -> None:
+    """Benchmark is sum of forward returns regardless of position.
+    Alpha is strategy - benchmark.
+    """
+
+    out = backtest.compute_backtest_metrics(
+        _series([("2024-01-15", -1), ("2024-02-15", 1)])
+    )
+    # forward: +1.0, -2.0 → cum buy-and-hold = 1.01 * 0.98 - 1 ≈ -0.99%
+    # strategy: -1.0 ($+1%*-1) + -2.0 (-2*+1) → cum strategy = 0.99 * 0.98 - 1 ≈ -2.99%
+    # alpha = -2.99 - (-0.99) ≈ -2.0
+    assert out["benchmark_cum_pct"] == pytest.approx(-1.02, abs=0.02)
+    assert out["cum_return_pct"] == pytest.approx(-2.99, abs=0.02)
+    assert out["alpha_cum_pct"] == pytest.approx(-1.97, abs=0.05)
+
+
+def test_invalid_position_raises() -> None:
+    """Position must be in {-1, 0, 1}."""
+
+    with pytest.raises(ValueError, match=r"position must be in \{-1,0,1\}"):
+        backtest.compute_backtest_metrics(_series([("2024-01-15", 2)]))
+
+
+def test_bool_position_rejected_as_int_lookalike() -> None:
+    """``bool`` is an ``int`` subclass; reject explicitly so a True/False
+    leak doesn't ride through as 1/0."""
+
+    with pytest.raises(ValueError, match="bool"):
+        backtest.compute_backtest_metrics(
+            [{"date": "2024-01-15", "position": True}]
+        )
+
+
+def test_missing_date_raises() -> None:
+    with pytest.raises(ValueError, match="missing 'date'"):
+        backtest.compute_backtest_metrics([{"position": 1}])

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -112,6 +112,31 @@ def test_benchmark_and_alpha_signs() -> None:
     assert out["alpha_cum_pct"] == pytest.approx(-1.97, abs=0.05)
 
 
+def test_benchmark_compounds_over_neutral_dates_too() -> None:
+    """#564 review F1: a neutral position contributes nothing to the
+    strategy but its forward return must still appear in the
+    buy-and-hold benchmark. Otherwise alpha looks artificially good
+    when the neutral spans a market move the strategy missed."""
+
+    # 2 trades + 1 neutral. Strategy sees only the 2 active trades.
+    # Benchmark must include the neutral's forward return too.
+    out = backtest.compute_backtest_metrics(
+        _series([
+            ("2024-01-15", 1),   # +1.0% strategy, +1.0% benchmark
+            ("2024-02-15", 0),   # skipped strategy, -2.0% benchmark
+            ("2024-05-15", 1),   # +2.0% strategy, +2.0% benchmark
+        ])
+    )
+    # strategy cum: 1.01 * 1.02 - 1 ≈ +3.02%
+    # benchmark cum: 1.01 * 0.98 * 1.02 - 1 ≈ +0.96% (NOT 1.01 * 1.02 = +3.02)
+    assert out["n_trades"] == 2
+    assert out["cum_return_pct"] == pytest.approx(3.02, abs=0.02)
+    assert out["benchmark_cum_pct"] == pytest.approx(0.96, abs=0.05)
+    # If the bug were back (benchmark restricted to realized), this
+    # alpha would read ~0; the fix makes it ~+2.
+    assert out["alpha_cum_pct"] == pytest.approx(2.06, abs=0.05)
+
+
 def test_invalid_position_raises() -> None:
     """Position must be in {-1, 0, 1}."""
 


### PR DESCRIPTION
Stance-directional backtest engine for the quant terminal.

## Engine
- `compute_backtest_metrics(positions, horizon_days, symbol)` in `backend/app/evaluation/backtest.py`
- Per-trade close-to-close % return (event-day close anchor — same convention as the analogs panel)
- Annualized Sharpe = mean/std × √(252 / horizon_days)
- HitRate, MaxDD, cum return, benchmark cum, alpha
- Bool-as-int leaks rejected explicitly

## Endpoint
- `POST /research/backtest` body `{positions: [{date, position in {-1,0,1}}], symbol, horizon_days}`
- Data-source agnostic — caller supplies signal series, engine looks up returns + aggregates

## Frontend
- `BacktestPanel` wired with a baked demo series (8 historical FOMC dates, proxied stances)
- Renders Sharpe / HitRate / MaxDD + cum / benchmark / alpha on button click
- Live predicted-stance backtest (full `/analyze` fan-out) is the v1.1 follow-up

## Test plan
- [x] `docker compose run --rm backend pytest tests/unit/test_backtest_engine.py -v` → 10 passed
- [x] `cd frontend && docker compose run --rm --no-deps frontend npx tsc --noEmit` → exit 0
- [x] `docker compose run --rm --no-deps frontend npm test -- --run` → 205 passed