### PR TITLE
fix: late-fusion past-runs strip stays empty after submit

### DIFF
--- a/frontend/components/analyze/RegimeHeadline.tsx
+++ b/frontend/components/analyze/RegimeHeadline.tsx
@@ -239,17 +239,22 @@ export function RegimeHeadline({
           <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
             Past {trendValues.length || 0} runs · top-pick regime
           </p>
-          {trendValues.length ? (
+          {trendValues.length >= 2 ? (
             <Sparkline
               values={trendValues}
               tone="neutral"
               height={56}
+              yDomain={[-1.5, 1.5]}
               formatTooltip={(value, label) => {
                 const regimeLabel = value > 0 ? "high" : value < 0 ? "calm" : "normal";
                 return `${label ?? ""} → ${regimeLabel}`;
               }}
               labels={history?.map((h) => h.documentDate)}
             />
+          ) : trendValues.length === 1 ? (
+            <p className="text-xs text-muted-foreground">
+              Insufficient history (1 run). Sparkline appears with two or more runs.
+            </p>
           ) : (
             <p className="text-xs text-muted-foreground">
               No prior runs for this symbol yet. Run history will appear here.

--- a/frontend/components/ui/sparkline.tsx
+++ b/frontend/components/ui/sparkline.tsx
@@ -4,6 +4,7 @@ import {
   AreaChart,
   ResponsiveContainer,
   Tooltip,
+  YAxis,
 } from "recharts";
 
 import { cn } from "@/lib/utils";
@@ -17,6 +18,10 @@ interface SparklineProps {
   height?: number;
   labels?: string[];
   formatTooltip?: (value: number, label?: string) => string;
+  // When provided, pins the chart's Y range to a fixed span so a series
+  // sitting flat at zero (or any single value) still renders inside the
+  // container instead of collapsing to the baseline.
+  yDomain?: [number, number];
 }
 
 const TONE_VARS: Record<SparklineTone, string> = {
@@ -44,6 +49,7 @@ export function Sparkline({
   height = 28,
   labels,
   formatTooltip,
+  yDomain,
 }: SparklineProps) {
   const effectiveTone = inferTone(values, tone);
   const stroke = `hsl(${TONE_VARS[effectiveTone]})`;
@@ -102,6 +108,7 @@ export function Sparkline({
               }}
             />
           ) : null}
+          {yDomain ? <YAxis domain={yDomain} hide /> : null}
           <Area
             type="monotone"
             dataKey="value"

--- a/frontend/lib/analyze/shared-context.tsx
+++ b/frontend/lib/analyze/shared-context.tsx
@@ -260,9 +260,13 @@ export function SymbolCalendarProvider({ children }: { children: React.ReactNode
             ...prev,
             [mapKey]: { data, loading: false, error: null },
           }));
-          // Clear the in-flight guard on success so a follow-up
-          // refresh (e.g., after /analyze persists a new row) can
-          // re-fetch instead of short-circuiting at the dedupe gate.
+          // Mirror ensureHarBaselines: only clear the in-flight guard on
+          // success so a follow-up refresh (e.g., after /analyze persists
+          // a new row) can re-fetch instead of short-circuiting at the
+          // dedupe gate. On error the guard stays set for the session
+          // lifetime to coalesce retries and prevent an effect that
+          // re-runs on every state change from thrashing the endpoint;
+          // the user can recover by changing the symbol or reloading.
           inFlight.current.delete(key);
         })
         .catch((err) => {
@@ -274,6 +278,8 @@ export function SymbolCalendarProvider({ children }: { children: React.ReactNode
               error: (err as Error).message || "history fetch failed",
             },
           }));
+          // Intentionally do NOT delete the in-flight guard here; see the
+          // success-path comment above for the rationale.
         });
     },
     [apiBaseUrl],

--- a/frontend/lib/analyze/shared-context.tsx
+++ b/frontend/lib/analyze/shared-context.tsx
@@ -71,6 +71,7 @@ interface SharedContextValue {
   harBaselinesMap: Record<string, HarBaselinesState>;
   ensureCoverage: (symbol: string | undefined) => void;
   ensureRecentHistory: (symbol: string | undefined, limit: number) => void;
+  refreshRecentHistory: (symbol: string | undefined, limit: number) => void;
   ensureHarBaselines: (symbol: string | undefined) => void;
 }
 
@@ -259,6 +260,10 @@ export function SymbolCalendarProvider({ children }: { children: React.ReactNode
             ...prev,
             [mapKey]: { data, loading: false, error: null },
           }));
+          // Clear the in-flight guard on success so a follow-up
+          // refresh (e.g., after /analyze persists a new row) can
+          // re-fetch instead of short-circuiting at the dedupe gate.
+          inFlight.current.delete(key);
         })
         .catch((err) => {
           setRecentHistoryMap((prev) => ({
@@ -274,6 +279,17 @@ export function SymbolCalendarProvider({ children }: { children: React.ReactNode
     [apiBaseUrl],
   );
 
+  const refreshRecentHistory = React.useCallback(
+    (symbol: string | undefined, limit: number) => {
+      const symKey = symbol ?? "";
+      const mapKey = `${symKey}|${limit}`;
+      const key = `history:${apiBaseUrl}:${mapKey}`;
+      inFlight.current.delete(key);
+      ensureRecentHistory(symbol, limit);
+    },
+    [apiBaseUrl, ensureRecentHistory],
+  );
+
   const value = React.useMemo<SharedContextValue>(
     () => ({
       apiBaseUrl,
@@ -284,6 +300,7 @@ export function SymbolCalendarProvider({ children }: { children: React.ReactNode
       harBaselinesMap,
       ensureCoverage,
       ensureRecentHistory,
+      refreshRecentHistory,
       ensureHarBaselines,
     }),
     [
@@ -295,6 +312,7 @@ export function SymbolCalendarProvider({ children }: { children: React.ReactNode
       harBaselinesMap,
       ensureCoverage,
       ensureRecentHistory,
+      refreshRecentHistory,
       ensureHarBaselines,
     ],
   );

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -138,7 +138,7 @@ export default function WorkspacePage() {
   const [struck, setStruck] = React.useState<Set<number>>(() => new Set());
   const [counterfactualLoading, setCounterfactualLoading] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
-  const { apiBaseUrl } = useSharedContext();
+  const { apiBaseUrl, refreshRecentHistory } = useSharedContext();
   const [historyEntries, setHistoryEntries] = React.useState<RegimeHistoryEntry[]>([]);
   const [volForecast, setVolForecast] = React.useState<RealizedVolForecastResponse | null>(null);
   const [volForecastLoading, setVolForecastLoading] = React.useState(false);
@@ -624,6 +624,9 @@ export default function WorkspacePage() {
       if (analyzeRes.status === "fulfilled") {
         setResult(analyzeRes.value);
         setBaselineResult(analyzeRes.value);
+        // Force the history strip to re-fetch so the row just
+        // persisted by /analyze shows up in the Past 12 runs card.
+        refreshRecentHistory(request.symbol, 12);
         toast.success("Analysis complete");
       } else {
         setResult(null);

--- a/frontend/tests/components/analyze/RegimeHeadline.test.tsx
+++ b/frontend/tests/components/analyze/RegimeHeadline.test.tsx
@@ -94,3 +94,48 @@ describe("RegimeHeadline regression-canonical surface (#338)", () => {
   });
 
 });
+
+describe("RegimeHeadline past-runs sparkline", () => {
+  const allNormalHistory = [
+    { documentDate: "2024-08-01", argmax: "normal", realized: null },
+    { documentDate: "2024-08-15", argmax: "normal", realized: null },
+    { documentDate: "2024-09-01", argmax: "normal", realized: null },
+    { documentDate: "2024-09-18", argmax: "normal", realized: null },
+  ];
+
+  it("renders the sparkline (not the empty-state copy) when all recent runs land on normal", () => {
+    const { container } = render(
+      <RegimeHeadline
+        regime={REGIME}
+        symbol="^GSPC"
+        documentDate="2024-09-18"
+        history={allNormalHistory}
+      />,
+    );
+    // Empty-state and single-run fallbacks must not appear when N >= 2.
+    expect(screen.queryByText(/No prior runs for this symbol/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Insufficient history/i)).not.toBeInTheDocument();
+    // Sparkline mounts a Recharts ResponsiveContainer — the container
+    // becomes evidence the chart rendered instead of the "no data"
+    // text-only fallback path.
+    const responsive = container.querySelector(".recharts-responsive-container");
+    expect(responsive).not.toBeNull();
+  });
+
+  it("shows the insufficient-history copy when only one prior run is available", () => {
+    render(
+      <RegimeHeadline
+        regime={REGIME}
+        symbol="^GSPC"
+        documentDate="2024-09-18"
+        history={[{ documentDate: "2024-09-18", argmax: "normal", realized: null }]}
+      />,
+    );
+    expect(screen.getByText(/Insufficient history \(1 run\)/i)).toBeInTheDocument();
+  });
+
+  it("shows the empty-state copy when no history is provided", () => {
+    render(<RegimeHeadline regime={REGIME} symbol="^GSPC" documentDate="2024-09-18" />);
+    expect(screen.getByText(/No prior runs for this symbol/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes two bugs that left the Past 12 runs sparkline in the late-fusion card empty after a user submitted their first run.

## Summary

- `ensureRecentHistory` now deletes the in-flight guard on success so a follow-up call can re-fetch.
- New `refreshRecentHistory(symbol, limit)` on the shared context, called from `handleSubmit` after `/analyze` fulfills, picks up the just-persisted row.
- `Sparkline` gains an optional `yDomain` prop. `RegimeHeadline` pins it to `[-1.5, 1.5]` so an all-normal window renders a visible flat line at the midpoint instead of collapsing to the zero baseline.
- `RegimeHeadline` shows an "Insufficient history (1 run)" copy when there is exactly one prior run, instead of a degenerate single-point chart.

## Test plan

- [x] `npx vitest run --reporter=verbose tests/components/analyze/RegimeHeadline.test.tsx`
- [x] `npx vitest run` full suite (1 pre-existing flake in `tests/pages/history.test.tsx` unrelated to this change; passes in isolation)
- [ ] Manual: submit analysis twice in a row, confirm the first run appears in the Past 12 runs strip after the second submit