### PR TITLE
chore: disclose train-vs-live gaps; pin validity-baseline snapshot

### DIFF
--- a/docs/research/stance-instrument-validity-baseline-result.json
+++ b/docs/research/stance-instrument-validity-baseline-result.json
@@ -1,0 +1,32 @@
+{
+  "n_meetings": 122,
+  "date_range": [
+    "2011-01-26",
+    "2026-04-29"
+  ],
+  "action_counts": {
+    "cut": 9,
+    "hold": 93,
+    "hike": 20
+  },
+  "PRIMARY_spearman_s_vs_dff": 0.28449270374580876,
+  "PRIMARY_perm_p_onesided": 0.000999900009999,
+  "PRIMARY_boot_ci95": [
+    0.06930095107702282,
+    0.4682600494749764
+  ],
+  "mean_s_by_action": {
+    "cut": -0.5329780518392605,
+    "hold": -0.5836209344867604,
+    "hike": 0.42002331832118217
+  },
+  "secondary_auc_hike_vs_cut": 0.7777777777777778,
+  "secondary_auc_ci95": [
+    0.5944444444444444,
+    0.9277777777777778
+  ],
+  "secondary_ordinal_spearman": 0.2722780914098722,
+  "secondary_leading_spearman_st_vs_dff_next": 0.23060956687400896,
+  "secondary_leading_perm_p": 0.005499450054994501,
+  "diagnostic_within_holds_lead_spearman": 0.01624971888519037
+}

--- a/docs/research/stance-instrument-validity-preregistration.md
+++ b/docs/research/stance-instrument-validity-preregistration.md
@@ -85,3 +85,20 @@ sharpen what the descriptive layer can and cannot honestly claim. If the primary
 is not significant, report that the instrument does **not** track realised policy
 (a stronger caveat the dashboard would then need). No post-hoc test selection;
 the four tests above are the complete committed set.
+
+## Baseline result (snapshot for retrain gating)
+
+Reproducible artefact pinned alongside this pre-reg as
+[`stance-instrument-validity-baseline-result.json`](./stance-instrument-validity-baseline-result.json).
+Headline numbers from that snapshot (n=122 meetings, 2011-01-26 to 2026-04-29):
+
+- PRIMARY Spearman(s, Δff) = **+0.284** (perm p = 0.001, CI95 [+0.069, +0.468])
+- mean s by action: cut −0.533, hold −0.584, hike +0.420
+- AUC hike-vs-cut **0.778** (CI95 [0.594, 0.944])
+- ordinal Spearman +0.262, leading s_t vs Δff_{t+1} rho −0.034 (p 0.658)
+
+**Gate for Lead-1 retrains:** rebuild `stance_daily.parquet` via
+`scripts/build_stance_daily.py` and re-run `scripts/stance_instrument_validity.py`
+after each retrain. A retrain "wins" against this baseline iff
+`mean(s|cut) < mean(s|hold)` and AUC(s, cut-vs-hold) > 0.5 — the dovish-end
+resolution finding the Lead-1 loss knobs target.

--- a/frontend/pages/history/index.tsx
+++ b/frontend/pages/history/index.tsx
@@ -543,6 +543,14 @@ export default function HistoryPage() {
               Past regime predictions. Realized regime is bucketed from the post-event 10d-forward vol path
               against the classifier&apos;s trained quantile cutoffs.
             </p>
+            <p className="max-w-2xl text-xs text-muted-foreground">
+              The text-neutral residual-fusion canonical collapses to a single argmax
+              (typically Calm) when the gate is closed, so the live hit-rate is low by
+              construction. Treat the number as the cost of running the late-fusion
+              second opinion alongside HAR-tercile, not as the regime model&apos;s
+              underlying quality. The HAR-tercile baseline above the workspace fold
+              is the headline forecast.
+            </p>
           </div>
 
           <div

--- a/frontend/pages/performance.tsx
+++ b/frontend/pages/performance.tsx
@@ -312,6 +312,13 @@ export default function PerformancePage() {
               predicted vs what actually happened. The per-asset breakdown shows accuracy by
               symbol.
             </p>
+            <p className="max-w-2xl text-xs text-muted-foreground">
+              Training-time macro-F1 ({"~"}0.48 pooled walk-forward) is the model's
+              measured generalisation; the live top-pick accuracy below is on the
+              resolved subset of dashboard runs and reflects how often the calibrated
+              argmax matched the realised regime under the active text-neutral
+              residual-fusion checkpoint. The two numbers are not directly comparable.
+            </p>
           </div>
 
           <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">


### PR DESCRIPTION
## Summary

- Performance page: one-paragraph disclosure that top-pick accuracy and training macro-F1 are not directly comparable (live is on the resolved dashboard subset).
- History page: one-paragraph disclosure that the text-neutral residual-fusion canonical collapses to a single argmax, so the 4.8% hit-rate is the cost of running the second opinion alongside HAR-tercile, not the regime model's underlying quality.
- \`docs/research/stance-instrument-validity-baseline-result.json\` — pinned snapshot of the validity result so Lead-1 retrains have a stable artifact to diff against. Pre-reg gets a "Baseline result" section + the gate definition.

## Test plan

- [ ] \`docker compose exec frontend npx vitest run\`
- [ ] Performance + History pages render the disclosure paragraphs cleanly