### PR TITLE
fix: surface zero-shot rerun bake-off in /research/artifacts

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
-from app.config import DATA_DIR
+from app.config import DATA_DIR, REPO_ROOT
 from app.db import (
     AnalysisRun,
     delete_run,
@@ -1819,7 +1819,7 @@ def research_artifacts() -> ResearchArtifactsResponse:
             )
             for info in infos
         ]
-    bakeoff = load_encoder_bakeoff(artifacts_root)
+    bakeoff = load_encoder_bakeoff(artifacts_root, repo_root=REPO_ROOT)
     transfer = load_cross_bank_transfer(artifacts_root)
     return ResearchArtifactsResponse(
         artifacts_root=str(artifacts_root),

--- a/backend/app/services/research_artifacts.py
+++ b/backend/app/services/research_artifacts.py
@@ -28,6 +28,14 @@ LOGGER = logging.getLogger(__name__)
 
 SECTIONS: tuple[str, ...] = ("phase3", "cross_bank", "cross_asset", "next_fomc")
 
+# Priority-ordered list of rerun JSON paths (relative to repo root). The
+# zero-shot NLP baseline rerun JSON lives outside ``data/artifacts/``, so
+# the bake-off loader checks these locations first and only falls back
+# to the legacy ``phase3/**aggregate.json`` walk when none exist.
+RERUN_BAKEOFF_CANDIDATES: tuple[str, ...] = (
+    "docs/research/nlp-baseline-bakeoff-2026-06-02-rerun.json",
+)
+
 
 @dataclass(frozen=True)
 class ArtifactFileInfo:
@@ -76,14 +84,125 @@ def _iter_aggregate_files(artifacts_root: Path) -> Iterable[Path]:
     yield from sorted(section_dir.rglob("aggregate.json"))
 
 
-def load_encoder_bakeoff(artifacts_root: Path) -> dict[str, Any]:
-    """Aggregate per-encoder macro-F1 across phase3/**/aggregate.json files.
+def _resolve_rerun_bakeoff_path(repo_root: Path | None) -> Path | None:
+    """Return the first existing rerun JSON path, or ``None``.
+
+    The rerun JSON is the source of truth for the Bake-off tab when it
+    exists; the legacy ``phase3/**aggregate.json`` walk is only a
+    fallback for environments without the ``docs/`` tree.
+    """
+
+    if repo_root is None:
+        return None
+    for relative in RERUN_BAKEOFF_CANDIDATES:
+        candidate = repo_root / relative
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def load_encoder_bakeoff_rerun(path: Path) -> dict[str, Any]:
+    """Read the rerun-JSON schema and aggregate per ``model_key``.
+
+    The rerun file has a flat ``results[]`` array, one entry per
+    (model_key, seed). This function groups by ``model_key``, collects
+    per-seed macro-F1 / weighted-F1 / accuracy, and returns the same
+    output shape as :func:`load_encoder_bakeoff` so the API response
+    stays unchanged.
+    """
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        LOGGER.warning("research_artifacts: failed to parse %s: %s", path, exc)
+        return {
+            "available": False,
+            "coverage": None,
+            "rows": [],
+            "source_files": [],
+        }
+
+    results = payload.get("results") or []
+    by_encoder: dict[str, dict[str, Any]] = {}
+    for entry in results:
+        model_key = entry.get("model_key")
+        if not isinstance(model_key, str) or not model_key:
+            continue
+        seed_value = entry.get("seed")
+        try:
+            seed_int = int(seed_value)
+        except (TypeError, ValueError):
+            continue
+        bucket = by_encoder.setdefault(
+            model_key,
+            {
+                "encoder_key": model_key,
+                "checkpoint": str(entry.get("checkpoint", "")),
+                "seeds": [],
+                "macro_f1_values": [],
+                "weighted_f1_values": [],
+                "accuracy_values": [],
+            },
+        )
+        if seed_int in bucket["seeds"]:
+            continue
+        if not bucket["checkpoint"] and entry.get("checkpoint"):
+            bucket["checkpoint"] = str(entry["checkpoint"])
+        classification = entry.get("classification") or {}
+        bucket["seeds"].append(seed_int)
+        bucket["macro_f1_values"].append(_safe_float(classification.get("macro_f1")))
+        bucket["weighted_f1_values"].append(_safe_float(classification.get("weighted_f1")))
+        bucket["accuracy_values"].append(_safe_float(classification.get("accuracy")))
+
+    rows: list[dict[str, Any]] = []
+    for encoder_key in sorted(by_encoder):
+        bucket = by_encoder[encoder_key]
+        # Keep seeds sorted so the UI renders a stable order.
+        paired = sorted(zip(bucket["seeds"], bucket["macro_f1_values"], strict=False))
+        seeds_sorted = [s for s, _ in paired]
+        macro_sorted = [m for _, m in paired]
+        rows.append(
+            {
+                "encoder_key": encoder_key,
+                "checkpoint": bucket["checkpoint"],
+                "seeds": seeds_sorted,
+                "macro_f1_values": macro_sorted,
+                "macro_f1_mean": _mean_or_zero(macro_sorted),
+                "macro_f1_ci_low": None,
+                "macro_f1_ci_high": None,
+                "weighted_f1_mean": _mean_or_zero(bucket["weighted_f1_values"]),
+                "accuracy_mean": _mean_or_zero(bucket["accuracy_values"]),
+                "cohen_kappa": None,
+            }
+        )
+
+    return {
+        "available": bool(rows),
+        "coverage": 0.95,
+        "rows": rows,
+        "source_files": [str(path)],
+    }
+
+
+def load_encoder_bakeoff(
+    artifacts_root: Path,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """Aggregate per-encoder macro-F1 for the Bake-off dashboard tab.
 
     Returns a dict with ``available``, ``coverage``, ``rows``, and
     ``source_files``. ``rows`` is a list of dicts shaped like
-    :class:`EncoderBakeoffRow` (see ``app.schemas``). When no aggregate
-    files exist, ``available`` is False and ``rows`` is empty.
+    :class:`EncoderBakeoffRow` (see ``app.schemas``).
+
+    When a rerun JSON listed in :data:`RERUN_BAKEOFF_CANDIDATES` exists
+    under ``repo_root``, it is the source of truth. Otherwise the loader
+    falls back to the legacy ``phase3/**/aggregate.json`` walk so local
+    dev environments without the ``docs/`` tree still work.
     """
+
+    rerun_path = _resolve_rerun_bakeoff_path(repo_root)
+    if rerun_path is not None:
+        return load_encoder_bakeoff_rerun(rerun_path)
 
     files = list(_iter_aggregate_files(artifacts_root))
     if not files:

--- a/backend/app/services/research_artifacts.py
+++ b/backend/app/services/research_artifacts.py
@@ -180,7 +180,11 @@ def load_encoder_bakeoff_rerun(path: Path) -> dict[str, Any]:
         "available": bool(rows),
         "coverage": 0.95,
         "rows": rows,
-        "source_files": [str(path)],
+        # Return just the basename so frontend consumers see a stable key
+        # regardless of whether the host repo is mounted at /docs (backend)
+        # or absent (backend-gpu falls back to phase3 walk under different
+        # paths).
+        "source_files": [path.name],
     }
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - ./tests:/app/tests:ro
       - ./scripts:/app/scripts:ro
       - ./data:/data
+      - ./docs:/docs:ro
     env_file:
       - path: .env
         required: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ./tests:/app/tests:ro
       - ./scripts:/app/scripts:ro
       - ./data:/data
+      - ./docs:/docs:ro
     env_file:
       - path: .env
         required: false

--- a/tests/unit/test_research_endpoints.py
+++ b/tests/unit/test_research_endpoints.py
@@ -44,6 +44,9 @@ def _write_cross_bank_matrix(root: Path, *, payload: dict, name: str = "transfer
 
 def test_research_artifacts_empty_state(client, monkeypatch, tmp_path):
     monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+    # Point REPO_ROOT at a temp dir so the rerun-JSON loader sees nothing
+    # and falls back to the phase3 walk (empty in tmp_path).
+    monkeypatch.setattr(main_mod, "REPO_ROOT", tmp_path)
     response = client.get("/research/artifacts")
     assert response.status_code == 200
     body = response.json()
@@ -94,6 +97,8 @@ def test_research_artifacts_with_bakeoff_and_transfer(
         },
     )
     monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+    # No rerun JSON under tmp_path → loader falls back to the phase3 walk.
+    monkeypatch.setattr(main_mod, "REPO_ROOT", tmp_path)
 
     response = client.get("/research/artifacts")
     assert response.status_code == 200
@@ -133,6 +138,7 @@ def test_research_artifacts_accepts_matrix_shape(client, monkeypatch, tmp_path):
         },
     )
     monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(main_mod, "REPO_ROOT", tmp_path)
 
     response = client.get("/research/artifacts")
     body = response.json()
@@ -141,6 +147,79 @@ def test_research_artifacts_accepts_matrix_shape(client, monkeypatch, tmp_path):
     cells = {(c["source"], c["target"]): c["metric"] for c in transfer["cells"]}
     assert cells[("fed", "fed")] == 0.63
     assert cells[("ecb", "ecb")] == 0.58
+
+
+def test_research_artifacts_prefers_rerun_json(client, monkeypatch, tmp_path):
+    # Phase3 fixture would yield 0.55/0.57 if the legacy walk fired.
+    artifacts_root = tmp_path / "artifacts"
+    _write_phase3_aggregate(
+        artifacts_root,
+        name="run-old/aggregate.json",
+        by_encoder={
+            "bert-base-uncased": {
+                "checkpoint": "bert-base-uncased",
+                "per_seed": {
+                    "11": {"macro_f1": 0.55, "weighted_f1": 0.58, "accuracy": 0.60},
+                },
+            },
+        },
+    )
+    # Drop a rerun JSON at the first known candidate path under tmp_path.
+    rerun_dir = tmp_path / "docs" / "research"
+    rerun_dir.mkdir(parents=True)
+    rerun_path = rerun_dir / "nlp-baseline-bakeoff-2026-06-02-rerun.json"
+    rerun_path.write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "model_key": "fomc_roberta",
+                        "checkpoint": "gtfintechlab/FOMC-RoBERTa",
+                        "seed": 11,
+                        "classification": {
+                            "macro_f1": 0.508,
+                            "weighted_f1": 0.50,
+                            "accuracy": 0.52,
+                        },
+                    },
+                    {
+                        "model_key": "fomc_roberta",
+                        "checkpoint": "gtfintechlab/FOMC-RoBERTa",
+                        "seed": 29,
+                        "classification": {
+                            "macro_f1": 0.508,
+                            "weighted_f1": 0.50,
+                            "accuracy": 0.52,
+                        },
+                    },
+                    {
+                        "model_key": "majority",
+                        "checkpoint": "majority-class",
+                        "seed": 11,
+                        "classification": {
+                            "macro_f1": 0.187,
+                            "weighted_f1": 0.22,
+                            "accuracy": 0.39,
+                        },
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(main_mod, "REPO_ROOT", tmp_path)
+
+    response = client.get("/research/artifacts")
+    body = response.json()
+    bakeoff = body["encoder_bakeoff"]
+    assert bakeoff["available"] is True
+    keys = {row["encoder_key"] for row in bakeoff["rows"]}
+    # Legacy phase3 row absent; rerun model_keys present.
+    assert keys == {"fomc_roberta", "majority"}
+    fomc_row = next(r for r in bakeoff["rows"] if r["encoder_key"] == "fomc_roberta")
+    assert fomc_row["seeds"] == [11, 29]
+    assert pytest.approx(fomc_row["macro_f1_mean"], rel=1e-4) == 0.508
 
 
 def test_research_artifacts_section_skips_dotfiles(tmp_path):


### PR DESCRIPTION
Replace the stale fine-tune phase3 aggregates on the Bake-off tab with the fresh zero-shot rerun JSON from docs/research/, falling back to the legacy phase3 walk when the rerun file is absent.

## Test plan
- [x] docker compose run --rm backend pytest tests/unit/test_research_endpoints.py -v
- [x] ruff check + ruff format --check on backend/app/services/research_artifacts.py and backend/app/main.py
- [x] Confirm loader returns fomc_roberta 0.508, finbert 0.497, random_class 0.333, bert/majority ~0.187 across all 5 seeds