### PR TITLE
Wire volume head into serving: GET /forecast/volume

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1675,6 +1675,41 @@ async def forecast_realized_vol(
     )
 
 
+@app.get("/forecast/volume")
+async def forecast_volume_endpoint(
+    symbol: str = Query(
+        "^GSPC",
+        description="Market ticker; the volume head is SPX-trained (^GSPC).",
+        min_length=1,
+        max_length=32,
+        pattern=r"^[A-Za-z0-9._=^/-]+$",
+    ),
+) -> Any:
+    """Multi-horizon expected-volume forecast (HAR volume head; see wiki page 25).
+
+    Pulls the published volume-head artifact (HF fallback) and applies the HAR
+    log-volume coefficients to recent daily volume. Returns a structured 503 when
+    the artifact or history is unavailable.
+    """
+    from app.services.volume_head import VolumeForecasterUnavailable, forecast_volume
+
+    try:
+        return await run_in_threadpool(forecast_volume, symbol)
+    except VolumeForecasterUnavailable as exc:
+        raise HTTPException(
+            status_code=503, detail={"error": "volume_head_unavailable", "message": str(exc)}
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=503, detail={"error": "history_invalid", "message": str(exc)}
+        ) from exc
+    except Exception as exc:  # pragma: no cover - defensive against yfinance/HF surprises
+        logger.warning("volume_forecast_failed", exc_info=True)
+        raise HTTPException(
+            status_code=503, detail={"error": "forecast_failed", "message": str(exc)}
+        ) from exc
+
+
 @app.get("/forecast/regime/baselines", response_model=HarTercileBaselineResponse)
 async def forecast_regime_baselines(
     symbol: str = Query(

--- a/backend/app/services/volume_head.py
+++ b/backend/app/services/volume_head.py
@@ -1,0 +1,137 @@
+"""Serving for the volume head — forward daily volume forecast.
+
+Loads the published HAR volume-head artifact (per-horizon Corsi-lag coefficients
+on log-volume) and emits a multi-horizon "expected volume" forecast. Mirrors
+``rv_forecaster``: the artifact is pulled from the Hub when no local copy exists
+(public + ungated), so the forecast is available in every environment. Volume is
+persistence-dominated (lag-1 autocorr ~0.99) so HAR is the deployed model; see
+wiki page 25.
+
+Self-contained on purpose (its own response models live here, not in schemas.py)
+so wiring it adds only one endpoint and touches no shared module.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+from pathlib import Path
+from typing import Any, cast
+
+from pydantic import BaseModel, Field
+
+from app.config import MODEL_CHECKPOINT_DIR
+
+logger = logging.getLogger(__name__)
+
+HF_REPO_ID = "yusufizzetmurat/fomc-rv-qlike-forecaster"
+_ARTIFACT_IN_REPO = "volume_head/volume_head_artifact.json"
+_LOCAL_ARTIFACT = MODEL_CHECKPOINT_DIR / "volume_head_artifact.json"
+_HORIZON_DAYS = {"h1": 1, "h5": 5, "h22": 22}
+
+_spec_cache: dict[str, Any] | None = None
+
+
+class VolumeForecasterUnavailable(RuntimeError):
+    """Raised when the volume-head artifact cannot be loaded (offline / missing)."""
+
+
+class VolumeHorizonForecast(BaseModel):
+    horizon_days: int = Field(..., description="Forecast horizon in trading days.")
+    expected_log_volume: float = Field(..., description="Forecast mean log-volume over the horizon.")
+    expected_volume: float = Field(..., description="exp(expected_log_volume) — volume level.")
+
+
+class VolumeForecastResponse(BaseModel):
+    symbol: str
+    horizons: list[VolumeHorizonForecast]
+    model: str = Field("volume-head-HAR", description="Deployed model (HAR on log-volume lags).")
+
+
+def _hf_token() -> str | None:
+    return os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_HUB_TOKEN")
+
+
+def _download_artifact() -> dict[str, Any]:
+    try:
+        from huggingface_hub import hf_hub_download
+
+        path = hf_hub_download(
+            repo_id=HF_REPO_ID, filename=_ARTIFACT_IN_REPO, token=_hf_token()
+        )
+    except Exception as exc:  # noqa: BLE001 - surface as a typed unavailable error
+        raise VolumeForecasterUnavailable(
+            f"could not fetch volume-head artifact from {HF_REPO_ID!r}: {exc}"
+        ) from exc
+    return cast(dict[str, Any], json.loads(Path(path).read_text(encoding="utf-8")))
+
+
+def _load_spec() -> dict[str, Any]:
+    """Local artifact if present, else pull from the Hub (memoized)."""
+    global _spec_cache
+    if _spec_cache is not None:
+        return _spec_cache
+    if _LOCAL_ARTIFACT.exists():
+        _spec_cache = cast(dict[str, Any], json.loads(_LOCAL_ARTIFACT.read_text(encoding="utf-8")))
+    else:
+        _spec_cache = _download_artifact()
+    return _spec_cache
+
+
+def _har_features(log_volume: list[float]) -> list[float]:
+    """Corsi HAR features: [lag1, mean over last 5, mean over last 22]."""
+    if len(log_volume) < 22:
+        raise ValueError(f"need >=22 days of volume history, got {len(log_volume)}")
+    return [
+        log_volume[-1],
+        sum(log_volume[-5:]) / 5,
+        sum(log_volume[-22:]) / 22,
+    ]
+
+
+def predict_volume(log_volume_history: list[float], symbol: str = "^GSPC") -> VolumeForecastResponse:
+    """Forecast forward mean log-volume at each horizon from recent daily log-volume.
+
+    ``log_volume_history`` is the trailing series of daily log(volume) (most recent
+    last, >= 22 points). Applies the saved per-horizon standardization + HAR
+    coefficients from the artifact.
+    """
+    spec = _load_spec()
+    feats = _har_features(log_volume_history)
+    horizons: list[VolumeHorizonForecast] = []
+    for key, days in _HORIZON_DAYS.items():
+        h = spec["by_horizon"].get(key)
+        if h is None:
+            continue
+        std = [(feats[i] - h["feat_mean"][i]) / (h["feat_std"][i] or 1.0) for i in range(len(feats))]
+        log_vol = float(sum(std[i] * h["coef"][i] for i in range(len(std))) + h["intercept"])
+        horizons.append(
+            VolumeHorizonForecast(
+                horizon_days=days,
+                expected_log_volume=round(log_vol, 6),
+                expected_volume=round(math.exp(log_vol), 2),
+            )
+        )
+    if not horizons:
+        raise VolumeForecasterUnavailable("artifact has no usable horizons")
+    return VolumeForecastResponse(symbol=symbol, horizons=horizons, model="volume-head-HAR")
+
+
+def load_recent_log_volume(symbol: str = "^GSPC", lookback_days: int = 60) -> list[float]:
+    """Recent daily log-volume for the symbol (yfinance), most-recent last."""
+    import yfinance as yf
+
+    hist = yf.Ticker(symbol).history(period=f"{lookback_days}d", auto_adjust=False)
+    if hist is None or hist.empty or "Volume" not in hist.columns:
+        raise VolumeForecasterUnavailable(f"no volume history for {symbol!r}")
+    vols = [float(v) for v in hist["Volume"].tolist() if v and v > 0]
+    if len(vols) < 22:
+        raise VolumeForecasterUnavailable(f"insufficient volume history for {symbol!r} ({len(vols)})")
+    return [math.log(v) for v in vols]
+
+
+def forecast_volume(symbol: str = "^GSPC") -> VolumeForecastResponse:
+    """End-to-end: fetch recent volume and forecast forward volume for the symbol."""
+    return predict_volume(load_recent_log_volume(symbol), symbol=symbol)

--- a/tests/unit/test_volume_head.py
+++ b/tests/unit/test_volume_head.py
@@ -1,0 +1,67 @@
+"""Unit tests for the volume-head serving loader (no network)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from app.services import volume_head as vh
+
+
+def _fake_spec() -> dict:
+    # identity standardization, coef picks lag1 only, +5 intercept -> easy to check
+    h = {"feat_mean": [0.0, 0.0, 0.0], "feat_std": [1.0, 1.0, 1.0], "coef": [1.0, 0.0, 0.0], "intercept": 5.0}
+    return {"model": "volume-head-HAR", "by_horizon": {"h1": h, "h5": h, "h22": h}}
+
+
+def test_har_features_lag1_mean5_mean22():
+    lv = [float(i) for i in range(22)]  # 0..21
+    feats = vh._har_features(lv)
+    assert feats[0] == 21.0  # lag1 = last
+    assert feats[1] == pytest.approx(sum(range(17, 22)) / 5)  # mean last 5
+    assert feats[2] == pytest.approx(sum(range(22)) / 22)  # mean last 22
+
+
+def test_har_features_requires_22():
+    with pytest.raises(ValueError, match=">=22"):
+        vh._har_features([1.0] * 10)
+
+
+def test_predict_volume_applies_coefficients(monkeypatch):
+    monkeypatch.setattr(vh, "_spec_cache", _fake_spec())  # skip load
+    lv = [0.0] * 21 + [10.0]  # lag1 = 10
+    out = vh.predict_volume(lv, symbol="^GSPC")
+    h1 = next(h for h in out.horizons if h.horizon_days == 1)
+    # pred = lag1*1 + 0 + 0 + 5 = 15
+    assert h1.expected_log_volume == pytest.approx(15.0)
+    assert h1.expected_volume == pytest.approx(math.exp(15.0), rel=1e-6)
+    assert {h.horizon_days for h in out.horizons} == {1, 5, 22}
+
+
+def test_load_spec_pulls_from_hf_when_no_local(monkeypatch, tmp_path):
+    import json
+
+    import huggingface_hub
+
+    monkeypatch.setattr(vh, "_spec_cache", None)
+    monkeypatch.setattr(vh, "_LOCAL_ARTIFACT", tmp_path / "absent.json")
+    art = tmp_path / "hf.json"
+    art.write_text(json.dumps(_fake_spec()))
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", lambda **k: str(art))
+    spec = vh._load_spec()
+    assert "by_horizon" in spec and "h1" in spec["by_horizon"]
+
+
+def test_load_spec_raises_unavailable_on_hf_failure(monkeypatch, tmp_path):
+    import huggingface_hub
+
+    monkeypatch.setattr(vh, "_spec_cache", None)
+    monkeypatch.setattr(vh, "_LOCAL_ARTIFACT", tmp_path / "absent.json")
+
+    def _boom(**k):
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", _boom)
+    with pytest.raises(vh.VolumeForecasterUnavailable, match="could not fetch"):
+        vh._load_spec()


### PR DESCRIPTION
## What

Makes the volume head **live and reachable** (it was a published artifact with no serving path). New self-contained `app/services/volume_head.py` + one appended `GET /forecast/volume` endpoint.

## How (conflict-safe by design)

- All logic + Pydantic response models live in the **new** `volume_head.py` — **no `schemas.py` change**.
- `main.py`: a single appended endpoint between `/forecast/realized-vol` and `/forecast/regime/baselines`, with function-local imports and structured 503s — mirrors the `rv_forecaster` pattern exactly.
- The artifact is pulled from HF (`fomc-rv-qlike-forecaster/volume_head/volume_head_artifact.json`, public+ungated) when no local copy exists (memoized; typed `VolumeForecasterUnavailable` on failure -> graceful 503).

## Verification

- 5 unit tests (HAR-feature math, coefficient application, HF-pull fallback, unavailable-on-failure); ruff (whole `backend`) + mypy --strict clean on the service.
- Live end-to-end: `^GSPC` -> expected volume 3.6B / 3.8B / 4.3B at 1d/1w/1mo.

## Notes

- HAR volume head (forward daily log-volume), per wiki page 25. The frontend 'expected volume' card can now consume `/forecast/volume`.
- Minor: `load_recent_log_volume` includes today's (possibly partial) day as the last point; the HAR 5-/22-day means smooth it, but a follow-up could drop the partial last bar for tighter 1-day forecasts.