### PR TITLE
Guard against silent sentiment-model fallback contaminating embeddings

### DIFF
--- a/backend/app/data/dense_fomc_text.py
+++ b/backend/app/data/dense_fomc_text.py
@@ -54,8 +54,10 @@ def build_fomc_embeddings(
     out_path = Path(out_path)
     if out_path.exists() and not force:
         return out_path
-    from app.services.text_encoder import encode_chunks
+    from app.services.text_encoder import assert_primary_model_loaded, encode_chunks
 
+    # Fail loudly rather than silently caching embeddings from a fallback model.
+    assert_primary_model_loaded()
     texts = statement_dates_and_text(events_parquet)
     rows = []
     for date_iso in sorted(texts):

--- a/backend/app/data/fed_comms_train.py
+++ b/backend/app/data/fed_comms_train.py
@@ -47,8 +47,10 @@ def build_corpus_embeddings(
     out_path = Path(out_path)
     if out_path.exists() and not force:
         return out_path
-    from app.services.text_encoder import encode_chunks
+    from app.services.text_encoder import assert_primary_model_loaded, encode_chunks
 
+    # Fail loudly rather than silently caching embeddings from a fallback model.
+    assert_primary_model_loaded()
     corpus = pd.read_parquet(corpus_path)
     embs: list[tuple[str, np.ndarray | None]] = []
     for _, doc in corpus.iterrows():

--- a/backend/app/services/text_encoder.py
+++ b/backend/app/services/text_encoder.py
@@ -32,6 +32,18 @@ MODEL_ID = _OVERRIDE or (
     DEFAULT_LOCAL_CHECKPOINT if Path(DEFAULT_LOCAL_CHECKPOINT).exists() else PRIMARY_HF_MODEL_ID
 )
 
+# When truthy, refuse to silently use the generic fallback classifier — raise
+# instead. Embedding/training pipelines set this so cached vectors can never be
+# built from the wrong encoder (the silent-fallback contamination bug: the
+# primary HF repo can 404, and the run would otherwise proceed on distilbert
+# sentiment vectors with no error).
+STRICT_PRIMARY = (
+    os.environ.get("FED_PULSE_REQUIRE_PRIMARY_SENTIMENT") or ""
+).strip().lower() in {"1", "true", "yes"}
+
+# The model id the singleton actually loaded; differs from MODEL_ID on fallback.
+_loaded_model_id: str | None = None
+
 DEFAULT_MAX_TOKENS = 480
 DEFAULT_STRIDE = 400
 DEFAULT_CLASSIFIER_MAX_LENGTH = 512
@@ -109,12 +121,21 @@ def get_classifier() -> Any:
                 )
         if _classifier is None and last_error is not None:
             raise last_error
+        global _loaded_model_id
+        _loaded_model_id = loaded_model_id
         if loaded_model_id != MODEL_ID:
             # We picked a fallback. The fallback's label space (e.g.
             # POSITIVE / NEGATIVE for distilbert-sst-2) is NOT
             # hawkish/dovish/neutral; the frontend's toStance() refuses to
             # silently relabel POSITIVE -> hawkish, so the dashboard will
             # surface "Sentiment unavailable" until the primary model loads.
+            if STRICT_PRIMARY:
+                raise RuntimeError(
+                    f"sentiment classifier fell back to {loaded_model_id!r} instead of "
+                    f"the primary {MODEL_ID!r}; refusing because "
+                    "FED_PULSE_REQUIRE_PRIMARY_SENTIMENT is set (the primary model is "
+                    "unavailable — see preceding classifier_load_failed warnings)"
+                )
             _logger.error(
                 "sentiment.classifier_using_fallback",
                 extra={
@@ -128,6 +149,27 @@ def get_classifier() -> Any:
                 },
             )
     return _classifier
+
+
+def get_loaded_model_id() -> str | None:
+    """The model id the singleton actually loaded (differs from MODEL_ID on fallback)."""
+    return _loaded_model_id
+
+
+def assert_primary_model_loaded() -> None:
+    """Raise unless the active classifier is the primary model, not the fallback.
+
+    Build/training pipelines call this before producing cached embeddings so a
+    silent fallback (e.g. the primary HF repo 404ing -> distilbert) can never
+    contaminate the artifacts undetected.
+    """
+    get_classifier()
+    if _loaded_model_id != MODEL_ID:
+        raise RuntimeError(
+            f"primary sentiment model {MODEL_ID!r} is not loaded "
+            f"(active model: {_loaded_model_id!r}); refusing to build embeddings with "
+            "a fallback encoder. Set FED_PULSE_SENTIMENT_MODEL to a valid model."
+        )
 
 
 def classifier_load_count() -> int:

--- a/tests/unit/test_text_encoder.py
+++ b/tests/unit/test_text_encoder.py
@@ -143,3 +143,31 @@ def test_aggregate_label_averages_scores_across_chunks():
 def test_aggregate_label_handles_empty_input():
     result = aggregate_label([])
     assert result == {"label": "UNKNOWN", "score": 0.0, "raw": []}
+
+
+def test_assert_primary_model_loaded_raises_on_fallback(monkeypatch):
+    # The silent-fallback guard: if the active model is the fallback (e.g. the
+    # primary HF repo 404'd -> distilbert), embedding builds must fail loudly.
+    import app.services.text_encoder as te
+
+    monkeypatch.setattr(te, "get_classifier", lambda: None)
+    monkeypatch.setattr(te, "MODEL_ID", "primary/stance-model")
+    monkeypatch.setattr(te, "_loaded_model_id", te.FALLBACK_MODEL_ID)
+    with pytest.raises(RuntimeError, match="refusing to build embeddings"):
+        te.assert_primary_model_loaded()
+
+
+def test_assert_primary_model_loaded_passes_when_primary(monkeypatch):
+    import app.services.text_encoder as te
+
+    monkeypatch.setattr(te, "get_classifier", lambda: None)
+    monkeypatch.setattr(te, "MODEL_ID", "primary/stance-model")
+    monkeypatch.setattr(te, "_loaded_model_id", "primary/stance-model")
+    te.assert_primary_model_loaded()  # must not raise
+
+
+def test_get_loaded_model_id_accessor(monkeypatch):
+    import app.services.text_encoder as te
+
+    monkeypatch.setattr(te, "_loaded_model_id", "some/model")
+    assert te.get_loaded_model_id() == "some/model"


### PR DESCRIPTION
## Problem

The primary HF sentiment repo `gtfintechlab/fomc-roberta-any-exp` is a dead repository (404 — verified via `huggingface_hub.model_info`). On any environment without the local fine-tuned checkpoint, `get_classifier()` silently degrades to `distilbert-sst-2`, whose POSITIVE/NEGATIVE labels are not hawkish/dovish/neutral. Embedding-build runs (`build_fomc_embeddings`, `build_corpus_embeddings`) then proceed on those wrong vectors with no error, contaminating cached artifacts.

## Fix

- `text_encoder`: track the actually-loaded model id; add `get_loaded_model_id()` and `assert_primary_model_loaded()`; honour `FED_PULSE_REQUIRE_PRIMARY_SENTIMENT` to raise instead of falling back. **Serving default behaviour is unchanged** — graceful degradation to 'sentiment unavailable'.
- `build_fomc_embeddings` / `build_corpus_embeddings`: assert the primary model is loaded before caching embeddings, so artifacts can never be silently built from the fallback encoder.

## Tests

Three new tests for the guard (fallback raises, primary passes, accessor). ruff + mypy --strict clean; text_encoder suite green (10 tests).