### PR TITLE
chore: bump training_package_vix to SHA 347d3e30 (VIX columns populated)

### DIFF
--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -504,7 +504,7 @@ artefacts:
 
   training_package_vix:
     hf_uri: hf://datasets/yusufizzetmurat/fed-pulse-training-package
-    revision: "aae4de0965345aeffbd58f9746fd0ecacccf5ead"
+    revision: "347d3e30465a170b4504358f4ace7a88c1652f84"
     eager: false
     description: |
       VIX-extended variant of the canonical training package (#478).


### PR DESCRIPTION
Bumps the canonical_vix registry pin from `aae4de09` (no VIX feature columns) to `347d3e30` (VIX columns present, 4/6 populated).

## Why
`_VIX_FEATURE_COLUMNS` in `backend/app/training/loaders.py:1558` lists the six columns the loader reads: `vix_t_minus_1`, `vix1m/3m/6m_t_minus_1`, `vix_3m_over_1m_slope`, `vrp_t_minus_1`. The old `aae4de09` events.parquet did not contain any of them, so `--use-vix-features` against canonical_vix at that revision was a silent no-op — the loader returned None for every event, zero-filled the per-bar tensor, and the VIX-on / VIX-off A/B came out byte-identical.

The new revision `347d3e30` carries the same TP build with all six columns present:
- `vix_t_minus_1`, `vix3m_t_minus_1`, `vix6m_t_minus_1`, `vrp_t_minus_1`: 78–94% coverage
- `vix1m_t_minus_1`, `vix_3m_over_1m_slope`: all-NaN (build-time `^VIX1M` fetch gap); zero-fill via the loader's missing flag

Enough coverage for the §6.41 vol-baseline encoder bake-off control. `^VIX1M` backfill is a separate follow-up.

## Test plan
- [x] HF upload: `347d3e30465a170b4504358f4ace7a88c1652f84` at `hf://datasets/yusufizzetmurat/fed-pulse-training-package`
- [x] Local `df.columns` check on the pushed events.parquet confirms 6/6 columns present