### PR TITLE
fix: HAR backtest h=1 realized variance + drop dead factor/Settings copy

### DIFF
--- a/backend/app/services/har_tercile_backtest.py
+++ b/backend/app/services/har_tercile_backtest.py
@@ -4,7 +4,7 @@ Walks the published FOMC meeting calendar (most recent first), replays
 ``services.har_tercile.predict_har_regime`` against the rolling-window
 RV history that the model would have seen at each historical event
 date, and compares the predicted tercile to the realized tercile from
-the forward 10-trading-day window.
+the single forward-day bar (h=1).
 
 This is the on-demand variant of the panel. The earlier service read a
 ``har_baselines`` block off ``analysis_runs.payload``, but the
@@ -17,10 +17,9 @@ realized columns in the same cutoff space.
 
 All bucketing is done in daily **realized-variance** space so the
 comparison reproduces what ``services.har_tercile.predict_har_regime``
-sees at prediction time. The realized forward window scalar is the
-mean of squared log-returns over the post-event bars — a one-period
-daily variance averaged across the 10-bar forward window, in the same
-variance space as the per-bar RV series the cutoffs were quantiled on.
+sees at prediction time. With ``_FORWARD_STEPS = 1`` the realized stat
+is simply ``r * r`` for the post-event bar — the same daily variance
+space the per-bar RV cutoffs were quantiled on.
 """
 
 from __future__ import annotations
@@ -40,8 +39,8 @@ from sqlalchemy.orm import Session  # kept for signature compatibility
 # the same ``(event_date, symbol)`` pairs across consecutive
 # dashboard hits, so a short staleness window amortises the network
 # hop without leaking yesterday's realisation into today's chart.
-# Six hours is a safe upper bound: FOMC forward 10-bar windows
-# resolve within a couple of trading days, well past the TTL.
+# Six hours is a safe upper bound: the h=1 forward bar resolves the
+# next trading day, well within the TTL.
 _BACKTEST_CACHE_TTL_SECONDS = 6 * 60 * 60
 _realized_rv_cache: dict[tuple[str, str], tuple[float, float | None]] = {}
 _rv_history_cache: dict[tuple[str, str], tuple[float, list[float]]] = {}
@@ -121,12 +120,13 @@ def _realized_variance_from_log_returns(log_returns: list[float]) -> float | Non
 
     The HAR-tercile cutoffs are quantiles of a per-bar variance series
     (``r * r``). To stay in the same space, the forward-window realized
-    stat is the mean of squared log-returns over the post-event bars —
-    a one-period daily variance averaged across the 10-bar forward
-    window. Returns None when the series is too short to be meaningful.
+    stat is the mean of squared log-returns over the post-event bars.
+    With ``_FORWARD_STEPS = 1`` the post-event window is a single bar
+    (the day after the meeting); the mean is then just ``r * r`` for
+    that bar. Returns None only when the series is empty.
     """
 
-    if len(log_returns) < 2:
+    if not log_returns:
         return None
     sq = [float(r) * float(r) for r in log_returns]
     if not sq:
@@ -140,7 +140,7 @@ _realized_vol_from_log_returns = _realized_variance_from_log_returns
 
 
 def _fetch_realized_rv_yf_uncached(event_date: str, symbol: str) -> float | None:
-    """Pull forward-10d realized **variance** off yfinance.
+    """Pull h=1 forward-day realized **variance** off yfinance.
 
     Wrapped behind a try / except so a yfinance flake on one row never
     nukes the whole backtest — the offending row just lands unresolved.
@@ -276,9 +276,10 @@ def _predict_for_meeting(
     """Run ``predict_har_regime`` on ``rv_history`` and read off the panel row.
 
     Returns ``(predicted_tercile, predicted_prob, q33, q67)``. Picks the
-    h=22 row from the per-horizon output (closest to the 10-day forward
-    window the realized stat covers). Any failure inside the predict
-    call collapses to a no-op tuple so the caller can skip the row.
+    h=1 row from the per-horizon output, matching the single forward-day
+    realized stat the panel buckets against. Any failure inside the
+    predict call collapses to a no-op tuple so the caller can skip the
+    row.
     """
 
     if not rv_history or len(rv_history) < _MIN_RV_HISTORY:
@@ -354,7 +355,7 @@ def build_har_tercile_backtest(
     Walks the published FOMC meeting calendar (most recent first) up to
     ``limit`` events, predicts the HAR-tercile regime against the
     rolling RV history strictly before each event, and resolves the
-    realized tercile from the forward 10-bar window. Deduplicates by
+    realized tercile from the single h=1 forward bar. Deduplicates by
     meeting date so the panel never carries two rows for the same
     event. Returns the dict-shape the endpoint wraps in
     ``HarTercileBacktestResponse``. ``session`` is accepted for API

--- a/frontend/components/analyze/HarAccuracyPanel.tsx
+++ b/frontend/components/analyze/HarAccuracyPanel.tsx
@@ -322,8 +322,9 @@ export function HarAccuracyPanel({
       <div className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-[11px] text-muted-foreground">
-            Resolved tercile is bucketed off the forward 10 trading days
-            of realized vol against the same cutoffs the prediction used.
+            Resolved tercile is bucketed off the single forward-day
+            realized variance against the same cutoffs the h=1 prediction
+            used.
           </p>
           {symbolBadge ? (
             <Badge

--- a/frontend/components/analyze/MarketReactionPanel.tsx
+++ b/frontend/components/analyze/MarketReactionPanel.tsx
@@ -7,7 +7,6 @@ import type {
   MarketReactionPanelResponse,
   RatesDirectionalBucket,
   RatesReactionCard as RatesReactionCardData,
-  VolRegimeReactionCard as VolRegimeReactionCardData,
 } from "@/lib/analyze/types";
 
 const HEAD_LABELS: Record<RatesReactionCardData["head"], string> = {
@@ -124,57 +123,18 @@ export function RatesReactionCard({ card }: RatesReactionCardProps) {
   );
 }
 
-interface VolRegimeReactionCardProps {
-  card: VolRegimeReactionCardData;
-}
-
-function VolRegimeCard({ card }: VolRegimeReactionCardProps) {
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <CardDescription className="flex items-center gap-1.5">
-          <TrendingUp className="h-3.5 w-3.5" />
-          Volatility Regime
-        </CardDescription>
-        <CardTitle className="flex items-center justify-between text-2xl capitalize">
-          <span>{card.regime_label}</span>
-          <Badge variant="outline">
-            {card.predicted_set.length > 0 ? `{${card.predicted_set.join(", ")}}` : "—"}
-          </Badge>
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-2">
-        {Object.entries(card.regime_probabilities).map(([label, value]) => (
-          <div key={label} className="space-y-1">
-            <div className="flex items-center justify-between text-xs text-muted-foreground">
-              <span className="capitalize">{label}</span>
-              <span className="font-medium text-foreground">{(value * 100).toFixed(0)}%</span>
-            </div>
-            <Progress value={value * 100} />
-          </div>
-        ))}
-        {card.log_rv_point != null ? (
-          <p className="text-xs text-muted-foreground pt-1">
-            Point estimate (log volatility): <span className="font-mono">{card.log_rv_point.toFixed(3)}</span>
-          </p>
-        ) : null}
-        {card.coverage != null ? (
-          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-            {(card.coverage * 100).toFixed(0)}% confidence level
-          </p>
-        ) : null}
-      </CardContent>
-    </Card>
-  );
-}
-
 interface MarketReactionPanelProps {
   panel: MarketReactionPanelResponse;
 }
 
+// The vol_regime sub-card was retired here in PR-after-#600: the
+// SecondOpinionRegime card at workspace slot 3 already owns the
+// {Calm, Normal, High} prediction set, and the duplicate at the bottom
+// of the page was confusing readers. The backend still emits
+// ``vol_regime`` on the response shape for backwards compatibility; the
+// frontend just ignores it.
 export function MarketReactionPanel({ panel }: MarketReactionPanelProps) {
-  const hasContent = panel.rates.length > 0 || panel.vol_regime != null;
-  if (!hasContent) {
+  if (panel.rates.length === 0) {
     return null;
   }
   return (
@@ -184,11 +144,10 @@ export function MarketReactionPanel({ panel }: MarketReactionPanelProps) {
           Market reaction
         </Badge>
       </div>
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         {panel.rates.map((card) => (
           <RatesReactionCard key={card.head} card={card} />
         ))}
-        {panel.vol_regime ? <VolRegimeCard card={panel.vol_regime} /> : null}
       </div>
     </div>
   );

--- a/frontend/components/analyze/MultiAxisInterpretation.tsx
+++ b/frontend/components/analyze/MultiAxisInterpretation.tsx
@@ -112,47 +112,26 @@ export function MultiAxisInterpretation({
           Sentiment breakdown returned no labels
         </p>
         <p>
-          The sentiment model ran but produced no labels for any axis. This usually means
-          the active model file is missing, or the passage is too short for the model to
-          read. Load a sentiment model, or paste a longer FOMC statement to populate stance,
-          factor, and certainty.
+          The sentiment model ran but produced no labels for any axis. Paste a
+          longer FOMC excerpt and re-run.
         </p>
       </div>
     );
   }
 
+  // The forward-guidance vs near-term-shock factor was retired in the
+  // 2026-05-12 multi-axis pivot — the training pool never carried enough
+  // labels to estimate it. The card stays in the type so legacy
+  // checkpoints can still surface it, but we no longer reserve a placeholder
+  // tile or "hidden" badge when it is absent.
   return (
     <div className="space-y-2">
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-          Sentiment breakdown
-        </Badge>
-        {!multiAxis.factor ? (
-          <Badge
-            variant="outline"
-            className="text-[10px]"
-            title="The forward-guidance vs near-term shock split needs more labelled examples than the current training pool has, so this axis is hidden until coverage improves."
-          >
-            Forward-guidance factor — hidden (too few labels)
-          </Badge>
-        ) : null}
-      </div>
+      <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+        Sentiment breakdown
+      </Badge>
       <div className="grid gap-3 sm:grid-cols-2">
         {multiAxis.stance ? <StanceTile stance={multiAxis.stance} history={stanceHistory} /> : null}
-        {multiAxis.factor ? (
-          <FactorTile factor={multiAxis.factor} history={factorHistory} />
-        ) : (
-          <div className="rounded-md border border-dashed border-border bg-muted/10 p-3 text-xs text-muted-foreground">
-            <p className="mb-1 text-[10px] uppercase tracking-wide text-foreground">
-              Forward-guidance factor · hidden
-            </p>
-            <p>
-              The forward-guidance vs near-term shock split needs more labelled examples than
-              the current training pool carries, so this axis stays hidden until coverage
-              improves.
-            </p>
-          </div>
-        )}
+        {multiAxis.factor ? <FactorTile factor={multiAxis.factor} history={factorHistory} /> : null}
         {multiAxis.certainty ? (
           <CertaintyTile certainty={multiAxis.certainty} history={certaintyHistory} />
         ) : null}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -908,8 +908,8 @@ export default function WorkspacePage() {
                   description={
                     <div className="space-y-2">
                       <p>
-                        The active checkpoint runs in regression mode. Switch to a
-                        classification-capable model in Settings to populate the calibrated{" "}
+                        The active checkpoint runs in regression mode. Re-run with a
+                        classification-capable checkpoint to populate the calibrated{" "}
                         <span className="numeric">calm / normal / high</span> prediction set.
                       </p>
                       <p className="text-muted-foreground">
@@ -926,7 +926,7 @@ export default function WorkspacePage() {
                 <PolicyActionCard action={result.policy_action} />
               ) : null}
 
-              {marketPanel && (marketPanel.rates.length > 0 || marketPanel.vol_regime) ? (
+              {marketPanel && marketPanel.rates.length > 0 ? (
                 <MarketReactionPanel panel={marketPanel} />
               ) : null}
 
@@ -938,7 +938,7 @@ export default function WorkspacePage() {
                   <EmptyState
                     variant="inline"
                     title="Sentiment breakdown unavailable."
-                    description="Load a sentiment model from the Settings page to populate stance, factor, and certainty."
+                    description="The active checkpoint did not return stance or certainty for this passage."
                   />
                 )}
                 {result.credibility ? (
@@ -947,7 +947,7 @@ export default function WorkspacePage() {
                   <EmptyState
                     variant="inline"
                     title="Credibility signals unavailable."
-                    description="Load the embedding model and the historical rate cache from the Settings page."
+                    description="The credibility checks need the embedding cache and the FRED rate history to be warm-loaded; this passage produced no signals."
                   />
                 )}
               </div>

--- a/frontend/tests/components/analyze/EmptyStateReasons.test.tsx
+++ b/frontend/tests/components/analyze/EmptyStateReasons.test.tsx
@@ -19,7 +19,9 @@ describe("Inline 'awaiting checkpoint' reasons", () => {
     expect(
       screen.getByText(/sentiment breakdown returned no labels/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/active model file is missing/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/paste a longer fomc excerpt and re-run/i),
+    ).toBeInTheDocument();
   });
 
   it("MultiAxisInterpretation renders the tile grid when at least one axis is present", () => {

--- a/frontend/tests/components/analyze/MarketReactionPanel.test.tsx
+++ b/frontend/tests/components/analyze/MarketReactionPanel.test.tsx
@@ -53,12 +53,16 @@ function fixture(): MarketReactionPanelResponse {
 }
 
 describe("MarketReactionPanel", () => {
-  it("renders one card per rates head plus the Volatility Regime card", () => {
+  it("renders one card per rates head and never the duplicate Volatility Regime tile", () => {
+    // The Volatility Regime tile used to render here alongside the
+    // rates cards; it was a duplicate of the SecondOpinionRegime card
+    // at workspace slot 3. The rates surfaces are still the panel's
+    // load-bearing content.
     render(<MarketReactionPanel panel={fixture()} />);
     expect(screen.getByText(/2y yield/i)).toBeInTheDocument();
     expect(screen.getByText(/5y yield/i)).toBeInTheDocument();
     expect(screen.getByText(/Terminal rate/i)).toBeInTheDocument();
-    expect(screen.getByText(/Volatility Regime/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Volatility Regime/i)).not.toBeInTheDocument();
   });
 
   it("shows the directional bucket badge", () => {
@@ -67,7 +71,7 @@ describe("MarketReactionPanel", () => {
     expect(tightenings.length).toBeGreaterThan(0);
   });
 
-  it("returns null when the panel has no rates or vol regime card", () => {
+  it("returns null when the panel has no rates", () => {
     const empty: MarketReactionPanelResponse = {
       rates: [],
       vol_regime: null,
@@ -75,6 +79,17 @@ describe("MarketReactionPanel", () => {
       checkpoint_path: null,
     };
     const { container } = render(<MarketReactionPanel panel={empty} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("returns null when only vol_regime is set — the duplicate tile is gone", () => {
+    const vol_only: MarketReactionPanelResponse = {
+      rates: [],
+      vol_regime: fixture().vol_regime,
+      encoder_alias: null,
+      checkpoint_path: null,
+    };
+    const { container } = render(<MarketReactionPanel panel={vol_only} />);
     expect(container).toBeEmptyDOMElement();
   });
 

--- a/tests/unit/test_har_tercile_backtest.py
+++ b/tests/unit/test_har_tercile_backtest.py
@@ -492,6 +492,23 @@ def test_realized_variance_aliases_legacy_name() -> None:
     )
 
 
+def test_realized_variance_single_bar_returns_squared_return() -> None:
+    """h=1 forward window yields a single bar; variance must still resolve.
+
+    Earlier revisions kept a ``len < 2`` guard from the legacy 10-bar
+    window, which collapsed every row to pending once the horizon moved
+    to h=1. The realized stat for one bar is just ``r * r``.
+    """
+
+    assert har_tercile_backtest._realized_variance_from_log_returns([0.005]) == pytest.approx(
+        0.005 * 0.005
+    )
+    assert har_tercile_backtest._realized_variance_from_log_returns([-0.012]) == pytest.approx(
+        0.012 * 0.012
+    )
+    assert har_tercile_backtest._realized_variance_from_log_returns([]) is None
+
+
 # ---------------------------------------------------------------------------
 # TTL in-process cache on yfinance fetchers.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- HAR backtest helper rejected single-bar windows after PR #600 moved horizon to h=1 — every row landed pending. Guard relaxed to empty-list only.
- Forward-guidance factor placeholder + "Settings page" empty-states dropped — factor axis was retired in the 2026-05-12 pivot and there is no Settings page in the top nav.
- Duplicate Volatility Regime tile inside Market Reaction removed — late-fusion at workspace slot 3 already owns it.

## Test plan

- [ ] `docker compose run --rm backend pytest tests/unit/test_har_tercile_backtest.py`
- [ ] `docker compose exec frontend npx vitest run`
- [ ] `curl http://localhost:8000/forecast/har-tercile-backtest?symbol=%5EGSPC&limit=3` returns `resolved_runs >= 1`