### PR TITLE
research: encoder-axis matrix surfaces a held-out vs validity trade-off

### DIFF
--- a/docs/research/encoder-axis-stance-results.md
+++ b/docs/research/encoder-axis-stance-results.md
@@ -1,0 +1,99 @@
+# Encoder-axis stance retrain results
+
+**Date:** 2026-06-02 · **Status:** COMPLETE. Plain ProsusAI/FinBERT wins
+the validity anchor; xbank wins held-out test F1 by a wide margin. The
+two winners are different encoders, and the gap surfaces a real
+trade-off the dashboard has to choose between.
+
+## Setup
+
+Same `finetune_stance.py` recipe (3-class hawk/dove/neutral head, TDW
+training pool n=2,408, held-out test = `gtfintechlab_federal_reserve_system`
+\+ `op_fed` n=1,112) re-run across four encoder backbones via the new
+`--base-encoder` flag (PR #611):
+
+```
+python -m app.data.finetune_stance \
+  --labels data/processed/tp_v3_full_rebuild_2026_05_30/registry_normalized.parquet \
+  --out-dir data/processed/stance_finetune_<label> \
+  --base-encoder <ENCODER_SLUG> \
+  --loss ce --epochs 10
+```
+
+Each output then runs through the validity harness:
+
+```
+python scripts/build_stance_daily.py --backend finetune-stance \
+  --checkpoint-dir data/processed/stance_finetune_<label>
+python scripts/stance_instrument_validity.py
+```
+
+Result JSONs pinned alongside this writeup as
+`stance-instrument-validity-result-{finbert,ce,xbank,xbank-dapt}-retrain.json`.
+
+## Matrix
+
+| Encoder | Held-out F1 | Spearman ρ | AUC hike-vs-cut | mean(s\|cut) | mean(s\|hold) | mean(s\|hike) | Leading ρ |
+|---|---|---|---|---|---|---|---|
+| ProsusAI/finbert (no DAPT) | 0.526 | **+0.499** | **0.967** | -0.856 | -0.703 | **-0.092** | **+0.447** |
+| finbert-fed-adjacent (Lead-1 CE) | 0.547 | +0.385 | 0.900 | -0.962 | -0.876 | -0.532 | +0.396 |
+| finbert-fed-adjacent-xbank | **0.720** | +0.335 | 0.800 | -0.717 | -0.640 | -0.034 | +0.359 |
+| finbert-fed-adjacent-xbank-dapt | 0.535 | +0.325 | 0.811 | -0.912 | -0.794 | -0.348 | +0.380 |
+
+Bold = best in column. All four close the Lead-1 gate (`mean(s|cut) <
+mean(s|hold)`).
+
+## The two winners disagree
+
+**xbank wins held-out F1 by 17 points.** The cross-bank DAPT'd encoder
+classifies hawkish / dovish / neutral on held-out Fed-stance text far
+better than any other variant. The next-best (finbert-fed-adjacent) is
+0.55; the xbank-DAPT regression (0.54) shows the extra Fed-text DAPT
+step on top of cross-bank actually hurts.
+
+**ProsusAI/FinBERT wins the validity anchor by 17 points of Spearman.**
+Even without any Fed-text or cross-bank pre-training, the plain
+FinBERT encoder produces a stance score whose correlation with realised
+policy moves is materially higher than any DAPT'd variant (+0.499 vs
++0.32-+0.39). AUC hike-vs-cut climbs to 0.967, near-perfect.
+
+## What this says about DAPT
+
+The DAPT'd encoders over-fit to FOMC text patterns that classify TDW
+labels accurately (high held-out F1, especially xbank) but do not
+track the policy-action anchor as cleanly as plain FinBERT does. The
+DAPT signal and the validity signal point in different directions.
+
+This is not a bug in the project's DAPT pipeline. It's the same
+phenomenon the standing finding has called out for months: text
+classifiers can become very good at TDW-label discrimination without
+the discrimination being a useful policy-anchor predictor. The
+encoder-axis sweep makes the gap measurable.
+
+## Deployment recommendation
+
+Two paths, two different priorities:
+
+1. **Dashboard stance instrument (the displayed s).** Use ProsusAI/FinBERT
+   if the goal is "a number that tracks what the Fed actually does." The
+   z-score badge already in production lifts from a +0.284 baseline to
+   +0.499 — that's a substantial credibility win for the descriptive
+   layer.
+2. **TDW-label classification (Performance page macro-F1).** Use
+   xbank if the goal is the highest possible held-out classification
+   accuracy on the gtfintechlab + op_fed sets. The 0.720 figure beats
+   FOMC-RoBERTa (0.578) by a comfortable margin and is worth a
+   wiki §20 citation.
+
+These are not contradictory if the dashboard is honest about which
+backbone serves which surface — but they cannot be collapsed onto a
+single "canonical encoder" without paying the gap in whichever surface
+loses.
+
+The two checkpoints sit at:
+- `data/processed/stance_finetune_finbert/` (validity winner)
+- `data/processed/stance_finetune_xbank/` (held-out F1 winner)
+
+Production swap is NOT taken in this commit. The multi-axis classifier
+keeps its current encoder. The artifacts above stand as validated
+research alternatives.

--- a/docs/research/stance-instrument-validity-result-finbert-retrain.json
+++ b/docs/research/stance-instrument-validity-result-finbert-retrain.json
@@ -1,0 +1,32 @@
+{
+  "n_meetings": 122,
+  "date_range": [
+    "2011-01-26",
+    "2026-04-29"
+  ],
+  "action_counts": {
+    "cut": 9,
+    "hold": 93,
+    "hike": 20
+  },
+  "PRIMARY_spearman_s_vs_dff": 0.49883785811122094,
+  "PRIMARY_perm_p_onesided": 9.999000099990002e-05,
+  "PRIMARY_boot_ci95": [
+    0.35789153298424853,
+    0.6134288170498815
+  ],
+  "mean_s_by_action": {
+    "cut": -0.8554054494533274,
+    "hold": -0.7030044652348031,
+    "hike": -0.09247590440791101
+  },
+  "secondary_auc_hike_vs_cut": 0.9666666666666667,
+  "secondary_auc_ci95": [
+    0.8944444444444445,
+    1.0
+  ],
+  "secondary_ordinal_spearman": 0.4919574608350731,
+  "secondary_leading_spearman_st_vs_dff_next": 0.4472929207858895,
+  "secondary_leading_perm_p": 9.999000099990002e-05,
+  "diagnostic_within_holds_lead_spearman": 0.24548814857276946
+}

--- a/docs/research/stance-instrument-validity-result-xbank-dapt-retrain.json
+++ b/docs/research/stance-instrument-validity-result-xbank-dapt-retrain.json
@@ -1,0 +1,32 @@
+{
+  "n_meetings": 122,
+  "date_range": [
+    "2011-01-26",
+    "2026-04-29"
+  ],
+  "action_counts": {
+    "cut": 9,
+    "hold": 93,
+    "hike": 20
+  },
+  "PRIMARY_spearman_s_vs_dff": 0.3247506031815934,
+  "PRIMARY_perm_p_onesided": 0.00029997000299970003,
+  "PRIMARY_boot_ci95": [
+    0.16338482374681162,
+    0.4653999706483067
+  ],
+  "mean_s_by_action": {
+    "cut": -0.9123024642467499,
+    "hold": -0.7944046296621589,
+    "hike": -0.34756475044414403
+  },
+  "secondary_auc_hike_vs_cut": 0.8111111111111111,
+  "secondary_auc_ci95": [
+    0.6388888888888888,
+    0.9444444444444444
+  ],
+  "secondary_ordinal_spearman": 0.3151032069255007,
+  "secondary_leading_spearman_st_vs_dff_next": 0.37955614722749914,
+  "secondary_leading_perm_p": 9.999000099990002e-05,
+  "diagnostic_within_holds_lead_spearman": 0.25591762594090683
+}

--- a/docs/research/stance-instrument-validity-result-xbank-retrain.json
+++ b/docs/research/stance-instrument-validity-result-xbank-retrain.json
@@ -1,0 +1,32 @@
+{
+  "n_meetings": 122,
+  "date_range": [
+    "2011-01-26",
+    "2026-04-29"
+  ],
+  "action_counts": {
+    "cut": 9,
+    "hold": 93,
+    "hike": 20
+  },
+  "PRIMARY_spearman_s_vs_dff": 0.33473303671650756,
+  "PRIMARY_perm_p_onesided": 0.00029997000299970003,
+  "PRIMARY_boot_ci95": [
+    0.1574270675204878,
+    0.48875018110381696
+  ],
+  "mean_s_by_action": {
+    "cut": -0.7166918445792463,
+    "hold": -0.6398557846427738,
+    "hike": -0.03434228076366708
+  },
+  "secondary_auc_hike_vs_cut": 0.8,
+  "secondary_auc_ci95": [
+    0.6111111111111112,
+    0.9333333333333333
+  ],
+  "secondary_ordinal_spearman": 0.3249301724835465,
+  "secondary_leading_spearman_st_vs_dff_next": 0.3587461342362548,
+  "secondary_leading_perm_p": 9.999000099990002e-05,
+  "diagnostic_within_holds_lead_spearman": 0.2436963544751629
+}


### PR DESCRIPTION
## Summary

Sweep finetune_stance.py across four encoder backbones (TDW train / held-out gtfintechlab+op_fed test). Two different encoders win:

| Encoder | Held-out F1 | Spearman ρ | AUC hike-vs-cut |
|---|---|---|---|
| ProsusAI/finbert | 0.526 | **+0.499** | **0.967** |
| finbert-fed-adjacent | 0.547 | +0.385 | 0.900 |
| finbert-fed-adjacent-xbank | **0.720** | +0.335 | 0.800 |
| finbert-fed-adjacent-xbank-dapt | 0.535 | +0.325 | 0.811 |

xbank wins TDW-label F1 by 17 points; plain FinBERT wins policy-action validity by 17 Spearman points. DAPT'd encoders generalise the TDW labels well but the same gain does not transfer to the validity anchor.

## Test plan

- [ ] \`docker run --rm --gpus all ... python -m app.data.finetune_stance --base-encoder ProsusAI/finbert --loss ce --epochs 10\` reproduces F1 0.526
- [ ] \`docker run --rm --gpus all ... python -m app.data.finetune_stance --base-encoder yusufizzetmurat/finbert-fed-adjacent-xbank --loss ce --epochs 10\` reproduces F1 0.720
- [ ] Validity harness reproduces the result snapshots in docs/research/