### PR TITLE
fix: fail-closed sentiment encoder fallback + provenance sidecar

### DIFF
--- a/backend/app/data/dense_fomc_text.py
+++ b/backend/app/data/dense_fomc_text.py
@@ -63,17 +63,28 @@ def build_fomc_embeddings(
 
     # Fail loudly rather than silently caching embeddings from a fallback model.
     assert_primary_model_loaded()
+    provenance = loaded_encoder_provenance()
     texts = statement_dates_and_text(events_parquet)
-    rows = []
+    encoded: list[tuple[str, np.ndarray | None]] = []
     for date_iso in sorted(texts):
         encs = encode_chunks(texts[date_iso])
         vecs = [np.asarray(e.embedding, dtype=np.float64) for e in encs if e.embedding]
-        emb = np.mean(vecs, axis=0) if vecs else np.zeros(768)
-        rows.append({"date": date_iso, **{f"emb_{i}": float(emb[i]) for i in range(len(emb))}})
+        encoded.append((date_iso, np.mean(vecs, axis=0) if vecs else None))
+    # Size to the encoder's actual width, not a hardcoded 768 (FOMC-RoBERTa is
+    # 1024); empty-text rows fall back to zeros of the SAME width.
+    dim = next(
+        (len(v) for _, v in encoded if v is not None),
+        provenance.get("hidden_size") or 768,
+    )
+    rows = [
+        {"date": date_iso, **{f"emb_{i}": float(emb[i]) for i in range(dim)}}
+        for date_iso, v in encoded
+        for emb in [v if v is not None else np.zeros(dim)]
+    ]
     out_path.parent.mkdir(parents=True, exist_ok=True)
     pd.DataFrame(rows).to_parquet(out_path, index=False)
     # Stamp which encoder produced these vectors so provenance is auditable.
-    write_encoder_sidecar(out_path, loaded_encoder_provenance())
+    write_encoder_sidecar(out_path, provenance)
     print(f"[dense_fomc_text] wrote {len(rows)} FOMC embeddings to {out_path}")
     return out_path
 

--- a/backend/app/data/dense_fomc_text.py
+++ b/backend/app/data/dense_fomc_text.py
@@ -54,7 +54,12 @@ def build_fomc_embeddings(
     out_path = Path(out_path)
     if out_path.exists() and not force:
         return out_path
-    from app.services.text_encoder import assert_primary_model_loaded, encode_chunks
+    from app.services.encoder_provenance import write_encoder_sidecar
+    from app.services.text_encoder import (
+        assert_primary_model_loaded,
+        encode_chunks,
+        loaded_encoder_provenance,
+    )
 
     # Fail loudly rather than silently caching embeddings from a fallback model.
     assert_primary_model_loaded()
@@ -67,6 +72,8 @@ def build_fomc_embeddings(
         rows.append({"date": date_iso, **{f"emb_{i}": float(emb[i]) for i in range(len(emb))}})
     out_path.parent.mkdir(parents=True, exist_ok=True)
     pd.DataFrame(rows).to_parquet(out_path, index=False)
+    # Stamp which encoder produced these vectors so provenance is auditable.
+    write_encoder_sidecar(out_path, loaded_encoder_provenance())
     print(f"[dense_fomc_text] wrote {len(rows)} FOMC embeddings to {out_path}")
     return out_path
 

--- a/backend/app/data/fed_comms_train.py
+++ b/backend/app/data/fed_comms_train.py
@@ -47,7 +47,12 @@ def build_corpus_embeddings(
     out_path = Path(out_path)
     if out_path.exists() and not force:
         return out_path
-    from app.services.text_encoder import assert_primary_model_loaded, encode_chunks
+    from app.services.encoder_provenance import write_encoder_sidecar
+    from app.services.text_encoder import (
+        assert_primary_model_loaded,
+        encode_chunks,
+        loaded_encoder_provenance,
+    )
 
     # Fail loudly rather than silently caching embeddings from a fallback model.
     assert_primary_model_loaded()
@@ -65,6 +70,8 @@ def build_corpus_embeddings(
     ]
     out_path.parent.mkdir(parents=True, exist_ok=True)
     pd.DataFrame(rows).to_parquet(out_path, index=False)
+    # Stamp which encoder produced these vectors so provenance is auditable.
+    write_encoder_sidecar(out_path, loaded_encoder_provenance())
     print(f"[fed_comms_train] wrote {len(rows)} doc embeddings (dim={dim}) to {out_path}")
     return out_path
 

--- a/backend/app/services/encoder_provenance.py
+++ b/backend/app/services/encoder_provenance.py
@@ -1,0 +1,49 @@
+"""Encoder-provenance sidecars for embedding artifacts.
+
+Writes a ``<artifact>.encoder.json`` next to any built embedding file recording
+which encoder produced it (model id, revision, hidden size, build time). This
+makes the encoder behind a cached embedding artifact permanently auditable, so
+the silent-fallback contamination risk cannot leave an unverifiable artifact
+behind (the bug that left ``fomc_embeddings.parquet`` ambiguous).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+
+_SIDECAR_SUFFIX = ".encoder.json"
+
+
+def _sidecar_path(artifact_path: Path | str) -> Path:
+    p = Path(artifact_path)
+    return p.parent / (p.name + _SIDECAR_SUFFIX)
+
+
+def write_encoder_sidecar(
+    artifact_path: Path | str,
+    provenance: dict[str, Any],
+    *,
+    built_at: str | None = None,
+) -> Path:
+    """Write the encoder provenance for ``artifact_path`` and return the sidecar path.
+
+    ``provenance`` should carry at least ``model_id``; ``revision`` and
+    ``hidden_size`` are recorded when present. ``built_at`` defaults to the
+    current UTC time (override for deterministic tests).
+    """
+    record = dict(provenance)
+    record.setdefault("built_at", built_at or datetime.now(timezone.utc).isoformat())
+    sidecar = _sidecar_path(artifact_path)
+    sidecar.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+    return sidecar
+
+
+def read_encoder_sidecar(artifact_path: Path | str) -> dict[str, Any] | None:
+    """Return the recorded provenance for ``artifact_path``, or None if absent."""
+    sidecar = _sidecar_path(artifact_path)
+    if not sidecar.exists():
+        return None
+    return cast("dict[str, Any]", json.loads(sidecar.read_text()))

--- a/backend/app/services/text_encoder.py
+++ b/backend/app/services/text_encoder.py
@@ -56,6 +56,7 @@ def _fallback_allowed() -> bool:
     allow = (os.environ.get("FED_PULSE_ALLOW_SENTIMENT_FALLBACK") or "").strip().lower()
     return allow in _TRUTHY
 
+
 # The model id the singleton actually loaded; differs from MODEL_ID on fallback.
 _loaded_model_id: str | None = None
 

--- a/backend/app/services/text_encoder.py
+++ b/backend/app/services/text_encoder.py
@@ -38,16 +38,23 @@ MODEL_ID = _OVERRIDE or (
     DEFAULT_LOCAL_CHECKPOINT if Path(DEFAULT_LOCAL_CHECKPOINT).exists() else PRIMARY_HF_MODEL_ID
 )
 
-# When truthy, refuse to silently use the generic fallback classifier — raise
-# instead. Embedding/training pipelines set this so cached vectors can never be
-# built from the wrong encoder (the silent-fallback contamination bug: the
-# primary HF repo can 404, and the run would otherwise proceed on distilbert
-# sentiment vectors with no error).
-STRICT_PRIMARY = (os.environ.get("FED_PULSE_REQUIRE_PRIMARY_SENTIMENT") or "").strip().lower() in {
-    "1",
-    "true",
-    "yes",
-}
+# Fallback policy. The silent fallback to the generic distilbert-sst-2 classifier
+# can contaminate cached embeddings undetected (the primary HF repo 404s and the
+# run proceeds on the wrong encoder with no error). We therefore FAIL CLOSED:
+# refuse the fallback by default for both build and serving. Degraded serving is
+# opt-in and explicit via FED_PULSE_ALLOW_SENTIMENT_FALLBACK, so it can never
+# happen silently. FED_PULSE_REQUIRE_PRIMARY_SENTIMENT is still honoured (now the
+# default behaviour) for backward compatibility.
+_TRUTHY = {"1", "true", "yes"}
+
+
+def _fallback_allowed() -> bool:
+    """True only when an operator has explicitly opted into the degraded fallback."""
+    require = (os.environ.get("FED_PULSE_REQUIRE_PRIMARY_SENTIMENT") or "").strip().lower()
+    if require in _TRUTHY:
+        return False
+    allow = (os.environ.get("FED_PULSE_ALLOW_SENTIMENT_FALLBACK") or "").strip().lower()
+    return allow in _TRUTHY
 
 # The model id the singleton actually loaded; differs from MODEL_ID on fallback.
 _loaded_model_id: str | None = None
@@ -174,27 +181,30 @@ def get_classifier() -> Any:
         global _loaded_model_id
         _loaded_model_id = loaded_model_id
         if loaded_model_id != MODEL_ID:
-            # We picked a fallback. The fallback's label space (e.g.
-            # POSITIVE / NEGATIVE for distilbert-sst-2) is NOT
-            # hawkish/dovish/neutral; the frontend's toStance() refuses to
-            # silently relabel POSITIVE -> hawkish, so the dashboard will
-            # surface "Sentiment unavailable" until the primary model loads.
-            if STRICT_PRIMARY:
+            # We picked a fallback. Its label space (e.g. POSITIVE / NEGATIVE for
+            # distilbert-sst-2) is NOT hawkish/dovish/neutral and its embeddings
+            # are generic, not FOMC-specific. Fail closed by default; only the
+            # explicit FED_PULSE_ALLOW_SENTIMENT_FALLBACK opt-out lets serving
+            # degrade (frontend toStance() then reports "Sentiment unavailable").
+            if not _fallback_allowed():
                 raise RuntimeError(
-                    f"sentiment classifier fell back to {loaded_model_id!r} instead of "
-                    f"the primary {MODEL_ID!r}; refusing because "
-                    "FED_PULSE_REQUIRE_PRIMARY_SENTIMENT is set (the primary model is "
-                    "unavailable — see preceding classifier_load_failed warnings)"
+                    f"refusing to use fallback sentiment model {loaded_model_id!r} "
+                    f"instead of the primary {MODEL_ID!r}: the fallback's labels are "
+                    "not hawkish/dovish/neutral and its embeddings are not "
+                    "FOMC-specific, so it can silently contaminate cached vectors. "
+                    "The primary model failed to load — see the preceding "
+                    "classifier_load_failed warnings. Set "
+                    "FED_PULSE_ALLOW_SENTIMENT_FALLBACK=1 to allow degraded serving."
                 )
-            _logger.error(
+            _logger.warning(
                 "sentiment.classifier_using_fallback",
                 extra={
                     "primary_model_id": MODEL_ID,
                     "loaded_model_id": loaded_model_id,
                     "note": (
-                        "Primary sentiment model failed to load. The active model's labels "
-                        "are NOT hawkish/dovish/neutral; the dashboard will report stance "
-                        "as unknown. Inspect the preceding classifier_load_failed warnings."
+                        "FED_PULSE_ALLOW_SENTIMENT_FALLBACK is set: serving on the generic "
+                        "fallback. Stance reports as unknown and any embeddings built now "
+                        "are NOT FOMC-specific."
                     ),
                 },
             )
@@ -220,6 +230,27 @@ def assert_primary_model_loaded() -> None:
             f"(active model: {_loaded_model_id!r}); refusing to build embeddings with "
             "a fallback encoder. Set FED_PULSE_SENTIMENT_MODEL to a valid model."
         )
+
+
+def loaded_encoder_provenance() -> dict[str, Any]:
+    """Provenance of the loaded sentiment encoder, for stamping built artifacts.
+
+    Returns the active model id, its pinned revision, and hidden size so a
+    ``<artifact>.encoder.json`` sidecar can record exactly which encoder produced
+    a cached embedding file.
+    """
+    classifier = get_classifier()
+    model = getattr(classifier, "model", None)
+    hidden = getattr(getattr(model, "config", None), "hidden_size", None)
+    try:
+        revision = revision_for(MODEL_ID)
+    except Exception:
+        revision = None
+    return {
+        "model_id": get_loaded_model_id(),
+        "revision": revision,
+        "hidden_size": int(hidden) if hidden is not None else None,
+    }
 
 
 def classifier_load_count() -> int:
@@ -330,6 +361,11 @@ def encode_chunks(text: str, classifier: Any = None) -> list[ChunkEncoding]:
     if not text:
         return []
     if classifier is None:
+        # Boundary guard: refuse to build encodings on a fallback encoder, so the
+        # silent-fallback contamination cannot occur for ANY caller of the global
+        # singleton — not just the build scripts that call this guard explicitly.
+        # Callers that inject their own classifier own that choice.
+        assert_primary_model_loaded()
         classifier = get_classifier()
     chunks = split_into_chunks(text, classifier=classifier)
     if not chunks:

--- a/tests/unit/test_dense_fomc_text_build.py
+++ b/tests/unit/test_dense_fomc_text_build.py
@@ -1,0 +1,43 @@
+"""build_fomc_embeddings must size embeddings to the actual encoder, not a
+hardcoded 768. FOMC-RoBERTa is 1024-dim; the old ``np.zeros(768)`` empty-text
+fallback would emit mixed-width rows (NaNs past column 768)."""
+
+from __future__ import annotations
+
+import types
+
+import pandas as pd
+
+import app.data.dense_fomc_text as dft
+import app.services.text_encoder as te
+
+
+def test_build_fomc_embeddings_dim_follows_encoder_not_hardcoded(tmp_path, monkeypatch):
+    # Two statements; the second yields no encodable chunks (empty-text fallback).
+    monkeypatch.setattr(
+        dft,
+        "statement_dates_and_text",
+        lambda _p: {"2024-01-31": "a hawkish statement", "2024-03-20": "blank"},
+    )
+
+    def _fake_encode(text: str, classifier=None):
+        if text == "blank":
+            return []
+        return [types.SimpleNamespace(embedding=[0.1] * 1024)]
+
+    monkeypatch.setattr(te, "encode_chunks", _fake_encode)
+    monkeypatch.setattr(te, "assert_primary_model_loaded", lambda: None)
+    monkeypatch.setattr(
+        te,
+        "loaded_encoder_provenance",
+        lambda: {"model_id": "gtfintechlab/FOMC-RoBERTa", "revision": "r", "hidden_size": 1024},
+    )
+
+    out = tmp_path / "emb.parquet"
+    dft.build_fomc_embeddings("ignored.parquet", out, force=True)
+
+    df = pd.read_parquet(out)
+    emb_cols = [c for c in df.columns if c.startswith("emb_")]
+    assert len(emb_cols) == 1024
+    # The empty-text row must be zeros(1024) — no NaNs from a 768/1024 width clash.
+    assert not df[emb_cols].isna().any().any()

--- a/tests/unit/test_encoder_fallback_guard.py
+++ b/tests/unit/test_encoder_fallback_guard.py
@@ -1,0 +1,111 @@
+"""Fail-closed encoder fallback + provenance guard (MLC1 hardening).
+
+The silent fallback from the primary FOMC sentiment model to the generic
+distilbert-sst-2 classifier could contaminate cached embeddings undetected.
+These tests lock the hardened contract: refuse the fallback by default, allow
+it only via an explicit opt-out, enforce the guard at the encode boundary, and
+stamp encoder provenance into built artifacts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import app.services.text_encoder as te
+
+
+@pytest.fixture
+def reset_classifier(monkeypatch):
+    monkeypatch.setattr(te, "_classifier", None)
+    monkeypatch.setattr(te, "_loaded_model_id", None)
+    yield
+
+
+def _build_factory(primary_id: str):
+    """Fake _build_pipeline: primary 404s, fallback loads."""
+
+    def _fake(model_id: str, device: int):
+        if model_id == primary_id:
+            raise RuntimeError("primary unavailable (simulated 404)")
+        return object()  # stand-in fallback pipeline
+
+    return _fake
+
+
+def test_get_classifier_raises_on_fallback_by_default(monkeypatch, reset_classifier):
+    monkeypatch.delenv("FED_PULSE_ALLOW_SENTIMENT_FALLBACK", raising=False)
+    monkeypatch.delenv("FED_PULSE_REQUIRE_PRIMARY_SENTIMENT", raising=False)
+    monkeypatch.setattr(te, "MODEL_ID", "primary/stance-model")
+    monkeypatch.setattr(te, "_build_pipeline", _build_factory("primary/stance-model"))
+
+    with pytest.raises(RuntimeError, match="fall"):
+        te.get_classifier()
+
+
+def test_get_classifier_allows_fallback_with_explicit_optout(monkeypatch, reset_classifier):
+    monkeypatch.setenv("FED_PULSE_ALLOW_SENTIMENT_FALLBACK", "1")
+    monkeypatch.delenv("FED_PULSE_REQUIRE_PRIMARY_SENTIMENT", raising=False)
+    monkeypatch.setattr(te, "MODEL_ID", "primary/stance-model")
+    sentinel = object()
+
+    def _fake(model_id: str, device: int):
+        if model_id == "primary/stance-model":
+            raise RuntimeError("primary down")
+        return sentinel
+
+    monkeypatch.setattr(te, "_build_pipeline", _fake)
+
+    clf = te.get_classifier()
+    assert clf is sentinel
+    assert te.get_loaded_model_id() == te.FALLBACK_MODEL_ID
+
+
+def test_require_primary_env_overrides_optout(monkeypatch, reset_classifier):
+    # Back-compat: REQUIRE wins even if ALLOW is also set.
+    monkeypatch.setenv("FED_PULSE_ALLOW_SENTIMENT_FALLBACK", "1")
+    monkeypatch.setenv("FED_PULSE_REQUIRE_PRIMARY_SENTIMENT", "1")
+    monkeypatch.setattr(te, "MODEL_ID", "primary/stance-model")
+    monkeypatch.setattr(te, "_build_pipeline", _build_factory("primary/stance-model"))
+
+    with pytest.raises(RuntimeError, match="fall"):
+        te.get_classifier()
+
+
+def test_encode_chunks_enforces_primary_guard_before_load(monkeypatch):
+    # encode_chunks must delegate to the primary guard BEFORE loading any model,
+    # so ANY caller is protected (not just the build scripts that call it today).
+    # Both deps are stubbed so this never touches the network in either state.
+    def _guard() -> None:
+        raise RuntimeError("primary guard tripped")
+
+    def _should_not_load() -> object:
+        raise AssertionError("get_classifier reached before the primary guard")
+
+    monkeypatch.setattr(te, "assert_primary_model_loaded", _guard)
+    monkeypatch.setattr(te, "get_classifier", _should_not_load)
+
+    with pytest.raises(RuntimeError, match="primary guard tripped"):
+        te.encode_chunks("a sufficiently long FOMC statement for encoding")
+
+
+def test_loaded_encoder_provenance_reports_active_encoder(monkeypatch):
+    class _Cfg:
+        hidden_size = 768
+
+    class _Model:
+        config = _Cfg()
+
+    class _Clf:
+        model = _Model()
+
+    monkeypatch.setattr(te, "get_classifier", lambda: _Clf())
+    monkeypatch.setattr(te, "get_loaded_model_id", lambda: "gtfintechlab/FOMC-RoBERTa")
+    monkeypatch.setattr(te, "revision_for", lambda _m: "rev-xyz")
+
+    prov = te.loaded_encoder_provenance()
+
+    assert prov == {
+        "model_id": "gtfintechlab/FOMC-RoBERTa",
+        "revision": "rev-xyz",
+        "hidden_size": 768,
+    }

--- a/tests/unit/test_encoder_provenance.py
+++ b/tests/unit/test_encoder_provenance.py
@@ -1,0 +1,43 @@
+"""Encoder-provenance sidecar for embedding artifacts (MLC1 hardening).
+
+Every built embedding artifact gets a ``<artifact>.encoder.json`` sidecar
+recording which encoder produced it, so the provenance ambiguity that made the
+May-31 ``fomc_embeddings.parquet`` unverifiable can never recur.
+"""
+
+from __future__ import annotations
+
+from app.services.encoder_provenance import (
+    read_encoder_sidecar,
+    write_encoder_sidecar,
+)
+
+
+def test_write_then_read_roundtrip(tmp_path):
+    art = tmp_path / "fomc_embeddings.parquet"
+    art.write_bytes(b"fake-parquet")
+    prov = {"model_id": "gtfintechlab/FOMC-RoBERTa", "revision": "abc123", "hidden_size": 768}
+
+    sidecar = write_encoder_sidecar(art, prov, built_at="2026-06-02T00:00:00+00:00")
+
+    assert sidecar.name == "fomc_embeddings.parquet.encoder.json"
+    got = read_encoder_sidecar(art)
+    assert got is not None
+    assert got["model_id"] == "gtfintechlab/FOMC-RoBERTa"
+    assert got["revision"] == "abc123"
+    assert got["hidden_size"] == 768
+    assert got["built_at"] == "2026-06-02T00:00:00+00:00"
+
+
+def test_built_at_is_stamped_when_not_supplied(tmp_path):
+    art = tmp_path / "emb.parquet"
+    art.write_bytes(b"x")
+    write_encoder_sidecar(art, {"model_id": "m", "revision": None, "hidden_size": 384})
+    got = read_encoder_sidecar(art)
+    assert got is not None
+    assert isinstance(got["built_at"], str) and got["built_at"]
+
+
+def test_read_returns_none_when_sidecar_absent(tmp_path):
+    art = tmp_path / "missing.parquet"
+    assert read_encoder_sidecar(art) is None

--- a/tests/unit/test_pseudo_labeling.py
+++ b/tests/unit/test_pseudo_labeling.py
@@ -227,6 +227,10 @@ def test_run_pseudo_labeling_scores_only_unlabelled_rows_and_writes_jsonl(tmp_pa
         threshold=0.85,
         teacher_model_id="fomc_roberta_s71",
         teacher_model_version="phase4_finetune_v1",
+        # Deterministic single-chunk splitter so the chunk-aware default strategy
+        # does not load the (gated) HF tokenizer — matches the sibling chunked
+        # tests and keeps this test independent of model availability.
+        splitter=lambda text: [text],
     )
 
     assert written == 1


### PR DESCRIPTION
## What

Make the FOMC sentiment encoder **fail closed** so a silent fallback to the generic `distilbert-sst-2` classifier can no longer contaminate cached embeddings or serve wrong stance, and record encoder provenance for every built embedding artifact.

## Why

The primary FOMC encoder could 404 and the run would silently proceed on a generic fallback (wrong label space, non-FOMC embeddings) with no error. Cached artifacts then carried no record of which encoder produced them.

## Changes

- `text_encoder.py`: refuse the fallback by default for build **and** serving; opt out explicitly with `FED_PULSE_ALLOW_SENTIMENT_FALLBACK=1` (`FED_PULSE_REQUIRE_PRIMARY_SENTIMENT` still honored). `encode_chunks()` enforces the primary-model guard at the boundary so every caller is protected, not just the build scripts. New `loaded_encoder_provenance()` helper.
- `encoder_provenance.py` (new): writes/reads a `<artifact>.encoder.json` sidecar (`model_id`, `revision`, `hidden_size`, `built_at`). Wired into the dense-fomc-text and fed-comms embedding builds.
- `dense_fomc_text.py`: size embeddings to the encoder width instead of a hardcoded 768 (FOMC-RoBERTa is 1024-dim; the old fallback produced mixed-width rows).

## Behaviour change

Paths that load the sentiment encoder now raise loudly if the primary model is unavailable instead of degrading silently. Normal operation (primary reachable) is unchanged. Degraded serving remains possible via the explicit opt-out.

## Tests

New: `test_encoder_fallback_guard.py`, `test_encoder_provenance.py`, `test_dense_fomc_text_build.py`. Local unit/properties/contract/regression suites pass; ruff + mypy clean on changed modules.

## Verification

Rebuilt the FOMC embeddings with the verified primary encoder (FOMC-RoBERTa, 1024-dim, provenance-stamped) and re-ran the dense-fomc-text marginal test across all three arms. The text-null is re-confirmed and unchanged: delta-only is text-neutral (CIs include 0), and PCA-16 / text-alone remain text-negative. No model retraining required.
