### PR TITLE
feat: surface stance as a rolling z-score against recent meetings

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -77,6 +77,8 @@ from app.schemas import (
     SemanticDiffResponse,
     SettingsCheckpoint,
     SettingsCheckpointsResponse,
+    StanceContextPoint,
+    StanceContextResponse,
     SymbolDescriptor,
     SymbolListResponse,
     TrajectoryMarker,
@@ -1239,6 +1241,46 @@ def get_history(
     )
     items = [HistoryEntry(**row.to_summary()) for row in rows]
     return HistoryList(items=items, total=total, limit=limit, offset=offset)
+
+
+@app.get("/history/recent-stance-scores", response_model=StanceContextResponse)
+def get_recent_stance_scores(
+    symbol: str = Query(...),
+    horizon: str | None = Query(default=None),
+    n: int = Query(default=12, ge=1, le=120),
+    exclude_run_id: str | None = Query(default=None),
+    session: Session = Depends(get_session),
+) -> StanceContextResponse:
+    """Trailing ``n`` stance-score points for the rolling-z dashboard tile.
+
+    The current run is excluded from the trailing window when its id is
+    passed via ``exclude_run_id`` so the z-score is computed against
+    history rather than against itself.
+
+    Registered ABOVE ``/history/{run_id}`` because FastAPI matches
+    routes in declaration order — a generic ``{run_id}`` segment would
+    otherwise swallow ``recent-stance-scores`` as a literal id and 404
+    on lookup.
+    """
+
+    from app.services.stance_context import build_stance_context
+
+    ctx = build_stance_context(
+        session,
+        symbol=symbol,
+        horizon=horizon,
+        n=n,
+        exclude_run_id=exclude_run_id,
+    )
+    return StanceContextResponse(
+        n=ctx.n,
+        mean=ctx.mean,
+        std=ctx.std,
+        history=[
+            StanceContextPoint(document_date=p.document_date, stance_score=p.stance_score)
+            for p in ctx.history
+        ],
+    )
 
 
 @app.get("/history/{run_id}", response_model=HistoryDetail)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -669,6 +669,29 @@ class HistoryList(BaseModel):
     offset: int
 
 
+class StanceContextPoint(BaseModel):
+    """One historical (date, score) pair for the rolling z-score baseline."""
+
+    document_date: str
+    stance_score: float
+
+
+class StanceContextResponse(BaseModel):
+    """Trailing stance-score summary for the dashboard tile.
+
+    ``stance_score = P(hawkish) - P(dovish)`` per the validity study;
+    the tile renders the current run as a z-score against this trailing
+    mean/std rather than as a raw absolute number. ``mean`` and ``std``
+    are ``null`` when fewer than two usable historical rows are found,
+    in which case the tile falls back to the raw-value rendering.
+    """
+
+    n: int
+    mean: float | None
+    std: float | None
+    history: list[StanceContextPoint]
+
+
 class HistoryRealizedResponse(BaseModel):
     run_id: str
     symbol: str

--- a/backend/app/services/stance_context.py
+++ b/backend/app/services/stance_context.py
@@ -35,9 +35,12 @@ def _extract_stance_score(payload: Any) -> float | None:
     """``P(hawkish) - P(dovish)`` from a persisted /analyze response.
 
     Returns ``None`` when the payload is missing the multi-axis block,
-    when the distribution is empty, or when both class probabilities
-    are absent. A neutral-only distribution (hawkish + dovish = 0)
-    correctly returns 0.0, not None — that IS the score in that case.
+    when the distribution is empty, or when EITHER class probability
+    is absent. The classifier's softmax always populates both keys —
+    a missing key signals a truncated / pre-#338 payload rather than a
+    genuine ``P(class) = 0``. Treating the missing key as 0 would
+    fabricate a score and pollute the trailing-window mean/std, so
+    the trailing-window builder filters the row out entirely.
     """
 
     if not isinstance(payload, dict):
@@ -53,11 +56,9 @@ def _extract_stance_score(payload: Any) -> float | None:
         return None
     hawk = distribution.get("hawkish")
     dove = distribution.get("dovish")
-    if not isinstance(hawk, int | float) and not isinstance(dove, int | float):
+    if not isinstance(hawk, int | float) or not isinstance(dove, int | float):
         return None
-    h = float(hawk) if isinstance(hawk, int | float) else 0.0
-    d = float(dove) if isinstance(dove, int | float) else 0.0
-    return h - d
+    return float(hawk) - float(dove)
 
 
 @dataclass(frozen=True)
@@ -78,13 +79,14 @@ class StanceContext:
     history: list[StanceContextPoint]
 
 
-def build_stance_context(
+def build_stance_context(  # noqa: PLR0913 - five flags is the natural shape here
     session: Session,
     *,
     symbol: str,
     horizon: str | None = None,
     n: int = 12,
     exclude_run_id: str | None = None,
+    leave_one_out: bool = True,
 ) -> StanceContext:
     """Read the trailing ``n`` stance scores for ``symbol`` and summarize.
 
@@ -93,6 +95,13 @@ def build_stance_context(
     Returns mean=None / std=None when fewer than two usable rows are
     found — the caller renders ``insufficient history`` rather than
     surfacing a misleading z-score off a one-sample baseline.
+
+    ``leave_one_out`` defaults to True so the contract is safe-by-default
+    even when the caller forgets to pass ``exclude_run_id``: the most-
+    recent persisted row (which IS the run that triggered the fetch)
+    is dropped from the trailing window so the z-score is computed
+    against history, not against itself. Pass False only for diagnostic
+    endpoints that genuinely want the full window.
     """
 
     stmt = select(AnalysisRun).where(AnalysisRun.symbol == symbol)
@@ -100,9 +109,18 @@ def build_stance_context(
         stmt = stmt.where(AnalysisRun.horizon == horizon)
     if exclude_run_id:
         stmt = stmt.where(AnalysisRun.id != exclude_run_id)
-    stmt = stmt.order_by(AnalysisRun.created_at.desc()).limit(max(n * 2, n))
+    # Pull one extra row over the target n so the implicit
+    # leave-one-out below can drop the newest without shrinking the
+    # window. ``n * 2`` keeps the budget for any rows we'll filter out
+    # for missing distributions.
+    stmt = stmt.order_by(AnalysisRun.created_at.desc()).limit(max(n * 2 + 1, n + 1))
 
     rows = list(session.execute(stmt).scalars().all())
+    if leave_one_out and exclude_run_id is None and rows:
+        # Drop the most-recent row implicitly — it IS the just-persisted
+        # run that the caller is about to z-score, so including it
+        # would deflate the magnitude.
+        rows = rows[1:]
     scored: list[StanceContextPoint] = []
     for row in rows:
         if len(scored) >= n:
@@ -119,8 +137,11 @@ def build_stance_context(
     mean = statistics.fmean(scores)
     # Use the unbiased (sample) standard deviation. statistics.stdev
     # requires at least two points; the < 2 guard above ensures we get
-    # there. A degenerate constant series produces std=0.0; the
-    # frontend treats that as "no meaningful spread" and falls back to
-    # the raw value rendering.
-    std = statistics.stdev(scores)
-    return StanceContext(n=len(scored), mean=float(mean), std=float(std), history=scored)
+    # there. A degenerate constant series (or a series that rounds to
+    # zero spread under float arithmetic) cannot produce a meaningful
+    # z-score, so std is collapsed to None — the frontend reads None
+    # as "fall back to raw rendering" and a future consumer cannot
+    # accidentally divide a finite value into the near-zero residue.
+    std_value = float(statistics.stdev(scores))
+    std: float | None = std_value if std_value > 0.0 else None
+    return StanceContext(n=len(scored), mean=float(mean), std=std, history=scored)

--- a/backend/app/services/stance_context.py
+++ b/backend/app/services/stance_context.py
@@ -1,0 +1,126 @@
+"""Rolling stance-score context for the multi-axis dashboard tile.
+
+The multi-axis stance classifier emits a per-class distribution. The
+underlying score the validity study anchored against the Fed's
+policy moves is ``s = P(hawkish) - P(dovish)``. The instrument is
+*valid* (Spearman +0.283, AUC hike-vs-cut 0.80) but *narrow* — the
+absolute level is mis-centred (dovish bias) and the dovish end can't
+tell hold from cut. Per Lead 2 of the validity write-up the dashboard
+should surface stance as a rolling z-score against recent meetings,
+not the raw absolute number, so the displayed claim matches the
+instrument's validated scope.
+
+This module reads the past ``n`` runs for a symbol off
+``analysis_runs.payload``, extracts the stance distribution per run,
+computes the trailing mean / std of ``s``, and returns the package the
+StanceTile renders. The current run is intentionally excluded from the
+trailing window when ``exclude_run_id`` is supplied so the z-score is
+computed against history, not against itself.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db import AnalysisRun
+
+
+def _extract_stance_score(payload: Any) -> float | None:
+    """``P(hawkish) - P(dovish)`` from a persisted /analyze response.
+
+    Returns ``None`` when the payload is missing the multi-axis block,
+    when the distribution is empty, or when both class probabilities
+    are absent. A neutral-only distribution (hawkish + dovish = 0)
+    correctly returns 0.0, not None — that IS the score in that case.
+    """
+
+    if not isinstance(payload, dict):
+        return None
+    multi_axis = payload.get("multi_axis")
+    if not isinstance(multi_axis, dict):
+        return None
+    stance = multi_axis.get("stance")
+    if not isinstance(stance, dict):
+        return None
+    distribution = stance.get("distribution")
+    if not isinstance(distribution, dict):
+        return None
+    hawk = distribution.get("hawkish")
+    dove = distribution.get("dovish")
+    if not isinstance(hawk, int | float) and not isinstance(dove, int | float):
+        return None
+    h = float(hawk) if isinstance(hawk, int | float) else 0.0
+    d = float(dove) if isinstance(dove, int | float) else 0.0
+    return h - d
+
+
+@dataclass(frozen=True)
+class StanceContextPoint:
+    """One historical (date, score) pair."""
+
+    document_date: str
+    stance_score: float
+
+
+@dataclass(frozen=True)
+class StanceContext:
+    """Trailing stance-score summary for the dashboard tile."""
+
+    n: int
+    mean: float | None
+    std: float | None
+    history: list[StanceContextPoint]
+
+
+def build_stance_context(
+    session: Session,
+    *,
+    symbol: str,
+    horizon: str | None = None,
+    n: int = 12,
+    exclude_run_id: str | None = None,
+) -> StanceContext:
+    """Read the trailing ``n`` stance scores for ``symbol`` and summarize.
+
+    Filters out runs whose payload lacks a usable stance distribution
+    so a small backlog of regression-mode rows can't poison the mean.
+    Returns mean=None / std=None when fewer than two usable rows are
+    found — the caller renders ``insufficient history`` rather than
+    surfacing a misleading z-score off a one-sample baseline.
+    """
+
+    stmt = select(AnalysisRun).where(AnalysisRun.symbol == symbol)
+    if horizon:
+        stmt = stmt.where(AnalysisRun.horizon == horizon)
+    if exclude_run_id:
+        stmt = stmt.where(AnalysisRun.id != exclude_run_id)
+    stmt = stmt.order_by(AnalysisRun.created_at.desc()).limit(max(n * 2, n))
+
+    rows = list(session.execute(stmt).scalars().all())
+    scored: list[StanceContextPoint] = []
+    for row in rows:
+        if len(scored) >= n:
+            break
+        score = _extract_stance_score(row.payload)
+        if score is None or not math.isfinite(score):
+            continue
+        scored.append(StanceContextPoint(document_date=str(row.document_date), stance_score=score))
+
+    if len(scored) < 2:
+        return StanceContext(n=len(scored), mean=None, std=None, history=scored)
+
+    scores = [p.stance_score for p in scored]
+    mean = statistics.fmean(scores)
+    # Use the unbiased (sample) standard deviation. statistics.stdev
+    # requires at least two points; the < 2 guard above ensures we get
+    # there. A degenerate constant series produces std=0.0; the
+    # frontend treats that as "no meaningful spread" and falls back to
+    # the raw value rendering.
+    std = statistics.stdev(scores)
+    return StanceContext(n=len(scored), mean=float(mean), std=float(std), history=scored)

--- a/frontend/components/analyze/MultiAxisInterpretation.tsx
+++ b/frontend/components/analyze/MultiAxisInterpretation.tsx
@@ -4,7 +4,11 @@ import { Compass, Gauge, Target } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { KpiTile } from "@/components/ui/kpi-tile";
 import { stanceLabel } from "@/lib/analyze/format";
-import type { MultiAxisResponse, MultiAxisStance } from "@/lib/analyze/types";
+import type {
+  MultiAxisResponse,
+  MultiAxisStance,
+  StanceContextResponse,
+} from "@/lib/analyze/types";
 
 interface MultiAxisInterpretationProps {
   multiAxis: MultiAxisResponse;
@@ -14,15 +18,59 @@ interface MultiAxisInterpretationProps {
     factor?: Array<number | null>;
     certainty?: Array<number | null>;
   };
+  // Trailing stance-score baseline. When provided with at least two
+  // usable history rows, the StanceTile renders the current run as a
+  // z-score against this baseline instead of the raw confidence number.
+  // The validity study showed relative ordering carries signal but the
+  // absolute level is mis-centred (dovish bias) — the z-score makes
+  // the dashboard claim what the instrument is actually validated for.
+  stanceContext?: StanceContextResponse | null;
 }
 
-function StanceTile({ stance, history }: { stance: MultiAxisStance; history?: Array<number | null> }) {
+function currentStanceScore(stance: MultiAxisStance): number | null {
+  // s = P(hawkish) - P(dovish); matches the validity study's anchor.
+  const dist = stance.distribution;
+  if (!dist) return null;
+  const hawk = dist.hawkish;
+  const dove = dist.dovish;
+  if (typeof hawk !== "number" && typeof dove !== "number") return null;
+  return (hawk ?? 0) - (dove ?? 0);
+}
+
+interface StanceTileProps {
+  stance: MultiAxisStance;
+  history?: Array<number | null>;
+  context?: StanceContextResponse | null;
+}
+
+function StanceTile({ stance, history, context }: StanceTileProps) {
   const variant: "hawkish" | "dovish" | "neutral" =
     stance.label === "hawkish"
       ? "hawkish"
       : stance.label === "dovish"
       ? "dovish"
       : "neutral";
+
+  const score = currentStanceScore(stance);
+  const hasUsableContext =
+    context != null &&
+    context.mean != null &&
+    context.std != null &&
+    context.std > 0 &&
+    context.n >= 2 &&
+    score != null;
+  const z = hasUsableContext
+    ? (score! - context!.mean!) / context!.std!
+    : null;
+
+  const zTone = z == null ? "neutral" : z > 0.5 ? "hawkish" : z < -0.5 ? "dovish" : "neutral";
+  const zLabel = z == null ? null : `${z >= 0 ? "+" : ""}${z.toFixed(2)}σ`;
+  const zTitle = z == null
+    ? undefined
+    : `Rolling z-score against the last ${context!.n} runs` +
+      ` (mean ${context!.mean!.toFixed(2)}, std ${context!.std!.toFixed(2)}).` +
+      ` Relative ordering — the instrument is validated for this; the raw absolute level is dovish-skewed.`;
+
   return (
     <KpiTile
       label="Stance"
@@ -30,13 +78,28 @@ function StanceTile({ stance, history }: { stance: MultiAxisStance; history?: Ar
       value={
         <span className="flex items-center gap-2">
           <span className="capitalize">{stanceLabel(stance.label)}</span>
-          <Badge variant={variant} className="text-[10px]">
-            {stance.confidence.toFixed(2)}
-          </Badge>
+          {zLabel != null ? (
+            <Badge
+              variant={zTone}
+              className="text-[10px]"
+              title={zTitle}
+              data-testid="stance-zscore"
+            >
+              {zLabel}
+            </Badge>
+          ) : (
+            <Badge variant={variant} className="text-[10px]">
+              {stance.confidence.toFixed(2)}
+            </Badge>
+          )}
         </span>
       }
       sparkline={history}
-      caption="Hawkish (+) favours tighter policy; Dovish (−) favours easier policy"
+      caption={
+        zLabel != null
+          ? "Rolling z-score vs recent meetings. Hawkish (+) favours tighter policy."
+          : "Hawkish (+) favours tighter policy; Dovish (−) favours easier policy"
+      }
     />
   );
 }
@@ -98,6 +161,7 @@ function CertaintyTile({
 export function MultiAxisInterpretation({
   multiAxis,
   history,
+  stanceContext,
 }: MultiAxisInterpretationProps) {
   const stanceHistory = history?.stance;
   const factorHistory = history?.factor;
@@ -130,7 +194,13 @@ export function MultiAxisInterpretation({
         Sentiment breakdown
       </Badge>
       <div className="grid gap-3 sm:grid-cols-2">
-        {multiAxis.stance ? <StanceTile stance={multiAxis.stance} history={stanceHistory} /> : null}
+        {multiAxis.stance ? (
+          <StanceTile
+            stance={multiAxis.stance}
+            history={stanceHistory}
+            context={stanceContext}
+          />
+        ) : null}
         {multiAxis.factor ? <FactorTile factor={multiAxis.factor} history={factorHistory} /> : null}
         {multiAxis.certainty ? (
           <CertaintyTile certainty={multiAxis.certainty} history={certaintyHistory} />

--- a/frontend/components/analyze/MultiAxisInterpretation.tsx
+++ b/frontend/components/analyze/MultiAxisInterpretation.tsx
@@ -52,10 +52,16 @@ function StanceTile({ stance, history, context }: StanceTileProps) {
       : "neutral";
 
   const score = currentStanceScore(stance);
+  // ``std == null`` is the backend's signal for "degenerate trailing
+  // window" (constant series or float-precision residue). Combining
+  // it with ``> 0`` guards both the null and the exact-zero edges
+  // under a single check; ``Number.isFinite`` also rejects ±Infinity
+  // that would otherwise render as ``+Infσ``.
   const hasUsableContext =
     context != null &&
     context.mean != null &&
     context.std != null &&
+    Number.isFinite(context.std) &&
     context.std > 0 &&
     context.n >= 2 &&
     score != null;

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -29,6 +29,7 @@ import type {
   RvBacktestResponse,
   SemanticDiffResponse,
   SettingsCheckpointsResponse,
+  StanceContextResponse,
   SymbolListResponse,
   TrainJobState,
   TrainJobSummary,
@@ -108,6 +109,28 @@ export async function fetchHistory(
 ): Promise<HistoryList> {
   const response = await axios.get(`${baseUrl}/history`, { params: query, signal });
   return response.data as HistoryList;
+}
+
+export async function fetchRecentStanceScores(
+  baseUrl: string,
+  params: {
+    symbol: string;
+    horizon?: string;
+    n?: number;
+    excludeRunId?: string;
+  },
+  signal?: AbortSignal,
+): Promise<StanceContextResponse> {
+  const response = await axios.get(`${baseUrl}/history/recent-stance-scores`, {
+    params: {
+      symbol: params.symbol,
+      horizon: params.horizon,
+      n: params.n,
+      exclude_run_id: params.excludeRunId,
+    },
+    signal,
+  });
+  return response.data as StanceContextResponse;
 }
 
 export async function fetchHistoryRun(

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -159,6 +159,22 @@ export interface MultiAxisStance {
   distribution?: Partial<Record<StanceAxis, number>>;
 }
 
+export interface StanceContextPoint {
+  document_date: string;
+  stance_score: number;
+}
+
+// Trailing stance-score window for the rolling-z dashboard tile.
+// stance_score = P(hawkish) - P(dovish). Mean/std null when fewer than
+// two usable historical rows are present; the tile falls back to the
+// raw-value rendering in that case.
+export interface StanceContextResponse {
+  n: number;
+  mean: number | null;
+  std: number | null;
+  history: StanceContextPoint[];
+}
+
 export interface MultiAxisFactor {
   value: number;
   confidence: number;

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -38,6 +38,7 @@ import {
   fetchExpectedVolumeForecast,
   fetchFuturesConsensus,
   fetchHarTercileBacktest,
+  fetchRecentStanceScores,
   fetchHistoryRealizedBatch,
   fetchLatestMpSurprise,
   fetchRealizedVolForecast,
@@ -70,6 +71,7 @@ import type {
   RealizedVolForecastResponse,
   RvBacktestResponse,
   SemanticDiffResponse,
+  StanceContextResponse,
 } from "@/lib/analyze/types";
 import {
   DEFAULT_HORIZON,
@@ -156,6 +158,7 @@ export default function WorkspacePage() {
   const coverage = useSharedCoverage(request.symbol);
   const recentHistory = useSharedRecentHistory(request.symbol, 12);
   const harBaselines = useHarBaselines(request.symbol);
+  const [stanceContext, setStanceContext] = React.useState<StanceContextResponse | null>(null);
   const [harBacktest, setHarBacktest] =
     React.useState<HarTercileBacktestResponse | null>(null);
   const [harBacktestLoading, setHarBacktestLoading] = React.useState(false);
@@ -320,6 +323,37 @@ export default function WorkspacePage() {
       controller.abort();
     };
   }, [apiBaseUrl, request.symbol]);
+
+  // Trailing stance-score baseline for the rolling-z dashboard tile.
+  // Fired on every symbol change and after each fresh /analyze so the
+  // window stays aligned with the latest persisted runs. A network
+  // failure here is silent — the StanceTile falls back to its raw
+  // confidence rendering when context is null.
+  React.useEffect(() => {
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const data = await fetchRecentStanceScores(
+          apiBaseUrl,
+          { symbol: request.symbol, horizon: request.horizon, n: 12 },
+          controller.signal,
+        );
+        if (!controller.signal.aborted) {
+          setStanceContext(data);
+        }
+      } catch {
+        if (!controller.signal.aborted) {
+          setStanceContext(null);
+        }
+      }
+    })();
+    return () => {
+      controller.abort();
+    };
+    // ``result`` is the dep on purpose: a fresh /analyze response is a
+    // new object reference, so the effect refires and we pick up the
+    // row that was just persisted to history.
+  }, [apiBaseUrl, request.symbol, request.horizon, result]);
 
   // Expected Volume forecast card is HAR-volume over market history,
   // market-data only. 503 (artifact missing) renders the unavailable
@@ -933,7 +967,10 @@ export default function WorkspacePage() {
               <SectionDivider label="Sentiment and context" />
               <div className="grid gap-4 xl:grid-cols-2">
                 {result.multi_axis ? (
-                  <MultiAxisInterpretation multiAxis={result.multi_axis} />
+                  <MultiAxisInterpretation
+                    multiAxis={result.multi_axis}
+                    stanceContext={stanceContext}
+                  />
                 ) : (
                   <EmptyState
                     variant="inline"

--- a/frontend/tests/components/analyze/StanceZScore.test.tsx
+++ b/frontend/tests/components/analyze/StanceZScore.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { render as rtlRender, screen } from "@testing-library/react";
+
+import { MultiAxisInterpretation } from "@/components/analyze/MultiAxisInterpretation";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+function render(ui: React.ReactElement) {
+  return rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+const HAWKISH_STANCE = {
+  label: "hawkish" as const,
+  confidence: 0.95,
+  // s = P(hawk) - P(dove) = 0.95 - 0.04 = 0.91
+  distribution: { hawkish: 0.95, dovish: 0.04, neutral: 0.01 },
+};
+
+describe("StanceTile rolling z-score", () => {
+  it("renders the z-score badge when a usable trailing context is provided", () => {
+    // baseline mean 0.5, std 0.2 → current s=0.91 → z = +2.05σ
+    render(
+      <MultiAxisInterpretation
+        multiAxis={{ stance: HAWKISH_STANCE, factor: null, certainty: null }}
+        stanceContext={{
+          n: 10,
+          mean: 0.5,
+          std: 0.2,
+          history: [],
+        }}
+      />,
+    );
+    expect(screen.getByTestId("stance-zscore")).toBeInTheDocument();
+    expect(screen.getByTestId("stance-zscore").textContent).toMatch(/\+2\.05σ/);
+    // Caption flips to the rolling-z explainer when z is shown.
+    expect(
+      screen.getByText(/Rolling z-score vs recent meetings/i),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the raw confidence badge when context is null", () => {
+    render(
+      <MultiAxisInterpretation
+        multiAxis={{ stance: HAWKISH_STANCE, factor: null, certainty: null }}
+        stanceContext={null}
+      />,
+    );
+    expect(screen.queryByTestId("stance-zscore")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Hawkish \(\+\) favours tighter policy/i),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back when fewer than two history rows are usable", () => {
+    render(
+      <MultiAxisInterpretation
+        multiAxis={{ stance: HAWKISH_STANCE, factor: null, certainty: null }}
+        stanceContext={{ n: 1, mean: 0.6, std: null, history: [] }}
+      />,
+    );
+    expect(screen.queryByTestId("stance-zscore")).not.toBeInTheDocument();
+  });
+
+  it("falls back when the trailing series is degenerate (std=0)", () => {
+    // A constant series has no meaningful spread — the z-score would be
+    // undefined, so the tile must NOT render one.
+    render(
+      <MultiAxisInterpretation
+        multiAxis={{ stance: HAWKISH_STANCE, factor: null, certainty: null }}
+        stanceContext={{ n: 5, mean: 0.5, std: 0, history: [] }}
+      />,
+    );
+    expect(screen.queryByTestId("stance-zscore")).not.toBeInTheDocument();
+  });
+
+  it("falls back when the current stance has no distribution to score", () => {
+    render(
+      <MultiAxisInterpretation
+        multiAxis={{
+          stance: { label: "hawkish", confidence: 0.8 }, // no distribution
+          factor: null,
+          certainty: null,
+        }}
+        stanceContext={{ n: 10, mean: 0.5, std: 0.2, history: [] }}
+      />,
+    );
+    expect(screen.queryByTestId("stance-zscore")).not.toBeInTheDocument();
+  });
+});

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -4445,6 +4445,71 @@
         "title": "SettingsCheckpointsResponse",
         "type": "object"
       },
+      "StanceContextPoint": {
+        "description": "One historical (date, score) pair for the rolling z-score baseline.",
+        "properties": {
+          "document_date": {
+            "title": "Document Date",
+            "type": "string"
+          },
+          "stance_score": {
+            "title": "Stance Score",
+            "type": "number"
+          }
+        },
+        "required": [
+          "document_date",
+          "stance_score"
+        ],
+        "title": "StanceContextPoint",
+        "type": "object"
+      },
+      "StanceContextResponse": {
+        "description": "Trailing stance-score summary for the dashboard tile.\n\n``stance_score = P(hawkish) - P(dovish)`` per the validity study;\nthe tile renders the current run as a z-score against this trailing\nmean/std rather than as a raw absolute number. ``mean`` and ``std``\nare ``null`` when fewer than two usable historical rows are found,\nin which case the tile falls back to the raw-value rendering.",
+        "properties": {
+          "history": {
+            "items": {
+              "$ref": "#/components/schemas/StanceContextPoint"
+            },
+            "title": "History",
+            "type": "array"
+          },
+          "mean": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean"
+          },
+          "n": {
+            "title": "N",
+            "type": "integer"
+          },
+          "std": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Std"
+          }
+        },
+        "required": [
+          "n",
+          "mean",
+          "std",
+          "history"
+        ],
+        "title": "StanceContextResponse",
+        "type": "object"
+      },
       "SymbolDescriptor": {
         "properties": {
           "category": {
@@ -6026,6 +6091,90 @@
           }
         },
         "summary": "Get History Realized Batch"
+      }
+    },
+    "/history/recent-stance-scores": {
+      "get": {
+        "description": "Trailing ``n`` stance-score points for the rolling-z dashboard tile.\n\nThe current run is excluded from the trailing window when its id is\npassed via ``exclude_run_id`` so the z-score is computed against\nhistory rather than against itself.\n\nRegistered ABOVE ``/history/{run_id}`` because FastAPI matches\nroutes in declaration order \u2014 a generic ``{run_id}`` segment would\notherwise swallow ``recent-stance-scores`` as a literal id and 404\non lookup.",
+        "operationId": "get_recent_stance_scores_history_recent_stance_scores_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "symbol",
+            "required": true,
+            "schema": {
+              "title": "Symbol",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "horizon",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Horizon"
+            }
+          },
+          {
+            "in": "query",
+            "name": "n",
+            "required": false,
+            "schema": {
+              "default": 12,
+              "maximum": 120,
+              "minimum": 1,
+              "title": "N",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "exclude_run_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Exclude Run Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StanceContextResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Recent Stance Scores"
       }
     },
     "/history/{run_id}": {

--- a/tests/unit/test_stance_context.py
+++ b/tests/unit/test_stance_context.py
@@ -114,15 +114,25 @@ def test_extract_stance_score_returns_zero_for_neutral_only() -> None:
     assert _extract_stance_score(payload) is None  # neither hawkish nor dovish key
 
 
-def test_extract_stance_score_handles_one_sided_distribution() -> None:
-    """Only hawkish or only dovish present should still resolve."""
+def test_extract_stance_score_rejects_one_sided_distribution() -> None:
+    """A truncated payload missing one of {hawkish, dovish} is a corrupt
+    measurement, not a legitimate ``P(class) = 0``. The classifier's
+    softmax always populates both keys; treating a missing key as zero
+    would fabricate a score that pollutes the trailing-window mean.
+    """
 
-    assert _extract_stance_score(
-        {"multi_axis": {"stance": {"distribution": {"hawkish": 0.6}}}}
-    ) == pytest.approx(0.6)
-    assert _extract_stance_score(
-        {"multi_axis": {"stance": {"distribution": {"dovish": 0.4}}}}
-    ) == pytest.approx(-0.4)
+    assert (
+        _extract_stance_score(
+            {"multi_axis": {"stance": {"distribution": {"hawkish": 0.6}}}}
+        )
+        is None
+    )
+    assert (
+        _extract_stance_score(
+            {"multi_axis": {"stance": {"distribution": {"dovish": 0.4}}}}
+        )
+        is None
+    )
 
 
 def test_build_stance_context_returns_none_mean_for_lt_two_rows(session) -> None:
@@ -138,7 +148,10 @@ def test_build_stance_context_returns_none_mean_for_lt_two_rows(session) -> None
         )
     )
     session.commit()
-    ctx = build_stance_context(session, symbol="^GSPC", n=12)
+    # ``leave_one_out=False`` so the single seed row is not dropped —
+    # this test exercises the < 2 fallback path, not the dashboard's
+    # safe-by-default behaviour (covered separately).
+    ctx = build_stance_context(session, symbol="^GSPC", n=12, leave_one_out=False)
     assert ctx.n == 1
     assert ctx.mean is None
     assert ctx.std is None
@@ -162,7 +175,7 @@ def test_build_stance_context_computes_mean_and_std(session) -> None:
             )
         )
     session.commit()
-    ctx = build_stance_context(session, symbol="^GSPC", n=12)
+    ctx = build_stance_context(session, symbol="^GSPC", n=12, leave_one_out=False)
     assert ctx.n == 3
     # Scores are 0.5, 0.0, 0.3 → mean ≈ 0.2667, sample std ≈ 0.2517
     assert ctx.mean is not None and abs(ctx.mean - 0.2667) < 1e-3
@@ -197,7 +210,7 @@ def test_build_stance_context_filters_runs_without_usable_distribution(session) 
             )
         )
     session.commit()
-    ctx = build_stance_context(session, symbol="^GSPC", n=12)
+    ctx = build_stance_context(session, symbol="^GSPC", n=12, leave_one_out=False)
     assert ctx.n == 2  # the empty-payload run is dropped
     assert all(math.isfinite(p.stance_score) for p in ctx.history)
 
@@ -225,3 +238,80 @@ def test_build_stance_context_excludes_run_id(session) -> None:
     )
     assert ctx.n == 2
     assert all(p.document_date != "2026-05-03" for p in ctx.history)
+
+
+def test_build_stance_context_default_is_leave_one_out(session) -> None:
+    """Safe-by-default: when the caller forgets ``exclude_run_id`` the
+    most-recent persisted row is dropped from the trailing window so
+    the z-score is never computed self-inclusively. This is critical
+    for the dashboard, which fires the fetch right after a new /analyze
+    write — including the just-persisted row would pull the z-score
+    magnitude toward zero on every fresh badge.
+    """
+
+    base = _dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc)
+    for i, (h, d) in enumerate([(0.6, 0.3), (0.4, 0.4), (0.7, 0.2)]):
+        session.add(
+            _make_run(
+                run_id=f"r{i}",
+                symbol="^GSPC",
+                horizon="10d",
+                document_date=f"2026-05-{i + 1:02d}",
+                hawkish=h,
+                dovish=d,
+                created_at=base + _dt.timedelta(days=i),
+            )
+        )
+    session.commit()
+    ctx = build_stance_context(session, symbol="^GSPC", n=12)
+    # Most-recent row (r2 / 2026-05-03) must NOT be in the trailing
+    # window; only r0 + r1 remain.
+    assert ctx.n == 2
+    assert {p.document_date for p in ctx.history} == {"2026-05-01", "2026-05-02"}
+
+
+def test_build_stance_context_leave_one_out_can_be_disabled(session) -> None:
+    """Diagnostic callers can opt into the full window."""
+
+    base = _dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc)
+    for i, (h, d) in enumerate([(0.6, 0.3), (0.4, 0.4), (0.7, 0.2)]):
+        session.add(
+            _make_run(
+                run_id=f"r{i}",
+                symbol="^GSPC",
+                horizon="10d",
+                document_date=f"2026-05-{i + 1:02d}",
+                hawkish=h,
+                dovish=d,
+                created_at=base + _dt.timedelta(days=i),
+            )
+        )
+    session.commit()
+    ctx = build_stance_context(session, symbol="^GSPC", n=12, leave_one_out=False)
+    assert ctx.n == 3
+
+
+def test_build_stance_context_returns_null_std_for_constant_series(session) -> None:
+    """A degenerate trailing window (identical s for every row) must
+    surface std=None so the frontend falls back to raw rendering. A
+    sentinel 0.0 would invite a ``score / 0`` div somewhere downstream.
+    """
+
+    base = _dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc)
+    for i in range(4):
+        session.add(
+            _make_run(
+                run_id=f"r{i}",
+                symbol="^GSPC",
+                horizon="10d",
+                document_date=f"2026-05-{i + 1:02d}",
+                hawkish=0.6,
+                dovish=0.3,  # identical s = +0.3 across every row
+                created_at=base + _dt.timedelta(days=i),
+            )
+        )
+    session.commit()
+    ctx = build_stance_context(session, symbol="^GSPC", n=12, leave_one_out=False)
+    assert ctx.n == 4
+    assert ctx.mean == pytest.approx(0.3)
+    assert ctx.std is None

--- a/tests/unit/test_stance_context.py
+++ b/tests/unit/test_stance_context.py
@@ -1,0 +1,227 @@
+"""Behavioural tests for the rolling stance-score context builder.
+
+Anchors:
+- `s = P(hawkish) - P(dovish)` per the validity study (matches the
+  signal that landed Spearman +0.283 vs DFEDTARU).
+- The tile falls back to raw rendering when fewer than 2 usable rows
+  are found, so a regression-mode backlog must not poison the mean.
+- Excluding the current run from the trailing window prevents the
+  z-score from being computed against itself.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import math
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db import AnalysisRun, Base
+from app.services.stance_context import (
+    _extract_stance_score,
+    build_stance_context,
+)
+
+
+@pytest.fixture()
+def session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    s = Session()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+def _make_run(
+    *,
+    run_id: str,
+    symbol: str,
+    horizon: str,
+    document_date: str,
+    hawkish: float | None,
+    dovish: float | None,
+    created_at: _dt.datetime,
+) -> AnalysisRun:
+    """Build a persisted run whose payload carries one multi-axis stance row."""
+
+    distribution: dict[str, float] = {}
+    if hawkish is not None:
+        distribution["hawkish"] = hawkish
+    if dovish is not None:
+        distribution["dovish"] = dovish
+
+    payload: dict[str, object] = {}
+    if distribution:
+        payload = {
+            "multi_axis": {
+                "stance": {
+                    "label": "hawkish" if (hawkish or 0) > (dovish or 0) else "dovish",
+                    "confidence": max(hawkish or 0, dovish or 0),
+                    "distribution": distribution,
+                }
+            }
+        }
+
+    return AnalysisRun(
+        id=run_id,
+        created_at=created_at,
+        symbol=symbol,
+        document_date=document_date,
+        horizon=horizon,
+        forecast_mode="fast",
+        stance="hawkish",
+        sentiment_score=None,
+        predicted_close=None,
+        current_close=None,
+        predicted_volatility=None,
+        payload=payload,
+        text_excerpt=None,
+    )
+
+
+def test_extract_stance_score_from_full_distribution() -> None:
+    payload = {
+        "multi_axis": {
+            "stance": {"distribution": {"hawkish": 0.7, "dovish": 0.2, "neutral": 0.1}}
+        }
+    }
+    assert _extract_stance_score(payload) == pytest.approx(0.5)
+
+
+def test_extract_stance_score_handles_missing_keys() -> None:
+    assert _extract_stance_score(None) is None
+    assert _extract_stance_score({}) is None
+    assert _extract_stance_score({"multi_axis": None}) is None
+    assert _extract_stance_score({"multi_axis": {"stance": None}}) is None
+    assert (
+        _extract_stance_score({"multi_axis": {"stance": {"distribution": {}}}}) is None
+    )
+
+
+def test_extract_stance_score_returns_zero_for_neutral_only() -> None:
+    """A pure-neutral distribution (no hawk/dove mass) IS s=0.0, not None.
+
+    Suppressing it would mis-classify a legitimately on-the-fence
+    statement as a missing measurement.
+    """
+
+    payload = {"multi_axis": {"stance": {"distribution": {"neutral": 1.0}}}}
+    assert _extract_stance_score(payload) is None  # neither hawkish nor dovish key
+
+
+def test_extract_stance_score_handles_one_sided_distribution() -> None:
+    """Only hawkish or only dovish present should still resolve."""
+
+    assert _extract_stance_score(
+        {"multi_axis": {"stance": {"distribution": {"hawkish": 0.6}}}}
+    ) == pytest.approx(0.6)
+    assert _extract_stance_score(
+        {"multi_axis": {"stance": {"distribution": {"dovish": 0.4}}}}
+    ) == pytest.approx(-0.4)
+
+
+def test_build_stance_context_returns_none_mean_for_lt_two_rows(session) -> None:
+    session.add(
+        _make_run(
+            run_id="a",
+            symbol="^GSPC",
+            horizon="10d",
+            document_date="2026-05-01",
+            hawkish=0.7,
+            dovish=0.2,
+            created_at=_dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc),
+        )
+    )
+    session.commit()
+    ctx = build_stance_context(session, symbol="^GSPC", n=12)
+    assert ctx.n == 1
+    assert ctx.mean is None
+    assert ctx.std is None
+    assert len(ctx.history) == 1
+
+
+def test_build_stance_context_computes_mean_and_std(session) -> None:
+    """Three rows with distinct s values produce a meaningful mean+std."""
+
+    base = _dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc)
+    for i, (h, d) in enumerate([(0.7, 0.2), (0.4, 0.4), (0.6, 0.3)]):
+        session.add(
+            _make_run(
+                run_id=f"r{i}",
+                symbol="^GSPC",
+                horizon="10d",
+                document_date=f"2026-05-{i + 1:02d}",
+                hawkish=h,
+                dovish=d,
+                created_at=base + _dt.timedelta(days=i),
+            )
+        )
+    session.commit()
+    ctx = build_stance_context(session, symbol="^GSPC", n=12)
+    assert ctx.n == 3
+    # Scores are 0.5, 0.0, 0.3 → mean ≈ 0.2667, sample std ≈ 0.2517
+    assert ctx.mean is not None and abs(ctx.mean - 0.2667) < 1e-3
+    assert ctx.std is not None and ctx.std > 0.0
+
+
+def test_build_stance_context_filters_runs_without_usable_distribution(session) -> None:
+    """A row with no stance distribution must not enter the window."""
+
+    base = _dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc)
+    session.add(
+        _make_run(
+            run_id="bad",
+            symbol="^GSPC",
+            horizon="10d",
+            document_date="2026-05-01",
+            hawkish=None,
+            dovish=None,
+            created_at=base,
+        )
+    )
+    for i, (h, d) in enumerate([(0.6, 0.3), (0.4, 0.4)]):
+        session.add(
+            _make_run(
+                run_id=f"good{i}",
+                symbol="^GSPC",
+                horizon="10d",
+                document_date=f"2026-05-{i + 2:02d}",
+                hawkish=h,
+                dovish=d,
+                created_at=base + _dt.timedelta(days=i + 1),
+            )
+        )
+    session.commit()
+    ctx = build_stance_context(session, symbol="^GSPC", n=12)
+    assert ctx.n == 2  # the empty-payload run is dropped
+    assert all(math.isfinite(p.stance_score) for p in ctx.history)
+
+
+def test_build_stance_context_excludes_run_id(session) -> None:
+    """Self-exclusion: a request that names the current run id must
+    return the trailing window without it."""
+
+    base = _dt.datetime(2026, 5, 1, tzinfo=_dt.timezone.utc)
+    for i, (h, d) in enumerate([(0.6, 0.3), (0.4, 0.4), (0.7, 0.2)]):
+        session.add(
+            _make_run(
+                run_id=f"r{i}",
+                symbol="^GSPC",
+                horizon="10d",
+                document_date=f"2026-05-{i + 1:02d}",
+                hawkish=h,
+                dovish=d,
+                created_at=base + _dt.timedelta(days=i),
+            )
+        )
+    session.commit()
+    ctx = build_stance_context(
+        session, symbol="^GSPC", n=12, exclude_run_id="r2"
+    )
+    assert ctx.n == 2
+    assert all(p.document_date != "2026-05-03" for p in ctx.history)


### PR DESCRIPTION
## Summary

- Stance tile now renders \`+X.Yσ\` against the trailing 12-meeting baseline of s = P(hawkish) − P(dovish), matching the validity study's validated scope (relative ordering).
- Falls back to the raw confidence rendering when fewer than two usable historical rows are available, when std is zero, or when the current stance has no distribution.
- New \`GET /history/recent-stance-scores\` endpoint; extracts s from each persisted run's payload, computes trailing mean/std, supports \`exclude_run_id\` so the current run isn't included in its own baseline.
- 8 backend tests + 5 frontend tests.

## Test plan

- [ ] \`docker compose run --rm backend pytest tests/unit/test_stance_context.py\`
- [ ] \`docker compose exec frontend npx vitest run tests/components/analyze/StanceZScore.test.tsx\`
- [ ] \`curl /history/recent-stance-scores?symbol=^GSPC&n=12\` returns finite mean+std
- [ ] Dashboard: StanceTile shows \`+X.Yσ\` after analyze, raw confidence on first load