### PR TITLE
fix(analyze): drop dead unfamiliarity rows from Encode step

### DIFF
--- a/frontend/components/analyze/PipelineTrace.tsx
+++ b/frontend/components/analyze/PipelineTrace.tsx
@@ -146,19 +146,17 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
     key: "encode",
     title: "Encode",
     blurb:
-      "Runs the text through the language model. Flags inputs that look unlike anything the model was trained on, so the workspace can warn before trusting the result.",
+      "Runs the text through the language model and emits the encoder embedding the downstream heads consume.",
     icon: <Layers className="h-3.5 w-3.5" />,
     state: "ok",
     summary: encoderKey
       ? `Model variant: ${friendlyEncoderName(encoderKey)}`
       : "Model variant: default",
     body: (
-      <div className="space-y-3">
-        <dl className="grid gap-x-4 gap-y-1.5 text-sm sm:grid-cols-2">
-          <dt className="text-muted-foreground">Model variant</dt>
-          <dd className="numeric text-right">{encoderKey ?? "default"}</dd>
-        </dl>
-      </div>
+      <p className="text-sm text-muted-foreground">
+        Model variant: <span className="numeric text-foreground">{encoderKey ?? "default"}</span>. No
+        OOD signal available.
+      </p>
     ),
   };
 

--- a/frontend/components/analyze/PipelineTrace.tsx
+++ b/frontend/components/analyze/PipelineTrace.tsx
@@ -111,14 +111,10 @@ function multiAxisSummary(multiAxis: MultiAxisResponse): string {
 }
 
 function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
-  const sentiment = result.sentiment;
   const multiAxis = result.multi_axis;
   const regime = result.regime_classification;
   const encoderKey = (result.model as { encoder_key?: string } | undefined)?.encoder_key;
   const xaiSentences = result.xai?.sentences?.length ?? 0;
-  const ood = sentiment?.is_in_distribution;
-  const oodEnergy = sentiment?.ood_energy;
-  const oodThreshold = sentiment?.ood_threshold;
 
   const ingestStep: Step = {
     key: "ingest",
@@ -152,62 +148,16 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
     blurb:
       "Runs the text through the language model. Flags inputs that look unlike anything the model was trained on, so the workspace can warn before trusting the result.",
     icon: <Layers className="h-3.5 w-3.5" />,
-    state: ood === false ? "warn" : "ok",
+    state: "ok",
     summary: encoderKey
-      ? `Model variant: ${friendlyEncoderName(encoderKey)}${ood === false ? " · unfamiliar text flag set" : ""}`
+      ? `Model variant: ${friendlyEncoderName(encoderKey)}`
       : "Model variant: default",
     body: (
       <div className="space-y-3">
         <dl className="grid gap-x-4 gap-y-1.5 text-sm sm:grid-cols-2">
           <dt className="text-muted-foreground">Model variant</dt>
           <dd className="numeric text-right">{encoderKey ?? "default"}</dd>
-          <dt className="text-muted-foreground">Unfamiliarity score</dt>
-          <dd className="numeric text-right">{oodEnergy != null ? oodEnergy.toFixed(3) : "—"}</dd>
-          <dt className="text-muted-foreground">Unfamiliarity threshold</dt>
-          <dd className="numeric text-right">
-            {oodThreshold != null ? oodThreshold.toFixed(3) : "—"}
-          </dd>
-          <dt className="text-muted-foreground">Familiar to model</dt>
-          <dd className="text-right">
-            {ood == null ? (
-              "—"
-            ) : ood ? (
-              <Badge variant="dovish" className="text-[10px]">
-                yes
-              </Badge>
-            ) : (
-              <Badge variant="hawkish" className="text-[10px]">
-                <AlertTriangle className="h-3 w-3" /> no
-              </Badge>
-            )}
-          </dd>
         </dl>
-        {oodEnergy != null && oodThreshold != null && oodThreshold !== 0 ? (
-          <div className="space-y-1">
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-muted-foreground">Score vs threshold</span>
-              <span className="numeric text-foreground">
-                {oodEnergy.toFixed(3)} / {oodThreshold.toFixed(3)}
-              </span>
-            </div>
-            <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-              <div
-                className={cn("h-full", ood === false ? "bg-hawkish" : "bg-up")}
-                style={{
-                  width: `${Math.min(
-                    100,
-                    Math.max(2, Math.abs(oodEnergy / oodThreshold) * 100),
-                  ).toFixed(1)}%`,
-                }}
-                aria-hidden="true"
-              />
-            </div>
-            <p className="text-[11px] text-muted-foreground">
-              A score below the threshold means the text looks familiar to the model; above
-              means it does not.
-            </p>
-          </div>
-        ) : null}
       </div>
     ),
   };


### PR DESCRIPTION
The Encode step rendered unfamiliarity score, unfamiliarity threshold, and the familiar-to-model badge as em-dashes on every analysis because no OOD calibration manifest is ever generated. This trims those rows (plus the unreachable progress bar below them) and keeps Model variant.

## Test plan
- [x] `docker compose run --rm backend pytest tests/unit/test_main_api.py -q`
- [x] `npx vitest run --reporter=verbose` (frontend container)
- [ ] Open the analyze page, run any FOMC text, expand the Encode step