### PR TITLE
scripts: preserve runpod experiment drivers + uncommitted local patches

### DIFF
--- a/scripts/runpod/README.md
+++ b/scripts/runpod/README.md
@@ -1,0 +1,7 @@
+Pod-only artefacts (not on laptop) — 2026-05-31 teardown kit.
+drivers/   every experiment driver written on the pod (wave1-4, stage2, salvage, jobs1-3,
+           absolute_nulls.py CPU null-table, dl_tp.py TP downloader). Exact recipes.
+patches/   two uncommitted local tweaks (defaults preserve byte-identity for other runs):
+  embedding_cache_gpu_device.patch  -> model.to(device), env FED_PULSE_EMBEDDING_CACHE_DEVICE (#553 contract)
+  run_dual_head_dropout_lr_flags.patch -> --dropout / --learning-rate CLI threaded to ModelConfig.dropout / train_model.lr
+NOTE: embedding caches (data/raw/embeddings/, ~610MB incl voyage @ API cost) NOT in this kit — see chat re: whether to ship.

--- a/scripts/runpod/drivers/absolute_nulls.py
+++ b/scripts/runpod/drivers/absolute_nulls.py
@@ -1,0 +1,97 @@
+"""Chance-level null table for the absolute-label regime task (§6.29-style).
+
+Majority-class and stratified-random nulls computed against the SAME absolute
+label set the wave-3 absolute_regime arm used, with the SAME macro-F1 convention
+(mean over classes present in the test fold). Train-prior derived from
+events.parquet via the runner's own vol_regime_absolute_class_for; test counts
+taken from the arm artefact's per-fold confusion matrices (exact).
+CPU only.
+"""
+import json
+import numpy as np
+import pandas as pd
+from app.training.loaders import vol_regime_absolute_class_for
+
+ART = "backend/artifacts/experiments/runpod_wave3_absolute_regime_20260530T211214Z.json"
+EVENTS = "data/processed/canonical/events.parquet"
+MANIFEST = "data/processed/canonical/fold_manifest_expanding_walk_forward.json"
+SEEDS = [11, 29, 47, 71, 97]
+
+d = json.load(open(ART))
+THR = tuple(d["absolute_vol_thresholds"])           # exact per-period cutoffs the arm used
+MODEL_CLS = d["summary"]["classification"]["regime_f1_macro"]["mean"]
+
+def macro_f1_present(y_true, y_pred, n_classes=3):
+    """Macro-F1 averaged over classes PRESENT in y_true (matches the arm)."""
+    present = [c for c in range(n_classes) if np.any(y_true == c)]
+    f1s = []
+    for c in present:
+        tp = np.sum((y_true == c) & (y_pred == c))
+        fp = np.sum((y_true != c) & (y_pred == c))
+        fn = np.sum((y_true == c) & (y_pred != c))
+        prec = tp / (tp + fp) if (tp + fp) else 0.0
+        rec = tp / (tp + fn) if (tp + fn) else 0.0
+        f1s.append(2 * prec * rec / (prec + rec) if (prec + rec) else 0.0)
+    return float(np.mean(f1s)) if f1s else 0.0
+
+# --- test counts per fold from the artefact (seed-independent true supports) ---
+test_counts = {}
+for t in d["trials"]["classification"]:
+    for f in t["folds"]:
+        cb = f["metrics"].get("classification_breakdown")
+        if not cb:
+            continue
+        sup = tuple(c["support"] for c in cb["per_class"])
+        test_counts.setdefault(f["fold_id"], sup)
+
+# --- train prior per fold from events.parquet, labeled with the runner's fn ---
+ev = pd.read_parquet(EVENTS, columns=["event_date", "forward_realized_vol_10d"])
+ev["lab"] = ev["forward_realized_vol_10d"].apply(lambda v: vol_regime_absolute_class_for(v, THR))
+manifest = json.load(open(MANIFEST))["folds"]
+folds = {f["fold_id"]: f for f in manifest}
+
+print(f"absolute thresholds (per-period): {THR}")
+print(f"model cls macro-F1 (arm)        : {MODEL_CLS:.4f}\n")
+print(f"{'fold':12s} {'test_counts':>14s} {'train_maj':>9s} {'major_f1':>8s} {'strat_f1':>8s}")
+
+maj_all, strat_all = [], []
+for fid, sup in test_counts.items():
+    fo = folds[fid]
+    tr = ev[(ev.event_date >= fo["train_start"]) & (ev.event_date <= fo["train_end"]) & (ev.lab >= 0)]
+    tr_counts = np.array([int((tr.lab == c).sum()) for c in range(3)], dtype=float)
+    prior = tr_counts / tr_counts.sum()
+    maj = int(np.argmax(tr_counts))
+    # exact test label vector from artefact supports
+    y_true = np.concatenate([np.full(n, c) for c, n in enumerate(sup)]).astype(int)
+    # majority null (deterministic): predict train-majority class everywhere
+    maj_f1 = macro_f1_present(y_true, np.full(y_true.shape, maj))
+    # stratified null: sample test preds ~ train prior, average over the seed grid
+    s_vals = []
+    for s in SEEDS:
+        rng = np.random.default_rng(s)
+        y_pred = rng.choice(3, size=y_true.shape, p=prior)
+        s_vals.append(macro_f1_present(y_true, y_pred))
+    strat_f1 = float(np.mean(s_vals))
+    maj_all.append(maj_f1); strat_all.append(strat_f1)
+    print(f"{fid:12s} {str(sup):>14s} {maj:>9d} {maj_f1:>8.4f} {strat_f1:>8.4f}")
+
+print(f"\n{'':12s} {'MEAN over folds':>14s}  ->  majority={np.mean(maj_all):.4f}  stratified={np.mean(strat_all):.4f}")
+print(f"model (arm)                                      = {MODEL_CLS:.4f}")
+print(f"model - majority_null = {MODEL_CLS-np.mean(maj_all):+.4f}   model - stratified_null = {MODEL_CLS-np.mean(strat_all):+.4f}")
+
+out = {
+    "label_set": "absolute", "thresholds_per_period": list(THR),
+    "calm_max_annualized": d.get("absolute_calm_max_annualized"),
+    "high_min_annualized": d.get("absolute_high_min_annualized"),
+    "macro_f1_convention": "mean over classes present in test fold (matches arm)",
+    "model_cls_macro_f1": MODEL_CLS,
+    "majority_class_null_macro_f1": float(np.mean(maj_all)),
+    "stratified_random_null_macro_f1": float(np.mean(strat_all)),
+    "model_minus_majority": MODEL_CLS - float(np.mean(maj_all)),
+    "model_minus_stratified": MODEL_CLS - float(np.mean(strat_all)),
+    "per_fold": [
+        {"fold_id": fid, "test_counts": list(test_counts[fid])} for fid in test_counts
+    ],
+}
+json.dump(out, open("backend/artifacts/experiments/absolute_label_nulls.json", "w"), indent=2)
+print("\nwrote backend/artifacts/experiments/absolute_label_nulls.json")

--- a/scripts/runpod/drivers/dl_tp.py
+++ b/scripts/runpod/drivers/dl_tp.py
@@ -1,0 +1,13 @@
+import os
+os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "0"
+
+from huggingface_hub import snapshot_download
+
+p = snapshot_download(
+    repo_id="yusufizzetmurat/fed-pulse-training-package",
+    repo_type="dataset",
+    revision="b0320d8731753bc5bf4a05b9dcd57898c3f84fbd",
+    local_dir="/root/fed-pulse/data/processed/canonical",
+    local_dir_use_symlinks=False,
+)
+print("DOWNLOAD_COMPLETE", p)

--- a/scripts/runpod/drivers/run_b2.sh
+++ b/scripts/runpod/drivers/run_b2.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -uo pipefail
+export PATH="/root/shim:$PATH"; cd /root/fed-pulse
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+ART="backend/artifacts/experiments"; LOG="$HOME/runpod-sweep-logs"
+SUM="$LOG/_b2_summary_${TS}.log"
+note(){ printf '[b2] %s\n' "$*" | tee -a "$SUM"; }
+run(){ local k=$1; shift; note "===== $k start $(date -u) ====="; if "$@" 2>&1 | tee "$LOG/b2_${k}_${TS}.log"; then note "$k OK"; else note "$k FAILED"; fi; }
+note "start $(date -u) HEAD=$(git rev-parse --short HEAD)"
+run xbank_aux_stance_masked python -m app.data.finetune_pilot_b2 \
+    --training-package-id canonical --output $ART/runpod_b2_xbank_aux_${TS}.json \
+    --encoder-alias finbert_fed_adjacent_xbank_aux_stance_masked --seeds 11 29 47 71 97 --epochs 5
+run xbank_aux_weighted python -m app.data.finetune_pilot_b2 \
+    --training-package-id canonical --output $ART/runpod_b2_xbank_aux_weighted_${TS}.json \
+    --encoder-alias finbert_fed_adjacent_xbank_aux_weighted --seeds 11 29 47 71 97 --epochs 5
+note "===== b2 finished $(date -u) ====="; note "B2_COMPLETE_MARKER"
+ls -la $ART/runpod_b2_xbank_aux_${TS}.json $ART/runpod_b2_xbank_aux_weighted_${TS}.json 2>&1 | tee -a "$SUM"

--- a/scripts/runpod/drivers/run_batch.sh
+++ b/scripts/runpod/drivers/run_batch.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Resilient serial sweep driver for a single-GPU Runpod pod.
+#
+# - Reuses the official /workspace/launch_sweeps.sh command templates, one key
+#   per invocation, so a failure in one sweep does NOT abort the rest (the
+#   upstream script's `set -e` only scopes a single key here).
+# - cross_source is run via the module directly because `make
+#   cross-source-transfer` shells out to `docker compose`, and docker is not
+#   usable on this pod.
+set -uo pipefail   # deliberately NOT -e: continue past per-sweep failures
+
+export PATH="/root/shim:$PATH"   # bare `python` -> system 3.12 (has the stack)
+cd /root/fed-pulse
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+ART="backend/artifacts/experiments"
+LOG_DIR="$HOME/runpod-sweep-logs"
+mkdir -p "$ART" "$LOG_DIR"
+SUMMARY="$LOG_DIR/_batch_summary_${TS}.log"
+
+note() { printf '[batch] %s\n' "$*" | tee -a "$SUMMARY"; }
+
+note "start $(date -u) TS=$TS host=$(hostname)"
+note "python -> $(PATH=/root/shim:$PATH command -v python) ($(PATH=/root/shim:$PATH python --version 2>&1))"
+
+# canonical already completed in a pre-run (runpod_canonical_*.json present) and
+# is byte-identical under #524 for the no-flag base path, so it is EXCLUDED here.
+LM_CSV="data/external/loughran_mcdonald/lm_master_2025__master_dictionary.csv"
+if [ -f "$LM_CSV" ]; then
+    note "LM dict present ($LM_CSV) — lm arm will run"
+else
+    note "WARNING: LM dict missing ($LM_CSV) — lm arm will FAIL (FileNotFoundError); other arms unaffected"
+fi
+if ! ls "$ART"/runpod_canonical_*.json >/dev/null 2>&1; then
+    note "WARNING: no runpod_canonical_*.json found — canonical was expected from the pre-run"
+fi
+
+# --- template-driven sweeps (isolated per key) ------------------------------
+for key in surprise retrieval regime derived b2 phrasebank \
+           statement_delta vote_tally lm press_conf mtl_verify; do
+    note "===== $key start $(date -u) ====="
+    if TP_ID=canonical FANOUT=serial SWEEPS="$key" bash /workspace/launch_sweeps.sh; then
+        note "$key OK"
+    else
+        note "$key FAILED (continuing) — see $LOG_DIR/${key}_*.log"
+    fi
+done
+
+# --- cross_source: direct module (docker workaround) ------------------------
+note "===== cross_source start $(date -u) (direct module; docker unusable) ====="
+CS_DIR="$LOG_DIR/cross_source_out_${TS}"
+CS_LOG="$LOG_DIR/cross_source_${TS}.log"
+if python -m app.evaluation.cross_source_transfer \
+        --training-package-id canonical \
+        --encoder-checkpoints finbert_fed_adjacent=yusufizzetmurat/finbert-fed-adjacent \
+        --output-dir "$CS_DIR" > "$CS_LOG" 2>&1; then
+    if [ -f "$CS_DIR/matrix.json" ]; then
+        cp "$CS_DIR/matrix.json" "$ART/runpod_cross_source_${TS}.json"
+        note "cross_source OK -> runpod_cross_source_${TS}.json"
+    else
+        note "cross_source ran but matrix.json missing (see $CS_LOG)"
+    fi
+else
+    note "cross_source FAILED (continuing) — see $CS_LOG"
+fi
+
+# --- wrap up ----------------------------------------------------------------
+note "DONE $(date -u)"
+note "artefacts written:"
+ls -1 "$ART"/runpod_*.json 2>/dev/null | tee -a "$SUMMARY" || note "  (none)"
+note "BATCH_COMPLETE_MARKER"

--- a/scripts/runpod/drivers/run_canonical.sh
+++ b/scripts/runpod/drivers/run_canonical.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Pre-run the slowest of the 9 green arms (canonical) at full seeds/epochs while
+# #524 + the LM dict land. Does NOT touch the statement_delta/vote/press code
+# path. Output name matches launch_sweeps.sh so sync_results.sh picks it up; this
+# arm is therefore EXCLUDED from the later 12-arm batch.
+set -uo pipefail
+export PATH="/root/shim:$PATH"          # bake the 3.12 shim in (tmux env-gotcha safe)
+cd /root/fed-pulse
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+ART="backend/artifacts/experiments"
+LOG_DIR="$HOME/runpod-sweep-logs"
+mkdir -p "$ART" "$LOG_DIR"
+LOG="$LOG_DIR/canonical_${TS}.log"
+OUT="$ART/runpod_canonical_${TS}.json"
+
+{
+  echo "[canonical] start $(date -u)  HEAD=$(git rev-parse --short HEAD)  python=$(command -v python) ($(python --version 2>&1))"
+  echo "[canonical] output -> $OUT"
+  python -m scripts.run_dual_head_comparison \
+      --training-package-id canonical \
+      --output "$OUT" \
+      --seeds 11 29 47 71 97 \
+      --epochs 40 \
+      --regression-alpha 0.5
+  rc=$?
+  echo "[canonical] exit=$rc $(date -u)"
+  if [ "$rc" -eq 0 ] && [ -f "$OUT" ]; then
+    echo "[canonical] OK artefact=$OUT"
+  else
+    echo "[canonical] FAILED rc=$rc (artefact present: $([ -f "$OUT" ] && echo yes || echo no))"
+  fi
+  echo "CANONICAL_DONE_MARKER rc=$rc"
+} 2>&1 | tee "$LOG"

--- a/scripts/runpod/drivers/run_job1.sh
+++ b/scripts/runpod/drivers/run_job1.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -uo pipefail
+export PATH="/root/shim:$PATH"; cd /root/fed-pulse
+TS=$(date -u +%Y%m%dT%H%M%SZ); ART="backend/artifacts/experiments"; LOG="$HOME/runpod-sweep-logs"
+SUM="$LOG/_job1_summary_${TS}.log"
+note(){ printf '[job1] %s\n' "$*" | tee -a "$SUM"; }
+ex(){ PATH=/root/shim:$PATH python - "$1" <<'PY'
+import json,sys
+s=json.load(open(sys.argv[1]))["summary"]
+def m(h):
+    v=s.get(h,{}).get("regime_f1_macro"); return f"{v['mean']:.4f}" if isinstance(v,dict) else "na"
+def r(h):
+    v=s.get(h,{}).get("regression_rmse_log_rv"); return f"{v['mean']:.4f}" if isinstance(v,dict) else "na"
+print(f"dual_f1={m('dual')} cls_f1={m('classification')} reg_rmse={r('dual')}")
+PY
+}
+note "start $(date -u) HEAD=$(git rev-parse --short HEAD) TS=$TS"
+for H in 5 10 20; do
+  out="$ART/pod_horizon_${H}d_${TS}.json"
+  note "===== horizon ${H}d start $(date -u) ====="
+  if python -m scripts.run_dual_head_comparison --training-package-id canonical \
+      --target-horizon $H --output "$out" --seeds 11 29 47 71 97 --epochs 40 \
+      2>&1 | tee "$LOG/job1_h${H}d_${TS}.log" >/dev/null; then
+    note "horizon ${H}d OK: $(ex "$out")"
+  else note "horizon ${H}d FAILED"; fi
+done
+note "===== JOB1 DONE $(date -u) ====="; note "JOB1_COMPLETE_MARKER"

--- a/scripts/runpod/drivers/run_job2.sh
+++ b/scripts/runpod/drivers/run_job2.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -uo pipefail
+export PATH="/root/shim:$PATH"; cd /root/fed-pulse
+TS=$(date -u +%Y%m%dT%H%M%SZ); ART="backend/artifacts/experiments"; LOG="$HOME/runpod-sweep-logs"
+SUM="$LOG/_job2_summary_${TS}.log"; RR="$LOG/arch_sweep_job2_${TS}"
+note(){ printf '[job2] %s\n' "$*" | tee -a "$SUM"; }
+note "start $(date -u) HEAD=$(git rev-parse --short HEAD) TS=$TS samples=8 (reduced from 20 for budget)"
+note "===== arch sweep start $(date -u) ====="
+if python scripts/run_regime_architecture_sweep.py --training-package-id canonical \
+    --random-search-samples 8 --no-llm-features --report-root "$RR" > "$LOG/job2_archsweep_${TS}.log" 2>&1; then
+  note "arch sweep OK -> $RR"
+else note "arch sweep FAILED (see job2_archsweep_${TS}.log)"; fi
+note "archs done: $(find "$RR" -name forecaster_sweep_results.json 2>/dev/null | sed 's#.*/##;s#/.*##' | wc -l)"
+find "$RR" -name forecaster_sweep_results.json 2>/dev/null | sed 's#.*/canonical/##;s#/forecaster.*##' | tr '\n' ' ' | xargs -I{} note "arch dirs: {}"
+note "===== ensemble aggregate $(date -u) ====="
+if python -m app.evaluation.ensemble_aggregator --arch-sweep-dir "$RR" \
+    --output-json "$ART/pod_arch_ensemble_${TS}.json" --output-markdown "$RR/ensemble_${TS}.md" \
+    > "$LOG/job2_aggregate_${TS}.log" 2>&1; then
+  note "ensemble OK -> pod_arch_ensemble_${TS}.json"
+else note "ensemble FAILED (see job2_aggregate_${TS}.log)"; fi
+note "===== JOB2 DONE $(date -u) ====="; note "JOB2_COMPLETE_MARKER"

--- a/scripts/runpod/drivers/run_job3.sh
+++ b/scripts/runpod/drivers/run_job3.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# JOB 3 — §6.41 VIX-on encoder bake-off (control for the text-as-vol-proxy claim).
+# Waits for JOB1+JOB2 (JOBS12_COMPLETE_MARKER), then runs on canonical_vix with
+# --use-vix-features: baseline (no text) + bge/finbert/xbank (+text). nomic/voyage
+# remain run-path-blocked (trust_remote_code / API from_pretrained), skipped.
+# 17:30Z budget guard before each arm.
+set -uo pipefail
+export PATH="/root/shim:$PATH"; cd /root/fed-pulse
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+ART="backend/artifacts/experiments"; LOG="$HOME/runpod-sweep-logs"
+SUM="$LOG/_job3_summary_${TS}.log"; GUARD=$(date -u -d 'today 17:30' +%s)
+note(){ printf '[job3] %s\n' "$*" | tee -a "$SUM"; }
+ex(){ PATH=/root/shim:$PATH python - "$1" <<'PY'
+import json,sys
+try:
+    s=json.load(open(sys.argv[1]))["summary"]
+    def m(h):
+        v=s.get(h,{}).get("regime_f1_macro"); return f"{v['mean']:.4f}" if isinstance(v,dict) else "na"
+    print(f"dual={m('dual')} cls={m('classification')}")
+except Exception as e: print("err",e)
+PY
+}
+run(){ local k=$1; shift; note "===== $k start $(date -u) ====="; if "$@" 2>&1 | tee "$LOG/job3_${k}_${TS}.log" >/dev/null; then note "$k OK"; return 0; else note "$k FAILED"; return 1; fi; }
+
+# wait for JOB1+JOB2
+J12=$(ls -t "$LOG"/_jobs12_summary_*.log 2>/dev/null | head -1)
+note "waiting for JOB1+JOB2 (JOBS12_COMPLETE_MARKER) before JOB3..."
+until [ -n "$J12" ] && grep -q JOBS12_COMPLETE_MARKER "$J12" 2>/dev/null; do sleep 30; J12=$(ls -t "$LOG"/_jobs12_summary_*.log 2>/dev/null | head -1); done
+note "JOB1+2 done; starting JOB3 $(date -u) TS=$TS"
+
+# VIX-on baseline (no text) — the new reference number
+if [ "$(date -u +%s)" -lt "$GUARD" ]; then
+  run vixon_baseline python -m scripts.run_dual_head_comparison --training-package-id canonical_vix \
+    --use-vix-features --output "$ART/pod_vixon_baseline_${TS}.json" --seeds 11 29 47 71 97 --epochs 40
+  [ -f "$ART/pod_vixon_baseline_${TS}.json" ] && note "vixon_baseline: $(ex "$ART/pod_vixon_baseline_${TS}.json")"
+fi
+
+# VIX-on + text, valid encoders only (caches built locally in salvage)
+for enc in bge_large_en_v15 finbert_fed_adjacent finbert_fed_adjacent_xbank; do
+  [ "$(date -u +%s)" -lt "$GUARD" ] || { note "17:30Z guard; stopping JOB3"; break; }
+  out="$ART/pod_vixon_${enc}_${TS}.json"
+  if run "vixon_${enc}" python -m scripts.run_dual_head_comparison --training-package-id canonical_vix \
+      --use-vix-features --text-encoder "$enc" --use-text-embeddings \
+      --output "$out" --seeds 11 29 47 71 97 --epochs 40; then
+    note "vixon_${enc}: $(ex "$out")"
+  fi
+done
+note "NOTE: nomic + voyage skipped (run-path blocked: trust_remote_code / API from_pretrained); independent of VIX."
+note "===== JOB3 DONE $(date -u) ====="; note "JOB3_COMPLETE_MARKER"

--- a/scripts/runpod/drivers/run_jobs12.sh
+++ b/scripts/runpod/drivers/run_jobs12.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# JOB 1 (#499 horizon 5/10/20, via --target-horizon, direct) then
+# JOB 2 (#217 arch ensemble, direct script + aggregator). 17:30Z budget guard
+# before JOB 2 (ship JOB 1 alone if past). JOB 3 (VIX) blocked on HF dataset rev.
+set -uo pipefail
+export PATH="/root/shim:$PATH"; cd /root/fed-pulse
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+ART="backend/artifacts/experiments"; LOG="$HOME/runpod-sweep-logs"
+SUM="$LOG/_jobs12_summary_${TS}.log"
+GUARD=$(date -u -d 'today 17:30' +%s)
+note(){ printf '[jobs12] %s\n' "$*" | tee -a "$SUM"; }
+ex(){ PATH=/root/shim:$PATH python - "$1" <<'PY'
+import json,sys
+try:
+    s=json.load(open(sys.argv[1]))["summary"]
+    def m(h,k):
+        v=s.get(h,{}).get(k); return f"{v['mean']:.4f}" if isinstance(v,dict) else "na"
+    print(f"dual_f1={m('dual','regime_f1_macro')} cls_f1={m('classification','regime_f1_macro')} reg_rmse={m('regression','regression_rmse_log_rv')}")
+except Exception as e: print("parse-error",e)
+PY
+}
+run(){ local k=$1; shift; note "===== $k start $(date -u) ====="; if "$@" 2>&1 | tee "$LOG/jobs12_${k}_${TS}.log" >/dev/null; then note "$k OK"; return 0; else note "$k FAILED"; return 1; fi; }
+
+note "start $(date -u) TS=$TS HEAD=$(git rev-parse --short HEAD) guard=17:30Z"
+
+# --- JOB 1: horizon sensitivity 5/10/20 -------------------------------------
+note "########## JOB 1 — #499 horizon 5/10/20 ##########"
+for H in 5 10 20; do
+  out="$ART/pod_horizon_${H}d_${TS}.json"
+  if run "horizon_${H}d" python -m scripts.run_dual_head_comparison --training-package-id canonical \
+      --target-horizon "$H" --output "$out" --seeds 11 29 47 71 97 --epochs 40; then
+    note "horizon_${H}d: $(ex "$out")"
+  fi
+done
+note "JOB1 horizon table:"
+for H in 5 10 20; do note "  ${H}d -> $(ex "$ART/pod_horizon_${H}d_${TS}.json" 2>/dev/null)"; done
+note "JOB1_DONE"
+
+# --- JOB 2: arch ensemble (budget-guarded) ----------------------------------
+if [ "$(date -u +%s)" -lt "$GUARD" ]; then
+  note "########## JOB 2 — #217 arch ensemble (5 archs × 5 samples) ##########"
+  ASD="$LOG/job2_arch_sweep_${TS}"
+  if run arch_sweep python scripts/run_regime_architecture_sweep.py --training-package-id canonical \
+      --architectures lstm lstm_attn gru tcn transformer --random-search-samples 5 \
+      --no-llm-features --report-root "$ASD"; then
+    run ensemble_aggregate python -m app.evaluation.ensemble_aggregator \
+      --arch-sweep-dir "$ASD" --output-json "$ART/pod_arch_ensemble_${TS}.json" || true
+    [ -f "$ART/pod_arch_ensemble_${TS}.json" ] && note "arch ensemble JSON written: pod_arch_ensemble_${TS}.json"
+  fi
+  note "JOB2_DONE"
+else
+  note "17:30Z guard passed before JOB 2 — shipping JOB 1 only (JOB2 skipped)"
+fi
+
+note "===== JOBS12 DONE $(date -u) ====="; note "JOBS12_COMPLETE_MARKER"

--- a/scripts/runpod/drivers/run_queue.sh
+++ b/scripts/runpod/drivers/run_queue.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Post-#545/#546 queue: A (doc_length×mp_off) -> C (bake-off rerun, fixed) ->
+# D (cross_bank rerun, fixed) -> B (2^3 composition matrix).
+# nomic excluded from C (needs trust_remote_code=True); voyage excluded (key).
+# E (vix on canonical_vix) is handled separately once the HF SHA lands.
+set -uo pipefail
+export PATH="/root/shim:$PATH"; cd /root/fed-pulse
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+ART="backend/artifacts/experiments"; LOG="$HOME/runpod-sweep-logs"
+mkdir -p "$ART" "$LOG"; SUM="$LOG/_queue_summary_${TS}.log"
+note(){ printf '[queue] %s\n' "$*" | tee -a "$SUM"; }
+run(){ local k=$1; shift; note "===== $k start $(date -u) ====="; if "$@" 2>&1 | tee "$LOG/q_${k}_${TS}.log"; then note "$k OK"; else note "$k FAILED (continuing)"; fi; }
+note "start $(date -u) HEAD=$(git rev-parse --short HEAD) TS=$TS"
+S="11 29 47 71 97"; E=40
+
+# A: doc_length × mp_off
+run A_doc_length_mp_off python -m scripts.run_dual_head_comparison \
+    --training-package-id canonical --output $ART/runpod_compo_doc_length_mp_off_${TS}.json \
+    --seeds $S --epochs $E --use-doc-length --no-mp-surprise
+
+# C: bake-off rerun under #546 (finbert, bge; nomic/voyage excluded)
+for enc in finbert_fed_adjacent bge_large_en_v15; do
+    run C_bakeoff_${enc}_v546 python -m scripts.run_dual_head_comparison \
+        --training-package-id canonical --output $ART/runpod_bakeoff_v546_${enc}_${TS}.json \
+        --seeds $S --epochs $E --text-encoder $enc --use-text-embeddings
+done
+
+# D: cross_bank_revisited rerun under #546
+run D_cross_bank_revisited_v546 python -m scripts.run_dual_head_comparison \
+    --training-package-id canonical --output $ART/runpod_cross_bank_revisited_v546_${TS}.json \
+    --seeds $S --epochs $E --text-encoder finbert_fed_adjacent_xbank --use-text-embeddings
+
+# B: 2^3 composition matrix (mp_surprise × doc_length × focal)
+for mp in "" "--no-mp-surprise"; do
+  for dl in "" "--use-doc-length"; do
+    for fl in ce focal; do
+      extra=""; [ "$fl" = "focal" ] && extra="--focal-gamma 2.0"
+      label="mp${mp:+_off}_dl${dl:+_on}_loss_${fl}"
+      run B_${label} python -m scripts.run_dual_head_comparison \
+          --training-package-id canonical --output $ART/runpod_compo_matrix_${label}_${TS}.json \
+          --seeds $S --epochs $E --regime-loss $fl $extra $mp $dl
+    done
+  done
+done
+
+note "===== queue finished $(date -u) ====="; note "QUEUE_COMPLETE_MARKER"
+ls -la $ART/runpod_compo_*_${TS}.json $ART/runpod_bakeoff_v546_*_${TS}.json $ART/runpod_cross_bank_revisited_v546_${TS}.json 2>&1 | tee -a "$SUM"

--- a/scripts/runpod/drivers/run_salvage.sh
+++ b/scripts/runpod/drivers/run_salvage.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Post-B salvage: build local embedding caches (full GPU, after B frees it),
+# then re-run C-finbert / D-cross_bank / C-voyage with real embeddings.
+# Caches stay LOCAL (no HF push per operator). nomic skipped (cache builder
+# needs trust_remote_code — tomorrow).
+set -uo pipefail
+export PATH="/root/shim:$PATH"; cd /root/fed-pulse
+LOG="$HOME/runpod-sweep-logs"; ART="backend/artifacts/experiments"
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+SUM="$LOG/_salvage_summary_${TS}.log"
+note(){ printf '[salvage] %s\n' "$*" | tee -a "$SUM"; }
+VKEY='pa-IBlhX6M_h-5iZL7vqQuz8PmT0fGIqXnSfsGOIDZHT_6'
+
+# 0. wait for B / the queue to finish so cache builds get full GPU
+QSUM=$(ls -t "$LOG"/_queue_summary_*.log | head -1)
+note "waiting for queue (B) to finish before salvage..."
+until grep -q QUEUE_COMPLETE_MARKER "$QSUM" 2>/dev/null; do sleep 20; done
+note "queue done; starting salvage $(date -u)"
+
+# 1. build BERT caches (full GPU, generous timeout)
+for enc in finbert_fed_adjacent finbert_fed_adjacent_xbank; do
+  note "build cache: $enc"
+  if timeout 1800 python -m app.data.embedding_cache --encoder "$enc" \
+        --training-package-id canonical --allow-network > "$LOG/cache_${enc}_${TS}.log" 2>&1; then
+    note "  cache $enc OK"
+  else
+    note "  cache $enc FAILED (see cache_${enc}_${TS}.log)"
+  fi
+done
+
+# 2. build voyage cache via API (key inline; not paying retail per operator)
+note "build cache: voyage_finance_2 (API)"
+if VOYAGE_API_KEY="$VKEY" timeout 1800 python scripts/cache_voyage_embeddings.py \
+      --encoder-alias voyage_finance_2 --training-package-id canonical \
+      --api-key "$VKEY" --allow-network > "$LOG/cache_voyage_${TS}.log" 2>&1; then
+  note "  cache voyage OK"
+else
+  note "  cache voyage FAILED (see cache_voyage_${TS}.log)"
+fi
+
+# 3. re-run the three arms with now-local caches (real embeddings)
+run(){ local k=$1; shift; note "===== rerun $k $(date -u) ====="; if "$@" 2>&1 | tee "$LOG/salvage_${k}_${TS}.log"; then note "$k OK"; else note "$k FAILED"; fi; }
+run C_finbert_cache python -m scripts.run_dual_head_comparison --training-package-id canonical \
+    --output "$ART/runpod_bakeoff_v546cache_finbert_fed_adjacent_${TS}.json" \
+    --seeds 11 29 47 71 97 --epochs 40 --text-encoder finbert_fed_adjacent --use-text-embeddings
+run D_cross_bank_cache python -m scripts.run_dual_head_comparison --training-package-id canonical \
+    --output "$ART/runpod_cross_bank_revisited_v546cache_${TS}.json" \
+    --seeds 11 29 47 71 97 --epochs 40 --text-encoder finbert_fed_adjacent_xbank --use-text-embeddings
+run C_voyage_cache python -m scripts.run_dual_head_comparison --training-package-id canonical \
+    --output "$ART/runpod_bakeoff_v546cache_voyage_finance_2_${TS}.json" \
+    --seeds 11 29 47 71 97 --epochs 40 --text-encoder voyage_finance_2 --use-text-embeddings
+
+note "===== salvage finished $(date -u) ====="; note "SALVAGE_COMPLETE_MARKER"
+ls -la "$ART"/runpod_bakeoff_v546cache_*_${TS}.json "$ART"/runpod_cross_bank_revisited_v546cache_${TS}.json 2>&1 | tee -a "$SUM"

--- a/scripts/runpod/drivers/run_stage2.sh
+++ b/scripts/runpod/drivers/run_stage2.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Stage-2 HP refine (F) + F2(top-5 × bge). E/E2 moved laptop-side.
+# F: 40 random samples from the FULL 5-dim grid
+#   hidden{32,64,128} × ralpha{0.3,0.5,0.7} × gamma{1,1.5,2} × dropout{0.1,0.2,0.3} × lr{1e-4,3e-4,1e-3}
+# Locked: --no-mp-surprise --use-doc-length --regime-loss focal. (dropout/lr via local CLI tweak.)
+# Stop: THRESHOLD_HIT marker if a cell dual>=0.50 or cls>=0.45; 8h hard cap -> stop + leave partial.
+set -uo pipefail
+export PATH="/root/shim:$PATH"; cd /root/fed-pulse
+TS=$(date -u +%Y%m%dT%H%M%SZ); START=$(date +%s); DEADLINE=$((START + 28800))
+ART="backend/artifacts/experiments"; LOG="$HOME/runpod-sweep-logs"
+SUM="$LOG/_stage2_summary_${TS}.log"; CSV="$LOG/stage2_ranking_${TS}.csv"
+CFG="$LOG/stage2_configs_${TS}.txt"
+note(){ printf '[stage2] %s\n' "$*" | tee -a "$SUM"; }
+S="11 29 47 71 97"; EP=40
+ok(){ [ "$(date +%s)" -lt "$DEADLINE" ]; }
+ex(){ PATH=/root/shim:$PATH python - "$1" <<'PY'
+import json,sys,math
+try:
+    s=json.load(open(sys.argv[1]))["summary"]
+    def m(h):
+        v=s.get(h,{}).get("regime_f1_macro"); return v["mean"] if isinstance(v,dict) else float("nan")
+    du,cl=m("dual"),m("classification")
+    gm=math.sqrt(du*cl) if du==du and cl==cl and du>0 and cl>0 else float("nan")
+    print(f"{du:.4f} {cl:.4f} {gm:.4f}")
+except Exception: print("nan nan nan")
+PY
+}
+run(){ local key=$1; shift; note "===== $key start $(date -u) ====="; if "$@" 2>&1 | tee "$LOG/stage2_${key}_${TS}.log" >/dev/null; then note "$key OK"; return 0; else note "$key FAILED"; return 1; fi; }
+
+# deterministic 40-sample draw from the 243-combo 5-dim grid
+PATH=/root/shim:$PATH python - "$CFG" <<'PY'
+import random, itertools, sys
+random.seed(42)
+grid=list(itertools.product([32,64,128],[0.3,0.5,0.7],[1.0,1.5,2.0],[0.1,0.2,0.3],[1e-4,3e-4,1e-3]))
+with open(sys.argv[1],"w") as f:
+    for hs,ra,fg,do,lr in random.sample(grid,40):
+        f.write(f"{hs} {ra} {fg} {do} {lr}\n")
+PY
+
+note "start $(date -u) TS=$TS HEAD=$(git rev-parse --short HEAD) hardcap=+8h  (F=40 samples 5-dim)"
+printf 'cell,hidden,ralpha,gamma,dropout,lr,dual,cls,geomean\n' > "$CSV"
+
+# --- F: 40-sample sweep -----------------------------------------------------
+while read -r hs ra fg dp lr; do
+  ok || { note "8h cap reached; stopping F sweep"; break; }
+  cell="h${hs}_a${ra}_g${fg}_d${dp}_l${lr}"; out="$ART/runpod_stage2_${cell}_${TS}.json"
+  if run "F_${cell}" python -m scripts.run_dual_head_comparison --training-package-id canonical \
+      --output "$out" --seeds $S --epochs $EP --no-mp-surprise --use-doc-length --regime-loss focal \
+      --hidden-size "$hs" --regression-alpha "$ra" --focal-gamma "$fg" --dropout "$dp" --learning-rate "$lr"; then
+    read du cl gm <<< "$(ex "$out")"
+    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s\n' "$cell" "$hs" "$ra" "$fg" "$dp" "$lr" "$du" "$cl" "$gm" >> "$CSV"
+    note "F ${cell}: dual=$du cls=$cl geomean=$gm"
+    awk -v d="$du" -v c="$cl" 'BEGIN{exit !((d+0)>=0.50 || (c+0)>=0.45)}' && { note "*** THRESHOLD_HIT ${cell} dual=$du cls=$cl ***"; touch "$LOG/THRESHOLD_HIT_${TS}"; }
+  fi
+done < "$CFG"
+
+note "===== F ranking by geomean ====="
+{ head -1 "$CSV"; tail -n +2 "$CSV" | sort -t, -k9 -gr; } | tee -a "$SUM"
+
+# --- F2: top-5 × bge --------------------------------------------------------
+note "===== F2: top-5 cells × bge ====="
+mapfile -t top5 < <(tail -n +2 "$CSV" | sort -t, -k9 -gr | head -5)
+for row in "${top5[@]}"; do
+  ok || { note "8h cap; stopping F2"; break; }
+  IFS=, read cell hs ra fg dp lr du cl gm <<< "$row"
+  out="$ART/runpod_stage2_bge_${cell}_${TS}.json"
+  if run "F2_${cell}_bge" python -m scripts.run_dual_head_comparison --training-package-id canonical \
+      --output "$out" --seeds $S --epochs $EP --no-mp-surprise --use-doc-length --regime-loss focal \
+      --hidden-size "$hs" --regression-alpha "$ra" --focal-gamma "$fg" --dropout "$dp" --learning-rate "$lr" \
+      --text-encoder bge_large_en_v15 --use-text-embeddings; then
+    note "F2 ${cell}+bge: $(ex "$out")"
+  fi
+done
+
+note "===== STAGE2 DONE $(date -u) ====="; note "STAGE2_COMPLETE_MARKER"

--- a/scripts/runpod/drivers/run_wave2_batch.sh
+++ b/scripts/runpod/drivers/run_wave2_batch.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Wave 2 runpod batch driver — 7 new arms against the canonical TP.
+#
+# Arms (canonical re-run + 6 new):
+#   canonical_v2         baseline dual-head canonical with the post-#529/#531 runner
+#   garch_residual       --vol-target-mode garch_residual on dual head
+#   horizon_5d           --target-horizon 5  (forward_realized_vol_5d target)
+#   horizon_20d          --target-horizon 20 (forward_realized_vol_20d target)
+#   ordinal_ce           --regime-loss ordinal_ce (bin-distance-weighted CE)
+#   confounder_ablation  5-cell ablation: baseline + year_fe + meeting_type_fe + doc_length + all_three
+#   arch_sweep           regime architecture sweep across 5 archs (LSTM / LSTM-attn / GRU / TCN / Transformer)
+#
+# Resilient serial driver: each arm runs in isolation; one failure does not
+# abort the rest. Output JSONs land at $ART/runpod_wave2_<arm>_<TS>.json.
+
+set -uo pipefail
+
+export PATH="/root/shim:$PATH"
+cd /root/fed-pulse
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+ART="backend/artifacts/experiments"
+LOG_DIR="$HOME/runpod-sweep-logs"
+mkdir -p "$ART" "$LOG_DIR"
+SUMMARY="$LOG_DIR/_wave2_summary_${TS}.log"
+
+note() { printf '[wave2] %s\n' "$*" | tee -a "$SUMMARY"; }
+
+note "start $(date -u) TS=$TS host=$(hostname)"
+note "python -> $(PATH=/root/shim:$PATH command -v python) ($(PATH=/root/shim:$PATH python --version 2>&1))"
+note "dev rev -> $(git rev-parse --short HEAD)"
+
+SEEDS="${SEEDS:-11 29 47 71 97}"
+EPOCHS="${EPOCHS:-40}"
+
+run_arm() {
+    local key=$1
+    shift
+    local log_file="$LOG_DIR/wave2_${key}_${TS}.log"
+    note "===== $key start $(date -u) ====="
+    if "$@" 2>&1 | tee "$log_file"; then
+        note "$key OK -> $log_file"
+    else
+        note "$key FAILED (continuing) — see $log_file"
+    fi
+}
+
+# --- canonical_v2 (re-baseline against the post-#529/#531 runner) -----------
+run_arm canonical_v2 \
+    python -m scripts.run_dual_head_comparison \
+        --training-package-id canonical \
+        --output $ART/runpod_wave2_canonical_v2_${TS}.json \
+        --seeds $SEEDS --epochs $EPOCHS \
+        --regression-alpha 0.5
+
+# --- garch_residual ---------------------------------------------------------
+run_arm garch_residual \
+    python -m scripts.run_dual_head_comparison \
+        --training-package-id canonical \
+        --output $ART/runpod_wave2_garch_residual_${TS}.json \
+        --seeds $SEEDS --epochs $EPOCHS \
+        --vol-target-mode garch_residual
+
+# --- horizon_5d -------------------------------------------------------------
+run_arm horizon_5d \
+    python -m scripts.run_dual_head_comparison \
+        --training-package-id canonical \
+        --output $ART/runpod_wave2_horizon_5d_${TS}.json \
+        --seeds $SEEDS --epochs $EPOCHS \
+        --target-horizon 5
+
+# --- horizon_20d ------------------------------------------------------------
+run_arm horizon_20d \
+    python -m scripts.run_dual_head_comparison \
+        --training-package-id canonical \
+        --output $ART/runpod_wave2_horizon_20d_${TS}.json \
+        --seeds $SEEDS --epochs $EPOCHS \
+        --target-horizon 20
+
+# --- ordinal_ce -------------------------------------------------------------
+run_arm ordinal_ce \
+    python -m scripts.run_dual_head_comparison \
+        --training-package-id canonical \
+        --output $ART/runpod_wave2_ordinal_ce_${TS}.json \
+        --seeds $SEEDS --epochs $EPOCHS \
+        --regime-loss ordinal_ce
+
+# --- confounder_ablation (5 cells inside one runner) ------------------------
+run_arm confounder_ablation \
+    python -m scripts.run_confounder_ablation \
+        --training-package-id canonical \
+        --output $ART/runpod_wave2_confounder_ablation_${TS}.json \
+        --seeds $SEEDS --epochs $EPOCHS \
+        --cells baseline year_fe meeting_type_fe doc_length all_three
+
+# --- arch_sweep (stage-1 screening) -----------------------------------------
+# 5 archs (lstm / lstm_attn / gru / tcn / transformer), 5 HP samples each
+# (stage-1 coarse screen, not full HP refinement). report-root under LOG_DIR so
+# sync_results.sh bundles it; ensemble_aggregator then writes one wave-2 JSON.
+# NB: aggregator flag is --output-json (not --output); report-root via rglob
+# picks up the <root>/canonical/<arch>/forecaster_sweep_results.json layout.
+run_arm arch_sweep \
+    bash -c "PATH=/root/shim:\$PATH python scripts/run_regime_architecture_sweep.py \
+        --training-package-id canonical \
+        --architectures lstm lstm_attn gru tcn transformer \
+        --random-search-samples 5 \
+        --no-llm-features \
+        --report-root $LOG_DIR/arch_sweep_${TS} \
+     && PATH=/root/shim:\$PATH python -m app.evaluation.ensemble_aggregator \
+        --arch-sweep-dir $LOG_DIR/arch_sweep_${TS} \
+        --output-json $ART/runpod_wave2_arch_sweep_${TS}.json"
+
+note "===== wave2 batch finished $(date -u) ====="
+note "WAVE2_BATCH_COMPLETE_MARKER"
+ls -la "$ART"/runpod_wave2_*_${TS}.json 2>&1 | tee -a "$SUMMARY"

--- a/scripts/runpod/drivers/run_wave35.sh
+++ b/scripts/runpod/drivers/run_wave35.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -uo pipefail
+export PATH="/root/shim:$PATH"
+cd /root/fed-pulse
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+ART="backend/artifacts/experiments"; LOG="$HOME/runpod-sweep-logs"
+SUM="$LOG/_wave35_summary_${TS}.log"
+note(){ printf '[wave3.5] %s\n' "$*" | tee -a "$SUM"; }
+note "start $(date -u) HEAD=$(git rev-parse --short HEAD)"
+run(){ local k=$1; shift; note "===== $k start $(date -u) ====="; if "$@" 2>&1 | tee "$LOG/wave35_${k}_${TS}.log"; then note "$k OK"; else note "$k FAILED"; fi; }
+run focal_loss python -m scripts.run_dual_head_comparison --training-package-id canonical \
+    --output $ART/runpod_wave3_focal_loss_${TS}.json --seeds 11 29 47 71 97 --epochs 40 \
+    --regime-loss focal --focal-gamma 2.0
+run class_balanced python -m scripts.run_dual_head_comparison --training-package-id canonical \
+    --output $ART/runpod_wave3_class_balanced_${TS}.json --seeds 11 29 47 71 97 --epochs 40 \
+    --regime-loss class_balanced --class-balanced-beta 0.999
+note "===== wave3.5 finished $(date -u) ====="; note "WAVE35_COMPLETE_MARKER"
+ls -la $ART/runpod_wave3_focal_loss_${TS}.json $ART/runpod_wave3_class_balanced_${TS}.json 2>&1 | tee -a "$SUM"

--- a/scripts/runpod/drivers/run_wave3_batch.sh
+++ b/scripts/runpod/drivers/run_wave3_batch.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Wave 3 runpod batch driver — 7 new arms against the canonical TP +
+# the seq_len_60 arm against the 60-bar TP variant.
+#
+# Arms:
+#   focal_loss             --regime-loss focal --focal-gamma 2.0
+#   class_balanced         --regime-loss class_balanced --class-balanced-beta 0.999
+#   multi_horizon_aux      --aux-horizons 5,20 --aux-horizon-alpha 0.3
+#   absolute_regime        --vol-regime-label-mode absolute (12% / 22% annualised)
+#   vix_features           --use-vix-features (requires TP rebuild with VIX columns)
+#   seq_len_60             --sequence-length 60 against canonical_60bar TP
+#   cross_bank_revisited   --text-encoder finbert_fed_adjacent_xbank
+#
+# Default: every arm runs at 5 seeds × 5 folds × 3 head modes via
+# run_dual_head_comparison.py. seq_len_60 uses canonical_60bar TP;
+# everything else uses canonical TP.
+
+set -uo pipefail
+
+export PATH="/root/shim:$PATH"
+cd /root/fed-pulse
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+ART="backend/artifacts/experiments"
+LOG_DIR="$HOME/runpod-sweep-logs"
+mkdir -p "$ART" "$LOG_DIR"
+SUMMARY="$LOG_DIR/_wave3_summary_${TS}.log"
+
+note() { printf '[wave3] %s\n' "$*" | tee -a "$SUMMARY"; }
+
+note "start $(date -u) TS=$TS host=$(hostname)"
+note "python -> $(PATH=/root/shim:$PATH command -v python) ($(PATH=/root/shim:$PATH python --version 2>&1))"
+note "dev rev -> $(git rev-parse --short HEAD)"
+
+SEEDS="${SEEDS:-11 29 47 71 97}"
+EPOCHS="${EPOCHS:-40}"
+SWEEPS="${SWEEPS:-focal_loss class_balanced multi_horizon_aux absolute_regime vix_features seq_len_60 cross_bank_revisited}"
+
+run_arm() {
+    local key=$1
+    shift
+    local log_file="$LOG_DIR/wave3_${key}_${TS}.log"
+    note "===== $key start $(date -u) ====="
+    if "$@" 2>&1 | tee "$log_file"; then
+        note "$key OK -> $log_file"
+    else
+        note "$key FAILED (continuing) — see $log_file"
+    fi
+}
+
+for key in $SWEEPS; do
+    case $key in
+    focal_loss)
+        run_arm focal_loss \
+            python -m scripts.run_dual_head_comparison \
+                --training-package-id canonical \
+                --output $ART/runpod_wave3_focal_loss_${TS}.json \
+                --seeds $SEEDS --epochs $EPOCHS \
+                --regime-loss focal --focal-gamma 2.0
+        ;;
+
+    class_balanced)
+        run_arm class_balanced \
+            python -m scripts.run_dual_head_comparison \
+                --training-package-id canonical \
+                --output $ART/runpod_wave3_class_balanced_${TS}.json \
+                --seeds $SEEDS --epochs $EPOCHS \
+                --regime-loss class_balanced --class-balanced-beta 0.999
+        ;;
+
+    multi_horizon_aux)
+        # aux heads share the primary log-RV head architecture, so they
+        # require head_mode regression/dual; the classification cell raises
+        # in factory.build_forecaster. Restrict head-modes accordingly.
+        run_arm multi_horizon_aux \
+            python -m scripts.run_dual_head_comparison \
+                --training-package-id canonical \
+                --output $ART/runpod_wave3_multi_horizon_aux_${TS}.json \
+                --seeds $SEEDS --epochs $EPOCHS \
+                --head-modes regression dual \
+                --aux-horizons 5,20 --aux-horizon-alpha 0.3
+        ;;
+
+    absolute_regime)
+        # Annualised thresholds: calm < 12%, normal 12-22%, high >= 22%.
+        # Runner converts to per-period internally.
+        run_arm absolute_regime \
+            python -m scripts.run_dual_head_comparison \
+                --training-package-id canonical \
+                --output $ART/runpod_wave3_absolute_regime_${TS}.json \
+                --seeds $SEEDS --epochs $EPOCHS \
+                --vol-regime-label-mode absolute \
+                --absolute-calm-max 12.0 --absolute-high-min 22.0
+        ;;
+
+    vix_features)
+        # NB: requires canonical TP rebuild with the 6 new VIX columns
+        # before the loader returns non-None values. On the current TP
+        # every row hits the missing-flag path -> arm runs but produces
+        # canonical-equivalent results. Worth running once the TP
+        # rebuild lands; flagged here so the operator notices.
+        run_arm vix_features \
+            python -m scripts.run_dual_head_comparison \
+                --training-package-id canonical \
+                --output $ART/runpod_wave3_vix_features_${TS}.json \
+                --seeds $SEEDS --epochs $EPOCHS \
+                --use-vix-features
+        ;;
+
+    seq_len_60)
+        run_arm seq_len_60 \
+            python -m scripts.run_dual_head_comparison \
+                --training-package-id canonical_60bar \
+                --output $ART/runpod_wave3_seq_len_60_${TS}.json \
+                --seeds $SEEDS --epochs $EPOCHS \
+                --sequence-length 60
+        ;;
+
+    cross_bank_revisited)
+        # Re-run the canonical dual-head cell with the cross-bank-
+        # supervised encoder. PR #231's prior null used the deprecated
+        # target convention + classification-only head; this re-tests
+        # the same encoder choice under strict-forward + dual head.
+        run_arm cross_bank_revisited \
+            python -m scripts.run_dual_head_comparison \
+                --training-package-id canonical \
+                --output $ART/runpod_wave3_cross_bank_revisited_${TS}.json \
+                --seeds $SEEDS --epochs $EPOCHS \
+                --text-encoder finbert_fed_adjacent_xbank
+        ;;
+
+    mp_off)
+        # Follow-up control: --no-mp-surprise isolates the -0.072 dual-vs-cls
+        # mp_surprise effect found in the bisect. Output keeps the runpod_mp_off_
+        # prefix (not wave3_) per the operator's spec.
+        run_arm mp_off \
+            python -m scripts.run_dual_head_comparison \
+                --training-package-id canonical \
+                --output $ART/runpod_mp_off_${TS}.json \
+                --seeds $SEEDS --epochs $EPOCHS \
+                --no-mp-surprise
+        ;;
+
+    *)
+        note "unknown arm: $key (skipping)"
+        ;;
+    esac
+done
+
+note "===== wave3 batch finished $(date -u) ====="
+note "WAVE3_BATCH_COMPLETE_MARKER"
+ls -la "$ART"/runpod_wave3_*_${TS}.json 2>&1 | tee -a "$SUMMARY"

--- a/scripts/runpod/drivers/run_wave4_batch.sh
+++ b/scripts/runpod/drivers/run_wave4_batch.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Wave 4 — focal-gamma sweep + #81 encoder bake-off (runnable subset).
+# voyage_finance_2 is EXCLUDED here (no VOYAGE_API_KEY / voyageai SDK on pod;
+# run as a follow-on once the key is staged). B2 xbank-aux arms are blocked on
+# the registry HF-SHA PR and handled separately.
+set -uo pipefail
+export PATH="/root/shim:$PATH"
+cd /root/fed-pulse
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+ART="backend/artifacts/experiments"; LOG_DIR="$HOME/runpod-sweep-logs"
+mkdir -p "$ART" "$LOG_DIR"
+SUMMARY="$LOG_DIR/_wave4_summary_${TS}.log"
+note(){ printf '[wave4] %s\n' "$*" | tee -a "$SUMMARY"; }
+run_arm(){ local k=$1; shift; local lf="$LOG_DIR/wave4_${k}_${TS}.log"; note "===== $k start $(date -u) ====="; if "$@" 2>&1 | tee "$lf"; then note "$k OK -> $lf"; else note "$k FAILED (continuing) -> $lf"; fi; }
+
+note "start $(date -u) TS=$TS HEAD=$(git rev-parse --short HEAD)"
+SEEDS="${SEEDS:-11 29 47 71 97}"; EPOCHS="${EPOCHS:-40}"
+
+# --- focal-gamma sweep ------------------------------------------------------
+for g in 0.5 1.0 2.0 5.0; do
+    run_arm "focal_gamma_${g}" \
+        python -m scripts.run_dual_head_comparison \
+            --training-package-id canonical \
+            --output "$ART/runpod_wave4_focal_gamma_${g}_${TS}.json" \
+            --seeds $SEEDS --epochs $EPOCHS \
+            --regime-loss focal --focal-gamma "$g"
+done
+
+# --- #81 encoder bake-off (voyage excluded) ---------------------------------
+for enc in nomic_embed_text_v15 bge_large_en_v15 finbert_fed_adjacent; do
+    run_arm "bakeoff_${enc}" \
+        python -m scripts.run_dual_head_comparison \
+            --training-package-id canonical \
+            --output "$ART/runpod_wave4_bakeoff_${enc}_${TS}.json" \
+            --seeds $SEEDS --epochs $EPOCHS \
+            --text-encoder "$enc" --use-text-embeddings
+done
+
+note "===== wave4 finished $(date -u) ====="; note "WAVE4_BATCH_COMPLETE_MARKER"
+ls -la "$ART"/runpod_wave4_*_${TS}.json 2>&1 | tee -a "$SUMMARY"

--- a/scripts/runpod/patches/embedding_cache_gpu_device.patch
+++ b/scripts/runpod/patches/embedding_cache_gpu_device.patch
@@ -1,0 +1,20 @@
+diff --git a/backend/app/data/embedding_cache.py b/backend/app/data/embedding_cache.py
+index 388d173..9c4782d 100644
+--- a/backend/app/data/embedding_cache.py
++++ b/backend/app/data/embedding_cache.py
+@@ -268,6 +268,15 @@ def build_cache(
+     sentence_embedding = ref.task in SENTENCE_EMBEDDING_TASKS
+     tokenizer, model = _load_encoder(ref)
+     model.eval()
++    # LOCAL POD TWEAK (uncommitted; mirrors #553 contract): place the encoder on
++    # GPU so the build uses the idle Blackwell card instead of CPU (~10x slower).
++    import os as _os
++    import torch as _torch
++    _device = (
++        _os.environ.get("FED_PULSE_EMBEDDING_CACHE_DEVICE", "").strip()
++        or ("cuda" if _torch.cuda.is_available() else "cpu")
++    )
++    model = model.to(_device)
+ 
+     pending_inputs: list[str] = []
+     pending_meta: list[tuple[str, str, str, int, str]] = []  # (record_id, doc_id, event_date, chunk_index, preview)

--- a/scripts/runpod/patches/run_dual_head_dropout_lr_flags.patch
+++ b/scripts/runpod/patches/run_dual_head_dropout_lr_flags.patch
@@ -1,0 +1,50 @@
+diff --git a/scripts/run_dual_head_comparison.py b/scripts/run_dual_head_comparison.py
+index 9cb3c61..c2d9135 100644
+--- a/scripts/run_dual_head_comparison.py
++++ b/scripts/run_dual_head_comparison.py
+@@ -336,6 +336,11 @@ def _parse_args() -> argparse.Namespace:
+             "examples more aggressively. Ignored under other loss modes."
+         ),
+     )
++    # LOCAL POD TWEAK (uncommitted): expose dropout + learning_rate for the
++    # Stage-2 HP sweep. Defaults match ModelConfig.dropout / train_model.lr so
++    # every non-sweep call stays byte-identical.
++    parser.add_argument("--dropout", dest="dropout", type=float, default=0.15)
++    parser.add_argument("--learning-rate", dest="learning_rate", type=float, default=0.001)
+     # #502 class-balanced hyperparameter. Only consulted when
+     # ``--regime-loss class_balanced`` is set; ignored under every other
+     # mode.
+@@ -616,6 +621,8 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
+     epochs: int,
+     regression_alpha: float,
+     hidden_size: int,
++    dropout: float = 0.15,
++    learning_rate: float = 0.001,
+     rates_target_mode: str = "raw",
+     vol_target_mode: str = "raw",
+     vol_target_horizon: int = 10,
+@@ -709,6 +716,7 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
+         regression_alpha=regression_alpha,
+         n_classes=3,
+         hidden_size=hidden_size,
++        dropout=dropout,
+         rates_heads=rates_heads,
+         rates_target_mode=rates_target_mode,
+         vol_target_mode=vol_target_mode,
+@@ -760,6 +768,7 @@ def _run_one_cell(  # noqa: PLR0913 -- canonical sweep needs every knob inline
+             protocol=split.protocol,
+             epochs=epochs,
+             seed=seed,
++            learning_rate=learning_rate,
+             save_checkpoint=False,
+         )
+         per_fold.append(
+@@ -851,6 +860,8 @@ def main() -> int:
+                     epochs=args.epochs,
+                     regression_alpha=args.regression_alpha,
+                     hidden_size=args.hidden_size,
++                    dropout=float(args.dropout),
++                    learning_rate=float(args.learning_rate),
+                     rates_target_mode=str(args.rates_target_mode),
+                     vol_target_mode=str(args.vol_target_mode),
+                     vol_target_horizon=int(args.target_horizon),


### PR DESCRIPTION
Pod-only artefacts that would have been lost on pod teardown. Lands them under \`scripts/runpod/\` so the recipes survive.

## What lands
- **\`scripts/runpod/drivers/\` (16 files):** exact recipes for every pod sweep this cycle — wave2/3/4 batches, stage2 HP refinement, salvage, jobs 1-3 (#499 horizon, #217 arch sweep, §6.41 VIX-on control), plus \`absolute_nulls.py\` (CPU null-table generator) and \`dl_tp.py\` (training-package downloader).
- **\`scripts/runpod/patches/\` (2 files):**
  - \`embedding_cache_gpu_device.patch\` — adds \`model.to(device)\` and the \`FED_PULSE_EMBEDDING_CACHE_DEVICE\` env passthrough (#553 GPU cache builder contract; defaults preserve byte-identity for non-opted-in runs)
  - \`run_dual_head_dropout_lr_flags.patch\` — exposes \`--dropout\` and \`--learning-rate\` on \`scripts/run_dual_head_comparison.py\`, threaded to \`ModelConfig.dropout\` and \`train_model.lr\`. Stage-2 F used these.

Patches are **not auto-applied** — they record exactly what the pod ran for reproducibility. Folding them into the forecaster sweep harness is a separate cleanup PR.

## Test plan
- [x] Drivers are pure shell + python recipes; no runtime code touched
- [x] Patches stored as \`.patch\` text, not applied