### PR TITLE
fix: history chart reads signed stance_score, not confidence

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -78,11 +78,12 @@ class AnalysisRun(Base):
 def _extract_stance_score(payload: Any) -> float | None:
     """``P(hawkish) - P(dovish)`` from a persisted /analyze response.
 
-    Inlined here (rather than imported from ``app.services.stance_context``)
-    because that module imports :class:`AnalysisRun` from this one. Returns
-    ``None`` when the payload lacks the multi-axis block or either class
-    probability so pre-#338 / regression-mode rows degrade to ``null``
-    rather than fabricating a zero.
+    Defined here rather than in ``app.services.stance_context`` because
+    ``db.py`` is the persistence boundary; co-locating the extractor
+    with the model keeps the schema-aware logic next to the column it
+    reads. Returns ``None`` when the payload lacks the multi-axis block
+    or either class probability so pre-#338 / regression-mode rows
+    degrade to ``null`` rather than fabricating a zero.
     """
 
     if not isinstance(payload, dict):

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -59,6 +59,7 @@ class AnalysisRun(Base):
             "forecast_mode": self.forecast_mode,
             "stance": self.stance,
             "sentiment_score": self.sentiment_score,
+            "stance_score": _extract_stance_score(self.payload),
             "predicted_close": self.predicted_close,
             "current_close": self.current_close,
             "predicted_volatility": self.predicted_volatility,
@@ -72,6 +73,34 @@ class AnalysisRun(Base):
         summary = self.to_summary()
         summary["payload"] = self.payload
         return summary
+
+
+def _extract_stance_score(payload: Any) -> float | None:
+    """``P(hawkish) - P(dovish)`` from a persisted /analyze response.
+
+    Inlined here (rather than imported from ``app.services.stance_context``)
+    because that module imports :class:`AnalysisRun` from this one. Returns
+    ``None`` when the payload lacks the multi-axis block or either class
+    probability so pre-#338 / regression-mode rows degrade to ``null``
+    rather than fabricating a zero.
+    """
+
+    if not isinstance(payload, dict):
+        return None
+    multi_axis = payload.get("multi_axis")
+    if not isinstance(multi_axis, dict):
+        return None
+    stance = multi_axis.get("stance")
+    if not isinstance(stance, dict):
+        return None
+    distribution = stance.get("distribution")
+    if not isinstance(distribution, dict):
+        return None
+    hawk = distribution.get("hawkish")
+    dove = distribution.get("dovish")
+    if not isinstance(hawk, int | float) or not isinstance(dove, int | float):
+        return None
+    return float(hawk) - float(dove)
 
 
 def _extract_regime_summary(payload: Any) -> dict[str, Any]:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -647,6 +647,12 @@ class HistoryEntry(BaseModel):
     forecast_mode: str
     stance: str
     sentiment_score: float | None = None
+    # Signed stance value ``P(hawkish) - P(dovish)`` derived from the persisted
+    # multi-axis distribution. ``None`` when the row pre-dates multi-axis or
+    # when the payload is regression-mode (no stance head). The History chart
+    # uses this for the Y-axis; ``sentiment_score`` is unsigned confidence and
+    # should not drive a signed axis.
+    stance_score: float | None = None
     predicted_close: float | None = None
     current_close: float | None = None
     predicted_volatility: float | None = None

--- a/backend/app/services/stance_context.py
+++ b/backend/app/services/stance_context.py
@@ -23,42 +23,11 @@ from __future__ import annotations
 import math
 import statistics
 from dataclasses import dataclass
-from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.db import AnalysisRun
-
-
-def _extract_stance_score(payload: Any) -> float | None:
-    """``P(hawkish) - P(dovish)`` from a persisted /analyze response.
-
-    Returns ``None`` when the payload is missing the multi-axis block,
-    when the distribution is empty, or when EITHER class probability
-    is absent. The classifier's softmax always populates both keys —
-    a missing key signals a truncated / pre-#338 payload rather than a
-    genuine ``P(class) = 0``. Treating the missing key as 0 would
-    fabricate a score and pollute the trailing-window mean/std, so
-    the trailing-window builder filters the row out entirely.
-    """
-
-    if not isinstance(payload, dict):
-        return None
-    multi_axis = payload.get("multi_axis")
-    if not isinstance(multi_axis, dict):
-        return None
-    stance = multi_axis.get("stance")
-    if not isinstance(stance, dict):
-        return None
-    distribution = stance.get("distribution")
-    if not isinstance(distribution, dict):
-        return None
-    hawk = distribution.get("hawkish")
-    dove = distribution.get("dovish")
-    if not isinstance(hawk, int | float) or not isinstance(dove, int | float):
-        return None
-    return float(hawk) - float(dove)
+from app.db import AnalysisRun, _extract_stance_score
 
 
 @dataclass(frozen=True)

--- a/frontend/components/analyze/HistoryTimelineChart.tsx
+++ b/frontend/components/analyze/HistoryTimelineChart.tsx
@@ -74,8 +74,13 @@ export function HistoryTimelineChart({ rows }: HistoryTimelineChartProps) {
       .map((row) => {
         const ts = new Date(row.document_date).getTime();
         if (!Number.isFinite(ts)) return null;
-        const stance = typeof row.sentiment_score === "number"
-          ? Math.max(-1, Math.min(1, row.sentiment_score))
+        // ``sentiment_score`` is the winning-class confidence (always
+        // in [0, 1]) and cannot drive a signed axis. Prefer the signed
+        // ``stance_score = P(hawk) - P(dove)`` surfaced by the backend
+        // and fall back to the ternary categorical mapping for rows
+        // that pre-date the multi-axis block.
+        const stance = typeof row.stance_score === "number" && Number.isFinite(row.stance_score)
+          ? Math.max(-1, Math.min(1, row.stance_score))
           : stanceToScore(row.stance);
         return {
           date: row.document_date,

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -416,6 +416,7 @@ export interface HistoryEntry {
   forecast_mode: string;
   stance: string;
   sentiment_score?: number | null;
+  stance_score?: number | null;
   predicted_close?: number | null;
   current_close?: number | null;
   predicted_volatility?: number | null;

--- a/frontend/tests/components/analyze/HistoryTimelineChart.test.tsx
+++ b/frontend/tests/components/analyze/HistoryTimelineChart.test.tsx
@@ -159,6 +159,59 @@ describe("HistoryTimelineChart", () => {
     expect(byDate["2026-03-15"]).toBe("-1");
   });
 
+  it("renders a line that crosses zero when the fixture mixes negative and positive stance_score", () => {
+    // Regression guard for the bug this PR fixes: before the fix, the
+    // chart fed `sentiment_score` (winning-class confidence, always in
+    // [0, 1]) into the stance line, so a series of dovish + hawkish
+    // runs sat entirely above the zero baseline. With the signed
+    // `stance_score`, the same fixture must straddle zero.
+    const rows = [
+      makeRow({
+        id: "dove-1",
+        document_date: "2026-02-01",
+        stance: "dovish",
+        sentiment_score: 0.80,
+        stance_score: -0.60,
+      }),
+      makeRow({
+        id: "dove-2",
+        document_date: "2026-02-08",
+        stance: "dovish",
+        sentiment_score: 0.55,
+        stance_score: -0.20,
+      }),
+      makeRow({
+        id: "hawk-1",
+        document_date: "2026-02-15",
+        stance: "hawkish",
+        sentiment_score: 0.65,
+        stance_score: 0.25,
+      }),
+      makeRow({
+        id: "hawk-2",
+        document_date: "2026-02-22",
+        stance: "hawkish",
+        sentiment_score: 0.90,
+        stance_score: 0.70,
+      }),
+    ];
+    render(<HistoryTimelineChart rows={rows} />);
+    const dots = screen.getAllByTestId("rc-row");
+    const stances = dots
+      .map((d) => d.getAttribute("data-stance"))
+      .filter((v): v is string => v != null && v !== "")
+      .map((v) => Number(v));
+    // Every emitted dot has a finite numeric stance; the fixture
+    // contains both signs, proving the rendered series crosses the
+    // zero line rather than staying in the [0, 1] confidence band.
+    expect(stances).toHaveLength(4);
+    expect(stances.every((v) => Number.isFinite(v))).toBe(true);
+    expect(stances.some((v) => v < 0)).toBe(true);
+    expect(stances.some((v) => v > 0)).toBe(true);
+    expect(Math.min(...stances)).toBeLessThan(0);
+    expect(Math.max(...stances)).toBeGreaterThan(0);
+  });
+
   it("shows the right axis and the vol line, with vol present only on the rows that carry it", () => {
     const rows = [
       makeRow({ id: "a", document_date: "2026-03-01", forward_realized_vol_10d: 0.12 }),

--- a/frontend/tests/components/analyze/HistoryTimelineChart.test.tsx
+++ b/frontend/tests/components/analyze/HistoryTimelineChart.test.tsx
@@ -23,13 +23,14 @@ vi.mock("recharts", () => {
             smoke test can count them and reason about the right-axis
             vol line covering only the rows that carry the metric. */}
         {(data ?? []).map((row, idx) => {
-          const r = row as { vol?: number | null; date?: string };
+          const r = row as { vol?: number | null; date?: string; stance?: number };
           return (
             <div
               key={idx}
               data-testid="rc-row"
               data-has-vol={r.vol != null ? "true" : "false"}
               data-date={r.date}
+              data-stance={typeof r.stance === "number" ? String(r.stance) : ""}
             />
           );
         })}
@@ -67,6 +68,7 @@ function makeRow(overrides: Partial<HistoryTimelineRow> = {}): HistoryTimelineRo
     forecast_mode: "fast",
     stance: overrides.stance ?? "neutral",
     sentiment_score: overrides.sentiment_score ?? 0,
+    stance_score: overrides.stance_score,
     predicted_close: null,
     current_close: null,
     predicted_volatility: null,
@@ -116,6 +118,45 @@ describe("HistoryTimelineChart", () => {
     expect(screen.queryByTestId("rc-line-vol")).toBeNull();
     // Card copy mirrors the axis state so the user sees a matching note.
     expect(screen.getByText(/No forward vol data on these rows\./i)).toBeInTheDocument();
+  });
+
+  it("uses the signed stance_score when present and falls back to the stance label otherwise", () => {
+    // sentiment_score is the winning-class confidence (always in [0, 1])
+    // so a dovish row used to render above the zero line. Surface stance_score
+    // from the multi-axis distribution instead. The row without stance_score
+    // falls back to stanceToScore("dovish") = -1.
+    const rows = [
+      makeRow({
+        id: "dove",
+        document_date: "2026-03-01",
+        stance: "dovish",
+        sentiment_score: 0.85,
+        stance_score: -0.45,
+      }),
+      makeRow({
+        id: "hawk",
+        document_date: "2026-03-08",
+        stance: "hawkish",
+        sentiment_score: 0.70,
+        stance_score: 0.30,
+      }),
+      makeRow({
+        id: "legacy",
+        document_date: "2026-03-15",
+        stance: "dovish",
+        sentiment_score: 0.62,
+        // No stance_score: pre-multi-axis row.
+      }),
+    ];
+    render(<HistoryTimelineChart rows={rows} />);
+    const dots = screen.getAllByTestId("rc-row");
+    const byDate = Object.fromEntries(
+      dots.map((d) => [d.getAttribute("data-date") ?? "", d.getAttribute("data-stance")]),
+    );
+    expect(byDate["2026-03-01"]).toBe("-0.45");
+    expect(byDate["2026-03-08"]).toBe("0.3");
+    // Legacy row drops to the categorical fallback: dovish → -1.
+    expect(byDate["2026-03-15"]).toBe("-1");
   });
 
   it("shows the right axis and the vol line, with vol present only on the rows that carry it", () => {

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -2010,6 +2010,17 @@
             "title": "Stance",
             "type": "string"
           },
+          "stance_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stance Score"
+          },
           "symbol": {
             "title": "Symbol",
             "type": "string"
@@ -2141,6 +2152,17 @@
           "stance": {
             "title": "Stance",
             "type": "string"
+          },
+          "stance_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stance Score"
           },
           "symbol": {
             "title": "Symbol",

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -104,3 +104,54 @@ def test_text_excerpt_truncates_long_input(session):
     assert record.text_excerpt is not None
     assert len(record.text_excerpt) <= 281
     assert record.text_excerpt.endswith("…")
+
+
+def test_to_summary_surfaces_signed_stance_score(session):
+    """A dovish-leaning multi-axis payload yields a negative ``stance_score``.
+
+    Guards the History chart: ``sentiment_score`` is unsigned confidence
+    in [0, 1] and cannot encode direction. ``stance_score`` is the signed
+    ``P(hawkish) - P(dovish)`` from the persisted ``multi_axis`` block and
+    is what the chart's Y-axis must read off the summary.
+    """
+
+    payload = _sample_response(
+        multi_axis={
+            "stance": {
+                "distribution": {
+                    "hawkish": 0.15,
+                    "neutral": 0.25,
+                    "dovish": 0.60,
+                },
+            },
+        },
+    )
+    record = db_module.persist_analysis_run(
+        session,
+        payload=payload,
+        request=_sample_request(),
+        response=payload,
+    )
+    summary = record.to_summary()
+    assert "stance_score" in summary
+    assert summary["stance_score"] is not None
+    assert summary["stance_score"] == pytest.approx(0.15 - 0.60)
+    assert summary["stance_score"] < 0
+
+
+def test_to_summary_stance_score_none_when_multi_axis_absent(session):
+    """Pre-multi-axis / regression-mode rows return ``stance_score=None``.
+
+    The chart falls back to ``stanceToScore(row.stance)`` in that case so
+    the X-axis still renders something, but the summary must not fabricate
+    a zero — the ``None`` signal is what tells the frontend to fall back.
+    """
+
+    record = db_module.persist_analysis_run(
+        session,
+        payload=_sample_response(),
+        request=_sample_request(),
+        response=_sample_response(),
+    )
+    summary = record.to_summary()
+    assert summary["stance_score"] is None


### PR DESCRIPTION
History's Stance over time chart used `sentiment_score` (winning-class confidence, always in [0, 1]) as the Y-axis value, so dovish runs rendered above the zero line. Fix surfaces signed `stance_score = P(hawk) - P(dove)` from the persisted multi-axis block; the chart falls back to the hawkish/neutral/dovish ternary for pre-multi-axis rows.

## Test plan
- [ ] `docker compose run --rm backend pytest tests/unit/test_db.py -q`
- [ ] `docker compose run --rm backend pytest tests/unit/test_history_endpoints.py tests/unit/test_stance_context.py tests/unit/test_analyze_persists_history.py -q`
- [ ] `docker compose -f docker-compose.yml run --rm frontend npx vitest run tests/components/analyze/HistoryTimelineChart.test.tsx`