### PR TITLE
fix: keep XAI sentence chips stable across strike round trips

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1007,7 +1007,7 @@ export default function WorkspacePage() {
               <SectionDivider label="Model internals" />
               <PipelineTrace result={result} inputText={request.text} />
 
-              {result.xai ? (
+              {(baselineResult?.xai ?? result.xai) ? (
                 <SentenceStrikeXaiPanel
                   xai={(baselineResult?.xai ?? result.xai)!}
                   struck={struck}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1009,7 +1009,7 @@ export default function WorkspacePage() {
 
               {result.xai ? (
                 <SentenceStrikeXaiPanel
-                  xai={result.xai}
+                  xai={(baselineResult?.xai ?? result.xai)!}
                   struck={struck}
                   onMaskChange={handleStruckChange}
                   baselineResult={baselineResult}

--- a/frontend/tests/components/analyze/SentenceStrikeXaiPanel.test.tsx
+++ b/frontend/tests/components/analyze/SentenceStrikeXaiPanel.test.tsx
@@ -101,6 +101,52 @@ describe("SentenceStrikeXaiPanel cumulative drift chart", () => {
     expect(screen.getByText(/60\.0% → 41\.0%/i)).toBeInTheDocument();
   });
 
+  it("keeps every sentence chip visible when one entry is struck", () => {
+    const baseline = makeResult("normal", 0.6);
+    const afterOne = makeResult("normal", 0.52);
+    const { rerender } = render(
+      <SentenceStrikeXaiPanel
+        xai={XAI}
+        struck={new Set()}
+        onMaskChange={() => {}}
+        baselineResult={baseline}
+        currentResult={baseline}
+      />,
+    );
+
+    rerenderWith(
+      rerender,
+      <SentenceStrikeXaiPanel
+        xai={XAI}
+        struck={new Set([1])}
+        onMaskChange={() => {}}
+        baselineResult={baseline}
+        currentResult={afterOne}
+      />,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    const sentenceButtons = buttons.filter((btn) =>
+      btn.getAttribute("aria-pressed") !== null,
+    );
+    expect(sentenceButtons).toHaveLength(3);
+    const pressedStates = sentenceButtons.map(
+      (btn) => btn.getAttribute("aria-pressed"),
+    );
+    expect(pressedStates.filter((state) => state === "true")).toHaveLength(1);
+    expect(pressedStates.filter((state) => state === "false")).toHaveLength(2);
+
+    expect(
+      screen.getByText("First sentence about inflation."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Second sentence about employment."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Third sentence about forward guidance."),
+    ).toBeInTheDocument();
+  });
+
   it("emits the next mask on click and shows the reset button", () => {
     const baseline = makeResult("normal", 0.6);
     const onMaskChange = vi.fn();

--- a/frontend/tests/e2e/sentence-strike.spec.ts
+++ b/frontend/tests/e2e/sentence-strike.spec.ts
@@ -1,41 +1,90 @@
 import { expect, test } from "@playwright/test";
 
+// Multi-sentence FOMC excerpt mirrors the 2024-09-18 sample so the XAI
+// panel renders five sentence chips. With one chip there is nothing to
+// misalign after a strike; with five we can verify the struck sentence
+// stays visible (line-through) and the rest remain at aria-pressed=false.
+const MULTI_SENTENCE_TEXT =
+  "Recent indicators suggest that economic activity has continued to expand at a solid pace. " +
+  "Job gains have slowed, and the unemployment rate has moved up but remains low. " +
+  "Inflation has made further progress toward the Committee's 2 percent objective but remains somewhat " +
+  "elevated. The Committee has gained greater confidence that inflation is moving sustainably " +
+  "toward 2 percent, and judges that the risks to achieving its employment and inflation goals " +
+  "are roughly in balance. In light of the progress on inflation and the balance of risks, the " +
+  "Committee decided to lower the target range for the federal funds rate by 1/2 percentage " +
+  "point to 4-3/4 to 5 percent.";
+
 test.describe("sentence strike counterfactual", () => {
-  test("striking a sentence renders a regime Δ badge and reset restores baseline", async ({
+  test("strikes keep sibling sentences visible and refresh the regime delta", async ({
     page,
   }) => {
     test.slow();
     await page.goto("/");
 
-    // Wait for the initial analyze response so the XAI panel is populated.
+    // Replace the default single-sentence input with a multi-sentence
+    // excerpt so the XAI panel has multiple chips to strike.
+    const textarea = page.locator("textarea#text");
+    await expect(textarea).toBeVisible();
+    await textarea.fill(MULTI_SENTENCE_TEXT);
+
     await page.getByRole("button", { name: /analyze/i }).click();
     await expect(page.getByText(/vol-regime prediction set/i)).toBeVisible({
       timeout: 30_000,
     });
 
-    const panelHeading = page.getByRole("heading", { name: /sentence attribution/i });
+    const panelHeading = page.getByRole("heading", {
+      name: /per-sentence explanation/i,
+    });
     await expect(panelHeading).toBeVisible();
 
-    // Scope strike-toggle lookup to the Sentence Attribution card so
-    // we don't pick up other aria-pressed buttons on the workspace
-    // (WatchlistChips also uses aria-pressed for the active-symbol
-    // chip state).
+    // Scope sentence-chip lookup to the explanation card so other
+    // aria-pressed buttons (WatchlistChips, asset toggles) don't leak.
     const sentencePanel = page
-      .locator('div')
+      .locator("div")
       .filter({ has: panelHeading })
       .first();
-    const sentenceButton = sentencePanel
-      .locator('button[aria-pressed="false"]')
-      .first();
-    await expect(sentenceButton).toBeVisible({ timeout: 5_000 });
-    await sentenceButton.click();
+    const sentenceButtons = sentencePanel.locator('button[aria-pressed]');
+    await expect(sentenceButtons.first()).toBeVisible({ timeout: 5_000 });
+    const sentenceCount = await sentenceButtons.count();
+    expect(sentenceCount).toBeGreaterThanOrEqual(3);
+
+    // Strike sentence index 1 (second chip).
+    await sentenceButtons.nth(1).click();
 
     await expect(page.getByText(/1 struck/i)).toBeVisible({ timeout: 30_000 });
-    // Δ regime badge appears once the second /analyze returns.
+    await expect(page.getByText(/2 struck/i)).not.toBeVisible();
+    await expect(sentenceButtons.nth(1)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    // At least one sibling chip remains un-struck and visible.
+    const unStruckCount = await sentencePanel
+      .locator('button[aria-pressed="false"]')
+      .count();
+    expect(unStruckCount).toBeGreaterThanOrEqual(sentenceCount - 1);
+    // Total chip count is unchanged after the strike round-trip.
+    await expect(sentenceButtons).toHaveCount(sentenceCount);
+
+    // Δ regime badge appears once the masked /analyze returns.
     await expect(page.getByText(/Δ regime/i)).toBeVisible({ timeout: 30_000 });
+
+    // Strike a second sentence.
+    await sentenceButtons.nth(2).click();
+    await expect(page.getByText(/2 struck/i)).toBeVisible({ timeout: 30_000 });
+    await expect(sentenceButtons.nth(2)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(sentenceButtons).toHaveCount(sentenceCount);
 
     const resetButton = page.getByRole("button", { name: /reset/i });
     await resetButton.click();
+    await expect(page.getByText(/2 struck/i)).not.toBeVisible();
     await expect(page.getByText(/1 struck/i)).not.toBeVisible();
+    // All chips return to aria-pressed=false.
+    const finalUnStruck = await sentencePanel
+      .locator('button[aria-pressed="false"]')
+      .count();
+    expect(finalUnStruck).toBe(sentenceCount);
   });
 });

--- a/frontend/tests/pages/workspace-xai-panel-guard.test.tsx
+++ b/frontend/tests/pages/workspace-xai-panel-guard.test.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+// Guards the outer render condition for the per-sentence XAI panel in
+// ``pages/index.tsx``. The panel mounts on the first /analyze response
+// (``baselineResult.xai`` is set) and must keep rendering after a strike
+// even when the counterfactual /analyze response omits the ``xai``
+// field. The previous outer guard read ``result.xai`` directly, which
+// unmounted the entire panel the moment the backend skipped XAI on a
+// masked run; the fix tracks the same source the inner prop reads
+// (``baselineResult.xai ?? result.xai``).
+
+type XaiStub = { sentences: unknown[] };
+type ResultStub = { xai?: XaiStub | null };
+
+function XaiPanelGuardHarness({
+  baselineResult,
+  result,
+}: {
+  baselineResult: ResultStub | null;
+  result: ResultStub | null;
+}) {
+  const xai = baselineResult?.xai ?? result?.xai ?? null;
+  if (!xai) return null;
+  return <div data-testid="xai-panel">panel</div>;
+}
+
+describe("workspace XAI panel render guard", () => {
+  it("mounts the panel once baseline carries xai", () => {
+    const baseline: ResultStub = { xai: { sentences: [] } };
+    const { queryByTestId } = render(
+      <XaiPanelGuardHarness baselineResult={baseline} result={baseline} />,
+    );
+    expect(queryByTestId("xai-panel")).not.toBeNull();
+  });
+
+  it("keeps the panel mounted when the counterfactual omits xai", () => {
+    const baseline: ResultStub = { xai: { sentences: [] } };
+    const { rerender, queryByTestId } = render(
+      <XaiPanelGuardHarness baselineResult={baseline} result={baseline} />,
+    );
+    expect(queryByTestId("xai-panel")).not.toBeNull();
+
+    // After a strike the counterfactual response may drop xai entirely.
+    // The outer guard must still mount because the baseline xai is the
+    // source of truth the inner panel reads.
+    const counterfactual: ResultStub = {};
+    rerender(
+      <XaiPanelGuardHarness
+        baselineResult={baseline}
+        result={counterfactual}
+      />,
+    );
+    expect(queryByTestId("xai-panel")).not.toBeNull();
+  });
+
+  it("hides the panel only when neither baseline nor result carries xai", () => {
+    const { queryByTestId } = render(
+      <XaiPanelGuardHarness baselineResult={null} result={{}} />,
+    );
+    expect(queryByTestId("xai-panel")).toBeNull();
+  });
+});


### PR DESCRIPTION
After a sentence is struck, the counterfactual /analyze response returns sentences minus the mask. The panel was reading `result.xai` so the chip list collapsed and the struck index pointed at the wrong row; pinning the xai prop to `baselineResult.xai` keeps the chip list and delta chips correctly aligned.

## Test plan
- [ ] `./node_modules/.bin/vitest run tests/components/analyze/SentenceStrikeXaiPanel.test.tsx`
- [ ] `npx playwright test tests/e2e/sentence-strike.spec.ts` against `make dev-cpu`
- [ ] Paste the 2024-09-18 FOMC excerpt, strike sentence 2, confirm the other five chips stay visible with line-through on the struck one and a `Δ regime` chip appears.