### PR TITLE
chore: register multi_axis_text_classifier HF pin + bump forecaster to LoRA-bearing rev

### DIFF
--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -423,15 +423,41 @@ artefacts:
 
   forecaster_canonical:
     hf_uri: hf://yusufizzetmurat/fed-pulse-forecaster
-    revision: "de318540e2c9def75c0b6068dcebf73fd22dbb1d"
+    revision: "2a178cb5470eb4f4cfe781b121fb5d3a4076632e"
     eager: true
     description: |
       Canonical multi-head forecaster checkpoint (#292). Loaded into
-      ``backend/models/forecaster_best.pt`` on first boot.
+      ``backend/models/forecaster_best.pt`` on first boot. The
+      ``2a178cb5`` revision adds the LoRA adapter sidecar
+      (``forecaster_best.pt.lora_adapter.pt``) and the conformal
+      calibration sidecar (``forecaster_calibration_fresh.pt``)
+      alongside the singleton checkpoint so a reproducer can pull
+      both layers in one snapshot.
     inference_features:
       - text_embedding
       - text_embedding_missing
       - credibility
+
+  multi_axis_text_classifier:
+    hf_uri: hf://yusufizzetmurat/fed-pulse-multi-axis-text-classifier
+    revision: "f3d2b524683a705f5940f71dc33e783bc20c2b8d"
+    eager: false
+    description: |
+      §6.41 multi-axis text classifier checkpoints. Each
+      ``text_multi_axis_seedNN.pt`` is a single-seed fine-tuned
+      ``finbert_fed_adjacent`` encoder with a multi-task
+      classification head (stance / factor / certainty);
+      ``text_multi_axis_best.pt`` is the singleton inference
+      checkpoint the ``/analyze`` multi-axis service loads from
+      ``backend/models/text_multi_axis_best.pt``. Seeds 11, 47, 97
+      are mirrored; seeds 29 and 71 ran pod-side and were not
+      retained as artefacts (canonical 5-seed mean was computed at
+      training time from the metrics, not from per-seed
+      checkpoints). MIT-licensed; backbone encoder pin is
+      ``encoder_finbert_fed_adjacent`` above.
+    inference_features:
+      - text_embedding
+      - text_embedding_missing
 
   rates_heads_canonical:
     hf_uri: hf://yusufizzetmurat/fed-pulse-rates-heads


### PR DESCRIPTION
Two registry entries updated to close the local-only-checkpoint gap. Every published §6 inference artefact now has an HF mirror.

## \`forecaster_canonical\` rev de318540 → 2a178cb5
The new revision adds two sidecars alongside the singleton checkpoint:
- \`forecaster_best.pt.lora_adapter.pt\` (1.2 MB) — LoRA adapter
- \`forecaster_calibration_fresh.pt\` (0.27 MB) — conformal calibration

Repo files now: README, .gitattributes, forecaster_best.pt, forecaster_best.conformal.json, forecaster_best.pt.lora_adapter.pt, forecaster_calibration_fresh.pt.

## New \`multi_axis_text_classifier\` pin
Pinned to \`hf://yusufizzetmurat/fed-pulse-multi-axis-text-classifier@f3d2b524\`.

Mirrors the §6.41 published checkpoints: \`text_multi_axis_best.pt\` + per-seed \`seed{11,47,97}.pt\` (1.75 GB total). Seeds 29 / 71 ran pod-side and were not retained as artefacts; the canonical 5-seed mean in §6.41 was computed from per-seed metrics, not per-seed checkpoints, so the mirror is complete for inference reproducibility. README on the HF repo documents this.

## Test plan
- [x] HF \`get_paths_info\` on both pins confirms files match local sha256