### PR TITLE
Repoint stance classifier to the correct FOMC-RoBERTa repo + label map

### DIFF
--- a/backend/app/services/text_encoder.py
+++ b/backend/app/services/text_encoder.py
@@ -19,7 +19,13 @@ from app.models.registry import revision_for
 # sentiment model. Override via the FED_PULSE_SENTIMENT_MODEL env var on any
 # deployment where the local checkpoint is not present.
 DEFAULT_LOCAL_CHECKPOINT = "/data/artifacts/phase3/pilot_finetune_20260505T142652Z/hf_checkpoints"
-PRIMARY_HF_MODEL_ID = "gtfintechlab/fomc-roberta-any-exp"
+PRIMARY_HF_MODEL_ID = "gtfintechlab/FOMC-RoBERTa"
+# gtfintechlab/FOMC-RoBERTa (Trillion Dollar Words) ships generic LABEL_0/1/2 in
+# its config. Empirically verified mapping (probs ~1.0 on hawkish/dovish/neutral
+# probe sentences): LABEL_0 = dovish, LABEL_1 = hawkish, LABEL_2 = neutral. The
+# repo is gated; a token with gate access is required (else the strict guard /
+# loud-fallback path engages instead of silently using distilbert).
+_FOMC_ROBERTA_ID2LABEL = {0: "dovish", 1: "hawkish", 2: "neutral"}
 # Last-resort fallback ONLY. Returns POSITIVE / NEGATIVE labels, NOT
 # hawkish/dovish/neutral, so the frontend should refuse to map the output
 # (see frontend/lib/analyze/format.ts::toStance).
@@ -74,7 +80,15 @@ def _build_pipeline(model_id: str, device: int) -> Any:
     revision = revision_for(model_id)
     if revision is not None:
         kwargs["revision"] = revision
-    return pipeline("text-classification", **kwargs)
+    clf = pipeline("text-classification", **kwargs)
+    # FOMC-RoBERTa exposes only generic LABEL_0/1/2; remap to stance names so the
+    # pipeline emits hawkish/dovish/neutral (the labels the rest of the stack and
+    # the frontend's toStance() expect). The local fine-tune checkpoint already
+    # carries proper labels, so this only touches the FOMC-RoBERTa fallback.
+    if model_id == PRIMARY_HF_MODEL_ID:
+        clf.model.config.id2label = dict(_FOMC_ROBERTA_ID2LABEL)
+        clf.model.config.label2id = {v: k for k, v in _FOMC_ROBERTA_ID2LABEL.items()}
+    return clf
 
 
 def get_classifier() -> Any:

--- a/tests/unit/test_text_encoder.py
+++ b/tests/unit/test_text_encoder.py
@@ -171,3 +171,38 @@ def test_get_loaded_model_id_accessor(monkeypatch):
 
     monkeypatch.setattr(te, "_loaded_model_id", "some/model")
     assert te.get_loaded_model_id() == "some/model"
+
+
+class _StanceCfg:
+    pass
+
+
+class _StanceModel:
+    def __init__(self):
+        self.config = _StanceCfg()
+
+
+class _StanceClf:
+    def __init__(self):
+        self.model = _StanceModel()
+
+
+def test_fomc_roberta_generic_labels_remapped_to_stance(monkeypatch):
+    # FOMC-RoBERTa ships LABEL_0/1/2; _build_pipeline must remap to stance names.
+    import app.services.text_encoder as te
+
+    monkeypatch.setattr(te, "pipeline", lambda *a, **k: _StanceClf())
+    monkeypatch.setattr(te, "revision_for", lambda _m: None)
+    clf = te._build_pipeline(te.PRIMARY_HF_MODEL_ID, -1)
+    assert clf.model.config.id2label == {0: "dovish", 1: "hawkish", 2: "neutral"}
+    assert clf.model.config.label2id["hawkish"] == 1
+
+
+def test_other_model_labels_not_remapped(monkeypatch):
+    # A non-FOMC-RoBERTa model id must NOT get the stance remap.
+    import app.services.text_encoder as te
+
+    monkeypatch.setattr(te, "pipeline", lambda *a, **k: _StanceClf())
+    monkeypatch.setattr(te, "revision_for", lambda _m: None)
+    clf = te._build_pipeline("some/other-classifier", -1)
+    assert not hasattr(clf.model.config, "id2label")


### PR DESCRIPTION
## Problem

The fallback sentiment model id is `gtfintechlab/fomc-roberta-any-exp` — **that repo does not exist** (404). The real model is `gtfintechlab/FOMC-RoBERTa` (Trillion Dollar Words). So whenever the local fine-tuned checkpoint isn't deployed (CI / fresh environments), the encoder 404s and silently falls back to distilbert sentiment — the actual root cause of the 'fed-communications classification failed' symptom. Not a model-quality problem, and no retrain needed.

## Fix

- Repoint `PRIMARY_HF_MODEL_ID` -> `gtfintechlab/FOMC-RoBERTa`.
- The model ships only generic `LABEL_0/1/2`; remap in `_build_pipeline` to stance names — empirically verified (probs ~1.0 on probe sentences): **LABEL_0=dovish, LABEL_1=hawkish, LABEL_2=neutral** — so the pipeline emits hawkish/dovish/neutral (what the rest of the stack + frontend `toStance()` expect). Only touches the FOMC-RoBERTa fallback; the local checkpoint already carries proper labels.

`FOMC-RoBERTa` is gated; PR #588's guard makes a token without gate access fail loudly instead of silently using distilbert.

## Verification

Live end-to-end through the repointed code path: a hawkish probe sentence scores **hawkish 0.997**. 12 tests pass (2 new for the remap); ruff + mypy --strict clean.