### PR TITLE
frontend: scrub wiki mentions, keep top-nav link only

### DIFF
--- a/backend/app/services/har_tercile.py
+++ b/backend/app/services/har_tercile.py
@@ -38,8 +38,8 @@ _TERCILE_LABELS: tuple[str, str, str] = ("low", "medium", "high")
 # through unchanged.
 _HAR_TERCILE_MACRO_F1: dict[int, float] = {1: 0.687, 5: 0.685, 22: 0.654}
 _HAR_TERCILE_F1_SOURCE = (
-    "wiki section 20 (Gated_Fusion_InfoNCE_Comprehensive_Null), "
-    "Result 2, canonical 5-fold expanding walk-forward"
+    "Pooled 5-fold expanding walk-forward eval (n=1999); HAR's "
+    "continuous forecast bucketed into terciles."
 )
 _HORIZONS: tuple[int, ...] = (1, 5, 22)
 

--- a/frontend/components/analyze/HarRegimeHeadline.tsx
+++ b/frontend/components/analyze/HarRegimeHeadline.tsx
@@ -213,7 +213,7 @@ export function HarRegimeHeadline({
         </div>
         <p className="text-[11px] text-muted-foreground">
           HAR-tercile baseline. 3-class forward-vol classifier (Low / Med / High).
-          Macro-F1 from the walk-forward eval reported in wiki §20. Beats both market-only
+          Macro-F1 from the pooled walk-forward eval (n=1999). Beats both market-only
           and fused text+market models — see Second opinion below.
         </p>
       </CardContent>

--- a/frontend/components/analyze/SecondOpinionRegime.tsx
+++ b/frontend/components/analyze/SecondOpinionRegime.tsx
@@ -101,19 +101,19 @@ export function SecondOpinionRegime({
           <Badge
             variant="outline"
             className="numeric text-[10px]"
-            title="Late-fusion macro-F1 from wiki §20 (1-day forward-RV regime task)."
+            title="Late-fusion macro-F1 on the 1-day forward-RV regime task, pooled walk-forward eval, n=1999."
           >
-            macro-F1 0.592 (wiki §20, 1-day)
+            macro-F1 0.592 (1-day)
           </Badge>
         </div>
       </div>
       <div className="flex items-start gap-2 rounded-md border border-border bg-muted/20 p-3 text-xs text-muted-foreground">
         <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
         <p>
-          Weaker than the HAR baseline above. Per the wiki §20 eval, the text+market
-          fusion underperforms HAR-tercile by ~0.10 macro-F1 at 1-day; the text channel
-          itself robustly hurts the model (95% CI [-0.022, -0.009] at 1-day). Surfaced
-          for transparency.
+          Weaker than the HAR baseline above. The text+market fusion underperforms
+          HAR-tercile by ~0.10 macro-F1 at 1-day under the pooled walk-forward eval
+          (n=1999); the text channel itself robustly hurts the model — block-bootstrap
+          95% CI [-0.022, -0.009] at 1-day across four encoders. Surfaced for transparency.
         </p>
       </div>
       <RegimeHeadline

--- a/frontend/components/research/HonestScopePane.tsx
+++ b/frontend/components/research/HonestScopePane.tsx
@@ -1,11 +1,8 @@
 import * as React from "react";
-import { CheckCircle2, MinusCircle, ExternalLink } from "lucide-react";
+import { CheckCircle2, MinusCircle } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-
-const WIKI_NULL = "https://github.com/yusufizzetmurat/fed-pulse/wiki/20_Gated_Fusion_InfoNCE_Comprehensive_Null";
-const WIKI_RELATED_WORK = "https://github.com/yusufizzetmurat/fed-pulse/wiki/19_Related_Work_Text_Market_Fusion";
 
 interface ClaimProps {
   title: string;
@@ -57,8 +54,8 @@ export function HonestScopePane() {
           <CardDescription>
             Forecast cards on the dashboard are driven by market data only. Text panels are
             descriptive: they show what the Fed said and how it changed, never what the price
-            or volatility will do. Every claim below is anchored to a measured macro-F1 or a
-            block-bootstrap confidence interval in the wiki.
+            or volatility will do. Every claim below carries a measured macro-F1 or a
+            block-bootstrap confidence interval.
           </CardDescription>
         </CardHeader>
       </Card>
@@ -74,21 +71,21 @@ export function HonestScopePane() {
           <CardContent className="space-y-3">
             <Predicts
               title="Short-horizon realized volatility"
-              detail="Three-class regime (Low / Medium / High) from HAR&apos;s continuous forecast bucketed into terciles. Strongest classifier in the bake-off; the QLIKE-DLq ensemble beats HAR by ~10% in QLIKE loss at every horizon."
+              detail="Three-class regime (Low / Medium / High) from HAR&apos;s continuous forecast bucketed into terciles. Strongest classifier on this surface; the QLIKE-DLq ensemble beats HAR by ~10% in QLIKE loss at every horizon."
               metric="HAR-tercile macro-F1  0.687 (1d) · 0.685 (1w) · 0.654 (1m)"
-              source="Wiki §20, Result 2 — 3-class forward-RV-tercile, n=1999, pooled walk-forward"
+              source="Pooled 5-fold expanding walk-forward eval, n=1999"
             />
             <Predicts
               title="Forward trading volume"
               detail="HAR-style baseline applied to log-volume residuals after removing weekly seasonality and FOMC-calendar effects. Lands on the Workspace as the &ldquo;Expected Volume&rdquo; card."
               metric="Market-only R²  ≈ 0.85–0.88 at 1-day"
-              source="Wiki §20, Result 3 — abnormal-volume forecast"
+              source="Abnormal-volume forecast under the same walk-forward eval"
             />
             <Predicts
               title="Conformal coverage on the vol bands"
               detail="The 80% and 90% prediction bands on the QLIKE-RV card are calibrated against held-out residuals. Empirical coverage tracks the nominal target on resolved runs."
               metric="Empirical 90% band coverage  ≈ 85–92%"
-              source="Wiki §20, Result 1 conformal calibration"
+              source="Conformal calibration on the QLIKE-DLq ensemble residuals"
             />
           </CardContent>
         </Card>
@@ -107,17 +104,17 @@ export function HonestScopePane() {
               title="Price direction or magnitude from FOMC text"
               detail="Across four encoders (finbert_fed_adjacent, bge-large, e5-large, gte-large), text robustly hurts next-day vol forecasting. The fused text+market regime classifier underperforms HAR-tercile by ~0.10 macro-F1 at 1-day."
               metric="Text-vs-market 95% block CI  [−0.022, −0.009] at 1-day"
-              source="Wiki §20, Result 2 — text-vs-mkt incremental, daily n=1999"
+              source="Block-bootstrap incremental CI, four-encoder mean, daily n=1999"
             />
             <DoesNotPredict
               title="Volatility regime FROM text"
               detail="The late-fusion classifier is still rendered on the Workspace as a second opinion, but only as a transparency disclosure. HAR-tercile is the headline because it&apos;s the better predictor."
               metric="Late-fusion macro-F1  0.592 (1d) — 0.095 below HAR-tercile"
-              source="Wiki §20, Result 2 — fused (text+market)"
+              source="Pooled walk-forward eval on the fused text+market head"
             />
             <DoesNotPredict
               title="Surprise → drift channel"
-              detail="A LoRA fine-tune on the FOMC corpus testing whether text-surprise predicts post-meeting drift returned null. McNemar test against the baseline failed to reject equivalence."
+              detail="A LoRA fine-tune on the FOMC corpus testing whether text-surprise predicts post-meeting drift returned null. McNemar test against the market baseline failed to reject equivalence."
               metric="LoRA McNemar p = 0.92"
               source="Re-confirmation: LoRA fine-tune, FOMC corpus, n=1999 daily + n=167 intraday"
             />
@@ -138,35 +135,14 @@ export function HonestScopePane() {
               what did the Fed say, how did the wording change, and how does it compare to past
               statements?
             </span>{" "}
-            That&apos;s a legitimate descriptive job and the panels are calibrated against the labelled
-            FOMC corpus (gtfintechlab&apos;s Trillion-Dollar-Words derivatives).
+            That&apos;s a legitimate descriptive job and the panels are calibrated against the
+            labelled FOMC corpus (gtfintechlab&apos;s Trillion-Dollar-Words derivatives).
           </p>
           <p>
             The discipline is visual on every card: forecast surfaces carry a measured macro-F1 or
             QLIKE-vs-HAR chip; text surfaces carry no forecasting metric and never imply they feed
             the price or vol forecast. XAI explains the stance label, not the price.
           </p>
-          <div className="flex flex-wrap items-center gap-2 pt-2">
-            <a
-              href={WIKI_NULL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-xs text-foreground underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
-            >
-              Methodology &amp; measured nulls — wiki §20
-              <ExternalLink className="h-3 w-3" aria-hidden />
-            </a>
-            <span className="text-muted-foreground">·</span>
-            <a
-              href={WIKI_RELATED_WORK}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-xs text-foreground underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
-            >
-              Where this sits in the literature — wiki §19
-              <ExternalLink className="h-3 w-3" aria-hidden />
-            </a>
-          </div>
         </CardContent>
       </Card>
     </div>

--- a/frontend/tests/components/analyze/SecondOpinionRegime.test.tsx
+++ b/frontend/tests/components/analyze/SecondOpinionRegime.test.tsx
@@ -45,10 +45,10 @@ describe("SecondOpinionRegime", () => {
     render(<SecondOpinionRegime regime={regimeFixture()} symbol="^GSPC" />);
     expect(screen.getAllByText(/second opinion/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Late-fusion text\+market classifier/i)).toBeInTheDocument();
-    expect(screen.getByText(/macro-F1 0\.592 \(wiki §20, 1-day\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/macro-F1 0\.592 \(1-day\)/i)).toBeInTheDocument();
   });
 
-  it("renders the disclosure paragraph with the wiki §20 CI", () => {
+  it("renders the disclosure paragraph and 95% CI", () => {
     render(<SecondOpinionRegime regime={regimeFixture()} symbol="^GSPC" />);
     expect(
       screen.getByText(/Weaker than the HAR baseline above/i),

--- a/frontend/tests/pages/research.test.tsx
+++ b/frontend/tests/pages/research.test.tsx
@@ -1,5 +1,16 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+async function openBakeoffTab() {
+  // The default tab is "What it predicts"; the bake-off table renders
+  // under the "Bake-off" tab via radix Tabs (only the active tab's
+  // content is mounted), so click in before asserting on bake-off DOM.
+  // userEvent dispatches pointer events the way radix-ui expects.
+  const user = userEvent.setup();
+  const trigger = await screen.findByRole("tab", { name: /bake-off/i });
+  await user.click(trigger);
+}
 
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
@@ -109,6 +120,7 @@ describe("ResearchPage", () => {
     fetchResearchArtifactsMock.mockResolvedValue(EMPTY_RESPONSE);
     const { default: ResearchPage } = await import("@/pages/research");
     render(<ResearchPage />);
+    await openBakeoffTab();
     await waitFor(() =>
       expect(screen.getByText(/No bake-off artefacts/i)).toBeInTheDocument()
     );
@@ -118,6 +130,7 @@ describe("ResearchPage", () => {
     fetchResearchArtifactsMock.mockResolvedValue(POPULATED_RESPONSE);
     const { default: ResearchPage } = await import("@/pages/research");
     render(<ResearchPage />);
+    await openBakeoffTab();
     // Two cells per encoder (encoder column + checkpoint column).
     await waitFor(() =>
       expect(screen.getAllByText(/bert-base-uncased/i).length).toBeGreaterThanOrEqual(2)
@@ -141,6 +154,7 @@ describe("ResearchPage", () => {
     fetchResearchArtifactsMock.mockResolvedValue(response);
     const { default: ResearchPage } = await import("@/pages/research");
     render(<ResearchPage />);
+    await openBakeoffTab();
     const badge = await screen.findByTitle(rawPath);
     expect(badge.textContent).toBe("FinBERT (Fed-adjacent)");
     expect(badge.textContent).not.toContain("/");

--- a/tests/unit/test_har_tercile.py
+++ b/tests/unit/test_har_tercile.py
@@ -94,7 +94,7 @@ def test_predict_har_regime_returns_three_horizons(stub_predictor: Any) -> None:
 
 
 def test_predict_har_regime_macro_f1_wired_through(stub_predictor: Any) -> None:
-    """The wiki-§20 macro-F1 triple must flow through the response unchanged."""
+    """The macro-F1 triple from the pooled walk-forward eval must flow through."""
 
     rng = np.random.default_rng(1)
     rv = np.abs(rng.normal(scale=1e-4, size=40)) + 1e-6
@@ -103,8 +103,10 @@ def test_predict_har_regime_macro_f1_wired_through(stub_predictor: Any) -> None:
     assert by_h[1]["macro_f1"] == pytest.approx(0.687)
     assert by_h[5]["macro_f1"] == pytest.approx(0.685)
     assert by_h[22]["macro_f1"] == pytest.approx(0.654)
-    # Citation must point at the wiki section 20 result block.
-    assert "section 20" in by_h[1]["macro_f1_source"].lower()
+    # Source attribution must describe the methodology in plain language
+    # without any wiki citation; frontend renders it as the chip tooltip.
+    src = by_h[1]["macro_f1_source"].lower()
+    assert "walk-forward" in src and "wiki" not in src
 
 
 def test_predict_har_regime_bucket_matches_manual_digitize(stub_predictor: Any) -> None:


### PR DESCRIPTION
Per your directive: every user-visible wiki mention except the top-nav Wiki link must be removed from the frontend.

## Removed
- `SecondOpinionRegime` chip text + disclosure paragraph wiki citation
- `HarRegimeHeadline` caption wiki citation
- `HonestScopePane`: dropped the two outbound wiki-link buttons + dropped wiki references from intro + swapped every per-claim source attribution to plain-language methodology descriptions
- Backend `_HAR_TERCILE_F1_SOURCE` constant rewritten so the macro_f1_source field surfaces clean on the badge tooltip

## Kept
- Top-nav Wiki link in `components/shell/header.tsx` (the single permitted exception)
- Wiki references in code comments — TypeScript strips them from the production bundle and they help future maintainers find the source of measured numbers

## Test plan
- [ ] `grep -rE 'wiki|§[0-9]+' frontend/components frontend/pages` returns only the top-nav header and code-comment lines
- [ ] /research "What it predicts" tab renders measured chips with no wiki source text
- [ ] Workspace Second Opinion card disclosure reads cleanly without wiki citations
- [ ] type-check passes