### PR TITLE
fix: research console heatmap, files tab, bake-off bar colour

### DIFF
--- a/frontend/pages/research.tsx
+++ b/frontend/pages/research.tsx
@@ -110,11 +110,13 @@ const BAKEOFF_TOOLTIP_STYLE: React.CSSProperties = {
 };
 
 function bakeoffBarColor(value: number, min: number, max: number): string {
-  if (max <= min) return "hsl(var(--primary))";
+  // Recharts sets this as an SVG fill attribute; CSS var() does not resolve there,
+  // so use a literal hsl() ramp anchored to the chart-1 hue (199).
+  if (max <= min) return "hsl(199 89% 48%)";
   const t = Math.max(0, Math.min(1, (value - min) / (max - min)));
-  // Sequential primary-tinted ramp; lighter at low scores.
-  const alpha = 0.35 + 0.6 * t;
-  return `hsla(var(--primary) / ${alpha.toFixed(3)})`;
+  // Lighter at low scores, saturated at high scores.
+  const lightness = 65 - 25 * t;
+  return `hsl(199 89% ${lightness.toFixed(1)}%)`;
 }
 
 interface BakeoffBarDatum {
@@ -387,7 +389,7 @@ function CrossBankTransferPane({ section }: { section: CrossBankTransferSection 
                         style={cell ? { backgroundColor: heatmapColor(cell.metric, min, max) } : undefined}
                         title={renderCellTooltip(src, tgt, cell)}
                       >
-                        {cell ? "" : "—"}
+                        {cell ? cell.metric.toFixed(3) : "—"}
                       </td>
                     );
                   })}
@@ -466,7 +468,7 @@ function ArtifactsExplorer({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Downloads</CardTitle>
+        <CardTitle>Files</CardTitle>
         <CardDescription>
           {totalFiles} files across {sectionEntries.length} sections. Each file lists its size, last update, and a short note on what it is.
         </CardDescription>
@@ -570,7 +572,7 @@ export default function ResearchPage() {
                 <TabsTrigger value="bakeoff">Bake-off</TabsTrigger>
                 <TabsTrigger value="transfer">Transfer</TabsTrigger>
                 <TabsTrigger value="decisions">Decisions</TabsTrigger>
-                <TabsTrigger value="files">Downloads</TabsTrigger>
+                <TabsTrigger value="files">Files</TabsTrigger>
               </TabsList>
               <TabsContent value="scope">
                 <HonestScopePane />

--- a/frontend/tests/pages/research.test.tsx
+++ b/frontend/tests/pages/research.test.tsx
@@ -12,6 +12,42 @@ async function openBakeoffTab() {
   await user.click(trigger);
 }
 
+async function openTransferTab() {
+  const user = userEvent.setup();
+  const trigger = await screen.findByRole("tab", { name: /transfer/i });
+  await user.click(trigger);
+}
+
+async function openFilesTab() {
+  const user = userEvent.setup();
+  const trigger = await screen.findByRole("tab", { name: /^files$/i });
+  await user.click(trigger);
+}
+
+// Recharts renders its <Bar> children into SVG inside a sized
+// ResponsiveContainer; in jsdom the container collapses to 0×0 and the
+// nested Cell elements never reach the DOM. Mock the chart primitives so
+// the rendered Cell surfaces its `fill` prop as a data attribute we can
+// assert on.
+vi.mock("recharts", () => {
+  const passthrough = ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  );
+  return {
+    Bar: passthrough,
+    BarChart: passthrough,
+    CartesianGrid: () => <div data-testid="rc-grid" />,
+    Cell: ({ fill }: { fill?: string }) => (
+      <div data-testid="rc-bar-cell" data-fill={fill ?? ""} />
+    ),
+    ErrorBar: () => <div data-testid="rc-error-bar" />,
+    ResponsiveContainer: passthrough,
+    Tooltip: () => <div data-testid="rc-tooltip" />,
+    XAxis: () => <div data-testid="rc-x-axis" />,
+    YAxis: () => <div data-testid="rc-y-axis" />,
+  };
+});
+
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
   Toaster: () => null,
@@ -139,6 +175,78 @@ describe("ResearchPage", () => {
     // Macro-F1 mean appears in the row body.
     expect(screen.getByText("0.530")).toBeInTheDocument();
     expect(screen.getByText("0.604")).toBeInTheDocument();
+  });
+
+  it("renders heatmap cells with the numeric metric and bank labels", async () => {
+    const response = {
+      ...POPULATED_RESPONSE,
+      cross_bank_transfer: {
+        available: true,
+        metric_name: "macro_f1",
+        sources: ["FED", "ECB"],
+        targets: ["FED", "ECB"],
+        cells: [
+          { source: "FED", target: "FED", metric: 0.612 },
+          { source: "FED", target: "ECB", metric: 0.481 },
+          { source: "ECB", target: "FED", metric: 0.395 },
+          { source: "ECB", target: "ECB", metric: 0.557 },
+        ],
+        source_files: ["cross_bank/transfer.json"],
+      },
+    };
+    fetchResearchArtifactsMock.mockResolvedValue(response);
+    const { default: ResearchPage } = await import("@/pages/research");
+    render(<ResearchPage />);
+    await openTransferTab();
+
+    // Numeric metric renders inside each populated cell (3-decimal format).
+    // Both heatmap + values tables carry the same tooltip title; the heatmap
+    // cell is the one keyed `heat-…` and tinted via an inline background.
+    const titledCells = await screen.findAllByTitle(/Trained on FED, evaluated on ECB/);
+    const heatmapCell = titledCells.find(
+      (el) => el.getAttribute("style")?.includes("background-color") ?? false,
+    );
+    expect(heatmapCell).toBeDefined();
+    expect(heatmapCell!.textContent).toContain("0.481");
+
+    // Source + target bank labels are present as row + column headers.
+    expect(screen.getAllByText("FED").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("ECB").length).toBeGreaterThan(0);
+  });
+
+  it("renders the Files tab with at least one artefact row under the new label", async () => {
+    fetchResearchArtifactsMock.mockResolvedValue(POPULATED_RESPONSE);
+    const { default: ResearchPage } = await import("@/pages/research");
+    render(<ResearchPage />);
+    await openFilesTab();
+
+    // Tab + card title both read "Files" (the rename) rather than the old
+    // "Downloads" label that had no matching download endpoint.
+    expect(await screen.findByRole("tab", { name: /^files$/i })).toBeInTheDocument();
+    expect(screen.queryByText(/^Downloads$/)).toBeNull();
+
+    // The populated phase3 artefact row surfaces its relative path.
+    expect(
+      screen.getByText("phase3/run-a/aggregate.json"),
+    ).toBeInTheDocument();
+  });
+
+  it("paints bake-off bars with a non-default colour ramp", async () => {
+    fetchResearchArtifactsMock.mockResolvedValue(POPULATED_RESPONSE);
+    const { default: ResearchPage } = await import("@/pages/research");
+    render(<ResearchPage />);
+    await openBakeoffTab();
+
+    const cells = await screen.findAllByTestId("rc-bar-cell");
+    expect(cells.length).toBeGreaterThan(0);
+    // The new ramp emits literal hsl() so Recharts can write it directly
+    // onto the SVG fill attribute; the old `hsla(var(--primary) / α)` form
+    // never resolved inside SVG and rendered as black.
+    for (const cell of cells) {
+      const fill = cell.getAttribute("data-fill") ?? "";
+      expect(fill).toMatch(/^hsl\(/);
+      expect(fill).not.toContain("var(");
+    }
   });
 
   it("renders source-file badges with a friendly encoder label, not the raw path", async () => {


### PR DESCRIPTION
Three independent bugs in the research console fixed in one file.

- Transfer heatmap cells render the metric value instead of an empty string.
- Files tab label matches the underlying tab `value` (was "Downloads", with no download endpoint).
- Bake-off bar fill uses a literal `hsl()` ramp because Recharts emits the fill as an SVG attribute, where `var()` does not resolve.

## Test plan
- [ ] `cd frontend && npx vitest run tests/pages/research.test.tsx` (passes locally)
- [ ] Open `/research`, Transfer tab: each populated heatmap cell shows a 3-decimal metric.
- [ ] Files tab trigger and card both read "Files".
- [ ] Bake-off tab bars render with a coloured fill; inspect the SVG `<rect fill>` attribute and confirm no `var()` reference.