### PR TITLE
Warm-load embedding cache and FRED rates so credibility tile populates

### DIFF
--- a/backend/app/boot/warm_load.py
+++ b/backend/app/boot/warm_load.py
@@ -1,0 +1,129 @@
+"""Boot-time warm-load of the credibility module inputs.
+
+The credibility tile on /analyze reads from two on-disk caches:
+
+- the per-encoder embedding parquet under ``data/raw/embeddings/`` —
+  produced once via ``make cache-embeddings`` and mirrored to the
+  ``yusufizzetmurat/fed-pulse-embedding-caches`` HF dataset for the
+  deploy lane.
+- the FRED ``DFF`` series under ``data/external/fred/`` — refreshed
+  via :func:`app.services.fred_client.fetch_fred_series` and cached
+  as JSON.
+
+A fresh container has neither, so /analyze used to surface an empty
+"signals unavailable" state for every passage. This helper runs from
+the FastAPI lifespan hook and pulls each input best-effort. It never
+raises out — every call site is wrapped in ``try / except`` so a
+missing token, a 404, or a network blip does not block uvicorn boot.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger("app.boot.warm_load")
+
+
+def _warm_embedding_cache(encoder_alias: str) -> Path | None:
+    """Best-effort warm of the canonical encoder's embedding parquet.
+
+    Returns the resolved parquet path when present (either pre-existing
+    or freshly pulled), ``None`` otherwise. Never raises.
+    """
+
+    try:
+        from app.data.embedding_cache import (
+            EmbeddingCacheUnavailable,
+            ensure_local,
+            resolve_cache_paths,
+        )
+        from app.models.registry import encoder_ref
+    except Exception:  # noqa: BLE001
+        logger.warning("warm_load: embedding_cache imports failed", exc_info=True)
+        return None
+
+    ref = encoder_ref(encoder_alias)
+    if ref is None or not ref.revision:
+        logger.info(
+            "warm_load: encoder %r absent from registry; skipping",
+            encoder_alias,
+        )
+        return None
+
+    paths = resolve_cache_paths(encoder_alias, revision=ref.revision)
+    if paths.parquet.exists():
+        logger.info("warm_load: embedding cache present at %s", paths.parquet)
+        return paths.parquet
+
+    # The HF dataset pull only runs when a token is set — otherwise
+    # the lazy-fetch returns an anonymous rate-limited error and the
+    # tile stays empty until an operator triggers ``make cache-embeddings``.
+    if not (os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_HUB_TOKEN")):
+        logger.info(
+            "warm_load: HF_TOKEN absent; embedding cache will degrade to "
+            "zero drift until the parquet lands on disk"
+        )
+        return None
+    try:
+        return ensure_local(encoder_alias, revision=ref.revision)
+    except (EmbeddingCacheUnavailable, FileNotFoundError) as exc:
+        logger.warning("warm_load: embedding cache fetch failed: %s", exc)
+    except Exception:  # noqa: BLE001
+        logger.warning("warm_load: embedding cache fetch raised", exc_info=True)
+    return None
+
+
+def _warm_fred_series(series_id: str = "DFF") -> Path | None:
+    """Best-effort warm of the FRED rate-history JSON cache.
+
+    Looks at the on-disk cache first — a fresh checkout that committed
+    the JSON under ``data/external/fred/`` resolves instantly. Falls
+    back to a network pull only when ``FRED_API_KEY`` is set so the
+    container that ships without the env var still boots quietly.
+    """
+
+    try:
+        from app.services.fred_client import DEFAULT_CACHE_DIR, fetch_fred_series
+    except Exception:  # noqa: BLE001
+        logger.warning("warm_load: fred_client imports failed", exc_info=True)
+        return None
+
+    cache_path = Path(DEFAULT_CACHE_DIR) / f"{series_id}.json"
+    if cache_path.exists():
+        logger.info("warm_load: FRED %s cache present at %s", series_id, cache_path)
+        return cache_path
+
+    if not (os.environ.get("FRED_API_KEY") or os.environ.get("FRED_TOKEN")):
+        logger.info(
+            "warm_load: FRED_API_KEY absent; %s realized series will "
+            "degrade to neutral until the cache JSON lands on disk",
+            series_id,
+        )
+        return None
+    try:
+        fetch_fred_series(series_id)
+    except Exception:  # noqa: BLE001
+        logger.warning("warm_load: FRED %s fetch raised", series_id, exc_info=True)
+        return None
+    return cache_path if cache_path.exists() else None
+
+
+def warm_credibility_inputs(
+    *,
+    encoder_alias: str = "finbert_fed_adjacent_xbank_dapt",
+    fred_series_id: str = "DFF",
+) -> None:
+    """Run both warm steps in sequence; never raises out.
+
+    The two helpers are independent — the FRED warm proceeds even when
+    the embedding warm fails so the realized-vs-stated axis can still
+    fire on a host that lacks the embedding parquet.
+    """
+
+    _warm_embedding_cache(encoder_alias)
+    _warm_fred_series(fred_series_id)
+
+
+__all__ = ["warm_credibility_inputs"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -730,12 +730,8 @@ def _build_credibility_block(
         embedding_path = None
 
     stance_by_date: list[tuple[str, float]] = []
-    current_stance_score = (
-        float(
-            (sentiment.get("score") or 0.0)
-            if isinstance(sentiment.get("score"), int | float)
-            else 0.0
-        )
+    current_stance_score = float(
+        (sentiment.get("score") or 0.0) if isinstance(sentiment.get("score"), int | float) else 0.0
     )
     try:
         with session_scope() as session:
@@ -770,9 +766,7 @@ def _build_credibility_block(
         logger.warning("credibility_loader_failed", exc_info=True)
         return None
 
-    drift_trend = _build_drift_trend(
-        embedding_path=embedding_path, as_of_ts=as_of
-    )
+    drift_trend = _build_drift_trend(embedding_path=embedding_path, as_of_ts=as_of)
 
     # The realized-vs-stated axis is reliable only when both the stance
     # series and the realized DFF window carry > 1 point. The loader
@@ -782,9 +776,7 @@ def _build_credibility_block(
     # when no API key is set, so check for the series file itself rather
     # than the directory to detect an actually-populated cache.
     realized_gap: float | None
-    _dff_cached = (
-        fred_cache_dir is not None and (Path(fred_cache_dir) / "DFF.json").exists()
-    )
+    _dff_cached = fred_cache_dir is not None and (Path(fred_cache_dir) / "DFF.json").exists()
     if _dff_cached and len(stance_by_date) >= 2:
         realized_gap = float(vector.realized_vs_stated_gap)
     else:
@@ -804,9 +796,7 @@ def _build_credibility_block(
     }
 
 
-def _build_drift_trend(
-    *, embedding_path: Path | None, as_of_ts: str
-) -> list[float]:
+def _build_drift_trend(*, embedding_path: Path | None, as_of_ts: str) -> list[float]:
     """Per-prior cosine distance against the mean of the remaining priors.
 
     Builds a short sparkline (newest-last) so the credibility card has
@@ -834,11 +824,7 @@ def _build_drift_trend(
         df = df.sort_values("event_date").tail(6)
     except Exception:  # noqa: BLE001
         return []
-    embeddings = [
-        [float(v) for v in row]
-        for row in df["embedding"].tolist()
-        if row is not None
-    ]
+    embeddings = [[float(v) for v in row] for row in df["embedding"].tolist() if row is not None]
     if len(embeddings) < 2:
         return []
     trend: list[float] = []

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -238,6 +238,16 @@ async def _lifespan(app: FastAPI):
             get_multi_axis_classifier()
     except Exception:  # pragma: no cover — never let warmup block startup
         get_logger("fed_pulse").warning("multi_axis_classifier_warmup_failed", exc_info=True)
+    # Warm the embedding parquet + FRED rate cache so the credibility
+    # tile on /analyze surfaces real numbers instead of an empty state.
+    # Both inputs degrade silently per axis when missing; the warm step
+    # tries the canonical encoder + DFF, logs on miss, and never raises.
+    try:
+        from app.boot.warm_load import warm_credibility_inputs
+
+        warm_credibility_inputs()
+    except Exception:  # pragma: no cover — never let warmup block startup
+        get_logger("fed_pulse").warning("credibility_warmup_failed", exc_info=True)
     get_logger("fed_pulse").info("startup", service="fomc-api")
     try:
         yield
@@ -683,6 +693,157 @@ def get_document_detail(type: str, date: str) -> DocumentDetailResponse:
     )
 
 
+def _build_credibility_block(
+    payload: AnalyzeRequest, *, sentiment: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Assemble the four-axis credibility block for the /analyze response.
+
+    Reads the encoder embedding parquet for the canonical DAPT encoder
+    plus the cached DFF FRED series, pulls prior-run stance scores out
+    of the local history table, and falls back per-axis to the loader's
+    zero defaults when any input is missing. Returns ``None`` only when
+    the underlying loader raises something other than a benign
+    ``ValueError`` / ``FileNotFoundError`` so the route still serialises.
+    """
+
+    from app.db import _extract_stance_score
+    from app.services.credibility_loader import load_credibility_for_run
+    from app.services.fred_client import DEFAULT_CACHE_DIR as _FRED_CACHE_DIR
+
+    as_of = str(payload.date)[:10]
+    if not as_of:
+        return None
+
+    embedding_path: Path | None = None
+    encoder_alias = "finbert_fed_adjacent_xbank_dapt"
+    try:
+        from app.data.embedding_cache import resolve_cache_paths
+        from app.models.registry import encoder_ref
+
+        ref = encoder_ref(encoder_alias)
+        if ref is not None and ref.revision:
+            paths = resolve_cache_paths(encoder_alias, revision=ref.revision)
+            if paths.parquet.exists():
+                embedding_path = paths.parquet
+    except Exception:  # noqa: BLE001
+        embedding_path = None
+
+    stance_by_date: list[tuple[str, float]] = []
+    current_stance_score = (
+        float(
+            (sentiment.get("score") or 0.0)
+            if isinstance(sentiment.get("score"), int | float)
+            else 0.0
+        )
+    )
+    try:
+        with session_scope() as session:
+            rows, _total = list_runs(session, limit=24, offset=0, symbol=payload.symbol)
+            for row in rows:
+                score = _extract_stance_score(row.payload)
+                if score is None:
+                    continue
+                doc_date = str(getattr(row, "document_date", "") or "")[:10]
+                if not doc_date:
+                    continue
+                stance_by_date.append((doc_date, float(score)))
+    except Exception:  # noqa: BLE001
+        logger.warning("credibility_history_load_failed", exc_info=True)
+    # Append the current run so the months-since-reversal axis can flip
+    # when the new statement breaks the trailing sign.
+    stance_by_date.append((as_of, current_stance_score))
+
+    fred_cache_dir = _FRED_CACHE_DIR if Path(_FRED_CACHE_DIR).exists() else None
+
+    try:
+        vector = load_credibility_for_run(
+            as_of_ts=as_of,
+            embedding_path=embedding_path,
+            stance_by_date=stance_by_date,
+            fred_response=None,
+            fred_cache_dir=fred_cache_dir,
+        )
+    except (ValueError, FileNotFoundError):
+        return None
+    except Exception:  # noqa: BLE001 — never break /analyze
+        logger.warning("credibility_loader_failed", exc_info=True)
+        return None
+
+    drift_trend = _build_drift_trend(
+        embedding_path=embedding_path, as_of_ts=as_of
+    )
+
+    # The realized-vs-stated axis is reliable only when both the stance
+    # series and the realized DFF window carry > 1 point. The loader
+    # returns 0.0 when either side is degenerate; treat that as
+    # unavailable so the UI renders N/A instead of an unearned reading.
+    realized_gap: float | None
+    if fred_cache_dir is not None and len(stance_by_date) >= 2:
+        realized_gap = float(vector.realized_vs_stated_gap)
+    else:
+        realized_gap = None
+    months_since: int | None = (
+        int(vector.months_since_reversal) if len(stance_by_date) >= 2 else None
+    )
+
+    return {
+        "drift_score": float(vector.drift_score),
+        "realized_vs_stated_gap": realized_gap,
+        # SEP / OIS scrape is still out — keep this axis as ``None`` so
+        # the dashboard renders N/A instead of an unearned zero.
+        "market_implied_gap": None,
+        "months_since_reversal": months_since,
+        "drift_trend": drift_trend,
+    }
+
+
+def _build_drift_trend(
+    *, embedding_path: Path | None, as_of_ts: str
+) -> list[float]:
+    """Per-prior cosine distance against the mean of the remaining priors.
+
+    Builds a short sparkline (newest-last) so the credibility card has
+    a trend curve next to the headline drift score. Returns an empty
+    list when fewer than two priors are available — the front-end
+    tolerates an empty array and renders the headline value alone.
+    """
+
+    if embedding_path is None or not embedding_path.exists():
+        return []
+    try:
+        import pandas as pd
+
+        from app.features.credibility import drift_vs_prior
+
+        df = pd.read_parquet(embedding_path)
+    except Exception:  # noqa: BLE001
+        return []
+    if df.empty or "event_date" not in df.columns or "embedding" not in df.columns:
+        return []
+    try:
+        df = df.copy()
+        df["event_date"] = df["event_date"].astype(str)
+        df = df[df["event_date"].str[:10] < as_of_ts]
+        df = df.sort_values("event_date").tail(6)
+    except Exception:  # noqa: BLE001
+        return []
+    embeddings = [
+        [float(v) for v in row]
+        for row in df["embedding"].tolist()
+        if row is not None
+    ]
+    if len(embeddings) < 2:
+        return []
+    trend: list[float] = []
+    for idx in range(1, len(embeddings)):
+        prior_window = embeddings[max(0, idx - 4) : idx]
+        if not prior_window:
+            continue
+        distance = drift_vs_prior(embeddings[idx], prior_window)
+        trend.append(float(distance))
+    return trend
+
+
 def _build_analyze_response(
     payload: AnalyzeRequest,
     *,
@@ -761,6 +922,7 @@ def _build_analyze_response(
         "regime_classification_status": regime_status,
         "rates_reaction": _safe_rates_reaction(history_vectors),
         "policy_action": _build_policy_action_card(payload),
+        "credibility": _build_credibility_block(payload, sentiment=sentiment),
     }
     if getattr(payload, "include_xai", False):
         attributions = attribute_text(payload.text)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -701,9 +701,10 @@ def _build_credibility_block(
     Reads the encoder embedding parquet for the canonical DAPT encoder
     plus the cached DFF FRED series, pulls prior-run stance scores out
     of the local history table, and falls back per-axis to the loader's
-    zero defaults when any input is missing. Returns ``None`` only when
-    the underlying loader raises something other than a benign
-    ``ValueError`` / ``FileNotFoundError`` so the route still serialises.
+    zero defaults when any input is missing. Returns ``None`` on any
+    loader exception — both benign ``ValueError`` / ``FileNotFoundError``
+    (missing inputs) and unexpected errors — so the route always
+    serialises.
     """
 
     from app.db import _extract_stance_score
@@ -777,8 +778,14 @@ def _build_credibility_block(
     # series and the realized DFF window carry > 1 point. The loader
     # returns 0.0 when either side is degenerate; treat that as
     # unavailable so the UI renders N/A instead of an unearned reading.
+    # ``fetch_fred_series`` creates the cache directory on first call even
+    # when no API key is set, so check for the series file itself rather
+    # than the directory to detect an actually-populated cache.
     realized_gap: float | None
-    if fred_cache_dir is not None and len(stance_by_date) >= 2:
+    _dff_cached = (
+        fred_cache_dir is not None and (Path(fred_cache_dir) / "DFF.json").exists()
+    )
+    if _dff_cached and len(stance_by_date) >= 2:
         realized_gap = float(vector.realized_vs_stated_gap)
     else:
         realized_gap = None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -245,9 +245,15 @@ class CredibilityResponse(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 
     drift_score: float
-    realized_vs_stated_gap: float
-    market_implied_gap: float
-    months_since_reversal: int
+    realized_vs_stated_gap: float | None = None
+    market_implied_gap: float | None = None
+    months_since_reversal: int | None = None
+    # Per-meeting drift sparkline newest-last. Each entry is the cosine
+    # distance of one prior statement embedding to the mean of the
+    # remaining priors, giving the workspace a short trend curve next
+    # to the headline shift score. Empty when the embedding cache is
+    # absent or only one prior statement is available.
+    drift_trend: list[float] = Field(default_factory=list)
 
 
 class MultiAxisStanceCard(BaseModel):

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -486,21 +486,23 @@ def compute_credibility_for_inference(
         return None
 
     # Best-effort embedding cache lookup; if the file is absent the
-    # drift axis degrades to 0.0 inside the loader.
+    # drift axis degrades to 0.0 inside the loader. Resolve the path via
+    # ``app.data.embedding_cache.resolve_cache_paths`` so the slug stays
+    # in lockstep with the builder (12-char revision prefix, hyphens
+    # normalised) instead of a hand-rolled ``ref.revision[:14]`` that
+    # silently missed the canonical parquet on disk.
     embedding_path: Path | None = None
     try:
+        from app.data.embedding_cache import resolve_cache_paths
         from app.models.registry import encoder_ref
 
         ref = encoder_ref("finbert_fed_adjacent_xbank_dapt")
         if ref is not None and ref.revision:
-            candidate = (
-                DATA_DIR
-                / "raw"
-                / "embeddings"
-                / f"finbert_fed_adjacent_xbank_dapt_{ref.revision[:14]}.parquet"
+            paths = resolve_cache_paths(
+                "finbert_fed_adjacent_xbank_dapt", revision=ref.revision
             )
-            if candidate.exists():
-                embedding_path = candidate
+            if paths.parquet.exists():
+                embedding_path = paths.parquet
     except Exception:  # pragma: no cover -- defensive
         embedding_path = None
 

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -322,8 +322,7 @@ def _get_model() -> ForecasterServingModel:
             ok, _status = _validate_serving_contract(BEST_MODEL_PATH)
             if not ok:
                 raise RuntimeError(
-                    "checkpoint inference contract incompatible with serving "
-                    f"signature: {_status}"
+                    f"checkpoint inference contract incompatible with serving signature: {_status}"
                 )
             raw_config = payload.get("model_config") if isinstance(payload, dict) else None
             resolved = _coerce_model_config(raw_config)
@@ -498,9 +497,7 @@ def compute_credibility_for_inference(
 
         ref = encoder_ref("finbert_fed_adjacent_xbank_dapt")
         if ref is not None and ref.revision:
-            paths = resolve_cache_paths(
-                "finbert_fed_adjacent_xbank_dapt", revision=ref.revision
-            )
+            paths = resolve_cache_paths("finbert_fed_adjacent_xbank_dapt", revision=ref.revision)
             if paths.parquet.exists():
                 embedding_path = paths.parquet
     except Exception:  # pragma: no cover -- defensive

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -867,24 +867,49 @@
             "title": "Drift Score",
             "type": "number"
           },
+          "drift_trend": {
+            "items": {
+              "type": "number"
+            },
+            "title": "Drift Trend",
+            "type": "array"
+          },
           "market_implied_gap": {
-            "title": "Market Implied Gap",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Market Implied Gap"
           },
           "months_since_reversal": {
-            "title": "Months Since Reversal",
-            "type": "integer"
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Months Since Reversal"
           },
           "realized_vs_stated_gap": {
-            "title": "Realized Vs Stated Gap",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Realized Vs Stated Gap"
           }
         },
         "required": [
-          "drift_score",
-          "realized_vs_stated_gap",
-          "market_implied_gap",
-          "months_since_reversal"
+          "drift_score"
         ],
         "title": "CredibilityResponse",
         "type": "object"

--- a/tests/unit/test_main_credibility_block.py
+++ b/tests/unit/test_main_credibility_block.py
@@ -68,6 +68,35 @@ def test_build_credibility_block_returns_none_axes_when_no_inputs(monkeypatch, t
     assert block["drift_trend"] == []
 
 
+def test_build_credibility_block_empty_fred_dir_leaves_realized_none(monkeypatch, tmp_path):
+    """An existing-but-empty FRED cache directory (no ``DFF.json``) must
+    still suppress the realized-vs-stated axis.
+
+    ``fetch_fred_series`` creates ``data/external/fred/`` on the first
+    call even without an API key, so the previous directory-existence
+    guard let a degenerate 0.0 reading leak through on subsequent runs.
+    """
+
+    monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+    import app.services.fred_client as fred_mod
+
+    empty_fred_dir = tmp_path / "fred"
+    empty_fred_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(fred_mod, "DEFAULT_CACHE_DIR", empty_fred_dir)
+    import app.data.embedding_cache as embedding_cache_mod
+
+    monkeypatch.setattr(
+        embedding_cache_mod, "DEFAULT_CACHE_DIR", tmp_path / "raw" / "embeddings"
+    )
+
+    payload = _make_payload()
+    block = main_mod._build_credibility_block(
+        payload, sentiment={"label": "neutral", "score": 0.0}
+    )
+    assert block is not None
+    assert block["realized_vs_stated_gap"] is None
+
+
 def test_build_credibility_block_populates_from_embedding_parquet(monkeypatch, tmp_path):
     """A real parquet under the canonical encoder slug must drive the
     drift score above zero and seed a non-empty drift_trend."""

--- a/tests/unit/test_main_credibility_block.py
+++ b/tests/unit/test_main_credibility_block.py
@@ -1,0 +1,112 @@
+"""Verify ``/analyze`` surfaces a populated credibility block.
+
+Before this change the response schema declared a ``credibility``
+field but ``_build_analyze_response`` never assigned to it, so the
+workspace rendered the "credibility signals unavailable" empty state
+for every passage. These tests pin the new behaviour:
+
+- a real loader response (embedding parquet present, FRED cache
+  present) lands in the ``credibility`` slot with axes populated;
+- a missing FRED / embedding pair falls back to None per axis so the
+  frontend renders N/A without 5xx;
+- the drift trend sparkline carries one entry per usable prior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("torch")
+
+import app.main as main_mod  # noqa: E402
+from app.schemas import AnalyzeRequest  # noqa: E402
+
+
+def _write_embeddings(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_parquet(path, index=False)
+
+
+def _make_payload() -> AnalyzeRequest:
+    return AnalyzeRequest(
+        text="Statement text about the federal funds rate.",
+        date="2024-05-01",
+        symbol="^GSPC",
+        horizon="3d",
+    )
+
+
+def test_build_credibility_block_returns_none_axes_when_no_inputs(monkeypatch, tmp_path):
+    """No embedding cache, no FRED cache -> realized/months_since are None."""
+
+    monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+    import app.services.fred_client as fred_mod
+
+    monkeypatch.setattr(fred_mod, "DEFAULT_CACHE_DIR", tmp_path / "fred_missing")
+    import app.data.embedding_cache as embedding_cache_mod
+
+    monkeypatch.setattr(
+        embedding_cache_mod, "DEFAULT_CACHE_DIR", tmp_path / "raw" / "embeddings"
+    )
+
+    payload = _make_payload()
+    block = main_mod._build_credibility_block(
+        payload, sentiment={"label": "neutral", "score": 0.0}
+    )
+    assert block is not None
+    assert block["drift_score"] == 0.0
+    assert block["realized_vs_stated_gap"] is None
+    assert block["market_implied_gap"] is None
+    # months_since stays None because only the current run is in
+    # ``stance_by_date`` (history table is empty under the in-memory
+    # session this test boots against).
+    assert block["months_since_reversal"] is None
+    assert block["drift_trend"] == []
+
+
+def test_build_credibility_block_populates_from_embedding_parquet(monkeypatch, tmp_path):
+    """A real parquet under the canonical encoder slug must drive the
+    drift score above zero and seed a non-empty drift_trend."""
+
+    from app.models.registry import encoder_ref
+
+    encoder_alias = "finbert_fed_adjacent_xbank_dapt"
+    ref = encoder_ref(encoder_alias)
+    assert ref is not None and ref.revision, "registry must pin the canonical encoder"
+
+    from app.data.embedding_cache import resolve_cache_paths
+
+    # Pivot the embedding cache root onto tmp_path so the resolver
+    # produces a parquet path we control.
+    monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
+    import app.data.embedding_cache as embedding_cache_mod
+
+    monkeypatch.setattr(
+        embedding_cache_mod, "DEFAULT_CACHE_DIR", tmp_path / "raw" / "embeddings"
+    )
+
+    paths = resolve_cache_paths(encoder_alias, revision=ref.revision)
+    _write_embeddings(
+        paths.parquet,
+        [
+            {"event_date": "2023-09-01", "embedding": [1.0, 0.0, 0.0]},
+            {"event_date": "2023-11-01", "embedding": [0.95, 0.05, 0.0]},
+            {"event_date": "2024-01-01", "embedding": [0.9, 0.1, 0.0]},
+            {"event_date": "2024-03-01", "embedding": [0.85, 0.15, 0.0]},
+            {"event_date": "2024-04-15", "embedding": [0.0, 1.0, 0.0]},  # orthogonal pivot
+        ],
+    )
+
+    payload = _make_payload()
+    block = main_mod._build_credibility_block(
+        payload, sentiment={"label": "neutral", "score": 0.0}
+    )
+    assert block is not None
+    assert block["drift_score"] > 0.5, (
+        f"expected a large drift after the orthogonal pivot; got {block['drift_score']}"
+    )
+    assert len(block["drift_trend"]) >= 2


### PR DESCRIPTION
## Summary
- Surface a real credibility block on /analyze instead of the empty-state tile.
- Fix encoder cache slug mismatch (was 14-char, builder writes 12).
- Pull canonical embedding parquet + FRED DFF cache at lifespan startup.
- Schema now allows null per axis when an input is absent.
- Adds drift_trend sparkline for the workspace card.

## Verification
- `docker compose run --rm backend pytest tests/unit/test_credibility_loader.py tests/unit/test_main_credibility_block.py tests/unit/test_credibility_inference_wired.py -q`
- `docker compose run --rm backend pytest tests/unit/test_main_api.py -q`
- `curl -s -X POST http://localhost:8000/analyze -H 'Content-Type: application/json' -d '{"text":"...","date":"2024-05-01","symbol":"^GSPC","horizon":"3d"}' | jq .credibility`