### PR TITLE
feat: wire live intraday realized measures into the QLIKE-DLq RV forecaster

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1945,6 +1945,7 @@ async def forecast_realized_vol(
     artifact cannot be loaded or the history is insufficient.
     """
 
+    from app.services.intraday_features import recent_realized_measures
     from app.services.rv_forecaster import (
         RvForecasterUnavailable,
         predict_rv,
@@ -1958,8 +1959,20 @@ async def forecast_realized_vol(
             status_code=503, detail={"error": "history_unavailable", "message": str(exc)}
         ) from exc
 
+    # Best-effort: pull the latest intraday realized measures so the
+    # QLIKE-DLq head sees real values for rs_pos/rs_neg/bv/rq/rskew/
+    # rkurt/parkinson/log(rvol) instead of training-set means. A
+    # ``None`` here is a soft degrade — predict_rv falls back to the
+    # feat_mean path (HAR-grade) and surfaces ``realized_features_source
+    # == "training_means"`` on the response.
     try:
-        out = await run_in_threadpool(predict_rv, rv_hist)
+        intraday_measures = await run_in_threadpool(recent_realized_measures, symbol)
+    except Exception:  # pragma: no cover -- defensive
+        logger.warning("rv_intraday_measures_failed", exc_info=True)
+        intraday_measures = None
+
+    try:
+        out = await run_in_threadpool(predict_rv, rv_hist, intraday_measures)
     except RvForecasterUnavailable as exc:
         raise HTTPException(
             status_code=503, detail={"error": "model_unavailable", "message": str(exc)}
@@ -1991,6 +2004,8 @@ async def forecast_realized_vol(
         history_dates=hist_dates,
         model_revision=out["model_revision"],
         historical_bands=historical_bands,
+        realized_features_source=out.get("realized_features_source", "training_means"),
+        realized_features_date=out.get("realized_features_date"),
     )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1457,6 +1457,18 @@ class RealizedVolForecastResponse(BaseModel):
     history_dates: list[str] = Field(default_factory=list)
     model_revision: str
     historical_bands: list[RealizedVolHistoricalBand] | None = None
+    # "live" when the QLIKE head was filled with intraday-derived
+    # realized measures (full QLIKE edge); "training_means" when the
+    # head fell back to feat_mean (HAR-grade forecast). The dashboard
+    # surfaces this so the displayed point + bands are not misread as
+    # the full edge when intraday isn't reachable.
+    realized_features_source: str = "training_means"
+    # ISO date of the most-recent full intraday session the live
+    # measures were reduced from. ``None`` when the head fell back to
+    # training_means. The dashboard renders this in the badge tooltip
+    # so the reader can tell a Friday measure feeding a Tuesday forecast
+    # from one off the previous full session.
+    realized_features_date: str | None = None
 
 
 class HarTercileHorizon(BaseModel):

--- a/backend/app/services/intraday_features.py
+++ b/backend/app/services/intraday_features.py
@@ -1,0 +1,181 @@
+"""Live intraday realized-measure fetcher for the RV forecaster.
+
+The QLIKE-DLq forecaster was trained on an 11-feature row:
+``[har_daily, har_weekly, har_monthly, rs_pos, rs_neg, bv, rq, rskew,
+rkurt, parkinson, log(rvol+1)]``. At serve time the three HAR lags are
+trivially derivable from any daily realized-variance history, but the
+eight realized-measure columns require intraday bars to compute.
+
+Without those features the head reduces to HAR plus a tiny learned
+bias on the lags — i.e. the project's "QLIKE beats HAR by ~10%" edge
+is not delivered in production. This module closes that gap: it pulls
+5-minute bars from yfinance for the recent window, runs the existing
+``intraday_realized.daily_realized_measures`` reducer, and returns the
+most-recent complete day's measures so the forecaster fills the row
+with live values instead of training-set means.
+
+Failure modes are silent by design: a yfinance hiccup, a half-day, or
+a symbol without intraday coverage all return ``None`` and the
+forecaster falls back to its existing feat_mean substitution. The
+caller logs the source so the dashboard can surface "QLIKE-full" vs
+"HAR-fallback" honestly.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import defaultdict
+from datetime import date, datetime, timezone
+from typing import Any
+
+logger = logging.getLogger("app.services.intraday_features")
+
+# Cache key: (symbol, as_of). Value: (monotonic_timestamp, payload).
+# Four-hour TTL — the realized stat changes once per trading day, so a
+# multi-hour window absorbs dashboard repeats without going stale.
+_CACHE_TTL_SECONDS = 4 * 60 * 60
+_cache: dict[tuple[str, str], tuple[float, dict[str, Any] | None]] = {}
+
+# How many calendar days of 5m bars to request. yfinance allows up to
+# 60 days at the 5m interval; 30 is plenty for the trailing 22-day HAR
+# window plus a few half-days / holidays.
+_LOOKBACK_DAYS = 30
+
+# Minimum 5m bars per day for the realized-measure reducer to be
+# trustworthy. NYSE regular hours are 6.5h × 12 bars/h ≈ 78 bars; this
+# threshold drops half-days and pre-/post-only sessions.
+_MIN_BARS_PER_DAY = 60
+
+
+def reset_cache() -> None:
+    """Clear the in-process TTL cache (test hook)."""
+    _cache.clear()
+
+
+def _today_iso() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _fetch_intraday_bars_yf(symbol: str) -> Any | None:
+    """Pull 5m bars off yfinance.
+
+    Wrapped behind a try/except so a yfinance hiccup never breaks the
+    request path — the caller falls back to training-mean features.
+    """
+
+    try:
+        import yfinance as yf
+    except Exception:
+        logger.warning("intraday_features: yfinance import failed; degrading to None")
+        return None
+
+    try:
+        ticker = yf.Ticker(symbol)
+        df = ticker.history(
+            period=f"{_LOOKBACK_DAYS}d",
+            interval="5m",
+            auto_adjust=False,
+            prepost=False,
+        )
+    except Exception as exc:
+        logger.warning(
+            "intraday_features: yfinance fetch failed for %r (%s); degrading", symbol, exc
+        )
+        return None
+
+    if df is None or len(df) == 0:
+        return None
+    return df
+
+
+def _reduce_to_daily(bars: Any) -> dict[str, Any] | None:
+    """Group bars by ET trading date and return the most-recent day's measures."""
+
+    from app.data.intraday_realized import daily_realized_measures
+
+    # yfinance returns a DatetimeIndex tz-aware in market timezone for intraday.
+    # Group by the date part of that index.
+    grouped: dict[date, dict[str, list[float]]] = defaultdict(
+        lambda: {"closes": [], "highs": [], "lows": [], "volumes": []}
+    )
+    for ts, row in bars.iterrows():
+        d = ts.date() if hasattr(ts, "date") else ts
+        try:
+            close = float(row["Close"])
+            high = float(row["High"])
+            low = float(row["Low"])
+            volume = float(row["Volume"])
+        except Exception:
+            continue
+        if not (close > 0 and high > 0 and low > 0):
+            continue
+        grouped[d]["closes"].append(close)
+        grouped[d]["highs"].append(high)
+        grouped[d]["lows"].append(low)
+        grouped[d]["volumes"].append(volume)
+
+    # Pick the most-recent day with enough bars to trust the reducer.
+    for d in sorted(grouped.keys(), reverse=True):
+        day = grouped[d]
+        if len(day["closes"]) < _MIN_BARS_PER_DAY:
+            continue
+        measures = daily_realized_measures(
+            closes=day["closes"],
+            highs=day["highs"],
+            lows=day["lows"],
+            volumes=day["volumes"],
+        )
+        if measures is None:
+            continue
+        # daily_realized_measures returns dict[str, float]; widen here so
+        # the date string sits alongside the numeric measures without
+        # tripping the strict-typed dict.
+        out: dict[str, Any] = dict(measures)
+        out["date"] = d.isoformat()
+        return out
+    return None
+
+
+def recent_realized_measures(symbol: str, *, as_of: str | None = None) -> dict[str, Any] | None:
+    """Live realized-measure row for ``symbol`` keyed on ``as_of``.
+
+    Returns ``{"date": iso, "rv", "rs_pos", "rs_neg", "bv", "rq",
+    "rskew", "rkurt", "parkinson", "rvol", "n_ret"}`` for the latest
+    full day inside the lookback window, or ``None`` when the fetch
+    fails, the reducer cannot trust the bars, or the symbol has no
+    intraday coverage. Caller treats ``None`` as a signal to fall back
+    to training-mean features and surface the "HAR-fallback" flag.
+
+    Cached for :data:`_CACHE_TTL_SECONDS` against ``(symbol, as_of)`` so
+    the dashboard does not hammer yfinance on every page refresh.
+    """
+
+    key = (symbol, as_of or _today_iso())
+    now = time.monotonic()
+    cached = _cache.get(key)
+    if cached is not None and now - cached[0] < _CACHE_TTL_SECONDS:
+        return cached[1]
+
+    bars = _fetch_intraday_bars_yf(symbol)
+    if bars is None:
+        _cache[key] = (now, None)
+        return None
+    try:
+        measures = _reduce_to_daily(bars)
+    except Exception as exc:
+        logger.warning("intraday_features: reducer failed for %r (%s); degrading", symbol, exc)
+        measures = None
+    if measures is None:
+        # Reducer returned cleanly but found no full-session day in the
+        # lookback window (holiday gap, half-day-only symbol, etc.).
+        # The endpoint will surface "HAR-fallback" so ops know to
+        # check yfinance coverage for this symbol.
+        logger.warning(
+            "intraday_features: no full session within %dd window for %r; "
+            "downstream RV head will fall back to training-mean features",
+            _LOOKBACK_DAYS,
+            symbol,
+        )
+    _cache[key] = (now, measures)
+    return measures

--- a/backend/app/services/rv_forecaster.py
+++ b/backend/app/services/rv_forecaster.py
@@ -17,6 +17,7 @@ for the process lifetime.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import threading
 from pathlib import Path
@@ -29,6 +30,8 @@ from app.data.intraday_rv_forecast import _EPS as _RVEPS, _LOGV_CLAMP, _har_lags
 
 if TYPE_CHECKING:
     import torch
+
+logger = logging.getLogger("app.services.rv_forecaster")
 
 
 HF_REPO_ID = "yusufizzetmurat/fomc-rv-qlike-forecaster"
@@ -175,22 +178,48 @@ class _RvPredictor:
         self.eval = _load_eval(self.model_dir)
         self.seed_models = _load_seed_models(self.spec, self.model_dir)
         self.revision = f"{self.spec.get('model', 'rv')}@{self.spec.get('date_last', '')}"
+        # Drift guard: the serving layer's _REALIZED_FEAT_COLS is the
+        # contract that intraday_features.recent_realized_measures
+        # promises to fill at indices full[3:10]. If a future training
+        # artifact reorders or renames any of these columns the live
+        # intraday wiring would silently scramble the feature row, so
+        # we hard-fail at load time instead of degrading silently.
+        artifact_cols = tuple(self.spec.get("feature_order", [])[3 : 3 + len(_REALIZED_FEAT_COLS)])
+        if artifact_cols and artifact_cols != _REALIZED_FEAT_COLS:
+            raise RvForecasterUnavailable(
+                f"realized-measure column order drift: artifact has {artifact_cols}, "
+                f"serving expects {_REALIZED_FEAT_COLS}. Re-sync "
+                "rv_forecaster._REALIZED_FEAT_COLS with the training pipeline."
+            )
+
+
+# Feature-row column order pinned at training time
+# (intraday_rv_production._FEAT_COLS + log(rvol+1) last).
+# ``full[0:3]`` are the HAR daily/weekly/monthly lags. ``full[3:10]``
+# are the seven realized-measure columns; ``full[10]`` is log(rvol+1).
+_REALIZED_FEAT_COLS = ("rs_pos", "rs_neg", "bv", "rq", "rskew", "rkurt", "parkinson")
 
 
 def _ensemble_log_rv(
     log_rv: np.ndarray,
     row: dict[str, Any],
     seeds: list["torch.nn.Module"],
-) -> float:
-    """One-step ensemble forecast in log-RV space for the latest window."""
+    intraday_measures: dict[str, Any] | None = None,
+) -> tuple[float, str]:
+    """One-step ensemble forecast in log-RV space for the latest window.
+
+    Returns ``(log_point, realized_features_source)``. The source flag is
+    ``"live"`` when ``intraday_measures`` was supplied and used to fill
+    the seven realized-measure columns plus ``log(rvol+1)``, and
+    ``"training_means"`` when the QLIKE head falls back to feat_mean
+    (HAR-only effective prediction). The dashboard surfaces this so the
+    user knows whether the displayed forecast is the full edge or the
+    HAR-grade fallback.
+    """
 
     import torch
 
     har = _har_lags(log_rv)  # backward HAR regressors at every index
-    # Reproduce the training-time feature layout for the LAST observation only.
-    # The QLIKE-DLq head takes the standardized full feature row and emits a
-    # standardized residual that is un-standardized and added to the OLS HAR
-    # prediction (intercept + d/w/m coef).
     last = har[-1]
     har_coef = np.asarray(row["har_coef"], dtype=np.float64)
     har_pred = float(
@@ -199,14 +228,29 @@ def _ensemble_log_rv(
 
     feat_mean = np.asarray(row["feat_mean"], dtype=np.float64)
     feat_std = np.asarray(row["feat_std"], dtype=np.float64)
-    # The non-HAR realized-measure columns are not available from a bare RV
-    # history; we substitute their training-set means (standardized → zeros)
-    # so the head reduces to a HAR-only point forecast plus the learned
-    # bias on the realized lags. This keeps the predictor usable from a
-    # plain RV series; richer features can be plumbed when intraday bars
-    # are reachable.
     full = feat_mean.copy()
-    full[0:3] = last  # the HAR daily/weekly/monthly lags
+    full[0:3] = last  # HAR daily / weekly / monthly lags
+
+    source = "training_means"
+    if intraday_measures is not None and len(full) >= 11:
+        try:
+            for i, col in enumerate(_REALIZED_FEAT_COLS):
+                full[3 + i] = float(intraday_measures[col])
+            full[10] = float(np.log(float(intraday_measures["rvol"]) + 1.0))
+            source = "live"
+        except (KeyError, TypeError, ValueError) as exc:
+            # Any missing / malformed key short-circuits to feat_mean
+            # fallback. The forecast remains valid (HAR-grade); only the
+            # source flag changes. Log so a contract drift between the
+            # intraday fetcher and this consumer is diagnosable.
+            logger.warning(
+                "rv_forecaster: intraday_measures malformed (%s); falling back to training_means",
+                exc,
+            )
+            full = feat_mean.copy()
+            full[0:3] = last
+            source = "training_means"
+
     x = (full - feat_mean) / feat_std
     xt = torch.tensor(x, dtype=torch.float32).reshape(1, -1)
     rs = float(row["resid_std"])
@@ -218,17 +262,23 @@ def _ensemble_log_rv(
         log_pred = har_pred + (r_std * rs + rm)
         log_pred = float(np.clip(log_pred, -_LOGV_CLAMP, _LOGV_CLAMP))
         preds.append(log_pred)
-    return float(np.mean(preds))
+    return float(np.mean(preds)), source
 
 
-def predict_rv(rv_history: list[float] | np.ndarray) -> dict[str, Any]:
+def predict_rv(
+    rv_history: list[float] | np.ndarray,
+    intraday_measures: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Multi-horizon banded RV forecast off a recent realized-vol series.
 
     ``rv_history`` is a chronologically ordered series of daily realized
     variance values (NOT log). Each entry is the per-day realized variance
     that ``intraday_realized.daily_realized_measures`` would output. The
     function returns the per-horizon point forecast in RV space, 80%/90%
-    conformal bands, and the QLIKE / coverage diagnostics for the card.
+    conformal bands, the QLIKE / coverage diagnostics, and the
+    ``realized_features_source`` flag (``"live"`` when ``intraday_measures``
+    was supplied and used; ``"training_means"`` when the QLIKE head fell
+    back to feat_mean and the forecast collapses to HAR-grade).
     """
 
     rv = np.asarray(rv_history, dtype=np.float64)
@@ -240,11 +290,18 @@ def predict_rv(rv_history: list[float] | np.ndarray) -> dict[str, Any]:
     log_rv = np.log(rv + _RVEPS)
     pred = _RvPredictor.get()
     horizons_out: list[dict[str, Any]] = []
+    # Source flag is determined by the first horizon's pass and held
+    # constant across the three. The flag is intentionally a single
+    # value per request — if intraday is unavailable, every horizon
+    # falls back together, not piecemeal.
+    realized_features_source = "training_means"
     for h in HORIZONS:
         hk = f"h{h}"
         row = pred.spec["by_horizon"][hk]
         seeds = pred.seed_models[hk]
-        log_point = _ensemble_log_rv(log_rv, row, seeds)
+        log_point, source = _ensemble_log_rv(log_rv, row, seeds, intraday_measures)
+        if h == HORIZONS[0]:
+            realized_features_source = source
         point = float(np.exp(log_point))
         quants = row["conformal_quantiles"]
         q80 = float(quants.get("0.20", 0.0))
@@ -268,9 +325,18 @@ def predict_rv(rv_history: list[float] | np.ndarray) -> dict[str, Any]:
                 "coverage_empirical_90": coverage_90,
             }
         )
+    realized_features_date: str | None = None
+    if (
+        realized_features_source == "live"
+        and intraday_measures is not None
+        and isinstance(intraday_measures.get("date"), str)
+    ):
+        realized_features_date = intraday_measures["date"]
     return {
         "horizons": horizons_out,
         "model_revision": pred.revision,
+        "realized_features_source": realized_features_source,
+        "realized_features_date": realized_features_date,
     }
 
 
@@ -313,9 +379,12 @@ def predict_rv_historical_bands(
 
     out: list[dict[str, Any]] = []
     for i in range(_HISTORICAL_BANDS_WARMUP, len(rv)):
-        # Predict day i using only rv_history[:i] (no leakage).
+        # Predict day i using only rv_history[:i] (no leakage). The
+        # historical-band walk is deliberately HAR-grade (intraday
+        # measures are not reconstructed for past days), so the second
+        # return value is ignored.
         log_rv_prefix = np.log(rv[:i] + _RVEPS)
-        log_point = _ensemble_log_rv(log_rv_prefix, row, seeds)
+        log_point, _ = _ensemble_log_rv(log_rv_prefix, row, seeds)
         out.append(
             {
                 "date": str(dates[i]),

--- a/frontend/components/analyze/VolatilityOutlookCard.tsx
+++ b/frontend/components/analyze/VolatilityOutlookCard.tsx
@@ -88,6 +88,40 @@ function HorizonColumn({ horizon }: HorizonColumnProps) {
   );
 }
 
+function RealizedFeatureSourceBadge({
+  source,
+  date,
+}: {
+  source: RealizedVolForecastResponse["realized_features_source"] | undefined;
+  date: RealizedVolForecastResponse["realized_features_date"] | undefined;
+}) {
+  if (source === "live") {
+    const tooltip = date
+      ? `Live intraday realized measures (rs_pos/rs_neg/bv/rq/rskew/rkurt/parkinson/log_rvol) from ${date} feed the QLIKE-DLq head this request. Full edge served.`
+      : "Live intraday realized measures feed the QLIKE-DLq head this request. Full edge served.";
+    return (
+      <Badge
+        variant="outline"
+        className="text-[10px] uppercase tracking-wide text-emerald-700 border-emerald-700/40"
+        title={tooltip}
+        data-testid="rv-source-live"
+      >
+        QLIKE-full{date ? ` · ${date}` : ""}
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      variant="outline"
+      className="text-[10px] uppercase tracking-wide text-amber-700 border-amber-700/40"
+      title="Intraday 5m bars unavailable for this symbol. The QLIKE-DLq head falls back to training-set means; the forecast collapses to HAR-grade. The ~10% QLIKE-over-HAR edge does not apply here."
+      data-testid="rv-source-fallback"
+    >
+      HAR-fallback
+    </Badge>
+  );
+}
+
 interface VolatilityOutlookCardProps {
   forecast: RealizedVolForecastResponse | null;
   loading?: boolean;
@@ -148,14 +182,22 @@ export function VolatilityOutlookCard({
         </CardDescription>
         <CardTitle className="flex items-center justify-between text-base">
           <span>QLIKE-DLq ensemble · {forecast.symbol}</span>
-          <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
-            Market readout
-          </Badge>
+          <div className="flex items-center gap-1.5">
+            <RealizedFeatureSourceBadge
+              source={forecast.realized_features_source}
+              date={forecast.realized_features_date}
+            />
+            <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+              Market readout
+            </Badge>
+          </div>
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
         <p className="text-[11px] text-muted-foreground">
-          Annualized realized volatility, ensemble mean with conformal bands.
+          {forecast.realized_features_source === "live"
+            ? "Annualized realized volatility, ensemble mean with conformal bands. Live intraday realized measures feed the QLIKE head."
+            : "Annualized realized volatility, ensemble mean with conformal bands. Intraday measures unavailable; the head falls back to HAR-grade."}
         </p>
         <div className="grid gap-2 md:grid-cols-3">
           {forecast.horizons.map((h) => (

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -711,6 +711,13 @@ export interface RealizedVolForecastResponse {
   history_dates: string[];
   model_revision: string;
   historical_bands?: RealizedVolHistoricalBand[] | null;
+  // "live" when the QLIKE-DLq head was filled with live intraday
+  // realized measures (full edge served). "training_means" when the
+  // head fell back to feat_mean and the forecast collapses to HAR-grade.
+  realized_features_source?: "live" | "training_means";
+  // ISO date of the most-recent full intraday session the live
+  // measures were derived from; null when the head fell back.
+  realized_features_date?: string | null;
 }
 
 export interface BacktestResponse {

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -3400,6 +3400,22 @@
             "title": "Model Revision",
             "type": "string"
           },
+          "realized_features_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Realized Features Date"
+          },
+          "realized_features_source": {
+            "default": "training_means",
+            "title": "Realized Features Source",
+            "type": "string"
+          },
           "symbol": {
             "title": "Symbol",
             "type": "string"

--- a/tests/unit/test_intraday_features.py
+++ b/tests/unit/test_intraday_features.py
@@ -1,0 +1,160 @@
+"""Behavioural tests for the live intraday realized-measure fetcher.
+
+The fetcher must:
+- never raise out; failures degrade to ``None`` so the RV forecaster
+  falls back to the HAR-grade training-mean path
+- cache against (symbol, as_of) with a TTL so dashboard repeats do not
+  hammer yfinance
+- skip half-days / sessions with fewer than the minimum bars
+- return a fully-populated measure dict for a typical full session
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.services import intraday_features
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    intraday_features.reset_cache()
+    yield
+    intraday_features.reset_cache()
+
+
+def _make_bars(days: list[str], bars_per_day: int = 78) -> pd.DataFrame:
+    """Build a yfinance-shaped intraday DataFrame.
+
+    Each row carries Open/High/Low/Close/Volume; the index is a tz-aware
+    DatetimeIndex per yfinance's convention.
+    """
+
+    rows: list[dict[str, Any]] = []
+    timestamps: list[pd.Timestamp] = []
+    rng = np.random.default_rng(seed=11)
+    base_close = 5000.0
+    for day in days:
+        d = datetime.date.fromisoformat(day)
+        # Session: 09:30 to 16:00 ET in 5m steps. The exact timezone is
+        # irrelevant to the reducer; it groups by date.
+        for i in range(bars_per_day):
+            ts = pd.Timestamp(
+                datetime.datetime.combine(d, datetime.time(13, 30, tzinfo=datetime.timezone.utc))
+                + datetime.timedelta(minutes=5 * i),
+            )
+            r = float(rng.normal(0.0, 0.001))
+            close = base_close * (1.0 + r)
+            high = close * (1.0 + abs(rng.normal(0.0, 0.0005)))
+            low = close * (1.0 - abs(rng.normal(0.0, 0.0005)))
+            timestamps.append(ts)
+            rows.append(
+                {
+                    "Open": close,
+                    "High": high,
+                    "Low": low,
+                    "Close": close,
+                    "Volume": float(1_000_000 + i),
+                }
+            )
+            base_close = close
+    return pd.DataFrame(rows, index=pd.DatetimeIndex(timestamps))
+
+
+def test_recent_realized_measures_returns_dict_for_full_session(monkeypatch):
+    bars = _make_bars(["2026-05-30", "2026-05-31", "2026-06-01"])
+    monkeypatch.setattr(
+        intraday_features, "_fetch_intraday_bars_yf", lambda _symbol: bars
+    )
+    out = intraday_features.recent_realized_measures("^GSPC", as_of="2026-06-02")
+    assert out is not None
+    assert out["date"] == "2026-06-01"  # most-recent day
+    # All eight realized-measure keys plus rv and n_ret should be present.
+    for key in (
+        "rv",
+        "rs_pos",
+        "rs_neg",
+        "bv",
+        "rq",
+        "rskew",
+        "rkurt",
+        "parkinson",
+        "rvol",
+        "n_ret",
+    ):
+        assert key in out
+    assert out["rv"] > 0
+    assert out["rvol"] > 0
+
+
+def test_recent_realized_measures_skips_half_days(monkeypatch):
+    # A 30-bar half-day must NOT be returned; the next-most-recent full
+    # session should be picked instead.
+    bars = pd.concat(
+        [
+            _make_bars(["2026-05-30"]),  # full
+            _make_bars(["2026-06-01"], bars_per_day=30),  # half-day, below MIN
+        ]
+    )
+    monkeypatch.setattr(
+        intraday_features, "_fetch_intraday_bars_yf", lambda _symbol: bars
+    )
+    out = intraday_features.recent_realized_measures("^GSPC", as_of="2026-06-02")
+    assert out is not None
+    assert out["date"] == "2026-05-30"
+
+
+def test_recent_realized_measures_none_on_empty_fetch(monkeypatch):
+    monkeypatch.setattr(
+        intraday_features, "_fetch_intraday_bars_yf", lambda _symbol: None
+    )
+    assert intraday_features.recent_realized_measures("^GSPC", as_of="2026-06-02") is None
+
+
+def test_recent_realized_measures_none_on_reducer_exception(monkeypatch):
+    bars = _make_bars(["2026-05-30"])
+    monkeypatch.setattr(
+        intraday_features, "_fetch_intraday_bars_yf", lambda _symbol: bars
+    )
+
+    def _explode(*_args: Any, **_kwargs: Any) -> dict[str, float]:
+        raise RuntimeError("simulated reducer crash")
+
+    # Patch the reducer the module imports inside _reduce_to_daily.
+    monkeypatch.setattr(
+        "app.data.intraday_realized.daily_realized_measures", _explode
+    )
+    assert intraday_features.recent_realized_measures("^GSPC", as_of="2026-06-02") is None
+
+
+def test_recent_realized_measures_caches_per_as_of(monkeypatch):
+    bars = _make_bars(["2026-05-30"])
+    calls = MagicMock(return_value=bars)
+    monkeypatch.setattr(intraday_features, "_fetch_intraday_bars_yf", calls)
+
+    a = intraday_features.recent_realized_measures("^GSPC", as_of="2026-06-02")
+    b = intraday_features.recent_realized_measures("^GSPC", as_of="2026-06-02")
+    assert a == b
+    # Cache must hit on the second call: yfinance fetched exactly once.
+    assert calls.call_count == 1
+
+    # Distinct as_of key triggers a fresh fetch.
+    intraday_features.recent_realized_measures("^GSPC", as_of="2026-06-03")
+    assert calls.call_count == 2
+
+
+def test_recent_realized_measures_caches_none_payload(monkeypatch):
+    """A negative result is cached so we don't re-hit yfinance every page load."""
+
+    calls = MagicMock(return_value=None)
+    monkeypatch.setattr(intraday_features, "_fetch_intraday_bars_yf", calls)
+
+    intraday_features.recent_realized_measures("^GSPC", as_of="2026-06-02")
+    intraday_features.recent_realized_measures("^GSPC", as_of="2026-06-02")
+    assert calls.call_count == 1

--- a/tests/unit/test_main_api.py
+++ b/tests/unit/test_main_api.py
@@ -383,10 +383,13 @@ def test_forecast_realized_vol_surfaces_historical_bands(monkeypatch):
     dates = [f"2026-03-{i + 1:02d}" for i in range(30)]
     rv = [1e-4 + i * 1e-6 for i in range(30)]
     monkeypatch.setattr(main_mod, "_load_rv_history", lambda symbol: (rv, dates))
+    # The endpoint passes ``intraday_measures`` as a second positional/
+    # keyword arg now (PR introducing live intraday wiring). The stub
+    # accepts and ignores it so the historical-bands surface still tests.
     monkeypatch.setattr(
         rv_forecaster,
         "predict_rv",
-        lambda hist: {
+        lambda hist, intraday_measures=None: {
             "horizons": [
                 {
                     "h": 1,
@@ -423,6 +426,8 @@ def test_forecast_realized_vol_surfaces_historical_bands(monkeypatch):
                 },
             ],
             "model_revision": "stub@2026-05-29",
+            "realized_features_source": "training_means",
+            "realized_features_date": None,
         },
     )
     monkeypatch.setattr(

--- a/tests/unit/test_rv_forecaster.py
+++ b/tests/unit/test_rv_forecaster.py
@@ -115,8 +115,17 @@ def test_predict_rv_returns_three_horizons_with_bands(stub_predictor: Any) -> No
     rv = np.abs(rng.normal(scale=1e-4, size=30)) + 1e-5
     out = rv_forecaster.predict_rv(rv.tolist())
 
-    assert set(out.keys()) == {"horizons", "model_revision"}
+    assert set(out.keys()) == {
+        "horizons",
+        "model_revision",
+        "realized_features_source",
+        "realized_features_date",
+    }
     assert out["model_revision"] == "stub@2026-05-29"
+    # No intraday_measures passed → forecaster must surface the
+    # HAR-grade fallback flag with no measure date.
+    assert out["realized_features_source"] == "training_means"
+    assert out["realized_features_date"] is None
     horizons = out["horizons"]
     assert [row["h"] for row in horizons] == [1, 5, 22]
 
@@ -129,6 +138,44 @@ def test_predict_rv_returns_three_horizons_with_bands(stub_predictor: Any) -> No
         assert math.isfinite(row["qlike_har"])
         assert row["qlike_model"] < row["qlike_har"]
         assert 0.5 < row["coverage_empirical_90"] < 1.0
+
+
+def test_predict_rv_surfaces_live_source_when_intraday_supplied(stub_predictor: Any) -> None:
+    """Passing live intraday measures flips the source flag to ``live``.
+
+    The forecast value itself need not differ much for the stub (which
+    holds feat_mean ≈ realized values), but the flag is the load-bearing
+    signal the dashboard uses to badge QLIKE-full vs HAR-fallback.
+    """
+
+    rng = np.random.default_rng(0)
+    rv = np.abs(rng.normal(scale=1e-4, size=30)) + 1e-5
+    intraday = {
+        "rv": 1.2e-4,
+        "rs_pos": 6e-5,
+        "rs_neg": 6e-5,
+        "bv": 1.0e-4,
+        "rq": 8e-8,
+        "rskew": -0.1,
+        "rkurt": 4.2,
+        "parkinson": 1.3e-4,
+        "rvol": 1.5e9,
+        "n_ret": 78.0,
+    }
+    out = rv_forecaster.predict_rv(rv.tolist(), intraday_measures=intraday)
+    assert out["realized_features_source"] == "live"
+
+
+def test_predict_rv_falls_back_when_intraday_measure_key_missing(stub_predictor: Any) -> None:
+    """Malformed intraday dict (missing key) must degrade to training_means
+    rather than raise — the forecast should still serve at HAR-grade.
+    """
+
+    rng = np.random.default_rng(1)
+    rv = np.abs(rng.normal(scale=1e-4, size=30)) + 1e-5
+    bad = {"rs_pos": 6e-5, "rs_neg": 6e-5}  # missing bv/rq/rskew/rkurt/parkinson/rvol
+    out = rv_forecaster.predict_rv(rv.tolist(), intraday_measures=bad)
+    assert out["realized_features_source"] == "training_means"
 
 
 def test_predict_rv_rejects_short_history(stub_predictor: Any) -> None:


### PR DESCRIPTION
## Summary

- The QLIKE-DLq head was trained on 11 features but at serve time the 8 non-HAR columns were pinned at training-set means, so the live forecast collapsed to HAR-grade. This closes that gap.
- New \`app/services/intraday_features.py\` reduces yfinance 5m bars into rs_pos/rs_neg/bv/rq/rskew/rkurt/parkinson/log_rvol and the forecaster fills \`full[3:10]\` with the live values when available.
- Soft-degrade contract: every failure mode returns \`None\` and the response surfaces \`realized_features_source = "training_means"\`; nothing breaks, only the dashboard badge flips.
- Drift guard at predictor load: \`spec.feature_order[3:10]\` must match \`_REALIZED_FEAT_COLS\` or the loader raises.

## Test plan

- [ ] \`docker compose run --rm backend pytest tests/unit/test_intraday_features.py tests/unit/test_rv_forecaster.py tests/unit/test_rv_backtest.py tests/contract\`
- [ ] \`curl /forecast/realized-vol?symbol=^GSPC\` returns \`realized_features_source: "live"\` with \`qlike_model < qlike_har\`
- [ ] Dashboard shows green \`QLIKE-full\` badge on the Volatility Outlook card