### PR TITLE
chore: scrub CLAUDE.md references from tracked files

### DIFF
--- a/backend/app/forecasting/cross_asset_response.py
+++ b/backend/app/forecasting/cross_asset_response.py
@@ -479,8 +479,8 @@ def _standardise(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Fit per-column ``(mean, std)`` on train; apply to both.
 
-    Train-only fit honours the leakage rules in CLAUDE.md. Zero-variance
-    columns are passed through unchanged.
+    Train-only fit honours the project's no-leakage contract.
+    Zero-variance columns are passed through unchanged.
     """
 
     if X_train.size == 0:

--- a/backend/app/forecasting/next_fomc_decision.py
+++ b/backend/app/forecasting/next_fomc_decision.py
@@ -947,8 +947,8 @@ def _standardise(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Fit per-column ``(mean, std)`` on train; apply to both.
 
-    Train-only fit honours the leakage rules in CLAUDE.md. Zero-variance
-    columns are passed through unchanged.
+    Train-only fit honours the project's no-leakage contract.
+    Zero-variance columns are passed through unchanged.
     """
 
     if X_train.size == 0:

--- a/docs/REPO_TOUR.md
+++ b/docs/REPO_TOUR.md
@@ -125,7 +125,6 @@ fed-pulse/
 ├── scripts/                 one-shot utility scripts
 ├── tests/                   pytest suite (unit / property / contract / regression / e2e)
 ├── configs/                 ablation configs (YAML)
-├── CLAUDE.md                project conventions
 ├── Makefile                 the entry-point for every workflow
 ├── docker-compose.yml       dev stack (backend + frontend + GPU profile)
 ├── pyproject.toml           backend Python deps + ruff/mypy config

--- a/docs/reproduce.md
+++ b/docs/reproduce.md
@@ -39,7 +39,7 @@ Expected wall time on the 8 GB / 4 vCPU droplet: ~15 minutes (~10 min cold artef
 
 What this does **not** validate:
 
-- Full-epoch training quality (use `make train-batch` for that — see `CLAUDE.md`).
+- Full-epoch training quality (use `make train-batch` for that — see the Makefile and `docs/`).
 - The bake-off comparisons (those need the per-encoder embedding caches, which lazy-fetch separately via `app.data.embedding_cache.ensure_local`).
 - The frontend dashboard (that runs against the deployed container; see `docs/deploy.md`).
 


### PR DESCRIPTION
\`CLAUDE.md\` is already gitignored (\`.gitignore:56\`) and has never been tracked. Four textual refs in tracked files pointed at it as the source of truth for project conventions / leakage rules — scrubbing them so the tracked repo has no dangling references.

- \`docs/reproduce.md:42\` — train-batch pointer goes to Makefile + \`docs/\`
- \`docs/REPO_TOUR.md:128\` — tree listing entry removed
- \`backend/app/forecasting/cross_asset_response.py:482\` — docstring rephrased as 'project no-leakage contract'
- \`backend/app/forecasting/next_fomc_decision.py:950\` — same docstring

Conventions content stays in the wiki + Makefile + \`docs/\` tree. No code behaviour change.

## Test plan
- [x] \`docker compose run --rm backend pytest tests/unit/test_cross_asset_response.py tests/unit/test_next_fomc_decision.py -q\` → 32 passed
- [x] \`grep -rn 'CLAUDE\\.md' docs/ backend/app/ scripts/ Makefile README.md\` → no matches