### PR TITLE
tests: resolve source-file paths via module __file__ in 3 ablation suites

### DIFF
--- a/tests/unit/test_class_weight_ablation.py
+++ b/tests/unit/test_class_weight_ablation.py
@@ -19,10 +19,11 @@ from pathlib import Path
 import pytest
 
 
-_LOOP_PATH = Path(__file__).resolve().parents[2] / "backend" / "app" / "training" / "loop.py"
-_TRAIN_FORECASTER_PATH = (
-    Path(__file__).resolve().parents[2] / "backend" / "app" / "train_forecaster.py"
-)
+import app.train_forecaster as _train_forecaster_mod
+from app.training import loop as _loop_mod
+
+_LOOP_PATH = Path(_loop_mod.__file__)
+_TRAIN_FORECASTER_PATH = Path(_train_forecaster_mod.__file__)
 
 
 def _read(path: Path) -> str:

--- a/tests/unit/test_encoder_lora_wiring.py
+++ b/tests/unit/test_encoder_lora_wiring.py
@@ -19,11 +19,19 @@ from __future__ import annotations
 from pathlib import Path
 
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
+from app import __file__ as _app_init_path
+
+_APP_DIR = Path(_app_init_path).parent
 
 
 def _read(rel_path: str) -> str:
-    return (_REPO_ROOT / rel_path).read_text(encoding="utf-8")
+    # Accepts both "models/config.py" and the legacy "backend/app/models/config.py"
+    # prefix. Resolves via the live ``app`` package so the same path works whether
+    # the test runs from the host repo root or inside the backend container (where
+    # ``backend/`` is the mount root and there is no nested ``backend/app/`` tree).
+    if rel_path.startswith("backend/app/"):
+        rel_path = rel_path[len("backend/app/"):]
+    return (_APP_DIR / rel_path).read_text(encoding="utf-8")
 
 
 def test_model_config_carries_encoder_lora_field() -> None:

--- a/tests/unit/test_time_decay_ablation.py
+++ b/tests/unit/test_time_decay_ablation.py
@@ -15,23 +15,17 @@ from pathlib import Path
 import pytest
 
 
-_TRAIN_FORECASTER_PATH = (
-    Path(__file__).resolve().parents[2] / "backend" / "app" / "train_forecaster.py"
-)
-_CONFIG_PATH = (
-    Path(__file__).resolve().parents[2] / "backend" / "app" / "models" / "config.py"
-)
+import app.train_forecaster as _train_forecaster_mod
+from app.models import config as _config_mod
+from app.models import forecaster_base as _forecaster_base_mod
+
+_TRAIN_FORECASTER_PATH = Path(_train_forecaster_mod.__file__)
+_CONFIG_PATH = Path(_config_mod.__file__)
 # Post-#336 the input-prep + the time-decay kwarg live on the shared
 # backbone (``forecaster_base.py``). The lstm.py module survives as a
 # back-compat shim; the canonical owner of ``use_time_decay`` is the
 # base class.
-_LSTM_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "backend"
-    / "app"
-    / "models"
-    / "forecaster_base.py"
-)
+_LSTM_PATH = Path(_forecaster_base_mod.__file__)
 
 
 def _read(path: Path) -> str:


### PR DESCRIPTION
Three source-wiring test files hardcoded \`Path(__file__).resolve().parents[2] / "backend" / "app" / ...\` to read backend source for token-level wiring assertions. The path resolves on the host where the worktree puts \`backend/\` at the repo root, but inside the backend container the same mount sits at \`/app\` (no nested \`backend/app/\` tree), so the tests crashed with \`FileNotFoundError\`.

Fix: resolve via the live \`app\` package's \`__file__\` (or the specific module under test). Works in both host and container.

## Files
- \`tests/unit/test_class_weight_ablation.py\`
- \`tests/unit/test_encoder_lora_wiring.py\`
- \`tests/unit/test_time_decay_ablation.py\`

## Test plan
- [x] Each file's 4-8 tests pass cleanly under the container
- [x] Sibling files \`test_encoder_lora.py\` (dual-candidate fallback) and \`test_derived_features_toggle.py\` (pytest.skip) were already portable; no change needed

## Out of scope
- 5 other tests that appeared as failures in the prior coverage run were stale-container artifacts (version pins / retrieval / inference_observability / schemas_strict pair) and pass cleanly in a fresh container. No code change required.