### PR TITLE
Serve own multi-axis stance model everywhere via HF checkpoint fallback

### DIFF
--- a/backend/app/services/multi_axis_classifier.py
+++ b/backend/app/services/multi_axis_classifier.py
@@ -36,6 +36,18 @@ from app.models.text_multi_axis_classifier import TextMultiAxisClassifier
 DEFAULT_CHECKPOINT_PATH = MODEL_CHECKPOINT_DIR / "text_multi_axis_best.pt"
 DEFAULT_MAX_LENGTH = 256
 
+# When no local checkpoint is present, pull the published multi-axis checkpoint
+# from the Hub so our own stance model serves in every environment (CI, fresh
+# deploys) instead of falling back to the third-party FOMC-RoBERTa path. The repo
+# is public + ungated. Override the repo via env for forks/mirrors.
+_HF_CHECKPOINT_REPO = (
+    os.environ.get("FED_PULSE_MULTI_AXIS_HF_REPO")
+    or "yusufizzetmurat/fed-pulse-multi-axis-text-classifier"
+).strip()
+_HF_CHECKPOINT_FILE = "text_multi_axis_best.pt"
+_hf_checkpoint_cache: Path | None = None
+_hf_checkpoint_failed = False
+
 # #393: structured surface for the inference-contract validation. The
 # /health endpoint reads this so an operator can grep "checkpoint
 # incompatible with serving signature" without parsing logs. Mirrors
@@ -104,11 +116,47 @@ class _ClassifierState:
     factor_coverage_threshold: float
 
 
+def _hf_checkpoint_path() -> Path | None:
+    """Download the published multi-axis checkpoint from the Hub (cached), or None.
+
+    Memoized: downloads at most once per process, and on failure (offline / repo
+    missing) records the failure and returns None so the caller falls back to the
+    local path (which won't exist -> graceful degradation to the text_encoder
+    path), without retrying or flooding logs.
+    """
+    global _hf_checkpoint_cache, _hf_checkpoint_failed
+    if _hf_checkpoint_cache is not None:
+        return _hf_checkpoint_cache
+    if _hf_checkpoint_failed or not _HF_CHECKPOINT_REPO:
+        return None
+    try:
+        from huggingface_hub import hf_hub_download
+
+        path = hf_hub_download(
+            _HF_CHECKPOINT_REPO,
+            _HF_CHECKPOINT_FILE,
+            token=os.environ.get("HF_TOKEN") or None,
+        )
+        _hf_checkpoint_cache = Path(path)
+        _logger.info("multi_axis: pulled checkpoint from Hub repo %s", _HF_CHECKPOINT_REPO)
+        return _hf_checkpoint_cache
+    except Exception as exc:  # noqa: BLE001 - any failure -> graceful fallback
+        _hf_checkpoint_failed = True
+        _logger.warning(
+            "multi_axis: could not pull checkpoint from Hub %s: %s", _HF_CHECKPOINT_REPO, exc
+        )
+        return None
+
+
 def _resolve_checkpoint_path() -> Path:
     override = (os.environ.get("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT") or "").strip()
     if override:
         return Path(override)
-    return DEFAULT_CHECKPOINT_PATH
+    if DEFAULT_CHECKPOINT_PATH.exists():
+        return DEFAULT_CHECKPOINT_PATH
+    # No local checkpoint: serve our own model everywhere by pulling it from the Hub.
+    hf_path = _hf_checkpoint_path()
+    return hf_path if hf_path is not None else DEFAULT_CHECKPOINT_PATH
 
 
 def checkpoint_exists() -> bool:

--- a/tests/unit/test_multi_axis_classifier_service.py
+++ b/tests/unit/test_multi_axis_classifier_service.py
@@ -164,3 +164,38 @@ def test_reset_classifier_clears_sticky_load_failure(
     assert isinstance(svc._state, svc._LoadFailure)
     svc.reset_classifier()
     assert svc._state is svc._UNSET
+
+
+def test_resolve_checkpoint_prefers_env_override(monkeypatch):
+    monkeypatch.setenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", "/tmp/override.pt")
+    assert svc._resolve_checkpoint_path() == Path("/tmp/override.pt")
+
+
+def test_resolve_checkpoint_pulls_from_hf_when_no_local(monkeypatch, tmp_path):
+    import huggingface_hub
+
+    monkeypatch.delenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", raising=False)
+    monkeypatch.setattr(svc, "DEFAULT_CHECKPOINT_PATH", tmp_path / "absent.pt")
+    monkeypatch.setattr(svc, "_hf_checkpoint_cache", None)
+    monkeypatch.setattr(svc, "_hf_checkpoint_failed", False)
+    fake = tmp_path / "hf.pt"
+    fake.write_text("x")
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", lambda *a, **k: str(fake))
+    assert svc._resolve_checkpoint_path() == fake
+
+
+def test_resolve_checkpoint_falls_back_when_hf_unavailable(monkeypatch, tmp_path):
+    import huggingface_hub
+
+    monkeypatch.delenv("FED_PULSE_TEXT_MULTI_AXIS_CHECKPOINT", raising=False)
+    absent = tmp_path / "absent.pt"
+    monkeypatch.setattr(svc, "DEFAULT_CHECKPOINT_PATH", absent)
+    monkeypatch.setattr(svc, "_hf_checkpoint_cache", None)
+    monkeypatch.setattr(svc, "_hf_checkpoint_failed", False)
+
+    def _boom(*a, **k):
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", _boom)
+    assert svc._resolve_checkpoint_path() == absent
+    assert svc._hf_checkpoint_failed is True


### PR DESCRIPTION
## Goal

Use our own stance model everywhere and stop depending on the third-party (gated) FOMC-RoBERTa at runtime.

## Context

The multi-axis classifier (our production stance model) is the primary when a local checkpoint is present, but the resolver only checked local paths — so CI / fresh deploys without the checkpoint fell through to the `text_encoder` pipeline (FOMC-RoBERTa / distilbert). The checkpoint is already published, public + ungated, at `yusufizzetmurat/fed-pulse-multi-axis-text-classifier`.

## Change

`_resolve_checkpoint_path` now tries, in order: env override -> local path -> **Hub download** (`text_multi_axis_best.pt`). The Hub pull is memoized (downloads once) and fail-safe (any failure -> returns the local path -> graceful degradation, no retry/log-flood). Result: `checkpoint_exists()` is true in every environment, so our own model serves everywhere and **FOMC-RoBERTa is never reached at runtime** (it stays a documented baseline). Repo overridable via `FED_PULSE_MULTI_AXIS_HF_REPO`.

## Verification

- 10 tests pass (3 new: env-override precedence, Hub-pull when no local, graceful fallback on Hub failure). ruff + mypy --strict clean.
- Live end-to-end (CPU, no local checkpoint): resolver pulls from Hub, `checkpoint_exists()` True, hawkish probe classifies as hawkish.

## Why not a new fine-tune

A clean head-to-head (our model vs FOMC-RoBERTa) isn't possible on existing labels — both trained on all available labeled sources, so every comparison is contaminated for one side (multi-axis 0.90 and FOMC-RoBERTa 0.81 are both leak-inflated; on a mutually-clean cross-scheme test both land ~0.55). A genuinely fair eval needs fresh labels neither trained on. So the right move is to serve the model we already have, not train a redundant one.