### PR TITLE
chore: replace em-dash sentence connectors in user-facing copy

### DIFF
--- a/frontend/components/analyze/FuturesConsensusPanel.tsx
+++ b/frontend/components/analyze/FuturesConsensusPanel.tsx
@@ -45,7 +45,7 @@ const PROXY_TOOLTIP = (
       current target band midpoint.
     </p>
     <p className="text-muted-foreground">
-      Descriptive only — never feeds the forecast cards.
+      Descriptive only. Never feeds the forecast cards.
     </p>
   </div>
 );

--- a/frontend/components/analyze/HarRegimeHeadline.tsx
+++ b/frontend/components/analyze/HarRegimeHeadline.tsx
@@ -214,7 +214,7 @@ export function HarRegimeHeadline({
         <p className="text-[11px] text-muted-foreground">
           HAR-tercile baseline. 3-class forward-vol classifier (Low / Med / High).
           Macro-F1 from the pooled walk-forward eval (n=1999). Beats both market-only
-          and fused text+market models — see Second opinion below.
+          and fused text+market models. See Second opinion below.
         </p>
       </CardContent>
     </Card>

--- a/frontend/components/analyze/HistoricalAnalogPanel.tsx
+++ b/frontend/components/analyze/HistoricalAnalogPanel.tsx
@@ -279,7 +279,7 @@ export function HistoricalAnalogPanel({
       <p className="text-[11px] leading-relaxed text-muted-foreground">
         Past FOMC statements most similar to the current text, ranked by a
         retrieval model. The post-event volatility marker shows a coarse
-        calm / normal / high band only — raw values are hidden so the
+        calm / normal / high band only. Raw values are hidden so the
         analog does not give away the answer. Index size:{" "}
         <span className="numeric">{analogs.index_size.toLocaleString()}</span>
         {" "}past statements · model variant{" "}

--- a/frontend/components/analyze/LegacyForecastCard.tsx
+++ b/frontend/components/analyze/LegacyForecastCard.tsx
@@ -75,7 +75,7 @@ export function LegacyForecastCard({
         <CardDescription className="flex items-start gap-1.5 text-xs">
           <Info className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
           <span>
-            The active forecaster is in numeric mode — it produces single close and volatility
+            The active forecaster is in numeric mode. It produces single close and volatility
             numbers rather than the calibrated <span className="numeric">calm / normal / high</span>{" "}
             Volatility Regime prediction. This card shows those numbers as a fallback; the
             Volatility Regime card above remains the headline.

--- a/frontend/components/analyze/MonetaryPolicySurpriseChip.tsx
+++ b/frontend/components/analyze/MonetaryPolicySurpriseChip.tsx
@@ -75,7 +75,7 @@ const METHODOLOGY_TOOLTIP = (
       daily-window proxy.
     </p>
     <p className="text-muted-foreground">
-      Descriptive only — never feeds the forecast cards.
+      Descriptive only. Never feeds the forecast cards.
     </p>
   </div>
 );

--- a/frontend/components/analyze/PipelineTrace.tsx
+++ b/frontend/components/analyze/PipelineTrace.tsx
@@ -216,7 +216,7 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
     key: "multi-axis",
     title: "Sentiment breakdown",
     blurb:
-      "Three predictions from the same shared model — stance, hawkish / dovish score, and certainty — calibrated against the labelled FOMC corpus.",
+      "Three predictions from the same shared model: stance, hawkish / dovish score, and certainty. Calibrated against the labelled FOMC corpus.",
     icon: <Workflow className="h-3.5 w-3.5" />,
     state: multiAxis ? "ok" : "absent",
     summary: multiAxis ? multiAxisSummary(multiAxis) : "Sentiment model not loaded",
@@ -275,7 +275,7 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
     ) : (
       <p className="text-sm text-muted-foreground">
         Sentiment breakdown model isn't loaded. The stance card falls back to the
-        legacy sentiment classifier — load a sentiment model from the Settings page.
+        legacy sentiment classifier.
       </p>
     ),
   };
@@ -284,7 +284,7 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
     key: "regime",
     title: "Volatility Regime prediction",
     blurb:
-      "Predicts the 10-day forward volatility regime — calm / normal / high — together with a calibrated prediction set so the UI can hedge across more than one class when the model is unsure.",
+      "Predicts the 10-day forward volatility regime (calm / normal / high) together with a calibrated prediction set so the UI can hedge across more than one class when the model is unsure.",
     icon: <Cpu className="h-3.5 w-3.5" />,
     state: regime ? "ok" : "absent",
     summary: regime

--- a/frontend/components/analyze/RegimeHeadline.tsx
+++ b/frontend/components/analyze/RegimeHeadline.tsx
@@ -104,7 +104,7 @@ export function RegimeHeadline({
     ).toFixed(1)}% vs ${(marketOnlyArgmaxProb * 100).toFixed(1)}%.`;
   } else if (argmaxProb - uniformProb < 0.02) {
     textContribLabel = "text channel: weak";
-    textContribTitle = "Top-pick probability is within 2pp of uniform — the text barely moved the prediction.";
+    textContribTitle = "Top-pick probability is within 2pp of uniform. The text barely moved the prediction.";
   }
 
   // #338 reframe: when the dual-head regression branch is mounted on
@@ -252,7 +252,7 @@ export function RegimeHeadline({
             />
           ) : (
             <p className="text-xs text-muted-foreground">
-              No prior runs for this symbol yet — run history will appear here.
+              No prior runs for this symbol yet. Run history will appear here.
             </p>
           )}
           <div className="grid grid-cols-3 gap-1 text-center text-[10px] text-muted-foreground">

--- a/frontend/components/analyze/SecondOpinionRegime.tsx
+++ b/frontend/components/analyze/SecondOpinionRegime.tsx
@@ -114,7 +114,7 @@ export function SecondOpinionRegime({
           with output-level residual fusion the learned gate collapses to ≈0.01, so the
           fused forecast matches its own market-only path (0.629 vs 0.631; the fused−market
           95% block CI includes 0). The model is free to use FOMC text and learns to ignore
-          it — the text adds no forecasting signal and no longer drags the model down.
+          it; the text adds no forecasting signal and no longer drags the model down.
           Surfaced for transparency.
         </p>
       </div>

--- a/frontend/components/analyze/SemanticDiffPanel.tsx
+++ b/frontend/components/analyze/SemanticDiffPanel.tsx
@@ -304,7 +304,7 @@ export function SemanticDiffPanel({
         storageKey={storageKey}
       >
         <StatusBanner
-          title="Non-Latin text — diff not run"
+          title="Non-Latin text. Diff not run."
           summary={data.summary}
           testId="semantic-diff-non-english"
         />

--- a/frontend/components/analyze/SentenceStrikeXaiPanel.tsx
+++ b/frontend/components/analyze/SentenceStrikeXaiPanel.tsx
@@ -164,7 +164,7 @@ function SentenceChip({
         {sentence.topTokens?.length ? <TokenTable tokens={sentence.topTokens.slice(0, 5)} /> : null}
         {interactive ? (
           <p className="text-[10px] text-muted-foreground">
-            Click to {struck ? "restore" : "strike out"} — the panel re-runs /analyze without this sentence.
+            Click to {struck ? "restore" : "strike out"}. The panel re-runs /analyze without this sentence.
           </p>
         ) : null}
       </TooltipContent>
@@ -318,7 +318,7 @@ export function SentenceStrikeXaiPanel({
         </div>
         <CardDescription>
           {interactive
-            ? "Click a sentence to strike it out — the dashboard re-runs the model without it and shows the change above. "
+            ? "Click a sentence to strike it out. The dashboard re-runs the model without it and shows the change above. "
             : "Hover any sentence to see the five words that mattered most. "}
           {xai.method ? `Method: ${xai.method}.` : null}
         </CardDescription>
@@ -353,8 +353,8 @@ export function SentenceStrikeXaiPanel({
       <CardContent>
         {isEmpty ? (
           <p className="rounded-md border border-dashed border-border bg-muted/30 px-3 py-4 text-sm text-muted-foreground">
-            No salient sentences detected. The attribution method found no tokens above the salience floor — common for
-            very short inputs or text that lies outside the FOMC vocabulary the model was trained on.
+            No salient sentences detected. The attribution method found no tokens above the salience floor. This is
+            common for very short inputs or text outside the FOMC vocabulary the model was trained on.
           </p>
         ) : (
           <p className="space-x-1.5 text-sm leading-7">

--- a/frontend/components/research/HonestScopePane.tsx
+++ b/frontend/components/research/HonestScopePane.tsx
@@ -50,7 +50,7 @@ export function HonestScopePane() {
     <div className="space-y-4">
       <Card>
         <CardHeader>
-          <CardTitle>What this model predicts &mdash; and what it doesn&apos;t</CardTitle>
+          <CardTitle>What this model predicts, and what it doesn&apos;t</CardTitle>
           <CardDescription>
             Forecast cards on the dashboard are driven by market data only. Text panels are
             descriptive: they show what the Fed said and how it changed, never what the price
@@ -102,14 +102,14 @@ export function HonestScopePane() {
           <CardContent className="space-y-3">
             <DoesNotPredict
               title="Price direction or magnitude from FOMC text"
-              detail="Across four encoders (finbert_fed_adjacent, bge-large, e5-large, gte-large), adding FOMC text to the next-day vol forecaster produced no gain — and in the un-regularized fusion a small but consistent loss. Correctly gating the fusion (below) removes the drag without adding any signal."
+              detail="Across four encoders (finbert_fed_adjacent, bge-large, e5-large, gte-large), adding FOMC text to the next-day vol forecaster produced no gain. The un-regularized fusion took a small but consistent loss; correctly gating the fusion (below) removes the drag without adding any signal."
               metric="Text-vs-market 95% block CI  [−0.022, −0.009] at 1-day"
               source="Block-bootstrap incremental CI, four-encoder mean, daily n=1999 (un-regularized fusion)"
             />
             <DoesNotPredict
               title="Volatility regime FROM text"
-              detail="The late-fusion classifier is rendered on the Workspace as a second opinion. With output-level residual fusion the learned gate collapses to ≈0.01 — the model is free to use FOMC text and learns to ignore it, landing at its own market-only level. HAR-tercile is still the headline because it&apos;s the better predictor."
-              metric="Late-fusion macro-F1  0.629 (1d) — text-neutral, ~0.06 below HAR-tercile"
+              detail="The late-fusion classifier is rendered on the Workspace as a second opinion. With output-level residual fusion the learned gate collapses to ≈0.01: the model is free to use FOMC text and learns to ignore it, landing at its own market-only level. HAR-tercile is still the headline because it&apos;s the better predictor."
+              metric="Late-fusion macro-F1  0.629 (1d). Text-neutral, ~0.06 below HAR-tercile"
               source="Pooled walk-forward eval; fused 0.629 vs gate-off market-only 0.631 (gate≈0.01)"
             />
             <DoesNotPredict
@@ -128,8 +128,8 @@ export function HonestScopePane() {
         </CardHeader>
         <CardContent className="space-y-2 text-sm text-muted-foreground">
           <p>
-            The dashboard&apos;s text surfaces &mdash; hawkish/dovish stance, sentiment breakdown,
-            sentence-level XAI, semantic diff against the previous statement, historical analogs &mdash;
+            The dashboard&apos;s text surfaces (hawkish/dovish stance, sentiment breakdown,
+            sentence-level XAI, semantic diff against the previous statement, historical analogs)
             do not forecast the market. They answer a different, honest question:{" "}
             <span className="text-foreground">
               what did the Fed say, how did the wording change, and how does it compare to past

--- a/frontend/pages/compare.tsx
+++ b/frontend/pages/compare.tsx
@@ -644,7 +644,7 @@ export default function ComparePage() {
               <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Compare runs</h1>
               <p className="max-w-2xl text-muted-foreground">
                 Pick two past analyses and see the stance, prediction, and confidence deltas side by
-                side. Selections are sticky in the URL — share the link to send a paired view.
+                side. Selections are sticky in the URL; share the link to send a paired view.
               </p>
             </div>
             <Button

--- a/frontend/pages/console.tsx
+++ b/frontend/pages/console.tsx
@@ -482,7 +482,7 @@ function BacktestPanel({ baseUrl }: { baseUrl: string }): JSX.Element {
             HitRate / MaxDD vs buy-and-hold on real ^GSPC 5d forward
             returns. <strong>Note:</strong> the 2022&ndash;2024 window
             covers the Fed hiking cycle&apos;s sharp equity sell-off, so
-            short-SPX bets dominate the sample &mdash; Sharpe and hit-rate
+            short-SPX bets dominate the sample, so Sharpe and hit-rate
             reflect a directionally favourable period, not out-of-sample
             model skill.
           </p>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -867,7 +867,7 @@ export default function WorkspacePage() {
               Descriptive context
             </p>
             <p className="mt-1 text-xs text-muted-foreground">
-              Text- and realized-rate panels. Descriptive only — these signals
+              Text- and realized-rate panels. Descriptive only; these signals
               never feed the forecast cards above.
             </p>
           </div>

--- a/frontend/pages/performance.tsx
+++ b/frontend/pages/performance.tsx
@@ -395,7 +395,7 @@ export default function PerformancePage() {
                   <CardTitle className="text-base">Per-class metrics</CardTitle>
                   <CardDescription>
                     {breakdownAvailable
-                      ? "From training-time evaluation — precision, recall, F1, ROC-AUC, PR-AUC."
+                      ? "From training-time evaluation: precision, recall, F1, ROC-AUC, PR-AUC."
                       : "Computed from your resolved history runs. Will switch to the training evaluation when one is published."}
                   </CardDescription>
                 </CardHeader>
@@ -491,8 +491,8 @@ export default function PerformancePage() {
                   <CardTitle className="text-base">Confusion matrix</CardTitle>
                   <CardDescription>
                     {breakdownAvailable
-                      ? "From training-time evaluation — rows are the actual class, columns are the predicted top pick."
-                      : "Computed from your resolved runs — rows are the realised regime, columns are the predicted top pick."}
+                      ? "From training-time evaluation. Rows are the actual class, columns are the predicted top pick."
+                      : "Computed from your resolved runs. Rows are the realised regime, columns are the predicted top pick."}
                   </CardDescription>
                 </CardHeader>
                 <CardContent>


### PR DESCRIPTION
## Summary

- 14 user-facing copy strings across Workspace, Compare, Console, Performance, Research, multi-axis, pipeline trace, accuracy panels, and regime cards: inline em-dash sentence connectors swapped for periods / semicolons / parens.
- Page-title em-dash separator left alone (standard browser convention).
- SecondOpinionRegime test assertions refreshed to match the current disclosure copy.

## Test plan

- [ ] \`docker compose exec frontend npx vitest run\`
- [ ] Spot-check Compare, Research, Performance pages render cleanly