### PR TITLE
Drop Volatility Regime badge, rename Predictions to Decisions

### DIFF
--- a/frontend/components/shell/command-palette.tsx
+++ b/frontend/components/shell/command-palette.tsx
@@ -4,6 +4,7 @@ import {
   Activity,
   Calendar,
   FlaskConical,
+  Gavel,
   GitCompare,
   History as HistoryIcon,
   LineChart,
@@ -52,7 +53,7 @@ interface CommandPaletteProps {
 
 const PAGE_ENTRIES = [
   { id: "page-workspace", label: "Workspace", hint: "/", icon: Activity, href: "/" },
-  { id: "page-predictions", label: "Predictions", hint: "/decisions", icon: LineChart, href: "/decisions" },
+  { id: "page-decisions", label: "Decisions", hint: "/decisions", icon: Gavel, href: "/decisions" },
   { id: "page-history", label: "History", hint: "/history", icon: HistoryIcon, href: "/history" },
   { id: "page-compare", label: "Compare", hint: "/compare", icon: GitCompare, href: "/compare" },
   { id: "page-calendar", label: "Calendar", hint: "/calendar", icon: Calendar, href: "/calendar" },

--- a/frontend/components/shell/header.tsx
+++ b/frontend/components/shell/header.tsx
@@ -6,6 +6,7 @@ import {
   BookOpen,
   Calendar,
   FlaskConical,
+  Gavel,
   GitCompare,
   Github,
   History as HistoryIcon,
@@ -16,14 +17,13 @@ import {
 } from "lucide-react";
 
 import { SkipLink } from "@/components/shell/skip-link";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { cn } from "@/lib/utils";
 
 const NAV_ITEMS: Array<{ href: string; label: string; icon: React.ComponentType<{ className?: string }> }> = [
   { href: "/", label: "Workspace", icon: Activity },
-  { href: "/decisions", label: "Predictions", icon: LineChart },
+  { href: "/decisions", label: "Decisions", icon: Gavel },
   { href: "/history", label: "History", icon: HistoryIcon },
   { href: "/compare", label: "Compare", icon: GitCompare },
   { href: "/calendar", label: "Calendar", icon: Calendar },
@@ -63,12 +63,6 @@ export function Header() {
           >
             <Activity className="h-4 w-4 text-primary" aria-hidden="true" />
             <span>Fed Pulse</span>
-            <Badge
-              variant="outline"
-              className="ml-1 hidden text-[10px] uppercase tracking-wide sm:inline-flex"
-            >
-              Volatility Regime
-            </Badge>
           </Link>
           <nav aria-label="Primary" className="hidden items-center gap-0.5 sm:flex">
             {NAV_ITEMS.map(({ href, label, icon: Icon }) => {


### PR DESCRIPTION
## Summary
- Remove the Volatility Regime chip from the header brand area.
- It hard-coded one research surface into the global brand.
- Rename the /decisions nav entry from Predictions to Decisions.
- Swap the nav icon from LineChart to Gavel.
- Mirror the same change in the command palette page entry.

## Verification
- docker compose run --rm frontend npm run type-check