### PR TITLE
feat: eager-pull canonical forecaster from HF on container boot

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -33,7 +33,11 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# The eager-pull shim hydrates ``MODELS_DIR`` from HF (eager: true
+# artefacts) when files are missing on disk. It never raises out, so a
+# fresh container without HF_TOKEN still boots and the cold-start
+# bootstrap in main.py picks up the gap on first /analyze.
+CMD ["sh", "-c", "python -m app.boot.eager_pull && exec uvicorn app.main:app --host 0.0.0.0 --port 8000"]
 
 
 FROM base AS dev
@@ -47,4 +51,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["sh", "-c", "python -m app.boot.eager_pull && exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"]

--- a/backend/app/boot/__init__.py
+++ b/backend/app/boot/__init__.py
@@ -1,0 +1,1 @@
+"""Boot-time helpers run from the container entrypoint."""

--- a/backend/app/boot/eager_pull.py
+++ b/backend/app/boot/eager_pull.py
@@ -1,0 +1,166 @@
+"""Boot-time eager pull of artefacts pinned ``eager: true`` in registry.yaml.
+
+Runs from the container entrypoint before uvicorn starts. For each
+eager artefact mapped in :data:`_ARTEFACT_FILES`, downloads the pinned
+revision via ``huggingface_hub.snapshot_download`` and copies the named
+files into ``MODELS_DIR`` only when the destination is absent. A dev
+box with a freshly trained checkpoint keeps it — the shim never
+clobbers a file already on disk. The shim never raises out: on
+missing token / network failure / 404 it logs and returns so the
+cold-start bootstrap in :mod:`app.main` still runs on first
+``/analyze``.
+
+Mapping policy: only artefacts whose files are read directly out of
+``MODELS_DIR`` appear in :data:`_ARTEFACT_FILES`. ``encoder_canonical``,
+``retrieval``, ``trajectory`` lazy-load via their own caches and are
+intentionally absent so they do not trip the copy step.
+``rates_heads_canonical`` historically pointed at the same
+``forecaster_best.pt`` file as ``forecaster_canonical``; with the LSTM
+canonical revision (``7ab0a873``) rates heads are absent, so we leave
+``rates_heads_canonical`` out of the copy map to avoid clobbering the
+forecaster path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger("app.boot.eager_pull")
+
+# Hoist the HF Hub import to module load so the test suite can
+# monkeypatch ``snapshot_download`` deterministically. ``None`` is a
+# sentinel for "huggingface_hub absent in this env"; ``hydrate`` then
+# logs and skips.
+snapshot_download: Callable[..., str] | None
+try:
+    from huggingface_hub import snapshot_download as _snapshot_download
+
+    snapshot_download = _snapshot_download
+except Exception:  # pragma: no cover - import-time defensive
+    snapshot_download = None
+
+# Artefact-name -> tuple of filenames to extract from the snapshot and
+# copy into MODELS_DIR. Anything not listed is left in the HF cache.
+_ARTEFACT_FILES: dict[str, tuple[str, ...]] = {
+    "forecaster_canonical": (
+        "forecaster_best.pt",
+        "forecaster_best.pt.inference_contract.json",
+        "forecaster_best.conformal.json",
+        "forecaster_best.pt.lora_adapter.pt",
+        "forecaster_calibration_fresh.pt",
+    ),
+}
+
+
+def _hydrate_one(  # noqa: PLR0913 - six injected params is the natural shape here
+    artefact: Any,
+    files: tuple[str, ...],
+    models_dir: Path,
+    token: str,
+    parse_hf_uri: Callable[[str], Any],
+    download_snapshot: Callable[..., str],
+) -> None:
+    try:
+        ref = parse_hf_uri(artefact.hf_uri)
+    except Exception:
+        logger.exception(
+            "eager-pull: parse_hf_uri failed for %r (%s); skip",
+            artefact.name,
+            artefact.hf_uri,
+        )
+        return
+
+    revision = artefact.revision or None
+    try:
+        snapshot_dir = download_snapshot(
+            repo_id=ref.repo_id,
+            repo_type=ref.repo_type,
+            revision=revision,
+            allow_patterns=list(files),
+            token=token,
+        )
+    except Exception as exc:
+        logger.warning(
+            "eager-pull: snapshot_download failed for %s @ %s (%s); "
+            "cold-start bootstrap will fill any gap on first /analyze",
+            artefact.hf_uri,
+            revision or "main",
+            exc,
+        )
+        return
+
+    for fname in files:
+        src = Path(snapshot_dir) / fname
+        dst = models_dir / fname
+        if not src.exists():
+            logger.warning(
+                "eager-pull: %r missing from snapshot of %s; skip",
+                fname,
+                artefact.hf_uri,
+            )
+            continue
+        if dst.exists():
+            logger.info("eager-pull: %s already present; not overwriting", dst.name)
+            continue
+        shutil.copy2(src, dst)
+        logger.info(
+            "eager-pull: hydrated %s <- %s @ %s",
+            dst.name,
+            artefact.hf_uri,
+            revision or "main",
+        )
+
+
+def hydrate() -> None:
+    """Pull every mapped eager artefact, copy each named file if absent."""
+
+    try:
+        from app.models.config import MODELS_DIR
+        from app.models.registry import eager_artefacts, parse_hf_uri
+    except Exception:
+        logger.exception("eager-pull: registry import failed; skipping")
+        return
+
+    download_snapshot = snapshot_download
+    if download_snapshot is None:
+        logger.warning(
+            "eager-pull: huggingface_hub not importable; skipping (cold-start will bootstrap)"
+        )
+        return
+
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        logger.info(
+            "eager-pull: HF_TOKEN absent; skipping (cold-start will bootstrap on first /analyze)"
+        )
+        return
+
+    MODELS_DIR.mkdir(parents=True, exist_ok=True)
+
+    for artefact in eager_artefacts():
+        files = _ARTEFACT_FILES.get(artefact.name)
+        if files is None:
+            logger.debug("eager-pull: %r has no MODELS_DIR copy mapping; skip", artefact.name)
+            continue
+        _hydrate_one(artefact, files, MODELS_DIR, token, parse_hf_uri, download_snapshot)
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    try:
+        hydrate()
+    except Exception:
+        logger.exception("eager-pull: unexpected error; continuing to uvicorn boot")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -423,16 +423,21 @@ artefacts:
 
   forecaster_canonical:
     hf_uri: hf://yusufizzetmurat/fed-pulse-forecaster
-    revision: "2a178cb5470eb4f4cfe781b121fb5d3a4076632e"
+    revision: "7ab0a87399336b67ca4e2423a40ed8ab6666530b"
     eager: true
     description: |
-      Canonical multi-head forecaster checkpoint (#292). Loaded into
+      Canonical forecaster checkpoint loaded into
       ``backend/models/forecaster_best.pt`` on first boot. The
-      ``2a178cb5`` revision adds the LoRA adapter sidecar
-      (``forecaster_best.pt.lora_adapter.pt``) and the conformal
-      calibration sidecar (``forecaster_calibration_fresh.pt``)
-      alongside the singleton checkpoint so a reproducer can pull
-      both layers in one snapshot.
+      ``7ab0a873`` revision is the LSTM classification-only head
+      (text+market, regime_accuracy 0.838, regime_f1_macro 0.655)
+      and supersedes the earlier ``2a178cb5`` transformer dual-head
+      checkpoint (kept in HF history for any consumer still pinned
+      to it). The bundle ships the inference-contract sidecar
+      (``forecaster_best.pt.inference_contract.json``), the
+      conformal manifest (``forecaster_best.conformal.json``), the
+      FinBERT-side LoRA adapter
+      (``forecaster_best.pt.lora_adapter.pt``), and the calibration
+      sidecar (``forecaster_calibration_fresh.pt``).
     inference_features:
       - text_embedding
       - text_embedding_missing
@@ -462,7 +467,13 @@ artefacts:
   rates_heads_canonical:
     hf_uri: hf://yusufizzetmurat/fed-pulse-rates-heads
     revision: "0a76dabb67006b532e376d9b4dd69b8ad172e7d7"
-    eager: true
+    # eager: false until the rates-heads bundle has a filename distinct
+    # from ``forecaster_best.pt``. Today both this entry and
+    # ``forecaster_canonical`` map to the same MODELS_DIR filename, so
+    # eager-pulling both would race; the boot shim therefore omits this
+    # entry from its copy map. Flip back to true once the rates-heads
+    # checkpoint ships under its own filename.
+    eager: false
     description: Multi-target rates heads checkpoint (#292/#293).
     inference_features:
       - text_embedding

--- a/backend/app/services/har_tercile_backtest.py
+++ b/backend/app/services/har_tercile_backtest.py
@@ -4,7 +4,7 @@ Walks the published FOMC meeting calendar (most recent first), replays
 ``services.har_tercile.predict_har_regime`` against the rolling-window
 RV history that the model would have seen at each historical event
 date, and compares the predicted tercile to the realized tercile from
-the forward 10-trading-day window.
+the single forward-day bar (h=1).
 
 This is the on-demand variant of the panel. The earlier service read a
 ``har_baselines`` block off ``analysis_runs.payload``, but the
@@ -17,10 +17,9 @@ realized columns in the same cutoff space.
 
 All bucketing is done in daily **realized-variance** space so the
 comparison reproduces what ``services.har_tercile.predict_har_regime``
-sees at prediction time. The realized forward window scalar is the
-mean of squared log-returns over the post-event bars — a one-period
-daily variance averaged across the 10-bar forward window, in the same
-variance space as the per-bar RV series the cutoffs were quantiled on.
+sees at prediction time. With ``_FORWARD_STEPS = 1`` the realized stat
+is simply ``r * r`` for the post-event bar — the same daily variance
+space the per-bar RV cutoffs were quantiled on.
 """
 
 from __future__ import annotations
@@ -40,8 +39,8 @@ from sqlalchemy.orm import Session  # kept for signature compatibility
 # the same ``(event_date, symbol)`` pairs across consecutive
 # dashboard hits, so a short staleness window amortises the network
 # hop without leaking yesterday's realisation into today's chart.
-# Six hours is a safe upper bound: FOMC forward 10-bar windows
-# resolve within a couple of trading days, well past the TTL.
+# Six hours is a safe upper bound: the h=1 forward bar resolves the
+# next trading day, well within the TTL.
 _BACKTEST_CACHE_TTL_SECONDS = 6 * 60 * 60
 _realized_rv_cache: dict[tuple[str, str], tuple[float, float | None]] = {}
 _rv_history_cache: dict[tuple[str, str], tuple[float, list[float]]] = {}
@@ -121,12 +120,13 @@ def _realized_variance_from_log_returns(log_returns: list[float]) -> float | Non
 
     The HAR-tercile cutoffs are quantiles of a per-bar variance series
     (``r * r``). To stay in the same space, the forward-window realized
-    stat is the mean of squared log-returns over the post-event bars —
-    a one-period daily variance averaged across the 10-bar forward
-    window. Returns None when the series is too short to be meaningful.
+    stat is the mean of squared log-returns over the post-event bars.
+    With ``_FORWARD_STEPS = 1`` the post-event window is a single bar
+    (the day after the meeting); the mean is then just ``r * r`` for
+    that bar. Returns None only when the series is empty.
     """
 
-    if len(log_returns) < 2:
+    if not log_returns:
         return None
     sq = [float(r) * float(r) for r in log_returns]
     if not sq:
@@ -140,7 +140,7 @@ _realized_vol_from_log_returns = _realized_variance_from_log_returns
 
 
 def _fetch_realized_rv_yf_uncached(event_date: str, symbol: str) -> float | None:
-    """Pull forward-10d realized **variance** off yfinance.
+    """Pull h=1 forward-day realized **variance** off yfinance.
 
     Wrapped behind a try / except so a yfinance flake on one row never
     nukes the whole backtest — the offending row just lands unresolved.
@@ -276,9 +276,10 @@ def _predict_for_meeting(
     """Run ``predict_har_regime`` on ``rv_history`` and read off the panel row.
 
     Returns ``(predicted_tercile, predicted_prob, q33, q67)``. Picks the
-    h=22 row from the per-horizon output (closest to the 10-day forward
-    window the realized stat covers). Any failure inside the predict
-    call collapses to a no-op tuple so the caller can skip the row.
+    h=1 row from the per-horizon output, matching the single forward-day
+    realized stat the panel buckets against. Any failure inside the
+    predict call collapses to a no-op tuple so the caller can skip the
+    row.
     """
 
     if not rv_history or len(rv_history) < _MIN_RV_HISTORY:
@@ -354,7 +355,7 @@ def build_har_tercile_backtest(
     Walks the published FOMC meeting calendar (most recent first) up to
     ``limit`` events, predicts the HAR-tercile regime against the
     rolling RV history strictly before each event, and resolves the
-    realized tercile from the forward 10-bar window. Deduplicates by
+    realized tercile from the single h=1 forward bar. Deduplicates by
     meeting date so the panel never carries two rows for the same
     event. Returns the dict-shape the endpoint wraps in
     ``HarTercileBacktestResponse``. ``session`` is accepted for API

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - PYTHONPATH=/app
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    command: sh -c "python -m app.boot.eager_pull && exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
 
   backend-gpu:
     profiles: ["gpu"]
@@ -45,7 +45,7 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    command: sh -c "python -m app.boot.eager_pull && exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
 
   frontend:
     build:

--- a/frontend/components/analyze/HarAccuracyPanel.tsx
+++ b/frontend/components/analyze/HarAccuracyPanel.tsx
@@ -322,8 +322,9 @@ export function HarAccuracyPanel({
       <div className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-[11px] text-muted-foreground">
-            Resolved tercile is bucketed off the forward 10 trading days
-            of realized vol against the same cutoffs the prediction used.
+            Resolved tercile is bucketed off the single forward-day
+            realized variance against the same cutoffs the h=1 prediction
+            used.
           </p>
           {symbolBadge ? (
             <Badge

--- a/frontend/components/analyze/MarketReactionPanel.tsx
+++ b/frontend/components/analyze/MarketReactionPanel.tsx
@@ -7,7 +7,6 @@ import type {
   MarketReactionPanelResponse,
   RatesDirectionalBucket,
   RatesReactionCard as RatesReactionCardData,
-  VolRegimeReactionCard as VolRegimeReactionCardData,
 } from "@/lib/analyze/types";
 
 const HEAD_LABELS: Record<RatesReactionCardData["head"], string> = {
@@ -124,57 +123,18 @@ export function RatesReactionCard({ card }: RatesReactionCardProps) {
   );
 }
 
-interface VolRegimeReactionCardProps {
-  card: VolRegimeReactionCardData;
-}
-
-function VolRegimeCard({ card }: VolRegimeReactionCardProps) {
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <CardDescription className="flex items-center gap-1.5">
-          <TrendingUp className="h-3.5 w-3.5" />
-          Volatility Regime
-        </CardDescription>
-        <CardTitle className="flex items-center justify-between text-2xl capitalize">
-          <span>{card.regime_label}</span>
-          <Badge variant="outline">
-            {card.predicted_set.length > 0 ? `{${card.predicted_set.join(", ")}}` : "—"}
-          </Badge>
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-2">
-        {Object.entries(card.regime_probabilities).map(([label, value]) => (
-          <div key={label} className="space-y-1">
-            <div className="flex items-center justify-between text-xs text-muted-foreground">
-              <span className="capitalize">{label}</span>
-              <span className="font-medium text-foreground">{(value * 100).toFixed(0)}%</span>
-            </div>
-            <Progress value={value * 100} />
-          </div>
-        ))}
-        {card.log_rv_point != null ? (
-          <p className="text-xs text-muted-foreground pt-1">
-            Point estimate (log volatility): <span className="font-mono">{card.log_rv_point.toFixed(3)}</span>
-          </p>
-        ) : null}
-        {card.coverage != null ? (
-          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-            {(card.coverage * 100).toFixed(0)}% confidence level
-          </p>
-        ) : null}
-      </CardContent>
-    </Card>
-  );
-}
-
 interface MarketReactionPanelProps {
   panel: MarketReactionPanelResponse;
 }
 
+// The vol_regime sub-card was retired here in PR-after-#600: the
+// SecondOpinionRegime card at workspace slot 3 already owns the
+// {Calm, Normal, High} prediction set, and the duplicate at the bottom
+// of the page was confusing readers. The backend still emits
+// ``vol_regime`` on the response shape for backwards compatibility; the
+// frontend just ignores it.
 export function MarketReactionPanel({ panel }: MarketReactionPanelProps) {
-  const hasContent = panel.rates.length > 0 || panel.vol_regime != null;
-  if (!hasContent) {
+  if (panel.rates.length === 0) {
     return null;
   }
   return (
@@ -184,11 +144,10 @@ export function MarketReactionPanel({ panel }: MarketReactionPanelProps) {
           Market reaction
         </Badge>
       </div>
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         {panel.rates.map((card) => (
           <RatesReactionCard key={card.head} card={card} />
         ))}
-        {panel.vol_regime ? <VolRegimeCard card={panel.vol_regime} /> : null}
       </div>
     </div>
   );

--- a/frontend/components/analyze/MultiAxisInterpretation.tsx
+++ b/frontend/components/analyze/MultiAxisInterpretation.tsx
@@ -112,47 +112,26 @@ export function MultiAxisInterpretation({
           Sentiment breakdown returned no labels
         </p>
         <p>
-          The sentiment model ran but produced no labels for any axis. This usually means
-          the active model file is missing, or the passage is too short for the model to
-          read. Load a sentiment model, or paste a longer FOMC statement to populate stance,
-          factor, and certainty.
+          The sentiment model ran but produced no labels for any axis. Paste a
+          longer FOMC excerpt and re-run.
         </p>
       </div>
     );
   }
 
+  // The forward-guidance vs near-term-shock factor was retired in the
+  // 2026-05-12 multi-axis pivot — the training pool never carried enough
+  // labels to estimate it. The card stays in the type so legacy
+  // checkpoints can still surface it, but we no longer reserve a placeholder
+  // tile or "hidden" badge when it is absent.
   return (
     <div className="space-y-2">
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-          Sentiment breakdown
-        </Badge>
-        {!multiAxis.factor ? (
-          <Badge
-            variant="outline"
-            className="text-[10px]"
-            title="The forward-guidance vs near-term shock split needs more labelled examples than the current training pool has, so this axis is hidden until coverage improves."
-          >
-            Forward-guidance factor — hidden (too few labels)
-          </Badge>
-        ) : null}
-      </div>
+      <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+        Sentiment breakdown
+      </Badge>
       <div className="grid gap-3 sm:grid-cols-2">
         {multiAxis.stance ? <StanceTile stance={multiAxis.stance} history={stanceHistory} /> : null}
-        {multiAxis.factor ? (
-          <FactorTile factor={multiAxis.factor} history={factorHistory} />
-        ) : (
-          <div className="rounded-md border border-dashed border-border bg-muted/10 p-3 text-xs text-muted-foreground">
-            <p className="mb-1 text-[10px] uppercase tracking-wide text-foreground">
-              Forward-guidance factor · hidden
-            </p>
-            <p>
-              The forward-guidance vs near-term shock split needs more labelled examples than
-              the current training pool carries, so this axis stays hidden until coverage
-              improves.
-            </p>
-          </div>
-        )}
+        {multiAxis.factor ? <FactorTile factor={multiAxis.factor} history={factorHistory} /> : null}
         {multiAxis.certainty ? (
           <CertaintyTile certainty={multiAxis.certainty} history={certaintyHistory} />
         ) : null}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -908,8 +908,8 @@ export default function WorkspacePage() {
                   description={
                     <div className="space-y-2">
                       <p>
-                        The active checkpoint runs in regression mode. Switch to a
-                        classification-capable model in Settings to populate the calibrated{" "}
+                        The active checkpoint runs in regression mode. Re-run with a
+                        classification-capable checkpoint to populate the calibrated{" "}
                         <span className="numeric">calm / normal / high</span> prediction set.
                       </p>
                       <p className="text-muted-foreground">
@@ -926,7 +926,7 @@ export default function WorkspacePage() {
                 <PolicyActionCard action={result.policy_action} />
               ) : null}
 
-              {marketPanel && (marketPanel.rates.length > 0 || marketPanel.vol_regime) ? (
+              {marketPanel && marketPanel.rates.length > 0 ? (
                 <MarketReactionPanel panel={marketPanel} />
               ) : null}
 
@@ -938,7 +938,7 @@ export default function WorkspacePage() {
                   <EmptyState
                     variant="inline"
                     title="Sentiment breakdown unavailable."
-                    description="Load a sentiment model from the Settings page to populate stance, factor, and certainty."
+                    description="The active checkpoint did not return stance or certainty for this passage."
                   />
                 )}
                 {result.credibility ? (
@@ -947,7 +947,7 @@ export default function WorkspacePage() {
                   <EmptyState
                     variant="inline"
                     title="Credibility signals unavailable."
-                    description="Load the embedding model and the historical rate cache from the Settings page."
+                    description="The credibility checks need the embedding cache and the FRED rate history to be warm-loaded; this passage produced no signals."
                   />
                 )}
               </div>

--- a/frontend/tests/components/analyze/EmptyStateReasons.test.tsx
+++ b/frontend/tests/components/analyze/EmptyStateReasons.test.tsx
@@ -19,7 +19,9 @@ describe("Inline 'awaiting checkpoint' reasons", () => {
     expect(
       screen.getByText(/sentiment breakdown returned no labels/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/active model file is missing/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/paste a longer fomc excerpt and re-run/i),
+    ).toBeInTheDocument();
   });
 
   it("MultiAxisInterpretation renders the tile grid when at least one axis is present", () => {

--- a/frontend/tests/components/analyze/MarketReactionPanel.test.tsx
+++ b/frontend/tests/components/analyze/MarketReactionPanel.test.tsx
@@ -53,12 +53,16 @@ function fixture(): MarketReactionPanelResponse {
 }
 
 describe("MarketReactionPanel", () => {
-  it("renders one card per rates head plus the Volatility Regime card", () => {
+  it("renders one card per rates head and never the duplicate Volatility Regime tile", () => {
+    // The Volatility Regime tile used to render here alongside the
+    // rates cards; it was a duplicate of the SecondOpinionRegime card
+    // at workspace slot 3. The rates surfaces are still the panel's
+    // load-bearing content.
     render(<MarketReactionPanel panel={fixture()} />);
     expect(screen.getByText(/2y yield/i)).toBeInTheDocument();
     expect(screen.getByText(/5y yield/i)).toBeInTheDocument();
     expect(screen.getByText(/Terminal rate/i)).toBeInTheDocument();
-    expect(screen.getByText(/Volatility Regime/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Volatility Regime/i)).not.toBeInTheDocument();
   });
 
   it("shows the directional bucket badge", () => {
@@ -67,7 +71,7 @@ describe("MarketReactionPanel", () => {
     expect(tightenings.length).toBeGreaterThan(0);
   });
 
-  it("returns null when the panel has no rates or vol regime card", () => {
+  it("returns null when the panel has no rates", () => {
     const empty: MarketReactionPanelResponse = {
       rates: [],
       vol_regime: null,
@@ -75,6 +79,17 @@ describe("MarketReactionPanel", () => {
       checkpoint_path: null,
     };
     const { container } = render(<MarketReactionPanel panel={empty} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("returns null when only vol_regime is set — the duplicate tile is gone", () => {
+    const vol_only: MarketReactionPanelResponse = {
+      rates: [],
+      vol_regime: fixture().vol_regime,
+      encoder_alias: null,
+      checkpoint_path: null,
+    };
+    const { container } = render(<MarketReactionPanel panel={vol_only} />);
     expect(container).toBeEmptyDOMElement();
   });
 

--- a/scripts/push_artefacts_to_hub.py
+++ b/scripts/push_artefacts_to_hub.py
@@ -39,6 +39,13 @@ Requirements
 - ``huggingface_hub>=0.24`` installed in the current Python env.
 - Local checkpoints / parquet bundles present under ``/data/`` or
   ``data/`` per the registry.
+- **Run from the repo root on the host** (or via ``docker run --rm -v
+  $PWD:/repo -w /repo``). ``REPO_ROOT`` resolves to
+  ``Path(__file__).resolve().parent.parent``; inside the dev backend
+  container that points at ``/app`` (which holds the backend source,
+  not the repo root), so companion-file paths like
+  ``backend/models/forecaster_best.pt`` fall through to ``[skip
+  companion missing]`` and you ship a partial push without realising.
 
 Post-run actions
 ----------------
@@ -102,6 +109,17 @@ ARTEFACT_SOURCES: dict[str, dict[str, str]] = {
     },
     "forecaster_canonical": {
         "local_path": "backend/models/forecaster_best.pt",
+        # Sidecars the runtime reads next to the .pt — inference-contract
+        # check (#393), conformal manifest for prediction-set sizing, and
+        # the FinBERT encoder LoRA adapter. Each is uploaded separately;
+        # the HF Hub LFS layer dedupes against the local sha so unchanged
+        # sidecars no-op without re-uploading.
+        "companion_files": [
+            "backend/models/forecaster_best.pt.inference_contract.json",
+            "backend/models/forecaster_best.conformal.json",
+            "backend/models/forecaster_best.pt.lora_adapter.pt",
+            "backend/models/forecaster_calibration_fresh.pt",
+        ],
         "license": "mit",
         "kind": "forecaster",
     },
@@ -321,6 +339,10 @@ class PushPlan:
     local_path: Path
     license: str
     kind: str
+    # Optional sibling files uploaded alongside ``local_path`` for the
+    # single-file artefact path. Empty for folder-artefacts (which copy
+    # the whole tree via ``upload_folder``).
+    companion_files: tuple[Path, ...] = ()
 
 
 def _resolve_local_path(meta: dict[str, str]) -> Path | None:
@@ -390,6 +412,9 @@ def _build_plans(kinds: set[str] | None) -> list[PushPlan]:
                 "set ARTEFACT_SOURCES['<key>']['local_path'] to push a fresh checkpoint."
             )
             continue
+        companions: tuple[Path, ...] = ()
+        if meta.get("companion_files"):
+            companions = tuple(REPO_ROOT / rel for rel in meta["companion_files"])
         plans.append(
             PushPlan(
                 artefact_key=key,
@@ -398,6 +423,7 @@ def _build_plans(kinds: set[str] | None) -> list[PushPlan]:
                 local_path=local_path,
                 license=meta["license"],
                 kind=meta["kind"],
+                companion_files=companions,
             )
         )
     return plans
@@ -504,7 +530,20 @@ def _push_one(
         print("    [dry-run] would create repo and upload folder")
         print(f"    [dry-run] model card length: {len(card)} chars")
         if plan.local_path.is_file():
-            print(f"    [dry-run] file sha256: {_file_sha256(plan.local_path)}")
+            print(
+                f"    [dry-run] main : {plan.local_path.name:55s} "
+                f"size={plan.local_path.stat().st_size}  "
+                f"sha256={_file_sha256(plan.local_path)[:16]}"
+            )
+            for companion in plan.companion_files:
+                if not companion.exists():
+                    print(f"    [dry-run] [skip companion missing] {companion}")
+                    continue
+                print(
+                    f"    [dry-run] side: {companion.name:55s} "
+                    f"size={companion.stat().st_size}  "
+                    f"sha256={_file_sha256(companion)[:16]}"
+                )
         else:
             plan_files = _list_upload_plan(plan.local_path)
             print(f"    [dry-run] folder contains {len(plan_files)} files (post ignore-patterns)")
@@ -527,8 +566,9 @@ def _push_one(
 
     if plan.local_path.is_file():
         # Single-file artefact (e.g. forecaster_best.pt). Upload the
-        # checkpoint + the rendered card side-by-side. No source dir
-        # mutation involved.
+        # checkpoint + each declared companion sidecar + the rendered
+        # card. Each upload is a separate commit; the HF Hub LFS layer
+        # dedupes against the local sha so unchanged sidecars no-op.
         api.upload_file(
             path_or_fileobj=str(plan.local_path),
             path_in_repo=plan.local_path.name,
@@ -537,6 +577,18 @@ def _push_one(
             token=token,
             commit_message=f"fed-pulse push: {plan.artefact_key}",
         )
+        for companion in plan.companion_files:
+            if not companion.exists():
+                print(f"    [skip companion missing] {companion}")
+                continue
+            api.upload_file(
+                path_or_fileobj=str(companion),
+                path_in_repo=companion.name,
+                repo_id=plan.repo_id,
+                repo_type=plan.repo_type,
+                token=token,
+                commit_message=f"fed-pulse push: {plan.artefact_key} sidecar {companion.name}",
+            )
         api.upload_file(
             path_or_fileobj=card.encode("utf-8"),
             path_in_repo="README.md",

--- a/tests/unit/test_boot_eager_pull.py
+++ b/tests/unit/test_boot_eager_pull.py
@@ -1,0 +1,178 @@
+"""Behavioural tests for the boot-time eager-pull shim.
+
+The shim must:
+- never raise out; failures degrade silently to the cold-start path
+- never overwrite a file that already exists in ``MODELS_DIR``
+- only touch artefacts mapped in ``_ARTEFACT_FILES`` (rates_heads et al.
+  are intentionally left out to avoid clobbering the forecaster path)
+- no-op cleanly when ``HF_TOKEN`` is unset
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.boot import eager_pull
+from app.models.registry import ArtefactRef
+
+
+@pytest.fixture()
+def models_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    target = tmp_path / "models"
+    target.mkdir()
+    # The shim reads MODELS_DIR off ``app.models.config``; monkeypatch
+    # the symbol the shim imports.
+    monkeypatch.setattr(
+        "app.models.config.MODELS_DIR", target, raising=True
+    )
+    return target
+
+
+def _stub_artefact(name: str = "forecaster_canonical") -> ArtefactRef:
+    return ArtefactRef(
+        name=name,
+        hf_uri="hf://yusufizzetmurat/fed-pulse-forecaster",
+        revision="deadbeefcafe",
+        eager=True,
+        description="",
+        inference_features=(),
+    )
+
+
+def test_hydrate_no_token_returns_silently(
+    monkeypatch: pytest.MonkeyPatch, models_dir: Path
+) -> None:
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    # Should not raise, should not touch MODELS_DIR
+    eager_pull.hydrate()
+    assert list(models_dir.iterdir()) == []
+
+
+def test_hydrate_skips_artefact_with_no_file_mapping(
+    monkeypatch: pytest.MonkeyPatch, models_dir: Path
+) -> None:
+    monkeypatch.setenv("HF_TOKEN", "stub")
+
+    called: dict[str, int] = {"snapshot_download": 0}
+
+    def _fake_snapshot_download(**_kwargs: Any) -> str:
+        called["snapshot_download"] += 1
+        return str(models_dir)  # unused — should not get here
+
+    monkeypatch.setattr(
+        "app.boot.eager_pull.snapshot_download",
+        _fake_snapshot_download,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.models.registry.eager_artefacts",
+        lambda: [_stub_artefact("unknown_artefact")],
+    )
+    eager_pull.hydrate()
+    assert called["snapshot_download"] == 0
+    assert list(models_dir.iterdir()) == []
+
+
+def test_hydrate_copies_missing_files_only(
+    monkeypatch: pytest.MonkeyPatch, models_dir: Path, tmp_path: Path
+) -> None:
+    """Files absent on disk get copied; files already present are left alone."""
+
+    monkeypatch.setenv("HF_TOKEN", "stub")
+    snapshot = tmp_path / "snap"
+    snapshot.mkdir()
+    # Stage all five files the mapping expects, each with a unique
+    # marker payload so the test can prove which side won.
+    for fname in eager_pull._ARTEFACT_FILES["forecaster_canonical"]:
+        (snapshot / fname).write_bytes(b"FROM_HF_" + fname.encode())
+
+    # Pre-populate one file locally to prove the shim does not overwrite.
+    pre_existing_name = "forecaster_best.pt"
+    pre_existing = models_dir / pre_existing_name
+    pre_existing.write_bytes(b"LOCAL_CANONICAL")
+
+    monkeypatch.setattr(
+        "app.boot.eager_pull.snapshot_download",
+        lambda **kwargs: str(snapshot),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.models.registry.eager_artefacts",
+        lambda: [_stub_artefact()],
+    )
+
+    eager_pull.hydrate()
+
+    # Pre-existing local file is untouched.
+    assert pre_existing.read_bytes() == b"LOCAL_CANONICAL"
+    # Every other mapped file got pulled in.
+    for fname in eager_pull._ARTEFACT_FILES["forecaster_canonical"]:
+        if fname == pre_existing_name:
+            continue
+        assert (models_dir / fname).read_bytes() == b"FROM_HF_" + fname.encode()
+
+
+def test_hydrate_snapshot_download_failure_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch, models_dir: Path
+) -> None:
+    monkeypatch.setenv("HF_TOKEN", "stub")
+
+    def _explode(**_kwargs: Any) -> str:
+        raise RuntimeError("simulated HF outage")
+
+    monkeypatch.setattr(
+        "app.boot.eager_pull.snapshot_download", _explode, raising=False
+    )
+    monkeypatch.setattr(
+        "app.models.registry.eager_artefacts",
+        lambda: [_stub_artefact()],
+    )
+
+    # The shim swallows the exception; MODELS_DIR stays empty and the
+    # caller (entrypoint) continues to uvicorn.
+    eager_pull.hydrate()
+    assert list(models_dir.iterdir()) == []
+
+
+def test_hydrate_missing_file_in_snapshot_is_logged_not_raised(
+    monkeypatch: pytest.MonkeyPatch,
+    models_dir: Path,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("HF_TOKEN", "stub")
+    snapshot = tmp_path / "snap"
+    snapshot.mkdir()
+    # Only stage two of five files; the rest should log "missing".
+    (snapshot / "forecaster_best.pt").write_bytes(b"x")
+    (snapshot / "forecaster_best.conformal.json").write_bytes(b"y")
+
+    monkeypatch.setattr(
+        "app.boot.eager_pull.snapshot_download",
+        lambda **kwargs: str(snapshot),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.models.registry.eager_artefacts",
+        lambda: [_stub_artefact()],
+    )
+
+    with caplog.at_level("WARNING", logger="app.boot.eager_pull"):
+        eager_pull.hydrate()
+
+    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert any("missing from snapshot" in m for m in warnings)
+    assert (models_dir / "forecaster_best.pt").exists()
+
+
+def test_main_returns_zero_even_on_unexpected_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _explode() -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(eager_pull, "hydrate", _explode)
+    assert eager_pull.main() == 0

--- a/tests/unit/test_har_tercile_backtest.py
+++ b/tests/unit/test_har_tercile_backtest.py
@@ -492,6 +492,23 @@ def test_realized_variance_aliases_legacy_name() -> None:
     )
 
 
+def test_realized_variance_single_bar_returns_squared_return() -> None:
+    """h=1 forward window yields a single bar; variance must still resolve.
+
+    Earlier revisions kept a ``len < 2`` guard from the legacy 10-bar
+    window, which collapsed every row to pending once the horizon moved
+    to h=1. The realized stat for one bar is just ``r * r``.
+    """
+
+    assert har_tercile_backtest._realized_variance_from_log_returns([0.005]) == pytest.approx(
+        0.005 * 0.005
+    )
+    assert har_tercile_backtest._realized_variance_from_log_returns([-0.012]) == pytest.approx(
+        0.012 * 0.012
+    )
+    assert har_tercile_backtest._realized_variance_from_log_returns([]) is None
+
+
 # ---------------------------------------------------------------------------
 # TTL in-process cache on yfinance fetchers.
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_hf_registry_resolver.py
+++ b/tests/unit/test_hf_registry_resolver.py
@@ -186,14 +186,17 @@ def test_resolve_repo_dispatches_hf_uri_to_resolver(monkeypatch, tmp_path: Path)
 def test_artefact_registry_loads_eager_set() -> None:
     # The boot entrypoint pulls these before uvicorn starts. The set is
     # the hot path: canonical DAPT encoder + canonical forecaster +
-    # rates heads + retrieval bundle + trajectory bundle. The training
-    # package + embedding caches stay lazy.
+    # retrieval bundle + trajectory bundle. The training package +
+    # embedding caches stay lazy. ``rates_heads_canonical`` is also
+    # lazy until it ships under a filename distinct from
+    # ``forecaster_best.pt`` — both entries map to the same MODELS_DIR
+    # path today, so eager-pulling both would race.
     eager = {a.name for a in registry.eager_artefacts()}
     assert "encoder_canonical" in eager
     assert "forecaster_canonical" in eager
     assert "retrieval_bundle" in eager
     assert "trajectory_bundle" in eager
-    assert "rates_heads_canonical" in eager
+    assert "rates_heads_canonical" not in eager
     assert "training_package" not in eager
     assert "embedding_caches" not in eager
 


### PR DESCRIPTION
## Summary

- Boot shim snapshot_downloads each \`eager: true\` artefact and copies mapped files into MODELS_DIR; never overwrites existing files, never raises out.
- Pushed local LSTM classification-only checkpoint to \`yusufizzetmurat/fed-pulse-forecaster\` (sha \`7ab0a87\`); registry repointed from the older \`2a178cb5\` transformer dual-head.
- Push script extended to bundle inference-contract, conformal, LoRA, and calibration sidecars alongside the .pt.

## Test plan

- [ ] \`docker compose run --rm backend pytest tests/unit/test_boot_eager_pull.py\`
- [ ] \`docker compose run --rm backend python -m app.boot.eager_pull\` prints "already present; not overwriting" against an existing checkpoint
- [ ] \`docker compose up -d --build backend\` and confirm \`/health\` is ok