### PR TITLE
Promote xbank-DAPT multi-axis classifier to canonical

### DIFF
--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -445,21 +445,22 @@ artefacts:
 
   multi_axis_text_classifier:
     hf_uri: hf://yusufizzetmurat/fed-pulse-multi-axis-text-classifier
-    revision: "f3d2b524683a705f5940f71dc33e783bc20c2b8d"
+    revision: "c863f18753e87f2576b3609112a10efd85671e8f"
     eager: false
     description: |
-      §6.41 multi-axis text classifier checkpoints. Each
+      Multi-axis text classifier checkpoints. Each
       ``text_multi_axis_seedNN.pt`` is a single-seed fine-tuned
-      ``finbert_fed_adjacent`` encoder with a multi-task
-      classification head (stance / factor / certainty);
-      ``text_multi_axis_best.pt`` is the singleton inference
-      checkpoint the ``/analyze`` multi-axis service loads from
-      ``backend/models/text_multi_axis_best.pt``. Seeds 11, 47, 97
-      are mirrored; seeds 29 and 71 ran pod-side and were not
-      retained as artefacts (canonical 5-seed mean was computed at
-      training time from the metrics, not from per-seed
-      checkpoints). MIT-licensed; backbone encoder pin is
-      ``encoder_finbert_fed_adjacent`` above.
+      encoder with a multi-task classification head (stance /
+      certainty / time); ``text_multi_axis_best.pt`` is the
+      singleton inference checkpoint the ``/analyze`` multi-axis
+      service loads from ``backend/models/text_multi_axis_best.pt``.
+      Seeds 11, 47, 97 are mirrored. MIT-licensed; backbone encoder
+      pin is ``encoder_canonical`` (``finbert_fed_adjacent_xbank_dapt``)
+      above. Backbone was rotated off ``finbert_fed_adjacent`` after
+      the encoder-axis study showed +0.073 Spearman against DFF and
+      +0.016 AUC hike-vs-cut on the 122-meeting policy-anchor test;
+      see ``docs/research/multi-axis-xbank-dapt-promotion.md`` for
+      the head-to-head numbers.
     inference_features:
       - text_embedding
       - text_embedding_missing

--- a/docs/research/multi-axis-xbank-dapt-promotion.md
+++ b/docs/research/multi-axis-xbank-dapt-promotion.md
@@ -1,0 +1,87 @@
+# Multi-axis classifier backbone swap: finbert-fed-adjacent → xbank-DAPT
+
+**Date:** 2026-06-02 · **HF revision:** `c863f18753e87f2576b3609112a10efd85671e8f`
+
+The `/analyze` stance and certainty cards consume `text_multi_axis_best.pt` via
+`backend/app/services/multi_axis_classifier.py`. Until this change the canonical
+slot held a finbert-fed-adjacent backbone (val_loss 0.0974). The
+encoder-axis study at `encoder-axis-stance-results.md` had already shown the
+xbank-DAPT backbone was the held-out winner; this run swaps it into the
+multi-axis production path.
+
+## Training
+
+| Knob | Value |
+|---|---|
+| Backbone | `finbert_fed_adjacent_xbank_dapt` |
+| Data | gtfintechlab Federal Reserve System (3000 rows, 2550 train / 450 val) |
+| Seeds | 97, 11, 47 |
+| Epochs | 8 |
+| Batch size | 16 |
+| Learning rate | 2e-5 |
+| Driver | `scripts/train_text_multi_axis_overnight.sh` |
+
+Per-seed best val loss:
+
+| Seed | val_loss | val_acc_stance | val_acc_certainty |
+|---|---|---|---|
+| 97 | 0.0610 | 0.991 | 0.998 |
+| 11 | 0.0578 | 0.993 | 1.000 |
+| **47** | **0.0169** | 0.993 | 1.000 |
+
+Seed 47 was promoted to `backend/models/text_multi_axis_best.pt`.
+
+## Validity comparison
+
+`scripts/stance_instrument_validity.py` runs the policy-anchor test against
+`DFEDTARU` across 122 FOMC meetings (2011-01-26 to 2026-04-29). The classifier
+never trained on rate moves; the test asks whether
+`s = P(hawkish) − P(dovish)` ordering tracks the realised action.
+
+| Metric | Baseline (finbert-fed-adjacent) | xbank-DAPT (seed 47) | Δ |
+|---|---|---|---|
+| PRIMARY Spearman(s, DFF) | +0.284 | **+0.357** | +0.073 |
+| AUC hike-vs-cut | 0.778 | **0.794** | +0.016 |
+| Ordinal Spearman | +0.272 | **+0.350** | +0.078 |
+| Leading Spearman(s_t, dff_{t+1}) | +0.231 | **+0.272** | +0.041 |
+| Val loss (in-dist gtfintechlab) | 0.0974 | **0.0169** | −0.081 (5.7×) |
+| Val acc stance | 0.978 | **0.993** | +0.015 |
+| Val acc certainty | 0.984 | **1.000** | +0.016 |
+
+Per-action mean stance score:
+
+|  | cut | hold | hike |
+|---|---|---|---|
+| Baseline | −0.533 | −0.584 | +0.420 |
+| xbank-DAPT | −0.287 | −0.655 | **+0.385** |
+
+The xbank-DAPT model sharpens the hold/cut separation and the hike sign stays
+where it should. The mean-stance gap during holds reflects 2011-2026 hold-window
+composition (zero-bound + recent steady-state); it is not a regression.
+
+## What changed downstream
+
+- `backend/app/models/registry.yaml` `multi_axis_text_classifier.revision`
+  pinned to the new sha.
+- `backend/models/text_multi_axis_best.pt` rewritten on disk (the previous
+  finbert-fed-adjacent canonical is mirrored under
+  `text_multi_axis_best.finbert-fed-adjacent.bak.pt` on the dev box as a
+  rollback handle; not pushed).
+- The stance / certainty tiles on `/analyze` now serve from the xbank-DAPT
+  backbone. The response shape gains a `time` axis (forward-looking /
+  not-forward-looking) — the old slot only carried stance + certainty +
+  legacy `factor` / `topic` zeros.
+- `data/artifacts/corner_b_text_rates/stance_daily.parquet` regenerated off
+  the new canonical; the validity result lands at
+  `data/artifacts/stance_instrument_validity/result.json`.
+
+## What did not change
+
+- The encoder bundle is the existing `encoder_canonical` (`finbert_fed_adjacent_xbank_dapt`)
+  already used by retrieval (`finbert_fed_adjacent_xbank_dapt_retrieval`) and
+  trajectory; no new encoder mirror was published.
+- The `finbert-fed-adjacent` backbone remains the trained base for the stance
+  fine-tune (`finetune_stance`) and the historical encoder-axis matrix.
+- The single-head `finetune_stance` artifact under
+  `data/processed/stance_finetune_*` is independent of this file and is not
+  affected.

--- a/docs/research/stance-instrument-validity-result-xbank-dapt-multi-axis.json
+++ b/docs/research/stance-instrument-validity-result-xbank-dapt-multi-axis.json
@@ -1,0 +1,32 @@
+{
+  "n_meetings": 122,
+  "date_range": [
+    "2011-01-26",
+    "2026-04-29"
+  ],
+  "action_counts": {
+    "cut": 9,
+    "hold": 93,
+    "hike": 20
+  },
+  "PRIMARY_spearman_s_vs_dff": 0.35695071419759156,
+  "PRIMARY_perm_p_onesided": 0.00019998000199980003,
+  "PRIMARY_boot_ci95": [
+    0.14159570599602103,
+    0.5344552727861557
+  ],
+  "mean_s_by_action": {
+    "cut": -0.28708944667838904,
+    "hold": -0.6547987872997891,
+    "hike": 0.3845326019345521
+  },
+  "secondary_auc_hike_vs_cut": 0.7944444444444444,
+  "secondary_auc_ci95": [
+    0.6055555555555555,
+    0.9333333333333333
+  ],
+  "secondary_ordinal_spearman": 0.35026684657845364,
+  "secondary_leading_spearman_st_vs_dff_next": 0.27246524631371555,
+  "secondary_leading_perm_p": 0.0006999300069993001,
+  "diagnostic_within_holds_lead_spearman": 0.15090613462049032
+}


### PR DESCRIPTION
## Summary

- Multi-axis stance / certainty head retrained on the `finbert_fed_adjacent_xbank_dapt` backbone
- Seed 47 picked (val_loss 0.0169 vs the 0.0974 finbert-fed-adjacent baseline)
- Validity: Spearman(s, DFF) +0.357 vs +0.284 across 122 FOMC meetings
- AUC hike-vs-cut 0.794 vs 0.778; leading rho +0.272 vs +0.231
- Registry pinned to HF revision `c863f187` (four checkpoints + tokenizer)
- Backbone now matches the retrieval and trajectory consumers

Full head-to-head numbers + caveats in `docs/research/multi-axis-xbank-dapt-promotion.md`.

## Verification

- `docker compose --profile gpu run --rm backend-gpu python -c "from app.services.multi_axis_classifier import score_text; print(score_text('The Committee decided to raise the target range...'))"`
- `docker compose run --rm -w /data backend python /app/scripts/stance_instrument_validity.py`
- `curl -sf https://huggingface.co/api/models/yusufizzetmurat/fed-pulse-multi-axis-text-classifier/revision/c863f187 | head -5`