### PR TITLE
fix(compare): label delta tiles and surface sentiment score delta

### DIFF
--- a/frontend/pages/compare.tsx
+++ b/frontend/pages/compare.tsx
@@ -423,18 +423,18 @@ function DeltaSummary({ delta }: { delta: CompareDelta }) {
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2 text-base">
           <GitCompare className="h-4 w-4 text-primary" />
-          Δ A − B
+          Run A vs. Run B
         </CardTitle>
         <CardDescription>{describeStanceShift(delta.stanceShift)}</CardDescription>
       </CardHeader>
       <CardContent>
-        <dl className="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
+        <dl className="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-5">
           <div>
             <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">Regime</dt>
             <dd className="mt-1 flex items-center gap-1">{argmaxLine}</dd>
           </div>
           <div>
-            <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">Set size</dt>
+            <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">Regime set size</dt>
             <dd className="numeric mt-1">
               {regime.setSizeA ?? "—"} vs {regime.setSizeB ?? "—"}
             </dd>
@@ -454,7 +454,16 @@ function DeltaSummary({ delta }: { delta: CompareDelta }) {
             ) : null}
           </div>
           <div>
-            <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">Shift score</dt>
+            <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">Sentiment score Δ</dt>
+            <dd
+              className={`numeric mt-1 flex items-center gap-1 ${deltaColorClass(delta.scoreDelta)}`}
+            >
+              <DeltaIcon value={delta.scoreDelta} />
+              {formatDelta(delta.scoreDelta, 3)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">Credibility drift Δ</dt>
             <dd
               className={`numeric mt-1 flex items-center gap-1 ${deltaColorClass(delta.driftDelta)}`}
             >
@@ -463,7 +472,7 @@ function DeltaSummary({ delta }: { delta: CompareDelta }) {
             </dd>
           </div>
           <div>
-            <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">What was done vs. said</dt>
+            <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">Realized vs. stated gap Δ</dt>
             <dd
               className={`numeric mt-1 flex items-center gap-1 ${deltaColorClass(delta.realizedGapDelta)}`}
             >
@@ -643,8 +652,10 @@ export default function ComparePage() {
             <div className="space-y-2">
               <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Compare runs</h1>
               <p className="max-w-2xl text-muted-foreground">
-                Pick two past analyses and see the stance, prediction, and confidence deltas side by
-                side. Selections are sticky in the URL; share the link to send a paired view.
+                Pick two past analyses to compare their monetary-policy stance, credibility signals,
+                and volatility-regime classifications. Each delta is Run A minus Run B: a positive
+                value means Run A is higher on that dimension. Selections are sticky in the URL;
+                share the link to send a paired view.
               </p>
             </div>
             <Button

--- a/frontend/tests/e2e/compare.spec.ts
+++ b/frontend/tests/e2e/compare.spec.ts
@@ -29,11 +29,10 @@ test.describe("history → compare flow", () => {
     await expect(optionList).toBeVisible({ timeout: 5_000 });
     await optionList.getByRole("option").nth(1).click();
 
-    // The Δ A − B card title appears 3× once both slots are populated
-    // (DeltaSummary + Multi-axis Δ + the table header). Anchor on
-    // .first() to dodge Playwright's strict-mode "more than one element"
-    // guard while still proving the delta surface rendered.
-    await expect(page.getByText(/Δ A − B/i).first()).toBeVisible({ timeout: 30_000 });
+    // The Run A vs. Run B card title is the DeltaSummary heading; anchor
+    // on .first() to dodge Playwright's strict-mode "more than one
+    // element" guard while still proving the delta surface rendered.
+    await expect(page.getByText(/Run A vs\. Run B/i).first()).toBeVisible({ timeout: 30_000 });
     await expect(page.getByText(/^Regime$/i).first()).toBeVisible();
   });
 });

--- a/frontend/tests/pages/compare.test.tsx
+++ b/frontend/tests/pages/compare.test.tsx
@@ -88,8 +88,8 @@ describe("ComparePage", () => {
     fetchHistoryMock.mockResolvedValue({ total: 2, limit: 50, offset: 0, items: ENTRIES });
     const { default: ComparePage } = await import("@/pages/compare");
     render(<ComparePage />);
-    await waitFor(() => expect(screen.getByText(/Run A/)).toBeInTheDocument());
-    expect(screen.getByText(/Run B/)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByText(/Run A/).length).toBeGreaterThan(0));
+    expect(screen.getAllByText(/Run B/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Pick a run/).length).toBeGreaterThan(0);
   });
 
@@ -109,7 +109,7 @@ describe("ComparePage", () => {
       expect(fetchHistoryRunMock).toHaveBeenCalledWith("http://localhost:8000", "run-a");
       expect(fetchHistoryRunMock).toHaveBeenCalledWith("http://localhost:8000", "run-b");
     });
-    await waitFor(() => expect(screen.getByText(/Δ A − B/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/Run A vs\. Run B/)).toBeInTheDocument());
     expect(screen.getByText(/A shifts hawkish vs\. B/i)).toBeInTheDocument();
   });
 });

--- a/frontend/tests/pages/compare.test.tsx
+++ b/frontend/tests/pages/compare.test.tsx
@@ -80,7 +80,11 @@ describe("ComparePage", () => {
     render(<ComparePage />);
     await waitFor(() => expect(screen.getAllByText(/Run A/).length).toBeGreaterThan(0));
     expect(screen.getAllByText(/Run B/).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Pick a run/).length).toBeGreaterThan(0);
+    // Both slot triggers should advertise themselves to AT and render the
+    // "Pick a run…" placeholder copy (U+2026 ellipsis) until a run is chosen.
+    expect(screen.getByLabelText(/Select Run A/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Select Run B/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Pick a run…/).length).toBeGreaterThan(0);
   });
 
   it("fetches and renders both runs when ?a and ?b query params are set", async () => {

--- a/frontend/tests/pages/compare.test.tsx
+++ b/frontend/tests/pages/compare.test.tsx
@@ -28,16 +28,6 @@ vi.mock("@/lib/analyze/api", () => ({
   resolveApiBaseUrl: () => "http://localhost:8000",
   fetchHistory: (...args: unknown[]) => fetchHistoryMock(...args),
   fetchHistoryRun: (...args: unknown[]) => fetchHistoryRunMock(...args),
-  // `compare()` defers to fetchHistoryRun under the hood; the page calls
-  // compare(baseUrl, id, id) for single-slot loads and compare(a, b) for
-  // pairs. Mirror that fan-out here so the test asserts both slot fetches.
-  compare: async (_base: string, idA: string, idB: string) => {
-    const [a, b] = await Promise.all([
-      fetchHistoryRunMock(_base, idA),
-      fetchHistoryRunMock(_base, idB),
-    ]);
-    return { a, b };
-  },
 }));
 
 const ENTRIES = [
@@ -111,5 +101,14 @@ describe("ComparePage", () => {
     });
     await waitFor(() => expect(screen.getByText(/Run A vs\. Run B/)).toBeInTheDocument());
     expect(screen.getByText(/A shifts hawkish vs\. B/i)).toBeInTheDocument();
+    // The renamed "Sentiment score Δ" tile should sit next to its formatted
+    // numeric badge: run-a scored 0.82, run-b scored 0.71, so the delta
+    // tile shows +0.110 (three-decimal signed delta).
+    const scoreLabel = screen.getByText(/Sentiment score Δ/);
+    const scoreValue = scoreLabel.parentElement?.querySelector("dd");
+    expect(scoreValue).not.toBeNull();
+    expect(scoreValue!.textContent).toMatch(/\+0\.110/);
+    expect(screen.getByText(/Credibility drift Δ/)).toBeInTheDocument();
+    expect(screen.getByText(/Realized vs\. stated gap Δ/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Renames the four DeltaSummary tile labels to human-readable text, rewrites the intro paragraph to match what is rendered, and surfaces the already-computed scoreDelta as a fifth tile so on-screen summary matches CSV/PDF exports.

## Test plan
- [ ] docker compose run --rm -v <worktree>/frontend:/app -w /app frontend npx vitest run tests/pages/compare.test.tsx tests/lib/analyze/compare.test.ts
- [ ] Open /compare with two runs loaded; confirm five tiles render with values and gracefully show "—" when credibility fields are absent.