### PR TITLE
fix: cold-start the expected-volume HAR forecaster off live yfinance

### DIFF
--- a/backend/app/services/volume_forecaster.py
+++ b/backend/app/services/volume_forecaster.py
@@ -34,8 +34,10 @@ caches the parsed spec for the process lifetime.
 from __future__ import annotations
 
 import json
+import logging
 import math
 import os
+import tempfile
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
@@ -44,6 +46,8 @@ from typing import Any, cast
 import numpy as np
 
 from app.config import BACKEND_ROOT
+
+logger = logging.getLogger(__name__)
 
 
 # No exact match for an existing volume artifact in code (rv_forecaster
@@ -111,17 +115,100 @@ def _download_artifact(target_dir: Path) -> dict[str, Any]:
     return cast(dict[str, Any], spec)
 
 
+# Cold-start fit defaults. Mirrors ``_VOLUME_HISTORY_DAYS`` in main.py:
+# 180 calendar days yields ~126 trading bars, which clears the
+# ``walk_forward_splits`` floor of ``n_folds * embargo = 5 * 22 = 110``.
+_COLD_START_PERIOD = "180d"
+_COLD_START_SYMBOL = "^GSPC"
+
+
+def _cold_start_fit(model_dir: Path) -> dict[str, Any]:
+    """Fit a serving artifact from live yfinance volume on first boot.
+
+    Pulls ~180 calendar days of daily volume for ``^GSPC``, writes a
+    temporary parquet, and calls
+    :func:`app.data.late_fusion_volume.fit_production_artifact` to build
+    the per-horizon HAR + seasonality + conformal-quantile spec. The
+    output is written to ``model_dir / ARTIFACT_FILENAME`` so subsequent
+    process restarts skip the fit. Re-raises
+    :class:`VolumeForecasterUnavailable` on any failure so the existing
+    503 path is preserved when yfinance is also unreachable.
+    """
+
+    import pandas as pd
+    import yfinance as yf
+
+    from app.data.late_fusion_volume import fit_production_artifact
+
+    try:
+        ticker = yf.Ticker(_COLD_START_SYMBOL)
+        frame = ticker.history(period=_COLD_START_PERIOD, auto_adjust=True)
+        if frame is None or frame.empty:
+            raise RuntimeError(f"no market history available for {_COLD_START_SYMBOL}")
+        vol = frame["Volume"].astype(float).dropna()
+        if hasattr(vol, "columns"):
+            vol = vol.iloc[:, 0].dropna()
+        vol = vol[vol > 0]
+        if vol.empty:
+            raise RuntimeError(f"no positive volume rows for {_COLD_START_SYMBOL}")
+        dates = pd.to_datetime(vol.index).tz_localize(None)
+        bars = pd.DataFrame({"date": dates, "volume": vol.to_numpy(dtype=float)}).reset_index(
+            drop=True
+        )
+
+        out_path = model_dir / ARTIFACT_FILENAME
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory() as tmp:
+            vol_path = Path(tmp) / "volume_cold_start.parquet"
+            bars.to_parquet(vol_path)
+            spec = fit_production_artifact(vol_path, out_path)
+        logger.info(
+            "volume_har_cold_start_fit symbol=%s rows=%d artifact=%s",
+            _COLD_START_SYMBOL,
+            len(bars),
+            out_path,
+        )
+        return cast(dict[str, Any], spec)
+    except VolumeForecasterUnavailable:
+        raise
+    except Exception as exc:
+        raise VolumeForecasterUnavailable(
+            f"cold-start fit failed for {_COLD_START_SYMBOL!r}: {exc}"
+        ) from exc
+
+
 def _load_spec(model_dir: Path) -> dict[str, Any]:
-    """Return the cached spec; fetch from HF Hub on a miss."""
+    """Return the cached spec; fetch from HF Hub on a miss.
+
+    Falls back to an in-process cold-start fit off live yfinance volume
+    when the HF Hub repo is missing or unreachable, so a fresh checkout
+    without a pre-trained artifact still serves the Expected Volume
+    card. The cold-start fit is the genuine fallback — the HF download
+    stays the primary path when an artifact is published.
+    """
 
     spec_path = model_dir / ARTIFACT_FILENAME
     if not spec_path.exists():
-        return _download_artifact(model_dir)
+        try:
+            return _download_artifact(model_dir)
+        except VolumeForecasterUnavailable as exc:
+            logger.info(
+                "volume_har_hf_unavailable falling_back_to_cold_start error=%s",
+                exc,
+            )
+            return _cold_start_fit(model_dir)
     try:
         return cast(dict[str, Any], json.loads(spec_path.read_text(encoding="utf-8")))
     except (json.JSONDecodeError, OSError):
         # Corrupt local cache; force a clean re-download.
-        return _download_artifact(model_dir)
+        try:
+            return _download_artifact(model_dir)
+        except VolumeForecasterUnavailable as exc:
+            logger.info(
+                "volume_har_hf_unavailable falling_back_to_cold_start error=%s",
+                exc,
+            )
+            return _cold_start_fit(model_dir)
 
 
 class _VolumePredictor:

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -340,27 +340,20 @@ export async function fetchRealizedVolForecast(
 
 // Workspace-spine expected-volume forecast. Backend returns 503 when
 // the HAR-volume artifact cannot be loaded or the volume history is
-// insufficient; the fetcher folds that into ``null`` so the card's
-// data==null branch renders the tailored "unavailable" placeholder
-// rather than the generic error path. Matches the parity contract
-// shared with ``fetchLatestMpSurprise`` and ``fetchFuturesConsensus``.
+// insufficient. The fetcher re-throws the axios error so the caller's
+// existing ``errorMessage`` path renders the "Model unavailable" copy
+// (matched on the 503 status) instead of folding to a bare ``null``
+// that leaves the card stuck on the ambiguous retry placeholder.
 export async function fetchExpectedVolumeForecast(
   baseUrl: string,
   symbol: string = "^GSPC",
   signal?: AbortSignal,
 ): Promise<ExpectedVolumeForecastResponse | null> {
-  try {
-    const response = await axios.get(`${baseUrl}/forecast/abnormal-volume`, {
-      params: { symbol },
-      signal,
-    });
-    return response.data as ExpectedVolumeForecastResponse;
-  } catch (err) {
-    if (axios.isAxiosError(err) && err.response?.status === 503) {
-      return null;
-    }
-    throw err;
-  }
+  const response = await axios.get(`${baseUrl}/forecast/abnormal-volume`, {
+    params: { symbol },
+    signal,
+  });
+  return response.data as ExpectedVolumeForecastResponse;
 }
 
 

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -348,7 +348,7 @@ export async function fetchExpectedVolumeForecast(
   baseUrl: string,
   symbol: string = "^GSPC",
   signal?: AbortSignal,
-): Promise<ExpectedVolumeForecastResponse | null> {
+): Promise<ExpectedVolumeForecastResponse> {
   const response = await axios.get(`${baseUrl}/forecast/abnormal-volume`, {
     params: { symbol },
     signal,

--- a/tests/unit/test_volume_forecaster.py
+++ b/tests/unit/test_volume_forecaster.py
@@ -309,24 +309,50 @@ def test_load_spec_falls_back_to_cold_start_fit(
     """HF download failure must trigger the in-process cold-start fit.
 
     Monkeypatches ``_download_artifact`` to raise
-    ``VolumeForecasterUnavailable`` and ``_cold_start_fit`` to return a
-    minimal valid spec, then asserts ``_load_spec`` returns it from the
-    cold-start branch (no HF hit succeeded, no on-disk artifact existed).
+    ``VolumeForecasterUnavailable``, fakes yfinance to return a synthetic
+    180-bar volume frame, and monkeypatches
+    ``app.data.late_fusion_volume.fit_production_artifact`` to return a
+    minimal valid spec, then asserts ``_load_spec`` returns the spec
+    from the cold-start branch (no HF hit succeeded, no on-disk
+    artifact existed).
     """
+
+    import pandas as pd
+
+    from app.data import late_fusion_volume
 
     def _raise(_target_dir: Any) -> dict[str, Any]:
         raise volume_forecaster.VolumeForecasterUnavailable("hf repo missing")
 
-    fake_spec: dict[str, Any] = _make_spec()
-    cold_start_calls: list[Any] = []
+    class _FakeTicker:
+        def __init__(self, _symbol: str) -> None:
+            pass
 
-    def _stub_cold_start(target_dir: Any) -> dict[str, Any]:
-        cold_start_calls.append(target_dir)
+        def history(self, period: str, auto_adjust: bool) -> pd.DataFrame:
+            dates = pd.bdate_range(end="2026-05-30", periods=180)
+            return pd.DataFrame(
+                {"Volume": np.linspace(1.0e9, 1.2e9, len(dates))},
+                index=dates,
+            )
+
+    fake_spec: dict[str, Any] = _make_spec()
+    fit_calls: list[tuple[Any, Any]] = []
+
+    def _stub_fit(vol_path: Any, out_path: Any) -> dict[str, Any]:
+        fit_calls.append((vol_path, out_path))
         return fake_spec
 
+    import yfinance as yf
+
     monkeypatch.setattr(volume_forecaster, "_download_artifact", _raise)
-    monkeypatch.setattr(volume_forecaster, "_cold_start_fit", _stub_cold_start)
+    monkeypatch.setattr(yf, "Ticker", _FakeTicker)
+    monkeypatch.setattr(late_fusion_volume, "fit_production_artifact", _stub_fit)
 
     spec = volume_forecaster._load_spec(tmp_path)
     assert spec is fake_spec
-    assert cold_start_calls == [tmp_path]
+    assert len(fit_calls) == 1
+    # ``fit_production_artifact`` is called with the temp parquet path
+    # the cold-start writes plus the on-disk artifact target under
+    # ``tmp_path / ARTIFACT_FILENAME``.
+    _, out_path = fit_calls[0]
+    assert out_path == tmp_path / volume_forecaster.ARTIFACT_FILENAME

--- a/tests/unit/test_volume_forecaster.py
+++ b/tests/unit/test_volume_forecaster.py
@@ -308,27 +308,43 @@ def test_load_spec_falls_back_to_cold_start_fit(
 ) -> None:
     """HF download failure must trigger the in-process cold-start fit.
 
-    Monkeypatches ``_download_artifact`` to raise
-    ``VolumeForecasterUnavailable``, fakes yfinance to return a synthetic
-    180-bar volume frame, and monkeypatches
-    ``app.data.late_fusion_volume.fit_production_artifact`` to return a
-    minimal valid spec, then asserts ``_load_spec`` returns the spec
-    from the cold-start branch (no HF hit succeeded, no on-disk
-    artifact existed).
+    Walks the full cold-start branch of ``_load_spec``:
+
+    * ``_download_artifact`` is forced to raise
+      ``VolumeForecasterUnavailable`` so the ``not spec_path.exists()``
+      arm falls through to ``_cold_start_fit``.
+    * ``yfinance.Ticker`` is replaced so ``_cold_start_fit.history`` returns
+      a synthetic 180-bar daily-volume frame instead of hitting the network.
+    * ``app.data.late_fusion_volume.fit_production_artifact`` is replaced
+      with a stub that records the parquet path the cold-start wrote, so
+      we can confirm the cold-start actually serialized real bars and
+      pointed the fit at them.
+
+    The assertions then prove the cold-start path executed end-to-end
+    (HF raised, ticker was instantiated, parquet was materialized, fit
+    was called with the on-disk artifact target) and that ``_load_spec``
+    returned the stubbed spec verbatim.
     """
 
     import pandas as pd
 
     from app.data import late_fusion_volume
 
-    def _raise(_target_dir: Any) -> dict[str, Any]:
+    download_calls: list[Any] = []
+
+    def _raise(target_dir: Any) -> dict[str, Any]:
+        download_calls.append(target_dir)
         raise volume_forecaster.VolumeForecasterUnavailable("hf repo missing")
 
+    ticker_calls: list[str] = []
+
     class _FakeTicker:
-        def __init__(self, _symbol: str) -> None:
-            pass
+        def __init__(self, symbol: str) -> None:
+            ticker_calls.append(symbol)
 
         def history(self, period: str, auto_adjust: bool) -> pd.DataFrame:
+            assert period == volume_forecaster._COLD_START_PERIOD
+            assert auto_adjust is True
             dates = pd.bdate_range(end="2026-05-30", periods=180)
             return pd.DataFrame(
                 {"Volume": np.linspace(1.0e9, 1.2e9, len(dates))},
@@ -339,7 +355,10 @@ def test_load_spec_falls_back_to_cold_start_fit(
     fit_calls: list[tuple[Any, Any]] = []
 
     def _stub_fit(vol_path: Any, out_path: Any) -> dict[str, Any]:
-        fit_calls.append((vol_path, out_path))
+        # Cold-start must hand off a real parquet on disk; loading it
+        # back proves the synthetic frame survived the round trip.
+        replayed = pd.read_parquet(vol_path)
+        fit_calls.append((replayed, out_path))
         return fake_spec
 
     import yfinance as yf
@@ -349,10 +368,17 @@ def test_load_spec_falls_back_to_cold_start_fit(
     monkeypatch.setattr(late_fusion_volume, "fit_production_artifact", _stub_fit)
 
     spec = volume_forecaster._load_spec(tmp_path)
-    assert spec is fake_spec
+
+    # HF arm was tried first, with the target dir _load_spec received.
+    assert download_calls == [tmp_path]
+    # Cold-start instantiated yfinance with the canonical symbol.
+    assert ticker_calls == [volume_forecaster._COLD_START_SYMBOL]
+    # Exactly one fit, with the on-disk artifact target under tmp_path.
     assert len(fit_calls) == 1
-    # ``fit_production_artifact`` is called with the temp parquet path
-    # the cold-start writes plus the on-disk artifact target under
-    # ``tmp_path / ARTIFACT_FILENAME``.
-    _, out_path = fit_calls[0]
+    replayed, out_path = fit_calls[0]
     assert out_path == tmp_path / volume_forecaster.ARTIFACT_FILENAME
+    assert list(replayed.columns) == ["date", "volume"]
+    assert len(replayed) == 180
+    assert (replayed["volume"] > 0).all()
+    # _load_spec returned the cold-start spec verbatim.
+    assert spec is fake_spec

--- a/tests/unit/test_volume_forecaster.py
+++ b/tests/unit/test_volume_forecaster.py
@@ -301,3 +301,32 @@ def test_safe_float_handles_none_and_garbage() -> None:
     assert volume_forecaster._safe_float(float("nan")) is None
     assert volume_forecaster._safe_float(1) == 1.0
     assert volume_forecaster._safe_float("3.5") == 3.5
+
+
+def test_load_spec_falls_back_to_cold_start_fit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """HF download failure must trigger the in-process cold-start fit.
+
+    Monkeypatches ``_download_artifact`` to raise
+    ``VolumeForecasterUnavailable`` and ``_cold_start_fit`` to return a
+    minimal valid spec, then asserts ``_load_spec`` returns it from the
+    cold-start branch (no HF hit succeeded, no on-disk artifact existed).
+    """
+
+    def _raise(_target_dir: Any) -> dict[str, Any]:
+        raise volume_forecaster.VolumeForecasterUnavailable("hf repo missing")
+
+    fake_spec: dict[str, Any] = _make_spec()
+    cold_start_calls: list[Any] = []
+
+    def _stub_cold_start(target_dir: Any) -> dict[str, Any]:
+        cold_start_calls.append(target_dir)
+        return fake_spec
+
+    monkeypatch.setattr(volume_forecaster, "_download_artifact", _raise)
+    monkeypatch.setattr(volume_forecaster, "_cold_start_fit", _stub_cold_start)
+
+    spec = volume_forecaster._load_spec(tmp_path)
+    assert spec is fake_spec
+    assert cold_start_calls == [tmp_path]


### PR DESCRIPTION
Fall back to an in-process HAR fit off live yfinance volume when the HF Hub artifact is unreachable, so the Expected Volume card resolves on a fresh checkout instead of sitting on the retry placeholder.

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit/test_volume_forecaster.py -q`
- [ ] `docker compose run --rm backend ruff check app/services/volume_forecaster.py tests/unit/test_volume_forecaster.py`
- [ ] `docker compose run --rm frontend npx vitest run`