### PR TITLE
Interest-rate vol target, QLIKE loss (beats HAR), architecture sweep + deployable forecaster

### DIFF
--- a/backend/app/data/fed_comms_dataset.py
+++ b/backend/app/data/fed_comms_dataset.py
@@ -62,13 +62,30 @@ def _forward_log_rv_windows(rv: np.ndarray, horizons: tuple[int, ...]) -> dict[i
 # rv/volume/downside are positive → log; jump-share ∈ [0,1) → identity. The two
 # corr_* second-moment targets are trailing cross-asset correlations ∈ [−1,1] →
 # identity (same case as jump); their daily columns are merged onto rv_df in
-# build() from the market cache, so a frame without them simply omits them.
-MEASURES = ("rv", "volume", "downside", "jump", "corr_tnx", "corr_dxy")
+# build() from the market cache, so a frame without them simply omits them. The
+# rate_vol_* targets are trailing realized vol of daily Treasury-yield changes
+# (strictly positive → log, same case as rv); likewise merged from the cache.
+MEASURES = (
+    "rv",
+    "volume",
+    "downside",
+    "jump",
+    "corr_tnx",
+    "corr_dxy",
+    "rate_vol_2y",
+    "rate_vol_10y",
+)
 
 # Correlation measures live in their own daily columns (not raw RV fields). The
 # trailing window guarantees the early span is NaN until it is full.
 _CORR_MEASURES = ("corr_tnx", "corr_dxy")
 _CORR_CLIP = 0.999  # keep targets strictly inside (−1, 1) for numerical safety
+
+# Interest-rate realized-vol measures: trailing-window std of daily yield CHANGES
+# (Δyield, not log returns — yields are levels). Like corr_*, they live in their
+# own daily columns merged onto rv_df from the market cache, so a cache-less
+# frame omits them. Unlike corr_*, vol is strictly positive → log lags/targets.
+_RATE_VOL_MEASURES = ("rate_vol_2y", "rate_vol_10y")
 
 
 def _measure_raw(rv_df: Any, measure: str) -> tuple[np.ndarray, bool]:
@@ -87,16 +104,25 @@ def _measure_raw(rv_df: Any, measure: str) -> tuple[np.ndarray, bool]:
     if measure in _CORR_MEASURES:  # trailing cross-asset correlation ∈ [−1,1]
         c = rv_df[measure].to_numpy(dtype=np.float64)
         return np.clip(c, -_CORR_CLIP, _CORR_CLIP), False
+    if measure in _RATE_VOL_MEASURES:  # trailing realized vol of Δyield, > 0 → log
+        return rv_df[measure].to_numpy(dtype=np.float64), True
     raise ValueError(f"unknown measure {measure!r}")
 
 
 def _measure_present(rv_df: Any, measure: str) -> bool:
-    """Whether the raw column(s) a measure needs are in rv_df (corr_* may be absent)."""
+    """Whether the raw column(s) a measure needs are in rv_df.
 
-    return measure not in _CORR_MEASURES or measure in rv_df.columns
+    corr_* and rate_vol_* live in their own daily columns merged from the market
+    cache in build(); a cache-less frame (e.g. the unit-test fixture) omits them.
+    """
+
+    if measure in _CORR_MEASURES or measure in _RATE_VOL_MEASURES:
+        return measure in rv_df.columns
+    return True
 
 
 _CORR_WINDOW = 22  # trailing trading days for the realized-correlation estimate
+_RATE_VOL_WINDOW = 22  # trailing trading days for the yield-change realized-vol estimate
 
 
 def _trailing_corr(a: np.ndarray, b: np.ndarray, window: int) -> np.ndarray:
@@ -173,6 +199,124 @@ def _correlation_columns(
         "corr_tnx": _trailing_corr(gspc_ret, tnx_chg, _CORR_WINDOW),
         "corr_dxy": _trailing_corr(gspc_ret, dxy_ret, _CORR_WINDOW),
     }
+
+
+def _trailing_vol(chg: np.ndarray, window: int) -> np.ndarray:
+    """Trailing realized volatility (std) of a daily change series.
+
+    vol[t] uses only the ``window`` changes ending at t (data ≤ t), so as a
+    feature it is backward-looking and leak-safe; the first ``window``−1 entries
+    are NaN until the window is full (and chg[0] is itself NaN, the first diff).
+    Population std (ddof=0). NaN inputs inside a window propagate to NaN.
+    """
+
+    n = len(chg)
+    out = np.full(n, np.nan)
+    for t in range(window - 1, n):
+        x = chg[t - window + 1 : t + 1]
+        if not np.isfinite(x).all():
+            continue
+        v = float(x.std())
+        out[t] = v if v > 0.0 else np.nan  # degenerate constant window → NaN, not log(0)
+    return out
+
+
+def _rate_vol_columns(dates: Any, market_cache_dir: Path | str) -> dict[str, np.ndarray]:
+    """Trailing 22-day realized vol of daily Treasury-yield CHANGES, aligned to `dates`.
+
+    rate_vol_2y[t] = std of Δ(2Y yield) over the trailing window ending at t;
+    rate_vol_10y[t] = std of Δ(10Y yield) likewise. Yields are levels, so the
+    daily signal is the first difference Δyield (in percentage-point units, e.g.
+    a 4.01→4.00 move is −0.01), NOT a log return. The std is left raw (not
+    annualized) and carries the units of a daily yield change; downstream the
+    measure is log-transformed (vol > 0) like rv. Series are left-joined onto the
+    RV dates and small gaps forward-filled (no bfill → no leak) before the window.
+
+    The 2Y yield is read from the FRED DGS2 cache (the most Fed-sensitive tenor);
+    the 10Y from TNX.parquet. If DGS2 cannot be loaded cleanly we fall back to the
+    3M bill (IRX.parquet) and emit rate_vol_3m instead — the caller reports which.
+    """
+
+    import pandas as pd
+
+    from app.data.dense_daily_dataset import load_market_cache
+
+    base = pd.DataFrame({"date": pd.Series(dates).astype(str)})
+
+    def _trailing_for(level: np.ndarray) -> np.ndarray:
+        chg = np.full(len(level), np.nan)
+        chg[1:] = level[1:] - level[:-1]  # daily yield change (Δyield, level diff)
+        return _trailing_vol(chg, _RATE_VOL_WINDOW)
+
+    def _merge_level(df: Any, name: str) -> np.ndarray:
+        s = df[["date", "close"]].rename(columns={"close": name}).copy()
+        s["date"] = s["date"].astype(str)
+        merged = base.merge(s, on="date", how="left").ffill()
+        return np.asarray(merged[name].to_numpy(dtype=np.float64), dtype=np.float64)
+
+    series = load_market_cache(market_cache_dir, symbols=("TNX", "IRX"))
+    out: dict[str, np.ndarray] = {}
+
+    tnx = series.get("TNX")
+    out["rate_vol_10y"] = (
+        _trailing_for(_merge_level(tnx, "TNX"))
+        if tnx is not None
+        else np.full(len(base), np.nan)
+    )
+
+    two_year = _load_dgs2_levels(base["date"].tolist(), market_cache_dir)
+    if two_year is not None:
+        out["rate_vol_2y"] = _trailing_for(two_year)
+    else:  # documented fallback: 3M bill (IRX) under the rate_vol_2y key so the
+        # short-tenor measure is still populated when DGS2 is unloadable.
+        irx = series.get("IRX")
+        print(
+            "[fed_comms_dataset] WARNING: DGS2 FRED cache unavailable; "
+            "substituting IRX 3M bill for the 2Y under the rate_vol_2y key"
+        )
+        out["rate_vol_2y"] = (
+            _trailing_for(_merge_level(irx, "IRX"))
+            if irx is not None
+            else np.full(len(base), np.nan)
+        )
+    return out
+
+
+def _load_dgs2_levels(dates: list[str], market_cache_dir: Path | str) -> np.ndarray | None:
+    """2Y yield levels (FRED DGS2) aligned + ffilled to `dates`; None if uncached.
+
+    Reuses :func:`app.services.fred_client.fetch_fred_series`, which serves the
+    on-disk ``DGS2.json`` cache without any network call or API key when present.
+    FRED encodes missing observations as the literal '.', which the client maps to
+    None; we drop those before the as-of merge so a holiday gap is forward-filled
+    rather than poisoning a window with NaN. The cache lives under the FRED cache
+    dir, NOT the market cache; we resolve it relative to DATA_DIR like mp_surprise.
+    """
+
+    import pandas as pd
+
+    from app.services.fred_client import DEFAULT_CACHE_DIR as FRED_CACHE_DIR
+    from app.services.fred_client import fetch_fred_series
+
+    if not (FRED_CACHE_DIR / "DGS2.json").exists():
+        return None
+    try:
+        resp = fetch_fred_series("DGS2", cache_dir=FRED_CACHE_DIR)
+    except Exception as exc:  # noqa: BLE001 — any load failure → documented 3M fallback
+        print(f"[fed_comms_dataset] WARNING: DGS2 load failed ({exc!r})")
+        return None
+    rows = [
+        {"date": obs.date, "DGS2": float(obs.value)}
+        for obs in resp.observations
+        if obs.value is not None and obs.date
+    ]
+    if not rows:
+        return None
+    s = pd.DataFrame(rows)
+    s["date"] = s["date"].astype(str)
+    base = pd.DataFrame({"date": pd.Series(dates).astype(str)})
+    merged = base.merge(s, on="date", how="left").ffill()
+    return np.asarray(merged["DGS2"].to_numpy(dtype=np.float64), dtype=np.float64)
 
 
 def _forward_target(raw: np.ndarray, h: int, *, is_log: bool) -> np.ndarray:
@@ -415,6 +559,11 @@ def build(
         corr = _correlation_columns(rv_df["date"], market_cache_dir)
         for name, col in corr.items():
             rv_df[name] = col
+        # Trailing realized vol of daily yield changes (2Y from FRED DGS2, 10Y
+        # from TNX) — the Fed's home-turf rate-vol targets. Merged the same way.
+        rate_vol = _rate_vol_columns(rv_df["date"], market_cache_dir)
+        for name, col in rate_vol.items():
+            rv_df[name] = col
     surprise = None
     if mp_surprise_path is not None and Path(mp_surprise_path).exists():
         surprise = pd.read_parquet(mp_surprise_path)
@@ -436,7 +585,7 @@ def build(
             f"[fed_comms_dataset] surprise: present={surprise is not None} "
             f"nonneutral_level_frac={nz:.3f}"
         )
-        for m in _CORR_MEASURES:
+        for m in (*_CORR_MEASURES, *_RATE_VOL_MEASURES):
             fwd_col = f"{m}_fwd_{max(horizons)}"
             if fwd_col in daily.columns:
                 v = daily[fwd_col].to_numpy(dtype=np.float64)

--- a/backend/app/data/fed_comms_train.py
+++ b/backend/app/data/fed_comms_train.py
@@ -366,6 +366,17 @@ def run(
                 f"h{h}_text_vs_mkt": _oos_r2(fused[sel, k], true[sel, k], mkt[sel, k])
                 for k, h in enumerate(horizons)
             },
+            # block-bootstrap CI of the text-vs-market gap within the era, so a
+            # positive point estimate (e.g. the FOMC-window slice) is testable
+            # rather than taken at face value on a small overlapping-window sample.
+            **{
+                f"h{h}_text_vs_mkt_ci": list(
+                    _block_bootstrap_r2_ci(
+                        fused[sel, k], true[sel, k], mkt[sel, k], block=max(h, 1), seed=seed
+                    )
+                )
+                for k, h in enumerate(horizons)
+            },
         }
         for era, sel in eras.items()
         if sel.sum() > 20

--- a/backend/app/data/intraday_rv_arch.py
+++ b/backend/app/data/intraday_rv_arch.py
@@ -1,0 +1,405 @@
+"""Intraday RV architecture sweep — does a TCN or a leverage-LSTM beat HAR by
+more than the QLIKE-trained MLP (DLq)?
+
+The bake-off (`intraday_rv_forecast`) already showed a QLIKE-trained residual MLP
+(DLq) edging HAR on the daily realized-measure series. This module asks the next
+question: does *sequence* structure over the last L=22 trading days buy anything
+the flat MLP cannot — either through a causal convolution stack (TCN) or through
+a recurrent cell with an explicit leverage-effect inductive bias.
+
+Both contenders consume the same per-day `full` feature matrix the bake-off
+builds (HAR daily/weekly/monthly lags + rs_pos, rs_neg, bv, rq, rskew, rkurt,
+parkinson, log rvol), windowed into leak-safe L-day sequences (window ending at
+t uses rows ≤ t only). The target is forward log-RV at h ∈ {1,5,22}, residual-
+stacked on HAR exactly as DLq: HAR is fit on the train split, the net learns the
+log-residual, HAR is added back at test, and the QLIKE loss is computed on the
+reconstructed variance σ² = exp(HAR + residual) — the econometric vol loss, not
+MSE on the log-residual.
+
+  - TCN          : a small causal Temporal Convolutional Network — stacked
+                   dilated causal conv1d (dilations 1,2,4) with residual
+                   connections, last-step pooled into a residual head.
+  - σLSTM        : a leverage-LSTM. The signed downside/upside semivariance
+                   asymmetry (rs_neg vs rs_pos) is split into an explicit signed
+                   channel and a learned gate weights downside vs upside before
+                   the LSTM rolls the window — a pragmatic leverage cell that
+                   lets a volatility spike driven by losses register differently
+                   from one driven by gains.
+
+Reported per horizon: QLIKE for HAR / TCN / σLSTM (lower better), OOS-R² in
+log-RV space, and a moving-block bootstrap QLIKE-gain CI (block = horizon) for
+TCN-vs-HAR and σLSTM-vs-HAR. The DLq numbers from the bake-off are the reference
+bar both sequence models are trying to clear by a wider margin.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+
+from app.data.dense_daily_dataset import walk_forward_splits
+from app.data.dense_forecast_train import _fit_predict_ols, _oos_r2
+from app.data.intraday_rv_forecast import (
+    _bootstrap_qlike_gain_ci,
+    _EPS,
+    _forward_log_rv,
+    _har_lags,
+    _LOGV_CLAMP,
+    _qlike,
+)
+
+_SEQ_LEN = 22  # sequence window length (one trading month), matching the seq-LSTM track
+
+# Column layout of the per-day `full` matrix (see `_feature_matrix`). The σLSTM
+# leverage gate needs to find rs_pos / rs_neg by position, so the layout is fixed.
+_RS_POS_COL = 3
+_RS_NEG_COL = 4
+
+
+def _feature_matrix(rv_path: Path | str) -> dict[str, np.ndarray]:
+    """Build the bake-off's `full` per-day feature matrix + HAR lags + targets.
+
+    Columns of `full`: [HAR daily, HAR weekly, HAR monthly, rs_pos, rs_neg, bv,
+    rq, rskew, rkurt, parkinson, log(rvol)] — identical to the matrix the DLq
+    contender trains on, so the architecture comparison is feature-for-feature.
+    """
+
+    import pandas as pd
+
+    df = pd.read_parquet(rv_path).sort_values("date").reset_index(drop=True)
+    rv = df["rv"].to_numpy(dtype=np.float64)
+    log_rv = np.log(rv + _EPS)
+    har = _har_lags(log_rv)
+    feat_cols = ["rs_pos", "rs_neg", "bv", "rq", "rskew", "rkurt", "parkinson"]
+    extra = np.column_stack([df[c].to_numpy(dtype=np.float64) for c in feat_cols])
+    extra = np.column_stack([extra, np.log(df["rvol"].to_numpy(dtype=np.float64) + 1.0)])
+    full = np.column_stack([har, extra])
+    return {"rv": rv, "har": har, "full": full, "dates": df["date"].astype(str).to_numpy()}
+
+
+def build_sequences(
+    feat: np.ndarray, valid: np.ndarray, *, seq_len: int = _SEQ_LEN
+) -> dict[str, np.ndarray]:
+    """Stack a leak-safe L×d window per valid origin day t.
+
+    For each origin index t the window is rows ``[t-L+1 .. t]`` of ``feat`` —
+    strictly rows ≤ t, so it never sees the future. Forward targets are NOT
+    touched here (they stay rows t+1..t+h in the caller), so the only leak
+    surface — the window — is closed by construction. Origins with fewer than
+    ``seq_len`` prior rows (t < L-1) or flagged invalid are dropped. Returns the
+    kept origin indices so the caller aligns targets / HAR / dates by ``origin``.
+    """
+
+    n = feat.shape[0]
+    origins = np.array([t for t in range(n) if t >= seq_len - 1 and bool(valid[t])], dtype=np.int64)
+    seqs = np.stack([feat[t - seq_len + 1 : t + 1] for t in origins], axis=0)
+    return {"origin": origins, "seq": seqs}  # seq: (M, L, d)
+
+
+def _standardize_seq(
+    seq_tr: np.ndarray, seq_te: np.ndarray, fit: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Standardize L×d windows per feature using stats from `fit` (train-core rows)."""
+
+    flat = fit.reshape(-1, fit.shape[-1])
+    m, s = flat.mean(0), flat.std(0)
+    s = np.where(s > 0, s, 1.0)
+    return (seq_tr - m) / s, (seq_te - m) / s
+
+
+def _build_tcn(d_in: int) -> Any:
+    """Small causal TCN: dilated causal conv1d stack (dilations 1,2,4) → residual.
+
+    Each block left-pads by (kernel-1)*dilation and trims the right tail, so the
+    output at step t depends only on inputs ≤ t (strict causality — verified in
+    the unit test). Two residual blocks keep parameter count tiny for ~5k rows.
+    """
+
+    import torch
+    from torch import nn
+
+    class _CausalConv1d(nn.Module):
+        def __init__(self, c_in: int, c_out: int, kernel: int, dilation: int) -> None:
+            super().__init__()
+            self.pad = (kernel - 1) * dilation
+            self.conv = nn.Conv1d(c_in, c_out, kernel, dilation=dilation)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:  # x: (B, C, L)
+            x = nn.functional.pad(x, (self.pad, 0))  # left-pad only → causal
+            return cast(torch.Tensor, self.conv(x))
+
+    class _TCNBlock(nn.Module):
+        def __init__(self, c_in: int, c_out: int, dilation: int) -> None:
+            super().__init__()
+            self.conv1 = _CausalConv1d(c_in, c_out, 3, dilation)
+            self.conv2 = _CausalConv1d(c_out, c_out, 3, dilation)
+            self.act = nn.GELU()
+            self.drop = nn.Dropout(0.1)
+            self.down = nn.Conv1d(c_in, c_out, 1) if c_in != c_out else None
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            y = self.drop(self.act(self.conv1(x)))
+            y = self.drop(self.act(self.conv2(y)))
+            res = x if self.down is None else self.down(x)
+            return cast(torch.Tensor, y + res)
+
+    class _TCN(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            ch = 32
+            self.blocks = nn.ModuleList(
+                [
+                    _TCNBlock(d_in, ch, dilation=1),
+                    _TCNBlock(ch, ch, dilation=2),
+                    _TCNBlock(ch, ch, dilation=4),
+                ]
+            )
+            self.head = nn.Sequential(nn.Linear(ch, ch), nn.GELU(), nn.Linear(ch, 1))
+
+        def forward(self, seq: torch.Tensor) -> torch.Tensor:  # seq: (B, L, d)
+            x = seq.transpose(1, 2)  # (B, d, L)
+            for blk in self.blocks:
+                x = blk(x)
+            last = x[:, :, -1]  # last-step pooling (output at origin t)
+            return cast(torch.Tensor, self.head(last))
+
+    return _TCN()
+
+
+def _build_sigma_lstm(d_in: int) -> Any:
+    """Leverage-LSTM: a learned gate weights downside vs upside before the LSTM.
+
+    The leverage inductive bias: an extra signed channel rs_neg − rs_pos is
+    appended (negative when the day's variance is upside-driven, positive when
+    downside-driven), and a per-step scalar gate g = σ(w·[rs_pos, rs_neg] + b)
+    multiplies the rs_neg channel. This lets a downside-driven volatility burst
+    enter the recurrence with a different effective weight from an upside one — a
+    pragmatic leverage cell that gates the semivariance channels rather than
+    rewiring the LSTM's internal gates.
+    """
+
+    import torch
+    from torch import nn
+
+    class _SigmaLstm(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.d_hidden = 64
+            # gate reads the two semivariance channels → scalar downside weight
+            self.lev_gate = nn.Linear(2, 1)
+            # input = original d features + signed (rs_neg − rs_pos) leverage channel
+            self.lstm = nn.LSTM(d_in + 1, self.d_hidden, num_layers=1, batch_first=True)
+            self.head = nn.Sequential(
+                nn.Linear(self.d_hidden, self.d_hidden), nn.GELU(), nn.Linear(self.d_hidden, 1)
+            )
+
+        def forward(self, seq: torch.Tensor) -> torch.Tensor:  # seq: (B, L, d)
+            rs_pos = seq[:, :, _RS_POS_COL : _RS_POS_COL + 1]
+            rs_neg = seq[:, :, _RS_NEG_COL : _RS_NEG_COL + 1]
+            gate = torch.sigmoid(self.lev_gate(torch.cat([rs_pos, rs_neg], dim=-1)))
+            signed = gate * rs_neg - (1.0 - gate) * rs_pos  # gated downside-minus-upside
+            x = torch.cat([seq, signed], dim=-1)
+            _, (h_n, _) = self.lstm(x)
+            return cast(torch.Tensor, self.head(h_n[-1]))
+
+    return _SigmaLstm()
+
+
+def _train_arch_fold(
+    arch: str,
+    seq_tr: np.ndarray,
+    seq_te: np.ndarray,
+    har_tr: np.ndarray,
+    har_te: np.ndarray,
+    tgt_tr: np.ndarray,
+    *,
+    seed: int,
+    epochs: int,
+    device: str,
+) -> np.ndarray:
+    """Train one walk-forward fold of a sequence arch; QLIKE-trained, HAR-stacked.
+
+    Mirrors `_train_fold_qlike`: HAR is fit on the train split (core-only for the
+    residual target so the early-stopping val residuals are not self-imputed),
+    the net learns the standardized log-residual, and the loss is QLIKE on the
+    reconstructed variance σ² = exp(HAR_pred + residual). Returns test predictions
+    in log-RV space (HAR_te + residual), so the caller scores it identically to
+    HAR. Grad-clipped (exp-loss → bound grads), deterministic, early-stopped.
+    """
+
+    import torch
+
+    from app.determinism import enable_deterministic_mode
+
+    enable_deterministic_mode(seed)
+    dev = torch.device(device)
+    n = len(seq_tr)
+    n_val = max(1, n // 5)
+    core, val = slice(0, n - n_val), slice(n - n_val, n)
+
+    # HAR floor: test prediction fit on the full train split (no leak); the
+    # residual TRAINING target uses a core-only HAR fit so val residuals are honest.
+    har_te_pred = _fit_predict_ols(har_tr, tgt_tr, har_te)
+    har_core_te = _fit_predict_ols(
+        har_tr[core], tgt_tr[core], har_tr
+    )  # in-sample on all train rows
+    resid = (tgt_tr - har_core_te).reshape(-1, 1)
+
+    seq_tr_s, seq_te_s = _standardize_seq(seq_tr, seq_te, seq_tr[core])
+    rm, rs = resid[core].mean(), resid[core].std()
+    rs = rs if rs > 0 else 1.0
+
+    xtr = torch.tensor(seq_tr_s, dtype=torch.float32, device=dev)
+    xte = torch.tensor(seq_te_s, dtype=torch.float32, device=dev)
+    har_t = torch.tensor(har_core_te, dtype=torch.float32, device=dev).reshape(-1, 1)
+    log_true_t = torch.tensor(tgt_tr.reshape(-1, 1), dtype=torch.float32, device=dev)
+
+    def qlike_loss(resid_std: torch.Tensor, har: torch.Tensor, log_true: torch.Tensor) -> Any:
+        log_pred = har + (resid_std * rs + rm)
+        log_pred = torch.clamp(log_pred, -_LOGV_CLAMP, _LOGV_CLAMP)
+        log_true_c = torch.clamp(log_true, -_LOGV_CLAMP, _LOGV_CLAMP)
+        var_pred = torch.exp(log_pred) + _EPS
+        var_true = torch.exp(log_true_c)
+        ratio = var_true / var_pred
+        return torch.mean(ratio - torch.log(ratio) - 1.0)
+
+    d_in = seq_tr.shape[-1]
+    model = (_build_tcn(d_in) if arch == "tcn" else _build_sigma_lstm(d_in)).to(dev)
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-3, weight_decay=1e-4)
+    best, best_state, bad = float("inf"), None, 0
+    rng = np.random.default_rng(seed)
+    core_pos = np.arange(0, n - n_val)
+    for _ in range(epochs):
+        model.train()
+        order = rng.permutation(len(core_pos))
+        for s in range(0, len(order), 256):
+            b = core_pos[order[s : s + 256]]
+            opt.zero_grad()
+            loss = qlike_loss(model(xtr[b]), har_t[b], log_true_t[b])
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)  # exp-loss → bound grads
+            opt.step()
+        model.eval()
+        with torch.no_grad():
+            vloss = float(qlike_loss(model(xtr[val]), har_t[val], log_true_t[val]))
+        if vloss < best - 1e-6:
+            best, bad = vloss, 0
+            best_state = {k: v.detach().clone() for k, v in model.state_dict().items()}
+        else:
+            bad += 1
+            if bad >= 25:
+                break
+    if best_state is not None:
+        model.load_state_dict(best_state)
+    model.eval()
+    with torch.no_grad():
+        resid_std = model(xte).cpu().numpy()
+    resid_pred = resid_std[:, 0] * rs + rm
+    return cast(np.ndarray, har_te_pred + resid_pred)
+
+
+def run(
+    rv_path: Path | str,
+    *,
+    seed: int = 11,
+    epochs: int = 120,
+    n_folds: int = 5,
+    horizons: tuple[int, ...] = (1, 5, 22),
+    device: str = "cpu",
+) -> dict[str, Any]:
+    data = _feature_matrix(rv_path)
+    rv, har, full = data["rv"], data["har"], data["full"]
+    valid = np.ones(len(rv), dtype=bool)
+    seqs = build_sequences(full, valid)
+    origin = seqs["origin"]
+    seq_all = seqs["seq"]
+
+    results: dict[str, Any] = {"n_days": int(len(rv)), "seq_len": _SEQ_LEN, "by_horizon": {}}
+    for h in horizons:
+        y = _forward_log_rv(rv, h)
+        # an origin is scorable only if its forward target window stays in range
+        ok = ~np.isnan(y[origin])
+        idx = np.where(ok)[0]
+        folds = walk_forward_splits(len(idx), n_folds=n_folds, embargo=h + 1)
+        pools: dict[str, list[float]] = {
+            k: [] for k in ("har", "tcn", "sigma_lstm", "true", "base")
+        }
+        for tr_l, te_l in folds:
+            tr, te = idx[np.array(tr_l)], idx[np.array(te_l)]
+            o_tr, o_te = origin[tr], origin[te]
+            ytr, yte = y[o_tr], y[o_te]
+            har_pred = _fit_predict_ols(har[o_tr], ytr, har[o_te])
+            pools["har"].extend(har_pred.tolist())
+            pools["base"].extend([float(ytr.mean())] * len(te))  # per-fold train mean, no leak
+            for arch, key in (("tcn", "tcn"), ("sigma_lstm", "sigma_lstm")):
+                pred = _train_arch_fold(
+                    arch,
+                    seq_all[tr],
+                    seq_all[te],
+                    har[o_tr],
+                    har[o_te],
+                    ytr,
+                    seed=seed,
+                    epochs=epochs,
+                    device=device,
+                )
+                pools[key].extend(pred.tolist())
+            pools["true"].extend(yte.tolist())
+        p = {k: np.asarray(v) for k, v in pools.items()}
+        base = p["base"]  # per-fold train mean (no cross-fold leakage into the R² baseline)
+        row: dict[str, Any] = {
+            "qlike": {k: _qlike(p[k], p["true"]) for k in ("har", "tcn", "sigma_lstm")},
+            "r2": {k: _oos_r2(p[k], p["true"], base) for k in ("har", "tcn", "sigma_lstm")},
+            "tcn_vs_har_qlike_ci90": _bootstrap_qlike_gain_ci(
+                p["tcn"], p["har"], p["true"], seed=seed, block=max(h, 1)
+            ),
+            "sigma_lstm_vs_har_qlike_ci90": _bootstrap_qlike_gain_ci(
+                p["sigma_lstm"], p["har"], p["true"], seed=seed, block=max(h, 1)
+            ),
+        }
+        results["by_horizon"][f"h{h}"] = row
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Intraday RV architecture sweep: HAR vs TCN vs leverage-LSTM (QLIKE-trained)."
+    )
+    parser.add_argument("--rv-path", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--epochs", type=int, default=120)
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--seed", type=int, default=11)
+    args = parser.parse_args()
+    res = run(args.rv_path, seed=args.seed, epochs=args.epochs, device=args.device)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    (args.out_dir / "intraday_rv_arch.json").write_text(json.dumps(res, indent=2), encoding="utf-8")
+    print(f"n_days={res['n_days']}  L={res['seq_len']}")
+    print("QLIKE (lower better) + block-bootstrap QLIKE-gain CI90 vs HAR (>0 ⇒ beats HAR)")
+    head = (
+        f"{'horizon':<8}{'HAR':>10}{'TCN':>10}{'sLSTM':>10}"
+        f"{'TCNgain_CI90':>22}{'sLSTMgain_CI90':>22}"
+    )
+    print(head)
+    for hk, r in res["by_horizon"].items():
+        q = r["qlike"]
+        gt = r["tcn_vs_har_qlike_ci90"]
+        gl = r["sigma_lstm_vs_har_qlike_ci90"]
+        print(
+            f"{hk:<8}{q['har']:>10.4f}{q['tcn']:>10.4f}{q['sigma_lstm']:>10.4f}"
+            f"{f'[{gt[0]:+.4f},{gt[1]:+.4f}]':>22}{f'[{gl[0]:+.4f},{gl[1]:+.4f}]':>22}"
+        )
+    print("OOS-R2 (log-RV space, vs mean, higher better)")
+    print(f"{'horizon':<8}{'HAR':>10}{'TCN':>10}{'sLSTM':>10}")
+    for hk, r in res["by_horizon"].items():
+        r2 = r["r2"]
+        print(f"{hk:<8}{r2['har']:>10.3f}{r2['tcn']:>10.3f}{r2['sigma_lstm']:>10.3f}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/app/data/intraday_rv_arch.py
+++ b/backend/app/data/intraday_rv_arch.py
@@ -59,6 +59,11 @@ _SEQ_LEN = 22  # sequence window length (one trading month), matching the seq-LS
 _RS_POS_COL = 3
 _RS_NEG_COL = 4
 
+# Bound the model's deviation from the HAR floor (in log-RV units) at both train
+# and inference, so an exp-loss can't blow up on an early/divergent prediction.
+# True residuals are well under 1; ±6 is generous yet prevents var=exp(−80)≈0.
+_RESID_CLAMP = 6.0
+
 
 def _feature_matrix(rv_path: Path | str) -> dict[str, np.ndarray]:
     """Build the bake-off's `full` per-day feature matrix + HAR lags + targets.
@@ -259,8 +264,8 @@ def _train_arch_fold(
     log_true_t = torch.tensor(tgt_tr.reshape(-1, 1), dtype=torch.float32, device=dev)
 
     def qlike_loss(resid_std: torch.Tensor, har: torch.Tensor, log_true: torch.Tensor) -> Any:
-        log_pred = har + (resid_std * rs + rm)
-        log_pred = torch.clamp(log_pred, -_LOGV_CLAMP, _LOGV_CLAMP)
+        resid = torch.clamp(resid_std * rs + rm, -_RESID_CLAMP, _RESID_CLAMP)
+        log_pred = torch.clamp(har + resid, -_LOGV_CLAMP, _LOGV_CLAMP)
         log_true_c = torch.clamp(log_true, -_LOGV_CLAMP, _LOGV_CLAMP)
         var_pred = torch.exp(log_pred) + _EPS
         var_true = torch.exp(log_true_c)
@@ -298,7 +303,7 @@ def _train_arch_fold(
     model.eval()
     with torch.no_grad():
         resid_std = model(xte).cpu().numpy()
-    resid_pred = resid_std[:, 0] * rs + rm
+    resid_pred = np.clip(resid_std[:, 0] * rs + rm, -_RESID_CLAMP, _RESID_CLAMP)
     return cast(np.ndarray, har_te_pred + resid_pred)
 
 

--- a/backend/app/data/intraday_rv_forecast.py
+++ b/backend/app/data/intraday_rv_forecast.py
@@ -8,7 +8,13 @@ Three contenders, each evaluated out-of-sample with a bootstrap CI:
   - HAR⁺  : HAR + realized-quarticity and downside-semivariance terms
             (HARQ / SHAR family — the strong intraday baselines).
   - DL    : MLP on the full realized-measure feature set, residual-stacked
-            on HAR (floors at HAR, learns the remainder).
+            on HAR (floors at HAR, learns the remainder), Huber-trained.
+  - DLq   : same residual-stacked MLP, but trained to minimize QLIKE on the
+            reconstructed variance exp(HAR + residual) — the econometric vol
+            loss — rather than Huber on the log-residual.
+
+Each contender is scored on OOS-R² (log-RV space) and QLIKE (variance space),
+so the beat-HAR verdict is read under the correct vol metric, not just MSE.
 
 This is where beating HAR is both achievable and meaningful — intraday RV
 carries the jump / semivariance / quarticity structure daily-close lacks.
@@ -19,7 +25,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 
@@ -27,6 +33,133 @@ from app.data.dense_daily_dataset import walk_forward_splits
 from app.data.dense_forecast_train import _bootstrap_r2_ci, _fit_predict_ols, _oos_r2, _train_fold
 
 _EPS = 1e-12
+# Clamp on log-variance before exp() — keeps reconstructed σ² finite for the
+# QLIKE loss (exp(80) ≈ 5e34, well inside float32) regardless of a stray
+# residual blow-up during early training.
+_LOGV_CLAMP = 80.0
+
+
+def _qlike(pred_logrv: np.ndarray, true_logrv: np.ndarray) -> float:
+    """QLIKE volatility loss on variance σ² = exp(log-RV), lower is better.
+
+    QLIKE = mean( σ²_true/σ²_pred − log(σ²_true/σ²_pred) − 1 ). Zero at a
+    perfect forecast and — unlike MSE on log-RV — asymmetric: it penalizes
+    under-prediction of a variance spike far harder than over-prediction,
+    which is the econometric-standard loss for ranking vol models.
+    """
+
+    var_pred = np.exp(np.clip(pred_logrv, -_LOGV_CLAMP, _LOGV_CLAMP)) + _EPS
+    var_true = np.exp(np.clip(true_logrv, -_LOGV_CLAMP, _LOGV_CLAMP))
+    ratio = var_true / var_pred
+    return float(np.mean(ratio - np.log(ratio) - 1.0))
+
+
+def _qlike_pointwise(pred_logrv: np.ndarray, true_logrv: np.ndarray) -> np.ndarray:
+    """Per-point QLIKE contributions (for bootstrapping the QLIKE difference)."""
+
+    var_pred = np.exp(np.clip(pred_logrv, -_LOGV_CLAMP, _LOGV_CLAMP)) + _EPS
+    var_true = np.exp(np.clip(true_logrv, -_LOGV_CLAMP, _LOGV_CLAMP))
+    ratio = var_true / var_pred
+    return cast(np.ndarray, ratio - np.log(ratio) - 1.0)
+
+
+def _bootstrap_qlike_gain_ci(
+    pred: np.ndarray,
+    base_pred: np.ndarray,
+    true: np.ndarray,
+    *,
+    seed: int = 11,
+    n_boot: int = 1000,
+) -> list[float]:
+    """90% CI of mean QLIKE gain (base − pred); >0 throughout ⇒ pred beats base."""
+
+    gain = _qlike_pointwise(base_pred, true) - _qlike_pointwise(pred, true)
+    rng = np.random.default_rng(seed)
+    n = len(gain)
+    boots = [float(gain[rng.integers(0, n, n)].mean()) for _ in range(n_boot)]
+    return [float(np.quantile(boots, 0.05)), float(np.quantile(boots, 0.95))]
+
+
+def _train_fold_qlike(
+    har_pred_tr: np.ndarray,
+    full_tr: np.ndarray,
+    resid_tr: np.ndarray,
+    full_te: np.ndarray,
+    har_pred_te: np.ndarray,
+    *,
+    seed: int,
+    epochs: int,
+    device: str,
+) -> np.ndarray:
+    """Residual-stacked DL trained to minimize QLIKE on reconstructed variance.
+
+    Same architecture / standardization / early-stopping discipline as
+    `_train_fold`, but the loss is QLIKE on σ² = exp(HAR_pred + DL_residual)
+    vs true σ², not Huber on the standardized log-
+    residual. Inputs are in log-RV space; HAR_pred floors the forecast and the
+    net learns the remainder. Returns test predictions in log-RV space
+    (HAR_pred + DL_residual), so the caller scores it identically to the others.
+    """
+
+    import torch
+
+    from app.data.dense_forecast_train import _build_model
+    from app.determinism import enable_deterministic_mode
+
+    enable_deterministic_mode(seed)
+    dev = torch.device(device)
+    xm, xs = full_tr.mean(0), full_tr.std(0)
+    xs = np.where(xs > 0, xs, 1.0)
+    # standardize the residual target only to keep the head's raw output O(1);
+    # the loss un-standardizes before reconstructing variance, so QLIKE is
+    # always computed on the true σ² scale.
+    rm, rs = resid_tr.mean(), resid_tr.std()
+    rs = rs if rs > 0 else 1.0
+    xtr = torch.tensor((full_tr - xm) / xs, dtype=torch.float32, device=dev)
+    xte = torch.tensor((full_te - xm) / xs, dtype=torch.float32, device=dev)
+    har_tr = torch.tensor(har_pred_tr, dtype=torch.float32, device=dev).reshape(-1, 1)
+    log_true_tr = torch.tensor(
+        (resid_tr.reshape(-1) + har_pred_tr).reshape(-1, 1), dtype=torch.float32, device=dev
+    )
+
+    def qlike_loss(resid_std: torch.Tensor, har: torch.Tensor, log_true: torch.Tensor) -> Any:
+        log_pred = har + (resid_std * rs + rm)
+        log_pred = torch.clamp(log_pred, -_LOGV_CLAMP, _LOGV_CLAMP)
+        log_true_c = torch.clamp(log_true, -_LOGV_CLAMP, _LOGV_CLAMP)
+        var_pred = torch.exp(log_pred) + _EPS
+        var_true = torch.exp(log_true_c)
+        ratio = var_true / var_pred
+        return torch.mean(ratio - torch.log(ratio) - 1.0)
+
+    n_val = max(1, len(xtr) // 5)
+    tr, val = slice(0, len(xtr) - n_val), slice(len(xtr) - n_val, len(xtr))
+    model = _build_model(full_tr.shape[1], 1).to(dev)
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-3, weight_decay=1e-4)
+    best, best_state, bad = float("inf"), None, 0
+    for _ in range(epochs):
+        model.train()
+        opt.zero_grad()
+        loss = qlike_loss(model(xtr[tr]), har_tr[tr], log_true_tr[tr])
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)  # exp-loss → bound grads
+        opt.step()
+        model.eval()
+        with torch.no_grad():
+            vloss = float(qlike_loss(model(xtr[val]), har_tr[val], log_true_tr[val]))
+        if vloss < best - 1e-6:
+            best, bad = vloss, 0
+            best_state = {k: v.detach().clone() for k, v in model.state_dict().items()}
+        else:
+            bad += 1
+            if bad >= 40:
+                break
+    if best_state is not None:
+        model.load_state_dict(best_state)
+    model.eval()
+    with torch.no_grad():
+        resid_std = model(xte).cpu().numpy()
+    resid_pred = resid_std[:, 0] * rs + rm
+    return cast(np.ndarray, har_pred_te + resid_pred)
 
 
 def _har_lags(log_rv: np.ndarray) -> np.ndarray:
@@ -109,7 +242,9 @@ def run(
     har_iv = np.column_stack([har, market]) if market is not None else None
     full_mkt = np.column_stack([full, market]) if market is not None else None
 
-    contenders = ["har", "harplus", "dl"] + (["har_iv", "dl_mkt"] if market is not None else [])
+    contenders = ["har", "harplus", "dl", "dl_qlike"] + (
+        ["har_iv", "dl_mkt"] if market is not None else []
+    )
     results: dict[str, Any] = {
         "n_days": len(df),
         "has_market": market is not None,
@@ -130,6 +265,11 @@ def run(
             pools["harplus"].extend(_fit_predict_ols(harplus[tr], ytr, harplus[te]).tolist())
             dl_resid = _train_fold(full[tr], resid, full[te], seed=seed, epochs=300, device="cpu")
             pools["dl"].extend((har_pred + dl_resid[:, 0]).tolist())
+            dl_q = _train_fold_qlike(
+                har_fit_tr, full[tr], resid, full[te], har_pred,
+                seed=seed, epochs=300, device="cpu",
+            )
+            pools["dl_qlike"].extend(dl_q.tolist())
             if market is not None:
                 assert har_iv is not None and full_mkt is not None
                 pools["har_iv"].extend(_fit_predict_ols(har_iv[tr], ytr, har_iv[te]).tolist())
@@ -141,9 +281,16 @@ def run(
             pools["base"].extend([float(ytr.mean())] * len(te))
         p = {k: np.asarray(v) for k, v in pools.items()}
         row: dict[str, Any] = {k: _oos_r2(p[k], p["true"], p["base"]) for k in contenders}
+        # QLIKE alongside R² — the econometric vol metric for the beat-HAR verdict.
+        row["qlike"] = {k: _qlike(p[k], p["true"]) for k in contenders}
         best_mkt = "dl_mkt" if market is not None else "dl"
         lo, hi = _bootstrap_r2_ci(p[best_mkt], p["true"], p["base"], seed=seed)
         row["dl_ci90"] = [lo, hi]
+        # Does the QLIKE-trained DL beat HAR on QLIKE? Bootstrap the per-point
+        # QLIKE difference (HAR − dl_qlike); >0 throughout ⇒ DL wins on QLIKE.
+        row["dl_qlike_vs_har_qlike_ci90"] = _bootstrap_qlike_gain_ci(
+            p["dl_qlike"], p["har"], p["true"], seed=seed
+        )
         if "har_iv" in row:
             # Incremental skill of IV *over HAR*: HAR predictions are the baseline
             # (denominator), so this CI is the marginal-R² of adding IV, distinct
@@ -170,11 +317,13 @@ def main() -> int:
     )
     print(f"n_days={res['n_days']}  market={res['has_market']}")
     mkt = res["has_market"]
-    head = f"{'horizon':<8}{'HAR':>8}{'HAR+':>8}{'DL':>8}"
+    # OOS-R² table (vs-mean R², higher is better).
+    head = f"{'horizon':<8}{'HAR':>8}{'HAR+':>8}{'DL':>8}{'DLq':>8}"
     head += f"{'HAR+IV':>8}{'DL+mkt':>8}{'IVvsHAR_CI90':>20}" if mkt else f"{'best_CI90':>18}"
+    print("OOS-R2 (vs mean, higher better)")
     print(head)
     for hk, r in res["by_horizon"].items():
-        line = f"{hk:<8}{r['har']:>8.3f}{r['harplus']:>8.3f}{r['dl']:>8.3f}"
+        line = f"{hk:<8}{r['har']:>8.3f}{r['harplus']:>8.3f}{r['dl']:>8.3f}{r['dl_qlike']:>8.3f}"
         if mkt:
             c = r["har_iv_vs_har_ci90"]
             line += f"{r['har_iv']:>8.3f}{r['dl_mkt']:>8.3f}{f'[{c[0]:+.3f},{c[1]:+.3f}]':>20}"
@@ -182,6 +331,17 @@ def main() -> int:
             c = r["dl_ci90"]
             line += f"{f'[{c[0]:.3f},{c[1]:.3f}]':>18}"
         print(line)
+    # QLIKE table (econometric vol loss, lower better) + DLq-vs-HAR QLIKE gain CI.
+    print("QLIKE (lower better)  +  DLq-vs-HAR QLIKE-gain CI90 (>0 ⇒ DLq beats HAR)")
+    qhead = f"{'horizon':<8}{'HAR':>10}{'HAR+':>10}{'DL':>10}{'DLq':>10}{'DLqGain_CI90':>22}"
+    print(qhead)
+    for hk, r in res["by_horizon"].items():
+        q = r["qlike"]
+        g = r["dl_qlike_vs_har_qlike_ci90"]
+        print(
+            f"{hk:<8}{q['har']:>10.4f}{q['harplus']:>10.4f}{q['dl']:>10.4f}{q['dl_qlike']:>10.4f}"
+            f"{f'[{g[0]:+.4f},{g[1]:+.4f}]':>22}"
+        )
     return 0
 
 

--- a/backend/app/data/intraday_rv_forecast.py
+++ b/backend/app/data/intraday_rv_forecast.py
@@ -70,13 +70,25 @@ def _bootstrap_qlike_gain_ci(
     *,
     seed: int = 11,
     n_boot: int = 1000,
+    block: int = 1,
 ) -> list[float]:
-    """90% CI of mean QLIKE gain (base − pred); >0 throughout ⇒ pred beats base."""
+    """90% CI of mean QLIKE gain (base − pred); >0 throughout ⇒ pred beats base.
+
+    Moving-block bootstrap (block = horizon) so overlapping multi-day forward
+    targets don't inflate significance; block=1 reduces to the iid bootstrap.
+    """
 
     gain = _qlike_pointwise(base_pred, true) - _qlike_pointwise(pred, true)
     rng = np.random.default_rng(seed)
     n = len(gain)
-    boots = [float(gain[rng.integers(0, n, n)].mean()) for _ in range(n_boot)]
+    if n <= block:
+        return [float("nan"), float("nan")]
+    n_blocks = int(np.ceil(n / block))
+    boots = []
+    for _ in range(n_boot):
+        starts = rng.integers(0, n - block + 1, size=n_blocks)
+        idx = np.concatenate([np.arange(s, s + block) for s in starts])[:n]
+        boots.append(float(gain[idx].mean()))
     return [float(np.quantile(boots, 0.05)), float(np.quantile(boots, 0.95))]
 
 
@@ -289,7 +301,7 @@ def run(
         # Does the QLIKE-trained DL beat HAR on QLIKE? Bootstrap the per-point
         # QLIKE difference (HAR − dl_qlike); >0 throughout ⇒ DL wins on QLIKE.
         row["dl_qlike_vs_har_qlike_ci90"] = _bootstrap_qlike_gain_ci(
-            p["dl_qlike"], p["har"], p["true"], seed=seed
+            p["dl_qlike"], p["har"], p["true"], seed=seed, block=max(h, 1)
         )
         if "har_iv" in row:
             # Incremental skill of IV *over HAR*: HAR predictions are the baseline

--- a/backend/app/data/intraday_rv_production.py
+++ b/backend/app/data/intraday_rv_production.py
@@ -1,0 +1,517 @@
+"""Deployable banded RV forecaster — QLIKE-DLq ensemble + walk-forward conformal.
+
+Productionizes the validated beat-HAR result from `intraday_rv_forecast`: the
+residual-stacked DL trained on QLIKE (`_train_fold_qlike`) that beats HAR on the
+econometric vol loss (block-bootstrap confirmed). Here we make it deployable:
+
+  - Multi-seed ensemble — the QLIKE-DLq is trained across `N_SEEDS` seeds and the
+    point forecast is the mean of the per-seed log-RV predictions. Averaging the
+    seeds stabilizes the beat-HAR (kills single-seed init variance) and lets us
+    report seed dispersion as a model-uncertainty diagnostic. Each fold's ensemble
+    trains on the FULL train fold — no calibration carve-out — so it reproduces the
+    bake-off DLq quality at the data-hungry h5/h22 horizons.
+
+  - Walk-forward (rolling) conformal bands — we never sacrifice training data for
+    calibration. Folds are processed in time order; the band for fold k uses the
+    |true_logRV − ens_logRV| nonconformity residuals ACCUMULATED FROM PRIOR FOLDS
+    (1..k-1), per horizon and per α. We take the (1−α) finite-sample quantile q and
+    emit symmetric log-RV intervals [ens − q, ens + q] on fold k, then measure
+    empirical coverage prospectively. Because the calibration residuals come from
+    strictly earlier folds, there is no leakage and no training-data loss. Exponen-
+    tiating the bounds maps them to variance/vol bands.
+
+LEAK-SAFETY: HAR + ensemble fit on the full train fold; conformal calibration uses
+only prior folds' OOS residuals (strictly precede the test fold); walk-forward
+embargo = max horizon + 1; the forward target stays t+1..t+h.
+
+The walk-forward eval (`run`) confirms the ensemble beat-HAR is seed-robust and the
+prospective bands are calibrated. `fit_production` then fits HAR + the ensemble on
+ALL history, derives the conformal quantiles from the pooled walk-forward OOS
+residuals, and saves a serving artifact (per-seed state_dicts + JSON spec) a serving
+layer can load to produce a banded multi-horizon forecast.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+
+from app.data.dense_daily_dataset import walk_forward_splits
+from app.data.dense_forecast_train import _fit_predict_ols, _oos_r2
+from app.data.intraday_rv_forecast import (
+    _bootstrap_qlike_gain_ci,
+    _forward_log_rv,
+    _har_lags,
+    _qlike,
+    _train_fold_qlike,
+)
+
+if TYPE_CHECKING:
+    import torch
+
+_EPS = 1e-12
+
+# Default ensemble seeds; the count (5) trades stability against compute.
+N_SEEDS = 5
+DEFAULT_SEEDS: tuple[int, ...] = (11, 22, 33, 44, 55)
+DEFAULT_HORIZONS: tuple[int, ...] = (1, 5, 22)
+# Nominal mis-coverage levels: α=0.2 → 80% band, α=0.1 → 90% band.
+DEFAULT_ALPHAS: tuple[float, ...] = (0.2, 0.1)
+
+# Realized-measure columns of the `full` feature matrix (must match the bake-off):
+# HAR daily/weekly/monthly are prepended; these follow, with log(rvol) last.
+_FEAT_COLS = ("rs_pos", "rs_neg", "bv", "rq", "rskew", "rkurt", "parkinson")
+
+
+def _build_full(df: Any) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return (rv, log_rv, full) — the realized-measure feature matrix.
+
+    `full` = [HAR daily/weekly/monthly, rs_pos, rs_neg, bv, rq, rskew, rkurt,
+    parkinson, log(rvol)] — identical column order to `intraday_rv_forecast.run`,
+    so the ensemble sees the exact features the bake-off validated. HAR daily/
+    weekly/monthly occupy `full[:, :3]`.
+    """
+
+    rv = df["rv"].to_numpy(dtype=np.float64)
+    log_rv = np.log(rv + _EPS)
+    har = _har_lags(log_rv)
+    extra = np.column_stack([df[c].to_numpy(dtype=np.float64) for c in _FEAT_COLS])
+    extra = np.column_stack([extra, np.log(df["rvol"].to_numpy(dtype=np.float64) + 1.0)])
+    full = np.column_stack([har, extra])
+    return rv, log_rv, full
+
+
+def _ensemble_predict(
+    har_fit_tr: np.ndarray,
+    full_tr: np.ndarray,
+    resid_tr: np.ndarray,
+    full_te: np.ndarray,
+    har_pred_te: np.ndarray,
+    *,
+    seeds: tuple[int, ...],
+    epochs: int,
+    device: str,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Per-seed QLIKE-DLq log-RV predictions on `full_te`, plus their mean.
+
+    Returns (per_seed, mean) where per_seed has shape (len(seeds), n_test) and
+    mean is the ensemble point forecast (mean across seeds in log-RV space).
+    """
+
+    per_seed = np.stack(
+        [
+            _train_fold_qlike(
+                har_fit_tr,
+                full_tr,
+                resid_tr,
+                full_te,
+                har_pred_te,
+                seed=s,
+                epochs=epochs,
+                device=device,
+            )
+            for s in seeds
+        ]
+    )
+    return per_seed, per_seed.mean(axis=0)
+
+
+def _conformal_quantile(scores: np.ndarray, alpha: float) -> float:
+    """Finite-sample conformal quantile of nonconformity scores.
+
+    The (1−α) coverage guarantee needs the ceil((n+1)(1−α))/n empirical quantile
+    of the |residual| calibration scores; the (n+1) correction is what makes the
+    band valid in finite samples rather than only asymptotically.
+    """
+
+    n = len(scores)
+    if n == 0:
+        return float("nan")
+    rank = int(np.ceil((n + 1) * (1.0 - alpha)))
+    if rank >= n:  # quantile level exceeds what n points can certify → widest score
+        return float(np.max(scores))
+    return float(np.sort(scores)[rank - 1])
+
+
+def _coverage(true: np.ndarray, pred: np.ndarray, q: float) -> float:
+    """Empirical fraction of test points inside the symmetric log-RV band ±q."""
+
+    if len(true) == 0:
+        return float("nan")
+    return float(np.mean(np.abs(true - pred) <= q))
+
+
+def run(
+    rv_path: Path | str,
+    *,
+    seeds: tuple[int, ...] = DEFAULT_SEEDS,
+    n_folds: int = 5,
+    epochs: int = 300,
+    horizons: tuple[int, ...] = DEFAULT_HORIZONS,
+    alphas: tuple[float, ...] = DEFAULT_ALPHAS,
+    device: str = "cpu",
+) -> dict[str, Any]:
+    """Walk-forward eval: HAR vs ensemble-DLq QLIKE + conformal band coverage.
+
+    Per horizon reports HAR QLIKE; per-seed and ensemble DLq QLIKE; the
+    ensemble-vs-HAR QLIKE-gain block-bootstrap CI (block=h); OOS-R²; and the
+    empirical coverage of the 80%/90% walk-forward conformal bands vs nominal.
+
+    The ensemble trains on the FULL train fold (no calibration carve-out), so it
+    reproduces the bake-off DLq quality. Bands come from prior-folds-only OOS
+    residuals: fold k is banded by the quantile of the residuals pooled over folds
+    1..k-1, so coverage is prospective and leakage-free (fold 1 has no prior
+    residuals and is skipped for coverage).
+    """
+
+    import pandas as pd
+
+    df = pd.read_parquet(rv_path).sort_values("date").reset_index(drop=True)
+    rv, _log_rv, full = _build_full(df)
+    har = full[:, :3]
+
+    results: dict[str, Any] = {
+        "n_days": int(len(df)),
+        "seeds": list(seeds),
+        "n_folds": n_folds,
+        "epochs": epochs,
+        "alphas": list(alphas),
+        "by_horizon": {},
+    }
+    for h in horizons:
+        y = _forward_log_rv(rv, h)
+        idx = np.where(~np.isnan(y))[0]
+        folds = walk_forward_splits(len(idx), n_folds=n_folds, embargo=max(h, 1) + 1)
+        har_pool: list[float] = []
+        ens_pool: list[float] = []
+        true_pool: list[float] = []
+        base_pool: list[float] = []
+        seed_pools: list[list[float]] = [[] for _ in seeds]
+        # Walk-forward conformal: residuals accumulate over folds; fold k is banded
+        # by the (1−α) quantile of the residuals from folds 1..k-1 (prior only).
+        cal_resid: list[float] = []
+        band_hits: dict[float, float] = dict.fromkeys(alphas, 0.0)
+        band_n: dict[float, int] = dict.fromkeys(alphas, 0)
+
+        for tr_l, te_l in folds:
+            tr, te = idx[np.array(tr_l)], idx[np.array(te_l)]
+            ytr, yte = y[tr], y[te]
+
+            # FULL-train HAR floors the residual stack and is the eval baseline.
+            har_fit_tr = _fit_predict_ols(har[tr], ytr, har[tr])
+            resid_tr = (ytr - har_fit_tr).reshape(-1, 1)
+            har_pred_te = _fit_predict_ols(har[tr], ytr, har[te])
+
+            # Ensemble trains on the FULL train fold (no calibration carve-out).
+            per_seed_te, ens_te = _ensemble_predict(
+                har_fit_tr, full[tr], resid_tr, full[te], har_pred_te,
+                seeds=seeds, epochs=epochs, device=device,
+            )
+
+            # Band fold k from the prior folds' OOS residuals (skip fold 1: none yet).
+            if cal_resid:
+                scores = np.asarray(cal_resid)
+                for a in alphas:
+                    q = _conformal_quantile(scores, a)
+                    band_hits[a] += _coverage(yte, ens_te, q) * len(te)
+                    band_n[a] += len(te)
+            # This fold's OOS residuals join the pool for later folds.
+            cal_resid.extend(np.abs(yte - ens_te).tolist())
+
+            har_pool.extend(har_pred_te.tolist())
+            ens_pool.extend(ens_te.tolist())
+            true_pool.extend(yte.tolist())
+            base_pool.extend([float(ytr.mean())] * len(te))
+            for j in range(len(seeds)):
+                seed_pools[j].extend(per_seed_te[j].tolist())
+
+        har_arr = np.asarray(har_pool)
+        ens_arr = np.asarray(ens_pool)
+        true_arr = np.asarray(true_pool)
+        base_arr = np.asarray(base_pool)
+        seed_arrs = [np.asarray(p) for p in seed_pools]
+
+        per_seed_qlike = [_qlike(s, true_arr) for s in seed_arrs]
+        row: dict[str, Any] = {
+            "qlike_har": _qlike(har_arr, true_arr),
+            "qlike_ens": _qlike(ens_arr, true_arr),
+            "qlike_per_seed": per_seed_qlike,
+            "qlike_per_seed_mean": float(np.mean(per_seed_qlike)),
+            "qlike_per_seed_std": float(np.std(per_seed_qlike)),
+            "r2_har": _oos_r2(har_arr, true_arr, base_arr),
+            "r2_ens": _oos_r2(ens_arr, true_arr, base_arr),
+            "ens_vs_har_qlike_gain_ci90": _bootstrap_qlike_gain_ci(
+                ens_arr, har_arr, true_arr, seed=seeds[0], block=max(h, 1)
+            ),
+            "coverage": {},
+        }
+        for a in alphas:
+            emp = band_hits[a] / band_n[a] if band_n[a] else float("nan")
+            row["coverage"][f"{1.0 - a:.2f}"] = {
+                "nominal": round(1.0 - a, 4),
+                "empirical": round(emp, 4),
+            }
+        results["by_horizon"][f"h{h}"] = row
+    return results
+
+
+def _walk_forward_oos_resid(
+    rv: np.ndarray,
+    full: np.ndarray,
+    har: np.ndarray,
+    h: int,
+    *,
+    seeds: tuple[int, ...],
+    n_folds: int,
+    epochs: int,
+    device: str,
+) -> np.ndarray:
+    """Pooled |true − ensemble| OOS residuals over a walk-forward at horizon h.
+
+    Each fold's ensemble trains on the FULL train fold (matching `run`), so the
+    residuals reflect the deployable full-train quality. The pool is the best
+    prospective estimate of the serving model's nonconformity.
+    """
+
+    y = _forward_log_rv(rv, h)
+    idx = np.where(~np.isnan(y))[0]
+    folds = walk_forward_splits(len(idx), n_folds=n_folds, embargo=max(h, 1) + 1)
+    resid: list[float] = []
+    for tr_l, te_l in folds:
+        tr, te = idx[np.array(tr_l)], idx[np.array(te_l)]
+        ytr, yte = y[tr], y[te]
+        har_fit_tr = _fit_predict_ols(har[tr], ytr, har[tr])
+        resid_tr = (ytr - har_fit_tr).reshape(-1, 1)
+        har_pred_te = _fit_predict_ols(har[tr], ytr, har[te])
+        _per_seed, ens_te = _ensemble_predict(
+            har_fit_tr, full[tr], resid_tr, full[te], har_pred_te,
+            seeds=seeds, epochs=epochs, device=device,
+        )
+        resid.extend(np.abs(yte - ens_te).tolist())
+    return np.asarray(resid)
+
+
+def fit_production(
+    rv_path: Path | str,
+    out_dir: Path | str,
+    *,
+    seeds: tuple[int, ...] = DEFAULT_SEEDS,
+    n_folds: int = 5,
+    epochs: int = 300,
+    horizons: tuple[int, ...] = DEFAULT_HORIZONS,
+    alphas: tuple[float, ...] = DEFAULT_ALPHAS,
+    device: str = "cpu",
+) -> dict[str, Any]:
+    """Fit HAR + the QLIKE-DLq ensemble on ALL history; save a serving artifact.
+
+    No test split — every row trains the deployable model on the FULL history
+    (no calibration carve-out), so the served ensemble reproduces the beat-HAR
+    quality. The conformal quantiles come from the pooled walk-forward OOS
+    residuals (the prospective nonconformity estimate), NOT a sacrificed tail.
+    Saves per-seed state_dicts (.pt) and a JSON spec (HAR coefficients, feature
+    standardization stats, conformal quantiles per horizon/α, metadata) so a
+    serving layer can reconstruct the banded forecast.
+    """
+
+    import pandas as pd
+    import torch
+
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    df = pd.read_parquet(rv_path).sort_values("date").reset_index(drop=True)
+    rv, _log_rv, full = _build_full(df)
+    har = full[:, :3]
+    n = len(df)
+
+    spec: dict[str, Any] = {
+        "model": "intraday_rv_production",
+        "kind": "qlike_dlq_ensemble+walk_forward_conformal",
+        "n_days": int(n),
+        "seeds": list(seeds),
+        "n_folds": n_folds,
+        "epochs": epochs,
+        "horizons": list(horizons),
+        "alphas": list(alphas),
+        "feature_order": ["har_daily", "har_weekly", "har_monthly", *_FEAT_COLS, "log_rvol"],
+        "date_first": str(df["date"].iloc[0]),
+        "date_last": str(df["date"].iloc[-1]),
+        "by_horizon": {},
+    }
+
+    for h in horizons:
+        y = _forward_log_rv(rv, h)
+        idx = np.where(~np.isnan(y))[0]
+        y_all = y[idx]
+
+        # HAR coefficients on ALL valid-target history (intercept first), for serving.
+        a_all = np.column_stack([np.ones(len(idx)), har[idx]])
+        coef, *_ = np.linalg.lstsq(a_all, y_all, rcond=None)
+        har_all_fit = a_all @ coef
+        resid_all = (y_all - har_all_fit).reshape(-1, 1)
+
+        # Standardization stats the QLIKE head used (all history), plus the residual
+        # mean/std the head's output is un-standardized with — saved so serving can
+        # reproduce exp(HAR + resid_std*rs + rm) without re-deriving anything.
+        full_all = full[idx]
+        xm, xs = full_all.mean(0), full_all.std(0)
+        xs = np.where(xs > 0, xs, 1.0)
+        rm = float(resid_all.mean())
+        rs = float(resid_all.std()) if resid_all.std() > 0 else 1.0
+
+        # Fit each seed's QLIKE-DLq on ALL history; serialize the all-history weights.
+        seed_files = []
+        for s in seeds:
+            sd = _fit_seed_state(
+                har_all_fit, full_all, resid_all, seed=s, epochs=epochs, device=device
+            )
+            fname = f"h{h}_seed{s}.pt"
+            torch.save(sd, out / fname)
+            seed_files.append(fname)
+
+        # Conformal quantiles from the pooled walk-forward OOS residuals (prospective
+        # nonconformity estimate), not from a held-out tail of the serving model.
+        scores = _walk_forward_oos_resid(
+            rv, full, har, h, seeds=seeds, n_folds=n_folds, epochs=epochs, device=device
+        )
+        quantiles = {f"{a:.2f}": _conformal_quantile(scores, a) for a in alphas}
+
+        spec["by_horizon"][f"h{h}"] = {
+            "har_coef": coef.tolist(),  # [intercept, daily, weekly, monthly]
+            "feat_mean": xm.tolist(),
+            "feat_std": xs.tolist(),
+            "resid_mean": rm,
+            "resid_std": rs,
+            "conformal_quantiles": quantiles,  # α → log-RV half-width
+            "seed_state_dicts": seed_files,
+            "n_oos_resid": int(len(scores)),
+        }
+
+    (out / "production_artifact.json").write_text(json.dumps(spec, indent=2), encoding="utf-8")
+    return spec
+
+
+def _fit_seed_state(
+    har_core_fit: np.ndarray,
+    full_core: np.ndarray,
+    resid_core: np.ndarray,
+    *,
+    seed: int,
+    epochs: int,
+    device: str,
+) -> dict[str, "torch.Tensor"]:
+    """Fit one QLIKE-DLq seed on the train-core; return its best state_dict.
+
+    Mirrors `_train_fold_qlike`'s training discipline (standardization, QLIKE
+    loss on reconstructed variance, grad-clip, early stop) but returns the
+    serializable weights instead of test predictions, so the saved artifact
+    reproduces the head a serving layer must run.
+    """
+
+    import torch
+
+    from app.data.dense_forecast_train import _build_model
+    from app.data.intraday_rv_forecast import _EPS as _RVEPS
+    from app.data.intraday_rv_forecast import _LOGV_CLAMP
+    from app.determinism import enable_deterministic_mode
+
+    enable_deterministic_mode(seed)
+    dev = torch.device(device)
+    xm, xs = full_core.mean(0), full_core.std(0)
+    xs = np.where(xs > 0, xs, 1.0)
+    rm = resid_core.mean()
+    rs = resid_core.std() if resid_core.std() > 0 else 1.0
+    xtr = torch.tensor((full_core - xm) / xs, dtype=torch.float32, device=dev)
+    har_tr = torch.tensor(har_core_fit, dtype=torch.float32, device=dev).reshape(-1, 1)
+    log_true_tr = torch.tensor(
+        (resid_core.reshape(-1) + har_core_fit).reshape(-1, 1), dtype=torch.float32, device=dev
+    )
+
+    def qlike_loss(resid_std: "torch.Tensor", har: "torch.Tensor", log_true: "torch.Tensor") -> Any:
+        log_pred = har + (resid_std * rs + rm)
+        log_pred = torch.clamp(log_pred, -_LOGV_CLAMP, _LOGV_CLAMP)
+        log_true_c = torch.clamp(log_true, -_LOGV_CLAMP, _LOGV_CLAMP)
+        var_pred = torch.exp(log_pred) + _RVEPS
+        var_true = torch.exp(log_true_c)
+        ratio = var_true / var_pred
+        return torch.mean(ratio - torch.log(ratio) - 1.0)
+
+    n_val = max(1, len(xtr) // 5)
+    tr, val = slice(0, len(xtr) - n_val), slice(len(xtr) - n_val, len(xtr))
+    model = _build_model(full_core.shape[1], 1).to(dev)
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-3, weight_decay=1e-4)
+    best, best_state, bad = float("inf"), None, 0
+    for _ in range(epochs):
+        model.train()
+        opt.zero_grad()
+        loss = qlike_loss(model(xtr[tr]), har_tr[tr], log_true_tr[tr])
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+        opt.step()
+        model.eval()
+        with torch.no_grad():
+            vloss = float(qlike_loss(model(xtr[val]), har_tr[val], log_true_tr[val]))
+        if vloss < best - 1e-6:
+            best, bad = vloss, 0
+            best_state = {k: v.detach().clone() for k, v in model.state_dict().items()}
+        else:
+            bad += 1
+            if bad >= 40:
+                break
+    if best_state is not None:
+        model.load_state_dict(best_state)
+    return cast("dict[str, torch.Tensor]", {k: v.cpu() for k, v in model.state_dict().items()})
+
+
+def _print_table(res: dict[str, Any]) -> None:
+    print(f"n_days={res['n_days']}  seeds={res['seeds']}  epochs={res['epochs']}")
+    print("QLIKE (lower better) + ensemble-vs-HAR gain CI90 (>0 ⇒ ensemble beats HAR)")
+    print(
+        f"{'horizon':<8}{'HAR':>10}{'seedMean':>10}{'seedStd':>9}{'ENS':>10}"
+        f"{'R2_HAR':>9}{'R2_ENS':>9}{'GainCI90':>22}"
+    )
+    for hk, r in res["by_horizon"].items():
+        g = r["ens_vs_har_qlike_gain_ci90"]
+        print(
+            f"{hk:<8}{r['qlike_har']:>10.4f}{r['qlike_per_seed_mean']:>10.4f}"
+            f"{r['qlike_per_seed_std']:>9.4f}{r['qlike_ens']:>10.4f}"
+            f"{r['r2_har']:>9.3f}{r['r2_ens']:>9.3f}"
+            f"{f'[{g[0]:+.4f},{g[1]:+.4f}]':>22}"
+        )
+    print("Conformal band coverage (empirical vs nominal)")
+    print(f"{'horizon':<8}{'level':>8}{'nominal':>10}{'empirical':>12}")
+    for hk, r in res["by_horizon"].items():
+        for level, cov in r["coverage"].items():
+            print(f"{hk:<8}{level:>8}{cov['nominal']:>10.2f}{cov['empirical']:>12.4f}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Deployable banded RV forecaster: QLIKE-DLq ensemble + conformal."
+    )
+    parser.add_argument("--rv-path", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--seeds", type=int, nargs="+", default=list(DEFAULT_SEEDS))
+    parser.add_argument("--epochs", type=int, default=300)
+    args = parser.parse_args()
+    seeds = tuple(args.seeds)
+
+    res = run(args.rv_path, seeds=seeds, epochs=args.epochs)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    (args.out_dir / "production_eval.json").write_text(
+        json.dumps(res, indent=2), encoding="utf-8"
+    )
+    _print_table(res)
+    spec = fit_production(args.rv_path, args.out_dir, seeds=seeds, epochs=args.epochs)
+    print(
+        f"artifact: {len(spec['horizons'])} horizons × {len(seeds)} seeds "
+        f"→ {args.out_dir}/production_artifact.json"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -152,6 +152,7 @@ ignore = [
 "app/audit.py" = ["PLR0913"]
 "app/data/alphavantage_spx.py" = ["PLR0913"]
 "app/data/intraday_realized.py" = ["PLR0913"]
+"app/data/intraday_rv_forecast.py" = ["PLR0913", "C901"]
 "app/data/fed_comms_scrape.py" = ["PLR0913"]
 "app/data/fed_comms_dataset.py" = ["PLR0913"]
 "app/data/gated_fusion.py" = ["PLR0913"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -153,6 +153,7 @@ ignore = [
 "app/data/alphavantage_spx.py" = ["PLR0913"]
 "app/data/intraday_realized.py" = ["PLR0913"]
 "app/data/intraday_rv_forecast.py" = ["PLR0913", "C901"]
+"app/data/intraday_rv_production.py" = ["PLR0913", "C901"]
 "app/data/intraday_rv_arch.py" = ["PLR0913", "C901"]
 "app/data/fed_comms_scrape.py" = ["PLR0913"]
 "app/data/fed_comms_dataset.py" = ["PLR0913"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -153,6 +153,7 @@ ignore = [
 "app/data/alphavantage_spx.py" = ["PLR0913"]
 "app/data/intraday_realized.py" = ["PLR0913"]
 "app/data/intraday_rv_forecast.py" = ["PLR0913", "C901"]
+"app/data/intraday_rv_arch.py" = ["PLR0913", "C901"]
 "app/data/fed_comms_scrape.py" = ["PLR0913"]
 "app/data/fed_comms_dataset.py" = ["PLR0913"]
 "app/data/gated_fusion.py" = ["PLR0913"]

--- a/tests/unit/test_fed_comms_dataset.py
+++ b/tests/unit/test_fed_comms_dataset.py
@@ -73,6 +73,46 @@ def test_daily_fusion_has_text_and_age() -> None:
     assert by_date["2020-01-06"]["doc_type"] == "speech"
 
 
+def test_trailing_vol_window_and_leak_safety() -> None:
+    # First `window`-1 entries NaN until the window is full; vol[t] uses only
+    # changes ending at t (backward-looking → leak-safe).
+    chg = np.array([np.nan, 1.0, -1.0, 1.0, -1.0, 1.0])
+    out = d._trailing_vol(chg, 3)
+    # t=0,1 below window; t=2 window [nan,1,-1] still carries the leading NaN.
+    assert np.isnan(out[0]) and np.isnan(out[1]) and np.isnan(out[2])
+    assert np.isfinite(out[3])  # first full all-finite window [1,-1,1]
+    assert np.isclose(out[3], np.std(np.array([1.0, -1.0, 1.0])))  # ddof=0
+    # A future spike at t=5 must not change vol at t=3 (no look-ahead).
+    chg2 = chg.copy()
+    chg2[5] = 99.0
+    out2 = d._trailing_vol(chg2, 3)
+    assert np.isclose(out[3], out2[3])
+
+
+def test_rate_vol_measures_omitted_without_cache_columns() -> None:
+    # The cache-less fixture has no rate_vol_* columns → measures cleanly omitted.
+    days = ["2020-01-02", "2020-01-03", "2020-01-06", "2020-01-07"]
+    rv = _rv_df(days, [1.0, 2.0, 4.0, 8.0])
+    for m in d._RATE_VOL_MEASURES:
+        assert d._measure_present(rv, m) is False
+    corpus = pd.DataFrame(
+        [
+            {
+                "date": "2020-01-03",
+                "timestamp_et": "2020-01-03 00:00",
+                "doc_type": "speech",
+                "time_known": False,
+                "speaker": "powell",
+                "text": "y" * 300,
+            }
+        ]
+    )
+    daily = d.build_daily_fusion_frame(rv, corpus, horizons=(1,))
+    for m in d._RATE_VOL_MEASURES:
+        assert f"{m}_daily" not in daily.columns
+        assert f"{m}_fwd_1" not in daily.columns
+
+
 def test_surprise_asof_join_is_leak_safe() -> None:
     days = ["2020-01-02", "2020-01-03", "2020-01-06", "2020-01-07"]
     rv = _rv_df(days, [1.0, 2.0, 4.0, 8.0])

--- a/tests/unit/test_intraday_rv_arch.py
+++ b/tests/unit/test_intraday_rv_arch.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.data.intraday_rv_arch import build_sequences
+
+torch = pytest.importorskip("torch")
+
+
+def test_window_ends_at_origin_and_is_leak_safe() -> None:
+    rng = np.random.default_rng(0)
+    n, d, seq_len = 40, 6, 22
+    feat = rng.standard_normal((n, d))
+    valid = np.ones(n, dtype=bool)
+    out = build_sequences(feat, valid, seq_len=seq_len)
+    for j, t in enumerate(out["origin"]):
+        # window is exactly rows [t-L+1 .. t]: last row is t, first is t-L+1,
+        # strictly rows <= t so no future row can leak in.
+        assert out["seq"].shape[1] == seq_len
+        np.testing.assert_array_equal(out["seq"][j, -1], feat[t])
+        np.testing.assert_array_equal(out["seq"][j, 0], feat[t - seq_len + 1])
+        np.testing.assert_array_equal(out["seq"][j], feat[t - seq_len + 1 : t + 1])
+
+
+def test_drops_short_history_and_invalid_origins() -> None:
+    rng = np.random.default_rng(1)
+    n, seq_len = 40, 22
+    feat = rng.standard_normal((n, 6))
+    valid = np.ones(n, dtype=bool)
+    valid[30] = False
+    out = build_sequences(feat, valid, seq_len=seq_len)
+    origins = set(out["origin"].tolist())
+    assert min(origins) == seq_len - 1  # no origin with insufficient history
+    assert 30 not in origins  # invalid origin excluded
+    assert origins == {t for t in range(seq_len - 1, n) if t != 30}
+
+
+def test_tcn_is_causal_future_cannot_change_past_output() -> None:
+    """A change to a future input row must not move the TCN's last-step output.
+
+    Build the model, push a window through, then perturb a row that is AFTER the
+    output position and confirm the output is bit-identical. Since the TCN pools
+    the LAST step, we instead verify the per-step output stream: perturbing input
+    at step k leaves outputs at steps < k unchanged (strict causality).
+    """
+
+    from app.data.intraday_rv_arch import _build_tcn
+
+    torch.manual_seed(0)
+    d_in, length = 6, 22
+    model = _build_tcn(d_in)
+    model.eval()
+
+    # tap the conv stack directly to get the full per-step output stream
+    def conv_stream(x_seq: "torch.Tensor") -> "torch.Tensor":
+        x = x_seq.transpose(1, 2)
+        for blk in model.blocks:
+            x = blk(x)
+        return x  # (B, C, L)
+
+    x = torch.randn(1, length, d_in)
+    with torch.no_grad():
+        out_a = conv_stream(x)
+        x2 = x.clone()
+        k = 15
+        x2[0, k] += 5.0  # perturb input at step k
+        out_b = conv_stream(x2)
+    # outputs at steps < k must be unchanged; step k and later may move
+    torch.testing.assert_close(out_a[:, :, :k], out_b[:, :, :k])
+    assert not torch.allclose(out_a[:, :, k], out_b[:, :, k])

--- a/tests/unit/test_intraday_rv_forecast.py
+++ b/tests/unit/test_intraday_rv_forecast.py
@@ -20,3 +20,19 @@ def test_forward_log_rv_target() -> None:
     y3 = f._forward_log_rv(rv, 3)
     assert np.isclose(y3[0], np.log((2 + 4 + 8) / 3))
     assert np.isnan(y3[-1]) and np.isnan(y3[-3])
+
+
+def test_qlike_perfect_prediction_is_zero() -> None:
+    true = np.log(np.array([1e-4, 4e-4, 9e-4, 1.6e-3]))
+    assert np.isclose(f._qlike(true, true), 0.0, atol=1e-9)
+
+
+def test_qlike_penalizes_underprediction_of_spike_more() -> None:
+    # one spike day, off-by the same multiplicative factor in log space
+    true = np.array([np.log(1e-4), np.log(1e-2)])  # second day is a 100x variance spike
+    delta = np.log(2.0)  # factor-of-2 miss either direction
+    under = true.copy()
+    under[1] -= delta  # under-predict the spike's variance
+    over = true.copy()
+    over[1] += delta  # over-predict it by the same factor
+    assert f._qlike(under, true) > f._qlike(over, true)

--- a/tests/unit/test_intraday_rv_production.py
+++ b/tests/unit/test_intraday_rv_production.py
@@ -1,0 +1,92 @@
+"""Pure-function tests for the deployable banded RV forecaster."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from app.data import intraday_rv_production as p
+
+
+def test_conformal_quantile_covers_nominal_on_synthetic() -> None:
+    # iid calibration + test draws from the same dist: a 90% conformal band
+    # should cover ~90% of test points (conformal validity).
+    rng = np.random.default_rng(0)
+    pred = np.zeros(4000)
+    cal_scores = np.abs(rng.standard_normal(2000))  # |residual| nonconformity
+    q = p._conformal_quantile(cal_scores, alpha=0.1)
+    test_true = rng.standard_normal(4000)  # residual = true - 0 = true
+    cov = p._coverage(test_true, pred, q)
+    assert 0.86 <= cov <= 0.94  # ~90% nominal, tolerance for sampling noise
+
+
+def test_walk_forward_conformal_covers_nominal_prior_folds_only() -> None:
+    # Emulate the run() walk-forward band scheme on synthetic iid folds: fold k is
+    # banded by the |residual| quantile of folds 1..k-1 (prior only, fold 1 skipped).
+    # Predictions are 0, so residual = true; a 90% band should cover ~90% pooled.
+    rng = np.random.default_rng(7)
+    folds = [rng.standard_normal(500) for _ in range(6)]
+    cal_resid: list[float] = []
+    hits = 0.0
+    n = 0
+    for true in folds:
+        pred = np.zeros_like(true)
+        if cal_resid:
+            q = p._conformal_quantile(np.asarray(cal_resid), alpha=0.1)
+            hits += p._coverage(true, pred, q) * len(true)
+            n += len(true)
+        cal_resid.extend(np.abs(true - pred).tolist())
+    cov = hits / n
+    assert 0.86 <= cov <= 0.94  # ~90% nominal, prospective coverage, no leakage
+
+
+def test_conformal_quantile_monotone_in_alpha() -> None:
+    scores = np.abs(np.random.default_rng(1).standard_normal(500))
+    q80 = p._conformal_quantile(scores, alpha=0.2)
+    q90 = p._conformal_quantile(scores, alpha=0.1)
+    assert q90 > q80  # tighter mis-coverage ⇒ wider band
+
+
+def test_conformal_quantile_small_sample_falls_back_to_max() -> None:
+    scores = np.array([0.5, 1.0, 2.0])  # n=3; ceil(4*0.9)=4 > n → widest score
+    assert p._conformal_quantile(scores, alpha=0.1) == 2.0
+    assert np.isnan(p._conformal_quantile(np.array([]), alpha=0.1))
+
+
+def test_coverage_empty_is_nan() -> None:
+    assert np.isnan(p._coverage(np.array([]), np.array([]), 1.0))
+
+
+def test_ensemble_mean_shape_and_value() -> None:
+    # The ensemble point forecast is the per-seed mean across axis 0.
+    per_seed = np.array([[1.0, 2.0, 3.0], [3.0, 4.0, 5.0]])
+    mean = per_seed.mean(axis=0)
+    assert mean.shape == (3,)
+    assert np.allclose(mean, [2.0, 3.0, 4.0])
+
+
+def test_build_full_column_layout() -> None:
+    import pandas as pd
+
+    n = 40
+    rng = np.random.default_rng(2)
+    df = pd.DataFrame(
+        {
+            "date": [f"2020-{1 + i // 28:02d}-{1 + i % 28:02d}" for i in range(n)],
+            "rv": np.abs(rng.standard_normal(n)) * 1e-4 + 1e-5,
+            "rs_pos": np.abs(rng.standard_normal(n)) * 1e-5,
+            "rs_neg": np.abs(rng.standard_normal(n)) * 1e-5,
+            "bv": np.abs(rng.standard_normal(n)) * 1e-4,
+            "rq": np.abs(rng.standard_normal(n)) * 1e-8,
+            "rskew": rng.standard_normal(n),
+            "rkurt": np.abs(rng.standard_normal(n)) * 5,
+            "parkinson": np.abs(rng.standard_normal(n)) * 1e-4,
+            "rvol": np.abs(rng.standard_normal(n)) * 1e6,
+        }
+    )
+    rv, log_rv, full = p._build_full(df)
+    assert rv.shape == (n,)
+    assert log_rv.shape == (n,)
+    # 3 HAR cols + 7 realized measures + log(rvol) = 11.
+    assert full.shape == (n, 11)
+    # HAR daily occupies col 0 and equals log(rv).
+    assert np.allclose(full[:, 0], log_rv)


### PR DESCRIPTION
## Summary
Training-round additions on the intraday realized-vol track. Additive — new modules + extensions to the fed-comms aligner/trainer; no existing serving code touched.

## What's included
- **Interest-rate vol targets** (`fed_comms_dataset.py`): trailing-22d realized vol of 2Y (FRED DGS2) / 10Y (TNX) yield changes + the MP-surprise and cross-asset-correlation measures. Text is null on rate vol too (the Fed's home turf); the 2Y FOMC-window flicker dies under a block bootstrap.
- **QLIKE loss + bake-off** (`intraday_rv_forecast.py`): a QLIKE-trained deep model (DLq) **beats HAR on QLIKE** at h=1/5/22, moving-block-bootstrap-confirmed. R² ties — an asymmetric-loss (risk-relevant) win. First beat-HAR in the project.
- **Architecture sweep** (`intraday_rv_arch.py`): causal TCN + leverage-effect σLSTM, QLIKE-trained. The win is **loss-driven, not architecture-driven** (σLSTM ≈ MLP-DLq).
- **Deployable forecaster** (`intraday_rv_production.py`): 5-seed QLIKE-DLq ensemble + walk-forward OOS conformal bands + a saved artifact (per-seed weights, HAR coefs, standardization, conformal quantiles). Beat-HAR restored and seed-robust; bands calibrated at h22 (modestly tight at h1/h5).
- **Per-era CI** (`fed_comms_train.py`): block-bootstrap CI on the per-era (incl. FOMC-window) text-vs-market gap.

## Result
Two-sided: FOMC/Fed text adds no forecasting signal anywhere (exhaustive null, wiki p.21), **but the QLIKE loss lets a deep model beat HAR on intraday realized measures** (wiki p.22). Deployable artifact published to HF (`fomc-rv-qlike-forecaster`).

## Verification
ruff + mypy-strict clean on all new modules; coverage 71% (≥65 gate); full suite green in a clean checkout (local-only failures are .env config + image version-drift).