### PR TITLE
wire user-paste text embedding into live forecaster

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -101,6 +101,7 @@ from app.services.market_data import (
 )
 from app.services.policy_action_extractor import extract_policy_action
 from app.services.text_encoder import analyze_text
+from app.services.forecaster_text_embedding import encode_text_pooled
 
 logger = logging.getLogger(__name__)
 
@@ -587,7 +588,17 @@ def _build_analyze_response(
         steps=horizon_steps,
     )
 
-    history_vectors = build_feature_vectors(market_history, sentiment_score=float(sentiment["score"]), document_date=payload.date)
+    # Encode the pasted statement once so the forecaster's text channel is
+    # populated at inference. Without it the model degenerates to a market-
+    # only predictor. None on load failure -> loader emits the missing-flag
+    # and the text slot zero-pads.
+    pooled_text_embedding = encode_text_pooled(payload.text)
+    history_vectors = build_feature_vectors(
+        market_history,
+        sentiment_score=float(sentiment["score"]),
+        document_date=payload.date,
+        text_embedding=pooled_text_embedding,
+    )
     forecast = forecast_quantitative_series(
         vectors=history_vectors,
         forecast_mode=mode,
@@ -1558,10 +1569,12 @@ async def analyze_market(payload: AnalyzeRequest) -> MarketReactionPanel:
         symbol=payload.symbol,
         history_length=30,
     )
+    pooled_text_embedding = encode_text_pooled(payload.text)
     history_vectors = build_feature_vectors(
         market_history,
         sentiment_score=float(sentiment["score"]),
         document_date=payload.date,
+        text_embedding=pooled_text_embedding,
     )
     try:
         result = await run_in_threadpool(

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -1302,6 +1302,17 @@ class FeatureVector:
         if previous_volatility is not None:
             volatility_change = float(market_volatility) - float(previous_volatility)
 
+        # Route the supplied embedding into BOTH the legacy
+        # ``text_embedding`` field and the rich-feature
+        # ``text_embedding_pooled`` field that the post-#173 forecaster
+        # tensor builder reads. ``text_embedding_missing`` flips to 0.0
+        # when an embedding is supplied so the model uses the channel
+        # instead of the absent-text zero-pad.
+        pooled: list[float] = []
+        missing = 1.0
+        if text_embedding is not None and len(text_embedding) > 0:
+            pooled = [float(v) for v in text_embedding]
+            missing = 0.0
         return cls(
             date=date,
             sentiment_score=float(sentiment_score),
@@ -1311,6 +1322,8 @@ class FeatureVector:
             volatility_change=float(volatility_change),
             elapsed_time=float(elapsed_time),
             text_embedding=list(text_embedding) if text_embedding is not None else None,
+            text_embedding_pooled=pooled,
+            text_embedding_missing=missing,
         )
 
     def as_list(self, close_scale: float = DEFAULT_CLOSE_SCALE) -> list[float]:

--- a/backend/app/services/forecaster_text_embedding.py
+++ b/backend/app/services/forecaster_text_embedding.py
@@ -75,7 +75,7 @@ def _load_state() -> _PooledEncoderState | None:
         if getattr(ref, "trust_remote_code", False):
             kwargs["trust_remote_code"] = True
         try:
-            tokenizer = AutoTokenizer.from_pretrained(ref.repo, **kwargs)
+            tokenizer = AutoTokenizer.from_pretrained(ref.repo, **kwargs)  # type: ignore[no-untyped-call]
             model = AutoModel.from_pretrained(ref.repo, **kwargs)
         except Exception as exc:
             LOGGER.warning(

--- a/backend/app/services/forecaster_text_embedding.py
+++ b/backend/app/services/forecaster_text_embedding.py
@@ -1,0 +1,148 @@
+"""Pooled text embedding helper for the live forecaster serving path.
+
+The training pipeline reads per-event embeddings from precomputed
+parquet caches keyed by encoder alias. The live ``/analyze`` path
+has no cache lookup for arbitrary user-pasted text, so we load the
+encoder on demand, mean-pool its last hidden state over non-pad
+tokens, and return the embedding as a Python list. The caller
+passes the list through ``build_feature_vectors``'s
+``text_embedding`` kwarg; ``FeatureVector.from_market_state``
+forwards it onto ``text_embedding_pooled`` (the field the serving
+forward path actually reads). Modifying the channel from this end
+requires touching both hops, not just this one.
+
+Singleton-cached after first load (one tokenizer + model + device).
+Default encoder is ``finbert_fed_adjacent`` pinned via the
+registry; override with ``FED_PULSE_FORECASTER_TEXT_ENCODER`` if a
+different alias becomes the production choice.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from transformers import AutoModel, AutoTokenizer
+
+from app.models.registry import encoder_ref
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_ENCODER_ALIAS = (
+    os.environ.get("FED_PULSE_FORECASTER_TEXT_ENCODER") or "finbert_fed_adjacent"
+).strip()
+
+# Trim very long pastes before tokenisation so a 10MB body cannot
+# stall the encoder.
+MAX_TEXT_CHARS = 12_000
+MAX_TOKENS = 512
+
+
+@dataclass(frozen=True)
+class _PooledEncoderState:
+    encoder_alias: str
+    tokenizer: Any
+    model: Any
+    device: torch.device
+
+
+_state: _PooledEncoderState | None = None
+_state_lock = threading.Lock()
+
+
+def _load_state() -> _PooledEncoderState | None:
+    global _state
+    if _state is not None:
+        return _state
+    with _state_lock:
+        if _state is not None:
+            return _state
+        try:
+            ref = encoder_ref(DEFAULT_ENCODER_ALIAS)
+        except Exception as exc:  # registry miss
+            LOGGER.warning("forecaster_text_embedding: encoder_ref(%s) failed: %s", DEFAULT_ENCODER_ALIAS, exc)
+            return None
+        if ref is None or not ref.repo:
+            LOGGER.warning("forecaster_text_embedding: alias %s unpinned", DEFAULT_ENCODER_ALIAS)
+            return None
+        kwargs: dict[str, Any] = {}
+        if ref.revision:
+            kwargs["revision"] = ref.revision
+        if getattr(ref, "trust_remote_code", False):
+            kwargs["trust_remote_code"] = True
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(ref.repo, **kwargs)
+            model = AutoModel.from_pretrained(ref.repo, **kwargs)
+        except Exception as exc:
+            LOGGER.warning(
+                "forecaster_text_embedding: failed to load encoder %s @ %s: %s",
+                ref.repo, ref.revision, exc,
+            )
+            return None
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        model = model.to(device).eval()
+        _state = _PooledEncoderState(
+            encoder_alias=DEFAULT_ENCODER_ALIAS,
+            tokenizer=tokenizer,
+            model=model,
+            device=device,
+        )
+        LOGGER.info(
+            "forecaster_text_embedding: loaded %s @ %s on %s (hidden_size=%s)",
+            ref.repo, ref.revision, device, getattr(model.config, "hidden_size", "?"),
+        )
+        return _state
+
+
+@torch.no_grad()
+def encode_text_pooled(text: str) -> list[float] | None:
+    """Return a mean-pooled embedding for ``text`` as a flat list of floats.
+
+    ``None`` when the encoder cannot be loaded or the text is empty
+    after trimming. Mean-pool is computed over non-pad tokens.
+    """
+
+    cleaned = (text or "").strip()[:MAX_TEXT_CHARS]
+    if not cleaned:
+        return None
+    state = _load_state()
+    if state is None:
+        return None
+    enc = state.tokenizer(
+        cleaned,
+        max_length=MAX_TOKENS,
+        padding="max_length",
+        truncation=True,
+        return_tensors="pt",
+    )
+    input_ids = enc["input_ids"].to(state.device)
+    attention_mask = enc["attention_mask"].to(state.device)
+    outputs = state.model(input_ids=input_ids, attention_mask=attention_mask)
+    hidden = outputs.last_hidden_state  # (1, T, H)
+    mask = attention_mask.unsqueeze(-1).float()
+    summed = (hidden * mask).sum(dim=1)
+    counts = mask.sum(dim=1).clamp(min=1.0)
+    pooled_cpu = (summed / counts).squeeze(0).cpu().tolist()
+    # Free the on-device intermediates explicitly so a long-lived server
+    # process does not stack ~1.5 MB of GPU residency per call until the
+    # next Python GC pass.
+    del input_ids, attention_mask, outputs, hidden, mask, summed, counts
+    return [float(v) for v in pooled_cpu]
+
+
+def get_loaded_encoder_alias() -> str | None:
+    """For diagnostics: which encoder alias the singleton is holding."""
+
+    return _state.encoder_alias if _state is not None else None
+
+
+def reset_state() -> None:
+    """Drop the cached singleton (used by tests)."""
+
+    global _state
+    with _state_lock:
+        _state = None


### PR DESCRIPTION
## Summary
- live `/analyze` was running the forecaster with an empty text channel; adapter zeroed the slot
- new `encode_text_pooled` helper mean-pools the encoder's last hidden state over non-pad tokens
- `FeatureVector.from_market_state` now routes the kwarg onto the field the serving forward reads
- intermediate GPU tensors freed explicitly per call
- sealed-2025 holdout now reflects the trained channel; underlying class imbalance still drives "calm"

## Test plan
- [ ] `docker compose run --rm backend pytest tests/`
- [ ] hit `/analyze` with hawkish vs dovish texts and confirm the regime distribution shifts