### PR TITLE
research: 'what it predicts' honest-scope tab

### DIFF
--- a/frontend/components/research/HonestScopePane.tsx
+++ b/frontend/components/research/HonestScopePane.tsx
@@ -1,0 +1,174 @@
+import * as React from "react";
+import { CheckCircle2, MinusCircle, ExternalLink } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const WIKI_NULL = "https://github.com/yusufizzetmurat/fed-pulse/wiki/20_Gated_Fusion_InfoNCE_Comprehensive_Null";
+const WIKI_RELATED_WORK = "https://github.com/yusufizzetmurat/fed-pulse/wiki/19_Related_Work_Text_Market_Fusion";
+
+interface ClaimProps {
+  title: string;
+  detail: string;
+  metric?: string;
+  source?: string;
+}
+
+function Predicts({ title, detail, metric, source }: ClaimProps) {
+  return (
+    <div className="flex gap-3 rounded-md border border-emerald-700/40 bg-emerald-700/5 p-3">
+      <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-700" aria-hidden />
+      <div className="space-y-1.5">
+        <p className="text-sm font-medium text-foreground">{title}</p>
+        <p className="text-sm text-muted-foreground">{detail}</p>
+        {metric ? (
+          <Badge variant="outline" className="numeric text-[10px]" title={source}>
+            {metric}
+          </Badge>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function DoesNotPredict({ title, detail, metric, source }: ClaimProps) {
+  return (
+    <div className="flex gap-3 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+      <MinusCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" aria-hidden />
+      <div className="space-y-1.5">
+        <p className="text-sm font-medium text-foreground">{title}</p>
+        <p className="text-sm text-muted-foreground">{detail}</p>
+        {metric ? (
+          <Badge variant="outline" className="numeric text-[10px]" title={source}>
+            {metric}
+          </Badge>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function HonestScopePane() {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>What this model predicts &mdash; and what it doesn&apos;t</CardTitle>
+          <CardDescription>
+            Forecast cards on the dashboard are driven by market data only. Text panels are
+            descriptive: they show what the Fed said and how it changed, never what the price
+            or volatility will do. Every claim below is anchored to a measured macro-F1 or a
+            block-bootstrap confidence interval in the wiki.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Predicts (market data only)</CardTitle>
+            <CardDescription>
+              Cards on the workspace that surface a number with a confidence band.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Predicts
+              title="Short-horizon realized volatility"
+              detail="Three-class regime (Low / Medium / High) from HAR&apos;s continuous forecast bucketed into terciles. Strongest classifier in the bake-off; the QLIKE-DLq ensemble beats HAR by ~10% in QLIKE loss at every horizon."
+              metric="HAR-tercile macro-F1  0.687 (1d) · 0.685 (1w) · 0.654 (1m)"
+              source="Wiki §20, Result 2 — 3-class forward-RV-tercile, n=1999, pooled walk-forward"
+            />
+            <Predicts
+              title="Forward trading volume"
+              detail="HAR-style baseline applied to log-volume residuals after removing weekly seasonality and FOMC-calendar effects. Lands on the Workspace as the &ldquo;Expected Volume&rdquo; card."
+              metric="Market-only R²  ≈ 0.85–0.88 at 1-day"
+              source="Wiki §20, Result 3 — abnormal-volume forecast"
+            />
+            <Predicts
+              title="Conformal coverage on the vol bands"
+              detail="The 80% and 90% prediction bands on the QLIKE-RV card are calibrated against held-out residuals. Empirical coverage tracks the nominal target on resolved runs."
+              metric="Empirical 90% band coverage  ≈ 85–92%"
+              source="Wiki §20, Result 1 conformal calibration"
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Does NOT predict (text is a description layer)</CardTitle>
+            <CardDescription>
+              FOMC text adds no measurable forecasting signal over the market baseline. The text
+              panels on the workspace (stance, semantic diff, topics, XAI) are honest about what
+              the Fed said. They do not feed the forecast cards.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <DoesNotPredict
+              title="Price direction or magnitude from FOMC text"
+              detail="Across four encoders (finbert_fed_adjacent, bge-large, e5-large, gte-large), text robustly hurts next-day vol forecasting. The fused text+market regime classifier underperforms HAR-tercile by ~0.10 macro-F1 at 1-day."
+              metric="Text-vs-market 95% block CI  [−0.022, −0.009] at 1-day"
+              source="Wiki §20, Result 2 — text-vs-mkt incremental, daily n=1999"
+            />
+            <DoesNotPredict
+              title="Volatility regime FROM text"
+              detail="The late-fusion classifier is still rendered on the Workspace as a second opinion, but only as a transparency disclosure. HAR-tercile is the headline because it&apos;s the better predictor."
+              metric="Late-fusion macro-F1  0.592 (1d) — 0.095 below HAR-tercile"
+              source="Wiki §20, Result 2 — fused (text+market)"
+            />
+            <DoesNotPredict
+              title="Surprise → drift channel"
+              detail="A LoRA fine-tune on the FOMC corpus testing whether text-surprise predicts post-meeting drift returned null. McNemar test against the baseline failed to reject equivalence."
+              metric="LoRA McNemar p = 0.92"
+              source="Re-confirmation: LoRA fine-tune, FOMC corpus, n=1999 daily + n=167 intraday"
+            />
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Why the text panels still matter</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            The dashboard&apos;s text surfaces &mdash; hawkish/dovish stance, sentiment breakdown,
+            sentence-level XAI, semantic diff against the previous statement, historical analogs &mdash;
+            do not forecast the market. They answer a different, honest question:{" "}
+            <span className="text-foreground">
+              what did the Fed say, how did the wording change, and how does it compare to past
+              statements?
+            </span>{" "}
+            That&apos;s a legitimate descriptive job and the panels are calibrated against the labelled
+            FOMC corpus (gtfintechlab&apos;s Trillion-Dollar-Words derivatives).
+          </p>
+          <p>
+            The discipline is visual on every card: forecast surfaces carry a measured macro-F1 or
+            QLIKE-vs-HAR chip; text surfaces carry no forecasting metric and never imply they feed
+            the price or vol forecast. XAI explains the stance label, not the price.
+          </p>
+          <div className="flex flex-wrap items-center gap-2 pt-2">
+            <a
+              href={WIKI_NULL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-xs text-foreground underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
+            >
+              Methodology &amp; measured nulls — wiki §20
+              <ExternalLink className="h-3 w-3" aria-hidden />
+            </a>
+            <span className="text-muted-foreground">·</span>
+            <a
+              href={WIKI_RELATED_WORK}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-xs text-foreground underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
+            >
+              Where this sits in the literature — wiki §19
+              <ExternalLink className="h-3 w-3" aria-hidden />
+            </a>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/components/shell/status-bar.tsx
+++ b/frontend/components/shell/status-bar.tsx
@@ -46,14 +46,23 @@ export function StatusBar({
   const checkpointLoaded = result?.model?.checkpoint_loaded;
   const runtimeMode = result?.model?.runtime_mode;
 
-  // Tri-state: loading (running) > result present (checkpoint loaded /
-  // no checkpoint based on diagnostics) > no result yet (awaiting).
-  // Before this branch the third case rendered as "no checkpoint",
-  // which read like an error on initial page load.
+  // Browse mode: pages that don't drive an /analyze submit (Calendar,
+  // Settings, Performance, Compare, Research) leave `result` and
+  // `loading` undefined. Suppress the analyze-state chip on those pages
+  // so the status bar does not read "awaiting analysis" forever; it's
+  // misleading copy outside the Workspace flow.
+  const isAnalyzeHost = result !== undefined || loading !== undefined;
+
+  // Tri-state on Workspace: loading (running) > result present
+  // (checkpoint loaded / no checkpoint based on diagnostics) > no result
+  // yet (awaiting).
   const hasResult = Boolean(result);
-  let stateLabel: string;
+  let stateLabel: string | null;
   let stateTone: string;
-  if (loading) {
+  if (!isAnalyzeHost) {
+    stateLabel = null;
+    stateTone = "text-muted-foreground";
+  } else if (loading) {
     stateLabel = "running";
     stateTone = "animate-pulse text-hawkish";
   } else if (!hasResult) {
@@ -76,13 +85,15 @@ export function StatusBar({
         className,
       )}
     >
-      <div className="flex items-center gap-1.5">
-        <CircleDot
-          className={cn("h-2 w-2 fill-current", stateTone)}
-          aria-hidden="true"
-        />
-        <span>{stateLabel}</span>
-      </div>
+      {stateLabel !== null ? (
+        <div className="flex items-center gap-1.5">
+          <CircleDot
+            className={cn("h-2 w-2 fill-current", stateTone)}
+            aria-hidden="true"
+          />
+          <span>{stateLabel}</span>
+        </div>
+      ) : null}
       {symbol ? (
         <div className="flex items-center gap-1.5">
           <span>symbol</span>

--- a/frontend/lib/analyze/encoders.ts
+++ b/frontend/lib/analyze/encoders.ts
@@ -21,6 +21,7 @@ const FRIENDLY_NAMES: Record<string, string> = {
   fomc_roberta: "FOMC-RoBERTa",
   roberta_base: "RoBERTa base",
   bert_base: "BERT base",
+  bert_base_fed_adjacent: "BERT base (Fed-adjacent)",
 };
 
 function prettifyAlias(alias: string): string {

--- a/frontend/lib/analyze/shared-context.tsx
+++ b/frontend/lib/analyze/shared-context.tsx
@@ -138,6 +138,13 @@ export function SymbolCalendarProvider({ children }: { children: React.ReactNode
       });
     return () => {
       controller.abort();
+      // Release the guard on unmount so React StrictMode's intentional
+      // double-mount (or a future apiBaseUrl change) re-fires the fetch
+      // and lands a fresh result. Without this the first mount's
+      // controller is aborted before its .then() can call setSymbols and
+      // the second mount short-circuits at the guard, leaving symbols
+      // stuck in its initial loading state for the rest of the session.
+      inFlight.current.delete(key);
     };
   }, [apiBaseUrl]);
 
@@ -161,6 +168,11 @@ export function SymbolCalendarProvider({ children }: { children: React.ReactNode
       });
     return () => {
       controller.abort();
+      // Same StrictMode-double-mount fix as the symbols effect above:
+      // release the guard so the second mount actually fires the fetch
+      // and lands a fresh result on calendar state. Without this the
+      // upcoming-FOMC chip stays blank on every non-Workspace page.
+      inFlight.current.delete(key);
     };
   }, [apiBaseUrl]);
 

--- a/frontend/pages/research.tsx
+++ b/frontend/pages/research.tsx
@@ -135,7 +135,8 @@ function buildBakeoffBarData(section: EncoderBakeoffSection): BakeoffBarDatum[] 
       const offsetLow = low != null ? Math.max(0, row.macro_f1_mean - low) : 0;
       const offsetHigh = high != null ? Math.max(0, high - row.macro_f1_mean) : 0;
       return {
-        name: row.encoder_key,
+        name: friendlyEncoderName(row.encoder_key),
+        rawName: row.encoder_key,
         macroF1: row.macro_f1_mean,
         ciLow: low,
         ciHigh: high,
@@ -151,7 +152,7 @@ function bakeoffCallout(section: EncoderBakeoffSection): string | null {
   const runner = sorted[1];
   const gapPoints = (leader.macro_f1_mean - runner.macro_f1_mean) * 100;
   if (!Number.isFinite(gapPoints) || gapPoints <= 0) return null;
-  return `${leader.encoder_key} leads the overall F1 score by ${gapPoints.toFixed(1)} percentage points over ${runner.encoder_key}.`;
+  return `${friendlyEncoderName(leader.encoder_key)} leads the overall F1 score by ${gapPoints.toFixed(1)} percentage points over ${friendlyEncoderName(runner.encoder_key)}.`;
 }
 
 function crossBankCallout(

--- a/frontend/pages/research.tsx
+++ b/frontend/pages/research.tsx
@@ -15,6 +15,7 @@ import {
 import { toast } from "sonner";
 
 import { DecisionsLink } from "@/components/research/DecisionsLink";
+import { HonestScopePane } from "@/components/research/HonestScopePane";
 import { Header } from "@/components/shell/header";
 import { StatusBar } from "@/components/shell/status-bar";
 import { Badge } from "@/components/ui/badge";
@@ -562,13 +563,17 @@ export default function ResearchPage() {
               <Skeleton className="h-48 w-full" />
             </div>
           ) : data ? (
-            <Tabs defaultValue="bakeoff" className="w-full">
+            <Tabs defaultValue="scope" className="w-full">
               <TabsList className="flex w-full flex-wrap justify-start">
+                <TabsTrigger value="scope">What it predicts</TabsTrigger>
                 <TabsTrigger value="bakeoff">Bake-off</TabsTrigger>
                 <TabsTrigger value="transfer">Transfer</TabsTrigger>
                 <TabsTrigger value="decisions">Decisions</TabsTrigger>
                 <TabsTrigger value="files">Downloads</TabsTrigger>
               </TabsList>
+              <TabsContent value="scope">
+                <HonestScopePane />
+              </TabsContent>
               <TabsContent value="bakeoff" className="space-y-3">
                 <EncoderBakeoffPane section={data.encoder_bakeoff} />
                 {data.encoder_bakeoff.source_files.length > 0 ? (


### PR DESCRIPTION
## Summary
Defense-critical plain-language tab on /research. Lists every claim the dashboard makes (with measured macro-F1 / block CI) and every one it explicitly does NOT.

## What landed
- New `HonestScopePane.tsx` rendering two side-by-side columns: "Predicts (market data only)" and "Does NOT predict (text is a description layer)".
- New default tab on /research: **What it predicts** → Bake-off → Transfer → Decisions → Downloads.
- Every claim chipped with a measured macro-F1 / CI / R² + tooltip pointing at the wiki source row.
- Two outbound wiki links: §20 (Gated_Fusion_InfoNCE_Comprehensive_Null) for the null methodology, §19 (Related_Work_Text_Market_Fusion) for context.

## Measured anchors surfaced
| | What | Number |
|---|---|---|
| Predicts | HAR-tercile macro-F1 | 0.687 / 0.685 / 0.654 at 1d/1w/1m |
| Predicts | QLIKE-DLq vs HAR | ~10% QLIKE-loss improvement |
| Predicts | Volume market-only R² | ≈ 0.85–0.88 at 1-day |
| Predicts | Conformal 90% coverage | 85–92% empirical |
| Does NOT | Text-vs-market block CI | [−0.022, −0.009] at 1-day |
| Does NOT | Late-fusion macro-F1 | 0.592 (1d), −0.095 vs HAR |
| Does NOT | LoRA fine-tune McNemar | p = 0.92 |

## Wiki updates
Follow-up PR per task 2 — `§01_Progress_Snapshot.md` + `§06.x` tables will be re-anchored on HAR-tercile as the headline. Not in this PR.

## Test plan
- [ ] /research with tab open shows the section as default
- [ ] Wiki §20 + §19 links open in new tab
- [ ] Tabs Bake-off / Transfer / Decisions / Downloads still work
- [ ] type-check passes