### PR TITLE
job-1 artefacts: #499 horizon sensitivity (5d/10d/20d, n=25)

### DIFF
--- a/backend/artifacts/experiments/job1_horizon_20260531T141630Z/findings_job1_horizon.md
+++ b/backend/artifacts/experiments/job1_horizon_20260531T141630Z/findings_job1_horizon.md
@@ -1,0 +1,9 @@
+# JOB 1 — #499 horizon sensitivity (canonical, --target-horizon, n=25)
+| horizon | dual_F1 | cls_F1 | reg_rmse_log_rv |
+|--|--|--|--|
+| 5d  | 0.3937 | 0.3945 | 0.7923 |
+| 10d | 0.3773 | 0.3934 | 0.7659 |
+| 20d | 0.3863 | 0.3812 | 0.7706 |
+Read: ~FLAT across horizons (dual within 0.016; cls within 0.013). 10d == canonical
+baseline exactly (sanity check). reg_rmse best at 10d. Modest, non-monotone horizon
+sensitivity — no coherent monotonic curve. (--target absent; --target-horizon used.)

--- a/backend/artifacts/experiments/job1_horizon_20260531T141630Z/pod_horizon_10d_20260531T141630Z.json
+++ b/backend/artifacts/experiments/job1_horizon_20260531T141630Z/pod_horizon_10d_20260531T141630Z.json
@@ -1,0 +1,5170 @@
+{
+  "head_modes": [
+    "classification",
+    "regression",
+    "dual"
+  ],
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "regression_alpha": 0.5,
+  "training_package_id": "canonical",
+  "rates_target_mode": "raw",
+  "rates_heads": [],
+  "vol_target_mode": "raw",
+  "vol_target_horizon": 10,
+  "sequence_length": 20,
+  "use_retrieval_analogs": false,
+  "use_regime_conditioning": false,
+  "use_statement_delta": false,
+  "use_vote_features": false,
+  "use_press_conf": false,
+  "use_vix_features": false,
+  "use_doc_length": false,
+  "regime_loss": "ce",
+  "focal_gamma": 2.0,
+  "class_balanced_beta": 0.999,
+  "text_encoder": null,
+  "use_text_embeddings": true,
+  "vol_regime_label_mode": "per_fold_quantile",
+  "absolute_vol_thresholds": null,
+  "absolute_calm_max_annualized": null,
+  "absolute_high_min_annualized": null,
+  "use_mp_surprise": true,
+  "aux_horizons": [],
+  "aux_horizon_alpha": 0.3,
+  "trials": {
+    "classification": [
+      {
+        "head_mode": "classification",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.37669058802024974,
+              "regime_accuracy": 0.4416666626930237,
+              "regime_loss": 1.1611134520151345,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    4,
+                    11
+                  ],
+                  [
+                    14,
+                    3,
+                    28
+                  ],
+                  [
+                    7,
+                    3,
+                    37
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.38235294117647056,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.41935483870967744,
+                    "support": 28,
+                    "roc_auc": 0.6793478260869565,
+                    "pr_auc": 0.33460464165704057
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3,
+                    "recall": 0.06666666666666667,
+                    "f1": 0.1090909090909091,
+                    "support": 45,
+                    "roc_auc": 0.5164444444444445,
+                    "pr_auc": 0.4189194556096044
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4868421052631579,
+                    "recall": 0.7872340425531915,
+                    "f1": 0.6016260162601627,
+                    "support": 47,
+                    "roc_auc": 0.6100262314194113,
+                    "pr_auc": 0.46317678054576794
+                  }
+                ],
+                "macro_precision": 0.3897316821465428,
+                "macro_recall": 0.4393954745018575,
+                "macro_f1": 0.37669058802024974,
+                "weighted_f1": 0.374395409643246,
+                "macro_roc_auc": 0.6019395006502708,
+                "macro_pr_auc": 0.4055669592708043
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.43462854349951124,
+              "regime_accuracy": 0.694915235042572,
+              "regime_loss": 0.6310518515312066,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    7,
+                    14,
+                    75
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.7,
+                    "f1": 0.45161290322580644,
+                    "support": 10,
+                    "roc_auc": 0.8953703703703704,
+                    "pr_auc": 0.3482418521021462
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.675314465408805,
+                    "pr_auc": 0.13511258675005994
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9375,
+                    "recall": 0.78125,
+                    "f1": 0.8522727272727273,
+                    "support": 96,
+                    "roc_auc": 0.8740530303030303,
+                    "pr_auc": 0.9710226532806459
+                  }
+                ],
+                "macro_precision": 0.4236111111111111,
+                "macro_recall": 0.49374999999999997,
+                "macro_f1": 0.43462854349951124,
+                "weighted_f1": 0.7316467021223718,
+                "macro_roc_auc": 0.814912622027402,
+                "macro_pr_auc": 0.484792364044284
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.39115646258503406,
+              "regime_accuracy": 0.38181817531585693,
+              "regime_loss": 1.080136934193698,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    4,
+                    0
+                  ],
+                  [
+                    41,
+                    21,
+                    16
+                  ],
+                  [
+                    2,
+                    5,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1568627450980392,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.25396825396825395,
+                    "support": 12,
+                    "roc_auc": 0.7219387755102041,
+                    "pr_auc": 0.2242327878415351
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7,
+                    "recall": 0.2692307692307692,
+                    "f1": 0.3888888888888889,
+                    "support": 78,
+                    "roc_auc": 0.3974358974358974,
+                    "pr_auc": 0.6960735232993932
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4482758620689655,
+                    "recall": 0.65,
+                    "f1": 0.5306122448979592,
+                    "support": 20,
+                    "roc_auc": 0.775,
+                    "pr_auc": 0.3769536696285534
+                  }
+                ],
+                "macro_precision": 0.43504620238900155,
+                "macro_recall": 0.5286324786324786,
+                "macro_f1": 0.39115646258503406,
+                "weighted_f1": 0.3999381570810142,
+                "macro_roc_auc": 0.6314582243153671,
+                "macro_pr_auc": 0.43241999358982725
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.39879833428220524,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.0760802686397852,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    22,
+                    9,
+                    13
+                  ],
+                  [
+                    20,
+                    16,
+                    12
+                  ],
+                  [
+                    7,
+                    4,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4489795918367347,
+                    "recall": 0.5,
+                    "f1": 0.47311827956989244,
+                    "support": 44,
+                    "roc_auc": 0.5386702849389416,
+                    "pr_auc": 0.3964243099709702
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5517241379310345,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.4155844155844156,
+                    "support": 48,
+                    "roc_auc": 0.5601851851851852,
+                    "pr_auc": 0.5151816451858581
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.24242424242424243,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.3076923076923077,
+                    "support": 19,
+                    "roc_auc": 0.5760869565217391,
+                    "pr_auc": 0.2611332949620183
+                  }
+                ],
+                "macro_precision": 0.41437599073067055,
+                "macro_recall": 0.4181286549707602,
+                "macro_f1": 0.39879833428220524,
+                "weighted_f1": 0.4199226134710005,
+                "macro_roc_auc": 0.5583141422152886,
+                "macro_pr_auc": 0.39091308337294883
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3871845579162652,
+              "regime_accuracy": 0.4038461446762085,
+              "regime_loss": 1.0876929943378155,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    14,
+                    6
+                  ],
+                  [
+                    14,
+                    16,
+                    22
+                  ],
+                  [
+                    6,
+                    0,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23076923076923078,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.23076923076923078,
+                    "support": 26,
+                    "roc_auc": 0.5788954635108481,
+                    "pr_auc": 0.3581608223101523
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5333333333333333,
+                    "recall": 0.3076923076923077,
+                    "f1": 0.3902439024390244,
+                    "support": 52,
+                    "roc_auc": 0.6039201183431953,
+                    "pr_auc": 0.6327419665284142
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4166666666666667,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5405405405405406,
+                    "support": 26,
+                    "roc_auc": 0.7061143984220908,
+                    "pr_auc": 0.5454513273492855
+                  }
+                ],
+                "macro_precision": 0.3935897435897436,
+                "macro_recall": 0.4358974358974359,
+                "macro_f1": 0.3871845579162652,
+                "weighted_f1": 0.387949394046955,
+                "macro_roc_auc": 0.6296433267587114,
+                "macro_pr_auc": 0.512118038729284
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.30513013326649124,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.1784072735978925,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    7,
+                    6
+                  ],
+                  [
+                    16,
+                    3,
+                    26
+                  ],
+                  [
+                    20,
+                    5,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.29411764705882354,
+                    "recall": 0.5357142857142857,
+                    "f1": 0.379746835443038,
+                    "support": 28,
+                    "roc_auc": 0.6979813664596274,
+                    "pr_auc": 0.3657321368855614
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2,
+                    "recall": 0.06666666666666667,
+                    "f1": 0.1,
+                    "support": 45,
+                    "roc_auc": 0.43466666666666665,
+                    "pr_auc": 0.33089912721643644
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4074074074074074,
+                    "recall": 0.46808510638297873,
+                    "f1": 0.43564356435643564,
+                    "support": 47,
+                    "roc_auc": 0.552608568930341,
+                    "pr_auc": 0.42509218244419317
+                  }
+                ],
+                "macro_precision": 0.30050835148874366,
+                "macro_recall": 0.35682201958797705,
+                "macro_f1": 0.30513013326649124,
+                "weighted_f1": 0.2967346576429795,
+                "macro_roc_auc": 0.561752200685545,
+                "macro_pr_auc": 0.373907815515397
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4960106382978724,
+              "regime_accuracy": 0.805084764957428,
+              "regime_loss": 0.5499987334518109,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    6,
+                    1,
+                    5
+                  ],
+                  [
+                    9,
+                    0,
+                    87
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 10,
+                    "roc_auc": 0.8824074074074074,
+                    "pr_auc": 0.2857082745685687
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.125,
+                    "support": 12,
+                    "roc_auc": 0.7625786163522013,
+                    "pr_auc": 0.2013851471603365
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9456521739130435,
+                    "recall": 0.90625,
+                    "f1": 0.9255319148936171,
+                    "support": 96,
+                    "roc_auc": 0.9337121212121212,
+                    "pr_auc": 0.9862287583516839
+                  }
+                ],
+                "macro_precision": 0.5046113306982872,
+                "macro_recall": 0.5631944444444444,
+                "macro_f1": 0.4960106382978724,
+                "weighted_f1": 0.8027632527948071,
+                "macro_roc_auc": 0.8595660483239099,
+                "macro_pr_auc": 0.4911073933601964
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.24288356514614948,
+              "regime_accuracy": 0.23636363446712494,
+              "regime_loss": 1.5233390656384556,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    3,
+                    3
+                  ],
+                  [
+                    27,
+                    6,
+                    45
+                  ],
+                  [
+                    2,
+                    4,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.17142857142857143,
+                    "recall": 0.5,
+                    "f1": 0.2553191489361702,
+                    "support": 12,
+                    "roc_auc": 0.6513605442176871,
+                    "pr_auc": 0.1517414136507725
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.13186813186813184,
+                    "support": 78,
+                    "roc_auc": 0.3733974358974359,
+                    "pr_auc": 0.6204693558121204
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.22580645161290322,
+                    "recall": 0.7,
+                    "f1": 0.3414634146341463,
+                    "support": 20,
+                    "roc_auc": 0.69,
+                    "pr_auc": 0.26123024180522597
+                  }
+                ],
+                "macro_precision": 0.2862578281933121,
+                "macro_recall": 0.4256410256410256,
+                "macro_f1": 0.24288356514614948,
+                "weighted_f1": 0.18344374877846592,
+                "macro_roc_auc": 0.5715859933717077,
+                "macro_pr_auc": 0.344480337089373
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3235978835978836,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.254188220450779,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    18,
+                    6,
+                    20
+                  ],
+                  [
+                    17,
+                    7,
+                    24
+                  ],
+                  [
+                    5,
+                    2,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.45,
+                    "recall": 0.4090909090909091,
+                    "f1": 0.4285714285714286,
+                    "support": 44,
+                    "roc_auc": 0.5915875169606513,
+                    "pr_auc": 0.41623800074453654
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4666666666666667,
+                    "recall": 0.14583333333333334,
+                    "f1": 0.22222222222222224,
+                    "support": 48,
+                    "roc_auc": 0.5092592592592593,
+                    "pr_auc": 0.4537248476680976
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21428571428571427,
+                    "recall": 0.631578947368421,
+                    "f1": 0.32,
+                    "support": 19,
+                    "roc_auc": 0.5886727688787186,
+                    "pr_auc": 0.21404935809265793
+                  }
+                ],
+                "macro_precision": 0.376984126984127,
+                "macro_recall": 0.39550106326422113,
+                "macro_f1": 0.3235978835978836,
+                "weighted_f1": 0.32075504075504074,
+                "macro_roc_auc": 0.563173181699543,
+                "macro_pr_auc": 0.36133740216843074
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.41419758475192775,
+              "regime_accuracy": 0.48076921701431274,
+              "regime_loss": 1.1266349462362437,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    11,
+                    12
+                  ],
+                  [
+                    0,
+                    29,
+                    23
+                  ],
+                  [
+                    0,
+                    8,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 1.0,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.20689655172413793,
+                    "support": 26,
+                    "roc_auc": 0.6429980276134122,
+                    "pr_auc": 0.4954248230540644
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6041666666666666,
+                    "recall": 0.5576923076923077,
+                    "f1": 0.5799999999999998,
+                    "support": 52,
+                    "roc_auc": 0.636094674556213,
+                    "pr_auc": 0.5969950024775049
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.33962264150943394,
+                    "recall": 0.6923076923076923,
+                    "f1": 0.4556962025316456,
+                    "support": 26,
+                    "roc_auc": 0.7135108481262328,
+                    "pr_auc": 0.6366446001859273
+                  }
+                ],
+                "macro_precision": 0.6479297693920335,
+                "macro_recall": 0.4551282051282051,
+                "macro_f1": 0.41419758475192775,
+                "weighted_f1": 0.45564818856394584,
+                "macro_roc_auc": 0.6642011834319527,
+                "macro_pr_auc": 0.5763548085724989
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.41152537533607747,
+              "regime_accuracy": 0.44999998807907104,
+              "regime_loss": 1.156699050877678,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    9,
+                    6
+                  ],
+                  [
+                    7,
+                    5,
+                    33
+                  ],
+                  [
+                    5,
+                    6,
+                    36
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.52,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.49056603773584906,
+                    "support": 28,
+                    "roc_auc": 0.7239906832298136,
+                    "pr_auc": 0.3642691955447649
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.1111111111111111,
+                    "f1": 0.15384615384615383,
+                    "support": 45,
+                    "roc_auc": 0.4699259259259259,
+                    "pr_auc": 0.35812746202150025
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.48,
+                    "recall": 0.7659574468085106,
+                    "f1": 0.5901639344262295,
+                    "support": 47,
+                    "roc_auc": 0.6009909647333139,
+                    "pr_auc": 0.45640157282401167
+                  }
+                ],
+                "macro_precision": 0.4166666666666667,
+                "macro_recall": 0.447118090735112,
+                "macro_f1": 0.41152537533607747,
+                "weighted_f1": 0.4033052574809457,
+                "macro_roc_auc": 0.5983025246296845,
+                "macro_pr_auc": 0.3929327434634256
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.46676426434058876,
+              "regime_accuracy": 0.6779661178588867,
+              "regime_loss": 0.6267092763367346,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    8,
+                    3,
+                    1
+                  ],
+                  [
+                    13,
+                    13,
+                    70
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.7,
+                    "f1": 0.3684210526315789,
+                    "support": 10,
+                    "roc_auc": 0.8953703703703704,
+                    "pr_auc": 0.3433332444361856
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.15789473684210525,
+                    "recall": 0.25,
+                    "f1": 0.1935483870967742,
+                    "support": 12,
+                    "roc_auc": 0.7044025157232704,
+                    "pr_auc": 0.14782829423111543
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9859154929577465,
+                    "recall": 0.7291666666666666,
+                    "f1": 0.8383233532934132,
+                    "support": 96,
+                    "roc_auc": 0.9067234848484849,
+                    "pr_auc": 0.9794770607286735
+                  }
+                ],
+                "macro_precision": 0.4646034099332839,
+                "macro_recall": 0.5597222222222222,
+                "macro_f1": 0.46676426434058876,
+                "weighted_f1": 0.7329307888783453,
+                "macro_roc_auc": 0.835498790314042,
+                "macro_pr_auc": 0.49021286646532486
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3365511531822833,
+              "regime_accuracy": 0.34545454382896423,
+              "regime_loss": 1.4010706121271306,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    1,
+                    3
+                  ],
+                  [
+                    24,
+                    20,
+                    34
+                  ],
+                  [
+                    5,
+                    5,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.21621621621621623,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.326530612244898,
+                    "support": 12,
+                    "roc_auc": 0.6658163265306123,
+                    "pr_auc": 0.15961015847896373
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7692307692307693,
+                    "recall": 0.2564102564102564,
+                    "f1": 0.38461538461538464,
+                    "support": 78,
+                    "roc_auc": 0.3112980769230769,
+                    "pr_auc": 0.612711301773481
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2127659574468085,
+                    "recall": 0.5,
+                    "f1": 0.2985074626865672,
+                    "support": 20,
+                    "roc_auc": 0.5616666666666666,
+                    "pr_auc": 0.18499459146415434
+                  }
+                ],
+                "macro_precision": 0.39940431429793133,
+                "macro_recall": 0.4743589743589743,
+                "macro_f1": 0.3365511531822833,
+                "weighted_f1": 0.3626228781879102,
+                "macro_roc_auc": 0.512927023373452,
+                "macro_pr_auc": 0.3191053505721997
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4521381886087768,
+              "regime_accuracy": 0.4864864945411682,
+              "regime_loss": 1.0380449102375886,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    31,
+                    3,
+                    10
+                  ],
+                  [
+                    20,
+                    15,
+                    13
+                  ],
+                  [
+                    7,
+                    4,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5344827586206896,
+                    "recall": 0.7045454545454546,
+                    "f1": 0.607843137254902,
+                    "support": 44,
+                    "roc_auc": 0.64280868385346,
+                    "pr_auc": 0.46557501642379245
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6818181818181818,
+                    "recall": 0.3125,
+                    "f1": 0.42857142857142855,
+                    "support": 48,
+                    "roc_auc": 0.5988756613756614,
+                    "pr_auc": 0.535542756457733
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.25806451612903225,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.31999999999999995,
+                    "support": 19,
+                    "roc_auc": 0.6069794050343249,
+                    "pr_auc": 0.270661523292035
+                  }
+                ],
+                "macro_precision": 0.4914551521893012,
+                "macro_recall": 0.479366028708134,
+                "macro_f1": 0.4521381886087768,
+                "weighted_f1": 0.4810497892850834,
+                "macro_roc_auc": 0.6162212500878154,
+                "macro_pr_auc": 0.42392643205785346
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3321123321123321,
+              "regime_accuracy": 0.3365384638309479,
+              "regime_loss": 1.1982083595716035,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    13,
+                    7
+                  ],
+                  [
+                    22,
+                    11,
+                    19
+                  ],
+                  [
+                    6,
+                    2,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.17647058823529413,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.20000000000000004,
+                    "support": 26,
+                    "roc_auc": 0.5616370808678501,
+                    "pr_auc": 0.30365880200179673
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4230769230769231,
+                    "recall": 0.21153846153846154,
+                    "f1": 0.28205128205128205,
+                    "support": 52,
+                    "roc_auc": 0.5377218934911243,
+                    "pr_auc": 0.49032235048414713
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4090909090909091,
+                    "recall": 0.6923076923076923,
+                    "f1": 0.5142857142857142,
+                    "support": 26,
+                    "roc_auc": 0.6711045364891519,
+                    "pr_auc": 0.42170652017845184
+                  }
+                ],
+                "macro_precision": 0.3362128068010421,
+                "macro_recall": 0.3782051282051282,
+                "macro_f1": 0.3321123321123321,
+                "weighted_f1": 0.3195970695970696,
+                "macro_roc_auc": 0.5901545036160422,
+                "macro_pr_auc": 0.40522922422146523
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.40487319500060664,
+              "regime_accuracy": 0.4416666626930237,
+              "regime_loss": 1.1638227334584388,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    8,
+                    8
+                  ],
+                  [
+                    8,
+                    5,
+                    32
+                  ],
+                  [
+                    2,
+                    9,
+                    36
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5454545454545454,
+                    "recall": 0.42857142857142855,
+                    "f1": 0.4799999999999999,
+                    "support": 28,
+                    "roc_auc": 0.7298136645962733,
+                    "pr_auc": 0.3715348217840605
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.22727272727272727,
+                    "recall": 0.1111111111111111,
+                    "f1": 0.14925373134328357,
+                    "support": 45,
+                    "roc_auc": 0.4411851851851852,
+                    "pr_auc": 0.3483245246609795
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.47368421052631576,
+                    "recall": 0.7659574468085106,
+                    "f1": 0.5853658536585366,
+                    "support": 47,
+                    "roc_auc": 0.5907898571844943,
+                    "pr_auc": 0.44265277139581155
+                  }
+                ],
+                "macro_precision": 0.4154704944178628,
+                "macro_recall": 0.43521332883035013,
+                "macro_f1": 0.40487319500060664,
+                "weighted_f1": 0.3972384419366582,
+                "macro_roc_auc": 0.5872629023219843,
+                "macro_pr_auc": 0.3875040392802838
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.48428950359984846,
+              "regime_accuracy": 0.7542372941970825,
+              "regime_loss": 0.5204971427634612,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    6,
+                    1,
+                    5
+                  ],
+                  [
+                    6,
+                    9,
+                    81
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3684210526315789,
+                    "recall": 0.7,
+                    "f1": 0.48275862068965514,
+                    "support": 10,
+                    "roc_auc": 0.9268518518518518,
+                    "pr_auc": 0.4327062847752503
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.07692307692307693,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.08,
+                    "support": 12,
+                    "roc_auc": 0.7429245283018868,
+                    "pr_auc": 0.16339978030684532
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9418604651162791,
+                    "recall": 0.84375,
+                    "f1": 0.8901098901098902,
+                    "support": 96,
+                    "roc_auc": 0.9142992424242424,
+                    "pr_auc": 0.9809302564934377
+                  }
+                ],
+                "macro_precision": 0.4624015315569783,
+                "macro_recall": 0.5423611111111111,
+                "macro_f1": 0.48428950359984846,
+                "weighted_f1": 0.7732045394698814,
+                "macro_roc_auc": 0.8613585408593271,
+                "macro_pr_auc": 0.5256787738585111
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.31440750213128726,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.3814350431615656,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    34,
+                    12,
+                    32
+                  ],
+                  [
+                    5,
+                    2,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1875,
+                    "recall": 0.75,
+                    "f1": 0.3,
+                    "support": 12,
+                    "roc_auc": 0.7185374149659864,
+                    "pr_auc": 0.20223489232486572
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8571428571428571,
+                    "recall": 0.15384615384615385,
+                    "f1": 0.2608695652173913,
+                    "support": 78,
+                    "roc_auc": 0.35336538461538464,
+                    "pr_auc": 0.6378939812708673
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2708333333333333,
+                    "recall": 0.65,
+                    "f1": 0.3823529411764705,
+                    "support": 20,
+                    "roc_auc": 0.6416666666666667,
+                    "pr_auc": 0.22364405942925558
+                  }
+                ],
+                "macro_precision": 0.4384920634920635,
+                "macro_recall": 0.517948717948718,
+                "macro_f1": 0.31440750213128726,
+                "weighted_f1": 0.287226226458963,
+                "macro_roc_auc": 0.5711898220826793,
+                "macro_pr_auc": 0.3545909776749962
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3898780768345986,
+              "regime_accuracy": 0.4054054021835327,
+              "regime_loss": 1.0872888464877501,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    24,
+                    6,
+                    14
+                  ],
+                  [
+                    17,
+                    11,
+                    20
+                  ],
+                  [
+                    5,
+                    4,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5217391304347826,
+                    "recall": 0.5454545454545454,
+                    "f1": 0.5333333333333332,
+                    "support": 44,
+                    "roc_auc": 0.5936227951153324,
+                    "pr_auc": 0.48826979926945213
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5238095238095238,
+                    "recall": 0.22916666666666666,
+                    "f1": 0.31884057971014496,
+                    "support": 48,
+                    "roc_auc": 0.6636904761904762,
+                    "pr_auc": 0.5807303151923859
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.22727272727272727,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.31746031746031744,
+                    "support": 19,
+                    "roc_auc": 0.6413043478260869,
+                    "pr_auc": 0.2874981542609759
+                  }
+                ],
+                "macro_precision": 0.42427379383901126,
+                "macro_recall": 0.4336456671982987,
+                "macro_f1": 0.3898780768345986,
+                "weighted_f1": 0.4036284731936905,
+                "macro_roc_auc": 0.6328725397106318,
+                "macro_pr_auc": 0.45216608957427135
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.41828988766003433,
+              "regime_accuracy": 0.5,
+              "regime_loss": 1.0892656858150775,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    15,
+                    8
+                  ],
+                  [
+                    4,
+                    35,
+                    13
+                  ],
+                  [
+                    0,
+                    12,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.18181818181818182,
+                    "support": 26,
+                    "roc_auc": 0.5813609467455622,
+                    "pr_auc": 0.3851535539377949
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5645161290322581,
+                    "recall": 0.6730769230769231,
+                    "f1": 0.6140350877192983,
+                    "support": 52,
+                    "roc_auc": 0.6257396449704142,
+                    "pr_auc": 0.559960041003408
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4,
+                    "recall": 0.5384615384615384,
+                    "f1": 0.45901639344262296,
+                    "support": 26,
+                    "roc_auc": 0.6735700197238659,
+                    "pr_auc": 0.5835960883082356
+                  }
+                ],
+                "macro_precision": 0.4643625192012289,
+                "macro_recall": 0.4423076923076923,
+                "macro_f1": 0.41828988766003433,
+                "weighted_f1": 0.46722618767485036,
+                "macro_roc_auc": 0.6268902038132808,
+                "macro_pr_auc": 0.5095698944164795
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.4373885418661538,
+              "regime_accuracy": 0.4416666626930237,
+              "regime_loss": 1.1254582789989132,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    3,
+                    8
+                  ],
+                  [
+                    11,
+                    13,
+                    21
+                  ],
+                  [
+                    18,
+                    6,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3695652173913043,
+                    "recall": 0.6071428571428571,
+                    "f1": 0.45945945945945943,
+                    "support": 28,
+                    "roc_auc": 0.7445652173913043,
+                    "pr_auc": 0.46747875840446057
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5909090909090909,
+                    "recall": 0.28888888888888886,
+                    "f1": 0.38805970149253727,
+                    "support": 45,
+                    "roc_auc": 0.46844444444444444,
+                    "pr_auc": 0.375340658278479
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4423076923076923,
+                    "recall": 0.48936170212765956,
+                    "f1": 0.46464646464646464,
+                    "support": 47,
+                    "roc_auc": 0.5631011366948412,
+                    "pr_auc": 0.42099713007420214
+                  }
+                ],
+                "macro_precision": 0.46759400020269587,
+                "macro_recall": 0.46179781605313514,
+                "macro_f1": 0.4373885418661538,
+                "weighted_f1": 0.4347161272534406,
+                "macro_roc_auc": 0.59203693284353,
+                "macro_pr_auc": 0.42127218225238056
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3857429718875502,
+              "regime_accuracy": 0.6271186470985413,
+              "regime_loss": 0.774016036825665,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    14,
+                    15,
+                    67
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23333333333333334,
+                    "recall": 0.7,
+                    "f1": 0.35,
+                    "support": 10,
+                    "roc_auc": 0.8953703703703704,
+                    "pr_auc": 0.6069127053698805
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6297169811320755,
+                    "pr_auc": 0.12015194161779642
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9571428571428572,
+                    "recall": 0.6979166666666666,
+                    "f1": 0.8072289156626506,
+                    "support": 96,
+                    "roc_auc": 0.8626893939393939,
+                    "pr_auc": 0.9686756366365338
+                  }
+                ],
+                "macro_precision": 0.3968253968253968,
+                "macro_recall": 0.46597222222222223,
+                "macro_f1": 0.3857429718875502,
+                "weighted_f1": 0.6863896263018174,
+                "macro_roc_auc": 0.7959255818139467,
+                "macro_pr_auc": 0.5652467612080703
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3588405989721779,
+              "regime_accuracy": 0.3545454442501068,
+              "regime_loss": 1.036292383887551,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    1,
+                    2
+                  ],
+                  [
+                    34,
+                    16,
+                    28
+                  ],
+                  [
+                    2,
+                    4,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2,
+                    "recall": 0.75,
+                    "f1": 0.31578947368421056,
+                    "support": 12,
+                    "roc_auc": 0.7491496598639455,
+                    "pr_auc": 0.29054236466603317
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7619047619047619,
+                    "recall": 0.20512820512820512,
+                    "f1": 0.3232323232323232,
+                    "support": 78,
+                    "roc_auc": 0.5268429487179487,
+                    "pr_auc": 0.7551947173681866
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 20,
+                    "roc_auc": 0.7577777777777778,
+                    "pr_auc": 0.4179160713769717
+                  }
+                ],
+                "macro_precision": 0.42669552669552663,
+                "macro_recall": 0.5517094017094016,
+                "macro_f1": 0.3588405989721779,
+                "weighted_f1": 0.34319631723937943,
+                "macro_roc_auc": 0.6779234621198906,
+                "macro_pr_auc": 0.4878843844703971
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3249407042510491,
+              "regime_accuracy": 0.342342346906662,
+              "regime_loss": 1.1123741938789595,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    21,
+                    8,
+                    15
+                  ],
+                  [
+                    17,
+                    5,
+                    26
+                  ],
+                  [
+                    5,
+                    2,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4883720930232558,
+                    "recall": 0.4772727272727273,
+                    "f1": 0.4827586206896552,
+                    "support": 44,
+                    "roc_auc": 0.583785617367707,
+                    "pr_auc": 0.4269202184737001
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.10416666666666667,
+                    "f1": 0.15873015873015875,
+                    "support": 48,
+                    "roc_auc": 0.5889550264550265,
+                    "pr_auc": 0.44714435605899827
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.22641509433962265,
+                    "recall": 0.631578947368421,
+                    "f1": 0.3333333333333333,
+                    "support": 19,
+                    "roc_auc": 0.584096109839817,
+                    "pr_auc": 0.31777757086532804
+                  }
+                ],
+                "macro_precision": 0.3493735068987373,
+                "macro_recall": 0.404339447102605,
+                "macro_f1": 0.3249407042510491,
+                "weighted_f1": 0.31706090326779984,
+                "macro_roc_auc": 0.5856122512208501,
+                "macro_pr_auc": 0.39728071513267543
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5470691570435816,
+              "regime_accuracy": 0.557692289352417,
+              "regime_loss": 1.1009519833784838,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    7,
+                    7
+                  ],
+                  [
+                    10,
+                    26,
+                    16
+                  ],
+                  [
+                    3,
+                    3,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.48,
+                    "recall": 0.46153846153846156,
+                    "f1": 0.47058823529411764,
+                    "support": 26,
+                    "roc_auc": 0.6632149901380671,
+                    "pr_auc": 0.38449630506651655
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7222222222222222,
+                    "recall": 0.5,
+                    "f1": 0.5909090909090908,
+                    "support": 52,
+                    "roc_auc": 0.6346153846153846,
+                    "pr_auc": 0.6779283407410267
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.46511627906976744,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5797101449275363,
+                    "support": 26,
+                    "roc_auc": 0.6987179487179487,
+                    "pr_auc": 0.5136743357156033
+                  }
+                ],
+                "macro_precision": 0.5557795004306633,
+                "macro_recall": 0.576923076923077,
+                "macro_f1": 0.5470691570435816,
+                "weighted_f1": 0.5580291405099589,
+                "macro_roc_auc": 0.6655161078238001,
+                "macro_pr_auc": 0.5253663271743821
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "regression": [
+      {
+        "head_mode": "regression",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.31836091410559497,
+              "regime_accuracy": 0.38333332538604736,
+              "regime_loss": 1.1211264863128203,
+              "regression_rmse_log_rv": 0.8873064794101865,
+              "regression_mae_log_rv": 0.7485121881880332,
+              "regression_loss": 0.7873127884032998,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    22,
+                    6,
+                    0
+                  ],
+                  [
+                    21,
+                    24,
+                    0
+                  ],
+                  [
+                    28,
+                    19,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.30985915492957744,
+                    "recall": 0.7857142857142857,
+                    "f1": 0.4444444444444445,
+                    "support": 28,
+                    "roc_auc": 0.6991459627329193,
+                    "pr_auc": 0.5010362307361633
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4897959183673469,
+                    "recall": 0.5333333333333333,
+                    "f1": 0.5106382978723404,
+                    "support": 45,
+                    "roc_auc": 0.605925925925926,
+                    "pr_auc": 0.49791180997401197
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.5654328184202856,
+                    "pr_auc": 0.52375012062029
+                  }
+                ],
+                "macro_precision": 0.26655169109897475,
+                "macro_recall": 0.4396825396825397,
+                "macro_f1": 0.31836091410559497,
+                "weighted_f1": 0.29519306540583135,
+                "macro_roc_auc": 0.6235015690263769,
+                "macro_pr_auc": 0.5075660537768217
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.0934126459572593,
+              "regime_accuracy": 0.06779661029577255,
+              "regime_loss": 1.3537720744892703,
+              "regression_rmse_log_rv": 0.8174932202715073,
+              "regression_mae_log_rv": 0.6402332168624941,
+              "regression_loss": 0.6682951651898791,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    4,
+                    0
+                  ],
+                  [
+                    10,
+                    2,
+                    0
+                  ],
+                  [
+                    25,
+                    71,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.14634146341463414,
+                    "recall": 0.6,
+                    "f1": 0.23529411764705882,
+                    "support": 10,
+                    "roc_auc": 0.45740740740740743,
+                    "pr_auc": 0.07562282564426778
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.025974025974025976,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.0449438202247191,
+                    "support": 12,
+                    "roc_auc": 0.24842767295597484,
+                    "pr_auc": 0.06470324154805471
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 96,
+                    "roc_auc": 0.4408143939393939,
+                    "pr_auc": 0.812731749694505
+                  }
+                ],
+                "macro_precision": 0.05743849646288671,
+                "macro_recall": 0.25555555555555554,
+                "macro_f1": 0.0934126459572593,
+                "weighted_f1": 0.02451073745056964,
+                "macro_roc_auc": 0.38221649143425873,
+                "macro_pr_auc": 0.31768593896227587
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.1175523349436393,
+              "regime_accuracy": 0.16363635659217834,
+              "regime_loss": 1.1066266038201071,
+              "regression_rmse_log_rv": 0.4404490652257521,
+              "regression_mae_log_rv": 0.3462698761818253,
+              "regression_loss": 0.19399537905823883,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    72,
+                    6,
+                    0
+                  ],
+                  [
+                    12,
+                    8,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.125,
+                    "recall": 1.0,
+                    "f1": 0.2222222222222222,
+                    "support": 12,
+                    "roc_auc": 0.6284013605442177,
+                    "pr_auc": 0.1473703863334927
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.13043478260869565,
+                    "support": 78,
+                    "roc_auc": 0.36939102564102566,
+                    "pr_auc": 0.6590910148854318
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.42944444444444446,
+                    "pr_auc": 0.16190006234435822
+                  }
+                ],
+                "macro_precision": 0.18452380952380953,
+                "macro_recall": 0.358974358974359,
+                "macro_f1": 0.1175523349436393,
+                "weighted_f1": 0.11673254281949932,
+                "macro_roc_auc": 0.475745610209896,
+                "macro_pr_auc": 0.32278715452109424
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3100282485875706,
+              "regime_accuracy": 0.4864864945411682,
+              "regime_loss": 1.054369720128465,
+              "regression_rmse_log_rv": 0.8077580569438437,
+              "regression_mae_log_rv": 0.6433630320725979,
+              "regression_loss": 0.6524730785576939,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    35,
+                    0
+                  ],
+                  [
+                    3,
+                    45,
+                    0
+                  ],
+                  [
+                    3,
+                    16,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6,
+                    "recall": 0.20454545454545456,
+                    "f1": 0.30508474576271183,
+                    "support": 44,
+                    "roc_auc": 0.4799864314789688,
+                    "pr_auc": 0.3544557634138551
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.46875,
+                    "recall": 0.9375,
+                    "f1": 0.625,
+                    "support": 48,
+                    "roc_auc": 0.5658068783068783,
+                    "pr_auc": 0.4435955492276041
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.4548054919908467,
+                    "pr_auc": 0.1624024300832227
+                  }
+                ],
+                "macro_precision": 0.35625,
+                "macro_recall": 0.3806818181818182,
+                "macro_f1": 0.3100282485875706,
+                "weighted_f1": 0.39120476408612004,
+                "macro_roc_auc": 0.5001996005922312,
+                "macro_pr_auc": 0.32015124757489394
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.25274663989738444,
+              "regime_accuracy": 0.4423076808452606,
+              "regime_loss": 1.0893356800079346,
+              "regression_rmse_log_rv": 0.8066807047977549,
+              "regression_mae_log_rv": 0.6563610105076805,
+              "regression_loss": 0.6507337594930026,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    23,
+                    0
+                  ],
+                  [
+                    9,
+                    43,
+                    0
+                  ],
+                  [
+                    5,
+                    21,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.17647058823529413,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.13953488372093026,
+                    "support": 26,
+                    "roc_auc": 0.5128205128205128,
+                    "pr_auc": 0.24915551617757914
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4942528735632184,
+                    "recall": 0.8269230769230769,
+                    "f1": 0.6187050359712231,
+                    "support": 52,
+                    "roc_auc": 0.40828402366863903,
+                    "pr_auc": 0.49320856664645685
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.40039447731755423,
+                    "pr_auc": 0.32825452309165504
+                  }
+                ],
+                "macro_precision": 0.22357448726617082,
+                "macro_recall": 0.3141025641025641,
+                "macro_f1": 0.25274663989738444,
+                "weighted_f1": 0.34423623891584404,
+                "macro_roc_auc": 0.440499671268902,
+                "macro_pr_auc": 0.35687286863856366
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.383543305642662,
+              "regime_accuracy": 0.38333332538604736,
+              "regime_loss": 1.111666911019194,
+              "regression_rmse_log_rv": 0.9142791256930193,
+              "regression_mae_log_rv": 0.7810065085747434,
+              "regression_loss": 0.8359063196779918,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    18,
+                    6,
+                    4
+                  ],
+                  [
+                    23,
+                    14,
+                    8
+                  ],
+                  [
+                    14,
+                    19,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.32727272727272727,
+                    "recall": 0.6428571428571429,
+                    "f1": 0.43373493975903615,
+                    "support": 28,
+                    "roc_auc": 0.5597826086956522,
+                    "pr_auc": 0.24379484177174018
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.358974358974359,
+                    "recall": 0.3111111111111111,
+                    "f1": 0.3333333333333333,
+                    "support": 45,
+                    "roc_auc": 0.4317037037037037,
+                    "pr_auc": 0.3472407068434645
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5384615384615384,
+                    "recall": 0.2978723404255319,
+                    "f1": 0.3835616438356164,
+                    "support": 47,
+                    "roc_auc": 0.4342757213640338,
+                    "pr_auc": 0.32814604711338036
+                  }
+                ],
+                "macro_precision": 0.40823620823620826,
+                "macro_recall": 0.41728019813126194,
+                "macro_f1": 0.383543305642662,
+                "weighted_f1": 0.37643312977939153,
+                "macro_roc_auc": 0.4752540112544632,
+                "macro_pr_auc": 0.30639386524286166
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3511166253101738,
+              "regime_accuracy": 0.5677965879440308,
+              "regime_loss": 1.0996430728395106,
+              "regression_rmse_log_rv": 0.7634164717069344,
+              "regression_mae_log_rv": 0.5881550256478585,
+              "regression_loss": 0.5828047092734646,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    33,
+                    6,
+                    57
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.19230769230769232,
+                    "recall": 1.0,
+                    "f1": 0.32258064516129037,
+                    "support": 10,
+                    "roc_auc": 0.8185185185185185,
+                    "pr_auc": 0.1857435215123776
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.22955974842767296,
+                    "pr_auc": 0.06375087516996314
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.95,
+                    "recall": 0.59375,
+                    "f1": 0.7307692307692308,
+                    "support": 96,
+                    "roc_auc": 0.5014204545454546,
+                    "pr_auc": 0.8194119574300217
+                  }
+                ],
+                "macro_precision": 0.38076923076923075,
+                "macro_recall": 0.53125,
+                "macro_f1": 0.3511166253101738,
+                "weighted_f1": 0.6218614627581276,
+                "macro_roc_auc": 0.5164995738305487,
+                "macro_pr_auc": 0.35630211803745415
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.11003236245954691,
+              "regime_accuracy": 0.15454545617103577,
+              "regime_loss": 1.1515350233424793,
+              "regression_rmse_log_rv": 0.4362644267269953,
+              "regression_mae_log_rv": 0.32312619101721796,
+              "regression_loss": 0.19032665002743382,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    12
+                  ],
+                  [
+                    24,
+                    0,
+                    54
+                  ],
+                  [
+                    3,
+                    0,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.48639455782312924,
+                    "pr_auc": 0.10676706685400744
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.7403846153846154,
+                    "pr_auc": 0.8828239224899339
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.20481927710843373,
+                    "recall": 0.85,
+                    "f1": 0.33009708737864074,
+                    "support": 20,
+                    "roc_auc": 0.7555555555555555,
+                    "pr_auc": 0.45528378011591647
+                  }
+                ],
+                "macro_precision": 0.06827309236947791,
+                "macro_recall": 0.2833333333333333,
+                "macro_f1": 0.11003236245954691,
+                "weighted_f1": 0.06001765225066195,
+                "macro_roc_auc": 0.6607782429211001,
+                "macro_pr_auc": 0.4816249231532859
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.260422615648201,
+              "regime_accuracy": 0.27927929162979126,
+              "regime_loss": 1.1364375057941516,
+              "regression_rmse_log_rv": 0.812248784035434,
+              "regression_mae_log_rv": 0.6835112147503071,
+              "regression_loss": 0.6597480871670411,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    32
+                  ],
+                  [
+                    9,
+                    3,
+                    36
+                  ],
+                  [
+                    3,
+                    0,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.2727272727272727,
+                    "f1": 0.3529411764705882,
+                    "support": 44,
+                    "roc_auc": 0.5366350067842606,
+                    "pr_auc": 0.4744568248351663
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.0625,
+                    "f1": 0.11764705882352941,
+                    "support": 48,
+                    "roc_auc": 0.41203703703703703,
+                    "pr_auc": 0.42724073417818864
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19047619047619047,
+                    "recall": 0.8421052631578947,
+                    "f1": 0.3106796116504854,
+                    "support": 19,
+                    "roc_auc": 0.4570938215102975,
+                    "pr_auc": 0.1821634380510849
+                  }
+                ],
+                "macro_precision": 0.5634920634920635,
+                "macro_recall": 0.39244417862838915,
+                "macro_f1": 0.260422615648201,
+                "weighted_f1": 0.24395840729364426,
+                "macro_roc_auc": 0.46858862177719834,
+                "macro_pr_auc": 0.36128699902148
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.21039631285532923,
+              "regime_accuracy": 0.2211538404226303,
+              "regime_loss": 1.124734484232389,
+              "regression_rmse_log_rv": 0.8514872880255354,
+              "regression_mae_log_rv": 0.6930585276747409,
+              "regression_loss": 0.7250306016690812,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    0,
+                    20
+                  ],
+                  [
+                    10,
+                    3,
+                    39
+                  ],
+                  [
+                    6,
+                    6,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2727272727272727,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.24999999999999994,
+                    "support": 26,
+                    "roc_auc": 0.5527613412228797,
+                    "pr_auc": 0.25002184916038905
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.057692307692307696,
+                    "f1": 0.09836065573770493,
+                    "support": 52,
+                    "roc_auc": 0.5451183431952663,
+                    "pr_auc": 0.536626216003543
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1917808219178082,
+                    "recall": 0.5384615384615384,
+                    "f1": 0.2828282828282828,
+                    "support": 26,
+                    "roc_auc": 0.44970414201183434,
+                    "pr_auc": 0.21768261121387406
+                  }
+                ],
+                "macro_precision": 0.26594714265947145,
+                "macro_recall": 0.2756410256410256,
+                "macro_f1": 0.21039631285532923,
+                "weighted_f1": 0.18238739857592312,
+                "macro_roc_auc": 0.5158612754766602,
+                "macro_pr_auc": 0.33477689212593537
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2532210741165965,
+              "regime_accuracy": 0.3583333194255829,
+              "regime_loss": 1.0746940643985365,
+              "regression_rmse_log_rv": 0.9356001800732537,
+              "regression_mae_log_rv": 0.7881809307941391,
+              "regression_loss": 0.8753476969531049,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    7,
+                    21
+                  ],
+                  [
+                    0,
+                    11,
+                    34
+                  ],
+                  [
+                    0,
+                    15,
+                    32
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 28,
+                    "roc_auc": 0.6032608695652174,
+                    "pr_auc": 0.2638585840168385
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.24444444444444444,
+                    "f1": 0.28205128205128205,
+                    "support": 45,
+                    "roc_auc": 0.5170370370370371,
+                    "pr_auc": 0.41830026409911336
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.367816091954023,
+                    "recall": 0.6808510638297872,
+                    "f1": 0.47761194029850745,
+                    "support": 47,
+                    "roc_auc": 0.4683765665986593,
+                    "pr_auc": 0.36173103401470863
+                  }
+                ],
+                "macro_precision": 0.23371647509578541,
+                "macro_recall": 0.30843183609141056,
+                "macro_f1": 0.2532210741165965,
+                "weighted_f1": 0.29283390738614623,
+                "macro_roc_auc": 0.5295581577336379,
+                "macro_pr_auc": 0.34796329404355353
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.2159090909090909,
+              "regime_accuracy": 0.4067796468734741,
+              "regime_loss": 0.9957442334142782,
+              "regression_rmse_log_rv": 0.8094432038160574,
+              "regression_mae_log_rv": 0.6371079017013564,
+              "regression_loss": 0.6551983002040034,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    10
+                  ],
+                  [
+                    2,
+                    2,
+                    8
+                  ],
+                  [
+                    9,
+                    41,
+                    46
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 10,
+                    "roc_auc": 0.6759259259259259,
+                    "pr_auc": 0.11433407747719126
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.046511627906976744,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.07272727272727272,
+                    "support": 12,
+                    "roc_auc": 0.3309748427672956,
+                    "pr_auc": 0.07125129095857669
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.71875,
+                    "recall": 0.4791666666666667,
+                    "f1": 0.575,
+                    "support": 96,
+                    "roc_auc": 0.3096590909090909,
+                    "pr_auc": 0.7194382550712718
+                  }
+                ],
+                "macro_precision": 0.2550872093023256,
+                "macro_recall": 0.2152777777777778,
+                "macro_f1": 0.2159090909090909,
+                "weighted_f1": 0.4751926040061633,
+                "macro_roc_auc": 0.43885328653410416,
+                "macro_pr_auc": 0.3016745411690132
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.2081422018348624,
+              "regime_accuracy": 0.290909081697464,
+              "regime_loss": 1.0984464970501986,
+              "regression_rmse_log_rv": 0.49147002160092274,
+              "regression_mae_log_rv": 0.3824703763471916,
+              "regression_loss": 0.24154278213241148,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    12
+                  ],
+                  [
+                    3,
+                    15,
+                    60
+                  ],
+                  [
+                    0,
+                    3,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.4549319727891156,
+                    "pr_auc": 0.0921164395479637
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8333333333333334,
+                    "recall": 0.19230769230769232,
+                    "f1": 0.3125,
+                    "support": 78,
+                    "roc_auc": 0.44190705128205127,
+                    "pr_auc": 0.722427493536787
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19101123595505617,
+                    "recall": 0.85,
+                    "f1": 0.3119266055045872,
+                    "support": 20,
+                    "roc_auc": 0.6705555555555556,
+                    "pr_auc": 0.34272021304361266
+                  }
+                ],
+                "macro_precision": 0.3414481897627965,
+                "macro_recall": 0.3474358974358975,
+                "macro_f1": 0.2081422018348624,
+                "weighted_f1": 0.27830483736447037,
+                "macro_roc_auc": 0.5224648598755741,
+                "macro_pr_auc": 0.38575471537612116
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.09039548022598871,
+              "regime_accuracy": 0.14414414763450623,
+              "regime_loss": 1.2381150004018726,
+              "regression_rmse_log_rv": 0.8394002639290348,
+              "regression_mae_log_rv": 0.6672987643176237,
+              "regression_loss": 0.7045928030841332,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    9,
+                    35
+                  ],
+                  [
+                    0,
+                    0,
+                    48
+                  ],
+                  [
+                    0,
+                    3,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.5149253731343284,
+                    "pr_auc": 0.4294698750803199
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.4252645502645503,
+                    "pr_auc": 0.36765186801839206
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.16161616161616163,
+                    "recall": 0.8421052631578947,
+                    "f1": 0.27118644067796616,
+                    "support": 19,
+                    "roc_auc": 0.5022883295194508,
+                    "pr_auc": 0.2321274009544977
+                  }
+                ],
+                "macro_precision": 0.05387205387205388,
+                "macro_recall": 0.2807017543859649,
+                "macro_f1": 0.09039548022598871,
+                "weighted_f1": 0.04641930065658881,
+                "macro_roc_auc": 0.48082608430610985,
+                "macro_pr_auc": 0.34308304801773654
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.12073490813648295,
+              "regime_accuracy": 0.2211538404226303,
+              "regime_loss": 1.169127684373122,
+              "regression_rmse_log_rv": 0.7954953630678794,
+              "regression_mae_log_rv": 0.6328394466187232,
+              "regression_loss": 0.6328128726624972,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    26
+                  ],
+                  [
+                    0,
+                    0,
+                    52
+                  ],
+                  [
+                    0,
+                    3,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.5359960552268245,
+                    "pr_auc": 0.4042738349059275
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.5255177514792899,
+                    "pr_auc": 0.4808829538505873
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.22772277227722773,
+                    "recall": 0.8846153846153846,
+                    "f1": 0.36220472440944884,
+                    "support": 26,
+                    "roc_auc": 0.5350098619329389,
+                    "pr_auc": 0.30518867104560665
+                  }
+                ],
+                "macro_precision": 0.07590759075907591,
+                "macro_recall": 0.2948717948717949,
+                "macro_f1": 0.12073490813648295,
+                "weighted_f1": 0.09055118110236221,
+                "macro_roc_auc": 0.5321745562130178,
+                "macro_pr_auc": 0.3967818199340405
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.19091067083767813,
+              "regime_accuracy": 0.2666666805744171,
+              "regime_loss": 1.1391286206869193,
+              "regression_rmse_log_rv": 0.9170949464524849,
+              "regression_mae_log_rv": 0.7704108571071022,
+              "regression_loss": 0.8410631408086862,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    27,
+                    1,
+                    0
+                  ],
+                  [
+                    40,
+                    5,
+                    0
+                  ],
+                  [
+                    42,
+                    5,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.24770642201834864,
+                    "recall": 0.9642857142857143,
+                    "f1": 0.39416058394160586,
+                    "support": 28,
+                    "roc_auc": 0.5201863354037267,
+                    "pr_auc": 0.30111813849934205
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.1111111111111111,
+                    "f1": 0.17857142857142855,
+                    "support": 45,
+                    "roc_auc": 0.5543703703703704,
+                    "pr_auc": 0.4406685609276626
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.6074030894782863,
+                    "pr_auc": 0.48744141958978787
+                  }
+                ],
+                "macro_precision": 0.23408395885460107,
+                "macro_recall": 0.35846560846560843,
+                "macro_f1": 0.19091067083767813,
+                "weighted_f1": 0.15893508863399372,
+                "macro_roc_auc": 0.5606532650841278,
+                "macro_pr_auc": 0.4097427063389308
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.06363300036995931,
+              "regime_accuracy": 0.06779661029577255,
+              "regime_loss": 1.2606016215631517,
+              "regression_rmse_log_rv": 0.7654367548829446,
+              "regression_mae_log_rv": 0.6020806483545545,
+              "regression_loss": 0.585893425725733,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    11,
+                    1,
+                    0
+                  ],
+                  [
+                    78,
+                    18,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.07291666666666667,
+                    "recall": 0.7,
+                    "f1": 0.1320754716981132,
+                    "support": 10,
+                    "roc_auc": 0.18055555555555555,
+                    "pr_auc": 0.05030802996169482
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.045454545454545456,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.05882352941176471,
+                    "support": 12,
+                    "roc_auc": 0.42845911949685533,
+                    "pr_auc": 0.08183137781160121
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 96,
+                    "roc_auc": 0.19128787878787878,
+                    "pr_auc": 0.6996099845495798
+                  }
+                ],
+                "macro_precision": 0.03945707070707071,
+                "macro_recall": 0.2611111111111111,
+                "macro_f1": 0.06363300036995931,
+                "weighted_f1": 0.01717489042307041,
+                "macro_roc_auc": 0.26676751794676323,
+                "macro_pr_auc": 0.2772497974409586
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.1810897435897436,
+              "regime_accuracy": 0.2454545497894287,
+              "regime_loss": 1.1477738878943704,
+              "regression_rmse_log_rv": 0.6726430795710472,
+              "regression_mae_log_rv": 0.5438377698523585,
+              "regression_loss": 0.45244871249482216,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    63,
+                    15,
+                    0
+                  ],
+                  [
+                    17,
+                    3,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.13043478260869565,
+                    "recall": 1.0,
+                    "f1": 0.23076923076923078,
+                    "support": 12,
+                    "roc_auc": 0.5586734693877551,
+                    "pr_auc": 0.11426061612940547
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8333333333333334,
+                    "recall": 0.19230769230769232,
+                    "f1": 0.3125,
+                    "support": 78,
+                    "roc_auc": 0.5224358974358975,
+                    "pr_auc": 0.7495131330413879
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.5155555555555555,
+                    "pr_auc": 0.17355233826966482
+                  }
+                ],
+                "macro_precision": 0.32125603864734303,
+                "macro_recall": 0.3974358974358974,
+                "macro_f1": 0.1810897435897436,
+                "weighted_f1": 0.24676573426573428,
+                "macro_roc_auc": 0.5322216407930694,
+                "macro_pr_auc": 0.3457753624801527
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.18924731182795698,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.0897512068147202,
+              "regression_rmse_log_rv": 0.8153327401155877,
+              "regression_mae_log_rv": 0.6506980763295213,
+              "regression_loss": 0.6647674771043924,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    44,
+                    0,
+                    0
+                  ],
+                  [
+                    48,
+                    0,
+                    0
+                  ],
+                  [
+                    19,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3963963963963964,
+                    "recall": 1.0,
+                    "f1": 0.567741935483871,
+                    "support": 44,
+                    "roc_auc": 0.5898914518317503,
+                    "pr_auc": 0.4950679438046266
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.5261243386243386,
+                    "pr_auc": 0.4177342285621418
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.4742562929061785,
+                    "pr_auc": 0.15192273975859505
+                  }
+                ],
+                "macro_precision": 0.13213213213213212,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.18924731182795698,
+                "weighted_f1": 0.22505085730892183,
+                "macro_roc_auc": 0.5300906944540892,
+                "macro_pr_auc": 0.3549083040417878
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.1092896174863388,
+              "regime_accuracy": 0.19230769574642181,
+              "regime_loss": 1.158210616845351,
+              "regression_rmse_log_rv": 0.803335419551524,
+              "regression_mae_log_rv": 0.637429037802996,
+              "regression_loss": 0.6453477963060231,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    20,
+                    0,
+                    6
+                  ],
+                  [
+                    50,
+                    0,
+                    2
+                  ],
+                  [
+                    26,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.20833333333333334,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.32786885245901637,
+                    "support": 26,
+                    "roc_auc": 0.3530571992110454,
+                    "pr_auc": 0.2810298374453743
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 52,
+                    "roc_auc": 0.4959319526627219,
+                    "pr_auc": 0.47406283608215233
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.46153846153846156,
+                    "pr_auc": 0.27523177951447947
+                  }
+                ],
+                "macro_precision": 0.06944444444444445,
+                "macro_recall": 0.25641025641025644,
+                "macro_f1": 0.1092896174863388,
+                "weighted_f1": 0.08196721311475409,
+                "macro_roc_auc": 0.4368425378040763,
+                "macro_pr_auc": 0.3434414843473354
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2641592920353983,
+              "regime_accuracy": 0.32499998807907104,
+              "regime_loss": 1.113596860773699,
+              "regression_rmse_log_rv": 0.891762278024795,
+              "regression_mae_log_rv": 0.7669251692229105,
+              "regression_loss": 0.7952399605079717,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    25,
+                    3,
+                    0
+                  ],
+                  [
+                    31,
+                    14,
+                    0
+                  ],
+                  [
+                    29,
+                    18,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.29411764705882354,
+                    "recall": 0.8928571428571429,
+                    "f1": 0.4424778761061947,
+                    "support": 28,
+                    "roc_auc": 0.6545031055900621,
+                    "pr_auc": 0.29454034353527614
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.3111111111111111,
+                    "f1": 0.35000000000000003,
+                    "support": 45,
+                    "roc_auc": 0.43822222222222224,
+                    "pr_auc": 0.3330643947618253
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.486447099970854,
+                    "pr_auc": 0.38846910304761567
+                  }
+                ],
+                "macro_precision": 0.23137254901960783,
+                "macro_recall": 0.40132275132275136,
+                "macro_f1": 0.2641592920353983,
+                "weighted_f1": 0.2344948377581121,
+                "macro_roc_auc": 0.5263908092610461,
+                "macro_pr_auc": 0.338691280448239
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.08893054253878996,
+              "regime_accuracy": 0.11016949266195297,
+              "regime_loss": 1.1352685306031824,
+              "regression_rmse_log_rv": 0.8781393854896685,
+              "regression_mae_log_rv": 0.6333836435766543,
+              "regression_loss": 0.7711287803481726,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    0
+                  ],
+                  [
+                    12,
+                    0,
+                    0
+                  ],
+                  [
+                    65,
+                    28,
+                    3
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.11494252873563218,
+                    "recall": 1.0,
+                    "f1": 0.20618556701030927,
+                    "support": 10,
+                    "roc_auc": 0.8527777777777777,
+                    "pr_auc": 0.24955193707930476
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.46226415094339623,
+                    "pr_auc": 0.0893159988399328
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.03125,
+                    "f1": 0.06060606060606061,
+                    "support": 96,
+                    "roc_auc": 0.6628787878787878,
+                    "pr_auc": 0.8917990310939002
+                  }
+                ],
+                "macro_precision": 0.3716475095785441,
+                "macro_recall": 0.34375,
+                "macro_f1": 0.08893054253878996,
+                "weighted_f1": 0.0667799787142789,
+                "macro_roc_auc": 0.6593069055333206,
+                "macro_pr_auc": 0.4102223223377126
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.29385964912280704,
+              "regime_accuracy": 0.4545454680919647,
+              "regime_loss": 1.0557788480411876,
+              "regression_rmse_log_rv": 0.38128493022619603,
+              "regression_mae_log_rv": 0.2859577146887949,
+              "regression_loss": 0.1453781980175952,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    4,
+                    0
+                  ],
+                  [
+                    33,
+                    42,
+                    3
+                  ],
+                  [
+                    11,
+                    9,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.15384615384615385,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.25,
+                    "support": 12,
+                    "roc_auc": 0.7270408163265306,
+                    "pr_auc": 0.27872670288447376
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7636363636363637,
+                    "recall": 0.5384615384615384,
+                    "f1": 0.6315789473684211,
+                    "support": 78,
+                    "roc_auc": 0.5849358974358975,
+                    "pr_auc": 0.80025640044267
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 20,
+                    "roc_auc": 0.7205555555555555,
+                    "pr_auc": 0.2774570096419609
+                  }
+                ],
+                "macro_precision": 0.30582750582750584,
+                "macro_recall": 0.40170940170940167,
+                "macro_f1": 0.29385964912280704,
+                "weighted_f1": 0.47511961722488044,
+                "macro_roc_auc": 0.6775107564393279,
+                "macro_pr_auc": 0.4521467043230349
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2509416195856874,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.069797227003064,
+              "regression_rmse_log_rv": 0.8072260569974846,
+              "regression_mae_log_rv": 0.6602355694180136,
+              "regression_loss": 0.6516139070957063,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    42,
+                    2,
+                    0
+                  ],
+                  [
+                    43,
+                    5,
+                    0
+                  ],
+                  [
+                    15,
+                    4,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42,
+                    "recall": 0.9545454545454546,
+                    "f1": 0.5833333333333334,
+                    "support": 44,
+                    "roc_auc": 0.4955902306648575,
+                    "pr_auc": 0.37203934693957463
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.10416666666666667,
+                    "f1": 0.1694915254237288,
+                    "support": 48,
+                    "roc_auc": 0.45072751322751325,
+                    "pr_auc": 0.40641374904826455
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.5177345537757437,
+                    "pr_auc": 0.1779659993663706
+                  }
+                ],
+                "macro_precision": 0.2915151515151515,
+                "macro_recall": 0.35290404040404044,
+                "macro_f1": 0.2509416195856874,
+                "weighted_f1": 0.3045248638468977,
+                "macro_roc_auc": 0.4880174325560382,
+                "macro_pr_auc": 0.3188063651180699
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2692307692307692,
+              "regime_accuracy": 0.36538460850715637,
+              "regime_loss": 1.078502370760991,
+              "regression_rmse_log_rv": 0.8075888302323571,
+              "regression_mae_log_rv": 0.6457809070035672,
+              "regression_loss": 0.6521997187160669,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    0,
+                    0
+                  ],
+                  [
+                    40,
+                    12,
+                    0
+                  ],
+                  [
+                    12,
+                    14,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 1.0,
+                    "f1": 0.5,
+                    "support": 26,
+                    "roc_auc": 0.7046351084812623,
+                    "pr_auc": 0.36519829986181784
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.30769230769230776,
+                    "support": 52,
+                    "roc_auc": 0.551405325443787,
+                    "pr_auc": 0.5415275925371656
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.7633136094674556,
+                    "pr_auc": 0.6308324425122929
+                  }
+                ],
+                "macro_precision": 0.26495726495726496,
+                "macro_recall": 0.4102564102564103,
+                "macro_f1": 0.2692307692307692,
+                "weighted_f1": 0.27884615384615385,
+                "macro_roc_auc": 0.6731180144641683,
+                "macro_pr_auc": 0.5125194449704255
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "dual": [
+      {
+        "head_mode": "dual",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.38361086170426567,
+              "regime_accuracy": 0.40833333134651184,
+              "regime_loss": 1.0965324048019345,
+              "regression_rmse_log_rv": 0.8505786546394971,
+              "regression_mae_log_rv": 0.7173251750316315,
+              "regression_loss": 0.723484047728337,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    7,
+                    8
+                  ],
+                  [
+                    11,
+                    7,
+                    27
+                  ],
+                  [
+                    10,
+                    8,
+                    29
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.38235294117647056,
+                    "recall": 0.4642857142857143,
+                    "f1": 0.41935483870967744,
+                    "support": 28,
+                    "roc_auc": 0.7135093167701864,
+                    "pr_auc": 0.3787791543307186
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.15555555555555556,
+                    "f1": 0.208955223880597,
+                    "support": 45,
+                    "roc_auc": 0.5481481481481482,
+                    "pr_auc": 0.4177883723161948
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.453125,
+                    "recall": 0.6170212765957447,
+                    "f1": 0.5225225225225225,
+                    "support": 47,
+                    "roc_auc": 0.6176041970271058,
+                    "pr_auc": 0.48128079007544156
+                  }
+                ],
+                "macro_precision": 0.38455325311942956,
+                "macro_recall": 0.4122875154790049,
+                "macro_f1": 0.38361086170426567,
+                "weighted_f1": 0.38086232597546993,
+                "macro_roc_auc": 0.6264205539818134,
+                "macro_pr_auc": 0.4259494389074517
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.46434108527131784,
+              "regime_accuracy": 0.6355932354927063,
+              "regime_loss": 0.644370133088807,
+              "regression_rmse_log_rv": 0.7783150687367171,
+              "regression_mae_log_rv": 0.6316225852154321,
+              "regression_loss": 0.6057743462226406,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    2,
+                    3
+                  ],
+                  [
+                    4,
+                    26,
+                    66
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3888888888888889,
+                    "recall": 0.7,
+                    "f1": 0.5,
+                    "support": 10,
+                    "roc_auc": 0.899074074074074,
+                    "pr_auc": 0.4490613259226866
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.06451612903225806,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.09302325581395349,
+                    "support": 12,
+                    "roc_auc": 0.6729559748427673,
+                    "pr_auc": 0.1348219574480229
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9565217391304348,
+                    "recall": 0.6875,
+                    "f1": 0.8,
+                    "support": 96,
+                    "roc_auc": 0.9086174242424242,
+                    "pr_auc": 0.9777899924950559
+                  }
+                ],
+                "macro_precision": 0.4699755856838606,
+                "macro_recall": 0.5180555555555556,
+                "macro_f1": 0.46434108527131784,
+                "weighted_f1": 0.7026803310997242,
+                "macro_roc_auc": 0.8268824910530884,
+                "macro_pr_auc": 0.5205577586219218
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3676516011577839,
+              "regime_accuracy": 0.37272727489471436,
+              "regime_loss": 1.0686483014713635,
+              "regression_rmse_log_rv": 0.4706702133448349,
+              "regression_mae_log_rv": 0.38732326164291325,
+              "regression_loss": 0.2215304497300724,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    3,
+                    1
+                  ],
+                  [
+                    40,
+                    23,
+                    15
+                  ],
+                  [
+                    5,
+                    5,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1509433962264151,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.24615384615384617,
+                    "support": 12,
+                    "roc_auc": 0.7227891156462585,
+                    "pr_auc": 0.25594328982302667
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7419354838709677,
+                    "recall": 0.2948717948717949,
+                    "f1": 0.4220183486238532,
+                    "support": 78,
+                    "roc_auc": 0.4078525641025641,
+                    "pr_auc": 0.7334702921834564
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.38461538461538464,
+                    "recall": 0.5,
+                    "f1": 0.4347826086956522,
+                    "support": 20,
+                    "roc_auc": 0.7411111111111112,
+                    "pr_auc": 0.3153010090728147
+                  }
+                ],
+                "macro_precision": 0.42583142157092246,
+                "macro_recall": 0.48717948717948717,
+                "macro_f1": 0.3676516011577839,
+                "weighted_f1": 0.40515390473108864,
+                "macro_roc_auc": 0.6239175969533113,
+                "macro_pr_auc": 0.4349048636930992
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.38340851027418194,
+              "regime_accuracy": 0.44144144654273987,
+              "regime_loss": 1.045460862073056,
+              "regression_rmse_log_rv": 0.8393251281942532,
+              "regression_mae_log_rv": 0.6749971588184168,
+              "regression_loss": 0.7044666708182995,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    33,
+                    4,
+                    7
+                  ],
+                  [
+                    24,
+                    11,
+                    13
+                  ],
+                  [
+                    10,
+                    4,
+                    5
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4925373134328358,
+                    "recall": 0.75,
+                    "f1": 0.5945945945945946,
+                    "support": 44,
+                    "roc_auc": 0.6136363636363636,
+                    "pr_auc": 0.44084609537591823
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5789473684210527,
+                    "recall": 0.22916666666666666,
+                    "f1": 0.3283582089552239,
+                    "support": 48,
+                    "roc_auc": 0.6190476190476191,
+                    "pr_auc": 0.5556578279524635
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2,
+                    "recall": 0.2631578947368421,
+                    "f1": 0.22727272727272727,
+                    "support": 19,
+                    "roc_auc": 0.6361556064073226,
+                    "pr_auc": 0.2874076770346354
+                  }
+                ],
+                "macro_precision": 0.4238282272846295,
+                "macro_recall": 0.4141081871345029,
+                "macro_f1": 0.38340851027418194,
+                "weighted_f1": 0.41659043252427685,
+                "macro_roc_auc": 0.6229465296971018,
+                "macro_pr_auc": 0.42797053345433905
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.29239060489060487,
+              "regime_accuracy": 0.29807692766189575,
+              "regime_loss": 1.0844683280357947,
+              "regression_rmse_log_rv": 0.795070374437534,
+              "regression_mae_log_rv": 0.6459373713990387,
+              "regression_loss": 0.6321369003082407,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    10,
+                    7
+                  ],
+                  [
+                    33,
+                    2,
+                    17
+                  ],
+                  [
+                    6,
+                    0,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1875,
+                    "recall": 0.34615384615384615,
+                    "f1": 0.24324324324324323,
+                    "support": 26,
+                    "roc_auc": 0.5616370808678501,
+                    "pr_auc": 0.39724486701345574
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.038461538461538464,
+                    "f1": 0.0625,
+                    "support": 52,
+                    "roc_auc": 0.5436390532544378,
+                    "pr_auc": 0.5404547712816299
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5714285714285714,
+                    "support": 26,
+                    "roc_auc": 0.6942800788954635,
+                    "pr_auc": 0.5037786506367319
+                  }
+                ],
+                "macro_precision": 0.26957070707070707,
+                "macro_recall": 0.38461538461538464,
+                "macro_f1": 0.29239060489060487,
+                "weighted_f1": 0.23491795366795365,
+                "macro_roc_auc": 0.5998520710059171,
+                "macro_pr_auc": 0.48049276297727256
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2949100015603541,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.1535907150267437,
+              "regression_rmse_log_rv": 0.8554902845438255,
+              "regression_mae_log_rv": 0.7273881772280826,
+              "regression_loss": 0.7318636269488754,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    12,
+                    10
+                  ],
+                  [
+                    12,
+                    4,
+                    29
+                  ],
+                  [
+                    7,
+                    8,
+                    32
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.24,
+                    "recall": 0.21428571428571427,
+                    "f1": 0.2264150943396226,
+                    "support": 28,
+                    "roc_auc": 0.6490683229813664,
+                    "pr_auc": 0.2812022362151518
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.08888888888888889,
+                    "f1": 0.11594202898550726,
+                    "support": 45,
+                    "roc_auc": 0.5202962962962963,
+                    "pr_auc": 0.3573978019730295
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4507042253521127,
+                    "recall": 0.6808510638297872,
+                    "f1": 0.5423728813559323,
+                    "support": 47,
+                    "roc_auc": 0.6339259691052171,
+                    "pr_auc": 0.5263712494327528
+                  }
+                ],
+                "macro_precision": 0.2857902973395931,
+                "macro_recall": 0.32800855566813014,
+                "macro_f1": 0.2949100015603541,
+                "weighted_f1": 0.308737828079884,
+                "macro_roc_auc": 0.6010968627942933,
+                "macro_pr_auc": 0.38832376254031137
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.48837695997939407,
+              "regime_accuracy": 0.7033898234367371,
+              "regime_loss": 0.5808135220559977,
+              "regression_rmse_log_rv": 0.7240358392599155,
+              "regression_mae_log_rv": 0.5785061995167349,
+              "regression_loss": 0.5242278965328103,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    4,
+                    3,
+                    5
+                  ],
+                  [
+                    13,
+                    10,
+                    73
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2916666666666667,
+                    "recall": 0.7,
+                    "f1": 0.4117647058823529,
+                    "support": 10,
+                    "roc_auc": 0.8981481481481481,
+                    "pr_auc": 0.39328687887898417
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.1875,
+                    "recall": 0.25,
+                    "f1": 0.21428571428571427,
+                    "support": 12,
+                    "roc_auc": 0.6926100628930818,
+                    "pr_auc": 0.15346675329994539
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9358974358974359,
+                    "recall": 0.7604166666666666,
+                    "f1": 0.8390804597701149,
+                    "support": 96,
+                    "roc_auc": 0.9119318181818182,
+                    "pr_auc": 0.9795115464098069
+                  }
+                ],
+                "macro_precision": 0.47168803418803423,
+                "macro_recall": 0.5701388888888889,
+                "macro_f1": 0.48837695997939407,
+                "weighted_f1": 0.7393288115947724,
+                "macro_roc_auc": 0.8342300097410161,
+                "macro_pr_auc": 0.5087550595295788
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4479809061167243,
+              "regime_accuracy": 0.5272727012634277,
+              "regime_loss": 1.039546368338845,
+              "regression_rmse_log_rv": 0.42280901565964296,
+              "regression_mae_log_rv": 0.32484391701873394,
+              "regression_loss": 0.17876746372307623,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    4,
+                    8,
+                    0
+                  ],
+                  [
+                    13,
+                    41,
+                    24
+                  ],
+                  [
+                    0,
+                    7,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23529411764705882,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.27586206896551724,
+                    "support": 12,
+                    "roc_auc": 0.6938775510204082,
+                    "pr_auc": 0.18924364409133346
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7321428571428571,
+                    "recall": 0.5256410256410257,
+                    "f1": 0.6119402985074627,
+                    "support": 78,
+                    "roc_auc": 0.47716346153846156,
+                    "pr_auc": 0.7381788636672982
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.35135135135135137,
+                    "recall": 0.65,
+                    "f1": 0.456140350877193,
+                    "support": 20,
+                    "roc_auc": 0.77,
+                    "pr_auc": 0.3289898383557644
+                  }
+                ],
+                "macro_precision": 0.4395961087137558,
+                "macro_recall": 0.502991452991453,
+                "macro_f1": 0.4479809061167243,
+                "weighted_f1": 0.5469499557155652,
+                "macro_roc_auc": 0.6470136708529566,
+                "macro_pr_auc": 0.4188041153714654
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3000949667616334,
+              "regime_accuracy": 0.30630630254745483,
+              "regime_loss": 1.3029215825307798,
+              "regression_rmse_log_rv": 1.017145310043042,
+              "regression_mae_log_rv": 0.8571149279942384,
+              "regression_loss": 1.0345845817425563,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    15,
+                    22
+                  ],
+                  [
+                    8,
+                    15,
+                    25
+                  ],
+                  [
+                    4,
+                    3,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3684210526315789,
+                    "recall": 0.1590909090909091,
+                    "f1": 0.22222222222222218,
+                    "support": 44,
+                    "roc_auc": 0.614314789687924,
+                    "pr_auc": 0.43180732788613146
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.3125,
+                    "f1": 0.3703703703703703,
+                    "support": 48,
+                    "roc_auc": 0.4679232804232804,
+                    "pr_auc": 0.4015239163761458
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2033898305084746,
+                    "recall": 0.631578947368421,
+                    "f1": 0.3076923076923077,
+                    "support": 19,
+                    "roc_auc": 0.5623569794050344,
+                    "pr_auc": 0.20189448572411028
+                  }
+                ],
+                "macro_precision": 0.3421187792285027,
+                "macro_recall": 0.3677232854864434,
+                "macro_f1": 0.3000949667616334,
+                "weighted_f1": 0.3009163009163009,
+                "macro_roc_auc": 0.5481983498387463,
+                "macro_pr_auc": 0.34507524332879586
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3588588588588588,
+              "regime_accuracy": 0.4711538553237915,
+              "regime_loss": 1.0694444454633272,
+              "regression_rmse_log_rv": 0.7767125046364782,
+              "regression_mae_log_rv": 0.6135823956171337,
+              "regression_loss": 0.6032823148586712,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    18,
+                    8
+                  ],
+                  [
+                    3,
+                    32,
+                    17
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 26,
+                    "roc_auc": 0.6247534516765286,
+                    "pr_auc": 0.348385730066408
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5423728813559322,
+                    "recall": 0.6153846153846154,
+                    "f1": 0.5765765765765766,
+                    "support": 52,
+                    "roc_auc": 0.6549556213017751,
+                    "pr_auc": 0.591073214793737
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.40476190476190477,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.5,
+                    "support": 26,
+                    "roc_auc": 0.7761341222879684,
+                    "pr_auc": 0.6657500133470546
+                  }
+                ],
+                "macro_precision": 0.31571159537261234,
+                "macro_recall": 0.4230769230769231,
+                "macro_f1": 0.3588588588588588,
+                "weighted_f1": 0.4132882882882883,
+                "macro_roc_auc": 0.6852810650887573,
+                "macro_pr_auc": 0.5350696527357331
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.39158730158730154,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.2419893689987502,
+              "regression_rmse_log_rv": 0.9752157098851508,
+              "regression_mae_log_rv": 0.8072253263303234,
+              "regression_loss": 0.9510456808067987,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    4,
+                    7
+                  ],
+                  [
+                    18,
+                    7,
+                    20
+                  ],
+                  [
+                    21,
+                    0,
+                    26
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.30357142857142855,
+                    "recall": 0.6071428571428571,
+                    "f1": 0.40476190476190477,
+                    "support": 28,
+                    "roc_auc": 0.6118012422360248,
+                    "pr_auc": 0.26194698159672564
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6363636363636364,
+                    "recall": 0.15555555555555556,
+                    "f1": 0.25,
+                    "support": 45,
+                    "roc_auc": 0.5837037037037037,
+                    "pr_auc": 0.4286026248733032
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.49056603773584906,
+                    "recall": 0.5531914893617021,
+                    "f1": 0.52,
+                    "support": 47,
+                    "roc_auc": 0.6266394637132031,
+                    "pr_auc": 0.4924412112098193
+                  }
+                ],
+                "macro_precision": 0.4768337008903047,
+                "macro_recall": 0.4386299673533716,
+                "macro_f1": 0.39158730158730154,
+                "weighted_f1": 0.3918611111111111,
+                "macro_roc_auc": 0.6073814698843106,
+                "macro_pr_auc": 0.39433027255994935
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4342228464419476,
+              "regime_accuracy": 0.7118644118309021,
+              "regime_loss": 0.6073085049451408,
+              "regression_rmse_log_rv": 0.6514802165483816,
+              "regression_mae_log_rv": 0.5249006636914307,
+              "regression_loss": 0.42442647255392624,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    8,
+                    11,
+                    77
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 10,
+                    "roc_auc": 0.9231481481481482,
+                    "pr_auc": 0.5080397102897103
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.6580188679245284,
+                    "pr_auc": 0.1344863149150224
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9390243902439024,
+                    "recall": 0.8020833333333334,
+                    "f1": 0.8651685393258427,
+                    "support": 96,
+                    "roc_auc": 0.884469696969697,
+                    "pr_auc": 0.9717624758857787
+                  }
+                ],
+                "macro_precision": 0.4190687361419068,
+                "macro_recall": 0.5006944444444444,
+                "macro_f1": 0.4342228464419476,
+                "weighted_f1": 0.7409422014854313,
+                "macro_roc_auc": 0.8218789043474578,
+                "macro_pr_auc": 0.5380961670301705
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.21891806390382793,
+              "regime_accuracy": 0.20000000298023224,
+              "regime_loss": 2.1235778916965833,
+              "regression_rmse_log_rv": 0.9075348627133606,
+              "regression_mae_log_rv": 0.7886679867007347,
+              "regression_loss": 0.8236195270401583,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    1,
+                    6
+                  ],
+                  [
+                    12,
+                    0,
+                    66
+                  ],
+                  [
+                    0,
+                    3,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.29411764705882354,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.3448275862068966,
+                    "support": 12,
+                    "roc_auc": 0.6947278911564626,
+                    "pr_auc": 0.20212346263133232
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 78,
+                    "roc_auc": 0.4519230769230769,
+                    "pr_auc": 0.6365213639812399
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19101123595505617,
+                    "recall": 0.85,
+                    "f1": 0.3119266055045872,
+                    "support": 20,
+                    "roc_auc": 0.6055555555555555,
+                    "pr_auc": 0.23154490326761118
+                  }
+                ],
+                "macro_precision": 0.16170962767129324,
+                "macro_recall": 0.4222222222222222,
+                "macro_f1": 0.21891806390382793,
+                "weighted_f1": 0.09433148313249547,
+                "macro_roc_auc": 0.5840688412116983,
+                "macro_pr_auc": 0.35672990996006115
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.39271566011803705,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.0716231450615248,
+              "regression_rmse_log_rv": 0.885755788745012,
+              "regression_mae_log_rv": 0.7024341625085956,
+              "regression_loss": 0.7845633172952985,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    18,
+                    12,
+                    14
+                  ],
+                  [
+                    15,
+                    15,
+                    18
+                  ],
+                  [
+                    7,
+                    1,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.45,
+                    "recall": 0.4090909090909091,
+                    "f1": 0.4285714285714286,
+                    "support": 44,
+                    "roc_auc": 0.6343283582089553,
+                    "pr_auc": 0.4562779139921054
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5357142857142857,
+                    "recall": 0.3125,
+                    "f1": 0.39473684210526316,
+                    "support": 48,
+                    "roc_auc": 0.5806878306878307,
+                    "pr_auc": 0.5121161603671021
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2558139534883721,
+                    "recall": 0.5789473684210527,
+                    "f1": 0.3548387096774194,
+                    "support": 19,
+                    "roc_auc": 0.618421052631579,
+                    "pr_auc": 0.34395657317464967
+                  }
+                ],
+                "macro_precision": 0.413842746400886,
+                "macro_recall": 0.43351275917065396,
+                "macro_f1": 0.39271566011803705,
+                "weighted_f1": 0.4013193401987969,
+                "macro_roc_auc": 0.6111457471761216,
+                "macro_pr_auc": 0.437450215844619
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5080446046240815,
+              "regime_accuracy": 0.557692289352417,
+              "regime_loss": 1.0501814576295705,
+              "regression_rmse_log_rv": 0.8187350436503744,
+              "regression_mae_log_rv": 0.6558725849653666,
+              "regression_loss": 0.6703270717011804,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    9,
+                    11
+                  ],
+                  [
+                    6,
+                    32,
+                    14
+                  ],
+                  [
+                    1,
+                    5,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.30769230769230776,
+                    "support": 26,
+                    "roc_auc": 0.5700197238658777,
+                    "pr_auc": 0.41183069129152583
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6956521739130435,
+                    "recall": 0.6153846153846154,
+                    "f1": 0.6530612244897959,
+                    "support": 52,
+                    "roc_auc": 0.713387573964497,
+                    "pr_auc": 0.6357846385993531
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4444444444444444,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5633802816901408,
+                    "support": 26,
+                    "roc_auc": 0.7578895463510849,
+                    "pr_auc": 0.6435101592583865
+                  }
+                ],
+                "macro_precision": 0.5338783599653164,
+                "macro_recall": 0.5384615384615384,
+                "macro_f1": 0.5080446046240815,
+                "weighted_f1": 0.5442987595905101,
+                "macro_roc_auc": 0.68043228139382,
+                "macro_pr_auc": 0.5637084963830885
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.34457829450125294,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.2738524331985954,
+              "regression_rmse_log_rv": 0.9319337162087739,
+              "regression_mae_log_rv": 0.7947176546537472,
+              "regression_loss": 0.8685004514066954,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    6,
+                    13
+                  ],
+                  [
+                    13,
+                    5,
+                    27
+                  ],
+                  [
+                    9,
+                    4,
+                    34
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2903225806451613,
+                    "recall": 0.32142857142857145,
+                    "f1": 0.3050847457627119,
+                    "support": 28,
+                    "roc_auc": 0.624611801242236,
+                    "pr_auc": 0.29914278364980745
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.1111111111111111,
+                    "f1": 0.16666666666666666,
+                    "support": 45,
+                    "roc_auc": 0.5407407407407407,
+                    "pr_auc": 0.39543474961867586
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4594594594594595,
+                    "recall": 0.723404255319149,
+                    "f1": 0.5619834710743802,
+                    "support": 47,
+                    "roc_auc": 0.6103176916350919,
+                    "pr_auc": 0.4844181613226388
+                  }
+                ],
+                "macro_precision": 0.36103845781265137,
+                "macro_recall": 0.3853146459529439,
+                "macro_f1": 0.34457829450125294,
+                "weighted_f1": 0.3537966335154317,
+                "macro_roc_auc": 0.5918900778726895,
+                "macro_pr_auc": 0.3929985648637074
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4437849162011173,
+              "regime_accuracy": 0.7372881174087524,
+              "regime_loss": 0.5474764735011731,
+              "regression_rmse_log_rv": 0.7103571337191649,
+              "regression_mae_log_rv": 0.5822619760440568,
+              "regression_loss": 0.5046072574257076,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    9,
+                    0,
+                    3
+                  ],
+                  [
+                    6,
+                    10,
+                    80
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 10,
+                    "roc_auc": 0.9416666666666667,
+                    "pr_auc": 0.5320012234142669
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7075471698113207,
+                    "pr_auc": 0.14708769330573807
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.963855421686747,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.8938547486033519,
+                    "support": 96,
+                    "roc_auc": 0.9564393939393939,
+                    "pr_auc": 0.9901128706454561
+                  }
+                ],
+                "macro_precision": 0.427345746622855,
+                "macro_recall": 0.5111111111111111,
+                "macro_f1": 0.4437849162011173,
+                "weighted_f1": 0.7642801344569643,
+                "macro_roc_auc": 0.8685510768057938,
+                "macro_pr_auc": 0.556400595788487
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.31161541149746635,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.0832756822759455,
+              "regression_rmse_log_rv": 0.41653511032248086,
+              "regression_mae_log_rv": 0.3334796794203364,
+              "regression_loss": 0.1735014981313613,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    34,
+                    14,
+                    30
+                  ],
+                  [
+                    5,
+                    3,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1702127659574468,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.2711864406779661,
+                    "support": 12,
+                    "roc_auc": 0.6938775510204082,
+                    "pr_auc": 0.17813927940147928
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7368421052631579,
+                    "recall": 0.1794871794871795,
+                    "f1": 0.288659793814433,
+                    "support": 78,
+                    "roc_auc": 0.49238782051282054,
+                    "pr_auc": 0.7684654768180346
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2727272727272727,
+                    "recall": 0.6,
+                    "f1": 0.37499999999999994,
+                    "support": 20,
+                    "roc_auc": 0.7633333333333333,
+                    "pr_auc": 0.36817567599633
+                  }
+                ],
+                "macro_precision": 0.3932607146492924,
+                "macro_recall": 0.48205128205128206,
+                "macro_f1": 0.31161541149746635,
+                "weighted_f1": 0.3024518291423761,
+                "macro_roc_auc": 0.6498662349555206,
+                "macro_pr_auc": 0.43826014407194797
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3962962962962963,
+              "regime_accuracy": 0.4144144058227539,
+              "regime_loss": 1.1660935258055736,
+              "regression_rmse_log_rv": 0.9610065991537114,
+              "regression_mae_log_rv": 0.7735907105175225,
+              "regression_loss": 0.9235336836169823,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    9,
+                    9
+                  ],
+                  [
+                    16,
+                    10,
+                    22
+                  ],
+                  [
+                    4,
+                    5,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5652173913043478,
+                    "recall": 0.5909090909090909,
+                    "f1": 0.5777777777777778,
+                    "support": 44,
+                    "roc_auc": 0.6275440976933514,
+                    "pr_auc": 0.45511150841228715
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4166666666666667,
+                    "recall": 0.20833333333333334,
+                    "f1": 0.2777777777777778,
+                    "support": 48,
+                    "roc_auc": 0.5277777777777778,
+                    "pr_auc": 0.49813854648053363
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.24390243902439024,
+                    "recall": 0.5263157894736842,
+                    "f1": 0.3333333333333333,
+                    "support": 19,
+                    "roc_auc": 0.6281464530892449,
+                    "pr_auc": 0.250695304842582
+                  }
+                ],
+                "macro_precision": 0.4085954989984682,
+                "macro_recall": 0.44185273790536944,
+                "macro_f1": 0.3962962962962963,
+                "weighted_f1": 0.4062062062062062,
+                "macro_roc_auc": 0.5944894428534581,
+                "macro_pr_auc": 0.40131511991180097
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.36461102250575933,
+              "regime_accuracy": 0.4134615361690521,
+              "regime_loss": 1.111283696614779,
+              "regression_rmse_log_rv": 0.79006357980604,
+              "regression_mae_log_rv": 0.6265051550357245,
+              "regression_loss": 0.624200460135935,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    15,
+                    8
+                  ],
+                  [
+                    4,
+                    23,
+                    25
+                  ],
+                  [
+                    0,
+                    9,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.18181818181818182,
+                    "support": 26,
+                    "roc_auc": 0.6272189349112426,
+                    "pr_auc": 0.4059993910485284
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.48936170212765956,
+                    "recall": 0.4423076923076923,
+                    "f1": 0.46464646464646464,
+                    "support": 52,
+                    "roc_auc": 0.5928254437869822,
+                    "pr_auc": 0.5210257808618893
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.34,
+                    "recall": 0.6538461538461539,
+                    "f1": 0.4473684210526316,
+                    "support": 26,
+                    "roc_auc": 0.7223865877712031,
+                    "pr_auc": 0.6266909556708464
+                  }
+                ],
+                "macro_precision": 0.41931104356636273,
+                "macro_recall": 0.4038461538461538,
+                "macro_f1": 0.36461102250575933,
+                "weighted_f1": 0.3896198830409357,
+                "macro_roc_auc": 0.6474769888231426,
+                "macro_pr_auc": 0.5179053758604214
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3727346096096096,
+              "regime_accuracy": 0.4583333432674408,
+              "regime_loss": 1.152744539246389,
+              "regression_rmse_log_rv": 0.9049669501934383,
+              "regression_mae_log_rv": 0.7779374349920545,
+              "regression_loss": 0.818965180942413,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    11,
+                    14
+                  ],
+                  [
+                    4,
+                    13,
+                    28
+                  ],
+                  [
+                    2,
+                    6,
+                    39
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.10714285714285714,
+                    "f1": 0.16216216216216214,
+                    "support": 28,
+                    "roc_auc": 0.6354813664596274,
+                    "pr_auc": 0.28465054210563395
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.43333333333333335,
+                    "recall": 0.28888888888888886,
+                    "f1": 0.3466666666666666,
+                    "support": 45,
+                    "roc_auc": 0.46074074074074073,
+                    "pr_auc": 0.3731789343751325
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.48148148148148145,
+                    "recall": 0.8297872340425532,
+                    "f1": 0.609375,
+                    "support": 47,
+                    "roc_auc": 0.5969105217137861,
+                    "pr_auc": 0.4577753566376586
+                  }
+                ],
+                "macro_precision": 0.41604938271604935,
+                "macro_recall": 0.40860632669143304,
+                "macro_f1": 0.3727346096096096,
+                "weighted_f1": 0.4065097128378378,
+                "macro_roc_auc": 0.5643775429713848,
+                "macro_pr_auc": 0.3718682777061417
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3910515934807433,
+              "regime_accuracy": 0.6355932354927063,
+              "regime_loss": 0.6637399247137167,
+              "regression_rmse_log_rv": 0.868540882830326,
+              "regression_mae_log_rv": 0.6572068160620786,
+              "regression_loss": 0.7543632651476821,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    5
+                  ],
+                  [
+                    14,
+                    14,
+                    68
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.7,
+                    "f1": 0.3684210526315789,
+                    "support": 10,
+                    "roc_auc": 0.8675925925925926,
+                    "pr_auc": 0.35083010635642214
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 12,
+                    "roc_auc": 0.7114779874213837,
+                    "pr_auc": 0.1483285419587466
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9315068493150684,
+                    "recall": 0.7083333333333334,
+                    "f1": 0.804733727810651,
+                    "support": 96,
+                    "roc_auc": 0.8816287878787878,
+                    "pr_auc": 0.9722272636443302
+                  }
+                ],
+                "macro_precision": 0.39383561643835613,
+                "macro_recall": 0.4694444444444444,
+                "macro_f1": 0.3910515934807433,
+                "weighted_f1": 0.685920749119816,
+                "macro_roc_auc": 0.8202331226309214,
+                "macro_pr_auc": 0.4904619706531663
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.41221370941505625,
+              "regime_accuracy": 0.4272727370262146,
+              "regime_loss": 1.019977376677773,
+              "regression_rmse_log_rv": 0.3861235846251395,
+              "regression_mae_log_rv": 0.29247302126181735,
+              "regression_loss": 0.14909142260376726,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    2,
+                    2
+                  ],
+                  [
+                    25,
+                    25,
+                    28
+                  ],
+                  [
+                    2,
+                    4,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.22857142857142856,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.3404255319148936,
+                    "support": 12,
+                    "roc_auc": 0.7542517006802721,
+                    "pr_auc": 0.3154477296790048
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8064516129032258,
+                    "recall": 0.32051282051282054,
+                    "f1": 0.45871559633027525,
+                    "support": 78,
+                    "roc_auc": 0.5817307692307693,
+                    "pr_auc": 0.7998801119406447
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.7,
+                    "f1": 0.4375,
+                    "support": 20,
+                    "roc_auc": 0.7394444444444445,
+                    "pr_auc": 0.35761945685505786
+                  }
+                ],
+                "macro_precision": 0.4510682865521575,
+                "macro_recall": 0.5623931623931624,
+                "macro_f1": 0.41221370941505625,
+                "weighted_f1": 0.4419538445158199,
+                "macro_roc_auc": 0.6918089714518286,
+                "macro_pr_auc": 0.49098243282490245
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.30854676489269656,
+              "regime_accuracy": 0.315315306186676,
+              "regime_loss": 1.118956965707632,
+              "regression_rmse_log_rv": 0.8444497673256942,
+              "regression_mae_log_rv": 0.6800824285627486,
+              "regression_loss": 0.713095409536419,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    18,
+                    11,
+                    15
+                  ],
+                  [
+                    17,
+                    8,
+                    23
+                  ],
+                  [
+                    4,
+                    6,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.4090909090909091,
+                    "f1": 0.4337349397590362,
+                    "support": 44,
+                    "roc_auc": 0.5654681139755766,
+                    "pr_auc": 0.4129272793102779
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.32,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.2191780821917808,
+                    "support": 48,
+                    "roc_auc": 0.5671296296296297,
+                    "pr_auc": 0.42557512423567406
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.19148936170212766,
+                    "recall": 0.47368421052631576,
+                    "f1": 0.2727272727272727,
+                    "support": 19,
+                    "roc_auc": 0.5715102974828375,
+                    "pr_auc": 0.3069017224813037
+                  }
+                ],
+                "macro_precision": 0.3243426077468631,
+                "macro_recall": 0.3498139287612972,
+                "macro_f1": 0.30854676489269656,
+                "weighted_f1": 0.31339372501280405,
+                "macro_roc_auc": 0.5680360136960146,
+                "macro_pr_auc": 0.38180137534241854
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.3599033816425121,
+              "regime_accuracy": 0.4038461446762085,
+              "regime_loss": 1.0740910676809459,
+              "regression_rmse_log_rv": 0.7971977854233677,
+              "regression_mae_log_rv": 0.6314986216602847,
+              "regression_loss": 0.6355243090839218,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    15,
+                    8
+                  ],
+                  [
+                    7,
+                    19,
+                    26
+                  ],
+                  [
+                    0,
+                    6,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3,
+                    "recall": 0.11538461538461539,
+                    "f1": 0.16666666666666669,
+                    "support": 26,
+                    "roc_auc": 0.6661735700197239,
+                    "pr_auc": 0.38000457672866234
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.475,
+                    "recall": 0.36538461538461536,
+                    "f1": 0.4130434782608696,
+                    "support": 52,
+                    "roc_auc": 0.5943047337278107,
+                    "pr_auc": 0.5235207915662597
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37037037037037035,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5,
+                    "support": 26,
+                    "roc_auc": 0.8007889546351085,
+                    "pr_auc": 0.6714082957362842
+                  }
+                ],
+                "macro_precision": 0.38179012345679014,
+                "macro_recall": 0.4166666666666667,
+                "macro_f1": 0.3599033816425121,
+                "weighted_f1": 0.3731884057971015,
+                "macro_roc_auc": 0.6870890861275477,
+                "macro_pr_auc": 0.5249778880104021
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "classification": {
+      "regime_f1_macro": {
+        "mean": 0.39340358976762146,
+        "std": 0.0667036724621657,
+        "min": 0.24288356514614948,
+        "max": 0.5470691570435816,
+        "n": 25
+      },
+      "regression_rmse_log_rv": null
+    },
+    "regression": {
+      "regime_f1_macro": {
+        "mean": 0.20789227909022046,
+        "std": 0.08839798872096578,
+        "min": 0.06363300036995931,
+        "max": 0.383543305642662,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7659454830747281,
+        "std": 0.15419338956180767,
+        "min": 0.38128493022619603,
+        "max": 0.9356001800732537,
+        "n": 25
+      }
+    },
+    "dual": {
+      "regime_f1_macro": {
+        "mean": 0.37729795333171295,
+        "std": 0.06573446535422937,
+        "min": 0.21891806390382793,
+        "max": 0.5080446046240815,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7752019649858463,
+        "std": 0.17390010271347114,
+        "min": 0.3861235846251395,
+        "max": 1.017145310043042,
+        "n": 25
+      }
+    }
+  }
+}

--- a/backend/artifacts/experiments/job1_horizon_20260531T141630Z/pod_horizon_20d_20260531T141630Z.json
+++ b/backend/artifacts/experiments/job1_horizon_20260531T141630Z/pod_horizon_20d_20260531T141630Z.json
@@ -1,0 +1,5170 @@
+{
+  "head_modes": [
+    "classification",
+    "regression",
+    "dual"
+  ],
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "regression_alpha": 0.5,
+  "training_package_id": "canonical",
+  "rates_target_mode": "raw",
+  "rates_heads": [],
+  "vol_target_mode": "raw",
+  "vol_target_horizon": 20,
+  "sequence_length": 20,
+  "use_retrieval_analogs": false,
+  "use_regime_conditioning": false,
+  "use_statement_delta": false,
+  "use_vote_features": false,
+  "use_press_conf": false,
+  "use_vix_features": false,
+  "use_doc_length": false,
+  "regime_loss": "ce",
+  "focal_gamma": 2.0,
+  "class_balanced_beta": 0.999,
+  "text_encoder": null,
+  "use_text_embeddings": true,
+  "vol_regime_label_mode": "per_fold_quantile",
+  "absolute_vol_thresholds": null,
+  "absolute_calm_max_annualized": null,
+  "absolute_high_min_annualized": null,
+  "use_mp_surprise": true,
+  "aux_horizons": [],
+  "aux_horizon_alpha": 0.3,
+  "trials": {
+    "classification": [
+      {
+        "head_mode": "classification",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3507435741752682,
+              "regime_accuracy": 0.4166666567325592,
+              "regime_loss": 1.1290787954221544,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    7,
+                    16
+                  ],
+                  [
+                    12,
+                    5,
+                    25
+                  ],
+                  [
+                    3,
+                    7,
+                    37
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.34782608695652173,
+                    "recall": 0.25806451612903225,
+                    "f1": 0.2962962962962963,
+                    "support": 31,
+                    "roc_auc": 0.5621602029720913,
+                    "pr_auc": 0.38627697218712864
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2631578947368421,
+                    "recall": 0.11904761904761904,
+                    "f1": 0.1639344262295082,
+                    "support": 42,
+                    "roc_auc": 0.5668498168498168,
+                    "pr_auc": 0.3912879211637876
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.47435897435897434,
+                    "recall": 0.7872340425531915,
+                    "f1": 0.592,
+                    "support": 47,
+                    "roc_auc": 0.5814631302827165,
+                    "pr_auc": 0.40156433054093105
+                  }
+                ],
+                "macro_precision": 0.3617809853507794,
+                "macro_recall": 0.38811539257661426,
+                "macro_f1": 0.3507435741752682,
+                "weighted_f1": 0.3657869257235377,
+                "macro_roc_auc": 0.5701577167015416,
+                "macro_pr_auc": 0.3930430746306158
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4733798253029022,
+              "regime_accuracy": 0.6694915294647217,
+              "regime_loss": 0.7263958802667715,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    4,
+                    4,
+                    0
+                  ],
+                  [
+                    4,
+                    6,
+                    3
+                  ],
+                  [
+                    19,
+                    9,
+                    69
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.14814814814814814,
+                    "recall": 0.5,
+                    "f1": 0.22857142857142856,
+                    "support": 8,
+                    "roc_auc": 0.8068181818181818,
+                    "pr_auc": 0.14531614271675036
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3157894736842105,
+                    "recall": 0.46153846153846156,
+                    "f1": 0.37499999999999994,
+                    "support": 13,
+                    "roc_auc": 0.8805860805860806,
+                    "pr_auc": 0.3744978391903768
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9583333333333334,
+                    "recall": 0.711340206185567,
+                    "f1": 0.8165680473372781,
+                    "support": 97,
+                    "roc_auc": 0.8478154148257241,
+                    "pr_auc": 0.9660998552632867
+                  }
+                ],
+                "macro_precision": 0.474090318388564,
+                "macro_recall": 0.5576262225746762,
+                "macro_f1": 0.4733798253029022,
+                "weighted_f1": 0.7280565425448084,
+                "macro_roc_auc": 0.8450732257433288,
+                "macro_pr_auc": 0.49530461239013795
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.24941397093295825,
+              "regime_accuracy": 0.23636363446712494,
+              "regime_loss": 1.106875706263659,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    7,
+                    5
+                  ],
+                  [
+                    42,
+                    0,
+                    26
+                  ],
+                  [
+                    1,
+                    3,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.21818181818181817,
+                    "recall": 0.5,
+                    "f1": 0.3037974683544304,
+                    "support": 24,
+                    "roc_auc": 0.6351744186046512,
+                    "pr_auc": 0.391040370067061
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 68,
+                    "roc_auc": 0.3918067226890756,
+                    "pr_auc": 0.5247859389060386
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3111111111111111,
+                    "recall": 0.7777777777777778,
+                    "f1": 0.44444444444444436,
+                    "support": 18,
+                    "roc_auc": 0.875,
+                    "pr_auc": 0.634158807401169
+                  }
+                ],
+                "macro_precision": 0.1764309764309764,
+                "macro_recall": 0.4259259259259259,
+                "macro_f1": 0.24941397093295825,
+                "weighted_f1": 0.1390103567318757,
+                "macro_roc_auc": 0.6339937137645756,
+                "macro_pr_auc": 0.5166617054580895
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3477327270430719,
+              "regime_accuracy": 0.36036035418510437,
+              "regime_loss": 1.1361163390554394,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    21,
+                    3,
+                    15
+                  ],
+                  [
+                    20,
+                    8,
+                    20
+                  ],
+                  [
+                    7,
+                    6,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4375,
+                    "recall": 0.5384615384615384,
+                    "f1": 0.4827586206896552,
+                    "support": 39,
+                    "roc_auc": 0.5220797720797721,
+                    "pr_auc": 0.33430783093866584
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.47058823529411764,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.24615384615384617,
+                    "support": 48,
+                    "roc_auc": 0.5611772486772487,
+                    "pr_auc": 0.46572981765824467
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2391304347826087,
+                    "recall": 0.4583333333333333,
+                    "f1": 0.3142857142857143,
+                    "support": 24,
+                    "roc_auc": 0.5287356321839081,
+                    "pr_auc": 0.30998424777607503
+                  }
+                ],
+                "macro_precision": 0.3824062233589088,
+                "macro_recall": 0.3878205128205128,
+                "macro_f1": 0.3477327270430719,
+                "weighted_f1": 0.3440164681543992,
+                "macro_roc_auc": 0.537330884313643,
+                "macro_pr_auc": 0.3700072987909952
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.48066847335140017,
+              "regime_accuracy": 0.5980392098426819,
+              "regime_loss": 0.9399606767778147,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    11,
+                    9
+                  ],
+                  [
+                    3,
+                    47,
+                    10
+                  ],
+                  [
+                    3,
+                    5,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.2,
+                    "f1": 0.2777777777777778,
+                    "support": 25,
+                    "roc_auc": 0.5641558441558442,
+                    "pr_auc": 0.3893092605342763
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.746031746031746,
+                    "recall": 0.7833333333333333,
+                    "f1": 0.7642276422764228,
+                    "support": 60,
+                    "roc_auc": 0.7376984126984127,
+                    "pr_auc": 0.8115856406989512
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.32142857142857145,
+                    "recall": 0.5294117647058824,
+                    "f1": 0.39999999999999997,
+                    "support": 17,
+                    "roc_auc": 0.8685121107266436,
+                    "pr_auc": 0.6388993588028369
+                  }
+                ],
+                "macro_precision": 0.5073352573352573,
+                "macro_recall": 0.5042483660130719,
+                "macro_f1": 0.48066847335140017,
+                "weighted_f1": 0.5842951272649982,
+                "macro_roc_auc": 0.7234554558603001,
+                "macro_pr_auc": 0.6132647533453548
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.34235690235690236,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.0976979744124757,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    4,
+                    15
+                  ],
+                  [
+                    15,
+                    10,
+                    17
+                  ],
+                  [
+                    17,
+                    10,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2727272727272727,
+                    "recall": 0.3870967741935484,
+                    "f1": 0.32,
+                    "support": 31,
+                    "roc_auc": 0.5346139905762958,
+                    "pr_auc": 0.3535753181453199
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4166666666666667,
+                    "recall": 0.23809523809523808,
+                    "f1": 0.30303030303030304,
+                    "support": 42,
+                    "roc_auc": 0.6111111111111112,
+                    "pr_auc": 0.4201154066430562
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.38461538461538464,
+                    "recall": 0.425531914893617,
+                    "f1": 0.40404040404040403,
+                    "support": 47,
+                    "roc_auc": 0.5700961818711746,
+                    "pr_auc": 0.3955925504059129
+                  }
+                ],
+                "macro_precision": 0.35800310800310803,
+                "macro_recall": 0.35024130906080114,
+                "macro_f1": 0.34235690235690236,
+                "weighted_f1": 0.346976430976431,
+                "macro_roc_auc": 0.5719404278528605,
+                "macro_pr_auc": 0.38976109173142964
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3470169677066228,
+              "regime_accuracy": 0.6610169410705566,
+              "regime_loss": 0.7043661636821295,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    4,
+                    4,
+                    0
+                  ],
+                  [
+                    10,
+                    0,
+                    3
+                  ],
+                  [
+                    20,
+                    3,
+                    74
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.11764705882352941,
+                    "recall": 0.5,
+                    "f1": 0.19047619047619047,
+                    "support": 8,
+                    "roc_auc": 0.7545454545454545,
+                    "pr_auc": 0.11800391755446109
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 13,
+                    "roc_auc": 0.8505494505494505,
+                    "pr_auc": 0.2770726581099058
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.961038961038961,
+                    "recall": 0.7628865979381443,
+                    "f1": 0.8505747126436781,
+                    "support": 97,
+                    "roc_auc": 0.8738340697103584,
+                    "pr_auc": 0.974424657568279
+                  }
+                ],
+                "macro_precision": 0.3595620066208301,
+                "macro_recall": 0.4209621993127148,
+                "macro_f1": 0.3470169677066228,
+                "weighted_f1": 0.712114886866494,
+                "macro_roc_auc": 0.8263096582684212,
+                "macro_pr_auc": 0.45650041107754863
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.25913054082068165,
+              "regime_accuracy": 0.26363635063171387,
+              "regime_loss": 1.123186278526102,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    11,
+                    4,
+                    9
+                  ],
+                  [
+                    36,
+                    0,
+                    32
+                  ],
+                  [
+                    0,
+                    0,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.23404255319148937,
+                    "recall": 0.4583333333333333,
+                    "f1": 0.3098591549295775,
+                    "support": 24,
+                    "roc_auc": 0.6792635658914729,
+                    "pr_auc": 0.5267725874971328
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 68,
+                    "roc_auc": 0.5241596638655462,
+                    "pr_auc": 0.640157296821327
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3050847457627119,
+                    "recall": 1.0,
+                    "f1": 0.4675324675324675,
+                    "support": 18,
+                    "roc_auc": 0.8973429951690821,
+                    "pr_auc": 0.6430817059395572
+                  }
+                ],
+                "macro_precision": 0.17970909965140044,
+                "macro_recall": 0.4861111111111111,
+                "macro_f1": 0.25913054082068165,
+                "weighted_f1": 0.14411094667176613,
+                "macro_roc_auc": 0.7002554083087004,
+                "macro_pr_auc": 0.6033371967526723
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3321786027265479,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.1348436885242497,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    8,
+                    16
+                  ],
+                  [
+                    16,
+                    11,
+                    21
+                  ],
+                  [
+                    7,
+                    6,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.39473684210526316,
+                    "recall": 0.38461538461538464,
+                    "f1": 0.38961038961038963,
+                    "support": 39,
+                    "roc_auc": 0.6004273504273504,
+                    "pr_auc": 0.3678006940044808
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.44,
+                    "recall": 0.22916666666666666,
+                    "f1": 0.3013698630136986,
+                    "support": 48,
+                    "roc_auc": 0.5115740740740741,
+                    "pr_auc": 0.4344289369839449
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.22916666666666666,
+                    "recall": 0.4583333333333333,
+                    "f1": 0.3055555555555555,
+                    "support": 24,
+                    "roc_auc": 0.4966475095785441,
+                    "pr_auc": 0.25806924659883407
+                  }
+                ],
+                "macro_precision": 0.3546345029239766,
+                "macro_recall": 0.3573717948717949,
+                "macro_f1": 0.3321786027265479,
+                "weighted_f1": 0.3332783058810456,
+                "macro_roc_auc": 0.5362163113599895,
+                "macro_pr_auc": 0.35343295919575324
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5646117878676019,
+              "regime_accuracy": 0.6078431606292725,
+              "regime_loss": 1.1372201626545304,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    18,
+                    0
+                  ],
+                  [
+                    11,
+                    43,
+                    6
+                  ],
+                  [
+                    0,
+                    5,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3888888888888889,
+                    "recall": 0.28,
+                    "f1": 0.32558139534883723,
+                    "support": 25,
+                    "roc_auc": 0.5594805194805195,
+                    "pr_auc": 0.4044458579511873
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6515151515151515,
+                    "recall": 0.7166666666666667,
+                    "f1": 0.6825396825396826,
+                    "support": 60,
+                    "roc_auc": 0.6674603174603174,
+                    "pr_auc": 0.7751031962600446
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.7058823529411765,
+                    "f1": 0.6857142857142857,
+                    "support": 17,
+                    "roc_auc": 0.8408304498269896,
+                    "pr_auc": 0.4396488314379761
+                  }
+                ],
+                "macro_precision": 0.569023569023569,
+                "macro_recall": 0.5675163398692811,
+                "macro_f1": 0.5646117878676019,
+                "weighted_f1": 0.5955790067965171,
+                "macro_roc_auc": 0.6892570955892755,
+                "macro_pr_auc": 0.539732628549736
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.312212128370881,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.1263484935051997,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    5,
+                    12
+                  ],
+                  [
+                    21,
+                    3,
+                    18
+                  ],
+                  [
+                    17,
+                    5,
+                    25
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2692307692307692,
+                    "recall": 0.45161290322580644,
+                    "f1": 0.3373493975903614,
+                    "support": 31,
+                    "roc_auc": 0.5472997462848859,
+                    "pr_auc": 0.380875808238178
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.23076923076923078,
+                    "recall": 0.07142857142857142,
+                    "f1": 0.10909090909090909,
+                    "support": 42,
+                    "roc_auc": 0.6114163614163615,
+                    "pr_auc": 0.49952386832422835
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.5319148936170213,
+                    "f1": 0.4901960784313725,
+                    "support": 47,
+                    "roc_auc": 0.5904983969688138,
+                    "pr_auc": 0.40884381280558996
+                  }
+                ],
+                "macro_precision": 0.3181818181818182,
+                "macro_recall": 0.35165212275713303,
+                "macro_f1": 0.312212128370881,
+                "weighted_f1": 0.3173238766116158,
+                "macro_roc_auc": 0.5830715015566871,
+                "macro_pr_auc": 0.42974782978933207
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.343205574912892,
+              "regime_accuracy": 0.5762711763381958,
+              "regime_loss": 0.8396044060335321,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    8,
+                    0
+                  ],
+                  [
+                    0,
+                    7,
+                    6
+                  ],
+                  [
+                    15,
+                    21,
+                    61
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 8,
+                    "roc_auc": 0.8352272727272727,
+                    "pr_auc": 0.1667019585268157
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.19444444444444445,
+                    "recall": 0.5384615384615384,
+                    "f1": 0.28571428571428575,
+                    "support": 13,
+                    "roc_auc": 0.5684981684981685,
+                    "pr_auc": 0.16832196110656014
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9104477611940298,
+                    "recall": 0.6288659793814433,
+                    "f1": 0.7439024390243902,
+                    "support": 97,
+                    "roc_auc": 0.6853215513009328,
+                    "pr_auc": 0.8727500520488817
+                  }
+                ],
+                "macro_precision": 0.3682974018794914,
+                "macro_recall": 0.3891091726143272,
+                "macro_f1": 0.343205574912892,
+                "weighted_f1": 0.6429900194885726,
+                "macro_roc_auc": 0.6963489975087912,
+                "macro_pr_auc": 0.40259132389408586
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3181115181115181,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.1013933696266989,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    19,
+                    5,
+                    0
+                  ],
+                  [
+                    46,
+                    8,
+                    14
+                  ],
+                  [
+                    2,
+                    9,
+                    7
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2835820895522388,
+                    "recall": 0.7916666666666666,
+                    "f1": 0.41758241758241754,
+                    "support": 24,
+                    "roc_auc": 0.6967054263565892,
+                    "pr_auc": 0.5115535299702137
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.36363636363636365,
+                    "recall": 0.11764705882352941,
+                    "f1": 0.17777777777777776,
+                    "support": 68,
+                    "roc_auc": 0.27380952380952384,
+                    "pr_auc": 0.47289214981881883
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.3888888888888889,
+                    "f1": 0.358974358974359,
+                    "support": 18,
+                    "roc_auc": 0.7856280193236715,
+                    "pr_auc": 0.3074171779681713
+                  }
+                ],
+                "macro_precision": 0.32685059550731194,
+                "macro_recall": 0.4327342047930283,
+                "macro_f1": 0.3181115181115181,
+                "weighted_f1": 0.2597491397491397,
+                "macro_roc_auc": 0.5853809898299281,
+                "macro_pr_auc": 0.4306209525857347
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.35454416418271834,
+              "regime_accuracy": 0.36036035418510437,
+              "regime_loss": 1.084553726322626,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    20,
+                    11,
+                    8
+                  ],
+                  [
+                    17,
+                    9,
+                    22
+                  ],
+                  [
+                    7,
+                    6,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.5128205128205128,
+                    "f1": 0.48192771084337344,
+                    "support": 39,
+                    "roc_auc": 0.6132478632478633,
+                    "pr_auc": 0.3846203557056277
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.34615384615384615,
+                    "recall": 0.1875,
+                    "f1": 0.24324324324324323,
+                    "support": 48,
+                    "roc_auc": 0.5046296296296297,
+                    "pr_auc": 0.4617768341901145
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2682926829268293,
+                    "recall": 0.4583333333333333,
+                    "f1": 0.3384615384615385,
+                    "support": 24,
+                    "roc_auc": 0.5589080459770115,
+                    "pr_auc": 0.40233624949283714
+                  }
+                ],
+                "macro_precision": 0.35633066120871,
+                "macro_recall": 0.3862179487179487,
+                "macro_f1": 0.35454416418271834,
+                "weighted_f1": 0.3476930929877853,
+                "macro_roc_auc": 0.5589285129515015,
+                "macro_pr_auc": 0.4162444797961931
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.45215763072905935,
+              "regime_accuracy": 0.4803921580314636,
+              "regime_loss": 1.2351821131312042,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    7,
+                    10
+                  ],
+                  [
+                    16,
+                    28,
+                    16
+                  ],
+                  [
+                    0,
+                    4,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.32,
+                    "f1": 0.32653061224489793,
+                    "support": 25,
+                    "roc_auc": 0.507012987012987,
+                    "pr_auc": 0.25196248980113356
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.717948717948718,
+                    "recall": 0.4666666666666667,
+                    "f1": 0.5656565656565657,
+                    "support": 60,
+                    "roc_auc": 0.6857142857142857,
+                    "pr_auc": 0.7534776354820066
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.7647058823529411,
+                    "f1": 0.4642857142857143,
+                    "support": 17,
+                    "roc_auc": 0.8221453287197232,
+                    "pr_auc": 0.4774356632135303
+                  }
+                ],
+                "macro_precision": 0.4615384615384615,
+                "macro_recall": 0.517124183006536,
+                "macro_f1": 0.45215763072905935,
+                "weighted_f1": 0.49015212145464254,
+                "macro_roc_auc": 0.671624200482332,
+                "macro_pr_auc": 0.49429192949889017
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3892545274659096,
+              "regime_accuracy": 0.44999998807907104,
+              "regime_loss": 1.0857413292397553,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    4,
+                    15
+                  ],
+                  [
+                    13,
+                    5,
+                    24
+                  ],
+                  [
+                    7,
+                    3,
+                    37
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.375,
+                    "recall": 0.3870967741935484,
+                    "f1": 0.38095238095238093,
+                    "support": 31,
+                    "roc_auc": 0.5621602029720913,
+                    "pr_auc": 0.3517128573703392
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4166666666666667,
+                    "recall": 0.11904761904761904,
+                    "f1": 0.18518518518518517,
+                    "support": 42,
+                    "roc_auc": 0.645909645909646,
+                    "pr_auc": 0.47588146707680357
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4868421052631579,
+                    "recall": 0.7872340425531915,
+                    "f1": 0.6016260162601627,
+                    "support": 47,
+                    "roc_auc": 0.6514135820460507,
+                    "pr_auc": 0.4480626645390351
+                  }
+                ],
+                "macro_precision": 0.4261695906432748,
+                "macro_recall": 0.4311261452647863,
+                "macro_f1": 0.3892545274659096,
+                "weighted_f1": 0.3988643695960769,
+                "macro_roc_auc": 0.6198278103092627,
+                "macro_pr_auc": 0.425218996328726
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.33016036360517964,
+              "regime_accuracy": 0.6186440587043762,
+              "regime_loss": 0.7560568340754105,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    8,
+                    0
+                  ],
+                  [
+                    6,
+                    4,
+                    3
+                  ],
+                  [
+                    7,
+                    21,
+                    69
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 8,
+                    "roc_auc": 0.8602272727272727,
+                    "pr_auc": 0.18640184365063653
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.12121212121212122,
+                    "recall": 0.3076923076923077,
+                    "f1": 0.17391304347826086,
+                    "support": 13,
+                    "roc_auc": 0.5875457875457876,
+                    "pr_auc": 0.15485605606838307
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9583333333333334,
+                    "recall": 0.711340206185567,
+                    "f1": 0.8165680473372781,
+                    "support": 97,
+                    "roc_auc": 0.7466863033873343,
+                    "pr_auc": 0.9287093500446898
+                  }
+                ],
+                "macro_precision": 0.35984848484848486,
+                "macro_recall": 0.3396775046259582,
+                "macro_f1": 0.33016036360517964,
+                "weighted_f1": 0.6904065267536725,
+                "macro_roc_auc": 0.7314864545534648,
+                "macro_pr_auc": 0.4233224165879031
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4994762892895321,
+              "regime_accuracy": 0.4909090995788574,
+              "regime_loss": 1.1855406832590278,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    4,
+                    3
+                  ],
+                  [
+                    21,
+                    21,
+                    26
+                  ],
+                  [
+                    0,
+                    2,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4473684210526316,
+                    "recall": 0.7083333333333334,
+                    "f1": 0.5483870967741936,
+                    "support": 24,
+                    "roc_auc": 0.7553294573643411,
+                    "pr_auc": 0.35240181482193655
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7777777777777778,
+                    "recall": 0.3088235294117647,
+                    "f1": 0.44210526315789467,
+                    "support": 68,
+                    "roc_auc": 0.4950980392156863,
+                    "pr_auc": 0.687101792092182
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.35555555555555557,
+                    "recall": 0.8888888888888888,
+                    "f1": 0.5079365079365079,
+                    "support": 18,
+                    "roc_auc": 0.7705314009661836,
+                    "pr_auc": 0.26842881396641105
+                  }
+                ],
+                "macro_precision": 0.5269005847953216,
+                "macro_recall": 0.6353485838779956,
+                "macro_f1": 0.4994762892895321,
+                "weighted_f1": 0.4760664123652239,
+                "macro_roc_auc": 0.673652965848737,
+                "macro_pr_auc": 0.4359774736268432
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.31539033838733677,
+              "regime_accuracy": 0.342342346906662,
+              "regime_loss": 1.1374607605302112,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    24,
+                    2,
+                    13
+                  ],
+                  [
+                    20,
+                    4,
+                    24
+                  ],
+                  [
+                    7,
+                    7,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.47058823529411764,
+                    "recall": 0.6153846153846154,
+                    "f1": 0.5333333333333333,
+                    "support": 39,
+                    "roc_auc": 0.6125356125356125,
+                    "pr_auc": 0.3775344198007435
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.13114754098360656,
+                    "support": 48,
+                    "roc_auc": 0.4603174603174603,
+                    "pr_auc": 0.39016931491148205
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2127659574468085,
+                    "recall": 0.4166666666666667,
+                    "f1": 0.28169014084507044,
+                    "support": 24,
+                    "roc_auc": 0.5359195402298851,
+                    "pr_auc": 0.36598566378792385
+                  }
+                ],
+                "macro_precision": 0.33034883347774463,
+                "macro_recall": 0.3717948717948718,
+                "macro_f1": 0.31539033838733677,
+                "weighted_f1": 0.30500581394139464,
+                "macro_roc_auc": 0.5362575376943193,
+                "macro_pr_auc": 0.3778964661667164
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.44915022501541046,
+              "regime_accuracy": 0.46078431606292725,
+              "regime_loss": 1.1408236561260099,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    11,
+                    3,
+                    11
+                  ],
+                  [
+                    23,
+                    24,
+                    13
+                  ],
+                  [
+                    0,
+                    5,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3235294117647059,
+                    "recall": 0.44,
+                    "f1": 0.3728813559322034,
+                    "support": 25,
+                    "roc_auc": 0.5142857142857142,
+                    "pr_auc": 0.289369703514945
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.75,
+                    "recall": 0.4,
+                    "f1": 0.5217391304347827,
+                    "support": 60,
+                    "roc_auc": 0.7031746031746032,
+                    "pr_auc": 0.8017706806972879
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.7058823529411765,
+                    "f1": 0.45283018867924524,
+                    "support": 17,
+                    "roc_auc": 0.8173010380622837,
+                    "pr_auc": 0.43168736392296697
+                  }
+                ],
+                "macro_precision": 0.468954248366013,
+                "macro_recall": 0.5152941176470588,
+                "macro_f1": 0.44915022501541046,
+                "weighted_f1": 0.4737695581562668,
+                "macro_roc_auc": 0.6782537851742004,
+                "macro_pr_auc": 0.5076092493784
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3849465877389944,
+              "regime_accuracy": 0.3916666805744171,
+              "regime_loss": 1.1520360399490952,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    5,
+                    13
+                  ],
+                  [
+                    12,
+                    12,
+                    18
+                  ],
+                  [
+                    13,
+                    12,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.34210526315789475,
+                    "recall": 0.41935483870967744,
+                    "f1": 0.3768115942028986,
+                    "support": 31,
+                    "roc_auc": 0.6027546212395796,
+                    "pr_auc": 0.41519727200275003
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.41379310344827586,
+                    "recall": 0.2857142857142857,
+                    "f1": 0.3380281690140845,
+                    "support": 42,
+                    "roc_auc": 0.5815018315018315,
+                    "pr_auc": 0.40171706668936175
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.41509433962264153,
+                    "recall": 0.46808510638297873,
+                    "f1": 0.44,
+                    "support": 47,
+                    "roc_auc": 0.5904983969688138,
+                    "pr_auc": 0.4080226367952702
+                  }
+                ],
+                "macro_precision": 0.3903309020762707,
+                "macro_recall": 0.3910514102689806,
+                "macro_f1": 0.3849465877389944,
+                "weighted_f1": 0.38798618765734505,
+                "macro_roc_auc": 0.5915849499034084,
+                "macro_pr_auc": 0.4083123251624607
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.34982454053411055,
+              "regime_accuracy": 0.6016949415206909,
+              "regime_loss": 0.8070151876595061,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    1,
+                    6,
+                    1
+                  ],
+                  [
+                    3,
+                    4,
+                    6
+                  ],
+                  [
+                    11,
+                    20,
+                    66
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.06666666666666667,
+                    "recall": 0.125,
+                    "f1": 0.08695652173913045,
+                    "support": 8,
+                    "roc_auc": 0.8227272727272728,
+                    "pr_auc": 0.15648655220660831
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.13333333333333333,
+                    "recall": 0.3076923076923077,
+                    "f1": 0.18604651162790697,
+                    "support": 13,
+                    "roc_auc": 0.5941391941391941,
+                    "pr_auc": 0.13078535766756588
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9041095890410958,
+                    "recall": 0.6804123711340206,
+                    "f1": 0.7764705882352942,
+                    "support": 97,
+                    "roc_auc": 0.7025036818851251,
+                    "pr_auc": 0.9072242198733448
+                  }
+                ],
+                "macro_precision": 0.3680365296803653,
+                "macro_recall": 0.37103489294210945,
+                "macro_f1": 0.34982454053411055,
+                "weighted_f1": 0.6646771515584692,
+                "macro_roc_auc": 0.7064567162505306,
+                "macro_pr_auc": 0.39816537658250634
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.46286472148541113,
+              "regime_accuracy": 0.4545454680919647,
+              "regime_loss": 1.081565604165966,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    10,
+                    0
+                  ],
+                  [
+                    20,
+                    22,
+                    26
+                  ],
+                  [
+                    0,
+                    4,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4117647058823529,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.4827586206896552,
+                    "support": 24,
+                    "roc_auc": 0.7592054263565892,
+                    "pr_auc": 0.4878005498145237
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6111111111111112,
+                    "recall": 0.3235294117647059,
+                    "f1": 0.42307692307692313,
+                    "support": 68,
+                    "roc_auc": 0.35714285714285715,
+                    "pr_auc": 0.5103812872246862
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.35,
+                    "recall": 0.7777777777777778,
+                    "f1": 0.48275862068965514,
+                    "support": 18,
+                    "roc_auc": 0.8176328502415459,
+                    "pr_auc": 0.321164611528764
+                  }
+                ],
+                "macro_precision": 0.4576252723311547,
+                "macro_recall": 0.5615468409586056,
+                "macro_f1": 0.46286472148541113,
+                "weighted_f1": 0.445864480347239,
+                "macro_roc_auc": 0.644660377913664,
+                "macro_pr_auc": 0.439782149522658
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3182020101060581,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.089264907505211,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    21,
+                    10,
+                    8
+                  ],
+                  [
+                    22,
+                    8,
+                    18
+                  ],
+                  [
+                    10,
+                    6,
+                    8
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.39622641509433965,
+                    "recall": 0.5384615384615384,
+                    "f1": 0.4565217391304348,
+                    "support": 39,
+                    "roc_auc": 0.5726495726495726,
+                    "pr_auc": 0.35403425780341485
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.16666666666666666,
+                    "f1": 0.2222222222222222,
+                    "support": 48,
+                    "roc_auc": 0.5152116402116402,
+                    "pr_auc": 0.44426629900338904
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.23529411764705882,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.27586206896551724,
+                    "support": 24,
+                    "roc_auc": 0.5416666666666666,
+                    "pr_auc": 0.32008158197493075
+                  }
+                ],
+                "macro_precision": 0.32161795535824395,
+                "macro_recall": 0.3461538461538461,
+                "macro_f1": 0.3182020101060581,
+                "weighted_f1": 0.3161414788101445,
+                "macro_roc_auc": 0.5431759598426265,
+                "macro_pr_auc": 0.37279404626057816
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.5036750483558994,
+              "regime_accuracy": 0.529411792755127,
+              "regime_loss": 1.0925210388302415,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    4,
+                    11
+                  ],
+                  [
+                    17,
+                    30,
+                    13
+                  ],
+                  [
+                    3,
+                    0,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.4,
+                    "f1": 0.3636363636363636,
+                    "support": 25,
+                    "roc_auc": 0.5709090909090909,
+                    "pr_auc": 0.5264216443344395
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8823529411764706,
+                    "recall": 0.5,
+                    "f1": 0.6382978723404256,
+                    "support": 60,
+                    "roc_auc": 0.7452380952380953,
+                    "pr_auc": 0.7713531791429182
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3684210526315789,
+                    "recall": 0.8235294117647058,
+                    "f1": 0.509090909090909,
+                    "support": 17,
+                    "roc_auc": 0.8546712802768166,
+                    "pr_auc": 0.6103433521412774
+                  }
+                ],
+                "macro_precision": 0.5280357757137942,
+                "macro_recall": 0.5745098039215687,
+                "macro_f1": 0.5036750483558994,
+                "weighted_f1": 0.5494443812341184,
+                "macro_roc_auc": 0.7236061554746676,
+                "macro_pr_auc": 0.6360393918728784
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "regression": [
+      {
+        "head_mode": "regression",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.36202274867782364,
+              "regime_accuracy": 0.4333333373069763,
+              "regime_loss": 1.1019634102706972,
+              "regression_rmse_log_rv": 0.7896501260093822,
+              "regression_mae_log_rv": 0.6470154760327811,
+              "regression_loss": 0.6235473215066333,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    27,
+                    4,
+                    0
+                  ],
+                  [
+                    17,
+                    25,
+                    0
+                  ],
+                  [
+                    32,
+                    15,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35526315789473684,
+                    "recall": 0.8709677419354839,
+                    "f1": 0.5046728971962617,
+                    "support": 31,
+                    "roc_auc": 0.708590068865531,
+                    "pr_auc": 0.46819474586903753
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5681818181818182,
+                    "recall": 0.5952380952380952,
+                    "f1": 0.5813953488372093,
+                    "support": 42,
+                    "roc_auc": 0.6623931623931624,
+                    "pr_auc": 0.5203341300176005
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.663071990673273,
+                    "pr_auc": 0.6217803917588969
+                  }
+                ],
+                "macro_precision": 0.3078149920255184,
+                "macro_recall": 0.4887352790578597,
+                "macro_f1": 0.36202274867782364,
+                "weighted_f1": 0.3338622038687242,
+                "macro_roc_auc": 0.6780184073106555,
+                "macro_pr_auc": 0.5367697558818451
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.08333333333333333,
+              "regime_accuracy": 0.11016949266195297,
+              "regime_loss": 1.3491792658628043,
+              "regression_rmse_log_rv": 0.8323919677189845,
+              "regression_mae_log_rv": 0.668235635534876,
+              "regression_loss": 0.6928763879230829,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    8,
+                    0
+                  ],
+                  [
+                    0,
+                    13,
+                    0
+                  ],
+                  [
+                    27,
+                    70,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 8,
+                    "roc_auc": 0.5806818181818182,
+                    "pr_auc": 0.07471679014569405
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.14285714285714285,
+                    "recall": 1.0,
+                    "f1": 0.25,
+                    "support": 13,
+                    "roc_auc": 0.8234432234432234,
+                    "pr_auc": 0.7402130437593974
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 97,
+                    "roc_auc": 0.5233186057928326,
+                    "pr_auc": 0.8597156066054835
+                  }
+                ],
+                "macro_precision": 0.047619047619047616,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.08333333333333333,
+                "weighted_f1": 0.02754237288135593,
+                "macro_roc_auc": 0.6424812158059581,
+                "macro_pr_auc": 0.5582151468368584
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.23790849673202616,
+              "regime_accuracy": 0.3272727131843567,
+              "regime_loss": 1.0935630253825637,
+              "regression_rmse_log_rv": 0.746062134475357,
+              "regression_mae_log_rv": 0.6324638374149799,
+              "regression_loss": 0.5566087084979255,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    20,
+                    4,
+                    0
+                  ],
+                  [
+                    52,
+                    16,
+                    0
+                  ],
+                  [
+                    4,
+                    14,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2631578947368421,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.39999999999999997,
+                    "support": 24,
+                    "roc_auc": 0.5557170542635659,
+                    "pr_auc": 0.2543930330859138
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.47058823529411764,
+                    "recall": 0.23529411764705882,
+                    "f1": 0.3137254901960785,
+                    "support": 68,
+                    "roc_auc": 0.3389355742296919,
+                    "pr_auc": 0.5458150212246939
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 18,
+                    "roc_auc": 0.11896135265700483,
+                    "pr_auc": 0.09181800038805976
+                  }
+                ],
+                "macro_precision": 0.24458204334365327,
+                "macro_recall": 0.3562091503267974,
+                "macro_f1": 0.23790849673202616,
+                "weighted_f1": 0.28121212121212125,
+                "macro_roc_auc": 0.33787132705008754,
+                "macro_pr_auc": 0.2973420182328892
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2865013774104683,
+              "regime_accuracy": 0.3963963985443115,
+              "regime_loss": 1.0755636272183657,
+              "regression_rmse_log_rv": 0.8739158327925358,
+              "regression_mae_log_rv": 0.6995078912550198,
+              "regression_loss": 0.7637288828054714,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    25,
+                    0
+                  ],
+                  [
+                    18,
+                    30,
+                    0
+                  ],
+                  [
+                    6,
+                    18,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3684210526315789,
+                    "recall": 0.358974358974359,
+                    "f1": 0.36363636363636365,
+                    "support": 39,
+                    "roc_auc": 0.5227920227920227,
+                    "pr_auc": 0.3364387429407976
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.410958904109589,
+                    "recall": 0.625,
+                    "f1": 0.49586776859504134,
+                    "support": 48,
+                    "roc_auc": 0.5076058201058201,
+                    "pr_auc": 0.4723871348157913
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 24,
+                    "roc_auc": 0.5483716475095786,
+                    "pr_auc": 0.23857860515151233
+                  }
+                ],
+                "macro_precision": 0.25979331891372265,
+                "macro_recall": 0.327991452991453,
+                "macro_f1": 0.2865013774104683,
+                "weighted_f1": 0.342193433102524,
+                "macro_roc_auc": 0.5262564968024738,
+                "macro_pr_auc": 0.34913482763603376
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.2902097902097902,
+              "regime_accuracy": 0.5,
+              "regime_loss": 1.0776876638688466,
+              "regression_rmse_log_rv": 0.6630115774039035,
+              "regression_mae_log_rv": 0.503442493500188,
+              "regression_loss": 0.43958435177161226,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    20,
+                    0
+                  ],
+                  [
+                    14,
+                    46,
+                    0
+                  ],
+                  [
+                    0,
+                    17,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2631578947368421,
+                    "recall": 0.2,
+                    "f1": 0.22727272727272727,
+                    "support": 25,
+                    "roc_auc": 0.655064935064935,
+                    "pr_auc": 0.3173714717732065
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5542168674698795,
+                    "recall": 0.7666666666666667,
+                    "f1": 0.6433566433566433,
+                    "support": 60,
+                    "roc_auc": 0.2781746031746032,
+                    "pr_auc": 0.4605227159517329
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 17,
+                    "roc_auc": 0.2664359861591695,
+                    "pr_auc": 0.1084996024718185
+                  }
+                ],
+                "macro_precision": 0.27245825406890717,
+                "macro_recall": 0.32222222222222224,
+                "macro_f1": 0.2902097902097902,
+                "weighted_f1": 0.43414918414918413,
+                "macro_roc_auc": 0.39989184146623585,
+                "macro_pr_auc": 0.2954645967322526
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.31004609260423216,
+              "regime_accuracy": 0.3083333373069763,
+              "regime_loss": 1.1382340341071517,
+              "regression_rmse_log_rv": 0.8843210647274415,
+              "regression_mae_log_rv": 0.7178280990493173,
+              "regression_loss": 0.7820237455206758,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    12,
+                    7
+                  ],
+                  [
+                    19,
+                    11,
+                    12
+                  ],
+                  [
+                    12,
+                    21,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.27906976744186046,
+                    "recall": 0.3870967741935484,
+                    "f1": 0.32432432432432434,
+                    "support": 31,
+                    "roc_auc": 0.5418629938383472,
+                    "pr_auc": 0.26869723865730427
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.2619047619047619,
+                    "f1": 0.2558139534883721,
+                    "support": 42,
+                    "roc_auc": 0.3263125763125763,
+                    "pr_auc": 0.25560087561791817
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.42424242424242425,
+                    "recall": 0.2978723404255319,
+                    "f1": 0.35,
+                    "support": 47,
+                    "roc_auc": 0.3614106674438939,
+                    "pr_auc": 0.312583732863161
+                  }
+                ],
+                "macro_precision": 0.31777073056142824,
+                "macro_recall": 0.3156246255079474,
+                "macro_f1": 0.31004609260423216,
+                "weighted_f1": 0.31040200083804736,
+                "macro_roc_auc": 0.4098620791982725,
+                "macro_pr_auc": 0.27896061571279446
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.42771084337349397,
+              "regime_accuracy": 0.6186440587043762,
+              "regime_loss": 1.0821298118365013,
+              "regression_rmse_log_rv": 0.8110195532844873,
+              "regression_mae_log_rv": 0.6585130519786123,
+              "regression_loss": 0.6577527158097694,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    0,
+                    3
+                  ],
+                  [
+                    9,
+                    3,
+                    1
+                  ],
+                  [
+                    28,
+                    4,
+                    65
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.11904761904761904,
+                    "recall": 0.625,
+                    "f1": 0.19999999999999998,
+                    "support": 8,
+                    "roc_auc": 0.5522727272727272,
+                    "pr_auc": 0.07221707566810869
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.3,
+                    "support": 13,
+                    "roc_auc": 0.5069597069597069,
+                    "pr_auc": 0.11971673412416176
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9420289855072463,
+                    "recall": 0.6701030927835051,
+                    "f1": 0.7831325301204819,
+                    "support": 97,
+                    "roc_auc": 0.7903780068728522,
+                    "pr_auc": 0.9578630088998233
+                  }
+                ],
+                "macro_precision": 0.49654934437543136,
+                "macro_recall": 0.5086241078509119,
+                "macro_f1": 0.42771084337349397,
+                "weighted_f1": 0.6903716561159894,
+                "macro_roc_auc": 0.616536813701762,
+                "macro_pr_auc": 0.3832656062306979
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.19724325373713839,
+              "regime_accuracy": 0.2181818187236786,
+              "regime_loss": 1.1330714952498073,
+              "regression_rmse_log_rv": 0.4740927654811497,
+              "regression_mae_log_rv": 0.3713868915696036,
+              "regression_loss": 0.22476395028156443,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    0,
+                    18
+                  ],
+                  [
+                    21,
+                    0,
+                    47
+                  ],
+                  [
+                    0,
+                    0,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.25,
+                    "f1": 0.23529411764705882,
+                    "support": 24,
+                    "roc_auc": 0.5571705426356589,
+                    "pr_auc": 0.36310558743104776
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 68,
+                    "roc_auc": 0.7489495798319328,
+                    "pr_auc": 0.8510404926764467
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21686746987951808,
+                    "recall": 1.0,
+                    "f1": 0.3564356435643564,
+                    "support": 18,
+                    "roc_auc": 0.6859903381642513,
+                    "pr_auc": 0.21825129578605726
+                  }
+                ],
+                "macro_precision": 0.1463632307005801,
+                "macro_recall": 0.4166666666666667,
+                "macro_f1": 0.19724325373713839,
+                "weighted_f1": 0.10966273097898024,
+                "macro_roc_auc": 0.6640368202106143,
+                "macro_pr_auc": 0.47746579196451727
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.28654970760233917,
+              "regime_accuracy": 0.29729729890823364,
+              "regime_loss": 1.1124887113958557,
+              "regression_rmse_log_rv": 0.8729294790672176,
+              "regression_mae_log_rv": 0.7218601281150572,
+              "regression_loss": 0.7620058754245639,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    0,
+                    30
+                  ],
+                  [
+                    6,
+                    6,
+                    36
+                  ],
+                  [
+                    3,
+                    3,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.3157894736842105,
+                    "support": 39,
+                    "roc_auc": 0.6506410256410257,
+                    "pr_auc": 0.4503776012636599
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.125,
+                    "f1": 0.21052631578947367,
+                    "support": 48,
+                    "roc_auc": 0.611441798941799,
+                    "pr_auc": 0.5790447019522251
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21428571428571427,
+                    "recall": 0.75,
+                    "f1": 0.3333333333333333,
+                    "support": 24,
+                    "roc_auc": 0.40229885057471265,
+                    "pr_auc": 0.16825742375225788
+                  }
+                ],
+                "macro_precision": 0.4603174603174603,
+                "macro_recall": 0.3685897435897436,
+                "macro_f1": 0.28654970760233917,
+                "weighted_f1": 0.27406353722143195,
+                "macro_roc_auc": 0.5547938917191791,
+                "macro_pr_auc": 0.39922657565604763
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.38504864311315923,
+              "regime_accuracy": 0.5490196347236633,
+              "regime_loss": 1.0542388221175665,
+              "regression_rmse_log_rv": 0.7536951501188446,
+              "regression_mae_log_rv": 0.592729088754448,
+              "regression_loss": 0.5680563793126677,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    5,
+                    14
+                  ],
+                  [
+                    10,
+                    48,
+                    2
+                  ],
+                  [
+                    4,
+                    11,
+                    2
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3,
+                    "recall": 0.24,
+                    "f1": 0.2666666666666666,
+                    "support": 25,
+                    "roc_auc": 0.6254545454545455,
+                    "pr_auc": 0.32607987543873806
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.75,
+                    "recall": 0.8,
+                    "f1": 0.7741935483870969,
+                    "support": 60,
+                    "roc_auc": 0.7075396825396826,
+                    "pr_auc": 0.6789645747705486
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1111111111111111,
+                    "recall": 0.11764705882352941,
+                    "f1": 0.11428571428571428,
+                    "support": 17,
+                    "roc_auc": 0.4027681660899654,
+                    "pr_auc": 0.1374152878056552
+                  }
+                ],
+                "macro_precision": 0.387037037037037,
+                "macro_recall": 0.3858823529411765,
+                "macro_f1": 0.38504864311315923,
+                "weighted_f1": 0.5398150658112708,
+                "macro_roc_auc": 0.5785874646947312,
+                "macro_pr_auc": 0.38081991267164733
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.23896103896103896,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.09709928352977,
+              "regression_rmse_log_rv": 0.8802278677935873,
+              "regression_mae_log_rv": 0.6874002430044736,
+              "regression_loss": 0.774801099240445,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    6,
+                    25
+                  ],
+                  [
+                    0,
+                    4,
+                    38
+                  ],
+                  [
+                    0,
+                    3,
+                    44
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 31,
+                    "roc_auc": 0.51830373323668,
+                    "pr_auc": 0.29787662554400446
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.09523809523809523,
+                    "f1": 0.14545454545454545,
+                    "support": 42,
+                    "roc_auc": 0.3153235653235653,
+                    "pr_auc": 0.25871687624328843
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.411214953271028,
+                    "recall": 0.9361702127659575,
+                    "f1": 0.5714285714285714,
+                    "support": 47,
+                    "roc_auc": 0.5118041387350627,
+                    "pr_auc": 0.3732099716647326
+                  }
+                ],
+                "macro_precision": 0.23963575365444525,
+                "macro_recall": 0.3438027693346843,
+                "macro_f1": 0.23896103896103896,
+                "weighted_f1": 0.2747186147186147,
+                "macro_roc_auc": 0.44847714576510267,
+                "macro_pr_auc": 0.3099344911506752
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.18143459915611815,
+              "regime_accuracy": 0.3644067943096161,
+              "regime_loss": 0.9960427617622634,
+              "regression_rmse_log_rv": 0.7972464349800383,
+              "regression_mae_log_rv": 0.6615172547556586,
+              "regression_loss": 0.6356018780883805,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    8
+                  ],
+                  [
+                    3,
+                    0,
+                    10
+                  ],
+                  [
+                    8,
+                    46,
+                    43
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 8,
+                    "roc_auc": 0.4784090909090909,
+                    "pr_auc": 0.059936172893423775
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 13,
+                    "roc_auc": 0.210989010989011,
+                    "pr_auc": 0.06957933873317891
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.7049180327868853,
+                    "recall": 0.44329896907216493,
+                    "f1": 0.5443037974683544,
+                    "support": 97,
+                    "roc_auc": 0.41973490427098675,
+                    "pr_auc": 0.7756674082537126
+                  }
+                ],
+                "macro_precision": 0.23497267759562843,
+                "macro_recall": 0.14776632302405499,
+                "macro_f1": 0.18143459915611815,
+                "weighted_f1": 0.4474361724951727,
+                "macro_roc_auc": 0.3697110020563629,
+                "macro_pr_auc": 0.3017276399601051
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.20060374389628602,
+              "regime_accuracy": 0.2181818187236786,
+              "regime_loss": 1.1239051004332024,
+              "regression_rmse_log_rv": 0.6384302221690742,
+              "regression_mae_log_rv": 0.522551054194231,
+              "regression_loss": 0.40759314857885337,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    0,
+                    21
+                  ],
+                  [
+                    0,
+                    3,
+                    65
+                  ],
+                  [
+                    0,
+                    0,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 1.0,
+                    "recall": 0.125,
+                    "f1": 0.2222222222222222,
+                    "support": 24,
+                    "roc_auc": 0.6216085271317829,
+                    "pr_auc": 0.46213537245572545
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.04411764705882353,
+                    "f1": 0.08450704225352113,
+                    "support": 68,
+                    "roc_auc": 0.6242997198879552,
+                    "pr_auc": 0.7501500519384664
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.17307692307692307,
+                    "recall": 1.0,
+                    "f1": 0.29508196721311475,
+                    "support": 18,
+                    "roc_auc": 0.5839371980676329,
+                    "pr_auc": 0.23376828269638383
+                  }
+                ],
+                "macro_precision": 0.7243589743589743,
+                "macro_recall": 0.3897058823529412,
+                "macro_f1": 0.20060374389628602,
+                "weighted_f1": 0.14901170560371668,
+                "macro_roc_auc": 0.6099484816957904,
+                "macro_pr_auc": 0.4820179023635252
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.14715447154471542,
+              "regime_accuracy": 0.21621622145175934,
+              "regime_loss": 1.2044805030047847,
+              "regression_rmse_log_rv": 0.9101884344808552,
+              "regression_mae_log_rv": 0.7254027107118016,
+              "regression_loss": 0.82844298626271,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    6,
+                    33
+                  ],
+                  [
+                    0,
+                    3,
+                    45
+                  ],
+                  [
+                    0,
+                    3,
+                    21
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 39,
+                    "roc_auc": 0.37037037037037035,
+                    "pr_auc": 0.3184774213282567
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.0625,
+                    "f1": 0.1,
+                    "support": 48,
+                    "roc_auc": 0.5023148148148148,
+                    "pr_auc": 0.41196664828362967
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.21212121212121213,
+                    "recall": 0.875,
+                    "f1": 0.3414634146341463,
+                    "support": 24,
+                    "roc_auc": 0.5067049808429118,
+                    "pr_auc": 0.2272211792748689
+                  }
+                ],
+                "macro_precision": 0.15404040404040406,
+                "macro_recall": 0.3125,
+                "macro_f1": 0.14715447154471542,
+                "weighted_f1": 0.11707317073170732,
+                "macro_roc_auc": 0.45979672200936567,
+                "macro_pr_auc": 0.3192217496289184
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.08259587020648967,
+              "regime_accuracy": 0.13725490868091583,
+              "regime_loss": 1.1836244172192887,
+              "regression_rmse_log_rv": 0.7056408919480924,
+              "regression_mae_log_rv": 0.5544728825380113,
+              "regression_loss": 0.49792906838929946,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    25
+                  ],
+                  [
+                    3,
+                    0,
+                    57
+                  ],
+                  [
+                    0,
+                    3,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 25,
+                    "roc_auc": 0.3537662337662338,
+                    "pr_auc": 0.2157003248114197
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 60,
+                    "roc_auc": 0.26587301587301587,
+                    "pr_auc": 0.48258259483387134
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.14583333333333334,
+                    "recall": 0.8235294117647058,
+                    "f1": 0.24778761061946902,
+                    "support": 17,
+                    "roc_auc": 0.17301038062283736,
+                    "pr_auc": 0.10107888669771564
+                  }
+                ],
+                "macro_precision": 0.04861111111111111,
+                "macro_recall": 0.2745098039215686,
+                "macro_f1": 0.08259587020648967,
+                "weighted_f1": 0.041297935103244844,
+                "macro_roc_auc": 0.26421654342069567,
+                "macro_pr_auc": 0.2664539354476689
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.29914529914529914,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.0978498329603623,
+              "regression_rmse_log_rv": 0.9680269731958419,
+              "regression_mae_log_rv": 0.7750067879989122,
+              "regression_loss": 0.9370762208347031,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    28,
+                    0,
+                    3
+                  ],
+                  [
+                    28,
+                    14,
+                    0
+                  ],
+                  [
+                    43,
+                    4,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2828282828282828,
+                    "recall": 0.9032258064516129,
+                    "f1": 0.43076923076923074,
+                    "support": 31,
+                    "roc_auc": 0.5498368974266038,
+                    "pr_auc": 0.2599363479480967
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7777777777777778,
+                    "recall": 0.3333333333333333,
+                    "f1": 0.4666666666666666,
+                    "support": 42,
+                    "roc_auc": 0.7231379731379731,
+                    "pr_auc": 0.6774831062414052
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.6435441562226756,
+                    "pr_auc": 0.4767520422810778
+                  }
+                ],
+                "macro_precision": 0.35353535353535354,
+                "macro_recall": 0.4121863799283154,
+                "macro_f1": 0.29914529914529914,
+                "weighted_f1": 0.2746153846153846,
+                "macro_roc_auc": 0.6388396755957508,
+                "macro_pr_auc": 0.4713904988235266
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.11703703703703705,
+              "regime_accuracy": 0.0762711837887764,
+              "regime_loss": 1.194120704117468,
+              "regression_rmse_log_rv": 0.6675605649462962,
+              "regression_mae_log_rv": 0.536705018352654,
+              "regression_loss": 0.44563710787141814,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    2,
+                    0
+                  ],
+                  [
+                    4,
+                    3,
+                    6
+                  ],
+                  [
+                    90,
+                    7,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.06,
+                    "recall": 0.75,
+                    "f1": 0.1111111111111111,
+                    "support": 8,
+                    "roc_auc": 0.18522727272727274,
+                    "pr_auc": 0.040156984123618206
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.23076923076923078,
+                    "f1": 0.24000000000000002,
+                    "support": 13,
+                    "roc_auc": 0.6871794871794872,
+                    "pr_auc": 0.16511114541812838
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 97,
+                    "roc_auc": 0.06381934216985763,
+                    "pr_auc": 0.6407870365597889
+                  }
+                ],
+                "macro_precision": 0.10333333333333333,
+                "macro_recall": 0.3269230769230769,
+                "macro_f1": 0.11703703703703705,
+                "weighted_f1": 0.03397363465160075,
+                "macro_roc_auc": 0.31207536735887254,
+                "macro_pr_auc": 0.2820183887005118
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.43251811594202905,
+              "regime_accuracy": 0.4272727370262146,
+              "regime_loss": 1.1368790915526197,
+              "regression_rmse_log_rv": 0.5405024651799619,
+              "regression_mae_log_rv": 0.4000669746913693,
+              "regression_loss": 0.292142914865616,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    6,
+                    4
+                  ],
+                  [
+                    23,
+                    18,
+                    27
+                  ],
+                  [
+                    3,
+                    0,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.4375,
+                    "support": 24,
+                    "roc_auc": 0.46124031007751937,
+                    "pr_auc": 0.2328285696769251
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.75,
+                    "recall": 0.2647058823529412,
+                    "f1": 0.39130434782608703,
+                    "support": 68,
+                    "roc_auc": 0.5612745098039216,
+                    "pr_auc": 0.6482225107110156
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.32608695652173914,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.46875000000000006,
+                    "support": 18,
+                    "roc_auc": 0.8218599033816425,
+                    "pr_auc": 0.33490134753595396
+                  }
+                ],
+                "macro_precision": 0.4753623188405797,
+                "macro_recall": 0.5604575163398693,
+                "macro_f1": 0.43251811594202905,
+                "weighted_f1": 0.414056324110672,
+                "macro_roc_auc": 0.6147915744210278,
+                "macro_pr_auc": 0.4053174759746316
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.20702754036087367,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.0999508263081343,
+              "regression_rmse_log_rv": 0.8460054089537691,
+              "regression_mae_log_rv": 0.6842984193390621,
+              "regression_loss": 0.715725151979034,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    35,
+                    0,
+                    4
+                  ],
+                  [
+                    39,
+                    0,
+                    9
+                  ],
+                  [
+                    22,
+                    0,
+                    2
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3645833333333333,
+                    "recall": 0.8974358974358975,
+                    "f1": 0.5185185185185185,
+                    "support": 39,
+                    "roc_auc": 0.6153846153846154,
+                    "pr_auc": 0.5178079682829252
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 48,
+                    "roc_auc": 0.42956349206349204,
+                    "pr_auc": 0.4080869025927242
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.13333333333333333,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.10256410256410255,
+                    "support": 24,
+                    "roc_auc": 0.5110153256704981,
+                    "pr_auc": 0.20819602707354065
+                  }
+                ],
+                "macro_precision": 0.16597222222222222,
+                "macro_recall": 0.3269230769230769,
+                "macro_f1": 0.20702754036087367,
+                "weighted_f1": 0.20435820435820434,
+                "macro_roc_auc": 0.5186544777062019,
+                "macro_pr_auc": 0.37803029931639665
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.1718020541549953,
+              "regime_accuracy": 0.27450981736183167,
+              "regime_loss": 1.142253752778454,
+              "regression_rmse_log_rv": 0.6687437961861039,
+              "regression_mae_log_rv": 0.537902226009607,
+              "regression_loss": 0.4472182649374013,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    25,
+                    0,
+                    0
+                  ],
+                  [
+                    52,
+                    3,
+                    5
+                  ],
+                  [
+                    17,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.26595744680851063,
+                    "recall": 1.0,
+                    "f1": 0.42016806722689076,
+                    "support": 25,
+                    "roc_auc": 0.4737662337662338,
+                    "pr_auc": 0.2321422513388016
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.05,
+                    "f1": 0.09523809523809523,
+                    "support": 60,
+                    "roc_auc": 0.5599206349206349,
+                    "pr_auc": 0.6325874565594615
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 17,
+                    "roc_auc": 0.44567474048442907,
+                    "pr_auc": 0.16629083978160258
+                  }
+                ],
+                "macro_precision": 0.4219858156028369,
+                "macro_recall": 0.35000000000000003,
+                "macro_f1": 0.1718020541549953,
+                "weighted_f1": 0.159004778381941,
+                "macro_roc_auc": 0.4931205363904326,
+                "macro_pr_auc": 0.3436735158932886
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.26184721306672526,
+              "regime_accuracy": 0.32499998807907104,
+              "regime_loss": 1.1157615674397021,
+              "regression_rmse_log_rv": 0.878758155649609,
+              "regression_mae_log_rv": 0.7253816717226679,
+              "regression_loss": 0.7722158961207024,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    5,
+                    0
+                  ],
+                  [
+                    29,
+                    13,
+                    0
+                  ],
+                  [
+                    25,
+                    22,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.325,
+                    "recall": 0.8387096774193549,
+                    "f1": 0.46846846846846846,
+                    "support": 31,
+                    "roc_auc": 0.6447988401594781,
+                    "pr_auc": 0.3201328285296959
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.325,
+                    "recall": 0.30952380952380953,
+                    "f1": 0.3170731707317073,
+                    "support": 42,
+                    "roc_auc": 0.31166056166056166,
+                    "pr_auc": 0.2668723750959936
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.559895074322355,
+                    "pr_auc": 0.4138188151229584
+                  }
+                ],
+                "macro_precision": 0.21666666666666667,
+                "macro_recall": 0.38274449564772145,
+                "macro_f1": 0.26184721306672526,
+                "weighted_f1": 0.23199663077711857,
+                "macro_roc_auc": 0.5054514920474649,
+                "macro_pr_auc": 0.3336080062495493
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.13530422379979903,
+              "regime_accuracy": 0.17796610295772552,
+              "regime_loss": 1.1331300250554488,
+              "regression_rmse_log_rv": 0.8595239917439802,
+              "regression_mae_log_rv": 0.6859883350020243,
+              "regression_loss": 0.7387814923835058,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    0,
+                    0
+                  ],
+                  [
+                    10,
+                    0,
+                    3
+                  ],
+                  [
+                    65,
+                    19,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0963855421686747,
+                    "recall": 1.0,
+                    "f1": 0.1758241758241758,
+                    "support": 8,
+                    "roc_auc": 0.6852272727272727,
+                    "pr_auc": 0.09977064196747629
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 13,
+                    "roc_auc": 0.4336996336996337,
+                    "pr_auc": 0.09082532825034
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.8125,
+                    "recall": 0.13402061855670103,
+                    "f1": 0.23008849557522126,
+                    "support": 97,
+                    "roc_auc": 0.39764359351988215,
+                    "pr_auc": 0.8175887013041759
+                  }
+                ],
+                "macro_precision": 0.3029618473895582,
+                "macro_recall": 0.37800687285223367,
+                "macro_f1": 0.13530422379979903,
+                "weighted_f1": 0.20106082607957515,
+                "macro_roc_auc": 0.5055234999822629,
+                "macro_pr_auc": 0.3360615571739974
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3791018071211308,
+              "regime_accuracy": 0.5181818008422852,
+              "regime_loss": 1.0624967849504319,
+              "regression_rmse_log_rv": 0.4967098537691419,
+              "regression_mae_log_rv": 0.367293681204319,
+              "regression_loss": 0.24672067883136234,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    20,
+                    1,
+                    3
+                  ],
+                  [
+                    28,
+                    37,
+                    3
+                  ],
+                  [
+                    9,
+                    9,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3508771929824561,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.4938271604938272,
+                    "support": 24,
+                    "roc_auc": 0.7713178294573644,
+                    "pr_auc": 0.4010043886180353
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7872340425531915,
+                    "recall": 0.5441176470588235,
+                    "f1": 0.6434782608695653,
+                    "support": 68,
+                    "roc_auc": 0.7160364145658263,
+                    "pr_auc": 0.8340406096288967
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 18,
+                    "roc_auc": 0.571256038647343,
+                    "pr_auc": 0.17137085617311051
+                  }
+                ],
+                "macro_precision": 0.3793704118452159,
+                "macro_recall": 0.4591503267973856,
+                "macro_f1": 0.3791018071211308,
+                "weighted_f1": 0.50553066900893,
+                "macro_roc_auc": 0.6862034275568446,
+                "macro_pr_auc": 0.4688052848066808
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.24057971014492754,
+              "regime_accuracy": 0.37837839126586914,
+              "regime_loss": 1.0779807664276917,
+              "regression_rmse_log_rv": 0.8884728561302087,
+              "regression_mae_log_rv": 0.7107219391687026,
+              "regression_loss": 0.7893840160801705,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    36,
+                    3,
+                    0
+                  ],
+                  [
+                    42,
+                    6,
+                    0
+                  ],
+                  [
+                    21,
+                    3,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.36363636363636365,
+                    "recall": 0.9230769230769231,
+                    "f1": 0.5217391304347827,
+                    "support": 39,
+                    "roc_auc": 0.6171652421652422,
+                    "pr_auc": 0.44459356393997823
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.125,
+                    "f1": 0.2,
+                    "support": 48,
+                    "roc_auc": 0.6071428571428571,
+                    "pr_auc": 0.5284180237873949
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 24,
+                    "roc_auc": 0.342911877394636,
+                    "pr_auc": 0.16506132961720657
+                  }
+                ],
+                "macro_precision": 0.2878787878787879,
+                "macro_recall": 0.3493589743589744,
+                "macro_f1": 0.24057971014492754,
+                "weighted_f1": 0.2698002350176264,
+                "macro_roc_auc": 0.5224066589009118,
+                "macro_pr_auc": 0.37935763911485987
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.40500228509701275,
+              "regime_accuracy": 0.5686274766921997,
+              "regime_loss": 1.05474408750365,
+              "regression_rmse_log_rv": 0.8175156998667726,
+              "regression_mae_log_rv": 0.6647229279327553,
+              "regression_loss": 0.6683319195286591,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    18,
+                    4,
+                    3
+                  ],
+                  [
+                    20,
+                    40,
+                    0
+                  ],
+                  [
+                    8,
+                    9,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.391304347826087,
+                    "recall": 0.72,
+                    "f1": 0.5070422535211268,
+                    "support": 25,
+                    "roc_auc": 0.6644155844155845,
+                    "pr_auc": 0.32392698926674174
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7547169811320755,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.7079646017699115,
+                    "support": 60,
+                    "roc_auc": 0.7257936507936508,
+                    "pr_auc": 0.8265145728515113
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 17,
+                    "roc_auc": 0.6027681660899654,
+                    "pr_auc": 0.1934112847269064
+                  }
+                ],
+                "macro_precision": 0.38200710965272083,
+                "macro_recall": 0.46222222222222226,
+                "macro_f1": 0.40500228509701275,
+                "weighted_f1": 0.5407248278845378,
+                "macro_roc_auc": 0.6643258004330669,
+                "macro_pr_auc": 0.44795094894838644
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "dual": [
+      {
+        "head_mode": "dual",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.38593958856775207,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.0977627031239954,
+              "regression_rmse_log_rv": 0.8041849753537412,
+              "regression_mae_log_rv": 0.6761757808111725,
+              "regression_loss": 0.6467134745846974,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    6,
+                    13
+                  ],
+                  [
+                    12,
+                    11,
+                    19
+                  ],
+                  [
+                    12,
+                    10,
+                    25
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.3870967741935484,
+                    "f1": 0.3582089552238806,
+                    "support": 31,
+                    "roc_auc": 0.5936933671620153,
+                    "pr_auc": 0.3973116306195365
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4074074074074074,
+                    "recall": 0.2619047619047619,
+                    "f1": 0.3188405797101449,
+                    "support": 42,
+                    "roc_auc": 0.5821123321123322,
+                    "pr_auc": 0.44576266240898854
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.43859649122807015,
+                    "recall": 0.5319148936170213,
+                    "f1": 0.4807692307692307,
+                    "support": 47,
+                    "roc_auc": 0.5995336636549111,
+                    "pr_auc": 0.4151811405907178
+                  }
+                ],
+                "macro_precision": 0.3931124106562703,
+                "macro_recall": 0.3936388099051105,
+                "macro_f1": 0.38593958856775207,
+                "weighted_f1": 0.3924327983826686,
+                "macro_roc_auc": 0.5917797876430861,
+                "macro_pr_auc": 0.41941847787308095
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4428483732351136,
+              "regime_accuracy": 0.7203390002250671,
+              "regime_loss": 0.742395794997781,
+              "regression_rmse_log_rv": 0.7215947872089742,
+              "regression_mae_log_rv": 0.5732600451525995,
+              "regression_loss": 0.5206990369271648,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    5,
+                    3
+                  ],
+                  [
+                    3,
+                    7,
+                    3
+                  ],
+                  [
+                    14,
+                    5,
+                    78
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 8,
+                    "roc_auc": 0.7477272727272727,
+                    "pr_auc": 0.1140580496369255
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4117647058823529,
+                    "recall": 0.5384615384615384,
+                    "f1": 0.4666666666666667,
+                    "support": 13,
+                    "roc_auc": 0.947985347985348,
+                    "pr_auc": 0.7389081132557105
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9285714285714286,
+                    "recall": 0.8041237113402062,
+                    "f1": 0.861878453038674,
+                    "support": 97,
+                    "roc_auc": 0.8468335787923417,
+                    "pr_auc": 0.9690688810427847
+                  }
+                ],
+                "macro_precision": 0.44677871148459386,
+                "macro_recall": 0.44752841660058157,
+                "macro_f1": 0.4428483732351136,
+                "weighted_f1": 0.7599057339950681,
+                "macro_roc_auc": 0.8475153998349875,
+                "macro_pr_auc": 0.6073450146451402
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.30158730158730157,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.1195266598386562,
+              "regression_rmse_log_rv": 0.3618648789992304,
+              "regression_mae_log_rv": 0.29632305703125894,
+              "regression_loss": 0.13094619065312768,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    0,
+                    7
+                  ],
+                  [
+                    42,
+                    0,
+                    26
+                  ],
+                  [
+                    1,
+                    0,
+                    17
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2833333333333333,
+                    "recall": 0.7083333333333334,
+                    "f1": 0.40476190476190477,
+                    "support": 24,
+                    "roc_auc": 0.5678294573643411,
+                    "pr_auc": 0.3126471045357115
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 68,
+                    "roc_auc": 0.38305322128851543,
+                    "pr_auc": 0.522372595559074
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.34,
+                    "recall": 0.9444444444444444,
+                    "f1": 0.5,
+                    "support": 18,
+                    "roc_auc": 0.8955314009661836,
+                    "pr_auc": 0.6299379989162591
+                  }
+                ],
+                "macro_precision": 0.20777777777777776,
+                "macro_recall": 0.5509259259259259,
+                "macro_f1": 0.30158730158730157,
+                "weighted_f1": 0.17012987012987013,
+                "macro_roc_auc": 0.6154713598730134,
+                "macro_pr_auc": 0.4883192330036816
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.2742378810594703,
+              "regime_accuracy": 0.29729729890823364,
+              "regime_loss": 1.1363916981375715,
+              "regression_rmse_log_rv": 0.871960213992219,
+              "regression_mae_log_rv": 0.6901222171811471,
+              "regression_loss": 0.7603146147853563,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    20,
+                    1,
+                    18
+                  ],
+                  [
+                    23,
+                    4,
+                    21
+                  ],
+                  [
+                    10,
+                    5,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.37735849056603776,
+                    "recall": 0.5128205128205128,
+                    "f1": 0.43478260869565216,
+                    "support": 39,
+                    "roc_auc": 0.5153133903133903,
+                    "pr_auc": 0.3226322589759253
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.13793103448275862,
+                    "support": 48,
+                    "roc_auc": 0.531415343915344,
+                    "pr_auc": 0.45663783442140715
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1875,
+                    "recall": 0.375,
+                    "f1": 0.25,
+                    "support": 24,
+                    "roc_auc": 0.48227969348659006,
+                    "pr_auc": 0.29815364856962684
+                  }
+                ],
+                "macro_precision": 0.3216194968553459,
+                "macro_recall": 0.32371794871794873,
+                "macro_f1": 0.2742378810594703,
+                "weighted_f1": 0.26646136391263825,
+                "macro_roc_auc": 0.509669475905108,
+                "macro_pr_auc": 0.3591412473223197
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.536545868347339,
+              "regime_accuracy": 0.6666666865348816,
+              "regime_loss": 1.0827388407319878,
+              "regression_rmse_log_rv": 0.6392246096999931,
+              "regression_mae_log_rv": 0.47467233307714407,
+              "regression_loss": 0.4086081016461085,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    10,
+                    9
+                  ],
+                  [
+                    0,
+                    53,
+                    7
+                  ],
+                  [
+                    3,
+                    5,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.24,
+                    "f1": 0.3529411764705882,
+                    "support": 25,
+                    "roc_auc": 0.5854545454545454,
+                    "pr_auc": 0.4942519142171922
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7794117647058824,
+                    "recall": 0.8833333333333333,
+                    "f1": 0.8281250000000001,
+                    "support": 60,
+                    "roc_auc": 0.792063492063492,
+                    "pr_auc": 0.8266217977277305
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.36,
+                    "recall": 0.5294117647058824,
+                    "f1": 0.42857142857142855,
+                    "support": 17,
+                    "roc_auc": 0.6373702422145329,
+                    "pr_auc": 0.5733011506272221
+                  }
+                ],
+                "macro_precision": 0.6020261437908497,
+                "macro_recall": 0.5509150326797386,
+                "macro_f1": 0.536545868347339,
+                "weighted_f1": 0.6450661146811667,
+                "macro_roc_auc": 0.6716294265775234,
+                "macro_pr_auc": 0.6313916208573817
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.329451343715093,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.6393401574835333,
+              "regression_rmse_log_rv": 0.9145575848114771,
+              "regression_mae_log_rv": 0.7344018742674961,
+              "regression_loss": 0.8364155759362022,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    6,
+                    11
+                  ],
+                  [
+                    21,
+                    8,
+                    13
+                  ],
+                  [
+                    9,
+                    20,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3181818181818182,
+                    "recall": 0.45161290322580644,
+                    "f1": 0.3733333333333333,
+                    "support": 31,
+                    "roc_auc": 0.5766582094961943,
+                    "pr_auc": 0.43012080012379916
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.23529411764705882,
+                    "recall": 0.19047619047619047,
+                    "f1": 0.21052631578947367,
+                    "support": 42,
+                    "roc_auc": 0.3241758241758242,
+                    "pr_auc": 0.2559397395964985
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.3829787234042553,
+                    "f1": 0.40449438202247195,
+                    "support": 47,
+                    "roc_auc": 0.5153016613232294,
+                    "pr_auc": 0.4039286949665039
+                  }
+                ],
+                "macro_precision": 0.32734912146676853,
+                "macro_recall": 0.34168927236875074,
+                "macro_f1": 0.329451343715093,
+                "weighted_f1": 0.32855562126289506,
+                "macro_roc_auc": 0.47204523166508267,
+                "macro_pr_auc": 0.36332974489560055
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.25142220630942436,
+              "regime_accuracy": 0.5254237055778503,
+              "regime_loss": 0.9308154249595384,
+              "regression_rmse_log_rv": 0.8012958236540371,
+              "regression_mae_log_rv": 0.6636852826923132,
+              "regression_loss": 0.6420749970054016,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    7,
+                    1
+                  ],
+                  [
+                    0,
+                    1,
+                    12
+                  ],
+                  [
+                    8,
+                    28,
+                    61
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 8,
+                    "roc_auc": 0.7818181818181819,
+                    "pr_auc": 0.1315131725840603
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.027777777777777776,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.04081632653061225,
+                    "support": 13,
+                    "roc_auc": 0.37142857142857144,
+                    "pr_auc": 0.08564504068592252
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.8243243243243243,
+                    "recall": 0.6288659793814433,
+                    "f1": 0.7134502923976608,
+                    "support": 97,
+                    "roc_auc": 0.5120274914089347,
+                    "pr_auc": 0.8155897149924266
+                  }
+                ],
+                "macro_precision": 0.28403403403403404,
+                "macro_recall": 0.23526301876817338,
+                "macro_f1": 0.25142220630942436,
+                "weighted_f1": 0.5909770390463648,
+                "macro_roc_auc": 0.5550914148852293,
+                "macro_pr_auc": 0.3442493094208032
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.423036223036223,
+              "regime_accuracy": 0.40909090638160706,
+              "regime_loss": 1.0765107948018517,
+              "regression_rmse_log_rv": 0.4633066746630045,
+              "regression_mae_log_rv": 0.3594956647266041,
+              "regression_loss": 0.2146530747872911,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    11,
+                    7,
+                    6
+                  ],
+                  [
+                    10,
+                    16,
+                    42
+                  ],
+                  [
+                    0,
+                    0,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5238095238095238,
+                    "recall": 0.4583333333333333,
+                    "f1": 0.4888888888888889,
+                    "support": 24,
+                    "roc_auc": 0.6661821705426356,
+                    "pr_auc": 0.4081867874777571
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6956521739130435,
+                    "recall": 0.23529411764705882,
+                    "f1": 0.3516483516483516,
+                    "support": 68,
+                    "roc_auc": 0.49719887955182074,
+                    "pr_auc": 0.655765366810362
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2727272727272727,
+                    "recall": 1.0,
+                    "f1": 0.42857142857142855,
+                    "support": 18,
+                    "roc_auc": 0.9154589371980676,
+                    "pr_auc": 0.6713267374792945
+                  }
+                ],
+                "macro_precision": 0.49739632348328006,
+                "macro_recall": 0.5645424836601307,
+                "macro_f1": 0.423036223036223,
+                "weighted_f1": 0.3941791541791541,
+                "macro_roc_auc": 0.6929466624308414,
+                "macro_pr_auc": 0.5784262972558045
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.26659723891158643,
+              "regime_accuracy": 0.29729729890823364,
+              "regime_loss": 1.1672871580408795,
+              "regression_rmse_log_rv": 0.9006539736778573,
+              "regression_mae_log_rv": 0.7506499589202708,
+              "regression_loss": 0.8111775803017145,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    20,
+                    16
+                  ],
+                  [
+                    3,
+                    21,
+                    24
+                  ],
+                  [
+                    9,
+                    6,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2,
+                    "recall": 0.07692307692307693,
+                    "f1": 0.1111111111111111,
+                    "support": 39,
+                    "roc_auc": 0.5957977207977208,
+                    "pr_auc": 0.3745341959914224
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.44680851063829785,
+                    "recall": 0.4375,
+                    "f1": 0.4421052631578947,
+                    "support": 48,
+                    "roc_auc": 0.49702380952380953,
+                    "pr_auc": 0.416902023420075
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.1836734693877551,
+                    "recall": 0.375,
+                    "f1": 0.24657534246575347,
+                    "support": 24,
+                    "roc_auc": 0.49377394636015326,
+                    "pr_auc": 0.2519108245435041
+                  }
+                ],
+                "macro_precision": 0.276827326675351,
+                "macro_recall": 0.296474358974359,
+                "macro_f1": 0.26659723891158643,
+                "weighted_f1": 0.283533280937751,
+                "macro_roc_auc": 0.5288651588938945,
+                "macro_pr_auc": 0.34778234798500046
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.576393466637369,
+              "regime_accuracy": 0.6666666865348816,
+              "regime_loss": 0.9313333769959175,
+              "regression_rmse_log_rv": 0.6145476008226017,
+              "regression_mae_log_rv": 0.4600841019841313,
+              "regression_loss": 0.3776687536768159,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    8,
+                    9
+                  ],
+                  [
+                    4,
+                    49,
+                    7
+                  ],
+                  [
+                    0,
+                    6,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.32,
+                    "f1": 0.43243243243243246,
+                    "support": 25,
+                    "roc_auc": 0.5958441558441558,
+                    "pr_auc": 0.4958467105355937
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7777777777777778,
+                    "recall": 0.8166666666666667,
+                    "f1": 0.7967479674796747,
+                    "support": 60,
+                    "roc_auc": 0.7845238095238095,
+                    "pr_auc": 0.8261420749435825
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4074074074074074,
+                    "recall": 0.6470588235294118,
+                    "f1": 0.5,
+                    "support": 17,
+                    "roc_auc": 0.9003460207612457,
+                    "pr_auc": 0.5115718281247874
+                  }
+                ],
+                "macro_precision": 0.6172839506172839,
+                "macro_recall": 0.5945751633986928,
+                "macro_f1": 0.576393466637369,
+                "weighted_f1": 0.6579969496038361,
+                "macro_roc_auc": 0.7602379953764037,
+                "macro_pr_auc": 0.6111868712013212
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3300959909655562,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.2212022881292504,
+              "regression_rmse_log_rv": 0.8576441904387663,
+              "regression_mae_log_rv": 0.7018642899851936,
+              "regression_loss": 0.7355535573933667,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    12,
+                    11
+                  ],
+                  [
+                    12,
+                    5,
+                    25
+                  ],
+                  [
+                    4,
+                    11,
+                    32
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.25806451612903225,
+                    "f1": 0.29090909090909095,
+                    "support": 31,
+                    "roc_auc": 0.5958680681406306,
+                    "pr_auc": 0.40311318004775987
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.17857142857142858,
+                    "recall": 0.11904761904761904,
+                    "f1": 0.14285714285714285,
+                    "support": 42,
+                    "roc_auc": 0.42002442002442003,
+                    "pr_auc": 0.29569922360873035
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.47058823529411764,
+                    "recall": 0.6808510638297872,
+                    "f1": 0.5565217391304348,
+                    "support": 47,
+                    "roc_auc": 0.5872923345963276,
+                    "pr_auc": 0.44428698490585533
+                  }
+                ],
+                "macro_precision": 0.32749766573295985,
+                "macro_recall": 0.3526543996688128,
+                "macro_f1": 0.3300959909655562,
+                "weighted_f1": 0.3431225296442688,
+                "macro_roc_auc": 0.5343949409204595,
+                "macro_pr_auc": 0.38103312952078183
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4001058201058201,
+              "regime_accuracy": 0.6610169410705566,
+              "regime_loss": 0.7362529973862535,
+              "regression_rmse_log_rv": 0.7039690204330067,
+              "regression_mae_log_rv": 0.5707503672278786,
+              "regression_loss": 0.49557238172940704,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    7,
+                    1
+                  ],
+                  [
+                    0,
+                    7,
+                    6
+                  ],
+                  [
+                    17,
+                    9,
+                    71
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 8,
+                    "roc_auc": 0.7840909090909091,
+                    "pr_auc": 0.13024661820126343
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.30434782608695654,
+                    "recall": 0.5384615384615384,
+                    "f1": 0.3888888888888889,
+                    "support": 13,
+                    "roc_auc": 0.7128205128205128,
+                    "pr_auc": 0.20246926197541526
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9102564102564102,
+                    "recall": 0.7319587628865979,
+                    "f1": 0.8114285714285714,
+                    "support": 97,
+                    "roc_auc": 0.7447226313205695,
+                    "pr_auc": 0.9394057814236139
+                  }
+                ],
+                "macro_precision": 0.40486807878112224,
+                "macro_recall": 0.4234734337827121,
+                "macro_f1": 0.4001058201058201,
+                "weighted_f1": 0.7098654829163303,
+                "macro_roc_auc": 0.7472113510773305,
+                "macro_pr_auc": 0.4240405538667642
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3305621407462735,
+              "regime_accuracy": 0.3181818127632141,
+              "regime_loss": 1.1491696326823866,
+              "regression_rmse_log_rv": 0.5782733065207973,
+              "regression_mae_log_rv": 0.39569118741095405,
+              "regression_loss": 0.334400017034496,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    18,
+                    3,
+                    3
+                  ],
+                  [
+                    41,
+                    6,
+                    21
+                  ],
+                  [
+                    0,
+                    7,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3050847457627119,
+                    "recall": 0.75,
+                    "f1": 0.4337349397590361,
+                    "support": 24,
+                    "roc_auc": 0.7097868217054264,
+                    "pr_auc": 0.5740354326545267
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.375,
+                    "recall": 0.08823529411764706,
+                    "f1": 0.14285714285714285,
+                    "support": 68,
+                    "roc_auc": 0.36554621848739494,
+                    "pr_auc": 0.5119711591928288
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3142857142857143,
+                    "recall": 0.6111111111111112,
+                    "f1": 0.41509433962264153,
+                    "support": 18,
+                    "roc_auc": 0.7596618357487923,
+                    "pr_auc": 0.2608776732444294
+                  }
+                ],
+                "macro_precision": 0.3314568200161421,
+                "macro_recall": 0.483115468409586,
+                "macro_f1": 0.3305621407462735,
+                "weighted_f1": 0.250869294379183,
+                "macro_roc_auc": 0.6116649586472046,
+                "macro_pr_auc": 0.44896142169726166
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3473688150310652,
+              "regime_accuracy": 0.36936935782432556,
+              "regime_loss": 1.1241331890482709,
+              "regression_rmse_log_rv": 0.9073719601606879,
+              "regression_mae_log_rv": 0.7237050673790142,
+              "regression_loss": 0.8233238740858491,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    22,
+                    7,
+                    10
+                  ],
+                  [
+                    20,
+                    4,
+                    24
+                  ],
+                  [
+                    7,
+                    2,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4489795918367347,
+                    "recall": 0.5641025641025641,
+                    "f1": 0.5,
+                    "support": 39,
+                    "roc_auc": 0.5665954415954416,
+                    "pr_auc": 0.3529166872708223
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.08333333333333333,
+                    "f1": 0.13114754098360656,
+                    "support": 48,
+                    "roc_auc": 0.47685185185185186,
+                    "pr_auc": 0.43263663482590325
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.30612244897959184,
+                    "recall": 0.625,
+                    "f1": 0.4109589041095891,
+                    "support": 24,
+                    "roc_auc": 0.5775862068965517,
+                    "pr_auc": 0.4037456504498883
+                  }
+                ],
+                "macro_precision": 0.3542647828362114,
+                "macro_recall": 0.42414529914529914,
+                "macro_f1": 0.3473688150310652,
+                "weighted_f1": 0.3212441050976869,
+                "macro_roc_auc": 0.5403445001146151,
+                "macro_pr_auc": 0.3964329908488713
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4579190166632691,
+              "regime_accuracy": 0.4901960790157318,
+              "regime_loss": 1.0907945989374719,
+              "regression_rmse_log_rv": 0.6935700039058215,
+              "regression_mae_log_rv": 0.5493939912503621,
+              "regression_loss": 0.48103935031792117,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    5,
+                    10
+                  ],
+                  [
+                    18,
+                    30,
+                    12
+                  ],
+                  [
+                    0,
+                    7,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35714285714285715,
+                    "recall": 0.4,
+                    "f1": 0.3773584905660378,
+                    "support": 25,
+                    "roc_auc": 0.56,
+                    "pr_auc": 0.3894580502908327
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7142857142857143,
+                    "recall": 0.5,
+                    "f1": 0.588235294117647,
+                    "support": 60,
+                    "roc_auc": 0.7063492063492064,
+                    "pr_auc": 0.7456671887096405
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3125,
+                    "recall": 0.5882352941176471,
+                    "f1": 0.40816326530612246,
+                    "support": 17,
+                    "roc_auc": 0.8588235294117647,
+                    "pr_auc": 0.6054163921124447
+                  }
+                ],
+                "macro_precision": 0.4613095238095238,
+                "macro_recall": 0.49607843137254903,
+                "macro_f1": 0.4579190166632691,
+                "weighted_f1": 0.5065377982491553,
+                "macro_roc_auc": 0.7083909119203238,
+                "macro_pr_auc": 0.5801805437043059
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3407224958949097,
+              "regime_accuracy": 0.46666666865348816,
+              "regime_loss": 1.1715155593296112,
+              "regression_rmse_log_rv": 0.7945016505275457,
+              "regression_mae_log_rv": 0.6593632820916052,
+              "regression_loss": 0.6312328726909944,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    11,
+                    0,
+                    20
+                  ],
+                  [
+                    14,
+                    0,
+                    28
+                  ],
+                  [
+                    2,
+                    0,
+                    45
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4074074074074074,
+                    "recall": 0.3548387096774194,
+                    "f1": 0.3793103448275862,
+                    "support": 31,
+                    "roc_auc": 0.555636100036245,
+                    "pr_auc": 0.37690943465645144
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 42,
+                    "roc_auc": 0.6144688644688645,
+                    "pr_auc": 0.49326468073037105
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4838709677419355,
+                    "recall": 0.9574468085106383,
+                    "f1": 0.6428571428571429,
+                    "support": 47,
+                    "roc_auc": 0.6047799475371611,
+                    "pr_auc": 0.4139294431556185
+                  }
+                ],
+                "macro_precision": 0.29709279171644765,
+                "macro_recall": 0.4374285060626859,
+                "macro_f1": 0.3407224958949097,
+                "weighted_f1": 0.34977422003284075,
+                "macro_roc_auc": 0.5916283040140903,
+                "macro_pr_auc": 0.428034519514147
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4492366977916111,
+              "regime_accuracy": 0.6610169410705566,
+              "regime_loss": 0.7222712085408679,
+              "regression_rmse_log_rv": 0.8127794485513451,
+              "regression_mae_log_rv": 0.6591787817493334,
+              "regression_loss": 0.6606104319874286,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    4,
+                    4,
+                    0
+                  ],
+                  [
+                    3,
+                    4,
+                    6
+                  ],
+                  [
+                    9,
+                    18,
+                    70
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.5,
+                    "f1": 0.3333333333333333,
+                    "support": 8,
+                    "roc_auc": 0.8909090909090909,
+                    "pr_auc": 0.2279011787719218
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.15384615384615385,
+                    "recall": 0.3076923076923077,
+                    "f1": 0.20512820512820515,
+                    "support": 13,
+                    "roc_auc": 0.7326007326007326,
+                    "pr_auc": 0.20913316720027528
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9210526315789473,
+                    "recall": 0.7216494845360825,
+                    "f1": 0.8092485549132947,
+                    "support": 97,
+                    "roc_auc": 0.7913598429062346,
+                    "pr_auc": 0.9491136257411343
+                  }
+                ],
+                "macro_precision": 0.4416329284750337,
+                "macro_recall": 0.5097805974094634,
+                "macro_f1": 0.4492366977916111,
+                "weighted_f1": 0.7104274844061265,
+                "macro_roc_auc": 0.8049565554720193,
+                "macro_pr_auc": 0.4620493239044438
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4797722250552439,
+              "regime_accuracy": 0.48181816935539246,
+              "regime_loss": 1.0566083710693883,
+              "regression_rmse_log_rv": 0.41124044437566953,
+              "regression_mae_log_rv": 0.3153917890719392,
+              "regression_loss": 0.16911870309029817,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    12,
+                    0
+                  ],
+                  [
+                    17,
+                    27,
+                    24
+                  ],
+                  [
+                    0,
+                    4,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.41379310344827586,
+                    "recall": 0.5,
+                    "f1": 0.4528301886792453,
+                    "support": 24,
+                    "roc_auc": 0.7456395348837209,
+                    "pr_auc": 0.4192831349367535
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.627906976744186,
+                    "recall": 0.39705882352941174,
+                    "f1": 0.48648648648648646,
+                    "support": 68,
+                    "roc_auc": 0.4114145658263305,
+                    "pr_auc": 0.5732941514420195
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3684210526315789,
+                    "recall": 0.7777777777777778,
+                    "f1": 0.5,
+                    "support": 18,
+                    "roc_auc": 0.8164251207729468,
+                    "pr_auc": 0.31915597784301186
+                  }
+                ],
+                "macro_precision": 0.4700403776080136,
+                "macro_recall": 0.5582788671023965,
+                "macro_f1": 0.4797722250552439,
+                "weighted_f1": 0.481354596448936,
+                "macro_roc_auc": 0.6578264071609995,
+                "macro_pr_auc": 0.43724442140726155
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3481225015471591,
+              "regime_accuracy": 0.36036035418510437,
+              "regime_loss": 1.2232364140721024,
+              "regression_rmse_log_rv": 0.9606467248254172,
+              "regression_mae_log_rv": 0.7879151723783899,
+              "regression_loss": 0.922842129917801,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    20,
+                    8,
+                    11
+                  ],
+                  [
+                    18,
+                    6,
+                    24
+                  ],
+                  [
+                    7,
+                    3,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4444444444444444,
+                    "recall": 0.5128205128205128,
+                    "f1": 0.47619047619047616,
+                    "support": 39,
+                    "roc_auc": 0.603988603988604,
+                    "pr_auc": 0.38736449544070684
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.35294117647058826,
+                    "recall": 0.125,
+                    "f1": 0.18461538461538463,
+                    "support": 48,
+                    "roc_auc": 0.44775132275132273,
+                    "pr_auc": 0.4138202791342021
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.5833333333333334,
+                    "f1": 0.3835616438356164,
+                    "support": 24,
+                    "roc_auc": 0.5727969348659003,
+                    "pr_auc": 0.28067263129133074
+                  }
+                ],
+                "macro_precision": 0.36103330220977276,
+                "macro_recall": 0.4070512820512821,
+                "macro_f1": 0.3481225015471591,
+                "weighted_f1": 0.3300760944596561,
+                "macro_roc_auc": 0.5415122872019423,
+                "macro_pr_auc": 0.3606191352887465
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4838845340301107,
+              "regime_accuracy": 0.5196078419685364,
+              "regime_loss": 1.1132855696201045,
+              "regression_rmse_log_rv": 0.7118824032690477,
+              "regression_mae_log_rv": 0.5581611309739232,
+              "regression_loss": 0.5067765560841151,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    6,
+                    11
+                  ],
+                  [
+                    14,
+                    31,
+                    15
+                  ],
+                  [
+                    0,
+                    3,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.36363636363636365,
+                    "recall": 0.32,
+                    "f1": 0.3404255319148936,
+                    "support": 25,
+                    "roc_auc": 0.5361038961038961,
+                    "pr_auc": 0.3566581558502391
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.775,
+                    "recall": 0.5166666666666667,
+                    "f1": 0.62,
+                    "support": 60,
+                    "roc_auc": 0.6880952380952381,
+                    "pr_auc": 0.6824184542434039
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.35,
+                    "recall": 0.8235294117647058,
+                    "f1": 0.4912280701754386,
+                    "support": 17,
+                    "roc_auc": 0.8228373702422145,
+                    "pr_auc": 0.5776508001098106
+                  }
+                ],
+                "macro_precision": 0.49621212121212127,
+                "macro_recall": 0.5533986928104575,
+                "macro_f1": 0.4838845340301107,
+                "weighted_f1": 0.5300148577534785,
+                "macro_roc_auc": 0.6823455014804495,
+                "macro_pr_auc": 0.5389091367344845
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3680685732596331,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.1794093498679907,
+              "regression_rmse_log_rv": 0.8739812581280975,
+              "regression_mae_log_rv": 0.7410389460235213,
+              "regression_loss": 0.7638432395591721,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    8,
+                    11
+                  ],
+                  [
+                    14,
+                    12,
+                    16
+                  ],
+                  [
+                    16,
+                    10,
+                    21
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.3870967741935484,
+                    "f1": 0.3287671232876712,
+                    "support": 31,
+                    "roc_auc": 0.5795578108010149,
+                    "pr_auc": 0.38659644186223124
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.2857142857142857,
+                    "f1": 0.3333333333333333,
+                    "support": 42,
+                    "roc_auc": 0.481990231990232,
+                    "pr_auc": 0.3415031672645189
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4375,
+                    "recall": 0.44680851063829785,
+                    "f1": 0.4421052631578947,
+                    "support": 47,
+                    "roc_auc": 0.5322063538327019,
+                    "pr_auc": 0.3788490203475132
+                  }
+                ],
+                "macro_precision": 0.3744047619047619,
+                "macro_recall": 0.37320652351537725,
+                "macro_f1": 0.3680685732596331,
+                "weighted_f1": 0.3747560682528238,
+                "macro_roc_auc": 0.5312514655413162,
+                "macro_pr_auc": 0.36898287649142114
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.36636896187457985,
+              "regime_accuracy": 0.6779661178588867,
+              "regime_loss": 0.7292218748795785,
+              "regression_rmse_log_rv": 0.7501483662550374,
+              "regression_mae_log_rv": 0.6046781848042698,
+              "regression_loss": 0.5627225713951017,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    3,
+                    0
+                  ],
+                  [
+                    7,
+                    0,
+                    6
+                  ],
+                  [
+                    19,
+                    3,
+                    75
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16129032258064516,
+                    "recall": 0.625,
+                    "f1": 0.2564102564102564,
+                    "support": 8,
+                    "roc_auc": 0.8090909090909091,
+                    "pr_auc": 0.14477919599252437
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 13,
+                    "roc_auc": 0.6483516483516484,
+                    "pr_auc": 0.14889020620596538
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9259259259259259,
+                    "recall": 0.7731958762886598,
+                    "f1": 0.8426966292134831,
+                    "support": 97,
+                    "roc_auc": 0.7839960726558665,
+                    "pr_auc": 0.9427017547978684
+                  }
+                ],
+                "macro_precision": 0.362405416168857,
+                "macro_recall": 0.4660652920962199,
+                "macro_f1": 0.36636896187457985,
+                "weighted_f1": 0.7101089413982197,
+                "macro_roc_auc": 0.7471462100328079,
+                "macro_pr_auc": 0.4121237189987861
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3169431126420374,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.243260905232257,
+              "regression_rmse_log_rv": 0.5900399711200899,
+              "regression_mae_log_rv": 0.44810212952169504,
+              "regression_loss": 0.34814716751939645,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    5,
+                    7
+                  ],
+                  [
+                    26,
+                    6,
+                    36
+                  ],
+                  [
+                    0,
+                    2,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3157894736842105,
+                    "recall": 0.5,
+                    "f1": 0.3870967741935484,
+                    "support": 24,
+                    "roc_auc": 0.7562984496124031,
+                    "pr_auc": 0.5890730166754926
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.46153846153846156,
+                    "recall": 0.08823529411764706,
+                    "f1": 0.14814814814814817,
+                    "support": 68,
+                    "roc_auc": 0.4068627450980392,
+                    "pr_auc": 0.543097670221978
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2711864406779661,
+                    "recall": 0.8888888888888888,
+                    "f1": 0.4155844155844156,
+                    "support": 18,
+                    "roc_auc": 0.7566425120772947,
+                    "pr_auc": 0.2653236254873326
+                  }
+                ],
+                "macro_precision": 0.3495047919668794,
+                "macro_recall": 0.49237472766884527,
+                "macro_f1": 0.3169431126420374,
+                "weighted_f1": 0.2440446921385338,
+                "macro_roc_auc": 0.6399345689292457,
+                "macro_pr_auc": 0.46583143746160105
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.28585965733561086,
+              "regime_accuracy": 0.28828829526901245,
+              "regime_loss": 1.1242849051051826,
+              "regression_rmse_log_rv": 0.8776568718495624,
+              "regression_mae_log_rv": 0.7024031439586332,
+              "regression_loss": 0.7702815847047593,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    12,
+                    13
+                  ],
+                  [
+                    18,
+                    9,
+                    21
+                  ],
+                  [
+                    10,
+                    5,
+                    9
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.358974358974359,
+                    "f1": 0.345679012345679,
+                    "support": 39,
+                    "roc_auc": 0.5516381766381766,
+                    "pr_auc": 0.3438071700288032
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.34615384615384615,
+                    "recall": 0.1875,
+                    "f1": 0.24324324324324323,
+                    "support": 48,
+                    "roc_auc": 0.47354497354497355,
+                    "pr_auc": 0.40543551282927454
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.20930232558139536,
+                    "recall": 0.375,
+                    "f1": 0.26865671641791045,
+                    "support": 24,
+                    "roc_auc": 0.5272988505747126,
+                    "pr_auc": 0.360457884566265
+                  }
+                ],
+                "macro_precision": 0.2962631683561916,
+                "macro_recall": 0.3071581196581197,
+                "macro_f1": 0.28585965733561086,
+                "weighted_f1": 0.2847289941548379,
+                "macro_roc_auc": 0.5174940002526209,
+                "macro_pr_auc": 0.36990018914144757
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.563491399404712,
+              "regime_accuracy": 0.6764705777168274,
+              "regime_loss": 0.9893853518098829,
+              "regression_rmse_log_rv": 0.6913704251247109,
+              "regression_mae_log_rv": 0.5351672580273932,
+              "regression_loss": 0.47799306473712355,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    16,
+                    3
+                  ],
+                  [
+                    0,
+                    53,
+                    7
+                  ],
+                  [
+                    3,
+                    4,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.24,
+                    "f1": 0.3529411764705882,
+                    "support": 25,
+                    "roc_auc": 0.5968831168831169,
+                    "pr_auc": 0.3653282528506245
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.726027397260274,
+                    "recall": 0.8833333333333333,
+                    "f1": 0.7969924812030076,
+                    "support": 60,
+                    "roc_auc": 0.7845238095238095,
+                    "pr_auc": 0.8230202901329563
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.5882352941176471,
+                    "f1": 0.5405405405405405,
+                    "support": 17,
+                    "roc_auc": 0.7633217993079585,
+                    "pr_auc": 0.6276489204637501
+                  }
+                ],
+                "macro_precision": 0.6308980213089802,
+                "macro_recall": 0.5705228758169935,
+                "macro_f1": 0.563491399404712,
+                "weighted_f1": 0.6454143869915132,
+                "macro_roc_auc": 0.7149095752382949,
+                "macro_pr_auc": 0.605332487815777
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "classification": {
+      "regime_f1_macro": {
+        "mean": 0.3812163616229947,
+        "std": 0.07989991019082043,
+        "min": 0.24941397093295825,
+        "max": 0.5646117878676019,
+        "n": 25
+      },
+      "regression_rmse_log_rv": null
+    },
+    "regression": {
+      "regime_f1_macro": {
+        "mean": 0.2546675718571313,
+        "std": 0.10231950066743027,
+        "min": 0.08259587020648967,
+        "max": 0.43251811594202905,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7705857307229054,
+        "std": 0.13015236501921484,
+        "min": 0.4740927654811497,
+        "max": 0.9680269731958419,
+        "n": 25
+      }
+    },
+    "dual": {
+      "regime_f1_macro": {
+        "mean": 0.38626325735017053,
+        "std": 0.0904710455960497,
+        "min": 0.25142220630942436,
+        "max": 0.576393466637369,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7323306867347497,
+        "std": 0.15811679660508723,
+        "min": 0.3618648789992304,
+        "max": 0.9606467248254172,
+        "n": 25
+      }
+    }
+  }
+}

--- a/backend/artifacts/experiments/job1_horizon_20260531T141630Z/pod_horizon_5d_20260531T141630Z.json
+++ b/backend/artifacts/experiments/job1_horizon_20260531T141630Z/pod_horizon_5d_20260531T141630Z.json
@@ -1,0 +1,5170 @@
+{
+  "head_modes": [
+    "classification",
+    "regression",
+    "dual"
+  ],
+  "seeds": [
+    11,
+    29,
+    47,
+    71,
+    97
+  ],
+  "fold_ids": [
+    "wf_fold_1",
+    "wf_fold_2",
+    "wf_fold_3",
+    "wf_fold_4",
+    "wf_fold_5"
+  ],
+  "epochs": 40,
+  "regression_alpha": 0.5,
+  "training_package_id": "canonical",
+  "rates_target_mode": "raw",
+  "rates_heads": [],
+  "vol_target_mode": "raw",
+  "vol_target_horizon": 5,
+  "sequence_length": 20,
+  "use_retrieval_analogs": false,
+  "use_regime_conditioning": false,
+  "use_statement_delta": false,
+  "use_vote_features": false,
+  "use_press_conf": false,
+  "use_vix_features": false,
+  "use_doc_length": false,
+  "regime_loss": "ce",
+  "focal_gamma": 2.0,
+  "class_balanced_beta": 0.999,
+  "text_encoder": null,
+  "use_text_embeddings": true,
+  "vol_regime_label_mode": "per_fold_quantile",
+  "absolute_vol_thresholds": null,
+  "absolute_calm_max_annualized": null,
+  "absolute_high_min_annualized": null,
+  "use_mp_surprise": true,
+  "aux_horizons": [],
+  "aux_horizon_alpha": 0.3,
+  "trials": {
+    "classification": [
+      {
+        "head_mode": "classification",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3293956043956044,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.2314142516337756,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    1,
+                    16
+                  ],
+                  [
+                    13,
+                    5,
+                    29
+                  ],
+                  [
+                    16,
+                    3,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3695652173913043,
+                    "recall": 0.5,
+                    "f1": 0.425,
+                    "support": 34,
+                    "roc_auc": 0.6060191518467852,
+                    "pr_auc": 0.39187902377247774
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.10638297872340426,
+                    "f1": 0.17857142857142855,
+                    "support": 47,
+                    "roc_auc": 0.5193821043427572,
+                    "pr_auc": 0.39147158642061664
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.5128205128205128,
+                    "f1": 0.38461538461538464,
+                    "support": 39,
+                    "roc_auc": 0.5216840772396328,
+                    "pr_auc": 0.33769836851204466
+                  }
+                ],
+                "macro_precision": 0.41093769354638915,
+                "macro_recall": 0.37306783051463904,
+                "macro_f1": 0.3293956043956044,
+                "weighted_f1": 0.31535714285714284,
+                "macro_roc_auc": 0.5490284444763918,
+                "macro_pr_auc": 0.373682992901713
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5588479870195721,
+              "regime_accuracy": 0.7372881174087524,
+              "regime_loss": 0.7143685473917145,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    1,
+                    1
+                  ],
+                  [
+                    5,
+                    8,
+                    6
+                  ],
+                  [
+                    8,
+                    10,
+                    74
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2777777777777778,
+                    "recall": 0.7142857142857143,
+                    "f1": 0.4,
+                    "support": 7,
+                    "roc_auc": 0.8532818532818532,
+                    "pr_auc": 0.18657617810743593
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.42105263157894735,
+                    "recall": 0.42105263157894735,
+                    "f1": 0.42105263157894735,
+                    "support": 19,
+                    "roc_auc": 0.7246145667198298,
+                    "pr_auc": 0.25892726757204504
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9135802469135802,
+                    "recall": 0.8043478260869565,
+                    "f1": 0.8554913294797687,
+                    "support": 92,
+                    "roc_auc": 0.7688127090301003,
+                    "pr_auc": 0.927563201130515
+                  }
+                ],
+                "macro_precision": 0.5374702187567685,
+                "macro_recall": 0.6465620573172061,
+                "macro_f1": 0.5588479870195721,
+                "weighted_f1": 0.7585186636621926,
+                "macro_roc_auc": 0.7822363763439277,
+                "macro_pr_auc": 0.45768888226999865
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.46781688861611825,
+              "regime_accuracy": 0.4636363685131073,
+              "regime_loss": 1.0125540321523494,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    1,
+                    2
+                  ],
+                  [
+                    28,
+                    20,
+                    19
+                  ],
+                  [
+                    6,
+                    3,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.30612244897959184,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.44776119402985076,
+                    "support": 18,
+                    "roc_auc": 0.7856280193236715,
+                    "pr_auc": 0.34295228864945027
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8333333333333334,
+                    "recall": 0.29850746268656714,
+                    "f1": 0.4395604395604395,
+                    "support": 67,
+                    "roc_auc": 0.5775772301284277,
+                    "pr_auc": 0.7177240317825251
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.43243243243243246,
+                    "recall": 0.64,
+                    "f1": 0.5161290322580645,
+                    "support": 25,
+                    "roc_auc": 0.7487058823529412,
+                    "pr_auc": 0.5085406358544662
+                  }
+                ],
+                "macro_precision": 0.5239627382484525,
+                "macro_recall": 0.5906135986733002,
+                "macro_f1": 0.46781688861611825,
+                "weighted_f1": 0.4583043340867125,
+                "macro_roc_auc": 0.7039703772683468,
+                "macro_pr_auc": 0.5230723187621472
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4302455010311608,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.0297448873631436,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    20,
+                    9
+                  ],
+                  [
+                    20,
+                    21,
+                    10
+                  ],
+                  [
+                    2,
+                    3,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.40540540540540543,
+                    "recall": 0.3409090909090909,
+                    "f1": 0.37037037037037035,
+                    "support": 44,
+                    "roc_auc": 0.5759837177747625,
+                    "pr_auc": 0.43034684147854263
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4772727272727273,
+                    "recall": 0.4117647058823529,
+                    "f1": 0.4421052631578948,
+                    "support": 51,
+                    "roc_auc": 0.5006535947712418,
+                    "pr_auc": 0.4323984713164955
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.36666666666666664,
+                    "recall": 0.6875,
+                    "f1": 0.47826086956521735,
+                    "support": 16,
+                    "roc_auc": 0.7447368421052631,
+                    "pr_auc": 0.2811378442172804
+                  }
+                ],
+                "macro_precision": 0.4164482664482665,
+                "macro_recall": 0.4800579322638146,
+                "macro_f1": 0.4302455010311608,
+                "weighted_f1": 0.41888142910263426,
+                "macro_roc_auc": 0.6071247182170891,
+                "macro_pr_auc": 0.38129438567077284
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.39759793052475983,
+              "regime_accuracy": 0.43809524178504944,
+              "regime_loss": 1.1366918802261352,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    4,
+                    17,
+                    8
+                  ],
+                  [
+                    6,
+                    19,
+                    18
+                  ],
+                  [
+                    1,
+                    9,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.36363636363636365,
+                    "recall": 0.13793103448275862,
+                    "f1": 0.2,
+                    "support": 29,
+                    "roc_auc": 0.6574410163339383,
+                    "pr_auc": 0.3592139872000072
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4222222222222222,
+                    "recall": 0.4418604651162791,
+                    "f1": 0.4318181818181818,
+                    "support": 43,
+                    "roc_auc": 0.5907726931732933,
+                    "pr_auc": 0.46099751896966423
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.46938775510204084,
+                    "recall": 0.696969696969697,
+                    "f1": 0.5609756097560976,
+                    "support": 33,
+                    "roc_auc": 0.7234848484848485,
+                    "pr_auc": 0.6361138663088681
+                  }
+                ],
+                "macro_precision": 0.41841544698687555,
+                "macro_recall": 0.42558706552291153,
+                "macro_f1": 0.39759793052475983,
+                "weighted_f1": 0.4083845422869814,
+                "macro_roc_auc": 0.6572328526640266,
+                "macro_pr_auc": 0.4854417908261799
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.35792315029603167,
+              "regime_accuracy": 0.38333332538604736,
+              "regime_loss": 1.4828807955600136,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    3,
+                    16
+                  ],
+                  [
+                    17,
+                    6,
+                    24
+                  ],
+                  [
+                    11,
+                    3,
+                    25
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3488372093023256,
+                    "recall": 0.4411764705882353,
+                    "f1": 0.38961038961038963,
+                    "support": 34,
+                    "roc_auc": 0.6002051983584131,
+                    "pr_auc": 0.33728228432353363
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5,
+                    "recall": 0.1276595744680851,
+                    "f1": 0.20338983050847456,
+                    "support": 47,
+                    "roc_auc": 0.45934129991256195,
+                    "pr_auc": 0.3621572838688729
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.38461538461538464,
+                    "recall": 0.6410256410256411,
+                    "f1": 0.4807692307692308,
+                    "support": 39,
+                    "roc_auc": 0.5428933206710984,
+                    "pr_auc": 0.3597761022300463
+                  }
+                ],
+                "macro_precision": 0.4111508646392368,
+                "macro_recall": 0.4032872286939872,
+                "macro_f1": 0.35792315029603167,
+                "weighted_f1": 0.34630062733876293,
+                "macro_roc_auc": 0.5341466063140244,
+                "macro_pr_auc": 0.35307189014081763
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.354546390690969,
+              "regime_accuracy": 0.6101694703102112,
+              "regime_loss": 0.8565577568830051,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    1,
+                    1
+                  ],
+                  [
+                    13,
+                    0,
+                    6
+                  ],
+                  [
+                    14,
+                    11,
+                    67
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.15625,
+                    "recall": 0.7142857142857143,
+                    "f1": 0.25641025641025644,
+                    "support": 7,
+                    "roc_auc": 0.8172458172458172,
+                    "pr_auc": 0.15384411133733575
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.6209463051568315,
+                    "pr_auc": 0.18981406174396825
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9054054054054054,
+                    "recall": 0.7282608695652174,
+                    "f1": 0.8072289156626506,
+                    "support": 92,
+                    "roc_auc": 0.7508361204013378,
+                    "pr_auc": 0.9166705010732369
+                  }
+                ],
+                "macro_precision": 0.3538851351351351,
+                "macro_recall": 0.4808488612836439,
+                "macro_f1": 0.354546390690969,
+                "weighted_f1": 0.6445756952189462,
+                "macro_roc_auc": 0.7296760809346622,
+                "macro_pr_auc": 0.4201095580515137
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.40079365079365087,
+              "regime_accuracy": 0.3909091055393219,
+              "regime_loss": 1.012370211427862,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    2,
+                    1
+                  ],
+                  [
+                    33,
+                    12,
+                    22
+                  ],
+                  [
+                    6,
+                    3,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2777777777777778,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.4166666666666667,
+                    "support": 18,
+                    "roc_auc": 0.7753623188405797,
+                    "pr_auc": 0.32360406318449514
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7058823529411765,
+                    "recall": 0.1791044776119403,
+                    "f1": 0.28571428571428575,
+                    "support": 67,
+                    "roc_auc": 0.5813953488372093,
+                    "pr_auc": 0.7051636680960333
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.41025641025641024,
+                    "recall": 0.64,
+                    "f1": 0.5,
+                    "support": 25,
+                    "roc_auc": 0.744,
+                    "pr_auc": 0.5478906720307783
+                  }
+                ],
+                "macro_precision": 0.46463884699178815,
+                "macro_recall": 0.5508126036484245,
+                "macro_f1": 0.40079365079365087,
+                "weighted_f1": 0.35584415584415585,
+                "macro_roc_auc": 0.7002525558925964,
+                "macro_pr_auc": 0.5255528011037689
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.42884531590413943,
+              "regime_accuracy": 0.4234234094619751,
+              "regime_loss": 1.0828447968879917,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    25,
+                    6
+                  ],
+                  [
+                    16,
+                    23,
+                    12
+                  ],
+                  [
+                    2,
+                    3,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.41935483870967744,
+                    "recall": 0.29545454545454547,
+                    "f1": 0.3466666666666667,
+                    "support": 44,
+                    "roc_auc": 0.6339891451831751,
+                    "pr_auc": 0.45861215954821155
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.45098039215686275,
+                    "recall": 0.45098039215686275,
+                    "f1": 0.45098039215686275,
+                    "support": 51,
+                    "roc_auc": 0.49640522875816995,
+                    "pr_auc": 0.45630126912196683
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3793103448275862,
+                    "recall": 0.6875,
+                    "f1": 0.4888888888888889,
+                    "support": 16,
+                    "roc_auc": 0.7677631578947368,
+                    "pr_auc": 0.3014551994373554
+                  }
+                ],
+                "macro_precision": 0.4165485252313754,
+                "macro_recall": 0.47797831253713613,
+                "macro_f1": 0.42884531590413943,
+                "weighted_f1": 0.41509509509509507,
+                "macro_roc_auc": 0.6327191772786939,
+                "macro_pr_auc": 0.40545620936917787
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.34928989139515454,
+              "regime_accuracy": 0.4476190507411957,
+              "regime_loss": 1.1470804163387844,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    24,
+                    5
+                  ],
+                  [
+                    0,
+                    26,
+                    17
+                  ],
+                  [
+                    0,
+                    12,
+                    21
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 29,
+                    "roc_auc": 0.7259528130671506,
+                    "pr_auc": 0.48710749835121975
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.41935483870967744,
+                    "recall": 0.6046511627906976,
+                    "f1": 0.49523809523809514,
+                    "support": 43,
+                    "roc_auc": 0.5982745686421606,
+                    "pr_auc": 0.49105296511806373
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4883720930232558,
+                    "recall": 0.6363636363636364,
+                    "f1": 0.5526315789473685,
+                    "support": 33,
+                    "roc_auc": 0.6893939393939394,
+                    "pr_auc": 0.6343172076681695
+                  }
+                ],
+                "macro_precision": 0.30257564391097774,
+                "macro_recall": 0.41367159971811135,
+                "macro_f1": 0.34928989139515454,
+                "weighted_f1": 0.37649600190953575,
+                "macro_roc_auc": 0.6712071070344169,
+                "macro_pr_auc": 0.5374925570458177
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.29322181086886967,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.5684685899689326,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    6,
+                    18
+                  ],
+                  [
+                    15,
+                    2,
+                    30
+                  ],
+                  [
+                    9,
+                    0,
+                    30
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.29411764705882354,
+                    "recall": 0.29411764705882354,
+                    "f1": 0.29411764705882354,
+                    "support": 34,
+                    "roc_auc": 0.5882352941176471,
+                    "pr_auc": 0.3015325924160274
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.0425531914893617,
+                    "f1": 0.07272727272727272,
+                    "support": 47,
+                    "roc_auc": 0.4625473622850481,
+                    "pr_auc": 0.37108545946477833
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.38461538461538464,
+                    "recall": 0.7692307692307693,
+                    "f1": 0.5128205128205128,
+                    "support": 39,
+                    "roc_auc": 0.5827793605571383,
+                    "pr_auc": 0.3893855606362706
+                  }
+                ],
+                "macro_precision": 0.30957767722473606,
+                "macro_recall": 0.3686338692596515,
+                "macro_f1": 0.29322181086886967,
+                "weighted_f1": 0.2784848484848485,
+                "macro_roc_auc": 0.5445206723199445,
+                "macro_pr_auc": 0.3540012041723588
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.3553113553113553,
+              "regime_accuracy": 0.6186440587043762,
+              "regime_loss": 0.7311831141161877,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    1,
+                    1
+                  ],
+                  [
+                    12,
+                    0,
+                    7
+                  ],
+                  [
+                    15,
+                    9,
+                    68
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.15625,
+                    "recall": 0.7142857142857143,
+                    "f1": 0.25641025641025644,
+                    "support": 7,
+                    "roc_auc": 0.8468468468468469,
+                    "pr_auc": 0.18588775836674995
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.7368421052631579,
+                    "pr_auc": 0.2557129813287983
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.8947368421052632,
+                    "recall": 0.7391304347826086,
+                    "f1": 0.8095238095238095,
+                    "support": 92,
+                    "roc_auc": 0.7989130434782609,
+                    "pr_auc": 0.9379241924979039
+                  }
+                ],
+                "macro_precision": 0.3503289473684211,
+                "macro_recall": 0.48447204968944096,
+                "macro_f1": 0.3553113553113553,
+                "weighted_f1": 0.6463649345005278,
+                "macro_roc_auc": 0.7942006651960885,
+                "macro_pr_auc": 0.4598416440644841
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.303775260937153,
+              "regime_accuracy": 0.30000001192092896,
+              "regime_loss": 1.1224905599247326,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    15,
+                    0,
+                    3
+                  ],
+                  [
+                    38,
+                    5,
+                    24
+                  ],
+                  [
+                    8,
+                    4,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2459016393442623,
+                    "recall": 0.8333333333333334,
+                    "f1": 0.379746835443038,
+                    "support": 18,
+                    "roc_auc": 0.6455314009661836,
+                    "pr_auc": 0.21568419465611208
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5555555555555556,
+                    "recall": 0.07462686567164178,
+                    "f1": 0.13157894736842105,
+                    "support": 67,
+                    "roc_auc": 0.4842068726136758,
+                    "pr_auc": 0.6428024271974799
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.325,
+                    "recall": 0.52,
+                    "f1": 0.4,
+                    "support": 25,
+                    "roc_auc": 0.7087058823529412,
+                    "pr_auc": 0.42697954706217883
+                  }
+                ],
+                "macro_precision": 0.37548573163327265,
+                "macro_recall": 0.47598673300165845,
+                "macro_f1": 0.303775260937153,
+                "weighted_f1": 0.2331930228332627,
+                "macro_roc_auc": 0.6128147186442668,
+                "macro_pr_auc": 0.42848872297192364
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4045743145743146,
+              "regime_accuracy": 0.38738739490509033,
+              "regime_loss": 1.0952245883756782,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    19,
+                    21,
+                    4
+                  ],
+                  [
+                    23,
+                    11,
+                    17
+                  ],
+                  [
+                    2,
+                    1,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4318181818181818,
+                    "recall": 0.4318181818181818,
+                    "f1": 0.4318181818181818,
+                    "support": 44,
+                    "roc_auc": 0.6336499321573948,
+                    "pr_auc": 0.5415521578432098
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.21568627450980393,
+                    "f1": 0.26190476190476186,
+                    "support": 51,
+                    "roc_auc": 0.4650326797385621,
+                    "pr_auc": 0.4838447125351481
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.38235294117647056,
+                    "recall": 0.8125,
+                    "f1": 0.52,
+                    "support": 16,
+                    "roc_auc": 0.8013157894736842,
+                    "pr_auc": 0.3371327453506316
+                  }
+                ],
+                "macro_precision": 0.3825014854426619,
+                "macro_recall": 0.48666815210932857,
+                "macro_f1": 0.4045743145743146,
+                "weighted_f1": 0.36646074646074644,
+                "macro_roc_auc": 0.633332800456547,
+                "macro_pr_auc": 0.45417653857632984
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.38978798978798984,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.0684758367992582,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    8,
+                    15,
+                    6
+                  ],
+                  [
+                    11,
+                    14,
+                    18
+                  ],
+                  [
+                    7,
+                    6,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.27586206896551724,
+                    "f1": 0.29090909090909095,
+                    "support": 29,
+                    "roc_auc": 0.6220508166969148,
+                    "pr_auc": 0.4244875062220674
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4,
+                    "recall": 0.32558139534883723,
+                    "f1": 0.35897435897435903,
+                    "support": 43,
+                    "roc_auc": 0.5731432858214554,
+                    "pr_auc": 0.42946621196583606
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.45454545454545453,
+                    "recall": 0.6060606060606061,
+                    "f1": 0.5194805194805195,
+                    "support": 33,
+                    "roc_auc": 0.6999158249158249,
+                    "pr_auc": 0.5921524493421032
+                  }
+                ],
+                "macro_precision": 0.3874125874125874,
+                "macro_recall": 0.40250135679165355,
+                "macro_f1": 0.38978798978798984,
+                "weighted_f1": 0.39062017347731637,
+                "macro_roc_auc": 0.6317033091447316,
+                "macro_pr_auc": 0.4820353891766689
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.27076515505688015,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.3405866272726896,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    0,
+                    21
+                  ],
+                  [
+                    10,
+                    0,
+                    37
+                  ],
+                  [
+                    12,
+                    0,
+                    27
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.37142857142857144,
+                    "recall": 0.38235294117647056,
+                    "f1": 0.37681159420289856,
+                    "support": 34,
+                    "roc_auc": 0.5861833105335157,
+                    "pr_auc": 0.35663181883496925
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.4485572719323812,
+                    "pr_auc": 0.34494535552308914
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3176470588235294,
+                    "recall": 0.6923076923076923,
+                    "f1": 0.4354838709677419,
+                    "support": 39,
+                    "roc_auc": 0.5574548907882241,
+                    "pr_auc": 0.38344239527268364
+                  }
+                ],
+                "macro_precision": 0.22969187675070027,
+                "macro_recall": 0.35822021116138764,
+                "macro_f1": 0.27076515505688015,
+                "weighted_f1": 0.2482955430886707,
+                "macro_roc_auc": 0.5307318244180403,
+                "macro_pr_auc": 0.36167318987691405
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4172096908939014,
+              "regime_accuracy": 0.6694915294647217,
+              "regime_loss": 0.6613866549082876,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    0,
+                    1
+                  ],
+                  [
+                    12,
+                    1,
+                    6
+                  ],
+                  [
+                    10,
+                    10,
+                    72
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.21428571428571427,
+                    "recall": 0.8571428571428571,
+                    "f1": 0.34285714285714286,
+                    "support": 7,
+                    "roc_auc": 0.8996138996138996,
+                    "pr_auc": 0.2649248335697915
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.09090909090909091,
+                    "recall": 0.05263157894736842,
+                    "f1": 0.06666666666666667,
+                    "support": 19,
+                    "roc_auc": 0.7682083997873471,
+                    "pr_auc": 0.3006727876908804
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9113924050632911,
+                    "recall": 0.782608695652174,
+                    "f1": 0.8421052631578948,
+                    "support": 92,
+                    "roc_auc": 0.8658026755852842,
+                    "pr_auc": 0.9582342412659747
+                  }
+                ],
+                "macro_precision": 0.4055290700860321,
+                "macro_recall": 0.5641277105807998,
+                "macro_f1": 0.4172096908939014,
+                "weighted_f1": 0.6876300921796016,
+                "macro_roc_auc": 0.8445416583288438,
+                "macro_pr_auc": 0.5079439541755488
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4036695937745413,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.0299674641002308,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    3,
+                    2
+                  ],
+                  [
+                    31,
+                    18,
+                    18
+                  ],
+                  [
+                    8,
+                    4,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.25,
+                    "recall": 0.7222222222222222,
+                    "f1": 0.37142857142857144,
+                    "support": 18,
+                    "roc_auc": 0.7306763285024155,
+                    "pr_auc": 0.3135100966899371
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.72,
+                    "recall": 0.26865671641791045,
+                    "f1": 0.391304347826087,
+                    "support": 67,
+                    "roc_auc": 0.5446025685525859,
+                    "pr_auc": 0.6829440382251557
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3939393939393939,
+                    "recall": 0.52,
+                    "f1": 0.44827586206896547,
+                    "support": 25,
+                    "roc_auc": 0.7190588235294118,
+                    "pr_auc": 0.43514087101051135
+                  }
+                ],
+                "macro_precision": 0.4546464646464646,
+                "macro_recall": 0.5036263128800442,
+                "macro_f1": 0.4036695937745413,
+                "weighted_f1": 0.4010000194707841,
+                "macro_roc_auc": 0.6647792401948044,
+                "macro_pr_auc": 0.4771983353085347
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4523809523809524,
+              "regime_accuracy": 0.46846845746040344,
+              "regime_loss": 1.1161865498275627,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    30,
+                    9,
+                    5
+                  ],
+                  [
+                    24,
+                    9,
+                    18
+                  ],
+                  [
+                    2,
+                    1,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5357142857142857,
+                    "recall": 0.6818181818181818,
+                    "f1": 0.6,
+                    "support": 44,
+                    "roc_auc": 0.6329715061058344,
+                    "pr_auc": 0.48271542490930064
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.47368421052631576,
+                    "recall": 0.17647058823529413,
+                    "f1": 0.2571428571428572,
+                    "support": 51,
+                    "roc_auc": 0.3715686274509804,
+                    "pr_auc": 0.37617560543142314
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3611111111111111,
+                    "recall": 0.8125,
+                    "f1": 0.5,
+                    "support": 16,
+                    "roc_auc": 0.8078947368421052,
+                    "pr_auc": 0.33969450417095515
+                  }
+                ],
+                "macro_precision": 0.4568365357839042,
+                "macro_recall": 0.5569295900178253,
+                "macro_f1": 0.4523809523809524,
+                "weighted_f1": 0.42805662805662803,
+                "macro_roc_auc": 0.6041449567996401,
+                "macro_pr_auc": 0.39952851150389296
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.48014085677062757,
+              "regime_accuracy": 0.48571428656578064,
+              "regime_loss": 1.057937342779977,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    13,
+                    4
+                  ],
+                  [
+                    12,
+                    23,
+                    8
+                  ],
+                  [
+                    9,
+                    8,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.36363636363636365,
+                    "recall": 0.41379310344827586,
+                    "f1": 0.3870967741935484,
+                    "support": 29,
+                    "roc_auc": 0.6347549909255898,
+                    "pr_auc": 0.3787928978022418
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5227272727272727,
+                    "recall": 0.5348837209302325,
+                    "f1": 0.5287356321839081,
+                    "support": 43,
+                    "roc_auc": 0.6432858214553638,
+                    "pr_auc": 0.48445944062931
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5714285714285714,
+                    "recall": 0.48484848484848486,
+                    "f1": 0.5245901639344263,
+                    "support": 33,
+                    "roc_auc": 0.6590909090909091,
+                    "pr_auc": 0.54068824047695
+                  }
+                ],
+                "macro_precision": 0.48593073593073594,
+                "macro_recall": 0.4778417697423311,
+                "macro_f1": 0.48014085677062757,
+                "weighted_f1": 0.4883134670986382,
+                "macro_roc_auc": 0.6457105738239542,
+                "macro_pr_auc": 0.4679801929695006
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "classification",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.34184987126163596,
+              "regime_accuracy": 0.375,
+              "regime_loss": 1.3064368662092016,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    20,
+                    0,
+                    14
+                  ],
+                  [
+                    18,
+                    4,
+                    25
+                  ],
+                  [
+                    18,
+                    0,
+                    21
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35714285714285715,
+                    "recall": 0.5882352941176471,
+                    "f1": 0.4444444444444445,
+                    "support": 34,
+                    "roc_auc": 0.585499316005472,
+                    "pr_auc": 0.3779250393329843
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.0851063829787234,
+                    "f1": 0.1568627450980392,
+                    "support": 47,
+                    "roc_auc": 0.48440687846109004,
+                    "pr_auc": 0.40538742251724935
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.35,
+                    "recall": 0.5384615384615384,
+                    "f1": 0.4242424242424242,
+                    "support": 39,
+                    "roc_auc": 0.5232668566001899,
+                    "pr_auc": 0.3434314006423104
+                  }
+                ],
+                "macro_precision": 0.569047619047619,
+                "macro_recall": 0.4039344051859696,
+                "macro_f1": 0.34184987126163596,
+                "weighted_f1": 0.32524262230144585,
+                "macro_roc_auc": 0.5310576836889173,
+                "macro_pr_auc": 0.3755812874975147
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5244705151398863,
+              "regime_accuracy": 0.7033898234367371,
+              "regime_loss": 0.7370904317281973,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    0,
+                    1
+                  ],
+                  [
+                    7,
+                    6,
+                    6
+                  ],
+                  [
+                    9,
+                    12,
+                    71
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2727272727272727,
+                    "recall": 0.8571428571428571,
+                    "f1": 0.41379310344827586,
+                    "support": 7,
+                    "roc_auc": 0.8468468468468469,
+                    "pr_auc": 0.19579629678405835
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.3157894736842105,
+                    "f1": 0.3243243243243243,
+                    "support": 19,
+                    "roc_auc": 0.7262094630515683,
+                    "pr_auc": 0.2538535997963158
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9102564102564102,
+                    "recall": 0.7717391304347826,
+                    "f1": 0.8352941176470589,
+                    "support": 92,
+                    "roc_auc": 0.7930602006688964,
+                    "pr_auc": 0.9348819706627005
+                  }
+                ],
+                "macro_precision": 0.5054390054390054,
+                "macro_recall": 0.6482238204206167,
+                "macro_f1": 0.5244705151398863,
+                "weighted_f1": 0.7280150229646568,
+                "macro_roc_auc": 0.7887055035224372,
+                "macro_pr_auc": 0.4615106224143582
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3572292800967937,
+              "regime_accuracy": 0.3545454442501068,
+              "regime_loss": 1.289847376129844,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    0,
+                    6
+                  ],
+                  [
+                    20,
+                    9,
+                    38
+                  ],
+                  [
+                    7,
+                    0,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.42105263157894735,
+                    "support": 18,
+                    "roc_auc": 0.6793478260869565,
+                    "pr_auc": 0.2389856688726666
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.13432835820895522,
+                    "f1": 0.2368421052631579,
+                    "support": 67,
+                    "roc_auc": 0.578965636931621,
+                    "pr_auc": 0.7473984482566685
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2903225806451613,
+                    "recall": 0.72,
+                    "f1": 0.4137931034482759,
+                    "support": 25,
+                    "roc_auc": 0.6423529411764706,
+                    "pr_auc": 0.29108344345943404
+                  }
+                ],
+                "macro_precision": 0.532671629445823,
+                "macro_recall": 0.5069983416252073,
+                "macro_f1": 0.3572292800967937,
+                "weighted_f1": 0.30720178188417757,
+                "macro_roc_auc": 0.6335554680650161,
+                "macro_pr_auc": 0.4258225201962564
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.38083207642031175,
+              "regime_accuracy": 0.36036035418510437,
+              "regime_loss": 1.0997814792864382,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    25,
+                    6
+                  ],
+                  [
+                    21,
+                    14,
+                    16
+                  ],
+                  [
+                    2,
+                    1,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3611111111111111,
+                    "recall": 0.29545454545454547,
+                    "f1": 0.325,
+                    "support": 44,
+                    "roc_auc": 0.6556987788331072,
+                    "pr_auc": 0.5324010314366185
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.35,
+                    "recall": 0.27450980392156865,
+                    "f1": 0.3076923076923077,
+                    "support": 51,
+                    "roc_auc": 0.46568627450980393,
+                    "pr_auc": 0.42762634483073375
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.37142857142857144,
+                    "recall": 0.8125,
+                    "f1": 0.5098039215686275,
+                    "support": 16,
+                    "roc_auc": 0.8328947368421052,
+                    "pr_auc": 0.37695564350922023
+                  }
+                ],
+                "macro_precision": 0.3608465608465608,
+                "macro_recall": 0.46082144979203804,
+                "macro_f1": 0.38083207642031175,
+                "weighted_f1": 0.34368622015680844,
+                "macro_roc_auc": 0.6514265967283388,
+                "macro_pr_auc": 0.4456610065921908
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4126294681022902,
+              "regime_accuracy": 0.41904762387275696,
+              "regime_loss": 1.141383449236552,
+              "regression_rmse_log_rv": null,
+              "regression_mae_log_rv": null,
+              "regression_loss": null,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    11,
+                    8,
+                    10
+                  ],
+                  [
+                    14,
+                    13,
+                    16
+                  ],
+                  [
+                    9,
+                    4,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3235294117647059,
+                    "recall": 0.3793103448275862,
+                    "f1": 0.3492063492063492,
+                    "support": 29,
+                    "roc_auc": 0.5948275862068966,
+                    "pr_auc": 0.4186898465982454
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.52,
+                    "recall": 0.3023255813953488,
+                    "f1": 0.38235294117647056,
+                    "support": 43,
+                    "roc_auc": 0.5198799699924981,
+                    "pr_auc": 0.416675312885596
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.43478260869565216,
+                    "recall": 0.6060606060606061,
+                    "f1": 0.5063291139240507,
+                    "support": 33,
+                    "roc_auc": 0.6418350168350169,
+                    "pr_auc": 0.4551752223076835
+                  }
+                ],
+                "macro_precision": 0.42610400682011934,
+                "macro_recall": 0.4292321774278471,
+                "macro_f1": 0.4126294681022902,
+                "weighted_f1": 0.4121621081625336,
+                "macro_roc_auc": 0.5855141910114705,
+                "macro_pr_auc": 0.43018012726384164
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "regression": [
+      {
+        "head_mode": "regression",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.3193124368048534,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.101004133896581,
+              "regression_rmse_log_rv": 1.0214754249559936,
+              "regression_mae_log_rv": 0.8392580187850399,
+              "regression_loss": 1.043412043789028,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    27,
+                    7,
+                    0
+                  ],
+                  [
+                    26,
+                    21,
+                    0
+                  ],
+                  [
+                    28,
+                    11,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.7941176470588235,
+                    "f1": 0.46956521739130425,
+                    "support": 34,
+                    "roc_auc": 0.6826265389876881,
+                    "pr_auc": 0.44213292623891753
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5384615384615384,
+                    "recall": 0.44680851063829785,
+                    "f1": 0.4883720930232558,
+                    "support": 47,
+                    "roc_auc": 0.6330515884581754,
+                    "pr_auc": 0.5970260681949958
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 39,
+                    "roc_auc": 0.4954099398543843,
+                    "pr_auc": 0.30038509696368626
+                  }
+                ],
+                "macro_precision": 0.2905982905982906,
+                "macro_recall": 0.41364205256570713,
+                "macro_f1": 0.3193124368048534,
+                "weighted_f1": 0.3243225480283114,
+                "macro_roc_auc": 0.6036960224334159,
+                "macro_pr_auc": 0.44651469713253317
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.1193337550073793,
+              "regime_accuracy": 0.12711864709854126,
+              "regime_loss": 1.3088173091872344,
+              "regression_rmse_log_rv": 0.7283240961609665,
+              "regression_mae_log_rv": 0.5812551957097346,
+              "regression_loss": 0.5304559890486888,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    5,
+                    0
+                  ],
+                  [
+                    6,
+                    13,
+                    0
+                  ],
+                  [
+                    36,
+                    56,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.045454545454545456,
+                    "recall": 0.2857142857142857,
+                    "f1": 0.0784313725490196,
+                    "support": 7,
+                    "roc_auc": 0.5019305019305019,
+                    "pr_auc": 0.059846042312193856
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.17567567567567569,
+                    "recall": 0.6842105263157895,
+                    "f1": 0.2795698924731183,
+                    "support": 19,
+                    "roc_auc": 0.5013290802764487,
+                    "pr_auc": 0.291323929536067
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 92,
+                    "roc_auc": 0.5999163879598662,
+                    "pr_auc": 0.8434209447112847
+                  }
+                ],
+                "macro_precision": 0.07371007371007371,
+                "macro_recall": 0.3233082706766917,
+                "macro_f1": 0.1193337550073793,
+                "weighted_f1": 0.04966819970196937,
+                "macro_roc_auc": 0.5343919900556057,
+                "macro_pr_auc": 0.39819697218651523
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.1557271557271557,
+              "regime_accuracy": 0.2181818187236786,
+              "regime_loss": 1.115101536837491,
+              "regression_rmse_log_rv": 0.6876264189195658,
+              "regression_mae_log_rv": 0.5296470452100038,
+              "regression_loss": 0.47283009199614623,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    18,
+                    0,
+                    0
+                  ],
+                  [
+                    61,
+                    6,
+                    0
+                  ],
+                  [
+                    14,
+                    11,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.1935483870967742,
+                    "recall": 1.0,
+                    "f1": 0.3243243243243243,
+                    "support": 18,
+                    "roc_auc": 0.6865942028985508,
+                    "pr_auc": 0.22357616520233578
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.35294117647058826,
+                    "recall": 0.08955223880597014,
+                    "f1": 0.14285714285714288,
+                    "support": 67,
+                    "roc_auc": 0.3575147518222839,
+                    "pr_auc": 0.5524912134868438
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 25,
+                    "roc_auc": 0.4127058823529412,
+                    "pr_auc": 0.2876845918158254
+                  }
+                ],
+                "macro_precision": 0.18216318785578747,
+                "macro_recall": 0.36318407960199006,
+                "macro_f1": 0.1557271557271557,
+                "weighted_f1": 0.14008424008424009,
+                "macro_roc_auc": 0.4856049456912586,
+                "macro_pr_auc": 0.354583990168335
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3164779874213836,
+              "regime_accuracy": 0.44144144654273987,
+              "regime_loss": 1.067280715714486,
+              "regression_rmse_log_rv": 0.7163743498747902,
+              "regression_mae_log_rv": 0.5566574766254472,
+              "regression_loss": 0.5131922091585283,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    27,
+                    17,
+                    0
+                  ],
+                  [
+                    29,
+                    22,
+                    0
+                  ],
+                  [
+                    6,
+                    10,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.43548387096774194,
+                    "recall": 0.6136363636363636,
+                    "f1": 0.5094339622641509,
+                    "support": 44,
+                    "roc_auc": 0.4487788331071913,
+                    "pr_auc": 0.35518772629524
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4489795918367347,
+                    "recall": 0.43137254901960786,
+                    "f1": 0.43999999999999995,
+                    "support": 51,
+                    "roc_auc": 0.4542483660130719,
+                    "pr_auc": 0.4030346325459283
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 16,
+                    "roc_auc": 0.3131578947368421,
+                    "pr_auc": 0.10526283916769966
+                  }
+                ],
+                "macro_precision": 0.29482115426815886,
+                "macro_recall": 0.34833630421865713,
+                "macro_f1": 0.3164779874213836,
+                "weighted_f1": 0.40409994900560936,
+                "macro_roc_auc": 0.40539503128570176,
+                "macro_pr_auc": 0.2878283993362893
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.23089046493301812,
+              "regime_accuracy": 0.4095238149166107,
+              "regime_loss": 1.0865763187408448,
+              "regression_rmse_log_rv": 0.821477395266527,
+              "regression_mae_log_rv": 0.6192851692974468,
+              "regression_loss": 0.6748251109338778,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    2,
+                    27,
+                    0
+                  ],
+                  [
+                    2,
+                    41,
+                    0
+                  ],
+                  [
+                    3,
+                    30,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.06896551724137931,
+                    "f1": 0.1111111111111111,
+                    "support": 29,
+                    "roc_auc": 0.6501814882032668,
+                    "pr_auc": 0.40795350343797254
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.41836734693877553,
+                    "recall": 0.9534883720930233,
+                    "f1": 0.5815602836879432,
+                    "support": 43,
+                    "roc_auc": 0.5783945986496624,
+                    "pr_auc": 0.5168075089160243
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 33,
+                    "roc_auc": 0.4297138047138047,
+                    "pr_auc": 0.3563505052769735
+                  }
+                ],
+                "macro_precision": 0.23469387755102042,
+                "macro_recall": 0.34081796311146756,
+                "macro_f1": 0.23089046493301812,
+                "weighted_f1": 0.26885061353146456,
+                "macro_roc_auc": 0.5527632971889113,
+                "macro_pr_auc": 0.4270371725436568
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.284704654441082,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.1105642830537623,
+              "regression_rmse_log_rv": 0.9990456772960636,
+              "regression_mae_log_rv": 0.8341098185318212,
+              "regression_loss": 0.9980922653239506,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    24,
+                    8,
+                    2
+                  ],
+                  [
+                    32,
+                    14,
+                    1
+                  ],
+                  [
+                    17,
+                    20,
+                    2
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3287671232876712,
+                    "recall": 0.7058823529411765,
+                    "f1": 0.44859813084112143,
+                    "support": 34,
+                    "roc_auc": 0.5188098495212038,
+                    "pr_auc": 0.27571188501634003
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.2978723404255319,
+                    "f1": 0.3146067415730337,
+                    "support": 47,
+                    "roc_auc": 0.4782862139317983,
+                    "pr_auc": 0.3812291098667327
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.4,
+                    "recall": 0.05128205128205128,
+                    "f1": 0.09090909090909091,
+                    "support": 39,
+                    "roc_auc": 0.5109211775878443,
+                    "pr_auc": 0.3335757080433932
+                  }
+                ],
+                "macro_precision": 0.35403348554033487,
+                "macro_recall": 0.35167891488291986,
+                "macro_f1": 0.284704654441082,
+                "weighted_f1": 0.2798692320665438,
+                "macro_roc_auc": 0.5026724136802821,
+                "macro_pr_auc": 0.330172234308822
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.19493464052287582,
+              "regime_accuracy": 0.24576270580291748,
+              "regime_loss": 1.1336294128687394,
+              "regression_rmse_log_rv": 0.601369169467767,
+              "regression_mae_log_rv": 0.47046574626623067,
+              "regression_loss": 0.3616448779863518,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    1,
+                    0
+                  ],
+                  [
+                    12,
+                    1,
+                    6
+                  ],
+                  [
+                    43,
+                    27,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.09836065573770492,
+                    "recall": 0.8571428571428571,
+                    "f1": 0.17647058823529413,
+                    "support": 7,
+                    "roc_auc": 0.6254826254826255,
+                    "pr_auc": 0.07355787047481645
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.034482758620689655,
+                    "recall": 0.05263157894736842,
+                    "f1": 0.041666666666666664,
+                    "support": 19,
+                    "roc_auc": 0.34768740031897927,
+                    "pr_auc": 0.11508023147347189
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.7857142857142857,
+                    "recall": 0.2391304347826087,
+                    "f1": 0.36666666666666664,
+                    "support": 92,
+                    "roc_auc": 0.43561872909698995,
+                    "pr_auc": 0.7843662742030414
+                  }
+                ],
+                "macro_precision": 0.30618590002422674,
+                "macro_recall": 0.38296829029094476,
+                "macro_f1": 0.19493464052287582,
+                "weighted_f1": 0.3030533399800598,
+                "macro_roc_auc": 0.4695962516328649,
+                "macro_pr_auc": 0.32433479205044324
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.39996176882885176,
+              "regime_accuracy": 0.5090909004211426,
+              "regime_loss": 1.0772624427622015,
+              "regression_rmse_log_rv": 0.7303021467642234,
+              "regression_mae_log_rv": 0.55099642298777,
+              "regression_loss": 0.5333412255684334,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    8,
+                    0
+                  ],
+                  [
+                    24,
+                    43,
+                    0
+                  ],
+                  [
+                    7,
+                    15,
+                    3
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.24390243902439024,
+                    "recall": 0.5555555555555556,
+                    "f1": 0.33898305084745767,
+                    "support": 18,
+                    "roc_auc": 0.5839371980676329,
+                    "pr_auc": 0.1930611578124559
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6515151515151515,
+                    "recall": 0.6417910447761194,
+                    "f1": 0.6466165413533834,
+                    "support": 67,
+                    "roc_auc": 0.547726483859771,
+                    "pr_auc": 0.6387421476653452
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.12,
+                    "f1": 0.21428571428571425,
+                    "support": 25,
+                    "roc_auc": 0.5425882352941176,
+                    "pr_auc": 0.3304518881662995
+                  }
+                ],
+                "macro_precision": 0.6318058635131806,
+                "macro_recall": 0.43911553344389165,
+                "macro_f1": 0.39996176882885176,
+                "weighted_f1": 0.49801950948248896,
+                "macro_roc_auc": 0.5580839724071738,
+                "macro_pr_auc": 0.38741839788136684
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.15993265993265993,
+              "regime_accuracy": 0.18018017709255219,
+              "regime_loss": 1.120900375570833,
+              "regression_rmse_log_rv": 0.7274049516210523,
+              "regression_mae_log_rv": 0.5827425711343551,
+              "regression_loss": 0.5291179636428255,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    0,
+                    34
+                  ],
+                  [
+                    12,
+                    0,
+                    39
+                  ],
+                  [
+                    6,
+                    0,
+                    10
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.35714285714285715,
+                    "recall": 0.22727272727272727,
+                    "f1": 0.2777777777777778,
+                    "support": 44,
+                    "roc_auc": 0.4908412483039349,
+                    "pr_auc": 0.3646851404452731
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 51,
+                    "roc_auc": 0.5375816993464052,
+                    "pr_auc": 0.46168596329557393
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.12048192771084337,
+                    "recall": 0.625,
+                    "f1": 0.20202020202020202,
+                    "support": 16,
+                    "roc_auc": 0.5394736842105263,
+                    "pr_auc": 0.18242199896455735
+                  }
+                ],
+                "macro_precision": 0.15920826161790017,
+                "macro_recall": 0.2840909090909091,
+                "macro_f1": 0.15993265993265993,
+                "weighted_f1": 0.13923013923013924,
+                "macro_roc_auc": 0.5226322106202889,
+                "macro_pr_auc": 0.33626436756846817
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.22157900197115885,
+              "regime_accuracy": 0.2571428716182709,
+              "regime_loss": 1.1093497719083514,
+              "regression_rmse_log_rv": 0.9125535760080719,
+              "regression_mae_log_rv": 0.7101914613800112,
+              "regression_loss": 0.8327540290851199,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    0,
+                    24
+                  ],
+                  [
+                    11,
+                    3,
+                    29
+                  ],
+                  [
+                    9,
+                    5,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2,
+                    "recall": 0.1724137931034483,
+                    "f1": 0.1851851851851852,
+                    "support": 29,
+                    "roc_auc": 0.5372050816696915,
+                    "pr_auc": 0.26257720618670083
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.375,
+                    "recall": 0.06976744186046512,
+                    "f1": 0.1176470588235294,
+                    "support": 43,
+                    "roc_auc": 0.5435108777194299,
+                    "pr_auc": 0.47962198894718056
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2638888888888889,
+                    "recall": 0.5757575757575758,
+                    "f1": 0.3619047619047619,
+                    "support": 33,
+                    "roc_auc": 0.5033670033670034,
+                    "pr_auc": 0.30204486311257495
+                  }
+                ],
+                "macro_precision": 0.2796296296296296,
+                "macro_recall": 0.2726462702404964,
+                "macro_f1": 0.22157900197115885,
+                "weighted_f1": 0.21306715278704075,
+                "macro_roc_auc": 0.5280276542520416,
+                "macro_pr_auc": 0.34808135274881874
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2114182114182114,
+              "regime_accuracy": 0.32499998807907104,
+              "regime_loss": 1.1430330255033099,
+              "regression_rmse_log_rv": 1.0328911360145374,
+              "regression_mae_log_rv": 0.840866910542051,
+              "regression_loss": 1.0668640988574016,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    6,
+                    28
+                  ],
+                  [
+                    0,
+                    5,
+                    42
+                  ],
+                  [
+                    0,
+                    5,
+                    34
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 34,
+                    "roc_auc": 0.4059507523939809,
+                    "pr_auc": 0.23088928783829166
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3125,
+                    "recall": 0.10638297872340426,
+                    "f1": 0.15873015873015872,
+                    "support": 47,
+                    "roc_auc": 0.408335762168464,
+                    "pr_auc": 0.3964966551867784
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3269230769230769,
+                    "recall": 0.8717948717948718,
+                    "f1": 0.4755244755244756,
+                    "support": 39,
+                    "roc_auc": 0.40424184868629315,
+                    "pr_auc": 0.27003236516870327
+                  }
+                ],
+                "macro_precision": 0.21314102564102563,
+                "macro_recall": 0.32605928350609203,
+                "macro_f1": 0.2114182114182114,
+                "weighted_f1": 0.21671476671476672,
+                "macro_roc_auc": 0.4061761210829127,
+                "macro_pr_auc": 0.2991394360645911
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.20930232558139536,
+              "regime_accuracy": 0.4576271176338196,
+              "regime_loss": 0.9869995361820765,
+              "regression_rmse_log_rv": 0.7817710774694135,
+              "regression_mae_log_rv": 0.64633940466506,
+              "regression_loss": 0.6111660175676877,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    7
+                  ],
+                  [
+                    0,
+                    0,
+                    19
+                  ],
+                  [
+                    11,
+                    27,
+                    54
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 7,
+                    "roc_auc": 0.3127413127413127,
+                    "pr_auc": 0.04157670188335522
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.4029771398192451,
+                    "pr_auc": 0.12615914053559404
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.675,
+                    "recall": 0.5869565217391305,
+                    "f1": 0.627906976744186,
+                    "support": 92,
+                    "roc_auc": 0.26714046822742477,
+                    "pr_auc": 0.6722282431908875
+                  }
+                ],
+                "macro_precision": 0.225,
+                "macro_recall": 0.1956521739130435,
+                "macro_f1": 0.20930232558139536,
+                "weighted_f1": 0.48955459203784,
+                "macro_roc_auc": 0.3276196402626608,
+                "macro_pr_auc": 0.27998802853661225
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.12535612535612536,
+              "regime_accuracy": 0.20000000298023224,
+              "regime_loss": 1.1391373157501221,
+              "regression_rmse_log_rv": 0.6709853210205332,
+              "regression_mae_log_rv": 0.49971238531764933,
+              "regression_loss": 0.45022130102502805,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    0,
+                    18
+                  ],
+                  [
+                    15,
+                    0,
+                    52
+                  ],
+                  [
+                    3,
+                    0,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 18,
+                    "roc_auc": 0.4468599033816425,
+                    "pr_auc": 0.1372071301706232
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 67,
+                    "roc_auc": 0.6227004512322111,
+                    "pr_auc": 0.6521294823263499
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.2391304347826087,
+                    "recall": 0.88,
+                    "f1": 0.37606837606837606,
+                    "support": 25,
+                    "roc_auc": 0.5463529411764706,
+                    "pr_auc": 0.2721765593782959
+                  }
+                ],
+                "macro_precision": 0.07971014492753624,
+                "macro_recall": 0.29333333333333333,
+                "macro_f1": 0.12535612535612536,
+                "weighted_f1": 0.08547008547008547,
+                "macro_roc_auc": 0.5386377652634414,
+                "macro_pr_auc": 0.353837723958423
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.10710835058661146,
+              "regime_accuracy": 0.14414414763450623,
+              "regime_loss": 1.2731949258671527,
+              "regression_rmse_log_rv": 0.7407602923149241,
+              "regression_mae_log_rv": 0.5902243975742913,
+              "regression_loss": 0.5487258106704919,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    0,
+                    6,
+                    38
+                  ],
+                  [
+                    0,
+                    3,
+                    48
+                  ],
+                  [
+                    0,
+                    3,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 44,
+                    "roc_auc": 0.41383989145183175,
+                    "pr_auc": 0.3441549169766978
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.058823529411764705,
+                    "f1": 0.09523809523809523,
+                    "support": 51,
+                    "roc_auc": 0.4669934640522876,
+                    "pr_auc": 0.4201113394549971
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.13131313131313133,
+                    "recall": 0.8125,
+                    "f1": 0.22608695652173916,
+                    "support": 16,
+                    "roc_auc": 0.3414473684210526,
+                    "pr_auc": 0.10915376216214852
+                  }
+                ],
+                "macro_precision": 0.1271043771043771,
+                "macro_recall": 0.29044117647058826,
+                "macro_f1": 0.10710835058661146,
+                "weighted_f1": 0.07634715460802419,
+                "macro_roc_auc": 0.40742690797505726,
+                "macro_pr_auc": 0.29114000619794783
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.22791353383458646,
+              "regime_accuracy": 0.34285715222358704,
+              "regime_loss": 1.148266649246216,
+              "regression_rmse_log_rv": 0.8378493705477518,
+              "regression_mae_log_rv": 0.6615118122508561,
+              "regression_loss": 0.7019915677272638,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    3,
+                    2,
+                    24
+                  ],
+                  [
+                    0,
+                    0,
+                    43
+                  ],
+                  [
+                    0,
+                    0,
+                    33
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 1.0,
+                    "recall": 0.10344827586206896,
+                    "f1": 0.1875,
+                    "support": 29,
+                    "roc_auc": 0.41833030852994557,
+                    "pr_auc": 0.31645392190989097
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 43,
+                    "roc_auc": 0.700675168792198,
+                    "pr_auc": 0.5401361270373668
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.33,
+                    "recall": 1.0,
+                    "f1": 0.49624060150375937,
+                    "support": 33,
+                    "roc_auc": 0.5858585858585859,
+                    "pr_auc": 0.37065092814435074
+                  }
+                ],
+                "macro_precision": 0.44333333333333336,
+                "macro_recall": 0.367816091954023,
+                "macro_f1": 0.22791353383458646,
+                "weighted_f1": 0.20774704618689582,
+                "macro_roc_auc": 0.5682880210602431,
+                "macro_pr_auc": 0.4090803256972029
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.23973540145985403,
+              "regime_accuracy": 0.32499998807907104,
+              "regime_loss": 1.1220922950647148,
+              "regression_rmse_log_rv": 0.9935206080225151,
+              "regression_mae_log_rv": 0.8105124764454862,
+              "regression_loss": 0.987083198565428,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    30,
+                    4,
+                    0
+                  ],
+                  [
+                    38,
+                    9,
+                    0
+                  ],
+                  [
+                    35,
+                    4,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2912621359223301,
+                    "recall": 0.8823529411764706,
+                    "f1": 0.43795620437956206,
+                    "support": 34,
+                    "roc_auc": 0.49350205198358416,
+                    "pr_auc": 0.3133664483468202
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5294117647058824,
+                    "recall": 0.19148936170212766,
+                    "f1": 0.28125,
+                    "support": 47,
+                    "roc_auc": 0.5733022442436607,
+                    "pr_auc": 0.5148837477396929
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 39,
+                    "roc_auc": 0.5641025641025641,
+                    "pr_auc": 0.3513263735236226
+                  }
+                ],
+                "macro_precision": 0.2735579668760708,
+                "macro_recall": 0.3579474342928661,
+                "macro_f1": 0.23973540145985403,
+                "weighted_f1": 0.2342438412408759,
+                "macro_roc_auc": 0.5436356201099363,
+                "macro_pr_auc": 0.39319218987004523
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.04938271604938271,
+              "regime_accuracy": 0.050847455859184265,
+              "regime_loss": 1.2811354518749056,
+              "regression_rmse_log_rv": 0.7274301368628626,
+              "regression_mae_log_rv": 0.5900588085938056,
+              "regression_loss": 0.529154604016323,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    2,
+                    0
+                  ],
+                  [
+                    18,
+                    1,
+                    0
+                  ],
+                  [
+                    78,
+                    14,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.04950495049504951,
+                    "recall": 0.7142857142857143,
+                    "f1": 0.09259259259259259,
+                    "support": 7,
+                    "roc_auc": 0.3178893178893179,
+                    "pr_auc": 0.044886883118007925
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.058823529411764705,
+                    "recall": 0.05263157894736842,
+                    "f1": 0.05555555555555555,
+                    "support": 19,
+                    "roc_auc": 0.31313131313131315,
+                    "pr_auc": 0.110467761497865
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 92,
+                    "roc_auc": 0.29055183946488294,
+                    "pr_auc": 0.6944891615285225
+                  }
+                ],
+                "macro_precision": 0.0361094933022714,
+                "macro_recall": 0.25563909774436094,
+                "macro_f1": 0.04938271604938271,
+                "weighted_f1": 0.014438166980539862,
+                "macro_roc_auc": 0.3071908234951713,
+                "macro_pr_auc": 0.2832812687147985
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.09375,
+              "regime_accuracy": 0.16363635659217834,
+              "regime_loss": 1.153471909869801,
+              "regression_rmse_log_rv": 0.6279788735301104,
+              "regression_mae_log_rv": 0.5101970023898916,
+              "regression_loss": 0.39435746560014645,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    18,
+                    0,
+                    0
+                  ],
+                  [
+                    67,
+                    0,
+                    0
+                  ],
+                  [
+                    25,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.16363636363636364,
+                    "recall": 1.0,
+                    "f1": 0.28125,
+                    "support": 18,
+                    "roc_auc": 0.37983091787439616,
+                    "pr_auc": 0.22867803800490566
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 67,
+                    "roc_auc": 0.4849010760152725,
+                    "pr_auc": 0.6496360786045141
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 25,
+                    "roc_auc": 0.576,
+                    "pr_auc": 0.30059584156570796
+                  }
+                ],
+                "macro_precision": 0.05454545454545454,
+                "macro_recall": 0.3333333333333333,
+                "macro_f1": 0.09375,
+                "weighted_f1": 0.04602272727272727,
+                "macro_roc_auc": 0.48024399796322287,
+                "macro_pr_auc": 0.3929699860583759
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.22191718142301534,
+              "regime_accuracy": 0.342342346906662,
+              "regime_loss": 1.11266997895826,
+              "regression_rmse_log_rv": 0.7048014810216293,
+              "regression_mae_log_rv": 0.550792470062571,
+              "regression_loss": 0.49674512765028206,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    36,
+                    0,
+                    8
+                  ],
+                  [
+                    30,
+                    0,
+                    21
+                  ],
+                  [
+                    14,
+                    0,
+                    2
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.45,
+                    "recall": 0.8181818181818182,
+                    "f1": 0.5806451612903226,
+                    "support": 44,
+                    "roc_auc": 0.5298507462686567,
+                    "pr_auc": 0.45032275611221245
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 51,
+                    "roc_auc": 0.47941176470588237,
+                    "pr_auc": 0.47189378422450784
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.06451612903225806,
+                    "recall": 0.125,
+                    "f1": 0.0851063829787234,
+                    "support": 16,
+                    "roc_auc": 0.27631578947368424,
+                    "pr_auc": 0.0943225744267634
+                  }
+                ],
+                "macro_precision": 0.17150537634408602,
+                "macro_recall": 0.3143939393939394,
+                "macro_f1": 0.22191718142301534,
+                "weighted_f1": 0.2424332362561601,
+                "macro_roc_auc": 0.4285261001494078,
+                "macro_pr_auc": 0.3388463715878279
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.12403100775193797,
+              "regime_accuracy": 0.22857142984867096,
+              "regime_loss": 1.1357207309632074,
+              "regression_rmse_log_rv": 0.8123120122126262,
+              "regression_mae_log_rv": 0.6102195591603439,
+              "regression_loss": 0.6598508051849257,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    24,
+                    0,
+                    5
+                  ],
+                  [
+                    43,
+                    0,
+                    0
+                  ],
+                  [
+                    33,
+                    0,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.24,
+                    "recall": 0.8275862068965517,
+                    "f1": 0.3720930232558139,
+                    "support": 29,
+                    "roc_auc": 0.44328493647912887,
+                    "pr_auc": 0.3042158317446335
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 43,
+                    "roc_auc": 0.532258064516129,
+                    "pr_auc": 0.5432642523320367
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 33,
+                    "roc_auc": 0.5088383838383839,
+                    "pr_auc": 0.3185234405838305
+                  }
+                ],
+                "macro_precision": 0.08,
+                "macro_recall": 0.27586206896551724,
+                "macro_f1": 0.12403100775193797,
+                "weighted_f1": 0.10276854928017716,
+                "macro_roc_auc": 0.4947937949445473,
+                "macro_pr_auc": 0.38866784155350026
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "regression",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.25413105413105413,
+              "regime_accuracy": 0.3166666626930237,
+              "regime_loss": 1.1095335585694757,
+              "regression_rmse_log_rv": 1.0223394159378785,
+              "regression_mae_log_rv": 0.8315530348879595,
+              "regression_loss": 1.0451778813802024,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    27,
+                    4,
+                    3
+                  ],
+                  [
+                    35,
+                    10,
+                    2
+                  ],
+                  [
+                    21,
+                    17,
+                    1
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3253012048192771,
+                    "recall": 0.7941176470588235,
+                    "f1": 0.4615384615384615,
+                    "support": 34,
+                    "roc_auc": 0.4887140902872777,
+                    "pr_auc": 0.254281699580501
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.3225806451612903,
+                    "recall": 0.2127659574468085,
+                    "f1": 0.2564102564102564,
+                    "support": 47,
+                    "roc_auc": 0.35733022442436607,
+                    "pr_auc": 0.31383305706534154
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.16666666666666666,
+                    "recall": 0.02564102564102564,
+                    "f1": 0.044444444444444446,
+                    "support": 39,
+                    "roc_auc": 0.561886672997784,
+                    "pr_auc": 0.4120229914693878
+                  }
+                ],
+                "macro_precision": 0.2715161722157447,
+                "macro_recall": 0.3441748767155526,
+                "macro_f1": 0.25413105413105413,
+                "weighted_f1": 0.24564102564102563,
+                "macro_roc_auc": 0.469310329236476,
+                "macro_pr_auc": 0.3267125827050768
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.19803478509663197,
+              "regime_accuracy": 0.20338982343673706,
+              "regime_loss": 1.1149525392705861,
+              "regression_rmse_log_rv": 0.7235561076055462,
+              "regression_mae_log_rv": 0.5792275600103756,
+              "regression_loss": 0.5235334408532888,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    1,
+                    0
+                  ],
+                  [
+                    15,
+                    4,
+                    0
+                  ],
+                  [
+                    61,
+                    17,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.07317073170731707,
+                    "recall": 0.8571428571428571,
+                    "f1": 0.1348314606741573,
+                    "support": 7,
+                    "roc_auc": 0.4066924066924067,
+                    "pr_auc": 0.04657092538584888
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.18181818181818182,
+                    "recall": 0.21052631578947367,
+                    "f1": 0.1951219512195122,
+                    "support": 19,
+                    "roc_auc": 0.4635832004253057,
+                    "pr_auc": 0.17613912477667926
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 1.0,
+                    "recall": 0.15217391304347827,
+                    "f1": 0.2641509433962264,
+                    "support": 92,
+                    "roc_auc": 0.6341973244147158,
+                    "pr_auc": 0.8816233335024558
+                  }
+                ],
+                "macro_precision": 0.4183296378418329,
+                "macro_recall": 0.4066143619919364,
+                "macro_f1": 0.19803478509663197,
+                "weighted_f1": 0.2453646109351073,
+                "macro_roc_auc": 0.501490977177476,
+                "macro_pr_auc": 0.368111127888328
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.3165653093601269,
+              "regime_accuracy": 0.4272727370262146,
+              "regime_loss": 1.0998856501145797,
+              "regression_rmse_log_rv": 0.6055585699612229,
+              "regression_mae_log_rv": 0.465831112946299,
+              "regression_loss": 0.36670118165348137,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    4,
+                    14,
+                    0
+                  ],
+                  [
+                    24,
+                    40,
+                    3
+                  ],
+                  [
+                    15,
+                    7,
+                    3
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.09302325581395349,
+                    "recall": 0.2222222222222222,
+                    "f1": 0.13114754098360654,
+                    "support": 18,
+                    "roc_auc": 0.3001207729468599,
+                    "pr_auc": 0.11162780888594967
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6557377049180327,
+                    "recall": 0.5970149253731343,
+                    "f1": 0.625,
+                    "support": 67,
+                    "roc_auc": 0.5657757723012843,
+                    "pr_auc": 0.6890188682399838
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.12,
+                    "f1": 0.1935483870967742,
+                    "support": 25,
+                    "roc_auc": 0.43529411764705883,
+                    "pr_auc": 0.3016284877956551
+                  }
+                ],
+                "macro_precision": 0.41625365357732874,
+                "macro_recall": 0.31307904919845214,
+                "macro_f1": 0.3165653093601269,
+                "weighted_f1": 0.4461305946829479,
+                "macro_roc_auc": 0.4337302209650677,
+                "macro_pr_auc": 0.36742505497386285
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.29162052417866374,
+              "regime_accuracy": 0.44144144654273987,
+              "regime_loss": 1.065909195420963,
+              "regression_rmse_log_rv": 0.706669061367702,
+              "regression_mae_log_rv": 0.555760120830356,
+              "regression_loss": 0.499381162294309,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    38,
+                    6,
+                    0
+                  ],
+                  [
+                    40,
+                    11,
+                    0
+                  ],
+                  [
+                    7,
+                    9,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4470588235294118,
+                    "recall": 0.8636363636363636,
+                    "f1": 0.5891472868217054,
+                    "support": 44,
+                    "roc_auc": 0.5023744911804613,
+                    "pr_auc": 0.37093051424878054
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4230769230769231,
+                    "recall": 0.21568627450980393,
+                    "f1": 0.28571428571428575,
+                    "support": 51,
+                    "roc_auc": 0.4888888888888889,
+                    "pr_auc": 0.4667150635434228
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 16,
+                    "roc_auc": 0.6723684210526316,
+                    "pr_auc": 0.20319705995466558
+                  }
+                ],
+                "macro_precision": 0.2900452488687783,
+                "macro_recall": 0.3597742127153892,
+                "macro_f1": 0.29162052417866374,
+                "weighted_f1": 0.36480999271696946,
+                "macro_roc_auc": 0.5545439337073272,
+                "macro_pr_auc": 0.346947545915623
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.22812667740203973,
+              "regime_accuracy": 0.3142857253551483,
+              "regime_loss": 1.0924799680709838,
+              "regression_rmse_log_rv": 0.8723301068127232,
+              "regression_mae_log_rv": 0.6531963758596075,
+              "regression_loss": 0.760959815251897,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    26,
+                    3,
+                    0
+                  ],
+                  [
+                    36,
+                    7,
+                    0
+                  ],
+                  [
+                    17,
+                    16,
+                    0
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3291139240506329,
+                    "recall": 0.896551724137931,
+                    "f1": 0.4814814814814815,
+                    "support": 29,
+                    "roc_auc": 0.6565335753176044,
+                    "pr_auc": 0.439659457050399
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2692307692307692,
+                    "recall": 0.16279069767441862,
+                    "f1": 0.2028985507246377,
+                    "support": 43,
+                    "roc_auc": 0.4714928732183046,
+                    "pr_auc": 0.37338780608356326
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 33,
+                    "roc_auc": 0.7289562289562289,
+                    "pr_auc": 0.5787771126364547
+                  }
+                ],
+                "macro_precision": 0.1994482310938007,
+                "macro_recall": 0.35311414060411656,
+                "macro_f1": 0.22812667740203973,
+                "weighted_f1": 0.21607238708687984,
+                "macro_roc_auc": 0.6189942258307126,
+                "macro_pr_auc": 0.46394145859013897
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "dual": [
+      {
+        "head_mode": "dual",
+        "seed": 11,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.38621757646147886,
+              "regime_accuracy": 0.4000000059604645,
+              "regime_loss": 1.1630778866255156,
+              "regression_rmse_log_rv": 0.9437533252600704,
+              "regression_mae_log_rv": 0.7702912994815657,
+              "regression_loss": 0.8906703389394401,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    19,
+                    2,
+                    13
+                  ],
+                  [
+                    14,
+                    8,
+                    25
+                  ],
+                  [
+                    15,
+                    3,
+                    21
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3958333333333333,
+                    "recall": 0.5588235294117647,
+                    "f1": 0.4634146341463415,
+                    "support": 34,
+                    "roc_auc": 0.6210670314637483,
+                    "pr_auc": 0.4028324163869021
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6153846153846154,
+                    "recall": 0.1702127659574468,
+                    "f1": 0.26666666666666666,
+                    "support": 47,
+                    "roc_auc": 0.5441562226756048,
+                    "pr_auc": 0.42552055750887957
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3559322033898305,
+                    "recall": 0.5384615384615384,
+                    "f1": 0.42857142857142855,
+                    "support": 39,
+                    "roc_auc": 0.5641025641025641,
+                    "pr_auc": 0.3640073694801742
+                  }
+                ],
+                "macro_precision": 0.4557167173692598,
+                "macro_recall": 0.4224992779435833,
+                "macro_f1": 0.38621757646147886,
+                "weighted_f1": 0.3750309717382888,
+                "macro_roc_auc": 0.5764419394139724,
+                "macro_pr_auc": 0.3974534477919853
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.5423066336361134,
+              "regime_accuracy": 0.7288135886192322,
+              "regime_loss": 0.7462705507661246,
+              "regression_rmse_log_rv": 0.7716193505131554,
+              "regression_mae_log_rv": 0.623317382803534,
+              "regression_loss": 0.5953964220863439,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    0,
+                    1
+                  ],
+                  [
+                    7,
+                    6,
+                    6
+                  ],
+                  [
+                    8,
+                    10,
+                    74
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2857142857142857,
+                    "recall": 0.8571428571428571,
+                    "f1": 0.42857142857142855,
+                    "support": 7,
+                    "roc_auc": 0.879021879021879,
+                    "pr_auc": 0.24827597705748963
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.375,
+                    "recall": 0.3157894736842105,
+                    "f1": 0.34285714285714286,
+                    "support": 19,
+                    "roc_auc": 0.733652312599681,
+                    "pr_auc": 0.2745410660895114
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9135802469135802,
+                    "recall": 0.8043478260869565,
+                    "f1": 0.8554913294797687,
+                    "support": 92,
+                    "roc_auc": 0.7913879598662207,
+                    "pr_auc": 0.9325935981223255
+                  }
+                ],
+                "macro_precision": 0.5247648442092886,
+                "macro_recall": 0.659093385638008,
+                "macro_f1": 0.5423066336361134,
+                "weighted_f1": 0.747622779884953,
+                "macro_roc_auc": 0.8013540504959269,
+                "macro_pr_auc": 0.4851368804231088
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.4400856301846401,
+              "regime_accuracy": 0.4545454680919647,
+              "regime_loss": 1.0080172668803822,
+              "regression_rmse_log_rv": 0.7226375290716918,
+              "regression_mae_log_rv": 0.5239297252868048,
+              "regression_loss": 0.5222049984228402,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    0,
+                    9
+                  ],
+                  [
+                    16,
+                    26,
+                    25
+                  ],
+                  [
+                    2,
+                    8,
+                    15
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.5,
+                    "f1": 0.4,
+                    "support": 18,
+                    "roc_auc": 0.6630434782608695,
+                    "pr_auc": 0.22301416805114277
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.7647058823529411,
+                    "recall": 0.3880597014925373,
+                    "f1": 0.5148514851485149,
+                    "support": 67,
+                    "roc_auc": 0.606039569593891,
+                    "pr_auc": 0.7247664606805595
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.30612244897959184,
+                    "recall": 0.6,
+                    "f1": 0.40540540540540543,
+                    "support": 25,
+                    "roc_auc": 0.7265882352941176,
+                    "pr_auc": 0.5617275746768324
+                  }
+                ],
+                "macro_precision": 0.4680538882219554,
+                "macro_recall": 0.4960199004975124,
+                "macro_f1": 0.4400856301846401,
+                "weighted_f1": 0.47118349672805115,
+                "macro_roc_auc": 0.6652237610496261,
+                "macro_pr_auc": 0.5031694011361783
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.40491452991453,
+              "regime_accuracy": 0.4054054021835327,
+              "regime_loss": 1.0495042673934816,
+              "regression_rmse_log_rv": 0.7307308422449441,
+              "regression_mae_log_rv": 0.5673357952419702,
+              "regression_loss": 0.5339675638080055,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    21,
+                    13,
+                    10
+                  ],
+                  [
+                    23,
+                    13,
+                    15
+                  ],
+                  [
+                    2,
+                    3,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.45652173913043476,
+                    "recall": 0.4772727272727273,
+                    "f1": 0.4666666666666666,
+                    "support": 44,
+                    "roc_auc": 0.5841248303934871,
+                    "pr_auc": 0.43935159126307094
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4482758620689655,
+                    "recall": 0.2549019607843137,
+                    "f1": 0.325,
+                    "support": 51,
+                    "roc_auc": 0.4980392156862745,
+                    "pr_auc": 0.47495367685543877
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3055555555555556,
+                    "recall": 0.6875,
+                    "f1": 0.42307692307692313,
+                    "support": 16,
+                    "roc_auc": 0.7421052631578947,
+                    "pr_auc": 0.30455218121836336
+                  }
+                ],
+                "macro_precision": 0.40345105225165195,
+                "macro_recall": 0.4732248960190137,
+                "macro_f1": 0.40491452991453,
+                "weighted_f1": 0.39529337029337025,
+                "macro_roc_auc": 0.6080897697458855,
+                "macro_pr_auc": 0.4062858164456244
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.4312169312169312,
+              "regime_accuracy": 0.43809524178504944,
+              "regime_loss": 1.1003558068048387,
+              "regression_rmse_log_rv": 0.8265040961992085,
+              "regression_mae_log_rv": 0.6432199459327551,
+              "regression_loss": 0.6831090210340706,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    17,
+                    3
+                  ],
+                  [
+                    10,
+                    17,
+                    16
+                  ],
+                  [
+                    6,
+                    7,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.36,
+                    "recall": 0.3103448275862069,
+                    "f1": 0.3333333333333333,
+                    "support": 29,
+                    "roc_auc": 0.6873865698729582,
+                    "pr_auc": 0.45085122473412464
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4146341463414634,
+                    "recall": 0.3953488372093023,
+                    "f1": 0.40476190476190477,
+                    "support": 43,
+                    "roc_auc": 0.5795198799699925,
+                    "pr_auc": 0.4401334535397631
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5128205128205128,
+                    "recall": 0.6060606060606061,
+                    "f1": 0.5555555555555556,
+                    "support": 33,
+                    "roc_auc": 0.7041245791245792,
+                    "pr_auc": 0.6134254681415829
+                  }
+                ],
+                "macro_precision": 0.42915155305399205,
+                "macro_recall": 0.4372514236187051,
+                "macro_f1": 0.4312169312169312,
+                "weighted_f1": 0.4324263038548753,
+                "macro_roc_auc": 0.6570103429891766,
+                "macro_pr_auc": 0.5014700488051569
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 29,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2885975669922894,
+              "regime_accuracy": 0.3166666626930237,
+              "regime_loss": 1.5294894881488033,
+              "regression_rmse_log_rv": 1.037871030962225,
+              "regression_mae_log_rv": 0.8596185750948886,
+              "regression_loss": 1.077176276910592,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    10,
+                    8,
+                    16
+                  ],
+                  [
+                    15,
+                    4,
+                    28
+                  ],
+                  [
+                    9,
+                    6,
+                    24
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.29411764705882354,
+                    "recall": 0.29411764705882354,
+                    "f1": 0.29411764705882354,
+                    "support": 34,
+                    "roc_auc": 0.5554035567715458,
+                    "pr_auc": 0.2948987207916614
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2222222222222222,
+                    "recall": 0.0851063829787234,
+                    "f1": 0.12307692307692307,
+                    "support": 47,
+                    "roc_auc": 0.4377732439522005,
+                    "pr_auc": 0.34117678886510705
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.35294117647058826,
+                    "recall": 0.6153846153846154,
+                    "f1": 0.4485981308411215,
+                    "support": 39,
+                    "roc_auc": 0.5549224438113327,
+                    "pr_auc": 0.36579851501801813
+                  }
+                ],
+                "macro_precision": 0.289760348583878,
+                "macro_recall": 0.3315362151407208,
+                "macro_f1": 0.2885975669922894,
+                "weighted_f1": 0.277332854061826,
+                "macro_roc_auc": 0.516033081511693,
+                "macro_pr_auc": 0.3339580082249289
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.47467990552551426,
+              "regime_accuracy": 0.7033898234367371,
+              "regime_loss": 0.7146116993955359,
+              "regression_rmse_log_rv": 0.6896716397940362,
+              "regression_mae_log_rv": 0.5540945907991569,
+              "regression_loss": 0.47564697073619483,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    0,
+                    1
+                  ],
+                  [
+                    10,
+                    3,
+                    6
+                  ],
+                  [
+                    9,
+                    9,
+                    74
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.24,
+                    "recall": 0.8571428571428571,
+                    "f1": 0.375,
+                    "support": 7,
+                    "roc_auc": 0.879021879021879,
+                    "pr_auc": 0.20924435287548954
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.15789473684210525,
+                    "f1": 0.1935483870967742,
+                    "support": 19,
+                    "roc_auc": 0.7496012759170654,
+                    "pr_auc": 0.25298587722832344
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9135802469135802,
+                    "recall": 0.8043478260869565,
+                    "f1": 0.8554913294797687,
+                    "support": 92,
+                    "roc_auc": 0.8591137123745819,
+                    "pr_auc": 0.9593393086761004
+                  }
+                ],
+                "macro_precision": 0.4678600823045267,
+                "macro_recall": 0.6064618066906396,
+                "macro_f1": 0.47467990552551426,
+                "weighted_f1": 0.7204035734489612,
+                "macro_roc_auc": 0.8292456224378421,
+                "macro_pr_auc": 0.47385651292663783
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.29523809523809524,
+              "regime_accuracy": 0.30909091234207153,
+              "regime_loss": 1.3882030313665217,
+              "regression_rmse_log_rv": 0.7625401261009138,
+              "regression_mae_log_rv": 0.5700671321458437,
+              "regression_loss": 0.5814674439139976,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    0,
+                    9
+                  ],
+                  [
+                    20,
+                    3,
+                    44
+                  ],
+                  [
+                    3,
+                    0,
+                    22
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.28125,
+                    "recall": 0.5,
+                    "f1": 0.36,
+                    "support": 18,
+                    "roc_auc": 0.6841787439613527,
+                    "pr_auc": 0.2353685207638778
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 1.0,
+                    "recall": 0.04477611940298507,
+                    "f1": 0.08571428571428572,
+                    "support": 67,
+                    "roc_auc": 0.6067337729954877,
+                    "pr_auc": 0.7363836861459379
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.29333333333333333,
+                    "recall": 0.88,
+                    "f1": 0.44,
+                    "support": 25,
+                    "roc_auc": 0.7769411764705882,
+                    "pr_auc": 0.5186438179382642
+                  }
+                ],
+                "macro_precision": 0.5248611111111111,
+                "macro_recall": 0.47492537313432837,
+                "macro_f1": 0.29523809523809524,
+                "weighted_f1": 0.21111688311688312,
+                "macro_roc_auc": 0.6892845644758095,
+                "macro_pr_auc": 0.49679867494936
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.38987189834647457,
+              "regime_accuracy": 0.38738739490509033,
+              "regime_loss": 1.1867818687327223,
+              "regression_rmse_log_rv": 0.7885295580677439,
+              "regression_mae_log_rv": 0.6082943400267411,
+              "regression_loss": 0.6217788639465116,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    20,
+                    12
+                  ],
+                  [
+                    15,
+                    18,
+                    18
+                  ],
+                  [
+                    1,
+                    2,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.2727272727272727,
+                    "f1": 0.33333333333333326,
+                    "support": 44,
+                    "roc_auc": 0.6126187245590231,
+                    "pr_auc": 0.4372721982764307
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.45,
+                    "recall": 0.35294117647058826,
+                    "f1": 0.39560439560439564,
+                    "support": 51,
+                    "roc_auc": 0.5104575163398692,
+                    "pr_auc": 0.46167941400953044
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3023255813953488,
+                    "recall": 0.8125,
+                    "f1": 0.44067796610169485,
+                    "support": 16,
+                    "roc_auc": 0.7835526315789474,
+                    "pr_auc": 0.29922982019829514
+                  }
+                ],
+                "macro_precision": 0.3936323366555925,
+                "macro_recall": 0.4793894830659537,
+                "macro_f1": 0.38987189834647457,
+                "weighted_f1": 0.37741746216322486,
+                "macro_roc_auc": 0.6355429574926132,
+                "macro_pr_auc": 0.39939381082808545
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.42076261958663164,
+              "regime_accuracy": 0.46666666865348816,
+              "regime_loss": 1.0499340948604403,
+              "regression_rmse_log_rv": 0.8814903885262559,
+              "regression_mae_log_rv": 0.6929191379390734,
+              "regression_loss": 0.7770253050641696,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    4,
+                    20,
+                    5
+                  ],
+                  [
+                    3,
+                    26,
+                    14
+                  ],
+                  [
+                    0,
+                    14,
+                    19
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.5714285714285714,
+                    "recall": 0.13793103448275862,
+                    "f1": 0.2222222222222222,
+                    "support": 29,
+                    "roc_auc": 0.6869328493647913,
+                    "pr_auc": 0.47709285500392706
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.43333333333333335,
+                    "recall": 0.6046511627906976,
+                    "f1": 0.5048543689320388,
+                    "support": 43,
+                    "roc_auc": 0.5693923480870218,
+                    "pr_auc": 0.47481149978014037
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.5757575757575758,
+                    "f1": 0.5352112676056339,
+                    "support": 33,
+                    "roc_auc": 0.6923400673400674,
+                    "pr_auc": 0.6243518620234155
+                  }
+                ],
+                "macro_precision": 0.5015873015873016,
+                "macro_recall": 0.439446591010344,
+                "macro_f1": 0.42076261958663164,
+                "weighted_f1": 0.43633480132864794,
+                "macro_roc_auc": 0.6495550882639601,
+                "macro_pr_auc": 0.5254187389358277
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 47,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2766355140186916,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.3242792442224596,
+              "regression_rmse_log_rv": 1.012639626386145,
+              "regression_mae_log_rv": 0.8355404114583507,
+              "regression_loss": 1.0254390129274715,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    0,
+                    17
+                  ],
+                  [
+                    19,
+                    0,
+                    28
+                  ],
+                  [
+                    15,
+                    1,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.3333333333333333,
+                    "recall": 0.5,
+                    "f1": 0.4,
+                    "support": 34,
+                    "roc_auc": 0.5872093023255814,
+                    "pr_auc": 0.33115604175030633
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 47,
+                    "roc_auc": 0.4782862139317983,
+                    "pr_auc": 0.3878999271228588
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3382352941176471,
+                    "recall": 0.5897435897435898,
+                    "f1": 0.42990654205607476,
+                    "support": 39,
+                    "roc_auc": 0.5511237733459956,
+                    "pr_auc": 0.3607468908623623
+                  }
+                ],
+                "macro_precision": 0.2238562091503268,
+                "macro_recall": 0.3632478632478633,
+                "macro_f1": 0.2766355140186916,
+                "weighted_f1": 0.25305295950155765,
+                "macro_roc_auc": 0.5388730965344585,
+                "macro_pr_auc": 0.3599342865785091
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.34907630522088356,
+              "regime_accuracy": 0.6186440587043762,
+              "regime_loss": 0.841949309408467,
+              "regression_rmse_log_rv": 0.792318957718207,
+              "regression_mae_log_rv": 0.6409441745934724,
+              "regression_loss": 0.6277693307596659,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    0,
+                    1
+                  ],
+                  [
+                    13,
+                    0,
+                    6
+                  ],
+                  [
+                    24,
+                    1,
+                    67
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.13953488372093023,
+                    "recall": 0.8571428571428571,
+                    "f1": 0.24,
+                    "support": 7,
+                    "roc_auc": 0.7207207207207207,
+                    "pr_auc": 0.09737433604386302
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "support": 19,
+                    "roc_auc": 0.6241360978203083,
+                    "pr_auc": 0.20664270048930952
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.9054054054054054,
+                    "recall": 0.7282608695652174,
+                    "f1": 0.8072289156626506,
+                    "support": 92,
+                    "roc_auc": 0.75,
+                    "pr_auc": 0.8873957796506576
+                  }
+                ],
+                "macro_precision": 0.3483134297087785,
+                "macro_recall": 0.5284679089026915,
+                "macro_f1": 0.34907630522088356,
+                "weighted_f1": 0.6436022054318972,
+                "macro_roc_auc": 0.698285606180343,
+                "macro_pr_auc": 0.39713760539461007
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.5012304316307138,
+              "regime_accuracy": 0.5090909004211426,
+              "regime_loss": 0.9763378154147755,
+              "regression_rmse_log_rv": 0.49401248811638887,
+              "regression_mae_log_rv": 0.40147487643090163,
+              "regression_loss": 0.24404833841494528,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    4,
+                    1
+                  ],
+                  [
+                    25,
+                    29,
+                    13
+                  ],
+                  [
+                    4,
+                    7,
+                    14
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.30952380952380953,
+                    "recall": 0.7222222222222222,
+                    "f1": 0.4333333333333334,
+                    "support": 18,
+                    "roc_auc": 0.7590579710144928,
+                    "pr_auc": 0.3174141831434202
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.725,
+                    "recall": 0.43283582089552236,
+                    "f1": 0.5420560747663551,
+                    "support": 67,
+                    "roc_auc": 0.5543214161749392,
+                    "pr_auc": 0.6900959252679622
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5,
+                    "recall": 0.56,
+                    "f1": 0.5283018867924528,
+                    "support": 25,
+                    "roc_auc": 0.7487058823529412,
+                    "pr_auc": 0.5356128288681938
+                  }
+                ],
+                "macro_precision": 0.5115079365079365,
+                "macro_recall": 0.5716860143725816,
+                "macro_f1": 0.5012304316307138,
+                "weighted_f1": 0.5211391289014283,
+                "macro_roc_auc": 0.6873617565141243,
+                "macro_pr_auc": 0.5143743124265253
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.3941798941798942,
+              "regime_accuracy": 0.38738739490509033,
+              "regime_loss": 1.0329405865107253,
+              "regression_rmse_log_rv": 0.7510405329000496,
+              "regression_mae_log_rv": 0.6025613503161449,
+              "regression_loss": 0.5640618820587905,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    17,
+                    10
+                  ],
+                  [
+                    21,
+                    14,
+                    16
+                  ],
+                  [
+                    2,
+                    2,
+                    12
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.425,
+                    "recall": 0.38636363636363635,
+                    "f1": 0.40476190476190477,
+                    "support": 44,
+                    "roc_auc": 0.6255088195386703,
+                    "pr_auc": 0.4660033050517106
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.42424242424242425,
+                    "recall": 0.27450980392156865,
+                    "f1": 0.33333333333333337,
+                    "support": 51,
+                    "roc_auc": 0.5013071895424837,
+                    "pr_auc": 0.4352188716578379
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3157894736842105,
+                    "recall": 0.75,
+                    "f1": 0.44444444444444436,
+                    "support": 16,
+                    "roc_auc": 0.7671052631578947,
+                    "pr_auc": 0.32636531922152234
+                  }
+                ],
+                "macro_precision": 0.38834396597554494,
+                "macro_recall": 0.470291146761735,
+                "macro_f1": 0.3941798941798942,
+                "weighted_f1": 0.3776633776633777,
+                "macro_roc_auc": 0.6313070907463496,
+                "macro_pr_auc": 0.40919583197702364
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.42185367185367184,
+              "regime_accuracy": 0.4571428596973419,
+              "regime_loss": 1.0391742286227998,
+              "regression_rmse_log_rv": 0.8373347862571586,
+              "regression_mae_log_rv": 0.6335594865608506,
+              "regression_loss": 0.7011295442763216,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    4,
+                    19,
+                    6
+                  ],
+                  [
+                    10,
+                    21,
+                    12
+                  ],
+                  [
+                    5,
+                    5,
+                    23
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.21052631578947367,
+                    "recall": 0.13793103448275862,
+                    "f1": 0.16666666666666666,
+                    "support": 29,
+                    "roc_auc": 0.618421052631579,
+                    "pr_auc": 0.36513974074642686
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.4666666666666667,
+                    "recall": 0.4883720930232558,
+                    "f1": 0.47727272727272724,
+                    "support": 43,
+                    "roc_auc": 0.5708927231807952,
+                    "pr_auc": 0.4125494138108599
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.5609756097560976,
+                    "recall": 0.696969696969697,
+                    "f1": 0.6216216216216217,
+                    "support": 33,
+                    "roc_auc": 0.7390572390572391,
+                    "pr_auc": 0.6493659915769138
+                  }
+                ],
+                "macro_precision": 0.41272286407074593,
+                "macro_recall": 0.4410909414919038,
+                "macro_f1": 0.42185367185367184,
+                "weighted_f1": 0.4368530868530868,
+                "macro_roc_auc": 0.6427903382898711,
+                "macro_pr_auc": 0.47568504871140016
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 71,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.2911827107384809,
+              "regime_accuracy": 0.3333333432674408,
+              "regime_loss": 1.3531560290645908,
+              "regression_rmse_log_rv": 0.9955695192178162,
+              "regression_mae_log_rv": 0.813680975480626,
+              "regression_loss": 0.9911586675955937,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    3,
+                    18
+                  ],
+                  [
+                    18,
+                    2,
+                    27
+                  ],
+                  [
+                    11,
+                    3,
+                    25
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.30952380952380953,
+                    "recall": 0.38235294117647056,
+                    "f1": 0.34210526315789475,
+                    "support": 34,
+                    "roc_auc": 0.5957592339261286,
+                    "pr_auc": 0.32587867570222456
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.25,
+                    "recall": 0.0425531914893617,
+                    "f1": 0.07272727272727272,
+                    "support": 47,
+                    "roc_auc": 0.47012532789274264,
+                    "pr_auc": 0.3995262848386498
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.35714285714285715,
+                    "recall": 0.6410256410256411,
+                    "f1": 0.45871559633027525,
+                    "support": 39,
+                    "roc_auc": 0.5811965811965812,
+                    "pr_auc": 0.40071479663859644
+                  }
+                ],
+                "macro_precision": 0.3055555555555556,
+                "macro_recall": 0.3553105912304911,
+                "macro_f1": 0.2911827107384809,
+                "weighted_f1": 0.2744972418535915,
+                "macro_roc_auc": 0.5490270476718174,
+                "macro_pr_auc": 0.37537325239315694
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.4139490139490139,
+              "regime_accuracy": 0.6186440587043762,
+              "regime_loss": 0.7637889657524173,
+              "regression_rmse_log_rv": 0.7569938996678172,
+              "regression_mae_log_rv": 0.5962454317832144,
+              "regression_loss": 0.5730397641342893,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    6,
+                    0,
+                    1
+                  ],
+                  [
+                    10,
+                    2,
+                    7
+                  ],
+                  [
+                    12,
+                    15,
+                    65
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.21428571428571427,
+                    "recall": 0.8571428571428571,
+                    "f1": 0.34285714285714286,
+                    "support": 7,
+                    "roc_auc": 0.8391248391248392,
+                    "pr_auc": 0.17732962902400243
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.11764705882352941,
+                    "recall": 0.10526315789473684,
+                    "f1": 0.1111111111111111,
+                    "support": 19,
+                    "roc_auc": 0.671451355661882,
+                    "pr_auc": 0.2060438946384731
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.8904109589041096,
+                    "recall": 0.7065217391304348,
+                    "f1": 0.7878787878787878,
+                    "support": 92,
+                    "roc_auc": 0.8039297658862876,
+                    "pr_auc": 0.9372815848781881
+                  }
+                ],
+                "macro_precision": 0.40744791067111774,
+                "macro_recall": 0.556309251389343,
+                "macro_f1": 0.4139490139490139,
+                "weighted_f1": 0.652508132169149,
+                "macro_roc_auc": 0.7715019868910029,
+                "macro_pr_auc": 0.4402183695135546
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.40017825311942956,
+              "regime_accuracy": 0.3909091055393219,
+              "regime_loss": 1.0072694930163297,
+              "regression_rmse_log_rv": 0.5169078818220626,
+              "regression_mae_log_rv": 0.41765212055973033,
+              "regression_loss": 0.2671937582897714,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    13,
+                    3,
+                    2
+                  ],
+                  [
+                    32,
+                    14,
+                    21
+                  ],
+                  [
+                    5,
+                    4,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.26,
+                    "recall": 0.7222222222222222,
+                    "f1": 0.3823529411764706,
+                    "support": 18,
+                    "roc_auc": 0.7397342995169082,
+                    "pr_auc": 0.2998461520252212
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.6666666666666666,
+                    "recall": 0.208955223880597,
+                    "f1": 0.3181818181818181,
+                    "support": 67,
+                    "roc_auc": 0.5237764665046859,
+                    "pr_auc": 0.6412068356386342
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.41025641025641024,
+                    "recall": 0.64,
+                    "f1": 0.5,
+                    "support": 25,
+                    "roc_auc": 0.7383529411764705,
+                    "pr_auc": 0.3820690976063928
+                  }
+                ],
+                "macro_precision": 0.44564102564102565,
+                "macro_recall": 0.5237258153676064,
+                "macro_f1": 0.40017825311942956,
+                "weighted_f1": 0.3700048614487117,
+                "macro_roc_auc": 0.6672879023993549,
+                "macro_pr_auc": 0.44104069509008276
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.37614722639395454,
+              "regime_accuracy": 0.36936935782432556,
+              "regime_loss": 1.088980954364997,
+              "regression_rmse_log_rv": 0.7788373673022625,
+              "regression_mae_log_rv": 0.6074222513130522,
+              "regression_loss": 0.6065876447063193,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    14,
+                    18,
+                    12
+                  ],
+                  [
+                    19,
+                    14,
+                    18
+                  ],
+                  [
+                    2,
+                    1,
+                    13
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4,
+                    "recall": 0.3181818181818182,
+                    "f1": 0.35443037974683544,
+                    "support": 44,
+                    "roc_auc": 0.6227951153324288,
+                    "pr_auc": 0.42810771703929534
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.42424242424242425,
+                    "recall": 0.27450980392156865,
+                    "f1": 0.33333333333333337,
+                    "support": 51,
+                    "roc_auc": 0.4781045751633987,
+                    "pr_auc": 0.43026356641942737
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3023255813953488,
+                    "recall": 0.8125,
+                    "f1": 0.44067796610169485,
+                    "support": 16,
+                    "roc_auc": 0.7835526315789474,
+                    "pr_auc": 0.32759983759002004
+                  }
+                ],
+                "macro_precision": 0.37552266854592437,
+                "macro_recall": 0.4683972073677956,
+                "macro_f1": 0.37614722639395454,
+                "weighted_f1": 0.35716922672511603,
+                "macro_roc_auc": 0.6281507740249249,
+                "macro_pr_auc": 0.3953237070162476
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.40235403151065796,
+              "regime_accuracy": 0.41904762387275696,
+              "regime_loss": 1.0485456023897444,
+              "regression_rmse_log_rv": 0.82166647127426,
+              "regression_mae_log_rv": 0.6194064161056997,
+              "regression_loss": 0.6751357900162942,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    7,
+                    11,
+                    11
+                  ],
+                  [
+                    11,
+                    19,
+                    13
+                  ],
+                  [
+                    5,
+                    10,
+                    18
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.30434782608695654,
+                    "recall": 0.2413793103448276,
+                    "f1": 0.2692307692307692,
+                    "support": 29,
+                    "roc_auc": 0.6211433756805808,
+                    "pr_auc": 0.3487645036996849
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.475,
+                    "recall": 0.4418604651162791,
+                    "f1": 0.4578313253012048,
+                    "support": 43,
+                    "roc_auc": 0.5667666916729183,
+                    "pr_auc": 0.42085593586663944
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.42857142857142855,
+                    "recall": 0.5454545454545454,
+                    "f1": 0.4799999999999999,
+                    "support": 33,
+                    "roc_auc": 0.6952861952861953,
+                    "pr_auc": 0.582755050254383
+                  }
+                ],
+                "macro_precision": 0.402639751552795,
+                "macro_recall": 0.40956477363855065,
+                "macro_f1": 0.40235403151065796,
+                "weighted_f1": 0.41270894567280103,
+                "macro_roc_auc": 0.6277320875465647,
+                "macro_pr_auc": 0.4507918299402358
+              }
+            }
+          }
+        ]
+      },
+      {
+        "head_mode": "dual",
+        "seed": 97,
+        "regression_alpha": 0.5,
+        "training_package_id": "canonical",
+        "folds": [
+          {
+            "fold_id": "wf_fold_1",
+            "metrics": {
+              "regime_f1_macro": 0.33102867248750195,
+              "regime_accuracy": 0.3499999940395355,
+              "regime_loss": 1.2550370690074644,
+              "regression_rmse_log_rv": 0.9861465597195272,
+              "regression_mae_log_rv": 0.8047697253525257,
+              "regression_loss": 0.972485037246659,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    17,
+                    4,
+                    13
+                  ],
+                  [
+                    13,
+                    5,
+                    29
+                  ],
+                  [
+                    15,
+                    4,
+                    20
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.37777777777777777,
+                    "recall": 0.5,
+                    "f1": 0.43037974683544306,
+                    "support": 34,
+                    "roc_auc": 0.6053351573187414,
+                    "pr_auc": 0.39947813695832474
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.38461538461538464,
+                    "recall": 0.10638297872340426,
+                    "f1": 0.16666666666666669,
+                    "support": 47,
+                    "roc_auc": 0.4739143106965899,
+                    "pr_auc": 0.39763212734475983
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3225806451612903,
+                    "recall": 0.5128205128205128,
+                    "f1": 0.39603960396039606,
+                    "support": 39,
+                    "roc_auc": 0.5276986388097499,
+                    "pr_auc": 0.3432883462847206
+                  }
+                ],
+                "macro_precision": 0.36165793585148426,
+                "macro_recall": 0.37306783051463904,
+                "macro_f1": 0.33102867248750195,
+                "weighted_f1": 0.3159315773349487,
+                "macro_roc_auc": 0.5356493689416938,
+                "macro_pr_auc": 0.38013287019593506
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_2",
+            "metrics": {
+              "regime_f1_macro": 0.429656862745098,
+              "regime_accuracy": 0.6440678238868713,
+              "regime_loss": 0.7245745925775736,
+              "regression_rmse_log_rv": 0.802210004672272,
+              "regression_mae_log_rv": 0.6261304632555378,
+              "regression_loss": 0.6435408915962866,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    5,
+                    1,
+                    1
+                  ],
+                  [
+                    7,
+                    3,
+                    9
+                  ],
+                  [
+                    13,
+                    11,
+                    68
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.2,
+                    "recall": 0.7142857142857143,
+                    "f1": 0.3125,
+                    "support": 7,
+                    "roc_auc": 0.8198198198198198,
+                    "pr_auc": 0.14155369894409214
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.2,
+                    "recall": 0.15789473684210525,
+                    "f1": 0.17647058823529413,
+                    "support": 19,
+                    "roc_auc": 0.733652312599681,
+                    "pr_auc": 0.24110337100354295
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.8717948717948718,
+                    "recall": 0.7391304347826086,
+                    "f1": 0.7999999999999999,
+                    "support": 92,
+                    "roc_auc": 0.8068561872909699,
+                    "pr_auc": 0.9430167484798249
+                  }
+                ],
+                "macro_precision": 0.4239316239316239,
+                "macro_recall": 0.5371036286368094,
+                "macro_f1": 0.429656862745098,
+                "weighted_f1": 0.670681704885344,
+                "macro_roc_auc": 0.7867761065701568,
+                "macro_pr_auc": 0.4418912728091533
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_3",
+            "metrics": {
+              "regime_f1_macro": 0.41277056277056284,
+              "regime_accuracy": 0.40909090638160706,
+              "regime_loss": 1.1006504600698297,
+              "regression_rmse_log_rv": 0.618810546759052,
+              "regression_mae_log_rv": 0.46448430799963797,
+              "regression_loss": 0.3829264927802369,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    12,
+                    1,
+                    5
+                  ],
+                  [
+                    19,
+                    17,
+                    31
+                  ],
+                  [
+                    6,
+                    3,
+                    16
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.32432432432432434,
+                    "recall": 0.6666666666666666,
+                    "f1": 0.4363636363636364,
+                    "support": 18,
+                    "roc_auc": 0.6829710144927537,
+                    "pr_auc": 0.22805387094454452
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.8095238095238095,
+                    "recall": 0.2537313432835821,
+                    "f1": 0.38636363636363635,
+                    "support": 67,
+                    "roc_auc": 0.5397431447414093,
+                    "pr_auc": 0.6426910473026048
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3076923076923077,
+                    "recall": 0.64,
+                    "f1": 0.4155844155844156,
+                    "support": 25,
+                    "roc_auc": 0.6597647058823529,
+                    "pr_auc": 0.3677029014120087
+                  }
+                ],
+                "macro_precision": 0.48051348051348053,
+                "macro_recall": 0.5201326699834162,
+                "macro_f1": 0.41277056277056284,
+                "weighted_f1": 0.4011865407319953,
+                "macro_roc_auc": 0.6274929550388386,
+                "macro_pr_auc": 0.412815939886386
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_4",
+            "metrics": {
+              "regime_f1_macro": 0.4285185185185186,
+              "regime_accuracy": 0.44144144654273987,
+              "regime_loss": 1.0154722354009642,
+              "regression_rmse_log_rv": 0.7135983179381257,
+              "regression_mae_log_rv": 0.5675359502317266,
+              "regression_loss": 0.5092225593641223,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    27,
+                    8,
+                    9
+                  ],
+                  [
+                    26,
+                    11,
+                    14
+                  ],
+                  [
+                    3,
+                    2,
+                    11
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.48214285714285715,
+                    "recall": 0.6136363636363636,
+                    "f1": 0.54,
+                    "support": 44,
+                    "roc_auc": 0.5637720488466758,
+                    "pr_auc": 0.41842777214969273
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.5238095238095238,
+                    "recall": 0.21568627450980393,
+                    "f1": 0.3055555555555556,
+                    "support": 51,
+                    "roc_auc": 0.4738562091503268,
+                    "pr_auc": 0.42254255755991144
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.3235294117647059,
+                    "recall": 0.6875,
+                    "f1": 0.44000000000000006,
+                    "support": 16,
+                    "roc_auc": 0.7460526315789474,
+                    "pr_auc": 0.4163574738853064
+                  }
+                ],
+                "macro_precision": 0.4431605975723623,
+                "macro_recall": 0.5056075460487225,
+                "macro_f1": 0.4285185185185186,
+                "weighted_f1": 0.41786786786786795,
+                "macro_roc_auc": 0.5945602965253166,
+                "macro_pr_auc": 0.4191092678649702
+              }
+            }
+          },
+          {
+            "fold_id": "wf_fold_5",
+            "metrics": {
+              "regime_f1_macro": 0.33935196958730285,
+              "regime_accuracy": 0.37142857909202576,
+              "regime_loss": 1.0661085037958054,
+              "regression_rmse_log_rv": 0.8446623640962365,
+              "regression_mae_log_rv": 0.6279348134444306,
+              "regression_loss": 0.7134545093206432,
+              "classification_breakdown": {
+                "n_classes": 3,
+                "confusion_matrix": [
+                  [
+                    9,
+                    8,
+                    12
+                  ],
+                  [
+                    13,
+                    4,
+                    26
+                  ],
+                  [
+                    0,
+                    7,
+                    26
+                  ]
+                ],
+                "per_class": [
+                  {
+                    "class_id": 0,
+                    "precision": 0.4090909090909091,
+                    "recall": 0.3103448275862069,
+                    "f1": 0.35294117647058826,
+                    "support": 29,
+                    "roc_auc": 0.676497277676951,
+                    "pr_auc": 0.36231414963254455
+                  },
+                  {
+                    "class_id": 1,
+                    "precision": 0.21052631578947367,
+                    "recall": 0.09302325581395349,
+                    "f1": 0.12903225806451613,
+                    "support": 43,
+                    "roc_auc": 0.4426106526631658,
+                    "pr_auc": 0.3521179353995649
+                  },
+                  {
+                    "class_id": 2,
+                    "precision": 0.40625,
+                    "recall": 0.7878787878787878,
+                    "f1": 0.5360824742268041,
+                    "support": 33,
+                    "roc_auc": 0.7504208754208754,
+                    "pr_auc": 0.63306074329683
+                  }
+                ],
+                "macro_precision": 0.34195574162679426,
+                "macro_recall": 0.39708229042631604,
+                "macro_f1": 0.33935196958730285,
+                "weighted_f1": 0.31880383679910274,
+                "macro_roc_auc": 0.6231762685869974,
+                "macro_pr_auc": 0.44916427610964654
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "summary": {
+    "classification": {
+      "regime_f1_macro": {
+        "mean": 0.3945260200817866,
+        "std": 0.06705824276252206,
+        "min": 0.27076515505688015,
+        "max": 0.5588479870195721,
+        "n": 25
+      },
+      "regression_rmse_log_rv": null
+    },
+    "regression": {
+      "regime_f1_macro": {
+        "mean": 0.2120499091688022,
+        "std": 0.08137787598498132,
+        "min": 0.04938271604938271,
+        "max": 0.39996176882885176,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.7922682710814799,
+        "std": 0.1325675602506395,
+        "min": 0.601369169467767,
+        "max": 1.0328911360145374,
+        "n": 25
+      }
+    },
+    "dual": {
+      "regime_f1_macro": {
+        "mean": 0.393680201033083,
+        "std": 0.06419251902736087,
+        "min": 0.2766355140186916,
+        "max": 0.5423066336361134,
+        "n": 25
+      },
+      "regression_rmse_log_rv": {
+        "mean": 0.795123888423505,
+        "std": 0.13417696967910905,
+        "min": 0.49401248811638887,
+        "max": 1.037871030962225,
+        "n": 25
+      }
+    }
+  }
+}


### PR DESCRIPTION
Pod-run on H100, synced via runpodctl. Three single-target arms varying \`--target-horizon\` on canonical setup. n=25 per cell.

| horizon | dual F1 | cls F1 | reg RMSE |
|--|--:|--:|--:|
| 5d  | **0.3937** | **0.3945** | 0.7923 |
| 10d | 0.3773 | 0.3934 | **0.7659** |
| 20d | 0.3863 | 0.3812 | 0.7706 |

10d = canonical baseline exactly (sanity).

**Read:** flat curve. dual range 0.016, cls range 0.013, rmse range 0.026 across horizons — within 5-seed noise. Per #499 decision rules: 'flat curve' bucket → honest negative narrowing the claim. Text-vol signal has no horizon specificity 5d–20d on the event-framework setup.

Closes #499.

Wiki §6.43 published with the read.

## Test plan
- [x] Artefacts parse as valid JSON