### PR TITLE
Push volume-HAR artifact to HF and add to eager-pull bundle

### DIFF
--- a/backend/app/boot/eager_pull.py
+++ b/backend/app/boot/eager_pull.py
@@ -46,7 +46,14 @@ except Exception:  # pragma: no cover - import-time defensive
 
 # Artefact-name -> tuple of filenames to extract from the snapshot and
 # copy into MODELS_DIR. Anything not listed is left in the HF cache.
-_ARTEFACT_FILES: dict[str, tuple[str, ...]] = {
+#
+# Each entry is either a flat filename (snapshot path == destination
+# path relative to ``MODELS_DIR``) or a ``(snapshot_name, dst_relpath)``
+# pair when the destination needs to land in a sub-directory under
+# ``MODELS_DIR``. The ``volume_har_canonical`` artefact uses the pair
+# form so the JSON spec sits in ``models/volume_har/`` where
+# :mod:`app.services.volume_forecaster` reads it.
+_ARTEFACT_FILES: dict[str, tuple[str | tuple[str, str], ...]] = {
     "forecaster_canonical": (
         "forecaster_best.pt",
         "forecaster_best.pt.inference_contract.json",
@@ -54,12 +61,27 @@ _ARTEFACT_FILES: dict[str, tuple[str, ...]] = {
         "forecaster_best.pt.lora_adapter.pt",
         "forecaster_calibration_fresh.pt",
     ),
+    "volume_har_canonical": (
+        ("volume_har_artifact.json", "volume_har/volume_har_artifact.json"),
+    ),
 }
+
+
+def _split_entry(entry: str | tuple[str, str]) -> tuple[str, str]:
+    """Return ``(snapshot_relpath, dst_relpath)`` for one mapping entry.
+
+    Plain strings collapse to ``(entry, entry)`` so the legacy flat-file
+    mapping is byte-identical.
+    """
+
+    if isinstance(entry, tuple):
+        return entry[0], entry[1]
+    return entry, entry
 
 
 def _hydrate_one(  # noqa: PLR0913 - six injected params is the natural shape here
     artefact: Any,
-    files: tuple[str, ...],
+    files: tuple[str | tuple[str, str], ...],
     models_dir: Path,
     token: str,
     parse_hf_uri: Callable[[str], Any],
@@ -75,13 +97,16 @@ def _hydrate_one(  # noqa: PLR0913 - six injected params is the natural shape he
         )
         return
 
+    pairs = [_split_entry(entry) for entry in files]
+    snapshot_names = [src_name for src_name, _ in pairs]
+
     revision = artefact.revision or None
     try:
         snapshot_dir = download_snapshot(
             repo_id=ref.repo_id,
             repo_type=ref.repo_type,
             revision=revision,
-            allow_patterns=list(files),
+            allow_patterns=snapshot_names,
             token=token,
         )
     except Exception as exc:
@@ -94,23 +119,24 @@ def _hydrate_one(  # noqa: PLR0913 - six injected params is the natural shape he
         )
         return
 
-    for fname in files:
-        src = Path(snapshot_dir) / fname
-        dst = models_dir / fname
+    for src_name, dst_relpath in pairs:
+        src = Path(snapshot_dir) / src_name
+        dst = models_dir / dst_relpath
         if not src.exists():
             logger.warning(
                 "eager-pull: %r missing from snapshot of %s; skip",
-                fname,
+                src_name,
                 artefact.hf_uri,
             )
             continue
         if dst.exists():
-            logger.info("eager-pull: %s already present; not overwriting", dst.name)
+            logger.info("eager-pull: %s already present; not overwriting", dst_relpath)
             continue
+        dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst)
         logger.info(
             "eager-pull: hydrated %s <- %s @ %s",
-            dst.name,
+            dst_relpath,
             artefact.hf_uri,
             revision or "main",
         )

--- a/backend/app/boot/eager_pull.py
+++ b/backend/app/boot/eager_pull.py
@@ -66,9 +66,7 @@ _ARTEFACT_FILES: dict[str, tuple[str | tuple[str, str], ...]] = {
         "forecaster_best.pt.lora_adapter.pt",
         "forecaster_calibration_fresh.pt",
     ),
-    "volume_har_canonical": (
-        ("volume_har_artifact.json", "volume_har/volume_har_artifact.json"),
-    ),
+    "volume_har_canonical": (("volume_har_artifact.json", "volume_har/volume_har_artifact.json"),),
 }
 
 

--- a/backend/app/boot/eager_pull.py
+++ b/backend/app/boot/eager_pull.py
@@ -11,9 +11,14 @@ cold-start bootstrap in :mod:`app.main` still runs on first
 ``/analyze``.
 
 Mapping policy: only artefacts whose files are read directly out of
-``MODELS_DIR`` appear in :data:`_ARTEFACT_FILES`. ``encoder_canonical``,
-``retrieval``, ``trajectory`` lazy-load via their own caches and are
-intentionally absent so they do not trip the copy step.
+``MODELS_DIR`` appear in :data:`_ARTEFACT_FILES`. Each entry is either
+a flat filename (snapshot path == destination path relative to
+``MODELS_DIR``) or a ``(snapshot_name, dst_relpath)`` pair when the
+file must land in a sub-directory of ``MODELS_DIR``; the tuple form
+is what ``volume_har_canonical`` uses to drop its JSON spec under
+``models/volume_har/``. ``encoder_canonical``, ``retrieval``,
+``trajectory`` lazy-load via their own caches and are intentionally
+absent so they do not trip the copy step.
 ``rates_heads_canonical`` historically pointed at the same
 ``forecaster_best.pt`` file as ``forecaster_canonical``; with the LSTM
 canonical revision (``7ab0a873``) rates heads are absent, so we leave

--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -480,6 +480,19 @@ artefacts:
       - text_embedding_missing
       - credibility
 
+  volume_har_canonical:
+    hf_uri: hf://yusufizzetmurat/fomc-volume-har
+    revision: "540b25a8d66c6f0110dd02b89f10e507139c80b8"
+    eager: true
+    description: |
+      HAR Corsi log-volume artifact for the Expected Volume card. JSON
+      bundle of per-horizon (h=1, 5, 22) regression coefficients, weekday
+      and month-end / quarter-end seasonality block, and conformal
+      residual quantiles. Eager-pulled into
+      ``backend/models/volume_har/volume_har_artifact.json`` so cold
+      starts skip the in-process fit against live yfinance volume.
+    inference_features: []
+
   retrieval_bundle:
     hf_uri: hf://yusufizzetmurat/fed-pulse-retrieval
     revision: "a4693b818e4e2a738f3e32c844f45c651424ee3e"

--- a/backend/app/services/volume_forecaster.py
+++ b/backend/app/services/volume_forecaster.py
@@ -78,7 +78,14 @@ def _hf_token() -> str | None:
 
 
 def _download_artifact(target_dir: Path) -> dict[str, Any]:
-    """Download the HAR-volume spec JSON into ``target_dir``."""
+    """Download the HAR-volume spec JSON into ``target_dir``.
+
+    Reads the pinned revision from ``registry.yaml`` when present so a
+    corrupt-cache or cold-start fallback through this path stays bound
+    to the same sha the boot-time eager-pull resolves. Falls back to
+    HEAD (``main``) only when the registry entry is missing or unpinned,
+    matching the conservative behaviour of the legacy implementation.
+    """
 
     from huggingface_hub import hf_hub_download
     from huggingface_hub.errors import (
@@ -86,6 +93,8 @@ def _download_artifact(target_dir: Path) -> dict[str, Any]:
         HfHubHTTPError,
         RepositoryNotFoundError,
     )
+
+    from app.models.registry import artefact_ref
 
     target_dir.mkdir(parents=True, exist_ok=True)
     token = _hf_token()
@@ -96,6 +105,12 @@ def _download_artifact(target_dir: Path) -> dict[str, Any]:
     }
     if token:
         kwargs["token"] = token
+    try:
+        ref = artefact_ref("volume_har_canonical")
+    except Exception:
+        ref = None
+    if ref is not None and ref.revision:
+        kwargs["revision"] = ref.revision
 
     try:
         spec_path = Path(hf_hub_download(**kwargs))

--- a/scripts/push_artefacts_to_hub.py
+++ b/scripts/push_artefacts_to_hub.py
@@ -128,6 +128,11 @@ ARTEFACT_SOURCES: dict[str, dict[str, str]] = {
         "license": "mit",
         "kind": "rates_heads",
     },
+    "volume_har_canonical": {
+        "local_path": "backend/models/volume_har/volume_har_artifact.json",
+        "license": "mit",
+        "kind": "volume_har",
+    },
     "retrieval_bundle": {
         "local_path": "data/artifacts/retrieval",
         "license": "mit",
@@ -249,6 +254,13 @@ ATTRIBUTION_BLURBS: dict[str, str] = {
         "- Encoders: `yusufizzetmurat/fed-pulse-encoder` family (see those "
         "cards for upstream attribution)."
     ),
+    "volume_har": (
+        "- Daily share-volume series: [Yahoo Finance](https://finance.yahoo.com) "
+        "via `yfinance` (`^GSPC` reference symbol).\n"
+        "- Fit recipe: per-horizon HAR Corsi regression on log-volume with a "
+        "weekday + month-end / quarter-end seasonality block; conformal "
+        "residual quantiles at the 80% / 90% bands."
+    ),
 }
 
 
@@ -290,6 +302,11 @@ CORPUS_BLURBS: dict[str, str] = {
         "revision). Each parquet carries `record_id`, `doc_id`, "
         "`event_date`, `chunk_index`, `chunk_preview`, and `embedding`."
     ),
+    "volume_har": (
+        "HAR Corsi log-volume regression coefficients + weekday / month-end / "
+        "quarter-end seasonality block + conformal residual quantiles for "
+        "horizons h=1, 5, 22. Fit on 180 calendar days of daily ^GSPC volume."
+    ),
 }
 
 
@@ -328,6 +345,7 @@ TRAIN_CMDS: dict[str, str] = {
     "trajectory": "python -m app.trajectory.train --architecture lstm",
     "training_package": "python -m app.data.pipeline_data_prep --all-sources",
     "embedding_caches": "python scripts/cache_embeddings.py --encoder <alias> --training-package-id <tp-id> --allow-network",
+    "volume_har": "python -m app.data.late_fusion_volume fit-production-artifact --symbol ^GSPC --period 180d",
 }
 
 

--- a/tests/unit/test_boot_eager_pull.py
+++ b/tests/unit/test_boot_eager_pull.py
@@ -176,3 +176,73 @@ def test_main_returns_zero_even_on_unexpected_error(
 
     monkeypatch.setattr(eager_pull, "hydrate", _explode)
     assert eager_pull.main() == 0
+
+
+def test_split_entry_plain_string_collapses_to_pair() -> None:
+    """A flat filename maps to ``(name, name)`` — both sides identical."""
+
+    assert eager_pull._split_entry("forecaster_best.pt") == (
+        "forecaster_best.pt",
+        "forecaster_best.pt",
+    )
+
+
+def test_split_entry_tuple_form_returns_src_and_dst() -> None:
+    """A ``(snapshot_name, dst_relpath)`` pair is preserved as-is."""
+
+    entry = ("volume_har_artifact.json", "volume_har/volume_har_artifact.json")
+    assert eager_pull._split_entry(entry) == entry
+
+
+def test_hydrate_tuple_entry_lands_in_subdirectory(
+    monkeypatch: pytest.MonkeyPatch, models_dir: Path, tmp_path: Path
+) -> None:
+    """The tuple-form mapping copies into ``MODELS_DIR / dst_relpath``.
+
+    Exercises the ``volume_har_canonical`` path end-to-end: the file in
+    the snapshot is named flat (``volume_har_artifact.json``), but the
+    destination must land under ``models/volume_har/``. Guards against
+    regressions in ``dst.parent.mkdir`` and the ``snapshot_names`` list
+    using the wrong side of the tuple.
+    """
+
+    monkeypatch.setenv("HF_TOKEN", "stub")
+    snapshot = tmp_path / "snap"
+    snapshot.mkdir()
+    (snapshot / "volume_har_artifact.json").write_bytes(b"FROM_HF_volume")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_snapshot_download(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return str(snapshot)
+
+    monkeypatch.setattr(
+        "app.boot.eager_pull.snapshot_download",
+        _fake_snapshot_download,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.models.registry.eager_artefacts",
+        lambda: [
+            ArtefactRef(
+                name="volume_har_canonical",
+                hf_uri="hf://yusufizzetmurat/fomc-volume-har",
+                revision="540b25a8d66c6f0110dd02b89f10e507139c80b8",
+                eager=True,
+                description="",
+                inference_features=(),
+            )
+        ],
+    )
+
+    eager_pull.hydrate()
+
+    # The destination sits under the sub-directory carved out of the
+    # tuple's right-hand side; the snapshot path itself was flat.
+    dst = models_dir / "volume_har" / "volume_har_artifact.json"
+    assert dst.exists()
+    assert dst.read_bytes() == b"FROM_HF_volume"
+    # ``allow_patterns`` must use the snapshot-side (flat) name, not the
+    # destination relpath, or HF would 404 on the prefix scan.
+    assert captured.get("allow_patterns") == ["volume_har_artifact.json"]


### PR DESCRIPTION
## Summary

- Mirror the HAR-volume JSON spec to `hf://yusufizzetmurat/fomc-volume-har`.
- Register `volume_har_canonical` artefact with revision `540b25a8d66c6f01`.
- Eager-pull copies the file into `backend/models/volume_har/` at boot.
- Existing local fits are preserved by the never-overwrite guard.
- Extend the eager-pull mapping to support sub-directory destinations.

## Verification

- `docker compose run --rm backend python -m app.boot.eager_pull`
- `docker compose run --rm backend python -m pytest tests/unit/test_boot_eager_pull.py tests/unit/test_volume_forecaster.py tests/unit/test_model_registry.py -q`
- `curl -sf https://huggingface.co/api/models/yusufizzetmurat/fomc-volume-har`