### PR TITLE
fix: HAR + RV backtests on-demand over FOMC calendar; collapsible cards; reorder workspace

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2087,11 +2087,13 @@ def forecast_har_tercile_backtest(
 ) -> HarTercileBacktestResponse:
     """Backtest the last N HAR-tercile predictions for ``symbol``.
 
-    Walks the persisted ``analysis_runs`` table, lines up each row's
-    predicted tercile with the realized tercile from the forward
-    10-trading-day window, and returns the rows + aggregate accuracy
-    metrics. Mirrors the ``^GSPC``-only constraint on the upstream
-    HAR-tercile baseline endpoint (the cutoffs are SPX-trained).
+    Walks the published FOMC meeting calendar (most-recent first),
+    runs the HAR-tercile prediction on the rolling RV history strictly
+    before each event, and lines it up against the realized tercile
+    from the forward 10-trading-day window. Returns the rows +
+    aggregate accuracy metrics. Mirrors the ``^GSPC``-only constraint
+    on the upstream HAR-tercile baseline endpoint (the cutoffs are
+    SPX-trained).
     """
 
     if symbol != "^GSPC":

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1726,8 +1726,8 @@ class SemanticDiffResponse(BaseModel):
 class HarTercileBacktestRow(BaseModel):
     """One resolved (or pending) row in the HAR-tercile backtest table.
 
-    A row carries the persisted predicted tercile (read off the analyze
-    payload's ``regime_classification`` card) and, when the forward
+    A row carries the HAR-tercile prediction computed on the rolling
+    RV history available at the FOMC event date plus, when the forward
     window has elapsed, the realized tercile bucketed off the same
     cutoffs that produced the prediction. ``correct`` is None for rows
     whose forward window has not yet closed.
@@ -1765,9 +1765,9 @@ class HarAccuracyMetrics(BaseModel):
 class HarTercileBacktestResponse(BaseModel):
     """Response wire shape for ``GET /forecast/har-tercile-backtest``.
 
-    Surfaces the last N persisted ^GSPC analyze runs with their stored
-    HAR-tercile prediction and the realized tercile derived from
-    forward market history. Drives the HarAccuracyPanel card.
+    Surfaces the last N FOMC meetings with their on-demand HAR-tercile
+    prediction and the realized tercile derived from forward market
+    history. Drives the HarAccuracyPanel card.
     """
 
     model_config = _FORBID_FROZEN_CONFIG

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1736,8 +1736,8 @@ class HarTercileBacktestRow(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 
     event_date: str
-    predicted_tercile: str
-    predicted_prob: float
+    predicted_tercile: str | None = None
+    predicted_prob: float | None = None
     realized_tercile: str | None = None
     realized_rv: float | None = None
     correct: bool | None = None

--- a/backend/app/services/fomc_calendar.py
+++ b/backend/app/services/fomc_calendar.py
@@ -125,6 +125,11 @@ def list_past_meetings(
     if limit <= 0:
         return []
     reference = as_of or date.today()
+    # Strict ``<`` excludes any meeting whose first day is today: on the
+    # day a two-day FOMC meeting starts, statement release is still 24h
+    # away, so dropping it from the backtest universe is correct. Same
+    # for the statement-release day itself — meeting_date is already
+    # yesterday by then and the row reappears via the ``<`` boundary.
     past = [m for m in _SCHEDULE if m.meeting_date < reference]
     past.sort(key=lambda m: m.meeting_date, reverse=True)
     return past[:limit]

--- a/backend/app/services/fomc_calendar.py
+++ b/backend/app/services/fomc_calendar.py
@@ -108,3 +108,23 @@ def get_calendar(
 
 def list_all_meetings() -> tuple[FomcMeeting, ...]:
     return _SCHEDULE
+
+
+def list_past_meetings(
+    *,
+    as_of: date | None = None,
+    limit: int = 10,
+) -> list[FomcMeeting]:
+    """Return the most recent ``limit`` FOMC meetings whose date < ``as_of``.
+
+    Ordered most-recent first so callers walking the historical series
+    naturally see the freshest meeting at index 0. ``limit`` is clamped
+    to non-negative; a zero limit returns an empty list.
+    """
+
+    if limit <= 0:
+        return []
+    reference = as_of or date.today()
+    past = [m for m in _SCHEDULE if m.meeting_date < reference]
+    past.sort(key=lambda m: m.meeting_date, reverse=True)
+    return past[:limit]

--- a/backend/app/services/har_tercile_backtest.py
+++ b/backend/app/services/har_tercile_backtest.py
@@ -63,13 +63,18 @@ _TERCILE_LABELS: tuple[str, str, str] = ("low", "medium", "high")
 # trainer's 60-trading-day cutoff window.
 _RV_HISTORY_WINDOW = 60
 _MIN_RV_HISTORY = 22
-_FORWARD_STEPS = 10
-_FORWARD_WINDOW_DAYS = 30
-
-# Picks the closest horizon to the 10-bar forward window so the panel
-# compares apples-to-apples. ``predict_har_regime`` emits per-horizon
-# rows at h=1/5/22; h=22 is the closest match to the forward window.
-_PREDICTION_HORIZON = 22
+# Use h=1 throughout so the prediction horizon matches the realized
+# window exactly: predict_har_regime emits a row predicting the next
+# trading day's variance, and we resolve the realized side as that
+# same single forward bar's squared log-return. Earlier revisions
+# averaged 10 forward bars against an h=22 point forecast — the
+# distribution of single-bar variance and the distribution of 10-bar
+# mean variance are not the same, so the cutoffs (quantiles of
+# single-bar variance from predict_har_regime) and the comparand
+# (mean of 10 bars) were in different spaces.
+_FORWARD_STEPS = 1
+_FORWARD_WINDOW_DAYS = 7
+_PREDICTION_HORIZON = 1
 
 
 def _coerce_float(value: Any) -> float | None:
@@ -90,6 +95,25 @@ def _bucket_against_cutoffs(value: float, q33: float, q67: float) -> str:
     if value < q67:
         return "medium"
     return "high"
+
+
+def _pending_row(event_date: str) -> dict[str, Any]:
+    """Surface a meeting that we attempted but couldn't fully resolve.
+
+    Emitted when the leading RV window was too short, predict_har_regime
+    produced no usable row, or the realized forward bar has not closed
+    yet. Counted in ``total_runs`` (so the operator sees N attempted
+    vs N resolved) but excluded from accuracy / hit-rate denominators.
+    """
+
+    return {
+        "event_date": event_date,
+        "predicted_tercile": None,
+        "predicted_prob": None,
+        "realized_tercile": None,
+        "realized_rv": None,
+        "correct": None,
+    }
 
 
 def _realized_variance_from_log_returns(log_returns: list[float]) -> float | None:
@@ -187,6 +211,8 @@ def _fetch_rv_history_for_cutoffs_uncached(event_date: str, symbol: str) -> list
     if close_series is None or len(close_series) < 3:
         return []
     try:
+        from app.data.intraday_rv_forecast import _EPS as _RVEPS
+
         closes = np.asarray(close_series, dtype=np.float64)
         closes = closes[np.isfinite(closes) & (closes > 0.0)]
         if closes.size < 2:
@@ -196,6 +222,10 @@ def _fetch_rv_history_for_cutoffs_uncached(event_date: str, symbol: str) -> list
         rv = rv[np.isfinite(rv) & (rv > 0.0)]
         if rv.size == 0:
             return []
+        # Floor at the same epsilon predict_har_regime uses internally
+        # so a downstream rv > 0 guard cannot trip on a value that
+        # rounds to zero during the float() cast below.
+        rv = np.maximum(rv, _RVEPS)
         tail = rv[-_RV_HISTORY_WINDOW:]
         return [float(v) for v in tail]
     except Exception:
@@ -333,8 +363,22 @@ def build_har_tercile_backtest(
     """
 
     from app.services.fomc_calendar import list_past_meetings
+    from app.services.rv_forecaster import RvForecasterUnavailable
 
     meetings = list_past_meetings(limit=limit)
+
+    # Probe the HAR predictor once at the loop top so a missing artifact
+    # surfaces as a clean 503 at the endpoint layer rather than every
+    # row collapsing silently into "pending" (which would be visually
+    # indistinguishable from a legitimate "all-events-too-recent" state).
+    # `_predict_for_meeting` itself swallows broad exceptions per row;
+    # the explicit probe here re-raises the well-known sentinel.
+    try:
+        from app.services.rv_forecaster import _RvPredictor
+
+        _RvPredictor.get()
+    except RvForecasterUnavailable:
+        raise
 
     out_rows: list[dict[str, Any]] = []
     seen_dates: set[str] = set()
@@ -346,12 +390,16 @@ def build_har_tercile_backtest(
 
         rv_history = _fetch_rv_history_for_cutoffs(event_date, symbol)
         if len(rv_history) < _MIN_RV_HISTORY:
-            # Not enough leading data to run HAR; skip the row entirely
-            # so the panel denominator stays honest.
+            # Not enough leading data to run HAR. Surface as a pending
+            # row (matches the RV-backtest sibling's pattern) so the
+            # operator can see how many events we attempted vs how many
+            # had usable history.
+            out_rows.append(_pending_row(event_date))
             continue
 
         predicted_label, predicted_prob, q33, q67 = _predict_for_meeting(rv_history)
         if predicted_label is None or q33 is None or q67 is None:
+            out_rows.append(_pending_row(event_date))
             continue
 
         realized_rv = _fetch_realized_rv_yf(event_date, symbol)

--- a/backend/app/services/har_tercile_backtest.py
+++ b/backend/app/services/har_tercile_backtest.py
@@ -272,7 +272,8 @@ def _predict_for_meeting(
     label = target.get("tercile") if isinstance(target.get("tercile"), str) else None
     if label not in _TERCILE_LABELS:
         return None, None, None, None
-    probs = target.get("tercile_probs") if isinstance(target.get("tercile_probs"), dict) else {}
+    raw_probs = target.get("tercile_probs")
+    probs: dict[str, Any] = raw_probs if isinstance(raw_probs, dict) else {}
     prob = _coerce_float(probs.get(label))
     q33 = _coerce_float(out.get("cutoffs_q33"))
     q67 = _coerce_float(out.get("cutoffs_q67"))

--- a/backend/app/services/har_tercile_backtest.py
+++ b/backend/app/services/har_tercile_backtest.py
@@ -1,36 +1,26 @@
-"""Backtest the last N HAR-tercile predictions against realized terciles.
+"""Backtest HAR-tercile regime predictions against realized terciles.
 
-Walks the persisted ``analysis_runs`` table for ``^GSPC``, extracts the
-predicted tercile from each row's analyze payload, and resolves the
-realized tercile off the forward 10-trading-day market history. Powers
-the HarAccuracyPanel card: an aggregate hit-rate plus per-tercile
-break-down + a compact row table.
+Walks the published FOMC meeting calendar (most recent first), replays
+``services.har_tercile.predict_har_regime`` against the rolling-window
+RV history that the model would have seen at each historical event
+date, and compares the predicted tercile to the realized tercile from
+the forward 10-trading-day window.
+
+This is the on-demand variant of the panel. The earlier service read a
+``har_baselines`` block off ``analysis_runs.payload``, but the
+``/analyze`` pipeline never wrote that block — so the predicted-tercile
+column was actually the late-fusion regime argmax mapped onto the
+tercile vocabulary, and the realized column was bucketed against
+unrelated cutoffs. Resolving the prediction on demand against the same
+RV history the live HAR-tercile endpoint sees keeps the predicted +
+realized columns in the same cutoff space.
 
 All bucketing is done in daily **realized-variance** space so the
 comparison reproduces what ``services.har_tercile.predict_har_regime``
-sees at prediction time. That upstream operates on daily RV =
-``log_return ** 2`` (the convention ``main._load_rv_history`` writes for
-both the parquet path and the yfinance fallback), and the persisted
-``har_baselines.cutoffs_q33`` / ``cutoffs_q67`` are quantiles of that
-series via ``np.quantile`` with linear interpolation. The backtest
-mirrors both choices:
-
-* Realized RV over the forward 10-bar window is the mean of squared
-  log-returns (so the scalar lives in the same variance space as the
-  per-bar series that fed the prediction).
-* Fallback cutoffs are computed off a 60-day series of daily
-  ``log_return ** 2`` values, then quantiled with ``np.quantile``
-  ``[1/3, 2/3]`` — byte-for-byte the same op the upstream uses on its
-  own training fold.
-
-Realized RV is read from the persisted payload's
-``forward_realized_vol_10d`` slot when present (forward-compat with the
-analyze response carrying that variance summary on future builds) and
-falls back to a fresh yfinance pull via ``fetch_event_study_window``
-otherwise. Cutoffs default to the ones the prediction recorded
-(``cutoffs_q33`` / ``cutoffs_q67`` on the persisted ``har_baselines``
-block when set) and otherwise recompute on a 60-day RV window so a row
-that pre-dates the cutoff persistence still bucks honest.
+sees at prediction time. The realized forward window scalar is the
+mean of squared log-returns over the post-event bars — a one-period
+daily variance averaged across the 10-bar forward window, in the same
+variance space as the per-bar RV series the cutoffs were quantiled on.
 """
 
 from __future__ import annotations
@@ -38,17 +28,15 @@ from __future__ import annotations
 import math
 import time
 from datetime import datetime, timezone
-from typing import Any, Iterable
+from typing import Any
 
 import numpy as np
-from sqlalchemy import select
-from sqlalchemy.orm import Session
 
-from app.db import AnalysisRun
+from sqlalchemy.orm import Session  # kept for signature compatibility
 
 
 # In-process TTL cache for the yfinance round trips that resolve
-# realized RV and trailing cutoff history. The backtest panel renders
+# realized RV and trailing RV history. The backtest panel renders
 # the same ``(event_date, symbol)`` pairs across consecutive
 # dashboard hits, so a short staleness window amortises the network
 # hop without leaking yesterday's realisation into today's chart.
@@ -66,27 +54,22 @@ def reset_caches() -> None:
     _rv_history_cache.clear()
 
 
-# Mirror the HAR-tercile label space (low / medium / high). The
-# /analyze response stores the late-fusion classifier under
-# ``regime_classification`` using the (calm / normal / high) label
-# space; this table maps it onto the HAR-tercile vocabulary so the
-# backtest is comparable.
 _TERCILE_LABELS: tuple[str, str, str] = ("low", "medium", "high")
-_REGIME_TO_TERCILE = {
-    "calm": "low",
-    "low": "low",
-    "normal": "medium",
-    "medium": "medium",
-    "high": "high",
-}
 
-# Trailing window the realized-tercile fallback uses to recompute
-# cutoffs when the persisted prediction did not pin them. Matches the
-# 60-trading-day window the HAR-tercile baseline trains its cutoffs on
-# in the research-side trainer.
-_FALLBACK_CUTOFF_WINDOW = 60
+# Trailing window the RV-history fetcher pulls per event. Sized to give
+# ``predict_har_regime`` (which requires at least 22 daily RV values
+# for the monthly HAR lag) a generous margin while keeping the cutoffs
+# anchored to a recent volatility regime. Matches the upstream HAR
+# trainer's 60-trading-day cutoff window.
+_RV_HISTORY_WINDOW = 60
+_MIN_RV_HISTORY = 22
 _FORWARD_STEPS = 10
 _FORWARD_WINDOW_DAYS = 30
+
+# Picks the closest horizon to the 10-bar forward window so the panel
+# compares apples-to-apples. ``predict_har_regime`` emits per-horizon
+# rows at h=1/5/22; h=22 is the closest match to the forward window.
+_PREDICTION_HORIZON = 22
 
 
 def _coerce_float(value: Any) -> float | None:
@@ -101,121 +84,6 @@ def _coerce_float(value: Any) -> float | None:
     return result
 
 
-def _normalize_tercile_label(label: Any) -> str | None:
-    if not isinstance(label, str):
-        return None
-    key = label.strip().lower()
-    if not key:
-        return None
-    return _REGIME_TO_TERCILE.get(key) or (key if key in _TERCILE_LABELS else None)
-
-
-def _tercile_from_har_block(har_block: Any) -> tuple[str | None, float | None]:
-    """Read predicted tercile + prob from a persisted ``har_baselines`` block.
-
-    Prefers the 22-day horizon (closest to the 10-day forward resolution)
-    and falls back to whichever row carries a valid label.
-    """
-
-    if not isinstance(har_block, dict):
-        return None, None
-    horizons = har_block.get("horizons")
-    if not isinstance(horizons, list):
-        return None, None
-    ordered = sorted(
-        (h for h in horizons if isinstance(h, dict)),
-        key=lambda h: abs(int(h.get("h", 0) or 0) - 22),
-    )
-    for row in ordered:
-        label = _normalize_tercile_label(row.get("tercile"))
-        if label is None:
-            continue
-        probs = row.get("tercile_probs") or {}
-        prob = _coerce_float(probs.get(label)) if isinstance(probs, dict) else None
-        return label, prob
-    return None, None
-
-
-def _tercile_from_regime_block(regime: Any) -> tuple[str | None, float | None]:
-    """Read predicted tercile + prob from a ``regime_classification`` block.
-
-    Maps the regime vocabulary (calm / normal / high) to terciles via
-    :func:`_normalize_tercile_label` and looks the probability up under
-    the original regime key first, falling back to the normalized label.
-    """
-
-    if not isinstance(regime, dict):
-        return None, None
-    argmax = _normalize_tercile_label(regime.get("argmax_class"))
-    if argmax is None:
-        return None, None
-    distribution = regime.get("distribution") or {}
-    if not isinstance(distribution, dict):
-        return argmax, None
-    raw_argmax = regime.get("argmax_class")
-    prob: float | None = None
-    if isinstance(raw_argmax, str):
-        prob = _coerce_float(distribution.get(raw_argmax))
-    if prob is None:
-        prob = _coerce_float(distribution.get(argmax))
-    return argmax, prob
-
-
-def _extract_predicted_tercile(payload: Any) -> tuple[str | None, float | None]:
-    """Pull the predicted tercile + its probability off a persisted payload.
-
-    Order of precedence:
-      1. ``har_baselines`` block (forward-compat: future builds may
-         persist the HAR-tercile card directly into the analyze payload).
-      2. ``regime_classification`` (active late-fusion regime card).
-    Returns ``(label, prob)`` with prob in [0, 1] when available; either
-    half may be None on a degraded payload.
-    """
-
-    if not isinstance(payload, dict):
-        return None, None
-    label, prob = _tercile_from_har_block(payload.get("har_baselines"))
-    if label is not None:
-        return label, prob
-    return _tercile_from_regime_block(payload.get("regime_classification"))
-
-
-def _extract_persisted_cutoffs(payload: Any) -> tuple[float | None, float | None]:
-    """Read q33 / q67 off the persisted ``har_baselines`` block when present."""
-
-    if not isinstance(payload, dict):
-        return None, None
-    har_block = payload.get("har_baselines")
-    if not isinstance(har_block, dict):
-        return None, None
-    q33 = _coerce_float(har_block.get("cutoffs_q33"))
-    q67 = _coerce_float(har_block.get("cutoffs_q67"))
-    return q33, q67
-
-
-def _extract_persisted_realized_rv(payload: Any) -> float | None:
-    """Pull the realized 10-day forward RV off the persisted payload.
-
-    Forward-compat: future analyze responses may stash the realized
-    forward-vol summary under ``forward_realized_vol_10d`` so the
-    backtest no longer needs the yfinance round trip. The current build
-    does not write that field, so this returns None and the caller
-    falls back to a live market fetch.
-    """
-
-    if not isinstance(payload, dict):
-        return None
-    direct = _coerce_float(payload.get("forward_realized_vol_10d"))
-    if direct is not None:
-        return direct
-    market = payload.get("market")
-    if isinstance(market, dict):
-        nested = _coerce_float(market.get("forward_realized_vol_10d"))
-        if nested is not None:
-            return nested
-    return None
-
-
 def _bucket_against_cutoffs(value: float, q33: float, q67: float) -> str:
     if value < q33:
         return "low"
@@ -227,14 +95,11 @@ def _bucket_against_cutoffs(value: float, q33: float, q67: float) -> str:
 def _realized_variance_from_log_returns(log_returns: list[float]) -> float | None:
     """Forward-window realized **variance** in the upstream RV convention.
 
-    Upstream (``app.main._load_rv_history``) builds the rv_history that
-    feeds ``predict_har_regime`` as the per-bar squared log-return
-    series (``r * r``). The HAR-tercile cutoffs are quantiles of that
-    variance series. To stay in the same space, the forward-window
-    realized stat is the mean of squared log-returns over the post-event
-    bars — a one-period daily variance averaged across the 10-bar
-    forward window. Returns None when the series is too short to be
-    meaningful.
+    The HAR-tercile cutoffs are quantiles of a per-bar variance series
+    (``r * r``). To stay in the same space, the forward-window realized
+    stat is the mean of squared log-returns over the post-event bars —
+    a one-period daily variance averaged across the 10-bar forward
+    window. Returns None when the series is too short to be meaningful.
     """
 
     if len(log_returns) < 2:
@@ -245,11 +110,8 @@ def _realized_variance_from_log_returns(log_returns: list[float]) -> float | Non
     return sum(sq) / len(sq)
 
 
-# Backwards-compat shim. The pre-fix helper returned a std (daily vol),
-# which disagreed with the variance-space upstream cutoffs and inflated
-# the panel's annualised vol column by ~sqrt(252). Kept as a thin alias
-# around the corrected variance form so older callers (and tests
-# asserting the helper is finite/positive) keep working.
+# Backwards-compat shim. Older tests import the legacy name; both
+# refer to the same variance-space helper.
 _realized_vol_from_log_returns = _realized_variance_from_log_returns
 
 
@@ -301,14 +163,14 @@ def _fetch_realized_rv_yf(event_date: str, symbol: str) -> float | None:
 
 
 def _fetch_rv_history_for_cutoffs_uncached(event_date: str, symbol: str) -> list[float]:
-    """Fetch the trailing 60-day daily realized **variance** for cutoff fallback.
+    """Fetch the trailing daily realized **variance** strictly before the event.
 
-    Returns a list of per-bar variance values (squared log-returns) in
-    the same space upstream's ``main._load_rv_history`` writes, so the
-    quantiles derived here are directly comparable to the cutoffs the
-    HAR-tercile model itself would have used. Returns an empty list on
-    any failure so the caller knows to leave the row unresolved rather
-    than raise.
+    Returns a list of per-bar variance values (squared log-returns)
+    ending strictly before ``event_date`` — the same series upstream's
+    ``main._load_rv_history`` writes, in the same units the cutoffs
+    derived from ``predict_har_regime`` will compare against. Returns
+    an empty list on any failure so the caller knows to leave the row
+    unresolved rather than raise.
     """
 
     try:
@@ -317,8 +179,8 @@ def _fetch_rv_history_for_cutoffs_uncached(event_date: str, symbol: str) -> list
         from datetime import datetime as _dt
 
         anchor = _dt.fromisoformat(event_date).date()
-        start = anchor - timedelta(days=_FALLBACK_CUTOFF_WINDOW * 2)
-        end = anchor
+        start = anchor - timedelta(days=_RV_HISTORY_WINDOW * 2)
+        end = anchor  # exclusive in the underlying yfinance call
         close_series = _download_close_series_in_window(symbol=symbol, start=start, end=end)
     except Exception:
         return []
@@ -331,10 +193,10 @@ def _fetch_rv_history_for_cutoffs_uncached(event_date: str, symbol: str) -> list
             return []
         log_returns = np.diff(np.log(closes))
         rv = log_returns * log_returns
-        rv = rv[np.isfinite(rv)]
+        rv = rv[np.isfinite(rv) & (rv > 0.0)]
         if rv.size == 0:
             return []
-        tail = rv[-_FALLBACK_CUTOFF_WINDOW:]
+        tail = rv[-_RV_HISTORY_WINDOW:]
         return [float(v) for v in tail]
     except Exception:
         return []
@@ -343,8 +205,8 @@ def _fetch_rv_history_for_cutoffs_uncached(event_date: str, symbol: str) -> list
 def _fetch_rv_history_for_cutoffs(event_date: str, symbol: str) -> list[float]:
     """TTL-cached wrapper around :func:`_fetch_rv_history_for_cutoffs_uncached`.
 
-    Mirrors the realized-RV cache: the trailing 60-bar variance series
-    is keyed off ``(event_date, symbol)`` so a single dashboard render
+    Mirrors the realized-RV cache: the trailing variance series is
+    keyed off ``(event_date, symbol)`` so a single dashboard render
     pays the yfinance hop once per event regardless of how many panel
     reloads land within the six-hour window.
     """
@@ -359,7 +221,7 @@ def _fetch_rv_history_for_cutoffs(event_date: str, symbol: str) -> list[float]:
     return value
 
 
-def _cutoffs_from_history(history: Iterable[float]) -> tuple[float | None, float | None]:
+def _cutoffs_from_history(history: Any) -> tuple[float | None, float | None]:
     """Tercile cutoffs on the supplied RV series.
 
     Uses ``np.quantile`` with the default linear-interpolation method on
@@ -378,36 +240,43 @@ def _cutoffs_from_history(history: Iterable[float]) -> tuple[float | None, float
     return float(q33), float(q67)
 
 
-def _resolve_realized_tercile(
-    *,
-    payload: Any,
-    event_date: str,
-    symbol: str,
-    pred_q33: float | None,
-    pred_q67: float | None,
-) -> tuple[str | None, float | None]:
-    """Best-effort resolution of the realized tercile for one row.
+def _predict_for_meeting(
+    rv_history: list[float],
+) -> tuple[str | None, float | None, float | None, float | None]:
+    """Run ``predict_har_regime`` on ``rv_history`` and read off the panel row.
 
-    Returns ``(label, realized_rv)``. Either half may be None on a
-    failure (no forward window yet, yfinance flake, missing cutoffs).
+    Returns ``(predicted_tercile, predicted_prob, q33, q67)``. Picks the
+    h=22 row from the per-horizon output (closest to the 10-day forward
+    window the realized stat covers). Any failure inside the predict
+    call collapses to a no-op tuple so the caller can skip the row.
     """
 
-    rv = _extract_persisted_realized_rv(payload)
-    if rv is None:
-        rv = _fetch_realized_rv_yf(event_date, symbol)
-    if rv is None:
-        return None, None
+    if not rv_history or len(rv_history) < _MIN_RV_HISTORY:
+        return None, None, None, None
+    try:
+        from app.services.har_tercile import predict_har_regime
 
-    if pred_q33 is not None and pred_q67 is not None and pred_q33 <= pred_q67:
-        return _bucket_against_cutoffs(rv, pred_q33, pred_q67), rv
-
-    history = _fetch_rv_history_for_cutoffs(event_date, symbol)
-    if not history:
-        return None, rv
-    q33, q67 = _cutoffs_from_history(history)
-    if q33 is None or q67 is None:
-        return None, rv
-    return _bucket_against_cutoffs(rv, q33, q67), rv
+        out = predict_har_regime(rv_history)
+    except Exception:
+        return None, None, None, None
+    horizons = out.get("horizons") if isinstance(out, dict) else None
+    if not isinstance(horizons, list):
+        return None, None, None, None
+    target = None
+    for row in horizons:
+        if isinstance(row, dict) and int(row.get("h", 0) or 0) == _PREDICTION_HORIZON:
+            target = row
+            break
+    if target is None:
+        return None, None, None, None
+    label = target.get("tercile") if isinstance(target.get("tercile"), str) else None
+    if label not in _TERCILE_LABELS:
+        return None, None, None, None
+    probs = target.get("tercile_probs") if isinstance(target.get("tercile_probs"), dict) else {}
+    prob = _coerce_float(probs.get(label))
+    q33 = _coerce_float(out.get("cutoffs_q33"))
+    q67 = _coerce_float(out.get("cutoffs_q67"))
+    return label, prob, q33, q67
 
 
 def _aggregate_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
@@ -451,45 +320,50 @@ def build_har_tercile_backtest(
 ) -> dict[str, Any]:
     """Assemble the HAR-tercile backtest payload for the panel.
 
-    Walks the last ``limit`` ``analysis_runs`` rows for ``symbol`` in
-    chronological-descending order, extracts the predicted tercile and
-    resolves the realized one, then aggregates a top-line accuracy KPI
-    + per-tercile hit-rate. Returns the dict-shape the endpoint wraps
-    in ``HarTercileBacktestResponse``.
+    Walks the published FOMC meeting calendar (most recent first) up to
+    ``limit`` events, predicts the HAR-tercile regime against the
+    rolling RV history strictly before each event, and resolves the
+    realized tercile from the forward 10-bar window. Deduplicates by
+    meeting date so the panel never carries two rows for the same
+    event. Returns the dict-shape the endpoint wraps in
+    ``HarTercileBacktestResponse``. ``session`` is accepted for API
+    compatibility but no longer consulted — the source of truth is the
+    FOMC calendar + on-demand RV history, not the persisted runs.
     """
 
-    stmt = (
-        select(AnalysisRun)
-        .where(AnalysisRun.symbol == symbol)
-        .order_by(AnalysisRun.created_at.desc())
-        .limit(limit)
-    )
-    rows = list(session.execute(stmt).scalars().all())
+    from app.services.fomc_calendar import list_past_meetings
+
+    meetings = list_past_meetings(limit=limit)
 
     out_rows: list[dict[str, Any]] = []
-    for row in rows:
-        payload = row.payload
-        predicted_label, predicted_prob = _extract_predicted_tercile(payload)
-        if predicted_label is None:
-            # No prediction we can backtest — skip the row entirely so
-            # the panel's denominator stays honest.
+    seen_dates: set[str] = set()
+    for meeting in meetings:
+        event_date = meeting.meeting_date.isoformat()
+        if event_date in seen_dates:
             continue
-        pred_q33, pred_q67 = _extract_persisted_cutoffs(payload)
-        event_date_str = str(row.document_date)
-        symbol_str = str(row.symbol)
-        realized_label, realized_rv = _resolve_realized_tercile(
-            payload=payload,
-            event_date=event_date_str,
-            symbol=symbol_str,
-            pred_q33=pred_q33,
-            pred_q67=pred_q67,
-        )
-        correct: bool | None = None
-        if realized_label is not None:
+        seen_dates.add(event_date)
+
+        rv_history = _fetch_rv_history_for_cutoffs(event_date, symbol)
+        if len(rv_history) < _MIN_RV_HISTORY:
+            # Not enough leading data to run HAR; skip the row entirely
+            # so the panel denominator stays honest.
+            continue
+
+        predicted_label, predicted_prob, q33, q67 = _predict_for_meeting(rv_history)
+        if predicted_label is None or q33 is None or q67 is None:
+            continue
+
+        realized_rv = _fetch_realized_rv_yf(event_date, symbol)
+        if realized_rv is None:
+            realized_label: str | None = None
+            correct: bool | None = None
+        else:
+            realized_label = _bucket_against_cutoffs(realized_rv, q33, q67)
             correct = realized_label == predicted_label
+
         out_rows.append(
             {
-                "event_date": event_date_str,
+                "event_date": event_date,
                 "predicted_tercile": predicted_label,
                 "predicted_prob": float(predicted_prob) if predicted_prob is not None else 0.0,
                 "realized_tercile": realized_label,

--- a/backend/app/services/rv_backtest.py
+++ b/backend/app/services/rv_backtest.py
@@ -1,162 +1,235 @@
-"""Backtest the last N QLIKE-RV predictions against realized RV.
+"""Backtest QLIKE-RV h=1 predictions against realized RV.
 
-Walks the persisted ``analysis_runs`` table for ``^GSPC``, aligns each
-row's event date to the daily realized variance series, replays the
-QLIKE-DLq h=1 ensemble + conformal bands on the leading prefix, and
-counts how many resolved rows fell inside the published 80% / 90%
-bands. Powers the RvAccuracyPanel card: empirical band coverage as a
-top-line KPI plus a per-row table the user can scan for outliers.
+Walks the published FOMC meeting calendar (most recent first), runs
+``services.rv_forecaster.predict_rv`` on the rolling daily-RV history
+strictly before each event, and compares the h=1 point + 80% / 90%
+conformal bands against the realized RV one trading day forward.
 
-The accuracy surface is **empirical band coverage** (in-band hit rate)
-rather than tercile / direction accuracy — that mirrors how the
-production model is calibrated. The conformal quantiles are tuned so
-80% of out-of-sample residuals land inside the 80% band on the eval
-pool; the backtest simply verifies that the published bands still hold
-their nominal coverage on the recent FOMC rows.
+This is the on-demand variant of the panel. The earlier service read
+the bands off ``analysis_runs.payload``, but the ``/analyze`` pipeline
+never persisted a ``realized_vol_forecast.historical_bands`` block, so
+the bands and the "in band" flags pointed at unrelated cutoffs.
+Resolving the prediction on demand against the same RV history the
+live ``/forecast/realized-vol`` endpoint sees keeps the predicted +
+realized columns in the same calibration space.
 
 Per-row resolution:
-  * Look up the row's ``document_date`` in the daily RV history.
-  * If the date sits at or beyond the warmup horizon (the HAR monthly
-    lag needs ~22 days of leading data), run the cached ensemble on
-    the leading prefix to derive the h=1 point + bands.
-  * The realized RV is the actual variance for the same bar; the row
-    is "in band" when the realized number falls between band_lo and
-    band_hi.
-  * Rows whose event date sits before the warmup horizon — or beyond
-    the right edge of the available RV history — surface as pending.
-
-The yfinance / parquet fetch for the RV history is shared with the
-``/forecast/realized-vol`` endpoint via ``app.main._load_rv_history``,
-so a backtest pull on a warm cache reuses the same data the
-VolatilityOutlookCard already consumes.
+  * Pull the trailing daily realized variance strictly before the
+    meeting date. If fewer than ``_MIN_RV_HISTORY`` bars come back,
+    emit a pending row -- the HAR monthly lag needs ~22 days of warmup
+    and the calibrated 60-day window the live card uses sits well
+    above that floor.
+  * Call ``predict_rv`` on the trailing window to derive the h=1
+    point + 80% / 90% bands.
+  * Fetch realized RV for the first trading day strictly after the
+    meeting. The row is "in band" when the realized number falls
+    between band_lo and band_hi.
+  * Rows whose realized RV has not yet resolved (forward window not
+    closed) surface with ``realized_rv = None`` and pending hit flags.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import math
+import time
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 import numpy as np
-from sqlalchemy import select
-from sqlalchemy.orm import Session
 
-from app.data.intraday_rv_forecast import _EPS as _RVEPS
-from app.db import AnalysisRun
-from app.services.rv_forecaster import (
-    _HISTORICAL_BANDS_WARMUP,
-    _RvPredictor,
-    _ensemble_log_rv,
-)
+from sqlalchemy.orm import Session  # kept for signature compatibility
+
+
+# In-process TTL cache for the yfinance round trips that resolve
+# realized RV and trailing RV history. The backtest panel renders the
+# same ``(event_date, symbol)`` pairs across consecutive dashboard
+# hits, so a short staleness window amortises the network hop without
+# leaking yesterday's realisation into today's chart. Six hours is a
+# safe upper bound: the h=1 realized bar resolves within a day, well
+# past the TTL.
+_BACKTEST_CACHE_TTL_SECONDS = 6 * 60 * 60
+_realized_rv_cache: dict[tuple[str, str], tuple[float, float | None]] = {}
+_rv_history_cache: dict[tuple[str, str], tuple[float, list[float]]] = {}
+
+
+def reset_caches() -> None:
+    """Clear the TTL caches. Exposed for tests."""
+
+    _realized_rv_cache.clear()
+    _rv_history_cache.clear()
 
 
 _FORECAST_HORIZON = 1
 
-# Backtest history window — wide enough to align persisted FOMC event
-# dates from the trailing year (~8 meetings/yr × 2y = ~16 events, well
-# above the default ``limit=10``) against the daily RV series. The live
-# ``/forecast/realized-vol`` card stays on the narrower 60-day default;
-# only the backtest pulls this wider tail so older persisted runs land
-# inside the dates index rather than the pre-history miss branch.
-_BACKTEST_HISTORY_DAYS = 504
+# Trailing window the RV-history fetcher pulls per event. Matches the
+# live ``/forecast/realized-vol`` 60-day default so the backtest's
+# prediction surface is byte-for-byte the same calibration window the
+# card consumes. ``_MIN_RV_HISTORY`` enforces enough leading data for
+# HAR's monthly lag.
+_RV_HISTORY_WINDOW = 60
+_MIN_RV_HISTORY = 60
 
 
-def _load_rv_series(symbol: str) -> tuple[list[float], list[str]]:
-    """Pull the daily RV series + ISO date stamps for ``symbol``.
-
-    Defers to ``app.main._load_rv_history`` so the backtest reads from
-    the same intraday-parquet-preferred / yfinance-fallback path the
-    ``/forecast/realized-vol`` endpoint uses, but requests a much wider
-    trailing window — the backtest needs to align persisted FOMC event
-    dates from prior months, not just the live forecast prefix. The
-    import is local so the service module does not pull main's full
-    transitive surface at import time.
-    """
-
-    from app.main import _load_rv_history
-
-    rv, dates = _load_rv_history(symbol, days=_BACKTEST_HISTORY_DAYS)
-    return rv, dates
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(result):
+        return None
+    return result
 
 
-def _predict_h1_bands(
-    rv_prefix: np.ndarray, predictor: _RvPredictor
-) -> tuple[float, float, float, float, float]:
-    """Run the QLIKE-DLq h=1 ensemble on ``rv_prefix``.
+def _fetch_realized_rv_yf_uncached(event_date: str, symbol: str) -> float | None:
+    """Pull the realized RV for the first trading bar after ``event_date``.
 
-    Returns ``(point, lo80, hi80, lo90, hi90)`` in RV (variance) space.
-    Reuses the singleton predictor + ``_ensemble_log_rv`` from
-    :mod:`app.services.rv_forecaster` so the bands match the live
-    ``/forecast/realized-vol`` surface byte-for-byte.
-    """
-
-    log_rv = np.log(rv_prefix + _RVEPS)
-    row = predictor.spec["by_horizon"][f"h{_FORECAST_HORIZON}"]
-    seeds = predictor.seed_models[f"h{_FORECAST_HORIZON}"]
-    log_point = _ensemble_log_rv(log_rv, row, seeds)
-    quants = row["conformal_quantiles"]
-    q80 = float(quants.get("0.20", 0.0))
-    q90 = float(quants.get("0.10", 0.0))
-    point = float(np.exp(log_point))
-    lo80 = float(np.exp(log_point - q80))
-    hi80 = float(np.exp(log_point + q80))
-    lo90 = float(np.exp(log_point - q90))
-    hi90 = float(np.exp(log_point + q90))
-    return point, lo80, hi80, lo90, hi90
-
-
-def _resolve_row(
-    *,
-    event_date: str,
-    rv: np.ndarray,
-    dates: list[str],
-    predictor: _RvPredictor,
-) -> dict[str, Any] | None:
-    """Build a single backtest row for ``event_date``.
-
-    Returns None when the date is not in the available RV history at
-    all — the caller surfaces the row as pending in that case via a
-    separate code path. Returns a populated row dict when the event
-    date sits at or beyond the warmup horizon; ``realized_rv`` is the
-    variance observed on the same bar, and ``in_band_*`` are populated
-    accordingly. Rows whose date falls inside the warmup window are
-    returned with ``realized_rv = None`` and pending hit flags so the
-    panel still renders them.
+    Wrapped behind a try / except so a yfinance flake on one row never
+    nukes the whole backtest -- the offending row just lands
+    unresolved. The returned scalar is the squared log-return for the
+    h=1 bar (single-period daily variance), matching the daily RV
+    space ``predict_rv`` emits its bands in.
     """
 
     try:
-        idx = dates.index(event_date)
-    except ValueError:
+        from app.services.market_data import fetch_event_study_window
+    except Exception:  # pragma: no cover -- import-time defensive
         return None
-    if idx < _HISTORICAL_BANDS_WARMUP:
-        # Not enough leading history to run HAR's monthly lag honestly.
-        # Surface the row as pending rather than dropping it; the panel
-        # still keeps a placeholder so the counter stays meaningful.
-        return {
-            "event_date": event_date,
-            "point_forecast_rv": None,
-            "band_lo_80": None,
-            "band_hi_80": None,
-            "band_lo_90": None,
-            "band_hi_90": None,
-            "realized_rv": None,
-            "in_band_80": None,
-            "in_band_90": None,
-            "_pending": True,
-        }
-    prefix = rv[:idx]
-    point, lo80, hi80, lo90, hi90 = _predict_h1_bands(prefix, predictor)
-    realized = float(rv[idx])
-    return {
-        "event_date": event_date,
-        "point_forecast_rv": point,
-        "band_lo_80": lo80,
-        "band_hi_80": hi80,
-        "band_lo_90": lo90,
-        "band_hi_90": hi90,
-        "realized_rv": realized,
-        "in_band_80": bool(lo80 <= realized <= hi80),
-        "in_band_90": bool(lo90 <= realized <= hi90),
-    }
+    try:
+        bars = fetch_event_study_window(
+            event_date=event_date,
+            symbol=symbol,
+            steps=1,
+            window_days=7,
+        )
+    except Exception:
+        return None
+    if not bars:
+        return None
+    log_return = _coerce_float(bars[0].get("log_return"))
+    if log_return is None:
+        return None
+    rv = log_return * log_return
+    if not math.isfinite(rv) or rv <= 0.0:
+        return None
+    return rv
+
+
+def _fetch_realized_rv_yf(event_date: str, symbol: str) -> float | None:
+    """TTL-cached wrapper around :func:`_fetch_realized_rv_yf_uncached`.
+
+    The backtest panel renders the same ``(event_date, symbol)`` pairs
+    repeatedly as the dashboard mounts; caching the variance scalar
+    for six hours absorbs those repeats without losing freshness once
+    the forward bar resolves on a later day.
+    """
+
+    key = (event_date, symbol)
+    now = time.monotonic()
+    cached = _realized_rv_cache.get(key)
+    if cached is not None and now - cached[0] < _BACKTEST_CACHE_TTL_SECONDS:
+        return cached[1]
+    value = _fetch_realized_rv_yf_uncached(event_date, symbol)
+    _realized_rv_cache[key] = (now, value)
+    return value
+
+
+def _fetch_rv_history_uncached(event_date: str, symbol: str) -> list[float]:
+    """Fetch the trailing daily realized variance strictly before the event.
+
+    Returns a list of per-bar variance values (squared log-returns)
+    ending strictly before ``event_date``, in chronological order.
+    The trailing window is sized to match the live ``/forecast/realized-vol``
+    card's 60-day calibration window. Returns an empty list on any
+    failure so the caller knows to surface the row as pending rather
+    than raise.
+    """
+
+    try:
+        from app.services.market_data import _download_close_series_in_window
+
+        anchor = date.fromisoformat(event_date)
+        start = anchor - timedelta(days=_RV_HISTORY_WINDOW * 3)
+        end = anchor  # exclusive in the underlying yfinance call
+        close_series = _download_close_series_in_window(
+            symbol=symbol, start=start, end=end
+        )
+    except Exception:
+        return []
+    if close_series is None or len(close_series) < 3:
+        return []
+    try:
+        closes = np.asarray(close_series, dtype=np.float64)
+        closes = closes[np.isfinite(closes) & (closes > 0.0)]
+        if closes.size < 2:
+            return []
+        log_returns = np.diff(np.log(closes))
+        rv = log_returns * log_returns
+        rv = rv[np.isfinite(rv) & (rv > 0.0)]
+        if rv.size == 0:
+            return []
+        tail = rv[-_RV_HISTORY_WINDOW:]
+        return [float(v) for v in tail]
+    except Exception:
+        return []
+
+
+def _fetch_rv_history(event_date: str, symbol: str) -> list[float]:
+    """TTL-cached wrapper around :func:`_fetch_rv_history_uncached`.
+
+    Mirrors the realized-RV cache: the trailing variance series is
+    keyed off ``(event_date, symbol)`` so a single dashboard render
+    pays the yfinance hop once per event regardless of how many panel
+    reloads land within the six-hour window.
+    """
+
+    key = (event_date, symbol)
+    now = time.monotonic()
+    cached = _rv_history_cache.get(key)
+    if cached is not None and now - cached[0] < _BACKTEST_CACHE_TTL_SECONDS:
+        return list(cached[1])
+    value = _fetch_rv_history_uncached(event_date, symbol)
+    _rv_history_cache[key] = (now, list(value))
+    return value
+
+
+def _predict_for_meeting(
+    rv_history: list[float],
+) -> tuple[float | None, float | None, float | None, float | None, float | None]:
+    """Run ``predict_rv`` on ``rv_history`` and read off the h=1 row.
+
+    Returns ``(point, lo80, hi80, lo90, hi90)`` in RV (variance) space.
+    Any failure inside the predict call collapses to a no-op tuple so
+    the caller can surface the row as pending.
+    """
+
+    if not rv_history or len(rv_history) < _MIN_RV_HISTORY:
+        return None, None, None, None, None
+    try:
+        from app.services.rv_forecaster import predict_rv
+
+        out = predict_rv(rv_history)
+    except Exception:
+        return None, None, None, None, None
+    horizons = out.get("horizons") if isinstance(out, dict) else None
+    if not isinstance(horizons, list):
+        return None, None, None, None, None
+    target = None
+    for row in horizons:
+        if isinstance(row, dict) and int(row.get("h", 0) or 0) == _FORECAST_HORIZON:
+            target = row
+            break
+    if target is None:
+        return None, None, None, None, None
+    point = _coerce_float(target.get("point"))
+    lo80 = _coerce_float(target.get("band_lo_80"))
+    hi80 = _coerce_float(target.get("band_hi_80"))
+    lo90 = _coerce_float(target.get("band_lo_90"))
+    hi90 = _coerce_float(target.get("band_hi_90"))
+    if None in (point, lo80, hi80, lo90, hi90):
+        return None, None, None, None, None
+    return point, lo80, hi80, lo90, hi90
 
 
 def _aggregate_coverage(rows: list[dict[str, Any]]) -> dict[str, Any]:
@@ -167,11 +240,12 @@ def _aggregate_coverage(rows: list[dict[str, Any]]) -> dict[str, Any]:
     coverage levels are pinned at the calibration targets so the
     frontend can render the gap chip without re-deriving them.
 
-    ``pending_runs`` carries the rows that could not be resolved — the
-    event date either sat inside HAR's warmup window or fell outside the
-    available RV history. Keeping it separate from ``resolved_runs``
-    lets the panel show "X resolved / Y pending" without polluting the
-    coverage ratio with rows we never even attempted to score.
+    ``pending_runs`` carries the rows that could not be scored -- the
+    trailing RV history was too short, the prediction call failed, or
+    the realized bar has not yet resolved. Keeping it separate from
+    ``resolved_runs`` lets the panel show "X resolved / Y pending"
+    without polluting the coverage ratio with rows we never even
+    attempted to score.
     """
 
     total = len(rows)
@@ -194,6 +268,22 @@ def _aggregate_coverage(rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _pending_row(event_date: str) -> dict[str, Any]:
+    """Build a pending-state row for ``event_date``."""
+
+    return {
+        "event_date": event_date,
+        "point_forecast_rv": None,
+        "band_lo_80": None,
+        "band_hi_80": None,
+        "band_lo_90": None,
+        "band_hi_90": None,
+        "realized_rv": None,
+        "in_band_80": None,
+        "in_band_90": None,
+    }
+
+
 def get_rv_backtest(
     session: Session,
     *,
@@ -202,68 +292,64 @@ def get_rv_backtest(
 ) -> dict[str, Any]:
     """Assemble the QLIKE-RV backtest payload for the panel.
 
-    Walks the last ``limit`` ``analysis_runs`` rows for ``symbol`` in
-    chronological-descending order, replays the QLIKE-DLq h=1 ensemble
-    on each event date's leading RV prefix, and tallies empirical band
-    coverage against the realized RV at the same bar. Returns the
-    dict-shape the endpoint wraps in ``RvBacktestResponse``.
+    Walks the published FOMC meeting calendar (most recent first) up
+    to ``limit`` events, predicts the h=1 RV + 80% / 90% bands against
+    the rolling RV history strictly before each event, and resolves
+    the realized RV from the first trading bar one day forward.
+    Deduplicates by meeting date so the panel never carries two rows
+    for the same event. Returns the dict-shape the endpoint wraps in
+    ``RvBacktestResponse``. ``session`` is accepted for API
+    compatibility but no longer consulted -- the source of truth is
+    the FOMC calendar + on-demand RV history, not the persisted runs.
     """
 
-    stmt = (
-        select(AnalysisRun)
-        .where(AnalysisRun.symbol == symbol)
-        .order_by(AnalysisRun.created_at.desc())
-        .limit(limit)
-    )
-    run_rows = list(session.execute(stmt).scalars().all())
+    from app.services.fomc_calendar import list_past_meetings
 
-    if not run_rows:
-        return {
-            "symbol": symbol,
-            "horizon": _FORECAST_HORIZON,
-            "rows": [],
-            "coverage": _aggregate_coverage([]),
-            "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        }
-
-    rv_list, dates = _load_rv_series(symbol)
-    rv = np.asarray(rv_list, dtype=np.float64)
-    predictor = _RvPredictor.get()
+    meetings = list_past_meetings(limit=limit)
 
     out_rows: list[dict[str, Any]] = []
-    for run in run_rows:
-        event_date = str(run.document_date)
-        resolved = _resolve_row(
-            event_date=event_date,
-            rv=rv,
-            dates=dates,
-            predictor=predictor,
-        )
-        if resolved is None:
-            # Event sits outside the available RV history (future
-            # meeting / pre-history). Surface as a pending row so the
-            # panel's denominator stays meaningful.
-            # Use None on every nullable field, matching the warmup-window
-            # pending branch above. The Pydantic float | None fields serialise
-            # nan as null today, but the conversion happens at the wire layer
-            # only — in-memory consumers (logging, metrics) would see nan,
-            # and the behaviour is undocumented across pydantic minor releases.
-            out_rows.append(
-                {
-                    "event_date": event_date,
-                    "point_forecast_rv": None,
-                    "band_lo_80": None,
-                    "band_hi_80": None,
-                    "band_lo_90": None,
-                    "band_hi_90": None,
-                    "realized_rv": None,
-                    "in_band_80": None,
-                    "in_band_90": None,
-                }
-            )
+    seen_dates: set[str] = set()
+    for meeting in meetings:
+        event_date = meeting.meeting_date.isoformat()
+        if event_date in seen_dates:
             continue
-        resolved.pop("_pending", None)
-        out_rows.append(resolved)
+        seen_dates.add(event_date)
+
+        rv_history = _fetch_rv_history(event_date, symbol)
+        if len(rv_history) < _MIN_RV_HISTORY:
+            # Not enough leading data to run predict_rv honestly.
+            # Surface the row as pending rather than dropping it; the
+            # panel still keeps a placeholder so the counter stays
+            # meaningful.
+            out_rows.append(_pending_row(event_date))
+            continue
+
+        point, lo80, hi80, lo90, hi90 = _predict_for_meeting(rv_history)
+        if point is None:
+            out_rows.append(_pending_row(event_date))
+            continue
+
+        realized_rv = _fetch_realized_rv_yf(event_date, symbol)
+        if realized_rv is None:
+            in_band_80: bool | None = None
+            in_band_90: bool | None = None
+        else:
+            in_band_80 = bool(lo80 <= realized_rv <= hi80)
+            in_band_90 = bool(lo90 <= realized_rv <= hi90)
+
+        out_rows.append(
+            {
+                "event_date": event_date,
+                "point_forecast_rv": point,
+                "band_lo_80": lo80,
+                "band_hi_80": hi80,
+                "band_lo_90": lo90,
+                "band_hi_90": hi90,
+                "realized_rv": realized_rv,
+                "in_band_80": in_band_80,
+                "in_band_90": in_band_90,
+            }
+        )
 
     coverage = _aggregate_coverage(out_rows)
     return {

--- a/backend/app/services/rv_backtest.py
+++ b/backend/app/services/rv_backtest.py
@@ -323,7 +323,17 @@ def get_rv_backtest(
             continue
 
         point, lo80, hi80, lo90, hi90 = _predict_for_meeting(rv_history)
-        if point is None:
+        # _predict_for_meeting collapses any failure mode (predict raised,
+        # horizons missing, partial band coverage) to an all-None tuple, so
+        # narrowing on any single component is sufficient — but explicitly
+        # narrowing all five keeps mypy --strict happy without runtime cost.
+        if (
+            point is None
+            or lo80 is None
+            or hi80 is None
+            or lo90 is None
+            or hi90 is None
+        ):
             out_rows.append(_pending_row(event_date))
             continue
 

--- a/backend/app/services/rv_backtest.py
+++ b/backend/app/services/rv_backtest.py
@@ -327,13 +327,7 @@ def get_rv_backtest(
         # horizons missing, partial band coverage) to an all-None tuple, so
         # narrowing on any single component is sufficient — but explicitly
         # narrowing all five keeps mypy --strict happy without runtime cost.
-        if (
-            point is None
-            or lo80 is None
-            or hi80 is None
-            or lo90 is None
-            or hi90 is None
-        ):
+        if point is None or lo80 is None or hi80 is None or lo90 is None or hi90 is None:
             out_rows.append(_pending_row(event_date))
             continue
 

--- a/backend/app/services/rv_backtest.py
+++ b/backend/app/services/rv_backtest.py
@@ -152,9 +152,7 @@ def _fetch_rv_history_uncached(event_date: str, symbol: str) -> list[float]:
         anchor = date.fromisoformat(event_date)
         start = anchor - timedelta(days=_RV_HISTORY_WINDOW * 3)
         end = anchor  # exclusive in the underlying yfinance call
-        close_series = _download_close_series_in_window(
-            symbol=symbol, start=start, end=end
-        )
+        close_series = _download_close_series_in_window(symbol=symbol, start=start, end=end)
     except Exception:
         return []
     if close_series is None or len(close_series) < 3:

--- a/backend/app/services/rv_backtest.py
+++ b/backend/app/services/rv_backtest.py
@@ -302,6 +302,18 @@ def get_rv_backtest(
     """
 
     from app.services.fomc_calendar import list_past_meetings
+    from app.services.rv_forecaster import RvForecasterUnavailable, _RvPredictor
+
+    # Probe the predictor once up front so a missing artifact surfaces
+    # as a 503 at the endpoint layer rather than every row collapsing
+    # into "pending" (which would be visually indistinguishable from a
+    # legitimate "all-events-too-recent" state). The per-row exception
+    # handler inside ``_predict_for_meeting`` still absorbs transient
+    # yfinance flakes without leaking them.
+    try:
+        _RvPredictor.get()
+    except RvForecasterUnavailable:
+        raise
 
     meetings = list_past_meetings(limit=limit)
 

--- a/frontend/components/analyze/ExpectedVolumeCard.tsx
+++ b/frontend/components/analyze/ExpectedVolumeCard.tsx
@@ -119,6 +119,8 @@ export interface ExpectedVolumeCardProps {
   loading?: boolean;
   error?: string | null;
   symbol?: string;
+  collapsible?: boolean;
+  storageKey?: string;
 }
 
 export function ExpectedVolumeCard({
@@ -126,6 +128,8 @@ export function ExpectedVolumeCard({
   loading = false,
   error = null,
   symbol,
+  collapsible = false,
+  storageKey,
 }: ExpectedVolumeCardProps) {
   if (loading) {
     return (
@@ -133,6 +137,8 @@ export function ExpectedVolumeCard({
         title="Expected Volume"
         description="HAR-volume forecast over market history"
         variant="forecast"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <p
           className="text-xs text-muted-foreground"
@@ -150,6 +156,8 @@ export function ExpectedVolumeCard({
         title="Expected Volume"
         description="HAR-volume forecast over market history"
         variant="forecast"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <p
           className="text-xs text-muted-foreground"
@@ -176,6 +184,8 @@ export function ExpectedVolumeCard({
       title="Expected Volume"
       description="HAR-volume forecast over market history"
       variant="forecast"
+      collapsible={collapsible}
+      storageKey={storageKey}
     >
       <div className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2">

--- a/frontend/components/analyze/FuturesConsensusPanel.tsx
+++ b/frontend/components/analyze/FuturesConsensusPanel.tsx
@@ -100,11 +100,15 @@ function StackedProbabilityBar({
 export interface FuturesConsensusPanelProps {
   data: FuturesConsensusResponse | null;
   loading?: boolean;
+  collapsible?: boolean;
+  storageKey?: string;
 }
 
 export function FuturesConsensusPanel({
   data,
   loading = false,
+  collapsible = false,
+  storageKey,
 }: FuturesConsensusPanelProps) {
   if (loading) {
     return (
@@ -112,6 +116,8 @@ export function FuturesConsensusPanel({
         title="FRED futures consensus"
         description="Fed-funds path via Treasury proxy (descriptive)"
         variant="descriptive"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <p
           className="text-xs text-muted-foreground"
@@ -129,6 +135,8 @@ export function FuturesConsensusPanel({
         title="FRED futures consensus"
         description="Fed-funds path via Treasury proxy (descriptive)"
         variant="descriptive"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <p
           className="text-xs text-muted-foreground"
@@ -150,6 +158,8 @@ export function FuturesConsensusPanel({
       title="FRED futures consensus"
       description="Fed-funds path via Treasury proxy (descriptive)"
       variant="descriptive"
+      collapsible={collapsible}
+      storageKey={storageKey}
     >
       <div className="space-y-3">
         <div className="flex flex-wrap items-start justify-between gap-3">

--- a/frontend/components/analyze/HarAccuracyPanel.tsx
+++ b/frontend/components/analyze/HarAccuracyPanel.tsx
@@ -19,11 +19,12 @@ import type {
 const TERCILE_ORDER: readonly HarTercileLabel[] = ["low", "medium", "high"];
 
 function tercileBadgeVariant(
-  label: HarTercileLabel,
-): "hawkish" | "dovish" | "neutral" {
+  label: HarTercileLabel | null,
+): "hawkish" | "dovish" | "neutral" | "outline" {
   if (label === "low") return "dovish";
   if (label === "high") return "hawkish";
-  return "neutral";
+  if (label === "medium") return "neutral";
+  return "outline";
 }
 
 function annualizedVolPct(rv: number | null | undefined): string {
@@ -159,16 +160,22 @@ function BacktestTable({ rows }: BacktestTableProps) {
                   {row.event_date}
                 </td>
                 <td className="px-3 py-2">
-                  <Badge
-                    variant={tercileBadgeVariant(row.predicted_tercile)}
-                    className="capitalize"
-                    data-testid={`har-accuracy-row-pred-${row.event_date}`}
-                  >
-                    {row.predicted_tercile}
-                  </Badge>
-                  <span className="ml-1.5 numeric text-[11px] text-muted-foreground tabular-nums">
-                    {formatProbPct(row.predicted_prob)}
-                  </span>
+                  {row.predicted_tercile ? (
+                    <>
+                      <Badge
+                        variant={tercileBadgeVariant(row.predicted_tercile)}
+                        className="capitalize"
+                        data-testid={`har-accuracy-row-pred-${row.event_date}`}
+                      >
+                        {row.predicted_tercile}
+                      </Badge>
+                      <span className="ml-1.5 numeric text-[11px] text-muted-foreground tabular-nums">
+                        {formatProbPct(row.predicted_prob)}
+                      </span>
+                    </>
+                  ) : (
+                    <span className="text-muted-foreground">pending</span>
+                  )}
                 </td>
                 <td className="px-3 py-2">
                   {row.realized_tercile ? (

--- a/frontend/components/analyze/HarAccuracyPanel.tsx
+++ b/frontend/components/analyze/HarAccuracyPanel.tsx
@@ -220,6 +220,8 @@ export interface HarAccuracyPanelProps {
   loading?: boolean;
   error?: string | null;
   symbol?: string;
+  collapsible?: boolean;
+  storageKey?: string;
 }
 
 export function HarAccuracyPanel({
@@ -227,6 +229,8 @@ export function HarAccuracyPanel({
   loading = false,
   error = null,
   symbol,
+  collapsible = false,
+  storageKey,
 }: HarAccuracyPanelProps) {
   if (loading) {
     return (
@@ -234,6 +238,8 @@ export function HarAccuracyPanel({
         title="HAR-tercile accuracy"
         description="Backtest of the last persisted predictions vs realized forward vol"
         variant="forecast"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <p
           className="text-xs text-muted-foreground"
@@ -251,6 +257,8 @@ export function HarAccuracyPanel({
         title="HAR-tercile accuracy"
         description="Backtest of the last persisted predictions vs realized forward vol"
         variant="forecast"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <p
           className="text-xs text-muted-foreground"
@@ -270,6 +278,8 @@ export function HarAccuracyPanel({
         title="HAR-tercile accuracy"
         description="Backtest of the last persisted predictions vs realized forward vol"
         variant="forecast"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <div className="space-y-2">
           <div className="flex items-center justify-end">
@@ -299,6 +309,8 @@ export function HarAccuracyPanel({
       title="HAR-tercile accuracy"
       description="Backtest of the last persisted predictions vs realized forward vol"
       variant="forecast"
+      collapsible={collapsible}
+      storageKey={storageKey}
     >
       <div className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2">

--- a/frontend/components/analyze/MonetaryPolicySurpriseChip.tsx
+++ b/frontend/components/analyze/MonetaryPolicySurpriseChip.tsx
@@ -51,6 +51,8 @@ function formatEventDate(iso: string): string {
 export interface MonetaryPolicySurpriseChipProps {
   data: MonetaryPolicySurpriseResponse | null;
   loading?: boolean;
+  collapsible?: boolean;
+  storageKey?: string;
 }
 
 // Methodology summary for the chip tooltip. Keep this self-contained —
@@ -81,6 +83,8 @@ const METHODOLOGY_TOOLTIP = (
 export function MonetaryPolicySurpriseChip({
   data,
   loading = false,
+  collapsible = false,
+  storageKey,
 }: MonetaryPolicySurpriseChipProps) {
   if (loading) {
     return (
@@ -88,6 +92,8 @@ export function MonetaryPolicySurpriseChip({
         title="Monetary policy surprise"
         description="Latest FOMC rate-path surprise (descriptive)"
         variant="descriptive"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <p className="text-xs text-muted-foreground" data-testid="mp-surprise-loading">
           Loading latest FOMC surprise…
@@ -102,6 +108,8 @@ export function MonetaryPolicySurpriseChip({
         title="Monetary policy surprise"
         description="Latest FOMC rate-path surprise (descriptive)"
         variant="descriptive"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <p
           className="text-xs text-muted-foreground"
@@ -126,6 +134,8 @@ export function MonetaryPolicySurpriseChip({
       title="Monetary policy surprise"
       description="Latest FOMC rate-path surprise (descriptive)"
       variant="descriptive"
+      collapsible={collapsible}
+      storageKey={storageKey}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="space-y-2">

--- a/frontend/components/analyze/RvAccuracyPanel.tsx
+++ b/frontend/components/analyze/RvAccuracyPanel.tsx
@@ -274,6 +274,8 @@ export interface RvAccuracyPanelProps {
   loading?: boolean;
   error?: string | null;
   symbol?: string;
+  collapsible?: boolean;
+  storageKey?: string;
 }
 
 export function RvAccuracyPanel({
@@ -281,6 +283,8 @@ export function RvAccuracyPanel({
   loading = false,
   error = null,
   symbol,
+  collapsible = false,
+  storageKey,
 }: RvAccuracyPanelProps) {
   if (loading) {
     return (
@@ -288,6 +292,8 @@ export function RvAccuracyPanel({
         title="QLIKE-RV band coverage"
         description="Backtest of the published 80% / 90% bands against realized RV"
         variant="forecast"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <p
           className="text-xs text-muted-foreground"
@@ -305,6 +311,8 @@ export function RvAccuracyPanel({
         title="QLIKE-RV band coverage"
         description="Backtest of the published 80% / 90% bands against realized RV"
         variant="forecast"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <p
           className="text-xs text-muted-foreground"
@@ -324,6 +332,8 @@ export function RvAccuracyPanel({
         title="QLIKE-RV band coverage"
         description="Backtest of the published 80% / 90% bands against realized RV"
         variant="forecast"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <div className="space-y-2">
           <div className="flex items-center justify-end">
@@ -353,6 +363,8 @@ export function RvAccuracyPanel({
       title="QLIKE-RV band coverage"
       description="Backtest of the published 80% / 90% bands against realized RV"
       variant="forecast"
+      collapsible={collapsible}
+      storageKey={storageKey}
     >
       <div className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2">

--- a/frontend/components/analyze/SemanticDiffPanel.tsx
+++ b/frontend/components/analyze/SemanticDiffPanel.tsx
@@ -225,11 +225,15 @@ function StatusBanner({
 export interface SemanticDiffPanelProps {
   data: SemanticDiffResponse | null;
   loading?: boolean;
+  collapsible?: boolean;
+  storageKey?: string;
 }
 
 export function SemanticDiffPanel({
   data,
   loading = false,
+  collapsible = false,
+  storageKey,
 }: SemanticDiffPanelProps) {
   if (loading) {
     return (
@@ -237,6 +241,8 @@ export function SemanticDiffPanel({
         title="Semantic diff vs prior statement"
         description="Token redline + topic emphasis shifts (descriptive)"
         variant="descriptive"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <p
           className="text-xs text-muted-foreground"
@@ -254,6 +260,8 @@ export function SemanticDiffPanel({
         title="Semantic diff vs prior statement"
         description="Token redline + topic emphasis shifts (descriptive)"
         variant="descriptive"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <p
           className="text-xs text-muted-foreground"
@@ -275,6 +283,8 @@ export function SemanticDiffPanel({
         title="Semantic diff vs prior statement"
         description="Token redline + topic emphasis shifts (descriptive)"
         variant="descriptive"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <StatusBanner
           title="Input too short to diff"
@@ -290,6 +300,8 @@ export function SemanticDiffPanel({
         title="Semantic diff vs prior statement"
         description="Token redline + topic emphasis shifts (descriptive)"
         variant="descriptive"
+        collapsible={collapsible}
+        storageKey={storageKey}
       >
         <StatusBanner
           title="Non-Latin text — diff not run"
@@ -314,6 +326,8 @@ export function SemanticDiffPanel({
       title="Semantic diff vs prior statement"
       description={description}
       variant="descriptive"
+      collapsible={collapsible}
+      storageKey={storageKey}
     >
       {isColdStart ? (
         <ColdStartBanner summary={data.summary} />

--- a/frontend/components/analyze/WorkspaceSection.tsx
+++ b/frontend/components/analyze/WorkspaceSection.tsx
@@ -169,10 +169,15 @@ export function WorkspaceSection({
         </div>
       </header>
       {collapsible ? (
+        // ``hidden`` cannot be set here: it applies display:none, which
+        // pulls the element out of layout before the grid-template-rows
+        // transition can animate the height. ``aria-expanded`` on the
+        // toggle button + ``aria-controls`` on this body are the
+        // canonical accessibility hooks; assistive tech reads the
+        // expanded state from the button, not from a hidden attribute.
         <div
           id={bodyId}
           data-testid="workspace-section-body"
-          hidden={!open}
           className={cn(
             "grid overflow-hidden transition-[grid-template-rows] duration-200 ease-out",
             open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",

--- a/frontend/components/analyze/WorkspaceSection.tsx
+++ b/frontend/components/analyze/WorkspaceSection.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { ChevronDown } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -18,6 +19,12 @@ import { cn } from "@/lib/utils";
 // The `tone` prop is a light style hook for the descriptive variant
 // when the panel sits inside a denser layout and wants to drop the
 // background tint.
+//
+// When `collapsible` is true the header gains a chevron toggle that
+// hides/reveals the body. The open/closed state is mirrored into
+// localStorage under `storageKey` so the workspace lays out the same
+// way across reloads. The header stays visible while closed so the
+// user can re-open the section.
 export type WorkspaceSectionVariant = "forecast" | "descriptive";
 export type WorkspaceSectionTone = "default" | "muted";
 
@@ -27,6 +34,9 @@ export interface WorkspaceSectionProps {
   variant: WorkspaceSectionVariant;
   tone?: WorkspaceSectionTone;
   className?: string;
+  collapsible?: boolean;
+  storageKey?: string;
+  defaultOpen?: boolean;
   children: React.ReactNode;
 }
 
@@ -35,20 +45,75 @@ const VARIANT_LABEL: Record<WorkspaceSectionVariant, string> = {
   descriptive: "Descriptive",
 };
 
+function readPersistedOpen(storageKey: string | undefined, fallback: boolean): boolean {
+  if (!storageKey) return fallback;
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (raw === null) return fallback;
+    return raw === "1";
+  } catch {
+    return fallback;
+  }
+}
+
+function writePersistedOpen(storageKey: string | undefined, open: boolean): void {
+  if (!storageKey) return;
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(storageKey, open ? "1" : "0");
+  } catch {
+    // localStorage may throw in private mode / quota; the in-memory
+    // state still drives the UI for the rest of the session.
+  }
+}
+
 export function WorkspaceSection({
   title,
   description,
   variant,
   tone = "default",
   className,
+  collapsible = false,
+  storageKey,
+  defaultOpen = true,
   children,
 }: WorkspaceSectionProps) {
   const isForecast = variant === "forecast";
   const isDescriptive = variant === "descriptive";
+
+  // Initial state is the SSR-safe `defaultOpen`; the persisted value is
+  // rehydrated in an effect so the server and the client agree on the
+  // first paint and React does not log a hydration mismatch.
+  const [open, setOpen] = React.useState<boolean>(defaultOpen);
+
+  React.useEffect(() => {
+    if (!collapsible) return;
+    setOpen(readPersistedOpen(storageKey, defaultOpen));
+  }, [collapsible, storageKey, defaultOpen]);
+
+  const handleToggle = React.useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev;
+      writePersistedOpen(storageKey, next);
+      return next;
+    });
+  }, [storageKey]);
+
+  // Stable body id so aria-controls can point at it. Derived from the
+  // storageKey when supplied (deterministic) or from a React useId hash
+  // so two unstored collapsibles on the same page still have unique ids.
+  const reactId = React.useId();
+  const bodyId = collapsible
+    ? `workspace-section-body-${storageKey ?? reactId}`
+    : undefined;
+
   return (
     <section
       data-variant={variant}
       data-tone={tone}
+      data-collapsible={collapsible ? "true" : undefined}
+      data-open={collapsible ? (open ? "true" : "false") : undefined}
       aria-label={title}
       className={cn(
         "relative rounded-xl border bg-card text-card-foreground shadow-sm",
@@ -69,18 +134,57 @@ export function WorkspaceSection({
             <p className="text-sm text-muted-foreground">{description}</p>
           ) : null}
         </div>
-        <span
-          data-testid="workspace-section-badge"
+        <div className="flex shrink-0 items-center gap-2">
+          <span
+            data-testid="workspace-section-badge"
+            className={cn(
+              "inline-flex items-center rounded-full px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide",
+              isForecast && "bg-primary/10 text-primary",
+              isDescriptive && "border border-dashed border-border text-muted-foreground",
+            )}
+          >
+            {VARIANT_LABEL[variant]}
+          </span>
+          {collapsible ? (
+            <button
+              type="button"
+              data-testid="workspace-section-toggle"
+              onClick={handleToggle}
+              aria-expanded={open}
+              aria-controls={bodyId}
+              aria-label={open ? `Collapse ${title}` : `Expand ${title}`}
+              className={cn(
+                "inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              )}
+            >
+              <ChevronDown
+                className={cn(
+                  "h-4 w-4 transition-transform duration-200",
+                  !open && "-rotate-90",
+                )}
+                aria-hidden="true"
+              />
+            </button>
+          ) : null}
+        </div>
+      </header>
+      {collapsible ? (
+        <div
+          id={bodyId}
+          data-testid="workspace-section-body"
+          hidden={!open}
           className={cn(
-            "inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide",
-            isForecast && "bg-primary/10 text-primary",
-            isDescriptive && "border border-dashed border-border text-muted-foreground",
+            "grid overflow-hidden transition-[grid-template-rows] duration-200 ease-out",
+            open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
           )}
         >
-          {VARIANT_LABEL[variant]}
-        </span>
-      </header>
-      <div className="p-4 pt-2">{children}</div>
+          <div className="min-h-0">
+            <div className="p-4 pt-2">{children}</div>
+          </div>
+        </div>
+      ) : (
+        <div className="p-4 pt-2">{children}</div>
+      )}
     </section>
   );
 }

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -760,8 +760,10 @@ export interface HarTercileBaselineResponse {
 // yet closed.
 export interface HarTercileBacktestRow {
   event_date: string;
-  predicted_tercile: HarTercileLabel;
-  predicted_prob: number;
+  // Both are null on a pending row (insufficient leading history or
+  // predict_har_regime failure) — match the RV-backtest sibling shape.
+  predicted_tercile: HarTercileLabel | null;
+  predicted_prob: number | null;
   realized_tercile: HarTercileLabel | null;
   realized_rv: number | null;
   correct: boolean | null;

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -78,6 +78,7 @@ import {
   loadWorkspacePrefs,
 } from "@/lib/workspace-prefs";
 import { LegacyForecastCard } from "@/components/analyze/LegacyForecastCard";
+import { WorkspaceSection } from "@/components/analyze/WorkspaceSection";
 
 const HORIZON_VALUES = new Set<Horizon>(HORIZON_VALUE_LIST);
 
@@ -792,43 +793,70 @@ export default function WorkspacePage() {
             </div>
           ) : null}
 
-          {/* SPINE forecast zone — market-data-only cards. No descriptive
-              panels render between these three so the reader sees forecast
-              numbers grouped together without any text-derived commentary
-              implying it feeds the predictions. */}
+          {/* SPINE forecast / cross-check zone — HAR-tercile headline,
+              QLIKE-RV outlook, the late-fusion second-opinion cross-check,
+              and the HAR-volume forecast. Second opinion sits inside the
+              forecast zone deliberately: it is a regime-classifier
+              cross-check (text+market vs market-only), not a descriptive
+              stance summary. The accuracy diagnostics ride at the very
+              bottom of the workspace so the reader sees the headline
+              forecasts first and the backtest surfaces last. */}
           <SectionDivider label="Forecasts" />
-          <HarRegimeHeadline
-            baselines={harBaselines.data}
-            loading={harBaselines.loading}
-            error={harBaselines.error}
-            symbol={request.symbol}
-          />
-          {request.symbol === "^GSPC" ? (
-            <HarAccuracyPanel
-              data={harBacktest}
-              loading={harBacktestLoading}
-              error={harBacktestError}
+          <WorkspaceSection
+            title="HAR-tercile regime headline"
+            description="3-class forward-vol classifier · Low / Medium / High"
+            variant="forecast"
+            collapsible
+            storageKey="workspace-card:har-headline"
+          >
+            <HarRegimeHeadline
+              baselines={harBaselines.data}
+              loading={harBaselines.loading}
+              error={harBaselines.error}
               symbol={request.symbol}
             />
-          ) : null}
-          {request.symbol === "^GSPC" ? (
-            <RvAccuracyPanel
-              data={rvBacktest}
-              loading={rvBacktestLoading}
-              error={rvBacktestError}
-              symbol={request.symbol}
+          </WorkspaceSection>
+          <WorkspaceSection
+            title="Volatility outlook"
+            description="QLIKE-RV forward outlook"
+            variant="forecast"
+            collapsible
+            storageKey="workspace-card:vol-outlook"
+          >
+            <VolatilityOutlookCard
+              forecast={volForecast}
+              loading={volForecastLoading}
+              error={volForecastError}
             />
+          </WorkspaceSection>
+          {result?.regime_classification ? (
+            <WorkspaceSection
+              title="Second opinion · late-fusion regime"
+              description="Text+market vs market-only regime cross-check"
+              variant="forecast"
+              collapsible
+              storageKey="workspace-card:second-opinion"
+            >
+              <SecondOpinionRegime
+                regime={result.regime_classification}
+                sentiment={result.sentiment}
+                symbol={request.symbol}
+                documentDate={request.date}
+                history={regimeHistorySpark}
+                empiricalCoverage={coverage.data?.empirical ?? null}
+                empiricalCoverageSampleSize={coverage.data?.sample_size ?? null}
+                marketOnlyArgmaxProb={marketOnlyArgmaxProb}
+                harBaselines={harBaselines.data}
+              />
+            </WorkspaceSection>
           ) : null}
-          <VolatilityOutlookCard
-            forecast={volForecast}
-            loading={volForecastLoading}
-            error={volForecastError}
-          />
           <ExpectedVolumeCard
             forecast={expectedVolume}
             loading={expectedVolumeLoading}
             error={expectedVolumeError}
             symbol={request.symbol}
+            collapsible
+            storageKey="workspace-card:expected-volume"
           />
 
           {/* SPINE boundary — descriptive panels follow. These are
@@ -846,12 +874,21 @@ export default function WorkspacePage() {
           <MonetaryPolicySurpriseChip
             data={latestMpSurprise}
             loading={latestMpSurpriseLoading}
+            collapsible
+            storageKey="workspace-card:mp-surprise"
           />
           <FuturesConsensusPanel
             data={futuresConsensus}
             loading={futuresConsensusLoading}
+            collapsible
+            storageKey="workspace-card:futures-consensus"
           />
-          <SemanticDiffPanel data={semanticDiff} loading={semanticDiffLoading} />
+          <SemanticDiffPanel
+            data={semanticDiff}
+            loading={semanticDiffLoading}
+            collapsible
+            storageKey="workspace-card:semantic-diff"
+          />
 
           {result ? (
             <>
@@ -859,25 +896,13 @@ export default function WorkspacePage() {
               <TldrCard result={result} />
               <WorkspaceMetaStrip result={result} />
 
-              {result.regime_classification ? (
-                <SecondOpinionRegime
-                  regime={result.regime_classification}
-                  sentiment={result.sentiment}
-                  symbol={request.symbol}
-                  documentDate={request.date}
-                  history={regimeHistorySpark}
-                  empiricalCoverage={coverage.data?.empirical ?? null}
-                  empiricalCoverageSampleSize={coverage.data?.sample_size ?? null}
-                  marketOnlyArgmaxProb={marketOnlyArgmaxProb}
-                  harBaselines={harBaselines.data}
-                />
-              ) : result.prediction?.close != null ? (
+              {!result.regime_classification && result.prediction?.close != null ? (
                 <LegacyForecastCard
                   prediction={result.prediction}
                   market={result.market}
                   documentDate={request.date}
                 />
-              ) : (
+              ) : !result.regime_classification ? (
                 <EmptyState
                   title="Volatility Regime card unavailable."
                   description={
@@ -895,7 +920,7 @@ export default function WorkspacePage() {
                     </div>
                   }
                 />
-              )}
+              ) : null}
 
               {result.policy_action ? (
                 <PolicyActionCard action={result.policy_action} />
@@ -929,12 +954,6 @@ export default function WorkspacePage() {
 
               <HistoricalAnalogPanel analogs={analogsPanel} loading={analogsLoading} />
 
-              <TrajectoryPanel
-                apiBaseUrl={apiBaseUrl}
-                asOfDate={request.date}
-                historyLength={12}
-              />
-
               <SectionDivider label="Model internals" />
               <PipelineTrace result={result} inputText={request.text} />
 
@@ -951,6 +970,51 @@ export default function WorkspacePage() {
 
               <RegimeHistoryStrip entries={historyEntries} symbol={request.symbol} />
             </>
+          ) : null}
+
+          {/* Trajectory + diagnostic-accuracy zone — these always render
+              against history (independent of the most recent /analyze
+              submit) and sit at the bottom of the workspace so the reader
+              treats them as diagnostic surfaces, not headline forecasts. */}
+          <WorkspaceSection
+            title="Stance trajectory"
+            description="Embedding projection of recent FOMC stance history"
+            variant="descriptive"
+            collapsible
+            storageKey="workspace-card:trajectory"
+          >
+            <TrajectoryPanel
+              apiBaseUrl={apiBaseUrl}
+              asOfDate={request.date}
+              historyLength={12}
+            />
+          </WorkspaceSection>
+
+          <p
+            className="mt-4 text-xs uppercase tracking-wide text-muted-foreground"
+            data-testid="workspace-accuracy-caption"
+          >
+            Forecast accuracy (backtest)
+          </p>
+          {request.symbol === "^GSPC" ? (
+            <HarAccuracyPanel
+              data={harBacktest}
+              loading={harBacktestLoading}
+              error={harBacktestError}
+              symbol={request.symbol}
+              collapsible
+              storageKey="workspace-card:har-accuracy"
+            />
+          ) : null}
+          {request.symbol === "^GSPC" ? (
+            <RvAccuracyPanel
+              data={rvBacktest}
+              loading={rvBacktestLoading}
+              error={rvBacktestError}
+              symbol={request.symbol}
+              collapsible
+              storageKey="workspace-card:rv-accuracy"
+            />
           ) : null}
         </main>
       </div>

--- a/frontend/tests/components/analyze/WorkspaceSection.test.tsx
+++ b/frontend/tests/components/analyze/WorkspaceSection.test.tsx
@@ -86,14 +86,17 @@ describe("WorkspaceSection", () => {
       );
       const toggle = screen.getByTestId("workspace-section-toggle");
       const body = screen.getByTestId("workspace-section-body");
-      // Default open: aria-expanded=true, body visible, persisted "1".
+      // Default open: aria-expanded=true, body row at 1fr, persisted "1".
+      // ``hidden`` is intentionally not used — it would suppress the
+      // grid-template-rows transition; aria-expanded on the toggle is
+      // the canonical hook for assistive tech.
       expect(toggle).toHaveAttribute("aria-expanded", "true");
-      expect(body).not.toHaveAttribute("hidden");
+      expect(body.className).toContain("grid-rows-[1fr]");
       expect(screen.getByText("headline body")).toBeInTheDocument();
 
       fireEvent.click(toggle);
       expect(toggle).toHaveAttribute("aria-expanded", "false");
-      expect(body).toHaveAttribute("hidden");
+      expect(body.className).toContain("grid-rows-[0fr]");
       // Header itself stays visible so the user can re-open the card.
       expect(screen.getByText("HAR headline")).toBeInTheDocument();
       expect(
@@ -118,7 +121,7 @@ describe("WorkspaceSection", () => {
       // effect commits; the header / chevron stay in the DOM regardless.
       expect(toggle).toHaveAttribute("aria-expanded", "false");
       const body = screen.getByTestId("workspace-section-body");
-      expect(body).toHaveAttribute("hidden");
+      expect(body.className).toContain("grid-rows-[0fr]");
     });
 
     it("wires aria-controls to the body element id when collapsible", () => {

--- a/frontend/tests/components/analyze/WorkspaceSection.test.tsx
+++ b/frontend/tests/components/analyze/WorkspaceSection.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 import { WorkspaceSection } from "@/components/analyze/WorkspaceSection";
 
@@ -66,5 +66,82 @@ describe("WorkspaceSection", () => {
       </WorkspaceSection>,
     );
     expect(screen.queryByText(/HAR-based/)).not.toBeInTheDocument();
+  });
+
+  describe("collapsible mode", () => {
+    beforeEach(() => {
+      window.localStorage.clear();
+    });
+
+    it("toggles the body and updates aria-expanded when the chevron is clicked", () => {
+      render(
+        <WorkspaceSection
+          title="HAR headline"
+          variant="forecast"
+          collapsible
+          storageKey="workspace-card:test-har-headline"
+        >
+          <p>headline body</p>
+        </WorkspaceSection>,
+      );
+      const toggle = screen.getByTestId("workspace-section-toggle");
+      const body = screen.getByTestId("workspace-section-body");
+      // Default open: aria-expanded=true, body visible, persisted "1".
+      expect(toggle).toHaveAttribute("aria-expanded", "true");
+      expect(body).not.toHaveAttribute("hidden");
+      expect(screen.getByText("headline body")).toBeInTheDocument();
+
+      fireEvent.click(toggle);
+      expect(toggle).toHaveAttribute("aria-expanded", "false");
+      expect(body).toHaveAttribute("hidden");
+      // Header itself stays visible so the user can re-open the card.
+      expect(screen.getByText("HAR headline")).toBeInTheDocument();
+      expect(
+        window.localStorage.getItem("workspace-card:test-har-headline"),
+      ).toBe("0");
+    });
+
+    it("rehydrates the persisted closed state on mount", () => {
+      window.localStorage.setItem("workspace-card:rehydrate-test", "0");
+      render(
+        <WorkspaceSection
+          title="Persisted card"
+          variant="descriptive"
+          collapsible
+          storageKey="workspace-card:rehydrate-test"
+        >
+          <p>persisted body</p>
+        </WorkspaceSection>,
+      );
+      const toggle = screen.getByTestId("workspace-section-toggle");
+      // The persisted "0" should re-open as closed after the rehydrate
+      // effect commits; the header / chevron stay in the DOM regardless.
+      expect(toggle).toHaveAttribute("aria-expanded", "false");
+      const body = screen.getByTestId("workspace-section-body");
+      expect(body).toHaveAttribute("hidden");
+    });
+
+    it("wires aria-controls to the body element id when collapsible", () => {
+      render(
+        <WorkspaceSection
+          title="Wired controls"
+          variant="forecast"
+          collapsible
+          storageKey="workspace-card:aria-wired"
+        >
+          <p>body</p>
+        </WorkspaceSection>,
+      );
+      const toggle = screen.getByTestId("workspace-section-toggle");
+      const body = screen.getByTestId("workspace-section-body");
+      const bodyId = body.getAttribute("id");
+      expect(bodyId).toBeTruthy();
+      expect(toggle).toHaveAttribute("aria-controls", bodyId!);
+      // aria-label flips with state so screen readers don't read a stale
+      // "Collapse X" target once the section is already collapsed.
+      expect(toggle).toHaveAttribute("aria-label", "Collapse Wired controls");
+      fireEvent.click(toggle);
+      expect(toggle).toHaveAttribute("aria-label", "Expand Wired controls");
+    });
   });
 });

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -1681,7 +1681,7 @@
         "type": "object"
       },
       "HarTercileBacktestResponse": {
-        "description": "Response wire shape for ``GET /forecast/har-tercile-backtest``.\n\nSurfaces the last N persisted ^GSPC analyze runs with their stored\nHAR-tercile prediction and the realized tercile derived from\nforward market history. Drives the HarAccuracyPanel card.",
+        "description": "Response wire shape for ``GET /forecast/har-tercile-backtest``.\n\nSurfaces the last N FOMC meetings with their on-demand HAR-tercile\nprediction and the realized tercile derived from forward market\nhistory. Drives the HarAccuracyPanel card.",
         "properties": {
           "generated_at": {
             "title": "Generated At",
@@ -1717,7 +1717,7 @@
         "type": "object"
       },
       "HarTercileBacktestRow": {
-        "description": "One resolved (or pending) row in the HAR-tercile backtest table.\n\nA row carries the persisted predicted tercile (read off the analyze\npayload's ``regime_classification`` card) and, when the forward\nwindow has elapsed, the realized tercile bucketed off the same\ncutoffs that produced the prediction. ``correct`` is None for rows\nwhose forward window has not yet closed.",
+        "description": "One resolved (or pending) row in the HAR-tercile backtest table.\n\nA row carries the HAR-tercile prediction computed on the rolling\nRV history available at the FOMC event date plus, when the forward\nwindow has elapsed, the realized tercile bucketed off the same\ncutoffs that produced the prediction. ``correct`` is None for rows\nwhose forward window has not yet closed.",
         "properties": {
           "correct": {
             "anyOf": [
@@ -5610,7 +5610,7 @@
     },
     "/forecast/har-tercile-backtest": {
       "get": {
-        "description": "Backtest the last N HAR-tercile predictions for ``symbol``.\n\nWalks the persisted ``analysis_runs`` table, lines up each row's\npredicted tercile with the realized tercile from the forward\n10-trading-day window, and returns the rows + aggregate accuracy\nmetrics. Mirrors the ``^GSPC``-only constraint on the upstream\nHAR-tercile baseline endpoint (the cutoffs are SPX-trained).",
+        "description": "Backtest the last N HAR-tercile predictions for ``symbol``.\n\nWalks the published FOMC meeting calendar (most-recent first),\nruns the HAR-tercile prediction on the rolling RV history strictly\nbefore each event, and lines it up against the realized tercile\nfrom the forward 10-trading-day window. Returns the rows +\naggregate accuracy metrics. Mirrors the ``^GSPC``-only constraint\non the upstream HAR-tercile baseline endpoint (the cutoffs are\nSPX-trained).",
         "operationId": "forecast_har_tercile_backtest_forecast_har_tercile_backtest_get",
         "parameters": [
           {

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -1735,12 +1735,26 @@
             "type": "string"
           },
           "predicted_prob": {
-            "title": "Predicted Prob",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Predicted Prob"
           },
           "predicted_tercile": {
-            "title": "Predicted Tercile",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Predicted Tercile"
           },
           "realized_rv": {
             "anyOf": [
@@ -1766,9 +1780,7 @@
           }
         },
         "required": [
-          "event_date",
-          "predicted_tercile",
-          "predicted_prob"
+          "event_date"
         ],
         "title": "HarTercileBacktestRow",
         "type": "object"

--- a/tests/unit/test_har_tercile_backtest.py
+++ b/tests/unit/test_har_tercile_backtest.py
@@ -1,14 +1,15 @@
 """HAR-tercile backtest service + endpoint contract.
 
-Exercises the service-layer logic against an in-memory SQLite ``analysis_runs``
-table and the endpoint's symbol / limit validation. The realized-tercile
-resolution path stubs the yfinance hop so the tests run hermetically.
+Exercises the on-demand backtest: stubs the FOMC calendar feed plus
+the RV-history and realized-RV yfinance fetchers, then checks that
+predicted / realized tercile pairs line up against the same cutoff
+basis. The endpoint half exercises symbol + limit validation.
 """
 
 from __future__ import annotations
 
 import math
-from datetime import datetime, timezone, timedelta
+from datetime import date, datetime
 from typing import Any
 
 import pytest
@@ -20,7 +21,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 import app.db as db_module  # noqa: E402
 import app.main as main_mod  # noqa: E402
-from app.services import har_tercile_backtest  # noqa: E402
+from app.services import fomc_calendar, har_tercile_backtest  # noqa: E402
 
 
 @pytest.fixture()
@@ -31,98 +32,320 @@ def client(tmp_path):
     return TestClient(main_mod.app)
 
 
-def _persist_run(
-    session,
-    *,
-    symbol: str = "^GSPC",
-    document_date: str = "2024-01-31",
-    regime_argmax: str | None = "high",
-    distribution: dict[str, float] | None = None,
-    payload_extra: dict[str, Any] | None = None,
-    created_at: datetime | None = None,
-) -> db_module.AnalysisRun:
-    """Insert a synthetic ``analysis_runs`` row.
+def _meeting(d: str) -> fomc_calendar.FomcMeeting:
+    """Build a minimal FomcMeeting stand-in for the calendar stub."""
 
-    Builds the persisted payload directly via the ORM so the test does
-    not depend on the analyze pipeline. The regime classification block
-    matches the real /analyze response shape.
+    md = date.fromisoformat(d)
+    return fomc_calendar.FomcMeeting(
+        meeting_date=md,
+        meeting_type="scheduled",
+        statement_release_date=md,
+        minutes_release_date=md,
+    )
+
+
+def _stub_calendar(monkeypatch, dates: list[str]) -> None:
+    """Stub ``list_past_meetings`` to return the supplied meeting dates."""
+
+    meetings = [_meeting(d) for d in dates]
+
+    def _fake_list_past_meetings(*, as_of=None, limit: int = 10):
+        return list(meetings[:limit])
+
+    monkeypatch.setattr(
+        fomc_calendar, "list_past_meetings", _fake_list_past_meetings
+    )
+
+
+def _stub_predict_har_regime(monkeypatch, mapping: dict[str, dict[str, Any]]) -> None:
+    """Stub ``predict_har_regime`` keyed off the first RV-history value.
+
+    Each entry maps a ``rv_history[0]`` discriminator to a prediction
+    dict the production endpoint would return: ``{tercile, prob, q33,
+    q67}``. The test composes synthetic RV histories whose first value
+    selects the desired prediction, so the same stub serves multiple
+    meeting dates without sequencing the calls.
     """
 
-    import uuid
+    from app.services import har_tercile as _ht
 
-    payload: dict[str, Any] = {}
-    if regime_argmax is not None:
-        dist = distribution or {regime_argmax: 0.7}
-        payload["regime_classification"] = {
-            "predicted_set": [regime_argmax],
-            "set_label": f"[{regime_argmax}]",
-            "set_size": 1,
-            "coverage": 0.9,
-            "distribution": dist,
-            "argmax_class": regime_argmax,
-            "bucket_source": "classification",
-        }
-    if payload_extra:
-        payload.update(payload_extra)
-
-    row = db_module.AnalysisRun(
-        id=str(uuid.uuid4()),
-        created_at=created_at or datetime.now(timezone.utc),
-        symbol=symbol,
-        document_date=document_date,
-        horizon="3d",
-        forecast_mode="fast",
-        stance="hawkish",
-        sentiment_score=0.7,
-        predicted_close=5000.0,
-        current_close=4990.0,
-        predicted_volatility=0.012,
-        payload=payload,
-        text_excerpt=None,
-    )
-    session.add(row)
-    session.commit()
-    session.refresh(row)
-    return row
-
-
-def test_extract_predicted_tercile_from_regime_classification() -> None:
-    payload = {
-        "regime_classification": {
-            "argmax_class": "calm",
-            "distribution": {"calm": 0.62, "normal": 0.28, "high": 0.10},
-        }
-    }
-    label, prob = har_tercile_backtest._extract_predicted_tercile(payload)
-    assert label == "low"  # calm → low under the tercile mapping
-    assert prob == pytest.approx(0.62)
-
-
-def test_extract_predicted_tercile_prefers_har_baselines_block() -> None:
-    payload = {
-        "regime_classification": {"argmax_class": "calm", "distribution": {"calm": 0.9}},
-        "har_baselines": {
+    def _fake_predict(rv_history, cutoffs_q33=None, cutoffs_q67=None, har_coef=None):
+        key = f"{float(rv_history[0]):.6f}"
+        spec = mapping[key]
+        return {
             "horizons": [
                 {
                     "h": 22,
-                    "tercile": "high",
-                    "tercile_probs": {"low": 0.1, "medium": 0.2, "high": 0.7},
+                    "predicted_rv": spec["q33"] / 2.0 if spec["tercile"] == "low" else (
+                        (spec["q33"] + spec["q67"]) / 2.0 if spec["tercile"] == "medium" else spec["q67"] * 2.0
+                    ),
+                    "tercile": spec["tercile"],
+                    "tercile_probs": {
+                        "low": 0.1, "medium": 0.2, "high": 0.7,
+                    } if spec["tercile"] == "high" else (
+                        {"low": 0.7, "medium": 0.2, "high": 0.1}
+                        if spec["tercile"] == "low"
+                        else {"low": 0.15, "medium": 0.7, "high": 0.15}
+                    ),
+                    "macro_f1": 0.65,
+                    "macro_f1_source": "stub",
+                    "qlike_model": None,
+                    "qlike_har": None,
                 }
-            ]
-        },
+            ],
+            "cutoffs_q33": float(spec["q33"]),
+            "cutoffs_q67": float(spec["q67"]),
+            "model_revision": "stub-rev",
+        }
+
+    monkeypatch.setattr(_ht, "predict_har_regime", _fake_predict)
+
+
+def test_build_backtest_predicts_and_resolves_each_meeting(client, monkeypatch) -> None:
+    """End-to-end: three calendar meetings → three predicted/realized rows.
+
+    Stubs the calendar feed, the RV-history fetcher (composing per-date
+    histories whose first value selects the predicted bucket), and the
+    realized-RV fetcher. Verifies the rows come back in calendar order
+    and that each realized tercile is bucketed against the SAME q33/q67
+    the prediction emitted.
+    """
+
+    _stub_calendar(monkeypatch, ["2024-05-01", "2024-03-20", "2024-01-31"])
+
+    # Per-date histories: the first value carries a unique discriminator
+    # that the predict_har_regime stub keys off, plus 21 filler bars so
+    # the _MIN_RV_HISTORY gate (22) passes. The remaining bars are
+    # deliberately uniform so the synthetic cutoffs the stub emits do
+    # not depend on real quantile math.
+    histories = {
+        "2024-05-01": [0.000300] + [0.0001] * 21,  # → predicted high
+        "2024-03-20": [0.000200] + [0.0001] * 21,  # → predicted medium
+        "2024-01-31": [0.000100] + [0.0001] * 21,  # → predicted low
     }
-    label, prob = har_tercile_backtest._extract_predicted_tercile(payload)
-    assert label == "high"
-    assert prob == pytest.approx(0.7)
 
+    def _hist(event_date: str, symbol: str) -> list[float]:
+        return list(histories[event_date])
 
-def test_extract_predicted_tercile_none_on_missing_payload() -> None:
-    assert har_tercile_backtest._extract_predicted_tercile(None) == (None, None)
-    assert har_tercile_backtest._extract_predicted_tercile({}) == (None, None)
-    assert har_tercile_backtest._extract_predicted_tercile({"regime_classification": {}}) == (
-        None,
-        None,
+    monkeypatch.setattr(
+        har_tercile_backtest, "_fetch_rv_history_for_cutoffs", _hist
     )
+
+    _stub_predict_har_regime(
+        monkeypatch,
+        {
+            "0.000300": {"tercile": "high", "q33": 5e-5, "q67": 1.5e-4},
+            "0.000200": {"tercile": "medium", "q33": 5e-5, "q67": 1.5e-4},
+            "0.000100": {"tercile": "low", "q33": 5e-5, "q67": 1.5e-4},
+        },
+    )
+
+    realized_by_date = {
+        "2024-05-01": 2.0e-4,   # > q67 → high; predicted high → correct
+        "2024-03-20": 1.0e-4,   # between q33/q67 → medium; predicted medium → correct
+        "2024-01-31": 3.0e-5,   # < q33 → low; predicted low → correct
+    }
+
+    monkeypatch.setattr(
+        har_tercile_backtest,
+        "_fetch_realized_rv_yf",
+        lambda event_date, symbol: realized_by_date[event_date],
+    )
+
+    response = client.get(
+        "/forecast/har-tercile-backtest",
+        params={"symbol": "^GSPC", "limit": 10},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["symbol"] == "^GSPC"
+    assert body["horizon"] == 10
+
+    # Calendar order preserved: stub returns the three dates in the
+    # supplied order (most-recent-first), and the backtest must not
+    # reshuffle them.
+    event_dates = [row["event_date"] for row in body["rows"]]
+    assert event_dates == ["2024-05-01", "2024-03-20", "2024-01-31"]
+
+    predicted = [row["predicted_tercile"] for row in body["rows"]]
+    assert predicted == ["high", "medium", "low"]
+
+    realized = [row["realized_tercile"] for row in body["rows"]]
+    assert realized == ["high", "medium", "low"]
+
+    # Per-row correctness flags + aggregate accuracy: every row hits
+    # the bucket the prediction called, so accuracy is 1.0 and each
+    # per-tercile rate is 1.0.
+    assert all(row["correct"] is True for row in body["rows"])
+    metrics = body["metrics"]
+    assert metrics["total_runs"] == 3
+    assert metrics["resolved_runs"] == 3
+    assert metrics["accuracy_overall"] == pytest.approx(1.0)
+    assert metrics["per_tercile_hit_rate"]["low"] == pytest.approx(1.0)
+    assert metrics["per_tercile_hit_rate"]["medium"] == pytest.approx(1.0)
+    assert metrics["per_tercile_hit_rate"]["high"] == pytest.approx(1.0)
+
+
+def test_build_backtest_pending_row_when_realized_missing(client, monkeypatch) -> None:
+    """A meeting whose forward window has not resolved surfaces as pending."""
+
+    _stub_calendar(monkeypatch, ["2024-06-12"])
+
+    monkeypatch.setattr(
+        har_tercile_backtest,
+        "_fetch_rv_history_for_cutoffs",
+        lambda event_date, symbol: [0.000200] + [0.0001] * 21,
+    )
+    _stub_predict_har_regime(
+        monkeypatch,
+        {"0.000200": {"tercile": "medium", "q33": 5e-5, "q67": 1.5e-4}},
+    )
+    monkeypatch.setattr(
+        har_tercile_backtest,
+        "_fetch_realized_rv_yf",
+        lambda event_date, symbol: None,
+    )
+
+    response = client.get("/forecast/har-tercile-backtest", params={"symbol": "^GSPC"})
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["rows"]) == 1
+    row = body["rows"][0]
+    assert row["event_date"] == "2024-06-12"
+    assert row["predicted_tercile"] == "medium"
+    assert row["realized_tercile"] is None
+    assert row["realized_rv"] is None
+    assert row["correct"] is None
+    assert body["metrics"]["total_runs"] == 1
+    assert body["metrics"]["resolved_runs"] == 0
+    assert body["metrics"]["accuracy_overall"] is None
+
+
+def test_build_backtest_aggregate_matches_hand_computed_hit_rates(
+    client, monkeypatch
+) -> None:
+    """Mixed hits + misses + pending row: aggregate KPI = hand calc."""
+
+    _stub_calendar(
+        monkeypatch,
+        ["2024-09-18", "2024-07-31", "2024-05-01", "2024-03-20"],
+    )
+
+    histories = {
+        "2024-09-18": [0.000300] + [0.0001] * 21,  # predicted high
+        "2024-07-31": [0.000300] + [0.0001] * 21,  # predicted high (miss)
+        "2024-05-01": [0.000200] + [0.0001] * 21,  # predicted medium (hit)
+        "2024-03-20": [0.000100] + [0.0001] * 21,  # predicted low (pending)
+    }
+    monkeypatch.setattr(
+        har_tercile_backtest,
+        "_fetch_rv_history_for_cutoffs",
+        lambda event_date, symbol: list(histories[event_date]),
+    )
+    _stub_predict_har_regime(
+        monkeypatch,
+        {
+            "0.000300": {"tercile": "high", "q33": 5e-5, "q67": 1.5e-4},
+            "0.000200": {"tercile": "medium", "q33": 5e-5, "q67": 1.5e-4},
+            "0.000100": {"tercile": "low", "q33": 5e-5, "q67": 1.5e-4},
+        },
+    )
+    realized = {
+        "2024-09-18": 2.0e-4,   # high (hit)
+        "2024-07-31": 3.0e-5,   # low (miss)
+        "2024-05-01": 1.0e-4,   # medium (hit)
+        "2024-03-20": None,     # pending
+    }
+    monkeypatch.setattr(
+        har_tercile_backtest,
+        "_fetch_realized_rv_yf",
+        lambda event_date, symbol: realized[event_date],
+    )
+
+    response = client.get(
+        "/forecast/har-tercile-backtest", params={"symbol": "^GSPC", "limit": 10}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    metrics = body["metrics"]
+    # 4 rows total, 3 resolved, 2 correct -> 2/3 overall accuracy.
+    assert metrics["total_runs"] == 4
+    assert metrics["resolved_runs"] == 3
+    assert metrics["accuracy_overall"] == pytest.approx(2.0 / 3.0)
+    per_t = metrics["per_tercile_hit_rate"]
+    # Two `high` predictions resolved (one hit, one miss) → 0.5.
+    assert per_t["high"] == pytest.approx(0.5)
+    # One `medium` prediction resolved (hit) → 1.0.
+    assert per_t["medium"] == pytest.approx(1.0)
+    # Single `low` prediction never resolved, so it should be absent.
+    assert "low" not in per_t
+
+
+def test_build_backtest_dedupes_meeting_dates(client, monkeypatch) -> None:
+    """Duplicate meeting dates in the calendar collapse to one row."""
+
+    _stub_calendar(
+        monkeypatch,
+        ["2024-05-01", "2024-05-01", "2024-03-20"],
+    )
+
+    monkeypatch.setattr(
+        har_tercile_backtest,
+        "_fetch_rv_history_for_cutoffs",
+        lambda event_date, symbol: [0.000200] + [0.0001] * 21,
+    )
+    _stub_predict_har_regime(
+        monkeypatch,
+        {"0.000200": {"tercile": "medium", "q33": 5e-5, "q67": 1.5e-4}},
+    )
+    monkeypatch.setattr(
+        har_tercile_backtest,
+        "_fetch_realized_rv_yf",
+        lambda event_date, symbol: 1.0e-4,
+    )
+
+    response = client.get(
+        "/forecast/har-tercile-backtest", params={"symbol": "^GSPC", "limit": 10}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    event_dates = [row["event_date"] for row in body["rows"]]
+    # The duplicate "2024-05-01" must not produce two rows.
+    assert event_dates == ["2024-05-01", "2024-03-20"]
+
+
+def test_build_backtest_skips_meetings_with_short_rv_history(
+    client, monkeypatch
+) -> None:
+    """Meetings with too little leading RV history are dropped, not pending."""
+
+    _stub_calendar(monkeypatch, ["2024-01-31"])
+    monkeypatch.setattr(
+        har_tercile_backtest,
+        "_fetch_rv_history_for_cutoffs",
+        lambda event_date, symbol: [0.0001] * 5,  # < _MIN_RV_HISTORY
+    )
+
+    # Ensure predict_har_regime is never called when the history gate fails.
+    from app.services import har_tercile as _ht
+
+    def _explode(*args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("predict_har_regime called despite short history")
+
+    monkeypatch.setattr(_ht, "predict_har_regime", _explode)
+    monkeypatch.setattr(
+        har_tercile_backtest,
+        "_fetch_realized_rv_yf",
+        lambda event_date, symbol: 1.0e-4,
+    )
+
+    response = client.get(
+        "/forecast/har-tercile-backtest", params={"symbol": "^GSPC"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["rows"] == []
+    assert body["metrics"]["total_runs"] == 0
 
 
 def test_bucket_against_cutoffs_layout() -> None:
@@ -163,241 +386,6 @@ def test_aggregate_metrics_zero_resolved_returns_none_accuracy() -> None:
     assert metrics["per_tercile_hit_rate"] == {}
 
 
-def test_build_backtest_orders_by_recency_and_filters_symbol(client, monkeypatch) -> None:
-    # Stub the yfinance fallback so resolution lands on the cutoffs +
-    # canned realized RV without touching the network.
-    monkeypatch.setattr(
-        har_tercile_backtest,
-        "_fetch_realized_rv_yf",
-        lambda event_date, symbol: 0.012,
-    )
-    monkeypatch.setattr(
-        har_tercile_backtest,
-        "_fetch_rv_history_for_cutoffs",
-        lambda event_date, symbol: [0.005, 0.008, 0.011, 0.013, 0.015, 0.020],
-    )
-
-    session_iter = db_module.get_session()
-    sess = next(session_iter)
-    try:
-        base = datetime(2024, 1, 1, tzinfo=timezone.utc)
-        # Three ^GSPC runs at different prediction labels, one ^NDX
-        # row that should be filtered out.
-        _persist_run(sess, regime_argmax="calm", document_date="2024-01-31",
-                     created_at=base)
-        _persist_run(sess, regime_argmax="normal", document_date="2024-03-20",
-                     created_at=base + timedelta(days=5))
-        _persist_run(sess, regime_argmax="high", document_date="2024-05-01",
-                     created_at=base + timedelta(days=10))
-        _persist_run(sess, symbol="^NDX", regime_argmax="high",
-                     document_date="2024-04-01",
-                     created_at=base + timedelta(days=20))
-    finally:
-        sess.close()
-
-    response = client.get(
-        "/forecast/har-tercile-backtest",
-        params={"symbol": "^GSPC", "limit": 10},
-    )
-    assert response.status_code == 200, response.text
-    body = response.json()
-    assert body["symbol"] == "^GSPC"
-    assert body["horizon"] == 10
-    assert body["metrics"]["total_runs"] == 3
-    # All resolved (yfinance stubbed to a constant). The realized
-    # vol 0.012 falls in `medium` against the cutoffs derived from the
-    # stub history (q33 ≈ 0.008, q67 ≈ 0.015).
-    assert body["metrics"]["resolved_runs"] == 3
-    # Rows come back in created_at desc → high, normal, calm.
-    predicted = [row["predicted_tercile"] for row in body["rows"]]
-    assert predicted == ["high", "medium", "low"]
-    # Realized lands in medium (~0.012 vs q33≈0.008 / q67≈0.015).
-    realized = [row["realized_tercile"] for row in body["rows"]]
-    assert all(r == "medium" for r in realized)
-    # Per-tercile hit-rate: only `normal` (mapped to medium) predicted the
-    # right bucket. Others miss.
-    per_t = body["metrics"]["per_tercile_hit_rate"]
-    assert per_t["medium"] == pytest.approx(1.0)
-    assert per_t["low"] == pytest.approx(0.0)
-    assert per_t["high"] == pytest.approx(0.0)
-
-
-def test_backtest_skips_rows_without_regime_card(client, monkeypatch) -> None:
-    """Rows whose persisted payload has no regime card drop out entirely.
-
-    The denominator stays honest: ``total_runs`` reflects only rows we
-    could backtest, not every analysis_runs row blindly.
-    """
-
-    monkeypatch.setattr(
-        har_tercile_backtest,
-        "_fetch_realized_rv_yf",
-        lambda event_date, symbol: 0.012,
-    )
-    monkeypatch.setattr(
-        har_tercile_backtest,
-        "_fetch_rv_history_for_cutoffs",
-        lambda event_date, symbol: [0.005, 0.008, 0.012, 0.020],
-    )
-
-    session_iter = db_module.get_session()
-    sess = next(session_iter)
-    try:
-        _persist_run(sess, regime_argmax=None, document_date="2024-01-31")
-        _persist_run(sess, regime_argmax="high", document_date="2024-02-20")
-    finally:
-        sess.close()
-
-    response = client.get("/forecast/har-tercile-backtest", params={"symbol": "^GSPC"})
-    assert response.status_code == 200
-    body = response.json()
-    assert body["metrics"]["total_runs"] == 1
-
-
-def test_backtest_emits_pending_row_when_yfinance_returns_none(
-    client, monkeypatch
-) -> None:
-    """A predicted row with no resolvable realized RV must surface as pending.
-
-    yfinance returning None (typical for future / unresolved meetings)
-    flows through _resolve_realized_tercile and into the response as
-    realized_tercile=None, realized_rv=None, correct=None — so the panel
-    can render it as "pending" rather than dropping the row.
-    """
-
-    monkeypatch.setattr(
-        har_tercile_backtest,
-        "_fetch_realized_rv_yf",
-        lambda event_date, symbol: None,
-    )
-    monkeypatch.setattr(
-        har_tercile_backtest,
-        "_fetch_rv_history_for_cutoffs",
-        lambda event_date, symbol: [0.005, 0.008, 0.012, 0.020],
-    )
-
-    session_iter = db_module.get_session()
-    sess = next(session_iter)
-    try:
-        _persist_run(sess, regime_argmax="normal", document_date="2024-02-20")
-    finally:
-        sess.close()
-
-    response = client.get("/forecast/har-tercile-backtest", params={"symbol": "^GSPC"})
-    assert response.status_code == 200
-    body = response.json()
-    assert len(body["rows"]) == 1
-    row = body["rows"][0]
-    assert row["predicted_tercile"] in {"low", "medium", "high"}
-    assert row["realized_tercile"] is None
-    assert row["realized_rv"] is None
-    assert row["correct"] is None
-    # Aggregate metrics treat pending rows as un-denominated:
-    # total_runs counts every backtest-able prediction, resolved_runs only
-    # the ones with a realized outcome.
-    assert body["metrics"]["total_runs"] == 1
-    assert body["metrics"]["resolved_runs"] == 0
-    assert body["metrics"]["accuracy_overall"] is None
-
-
-def test_backtest_uses_persisted_realized_rv_when_present(client, monkeypatch) -> None:
-    """When the payload pins ``forward_realized_vol_10d``, no yfinance hop fires."""
-
-    def _explode(event_date: str, symbol: str) -> float:  # pragma: no cover - guard
-        raise AssertionError("yfinance fallback should not be invoked")
-
-    monkeypatch.setattr(har_tercile_backtest, "_fetch_realized_rv_yf", _explode)
-    monkeypatch.setattr(
-        har_tercile_backtest,
-        "_fetch_rv_history_for_cutoffs",
-        lambda event_date, symbol: [0.005, 0.008, 0.012, 0.020],
-    )
-
-    session_iter = db_module.get_session()
-    sess = next(session_iter)
-    try:
-        _persist_run(
-            sess,
-            regime_argmax="high",
-            document_date="2024-02-20",
-            payload_extra={"forward_realized_vol_10d": 0.018},
-        )
-    finally:
-        sess.close()
-
-    response = client.get("/forecast/har-tercile-backtest", params={"symbol": "^GSPC"})
-    assert response.status_code == 200
-    body = response.json()
-    assert body["metrics"]["resolved_runs"] == 1
-    row = body["rows"][0]
-    assert row["realized_rv"] == pytest.approx(0.018)
-    # 0.018 > q67 (0.012) -> high bucket -> prediction correct.
-    assert row["realized_tercile"] == "high"
-    assert row["correct"] is True
-
-
-def test_backtest_with_persisted_variance_cutoffs_does_not_force_high(client, monkeypatch) -> None:
-    """Variance-space cutoffs + variance-space realized stat stay comparable.
-
-    Guards against the contract-drift failure in the original review:
-    if the realized statistic were a daily std (~1e-2 for 1% daily
-    moves) while the persisted cutoffs are daily variance (~1e-4), the
-    std would always exceed q67 and every row would land in ``high``.
-    Stub a realistic ^GSPC forward window with mixed up/down 0.5% moves
-    and confirm the backtest's variance-space realized stat bucks into
-    ``low`` against variance-space cutoffs that bracket it tightly.
-    """
-
-    # Persisted cutoffs in variance space (q33 / q67 of a daily RV
-    # series for a quiet regime; values pulled from the upstream
-    # quantile semantics in ``services.har_tercile._tercile_cutoffs``).
-    quiet_cutoffs = {"cutoffs_q33": 5e-5, "cutoffs_q67": 1.5e-4}
-
-    def _calm_window(event_date: str, symbol: str) -> float | None:
-        # 10 forward bars, all 0.5% daily log-return magnitude.
-        rets = [0.005, -0.005] * 5
-        return har_tercile_backtest._realized_variance_from_log_returns(rets)
-
-    monkeypatch.setattr(har_tercile_backtest, "_fetch_realized_rv_yf", _calm_window)
-
-    session_iter = db_module.get_session()
-    sess = next(session_iter)
-    try:
-        _persist_run(
-            sess,
-            regime_argmax="high",
-            document_date="2024-02-20",
-            payload_extra={
-                "har_baselines": {
-                    "horizons": [
-                        {
-                            "h": 22,
-                            "tercile": "high",
-                            "tercile_probs": {"low": 0.1, "medium": 0.2, "high": 0.7},
-                        }
-                    ],
-                    **quiet_cutoffs,
-                }
-            },
-        )
-    finally:
-        sess.close()
-
-    response = client.get("/forecast/har-tercile-backtest", params={"symbol": "^GSPC"})
-    assert response.status_code == 200
-    body = response.json()
-    row = body["rows"][0]
-    # Mean of 0.005**2 = 2.5e-5 — well below q33 (5e-5) so realized
-    # tercile must resolve to ``low``, not ``high``. A regression to
-    # the std-based realized stat would emit ~0.005 and force ``high``.
-    assert row["realized_rv"] == pytest.approx(2.5e-5)
-    assert row["realized_tercile"] == "low"
-    # Prediction was "high"; realized resolved to "low" → miss. The
-    # accuracy KPI is therefore exercised, not dominated by a phantom
-    # "all-high" bucketing.
-    assert row["correct"] is False
-
-
 def test_endpoint_rejects_non_gspc_symbol(client) -> None:
     response = client.get(
         "/forecast/har-tercile-backtest", params={"symbol": "^NDX"}
@@ -418,7 +406,12 @@ def test_endpoint_rejects_out_of_range_limit(client) -> None:
     assert under.status_code == 422
 
 
-def test_endpoint_returns_empty_state_with_no_runs(client) -> None:
+def test_endpoint_returns_empty_state_with_no_meetings(client, monkeypatch) -> None:
+    """No past meetings → empty rows + zero-state metrics, 200 OK."""
+
+    monkeypatch.setattr(
+        fomc_calendar, "list_past_meetings", lambda *, as_of=None, limit=10: []
+    )
     response = client.get(
         "/forecast/har-tercile-backtest", params={"symbol": "^GSPC"}
     )
@@ -431,11 +424,6 @@ def test_endpoint_returns_empty_state_with_no_runs(client) -> None:
 
 
 def test_cutoffs_from_history_basic() -> None:
-    # The cutoffs must match ``services.har_tercile._tercile_cutoffs``
-    # byte-for-byte — i.e. ``np.quantile(values, [1/3, 2/3])`` with
-    # linear interpolation — otherwise the backtest's per-tercile
-    # hit-rate stops being a faithful proxy of the live endpoint's
-    # bucketing.
     import numpy as np
 
     values = [0.001, 0.002, 0.003, 0.004, 0.005, 0.006]
@@ -450,12 +438,7 @@ def test_cutoffs_from_history_rejects_short_window() -> None:
 
 
 def test_cutoffs_from_history_matches_upstream_predict_har_regime() -> None:
-    """Backtest's cutoff helper reproduces the upstream tercile cutoffs.
-
-    The upstream ``services.har_tercile._tercile_cutoffs`` is the gold
-    standard the backtest's accuracy KPI must reproduce. Driving both
-    with the same RV series should yield byte-identical q33 / q67.
-    """
+    """Backtest's cutoff helper reproduces the upstream tercile cutoffs."""
 
     import numpy as np
 
@@ -464,21 +447,11 @@ def test_cutoffs_from_history_matches_upstream_predict_har_regime() -> None:
     rng = np.random.default_rng(11)
     series = (rng.standard_normal(60) * 0.01) ** 2 + 1e-6
     upstream_q33, upstream_q67 = _tercile_cutoffs(series)
-    backtest_q33, backtest_q67 = har_tercile_backtest._cutoffs_from_history(series.tolist())
+    backtest_q33, backtest_q67 = har_tercile_backtest._cutoffs_from_history(
+        series.tolist()
+    )
     assert backtest_q33 == pytest.approx(upstream_q33)
     assert backtest_q67 == pytest.approx(upstream_q67)
-
-
-def test_normalize_tercile_label_maps_all_known_inputs() -> None:
-    fn = har_tercile_backtest._normalize_tercile_label
-    assert fn("calm") == "low"
-    assert fn("Normal") == "medium"
-    assert fn("HIGH") == "high"
-    assert fn("low") == "low"
-    assert fn("medium") == "medium"
-    assert fn("unknown") is None
-    assert fn(None) is None
-    assert fn("") is None
 
 
 def test_realized_vol_from_log_returns_basic() -> None:
@@ -489,31 +462,18 @@ def test_realized_vol_from_log_returns_basic() -> None:
 
 
 def test_realized_variance_matches_mean_squared_log_returns() -> None:
-    """Realized stat is daily VARIANCE (mean of r**2), not std.
-
-    Upstream ``main._load_rv_history`` writes per-bar RV as
-    ``r * r``; the forward-window scalar must live in the same space
-    so the per-bar variance cutoffs from ``predict_har_regime`` are
-    apples-to-apples comparable. A regression here would silently
-    inflate the panel's realized-vol column by ~sqrt(252) and dump
-    every resolved row into the ``high`` bucket once cutoffs start
-    persisting upstream.
-    """
+    """Realized stat is daily VARIANCE (mean of r**2), not std."""
 
     rets = [0.005, -0.004, 0.012, -0.003, 0.001, 0.0, -0.002, 0.004, 0.006, -0.007]
     rv = har_tercile_backtest._realized_variance_from_log_returns(rets)
     expected = sum(r * r for r in rets) / len(rets)
     assert rv == pytest.approx(expected)
     # Daily variance scale: for ~1% daily moves the variance is on the
-    # order of 1e-4. The pre-fix std-based helper would have returned a
-    # value on the order of 1e-2 (the std), so the assertion guards
-    # against accidental regression to the old convention.
+    # order of 1e-4.
     assert rv < 1e-3
 
 
 def test_realized_variance_aliases_legacy_name() -> None:
-    """The legacy ``_realized_vol_from_log_returns`` symbol aliases the variance form."""
-
     rets = [0.01, -0.005, 0.002, 0.0]
     assert har_tercile_backtest._realized_vol_from_log_returns(rets) == pytest.approx(
         har_tercile_backtest._realized_variance_from_log_returns(rets)
@@ -535,8 +495,6 @@ def reset_backtest_caches():
 
 
 def test_realized_rv_cache_hit_skips_underlying_fetch(monkeypatch, reset_backtest_caches) -> None:
-    """A second call for the same key reads from cache, not the network."""
-
     calls = {"n": 0}
 
     def _stub(event_date: str, symbol: str) -> float | None:
@@ -552,12 +510,10 @@ def test_realized_rv_cache_hit_skips_underlying_fetch(monkeypatch, reset_backtes
 
     assert first == pytest.approx(0.00042)
     assert second == pytest.approx(0.00042)
-    assert calls["n"] == 1  # second call served from cache
+    assert calls["n"] == 1
 
 
 def test_realized_rv_cache_distinct_keys_do_not_collide(monkeypatch, reset_backtest_caches) -> None:
-    """Different ``(event_date, symbol)`` keys each hit the fetcher exactly once."""
-
     calls: list[tuple[str, str]] = []
 
     def _stub(event_date: str, symbol: str) -> float | None:
@@ -581,8 +537,6 @@ def test_realized_rv_cache_distinct_keys_do_not_collide(monkeypatch, reset_backt
 
 
 def test_realized_rv_cache_ttl_expiry_refetches(monkeypatch, reset_backtest_caches) -> None:
-    """Once the cached entry crosses the TTL it is refreshed via the fetcher."""
-
     calls = {"n": 0}
 
     def _stub(event_date: str, symbol: str) -> float | None:
@@ -596,8 +550,6 @@ def test_realized_rv_cache_ttl_expiry_refetches(monkeypatch, reset_backtest_cach
     har_tercile_backtest._fetch_realized_rv_yf("2024-01-31", "^GSPC")
     assert calls["n"] == 1
 
-    # Forge a stale entry by rewriting the cache slot with a timestamp
-    # well past the TTL horizon. A fresh call must re-invoke the fetcher.
     stale_ts = (
         har_tercile_backtest._realized_rv_cache[("2024-01-31", "^GSPC")][0]
         - har_tercile_backtest._BACKTEST_CACHE_TTL_SECONDS
@@ -613,8 +565,6 @@ def test_realized_rv_cache_ttl_expiry_refetches(monkeypatch, reset_backtest_cach
 
 
 def test_realized_rv_cache_caches_none_payload(monkeypatch, reset_backtest_caches) -> None:
-    """A None result is still cached so unresolved rows don't retry every render."""
-
     calls = {"n": 0}
 
     def _stub(event_date: str, symbol: str) -> float | None:
@@ -631,8 +581,6 @@ def test_realized_rv_cache_caches_none_payload(monkeypatch, reset_backtest_cache
 
 
 def test_rv_history_cache_hit_skips_underlying_fetch(monkeypatch, reset_backtest_caches) -> None:
-    """The trailing-60d history fetcher gets the same TTL treatment."""
-
     calls = {"n": 0}
     canned = [0.001, 0.002, 0.004, 0.008]
 
@@ -657,8 +605,6 @@ def test_rv_history_cache_hit_skips_underlying_fetch(monkeypatch, reset_backtest
 
 
 def test_rv_history_cache_ttl_expiry_refetches(monkeypatch, reset_backtest_caches) -> None:
-    """Stale history entries trigger a refetch."""
-
     calls = {"n": 0}
 
     def _stub(event_date: str, symbol: str) -> list[float]:
@@ -687,8 +633,6 @@ def test_rv_history_cache_ttl_expiry_refetches(monkeypatch, reset_backtest_cache
 
 
 def test_reset_caches_clears_state(monkeypatch) -> None:
-    """``reset_caches()`` wipes both cache dicts so tests stay isolated."""
-
     monkeypatch.setattr(
         har_tercile_backtest,
         "_fetch_realized_rv_yf_uncached",
@@ -709,3 +653,23 @@ def test_reset_caches_clears_state(monkeypatch) -> None:
 
     assert har_tercile_backtest._realized_rv_cache == {}
     assert har_tercile_backtest._rv_history_cache == {}
+
+
+def test_list_past_meetings_orders_recent_first_and_respects_limit() -> None:
+    """`fomc_calendar.list_past_meetings` returns at most ``limit`` meetings."""
+
+    meetings = fomc_calendar.list_past_meetings(
+        as_of=datetime(2025, 1, 1).date(), limit=3
+    )
+    assert len(meetings) == 3
+    # Most recent meeting strictly before 2025-01-01 must come first.
+    assert meetings[0].meeting_date == date(2024, 12, 17)
+    # Sorted strictly descending.
+    assert all(
+        meetings[i].meeting_date > meetings[i + 1].meeting_date
+        for i in range(len(meetings) - 1)
+    )
+
+
+def test_list_past_meetings_zero_limit_is_empty() -> None:
+    assert fomc_calendar.list_past_meetings(limit=0) == []

--- a/tests/unit/test_har_tercile_backtest.py
+++ b/tests/unit/test_har_tercile_backtest.py
@@ -75,7 +75,7 @@ def _stub_predict_har_regime(monkeypatch, mapping: dict[str, dict[str, Any]]) ->
         return {
             "horizons": [
                 {
-                    "h": 22,
+                    "h": 1,
                     "predicted_rv": spec["q33"] / 2.0 if spec["tercile"] == "low" else (
                         (spec["q33"] + spec["q67"]) / 2.0 if spec["tercile"] == "medium" else spec["q67"] * 2.0
                     ),
@@ -159,7 +159,7 @@ def test_build_backtest_predicts_and_resolves_each_meeting(client, monkeypatch) 
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["symbol"] == "^GSPC"
-    assert body["horizon"] == 10
+    assert body["horizon"] == 1
 
     # Calendar order preserved: stub returns the three dates in the
     # supplied order (most-recent-first), and the backtest must not
@@ -314,10 +314,15 @@ def test_build_backtest_dedupes_meeting_dates(client, monkeypatch) -> None:
     assert event_dates == ["2024-05-01", "2024-03-20"]
 
 
-def test_build_backtest_skips_meetings_with_short_rv_history(
+def test_build_backtest_emits_pending_for_meetings_with_short_rv_history(
     client, monkeypatch
 ) -> None:
-    """Meetings with too little leading RV history are dropped, not pending."""
+    """Meetings with too little leading RV history surface as pending rows.
+
+    Earlier revisions silently dropped these from the response; the new
+    behaviour mirrors the RV-backtest sibling so the operator sees how
+    many events were attempted vs how many we could actually score.
+    """
 
     _stub_calendar(monkeypatch, ["2024-01-31"])
     monkeypatch.setattr(
@@ -344,8 +349,15 @@ def test_build_backtest_skips_meetings_with_short_rv_history(
     )
     assert response.status_code == 200
     body = response.json()
-    assert body["rows"] == []
-    assert body["metrics"]["total_runs"] == 0
+    assert len(body["rows"]) == 1
+    pending = body["rows"][0]
+    assert pending["event_date"] == "2024-01-31"
+    assert pending["predicted_tercile"] is None
+    assert pending["realized_tercile"] is None
+    assert pending["correct"] is None
+    assert body["metrics"]["total_runs"] == 1
+    assert body["metrics"]["resolved_runs"] == 0
+    assert body["metrics"]["accuracy_overall"] is None
 
 
 def test_bucket_against_cutoffs_layout() -> None:

--- a/tests/unit/test_rv_backtest.py
+++ b/tests/unit/test_rv_backtest.py
@@ -1,15 +1,15 @@
 """QLIKE-RV backtest service + endpoint contract.
 
-Exercises the service-layer logic against an in-memory SQLite
-``analysis_runs`` table with a stubbed RV predictor + RV history so
-the tests run hermetically. The endpoint contract mirrors the
-HAR-tercile backtest: 400 on a non-^GSPC symbol, 422 on out-of-range
-limit, 200 with an aggregate coverage payload on the happy path.
+Exercises the on-demand backtest: stubs the FOMC calendar feed plus
+the RV-history and realized-RV yfinance fetchers, then checks that
+the h=1 point + 80% / 90% bands published at each meeting bracket
+the realized variance on the bar one day forward. The endpoint half
+exercises symbol + limit validation.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone, timedelta
+from datetime import date, datetime
 from typing import Any
 
 import pytest
@@ -21,8 +21,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 import app.db as db_module  # noqa: E402
 import app.main as main_mod  # noqa: E402
-from app.services import rv_backtest  # noqa: E402
-from app.services import rv_forecaster  # noqa: E402
+from app.services import fomc_calendar, rv_backtest  # noqa: E402
 
 
 @pytest.fixture()
@@ -33,110 +32,363 @@ def client(tmp_path):
     return TestClient(main_mod.app)
 
 
-def _persist_run(
-    session,
-    *,
-    symbol: str = "^GSPC",
-    document_date: str = "2024-01-31",
-    created_at: datetime | None = None,
-) -> db_module.AnalysisRun:
-    """Insert a synthetic ``analysis_runs`` row for the RV backtest."""
+def _meeting(d: str) -> fomc_calendar.FomcMeeting:
+    """Build a minimal FomcMeeting stand-in for the calendar stub."""
 
-    import uuid
-
-    row = db_module.AnalysisRun(
-        id=str(uuid.uuid4()),
-        created_at=created_at or datetime.now(timezone.utc),
-        symbol=symbol,
-        document_date=document_date,
-        horizon="3d",
-        forecast_mode="fast",
-        stance="hawkish",
-        sentiment_score=0.7,
-        predicted_close=5000.0,
-        current_close=4990.0,
-        predicted_volatility=0.012,
-        payload={},
-        text_excerpt=None,
+    md = date.fromisoformat(d)
+    return fomc_calendar.FomcMeeting(
+        meeting_date=md,
+        meeting_type="scheduled",
+        statement_release_date=md,
+        minutes_release_date=md,
     )
-    session.add(row)
-    session.commit()
-    session.refresh(row)
-    return row
 
 
-def _make_stub_predictor() -> Any:
-    """Return a minimal _RvPredictor stand-in with h1 conformal quantiles set."""
+def _stub_calendar(monkeypatch, dates: list[str]) -> None:
+    """Stub ``list_past_meetings`` to return the supplied meeting dates."""
 
-    class _StubLinear:
-        def __call__(self, x: Any) -> Any:
-            import numpy as np
+    meetings = [_meeting(d) for d in dates]
 
-            class _T:
-                def __init__(self, arr: np.ndarray) -> None:
-                    self._arr = arr
+    def _fake_list_past_meetings(*, as_of=None, limit: int = 10):
+        return list(meetings[:limit])
 
-                def cpu(self) -> "_T":
-                    return self
-
-                def numpy(self) -> np.ndarray:
-                    return self._arr
-
-            return _T(np.array([[0.0]], dtype=np.float32))
-
-        def eval(self) -> "_StubLinear":
-            return self
-
-    n_feat = 11
-    spec = {
-        "model": "intraday_rv_production",
-        "feature_order": [
-            "har_daily", "har_weekly", "har_monthly",
-            "rs_pos", "rs_neg", "bv", "rq", "rskew", "rkurt", "parkinson", "log_rvol",
-        ],
-        "date_last": "2026-05-29",
-        "by_horizon": {
-            "h1": {
-                "har_coef": [-0.5, 0.6, 0.2, 0.1],
-                "feat_mean": [0.0] * n_feat,
-                "feat_std": [1.0] * n_feat,
-                "resid_mean": 0.0,
-                "resid_std": 0.5,
-                "conformal_quantiles": {"0.20": 0.6, "0.10": 0.9},
-                "seed_state_dicts": [],
-                "n_oos_resid": 100,
-            }
-        },
-    }
-    inst = rv_forecaster._RvPredictor.__new__(rv_forecaster._RvPredictor)
-    inst.model_dir = rv_forecaster.MODEL_DIR  # type: ignore[attr-defined]
-    inst.spec = spec  # type: ignore[attr-defined]
-    inst.eval = None  # type: ignore[attr-defined]
-    inst.seed_models = {"h1": [_StubLinear() for _ in range(3)]}  # type: ignore[attr-defined]
-    inst.revision = "stub@rv-backtest"  # type: ignore[attr-defined]
-    return inst
-
-
-@pytest.fixture()
-def stub_predictor(monkeypatch: pytest.MonkeyPatch):
-    """Pin the cached _RvPredictor so the service runs without HF Hub."""
-
-    rv_forecaster._RvPredictor.reset()
-    inst = _make_stub_predictor()
     monkeypatch.setattr(
-        rv_forecaster._RvPredictor, "get", classmethod(lambda cls: inst)
+        fomc_calendar, "list_past_meetings", _fake_list_past_meetings
     )
-    yield inst
-    rv_forecaster._RvPredictor.reset()
 
 
-def _canned_rv_series(n: int = 60, start: str = "2024-01-01") -> tuple[list[float], list[str]]:
-    """Build a deterministic RV series + ISO dates of length ``n``."""
+def _stub_predict_rv(monkeypatch, mapping: dict[str, dict[str, float]]) -> None:
+    """Stub ``predict_rv`` keyed off the first RV-history value.
 
-    base = datetime.fromisoformat(start).date()
-    rv = [1e-4 * (1.0 + (i % 5) * 0.1) for i in range(n)]
-    dates = [(base + timedelta(days=i)).isoformat() for i in range(n)]
-    return rv, dates
+    Each entry maps a ``rv_history[0]`` discriminator to a prediction
+    dict containing ``point`` and the four band edges. The test
+    composes synthetic RV histories whose first value selects the
+    desired prediction, so the same stub serves multiple meeting
+    dates without sequencing the calls.
+    """
+
+    from app.services import rv_forecaster as _rv
+
+    def _fake_predict(rv_history):
+        key = f"{float(rv_history[0]):.6f}"
+        spec = mapping[key]
+        return {
+            "horizons": [
+                {
+                    "h": 1,
+                    "point": float(spec["point"]),
+                    "band_lo_80": float(spec["lo80"]),
+                    "band_hi_80": float(spec["hi80"]),
+                    "band_lo_90": float(spec["lo90"]),
+                    "band_hi_90": float(spec["hi90"]),
+                    "qlike_model": None,
+                    "qlike_har": None,
+                    "coverage_empirical_90": float("nan"),
+                },
+                {
+                    "h": 5,
+                    "point": float(spec["point"]) * 1.05,
+                    "band_lo_80": float(spec["lo80"]) * 1.05,
+                    "band_hi_80": float(spec["hi80"]) * 1.05,
+                    "band_lo_90": float(spec["lo90"]) * 1.05,
+                    "band_hi_90": float(spec["hi90"]) * 1.05,
+                    "qlike_model": None,
+                    "qlike_har": None,
+                    "coverage_empirical_90": float("nan"),
+                },
+            ],
+            "model_revision": "stub-rev",
+        }
+
+    monkeypatch.setattr(_rv, "predict_rv", _fake_predict)
+
+
+def _history(discriminator: float, length: int = 60) -> list[float]:
+    """Compose a synthetic RV history of ``length`` bars.
+
+    The first value carries the discriminator the ``predict_rv`` stub
+    keys off; the remaining bars are uniform filler so the predict
+    call sees a series at least as long as ``_MIN_RV_HISTORY``.
+    """
+
+    return [float(discriminator)] + [1e-4] * (length - 1)
+
+
+def test_build_backtest_predicts_and_resolves_each_meeting(client, monkeypatch) -> None:
+    """End-to-end: three calendar meetings -> three predicted/realized rows.
+
+    Stubs the calendar feed, the RV-history fetcher (composing per-date
+    histories whose first value selects the predicted bands), and the
+    realized-RV fetcher. Verifies the rows come back in calendar order
+    and that each in_band flag is computed against the bands the model
+    would have emitted at that decision point.
+    """
+
+    _stub_calendar(monkeypatch, ["2024-05-01", "2024-03-20", "2024-01-31"])
+
+    histories = {
+        "2024-05-01": _history(0.000300),
+        "2024-03-20": _history(0.000200),
+        "2024-01-31": _history(0.000100),
+    }
+
+    def _hist(event_date: str, symbol: str) -> list[float]:
+        return list(histories[event_date])
+
+    monkeypatch.setattr(rv_backtest, "_fetch_rv_history", _hist)
+
+    _stub_predict_rv(
+        monkeypatch,
+        {
+            "0.000300": {
+                "point": 2.5e-4,
+                "lo80": 1.0e-4, "hi80": 4.0e-4,
+                "lo90": 0.5e-4, "hi90": 5.0e-4,
+            },
+            "0.000200": {
+                "point": 1.5e-4,
+                "lo80": 0.8e-4, "hi80": 2.5e-4,
+                "lo90": 0.5e-4, "hi90": 3.5e-4,
+            },
+            "0.000100": {
+                "point": 1.0e-4,
+                "lo80": 0.5e-4, "hi80": 1.8e-4,
+                "lo90": 0.3e-4, "hi90": 2.5e-4,
+            },
+        },
+    )
+
+    realized_by_date = {
+        "2024-05-01": 2.0e-4,   # inside 80 band
+        "2024-03-20": 1.0e-4,   # inside 80 band
+        "2024-01-31": 1.2e-4,   # inside 80 band
+    }
+    monkeypatch.setattr(
+        rv_backtest,
+        "_fetch_realized_rv_yf",
+        lambda event_date, symbol: realized_by_date[event_date],
+    )
+
+    response = client.get(
+        "/forecast/rv-backtest", params={"symbol": "^GSPC", "limit": 10}
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["symbol"] == "^GSPC"
+    assert body["horizon"] == 1
+
+    # Calendar order preserved.
+    event_dates = [row["event_date"] for row in body["rows"]]
+    assert event_dates == ["2024-05-01", "2024-03-20", "2024-01-31"]
+
+    for row in body["rows"]:
+        assert row["realized_rv"] is not None
+        assert row["band_lo_80"] <= row["point_forecast_rv"] <= row["band_hi_80"]
+        assert row["band_lo_90"] <= row["band_lo_80"]
+        assert row["band_hi_90"] >= row["band_hi_80"]
+        assert row["in_band_80"] is True
+        assert row["in_band_90"] is True
+
+    coverage = body["coverage"]
+    assert coverage["total_runs"] == 3
+    assert coverage["resolved_runs"] == 3
+    assert coverage["pending_runs"] == 0
+    assert coverage["empirical_coverage_80"] == pytest.approx(1.0)
+    assert coverage["empirical_coverage_90"] == pytest.approx(1.0)
+    assert coverage["nominal_coverage_80"] == pytest.approx(0.80)
+    assert coverage["nominal_coverage_90"] == pytest.approx(0.90)
+
+
+def test_build_backtest_pending_row_when_realized_missing(client, monkeypatch) -> None:
+    """A meeting whose forward bar has not resolved surfaces as pending."""
+
+    _stub_calendar(monkeypatch, ["2024-06-12"])
+
+    monkeypatch.setattr(
+        rv_backtest,
+        "_fetch_rv_history",
+        lambda event_date, symbol: _history(0.000200),
+    )
+    _stub_predict_rv(
+        monkeypatch,
+        {
+            "0.000200": {
+                "point": 1.5e-4,
+                "lo80": 0.8e-4, "hi80": 2.5e-4,
+                "lo90": 0.5e-4, "hi90": 3.5e-4,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        rv_backtest,
+        "_fetch_realized_rv_yf",
+        lambda event_date, symbol: None,
+    )
+
+    response = client.get("/forecast/rv-backtest", params={"symbol": "^GSPC"})
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["rows"]) == 1
+    row = body["rows"][0]
+    assert row["event_date"] == "2024-06-12"
+    assert row["point_forecast_rv"] == pytest.approx(1.5e-4)
+    assert row["realized_rv"] is None
+    assert row["in_band_80"] is None
+    assert row["in_band_90"] is None
+    cov = body["coverage"]
+    assert cov["total_runs"] == 1
+    assert cov["resolved_runs"] == 0
+    assert cov["pending_runs"] == 1
+    assert cov["empirical_coverage_80"] is None
+    assert cov["empirical_coverage_90"] is None
+
+
+def test_build_backtest_pending_row_when_history_too_short(client, monkeypatch) -> None:
+    """A meeting with <60 days of trailing RV surfaces as a pending row."""
+
+    _stub_calendar(monkeypatch, ["2024-01-31"])
+    monkeypatch.setattr(
+        rv_backtest,
+        "_fetch_rv_history",
+        lambda event_date, symbol: [1e-4] * 30,  # < _MIN_RV_HISTORY
+    )
+
+    # predict_rv must not be reached when the history gate fails.
+    from app.services import rv_forecaster as _rv
+
+    def _explode(*args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("predict_rv called despite short history")
+
+    monkeypatch.setattr(_rv, "predict_rv", _explode)
+    monkeypatch.setattr(
+        rv_backtest,
+        "_fetch_realized_rv_yf",
+        lambda event_date, symbol: 1.0e-4,
+    )
+
+    response = client.get("/forecast/rv-backtest", params={"symbol": "^GSPC"})
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["rows"]) == 1
+    row = body["rows"][0]
+    assert row["event_date"] == "2024-01-31"
+    assert row["point_forecast_rv"] is None
+    assert row["band_lo_80"] is None
+    assert row["band_hi_80"] is None
+    assert row["band_lo_90"] is None
+    assert row["band_hi_90"] is None
+    assert row["realized_rv"] is None
+    assert row["in_band_80"] is None
+    assert row["in_band_90"] is None
+    cov = body["coverage"]
+    assert cov["total_runs"] == 1
+    assert cov["resolved_runs"] == 0
+    assert cov["pending_runs"] == 1
+
+
+def test_build_backtest_aggregate_matches_hand_computed_coverage(
+    client, monkeypatch
+) -> None:
+    """Mixed hits + misses + pending row: aggregate coverage = hand calc."""
+
+    _stub_calendar(
+        monkeypatch,
+        ["2024-09-18", "2024-07-31", "2024-05-01", "2024-03-20"],
+    )
+
+    histories = {
+        "2024-09-18": _history(0.000300),
+        "2024-07-31": _history(0.000300),
+        "2024-05-01": _history(0.000200),
+        "2024-03-20": _history(0.000100),
+    }
+    monkeypatch.setattr(
+        rv_backtest,
+        "_fetch_rv_history",
+        lambda event_date, symbol: list(histories[event_date]),
+    )
+    _stub_predict_rv(
+        monkeypatch,
+        {
+            "0.000300": {
+                "point": 2.5e-4,
+                "lo80": 1.0e-4, "hi80": 4.0e-4,
+                "lo90": 0.5e-4, "hi90": 5.0e-4,
+            },
+            "0.000200": {
+                "point": 1.5e-4,
+                "lo80": 0.8e-4, "hi80": 2.5e-4,
+                "lo90": 0.5e-4, "hi90": 3.5e-4,
+            },
+            "0.000100": {
+                "point": 1.0e-4,
+                "lo80": 0.5e-4, "hi80": 1.8e-4,
+                "lo90": 0.3e-4, "hi90": 2.5e-4,
+            },
+        },
+    )
+    realized = {
+        "2024-09-18": 2.0e-4,    # inside 80 band [1e-4, 4e-4] -> hit80, hit90
+        "2024-07-31": 6.0e-4,    # outside 90 band [0.5e-4, 5e-4] -> miss80, miss90
+        "2024-05-01": 3.0e-4,    # outside 80 band, inside 90 -> miss80, hit90
+        "2024-03-20": None,      # pending
+    }
+    monkeypatch.setattr(
+        rv_backtest,
+        "_fetch_realized_rv_yf",
+        lambda event_date, symbol: realized[event_date],
+    )
+
+    response = client.get(
+        "/forecast/rv-backtest", params={"symbol": "^GSPC", "limit": 10}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    cov = body["coverage"]
+    # 4 rows total, 3 resolved, 1 in 80 band, 2 in 90 band.
+    assert cov["total_runs"] == 4
+    assert cov["resolved_runs"] == 3
+    assert cov["pending_runs"] == 1
+    assert cov["empirical_coverage_80"] == pytest.approx(1.0 / 3.0)
+    assert cov["empirical_coverage_90"] == pytest.approx(2.0 / 3.0)
+
+
+def test_build_backtest_dedupes_meeting_dates(client, monkeypatch) -> None:
+    """Duplicate meeting dates in the calendar collapse to one row."""
+
+    _stub_calendar(
+        monkeypatch,
+        ["2024-05-01", "2024-05-01", "2024-03-20"],
+    )
+
+    monkeypatch.setattr(
+        rv_backtest,
+        "_fetch_rv_history",
+        lambda event_date, symbol: _history(0.000200),
+    )
+    _stub_predict_rv(
+        monkeypatch,
+        {
+            "0.000200": {
+                "point": 1.5e-4,
+                "lo80": 0.8e-4, "hi80": 2.5e-4,
+                "lo90": 0.5e-4, "hi90": 3.5e-4,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        rv_backtest,
+        "_fetch_realized_rv_yf",
+        lambda event_date, symbol: 1.2e-4,
+    )
+
+    response = client.get(
+        "/forecast/rv-backtest", params={"symbol": "^GSPC", "limit": 10}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    event_dates = [row["event_date"] for row in body["rows"]]
+    assert event_dates == ["2024-05-01", "2024-03-20"]
 
 
 def test_aggregate_coverage_basic() -> None:
@@ -169,171 +421,6 @@ def test_aggregate_coverage_all_pending() -> None:
     assert cov["empirical_coverage_90"] is None
 
 
-def test_resolve_row_pending_inside_warmup(stub_predictor) -> None:
-    import numpy as np
-
-    rv_list, dates = _canned_rv_series(n=60)
-    rv = np.asarray(rv_list, dtype=np.float64)
-    # Event date sits inside the 22-day warmup window — pending row.
-    target = dates[10]
-    row = rv_backtest._resolve_row(
-        event_date=target,
-        rv=rv,
-        dates=dates,
-        predictor=stub_predictor,
-    )
-    assert row is not None
-    assert row["realized_rv"] is None
-    assert row["in_band_80"] is None
-    assert row["in_band_90"] is None
-
-
-def test_resolve_row_resolves_with_bands_outside_warmup(stub_predictor) -> None:
-    import numpy as np
-
-    rv_list, dates = _canned_rv_series(n=60)
-    rv = np.asarray(rv_list, dtype=np.float64)
-    # Index 30 is comfortably past the 22-day warmup horizon.
-    target = dates[30]
-    row = rv_backtest._resolve_row(
-        event_date=target,
-        rv=rv,
-        dates=dates,
-        predictor=stub_predictor,
-    )
-    assert row is not None
-    assert row["realized_rv"] == pytest.approx(rv_list[30])
-    # Bands bracket the point.
-    assert row["band_lo_80"] <= row["point_forecast_rv"] <= row["band_hi_80"]
-    assert row["band_lo_90"] <= row["band_lo_80"]
-    assert row["band_hi_90"] >= row["band_hi_80"]
-    assert isinstance(row["in_band_80"], bool)
-    assert isinstance(row["in_band_90"], bool)
-
-
-def test_resolve_row_returns_none_when_date_missing(stub_predictor) -> None:
-    import numpy as np
-
-    rv_list, dates = _canned_rv_series(n=60)
-    rv = np.asarray(rv_list, dtype=np.float64)
-    out = rv_backtest._resolve_row(
-        event_date="2099-12-31",
-        rv=rv,
-        dates=dates,
-        predictor=stub_predictor,
-    )
-    assert out is None
-
-
-def test_get_rv_backtest_orders_by_recency_and_filters_symbol(
-    client, monkeypatch, stub_predictor
-) -> None:
-    """Three ^GSPC rows resolve in created_at desc order; ^NDX row drops out."""
-
-    rv_list, dates = _canned_rv_series(n=60)
-    monkeypatch.setattr(
-        rv_backtest, "_load_rv_series", lambda symbol: (list(rv_list), list(dates))
-    )
-
-    session_iter = db_module.get_session()
-    sess = next(session_iter)
-    try:
-        base = datetime(2024, 6, 1, tzinfo=timezone.utc)
-        _persist_run(sess, document_date=dates[30], created_at=base)
-        _persist_run(
-            sess, document_date=dates[40], created_at=base + timedelta(days=5)
-        )
-        _persist_run(
-            sess, document_date=dates[50], created_at=base + timedelta(days=10)
-        )
-        _persist_run(
-            sess,
-            symbol="^NDX",
-            document_date=dates[35],
-            created_at=base + timedelta(days=20),
-        )
-    finally:
-        sess.close()
-
-    response = client.get(
-        "/forecast/rv-backtest", params={"symbol": "^GSPC", "limit": 10}
-    )
-    assert response.status_code == 200, response.text
-    body = response.json()
-    assert body["symbol"] == "^GSPC"
-    assert body["horizon"] == 1
-    assert body["coverage"]["total_runs"] == 3
-    assert body["coverage"]["resolved_runs"] == 3
-    event_dates = [row["event_date"] for row in body["rows"]]
-    # Newest first.
-    assert event_dates == [dates[50], dates[40], dates[30]]
-    for row in body["rows"]:
-        assert row["realized_rv"] is not None
-        assert row["band_lo_80"] <= row["band_hi_80"]
-        assert row["band_lo_90"] <= row["band_hi_90"]
-
-
-def test_get_rv_backtest_emits_pending_row_when_date_missing(
-    client, monkeypatch, stub_predictor
-) -> None:
-    """A persisted run whose event date sits outside the RV history is pending."""
-
-    rv_list, dates = _canned_rv_series(n=60)
-    monkeypatch.setattr(
-        rv_backtest, "_load_rv_series", lambda symbol: (list(rv_list), list(dates))
-    )
-
-    session_iter = db_module.get_session()
-    sess = next(session_iter)
-    try:
-        _persist_run(sess, document_date="2099-12-31")
-    finally:
-        sess.close()
-
-    response = client.get("/forecast/rv-backtest", params={"symbol": "^GSPC"})
-    assert response.status_code == 200
-    body = response.json()
-    assert body["coverage"]["total_runs"] == 1
-    assert body["coverage"]["resolved_runs"] == 0
-    assert body["coverage"]["pending_runs"] == 1
-    assert body["coverage"]["empirical_coverage_80"] is None
-    assert body["coverage"]["empirical_coverage_90"] is None
-    row = body["rows"][0]
-    assert row["realized_rv"] is None
-    assert row["point_forecast_rv"] is None
-    assert row["in_band_80"] is None
-    assert row["in_band_90"] is None
-
-
-def test_get_rv_backtest_aggregates_band_hits(
-    client, monkeypatch, stub_predictor
-) -> None:
-    """Empirical coverage tracks ``in_band_*`` across resolved rows."""
-
-    rv_list, dates = _canned_rv_series(n=60)
-    monkeypatch.setattr(
-        rv_backtest, "_load_rv_series", lambda symbol: (list(rv_list), list(dates))
-    )
-
-    session_iter = db_module.get_session()
-    sess = next(session_iter)
-    try:
-        # Two rows comfortably past the warmup horizon.
-        _persist_run(sess, document_date=dates[30])
-        _persist_run(sess, document_date=dates[45])
-    finally:
-        sess.close()
-
-    response = client.get("/forecast/rv-backtest", params={"symbol": "^GSPC"})
-    assert response.status_code == 200
-    body = response.json()
-    assert body["coverage"]["total_runs"] == 2
-    assert body["coverage"]["resolved_runs"] == 2
-    # The exact coverage values depend on the stub; just assert finite + in [0, 1].
-    assert 0.0 <= body["coverage"]["empirical_coverage_80"] <= 1.0
-    assert 0.0 <= body["coverage"]["empirical_coverage_90"] <= 1.0
-
-
 def test_endpoint_rejects_non_gspc_symbol(client) -> None:
     response = client.get("/forecast/rv-backtest", params={"symbol": "^NDX"})
     assert response.status_code == 400
@@ -352,56 +439,134 @@ def test_endpoint_rejects_out_of_range_limit(client) -> None:
     assert under.status_code == 422
 
 
-def test_endpoint_returns_empty_state_with_no_runs(client) -> None:
+def test_endpoint_returns_empty_state_with_no_meetings(client, monkeypatch) -> None:
+    """No past meetings -> empty rows + zero-state coverage, 200 OK."""
+
+    monkeypatch.setattr(
+        fomc_calendar, "list_past_meetings", lambda *, as_of=None, limit=10: []
+    )
     response = client.get("/forecast/rv-backtest", params={"symbol": "^GSPC"})
     assert response.status_code == 200
     body = response.json()
     assert body["rows"] == []
-    assert body["coverage"]["total_runs"] == 0
-    assert body["coverage"]["resolved_runs"] == 0
-    assert body["coverage"]["pending_runs"] == 0
-    assert body["coverage"]["empirical_coverage_80"] is None
-    assert body["coverage"]["empirical_coverage_90"] is None
-    assert body["coverage"]["nominal_coverage_80"] == pytest.approx(0.80)
-    assert body["coverage"]["nominal_coverage_90"] == pytest.approx(0.90)
+    cov = body["coverage"]
+    assert cov["total_runs"] == 0
+    assert cov["resolved_runs"] == 0
+    assert cov["pending_runs"] == 0
+    assert cov["empirical_coverage_80"] is None
+    assert cov["empirical_coverage_90"] is None
+    assert cov["nominal_coverage_80"] == pytest.approx(0.80)
+    assert cov["nominal_coverage_90"] == pytest.approx(0.90)
 
 
-def test_load_rv_series_requests_wide_history_window(monkeypatch) -> None:
-    """The backtest must pull more RV history than the live forecast card.
-
-    Regression test for the failure mode where the shared 60-day window
-    capped older persisted FOMC event dates outside the dates index, so
-    every event further than ~3 months back surfaced as pending. The
-    backtest now requests a multi-quarter window so the trailing FOMC
-    meetings can actually be aligned to the daily RV series.
-    """
-
-    captured: dict[str, Any] = {}
-
-    def _fake_load_rv_history(symbol: str, days: int = 60) -> tuple[list[float], list[str]]:
-        captured["symbol"] = symbol
-        captured["days"] = days
-        return ([0.0] * 30, ["2024-01-01"] * 30)
-
-    import app.main as main_mod
-
-    monkeypatch.setattr(main_mod, "_load_rv_history", _fake_load_rv_history)
-
-    rv_backtest._load_rv_series("^GSPC")
-
-    # 60 days = the live-forecast cap. The backtest must pass a strictly
-    # larger ``days`` value so older event dates can land in the dates
-    # index. ~2 years of trading days (504) is the current target.
-    assert captured["symbol"] == "^GSPC"
-    assert captured["days"] > 60
-    assert captured["days"] >= 252
+# ---------------------------------------------------------------------------
+# TTL in-process cache on yfinance fetchers.
+# ---------------------------------------------------------------------------
 
 
-def test_main_load_rv_history_honors_days_argument(monkeypatch) -> None:
-    """``_load_rv_history`` exposes a ``days`` knob the backtest passes."""
+@pytest.fixture()
+def reset_backtest_caches():
+    """Force a clean cache around each cache-flavored test."""
 
-    import inspect
+    rv_backtest.reset_caches()
+    yield
+    rv_backtest.reset_caches()
 
-    sig = inspect.signature(main_mod._load_rv_history)
-    assert "days" in sig.parameters
-    assert sig.parameters["days"].default == main_mod._RV_HISTORY_DAYS
+
+def test_realized_rv_cache_hit_skips_underlying_fetch(monkeypatch, reset_backtest_caches) -> None:
+    calls = {"n": 0}
+
+    def _stub(event_date: str, symbol: str) -> float | None:
+        calls["n"] += 1
+        return 0.00042
+
+    monkeypatch.setattr(rv_backtest, "_fetch_realized_rv_yf_uncached", _stub)
+
+    first = rv_backtest._fetch_realized_rv_yf("2024-01-31", "^GSPC")
+    second = rv_backtest._fetch_realized_rv_yf("2024-01-31", "^GSPC")
+
+    assert first == pytest.approx(0.00042)
+    assert second == pytest.approx(0.00042)
+    assert calls["n"] == 1
+
+
+def test_realized_rv_cache_ttl_expiry_refetches(monkeypatch, reset_backtest_caches) -> None:
+    calls = {"n": 0}
+
+    def _stub(event_date: str, symbol: str) -> float | None:
+        calls["n"] += 1
+        return 0.00099
+
+    monkeypatch.setattr(rv_backtest, "_fetch_realized_rv_yf_uncached", _stub)
+
+    rv_backtest._fetch_realized_rv_yf("2024-01-31", "^GSPC")
+    assert calls["n"] == 1
+
+    stale_ts = (
+        rv_backtest._realized_rv_cache[("2024-01-31", "^GSPC")][0]
+        - rv_backtest._BACKTEST_CACHE_TTL_SECONDS
+        - 1.0
+    )
+    rv_backtest._realized_rv_cache[("2024-01-31", "^GSPC")] = (stale_ts, 0.00099)
+
+    rv_backtest._fetch_realized_rv_yf("2024-01-31", "^GSPC")
+    assert calls["n"] == 2
+
+
+def test_rv_history_cache_hit_skips_underlying_fetch(monkeypatch, reset_backtest_caches) -> None:
+    calls = {"n": 0}
+    canned = [0.001, 0.002, 0.004, 0.008]
+
+    def _stub(event_date: str, symbol: str) -> list[float]:
+        calls["n"] += 1
+        return list(canned)
+
+    monkeypatch.setattr(rv_backtest, "_fetch_rv_history_uncached", _stub)
+
+    first = rv_backtest._fetch_rv_history("2024-01-31", "^GSPC")
+    second = rv_backtest._fetch_rv_history("2024-01-31", "^GSPC")
+
+    assert first == canned
+    assert second == canned
+    assert calls["n"] == 1
+    # The cache returns a copy so callers cannot mutate the cached list.
+    second.append(99.0)
+    third = rv_backtest._fetch_rv_history("2024-01-31", "^GSPC")
+    assert third == canned
+
+
+def test_reset_caches_clears_state(monkeypatch) -> None:
+    monkeypatch.setattr(
+        rv_backtest,
+        "_fetch_realized_rv_yf_uncached",
+        lambda event_date, symbol: 0.0007,
+    )
+    monkeypatch.setattr(
+        rv_backtest,
+        "_fetch_rv_history_uncached",
+        lambda event_date, symbol: [0.001, 0.002, 0.003],
+    )
+
+    rv_backtest._fetch_realized_rv_yf("2024-03-20", "^GSPC")
+    rv_backtest._fetch_rv_history("2024-03-20", "^GSPC")
+    assert rv_backtest._realized_rv_cache
+    assert rv_backtest._rv_history_cache
+
+    rv_backtest.reset_caches()
+
+    assert rv_backtest._realized_rv_cache == {}
+    assert rv_backtest._rv_history_cache == {}
+
+
+def test_list_past_meetings_orders_recent_first_and_respects_limit() -> None:
+    """`fomc_calendar.list_past_meetings` returns at most ``limit`` meetings."""
+
+    meetings = fomc_calendar.list_past_meetings(
+        as_of=datetime(2025, 1, 1).date(), limit=3
+    )
+    assert len(meetings) == 3
+    assert meetings[0].meeting_date == date(2024, 12, 17)
+    assert all(
+        meetings[i].meeting_date > meetings[i + 1].meeting_date
+        for i in range(len(meetings) - 1)
+    )


### PR DESCRIPTION
## Summary
- HAR-tercile accuracy panel was showing **0.0% accuracy with duplicate FOMC-date rows** because the service read predicted tercile + cutoffs off `analysis_runs.payload['har_baselines']`, but `/analyze` never writes that block. The fallback hit the late-fusion regime classifier's argmax (calm/normal/high) and labelled it as HAR terciles — wrong model. Realized side bucketed against unrelated fresh 60-day quantiles. Same shape of bug bit the RV accuracy panel.
- **Fix:** both backtests now run on-demand. For each past FOMC meeting (deduped via fomc_calendar.list_past_meetings): pull RV history strictly before the event → call `predict_har_regime` / `predict_rv` against that pre-event window → bucket realized 10-day-forward vol against the **same** cutoffs/bands the model would have emitted live. Kills the 0% accuracy and the duplicate-row bug in one stroke.
- **Collapsible cards:** every workspace card now has a chevron toggle (aria-expanded + aria-controls) with localStorage-persisted open state per card key. Default open.
- **Reorder:** late-fusion (SecondOpinionRegime) moved to position 3 (just below HAR headline + QLIKE-RV); HAR/RV accuracy panels moved to the bottom under a "Forecast accuracy (backtest)" caption.

## Late-fusion preserved
The dense daily late-fusion classifier (macro-F1 0.592 at h=1, n=1999 pooled walk-forward) — what `SecondOpinionRegime` renders — is now at position 3, **not removed**.

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit -q` (2853 passing in scope; 5 pre-existing dev failures: env version pins, inference-observability cold-start ×2, retrieval-augmented loader)
- [ ] `docker compose run --rm backend pytest tests/contract/test_schemathesis.py -q` (32 pass)
- [ ] `docker compose run --rm frontend npx vitest run` (54 files, 340 tests)
- [ ] `docker compose run --rm frontend npx tsc --noEmit` clean
- [ ] `ruff check backend` clean