### PR TITLE
fix: drop stale macro-F1 figure and source tier from performance page

### DIFF
--- a/frontend/pages/performance.tsx
+++ b/frontend/pages/performance.tsx
@@ -313,11 +313,12 @@ export default function PerformancePage() {
               symbol.
             </p>
             <p className="max-w-2xl text-xs text-muted-foreground">
-              Training-time macro-F1 ({"~"}0.48 pooled walk-forward) is the model's
-              measured generalisation; the live top-pick accuracy below is on the
-              resolved subset of dashboard runs and reflects how often the calibrated
-              argmax matched the realised regime under the active text-neutral
-              residual-fusion checkpoint. The two numbers are not directly comparable.
+              Training-time macro-F1 (shown in the tile below as &quot;Overall F1
+              score&quot;) is the model's measured generalisation; the live top-pick
+              accuracy below is on the resolved subset of dashboard runs and reflects
+              how often the calibrated argmax matched the realised regime under the
+              active text-neutral residual-fusion checkpoint. The two numbers are not
+              directly comparable.
             </p>
           </div>
 
@@ -480,10 +481,7 @@ export default function PerformancePage() {
                 </CardContent>
                 {breakdownAvailable && breakdown?.source ? (
                   <div className="border-t border-border bg-muted/20 px-4 py-2 text-[10px] text-muted-foreground">
-                    Source: tier 7 (market + rich + NLP + xBank + LLM), 5 seeds x 4 folds, pooled walk-forward
-                    {breakdown.source.training_package_id
-                      ? ` · ${breakdown.source.training_package_id}`
-                      : ""}
+                    Source: {breakdown.source.relative_path}
                     {" · "}
                     {new Date(breakdown.source.modified_at).toLocaleString(undefined, {
                       dateStyle: "short",

--- a/frontend/tests/pages/performance.test.tsx
+++ b/frontend/tests/pages/performance.test.tsx
@@ -208,6 +208,10 @@ describe("PerformancePage", () => {
     // The phrase appears in both the per-class table and the confusion matrix
     // descriptions when the artifact is loaded — assert presence, not uniqueness.
     expect(screen.getAllByText(/training-time evaluation/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/tp_fixture/)).toBeInTheDocument();
+    expect(screen.getByText(/regime_baseline_tiers\/tp_fixture\/forecaster_sweep_results\.json/)).toBeInTheDocument();
+    expect(screen.queryByText(/tier 7/i)).not.toBeInTheDocument();
+    // Subtitle no longer hardcodes the macro-F1 figure and now references the KPI tile.
+    expect(document.body.textContent ?? "").not.toMatch(/0\.48/);
+    expect(screen.getAllByText(/Overall F1\s+score/).length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Removes a hardcoded ~0.48 figure from the subtitle and replaces the stale "tier 7 / 5 seeds x 4 folds" source footer with the artifact's relative path, both of which had drifted from the live breakdown payload.

## Test plan

- [ ] `docker compose run --rm frontend npx vitest run tests/pages/performance.test.tsx tests/lib/analyze/performance.test.ts`
- [ ] Visit `http://localhost:3000/performance` and confirm the subtitle no longer mentions 0.48 and the per-class table footer shows the artifact relative path
- [ ] `curl -s http://localhost:8000/evaluation/classification-breakdown | python3 -m json.tool` confirms `source.relative_path` is non-null when `available` is true