### PR TITLE
fix /analyze persistence + drop roadmap copy from terminal page

### DIFF
--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -1590,6 +1590,13 @@ def get_model_artifact_metadata(
             }
         )
     base_metadata.setdefault("encoder_key", _resolve_encoder_key())
+    # The internal _model_artifact_metadata cache holds a
+    # ``RichFeatureScalerParams`` dataclass under ``rich_feature_scaler``
+    # so the inference-time scaler-apply path can read it; the public
+    # facing metadata is JSON-serialised into the /analyze response and
+    # the analysis_runs.payload column, where a dataclass would crash
+    # ``json.dumps``. Strip it here so callers get a serialisable dict.
+    base_metadata.pop("rich_feature_scaler", None)
     return base_metadata
 
 

--- a/frontend/components/analyze/TldrCard.tsx
+++ b/frontend/components/analyze/TldrCard.tsx
@@ -10,13 +10,13 @@ import type {
 function regimeLine(regime: RegimeClassificationResponse | null | undefined): string | null {
   if (!regime?.argmax_class) return null;
   if (regime.argmax_class === "high") {
-    return "Expect tighter markets and elevated volatility over the next 10 days.";
+    return "Predicts elevated realised volatility over the next 10 days.";
   }
   if (regime.argmax_class === "calm") {
-    return "Expect easier conditions and calmer volatility.";
+    return "Predicts low realised volatility over the next 10 days.";
   }
   if (regime.argmax_class === "normal") {
-    return "The model expects market volatility in line with the recent baseline.";
+    return "Predicts realised volatility in line with the recent baseline.";
   }
   return null;
 }

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -144,7 +144,11 @@ export async function fetchHistoryRealizedBatch(
   for (let i = 0; i < runIds.length; i += HISTORY_REALIZED_CHUNK) {
     chunks.push(runIds.slice(i, i + HISTORY_REALIZED_CHUNK) as string[]);
   }
-  const responses = await Promise.all(
+  // ``allSettled`` so a transient failure on one chunk does not blank the
+  // whole table — the surviving chunks' rows still render and the failed
+  // chunk's ids fall under ``missing`` so the caller can show them as
+  // unresolved.
+  const settled = await Promise.allSettled(
     chunks.map((chunk) =>
       axios
         .get(`${baseUrl}/history-realized`, {
@@ -156,10 +160,14 @@ export async function fetchHistoryRealizedBatch(
   );
   const items: HistoryRealizedBatchResponse["items"] = {};
   const missing: string[] = [];
-  for (const r of responses) {
-    Object.assign(items, r.items);
-    missing.push(...r.missing);
-  }
+  settled.forEach((result, idx) => {
+    if (result.status === "fulfilled") {
+      Object.assign(items, result.value.items);
+      missing.push(...result.value.missing);
+    } else {
+      missing.push(...chunks[idx]);
+    }
+  });
   return { items, missing };
 }
 

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -126,6 +126,12 @@ export async function fetchHistoryRealized(
 // used to fan out N parallel per-row requests; this collapses them to
 // one round trip. Deleted runs and yfinance failures land under
 // ``missing`` so a single broken row does not nuke the table render.
+//
+// The backend caps ``ids`` at 50 per call (see ``/history-realized``);
+// chunk locally so the caller can pass any number of ids without
+// hitting a 422.
+const HISTORY_REALIZED_CHUNK = 50;
+
 export async function fetchHistoryRealizedBatch(
   baseUrl: string,
   runIds: readonly string[],
@@ -134,11 +140,27 @@ export async function fetchHistoryRealizedBatch(
   if (runIds.length === 0) {
     return { items: {}, missing: [] };
   }
-  const response = await axios.get(`${baseUrl}/history-realized`, {
-    params: { ids: runIds.join(",") },
-    signal,
-  });
-  return response.data as HistoryRealizedBatchResponse;
+  const chunks: string[][] = [];
+  for (let i = 0; i < runIds.length; i += HISTORY_REALIZED_CHUNK) {
+    chunks.push(runIds.slice(i, i + HISTORY_REALIZED_CHUNK) as string[]);
+  }
+  const responses = await Promise.all(
+    chunks.map((chunk) =>
+      axios
+        .get(`${baseUrl}/history-realized`, {
+          params: { ids: chunk.join(",") },
+          signal,
+        })
+        .then((r) => r.data as HistoryRealizedBatchResponse),
+    ),
+  );
+  const items: HistoryRealizedBatchResponse["items"] = {};
+  const missing: string[] = [];
+  for (const r of responses) {
+    Object.assign(items, r.items);
+    missing.push(...r.missing);
+  }
+  return { items, missing };
 }
 
 export async function fetchEvaluationCoverage(

--- a/frontend/pages/console.tsx
+++ b/frontend/pages/console.tsx
@@ -3,7 +3,6 @@ import Head from "next/head";
 import { Terminal as TerminalIcon } from "lucide-react";
 
 import { Header } from "@/components/shell/header";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -122,7 +121,6 @@ export default function ConsolePage(): JSX.Element {
         <div className="flex items-center gap-3">
           <TerminalIcon className="h-5 w-5" />
           <h1 className="text-2xl font-semibold">FOMC Signal Terminal</h1>
-          <Badge variant="outline">v1</Badge>
         </div>
 
         <ActiveCheckpointBar
@@ -258,9 +256,8 @@ function ActiveCheckpointBar({
           </div>
         )}
         <p className="text-xs text-muted-foreground">
-          Display only in v1: checkpoint selection drives the Registry strip
-          ranking; the analysis panels above use the backend&apos;s active
-          checkpoint. Server-side hot-swap lands in the follow-up PR.
+          Display only: checkpoint selection drives the Registry strip ranking;
+          the analysis panels above run on the backend&apos;s active checkpoint.
         </p>
       </CardContent>
     </Card>
@@ -396,13 +393,11 @@ function AnalogsPanel({ analogs }: { analogs: AnalogsResponse | null }): JSX.Ele
   );
 }
 
-// #299 PR-B demo series: 8 historical FOMC dates with hard-coded
-// stance proxies (hawkish=-1 short S&P, dovish=+1 long, neutral=0).
-// The stances are conservative reads of the published Fed direction
-// at each meeting; this lets the backtest panel render real Sharpe
-// / HitRate / MaxDD numbers from real S&P forward returns without
-// needing the full predicted-stance fan-out infra. A follow-up PR
-// can swap this for live /analyze predictions over the same dates.
+// Historical FOMC dates with hard-coded stance proxies (hawkish=-1
+// short S&P, dovish=+1 long, neutral=0). Conservative reads of the
+// published Fed direction at each meeting so the backtest panel can
+// render real Sharpe / HitRate / MaxDD numbers from real S&P forward
+// returns without depending on a live predicted-stance fan-out.
 const DEMO_BACKTEST_POSITIONS: BacktestPositionEntry[] = [
   { date: "2022-03-16", position: -1 }, // 25bp hike, start of cycle
   { date: "2022-06-15", position: -1 }, // 75bp hike, surprise
@@ -454,15 +449,14 @@ function BacktestPanel({ baseUrl }: { baseUrl: string }): JSX.Element {
         )}
         {!result && !running && (
           <p className="text-xs text-muted-foreground">
-            Demo series: 8 historical FOMC dates with proxied stances
+            Eight historical FOMC dates with proxied stances
             (hawkish=-1 short S&amp;P, dovish=+1 long). Computes Sharpe /
             HitRate / MaxDD vs buy-and-hold on real ^GSPC 5d forward
             returns. <strong>Note:</strong> the 2022&ndash;2024 window
             covers the Fed hiking cycle&apos;s sharp equity sell-off, so
-            short-SPX bets dominate the sample. Hit-rate and Sharpe
-            reflect a directionally favorable period, not out-of-
-            sample model performance. Live predicted-stance backtest
-            lands in v1.1.
+            short-SPX bets dominate the sample &mdash; Sharpe and hit-rate
+            reflect a directionally favourable period, not out-of-sample
+            model skill.
           </p>
         )}
         {result && (

--- a/frontend/pages/decisions.tsx
+++ b/frontend/pages/decisions.tsx
@@ -493,7 +493,6 @@ export default function DecisionsPage() {
             </h1>
             <p className="max-w-2xl text-muted-foreground">
               Next-FOMC rate-decision forecast as an ordinal class with the OIS-implied baseline alongside.
-              Reads <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">data/artifacts/next_fomc/</code>.
             </p>
           </div>
 
@@ -533,23 +532,13 @@ export default function DecisionsPage() {
           ) : (
             <Card>
               <CardHeader>
-                <CardTitle>No forecast available.</CardTitle>
+                <CardTitle>No forecast available yet.</CardTitle>
                 <CardDescription>
-                  Train a checkpoint to populate this page. The forecaster reads from{" "}
-                  <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
-                    data/artifacts/next_fomc/
-                  </code>
-                  .
+                  A rate-decision forecast for the next FOMC meeting will appear here once the
+                  decision model has been trained against the current data window.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-2 text-sm text-muted-foreground">
-                <p>
-                  Run{" "}
-                  <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
-                    make next-fomc TRAINING_PACKAGE_ID=&lt;id&gt;
-                  </code>{" "}
-                  to publish a forecast.
-                </p>
                 {data?.upcoming_meeting ? (
                   <p>
                     Next scheduled meeting:{" "}

--- a/frontend/pages/research.tsx
+++ b/frontend/pages/research.tsx
@@ -509,8 +509,7 @@ export default function ResearchPage() {
             <p className="max-w-2xl text-sm text-muted-foreground">
               Research artefacts the model is built on. The Bake-off compares text encoders.
               The Transfer matrix shows how a model trained on one central bank&apos;s statements
-              performs on another&apos;s. Decisions and Jobs link to training runs. Files lists the
-              raw artefact JSONs you can download.
+              performs on another&apos;s. Files lists the raw artefact JSONs you can download.
             </p>
           </div>
 

--- a/frontend/tests/pages/decisions.test.tsx
+++ b/frontend/tests/pages/decisions.test.tsx
@@ -163,12 +163,14 @@ describe("DecisionsPage", () => {
     fetchNextFomcForecastMock.mockReset();
   });
 
-  it("renders the empty state with the make instruction", async () => {
+  it("renders the empty state with the next-meeting context", async () => {
     fetchNextFomcForecastMock.mockResolvedValue(EMPTY_RESPONSE);
     const { default: DecisionsPage } = await import("@/pages/decisions");
     render(<DecisionsPage />);
     await waitFor(() => expect(screen.getByText(/No forecast available/i)).toBeInTheDocument());
-    expect(screen.getByText(/make next-fomc/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/rate-decision forecast for the next FOMC meeting/i),
+    ).toBeInTheDocument();
     expect(screen.getByText(/2026-06-16/)).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- `get_model_artifact_metadata` strips `rich_feature_scaler` from the public dict so DB persistence stops failing with `TypeError: RichFeatureScalerParams is not JSON serializable`
- History page populates again on the next /analyze
- Drop the "v1 / lands in v1.1 / follow-up PR" planning prose + v1 chip from the FOMC Signal Terminal page
- Drop the dead "Decisions and Jobs link to training runs" line from the Research console intro

## Test plan
- [ ] `docker compose run --rm frontend npm run type-check`
- [ ] hit /analyze and confirm the row appears on /history