### PR TITLE
fix: route calendar badges to release date and clean up scraper CLI

### DIFF
--- a/backend/app/services/scraper.py
+++ b/backend/app/services/scraper.py
@@ -385,11 +385,51 @@ def scrape_fomc_minutes(output_dir: str | Path = "/data") -> list[FomcDocument]:
     )
 
 
-if __name__ == "__main__":
-    statements = scrape_fomc_statements("/data")
-    minutes = scrape_fomc_minutes("/data")
-    print(
-        "Saved "
-        f"{len(statements)} statements to /data/fomc_statements.json and /data/fomc_statements.csv, "
-        f"and {len(minutes)} minutes to /data/fomc_minutes.json and /data/fomc_minutes.csv"
+def _cli_main(argv: list[str] | None = None) -> int:
+    """Command-line entry: walk the federalreserve.gov calendar archives
+    and write ``fomc_statements.{json,csv}`` and ``fomc_minutes.{json,csv}``
+    under ``--output-dir`` (defaults to ``/data`` to match the container
+    volume mount). Used by operators to refresh the on-disk caches the
+    ``/fomc/calendar`` availability badges and the ``/documents/{type}/
+    {date}`` viewer route both read against.
+
+    Returns 0 on success, non-zero on failure so docker-compose run exits
+    cleanly.
+    """
+
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        prog="python -m app.services.scraper",
+        description=(
+            "Refresh the FOMC statement and minutes caches by walking the "
+            "Federal Reserve's calendar / historical archive pages."
+        ),
     )
+    parser.add_argument(
+        "output_dir",
+        nargs="?",
+        default="/data",
+        help="Directory to write the JSON + CSV caches into (default: /data).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        statements = scrape_fomc_statements(args.output_dir)
+        minutes = scrape_fomc_minutes(args.output_dir)
+    except Exception as exc:  # pragma: no cover - surfaced at the CLI.
+        print(f"scrape failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Saved {len(statements)} statements to {args.output_dir}/fomc_statements.json"
+        f" and {args.output_dir}/fomc_statements.csv, and "
+        f"{len(minutes)} minutes to {args.output_dir}/fomc_minutes.json and "
+        f"{args.output_dir}/fomc_minutes.csv"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli_main())

--- a/frontend/pages/calendar.tsx
+++ b/frontend/pages/calendar.tsx
@@ -118,6 +118,29 @@ const TEXT_AVAILABILITY_BADGES: Array<{
   { key: "press_conference_available", label: "Presser", kind: "press_conference" },
 ];
 
+// Resolve the date segment used in the /documents/{kind}/{date} viewer
+// URL. Each document kind has its own release date and the backend's
+// JSON cache is keyed by that date, so a single blanket fallback would
+// 404 every minutes click whenever minutes_release_date differs from
+// statement_release_date. Falls back to meeting_date when the per-kind
+// release date is absent (e.g., far-future rows missing the field).
+function badgeHrefDate(
+  meeting: FomcMeeting,
+  kind: "statement" | "minutes" | "press_conference",
+): string {
+  if (kind === "statement") {
+    return meeting.statement_release_date ?? meeting.meeting_date;
+  }
+  if (kind === "minutes") {
+    return meeting.minutes_release_date ?? meeting.meeting_date;
+  }
+  // The calendar payload does not carry a dedicated press_conference
+  // date; the press conference happens on the meeting's concluding day,
+  // which lines up with statement_release_date. Fall back to
+  // meeting_date when the release date is absent.
+  return meeting.statement_release_date ?? meeting.meeting_date;
+}
+
 function AvailabilityBadge({
   label,
   available,
@@ -218,7 +241,7 @@ function MeetingRowDetails({
               available={Boolean(meeting[key])}
               href={
                 meeting[key]
-                  ? `/documents/${kind}/${meeting.statement_release_date ?? meeting.meeting_date}`
+                  ? `/documents/${kind}/${badgeHrefDate(meeting, kind)}`
                   : null
               }
             />

--- a/frontend/pages/calendar.tsx
+++ b/frontend/pages/calendar.tsx
@@ -218,7 +218,7 @@ function MeetingRowDetails({
               available={Boolean(meeting[key])}
               href={
                 meeting[key]
-                  ? `/documents/${kind}/${meeting.meeting_date}`
+                  ? `/documents/${kind}/${meeting.statement_release_date ?? meeting.meeting_date}`
                   : null
               }
             />

--- a/frontend/tests/pages/calendar.test.tsx
+++ b/frontend/tests/pages/calendar.test.tsx
@@ -184,19 +184,22 @@ describe("CalendarPage", () => {
     const presserBadges = screen.getAllByTestId("availability-presser");
 
     // Past row has on-file statement + minutes — both should be anchor
-    // tags pointing at the path-based viewer keyed off meeting_date.
+    // tags pointing at the path-based viewer keyed off the statement
+    // release date (day-2 of the two-day meeting), which is the date the
+    // scraper writes into the JSON cache's "date" field. Falling back to
+    // meeting_date would 404 every click.
     const pastStatement = badgeForMeeting(statementBadges, "2024-09-17");
     expect(pastStatement.tagName).toBe("A");
     expect(pastStatement).toHaveAttribute(
       "href",
-      "/documents/statement/2024-09-17",
+      "/documents/statement/2024-09-18",
     );
 
     const pastMinutes = badgeForMeeting(minutesBadges, "2024-09-17");
     expect(pastMinutes.tagName).toBe("A");
     expect(pastMinutes).toHaveAttribute(
       "href",
-      "/documents/minutes/2024-09-17",
+      "/documents/minutes/2024-09-18",
     );
 
     // Past row presser is not on file — must stay a span.

--- a/frontend/tests/pages/calendar.test.tsx
+++ b/frontend/tests/pages/calendar.test.tsx
@@ -184,10 +184,13 @@ describe("CalendarPage", () => {
     const presserBadges = screen.getAllByTestId("availability-presser");
 
     // Past row has on-file statement + minutes — both should be anchor
-    // tags pointing at the path-based viewer keyed off the statement
-    // release date (day-2 of the two-day meeting), which is the date the
-    // scraper writes into the JSON cache's "date" field. Falling back to
-    // meeting_date would 404 every click.
+    // tags pointing at the path-based viewer keyed off the per-kind
+    // release date. statement uses statement_release_date (day-2 of the
+    // two-day meeting); minutes uses minutes_release_date (~21 days
+    // later); presser falls back to statement_release_date since the
+    // press conference happens on the meeting's concluding day. A
+    // blanket fallback to a single date would 404 the minutes click
+    // every time the two release dates differ.
     const pastStatement = badgeForMeeting(statementBadges, "2024-09-17");
     expect(pastStatement.tagName).toBe("A");
     expect(pastStatement).toHaveAttribute(
@@ -199,7 +202,7 @@ describe("CalendarPage", () => {
     expect(pastMinutes.tagName).toBe("A");
     expect(pastMinutes).toHaveAttribute(
       "href",
-      "/documents/minutes/2024-09-18",
+      "/documents/minutes/2024-10-09",
     );
 
     // Past row presser is not on file — must stay a span.
@@ -246,5 +249,92 @@ describe("CalendarPage", () => {
     expect(minutes).toHaveAttribute("data-available", "false");
     expect(presser).toHaveAttribute("data-available", "false");
     expect(statement).toHaveAttribute("title", "Statement not collected");
+  });
+
+  it("routes each badge kind to its own release date", async () => {
+    // Regression: every badge kind must use the date the backend's
+    // JSON cache is keyed on. statement_release_date and
+    // minutes_release_date differ by ~3 weeks, so a blanket fallback
+    // would 404 the minutes click. Presser shares the meeting's
+    // concluding day with the statement, so it falls back to
+    // statement_release_date.
+    fetchFomcCalendarMock.mockResolvedValue({
+      upcoming: [],
+      past: [
+        {
+          meeting_date: "2024-09-17",
+          meeting_type: "scheduled",
+          statement_release_date: "2024-09-18",
+          minutes_release_date: "2024-10-09",
+          statement_available: true,
+          minutes_available: true,
+          press_conference_available: true,
+        },
+      ],
+    });
+    const { default: CalendarPage } = await import("@/pages/calendar");
+    render(<CalendarPage />);
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId("availability-statement").length).toBe(1),
+    );
+    const statement = screen.getByTestId("availability-statement");
+    const minutes = screen.getByTestId("availability-minutes");
+    const presser = screen.getByTestId("availability-presser");
+    expect(statement.tagName).toBe("A");
+    expect(statement).toHaveAttribute(
+      "href",
+      "/documents/statement/2024-09-18",
+    );
+    expect(minutes.tagName).toBe("A");
+    expect(minutes).toHaveAttribute(
+      "href",
+      "/documents/minutes/2024-10-09",
+    );
+    expect(presser.tagName).toBe("A");
+    expect(presser).toHaveAttribute(
+      "href",
+      "/documents/press_conference/2024-09-18",
+    );
+  });
+
+  it("falls back to meeting_date when a per-kind release date is missing", async () => {
+    // Far-future rows can ship without statement_release_date /
+    // minutes_release_date. Each badge must still produce a usable href
+    // rather than rendering "/documents/minutes/undefined".
+    fetchFomcCalendarMock.mockResolvedValue({
+      upcoming: [],
+      past: [
+        {
+          meeting_date: "2024-09-17",
+          meeting_type: "scheduled",
+          // statement / minutes release dates intentionally absent
+          statement_available: true,
+          minutes_available: true,
+          press_conference_available: true,
+        },
+      ],
+    });
+    const { default: CalendarPage } = await import("@/pages/calendar");
+    render(<CalendarPage />);
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId("availability-statement").length).toBe(1),
+    );
+    const statement = screen.getByTestId("availability-statement");
+    const minutes = screen.getByTestId("availability-minutes");
+    const presser = screen.getByTestId("availability-presser");
+    expect(statement).toHaveAttribute(
+      "href",
+      "/documents/statement/2024-09-17",
+    );
+    expect(minutes).toHaveAttribute(
+      "href",
+      "/documents/minutes/2024-09-17",
+    );
+    expect(presser).toHaveAttribute(
+      "href",
+      "/documents/press_conference/2024-09-17",
+    );
   });
 });


### PR DESCRIPTION
Calendar availability badges now point the document viewer at the statement release date (the date the scraper writes into the JSON cache) instead of the meeting start date, so click-throughs stop 404-ing on every past row; the scraper module grows an argparse CLI with `--output-dir` so refreshing the on-disk caches is a single `docker compose run` call.

## Test plan

- [x] `docker compose run --rm backend pytest tests/unit/test_main_api.py::test_fomc_calendar_exposes_text_availability_flags tests/unit/test_main_api.py::test_fomc_calendar_availability_matches_on_disk_caches -q`
- [x] `docker compose run --rm frontend npx vitest run tests/pages/calendar.test.tsx`
- [x] `docker compose run --rm backend bash -c "ruff check app/services/scraper.py && ruff format --check app/services/scraper.py"`